### PR TITLE
Limit # of child runs created for hyperparam search models

### DIFF
--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -694,8 +694,11 @@ def autolog(
     )
 
     if max_tuning_runs is not None and max_tuning_runs < 0:
-        raise ValueError(
-            "`max_tuning_runs` must be non-negative, instead got {}.".format(max_tuning_runs,)
+        raise MlflowException(
+            message=(
+                "`max_tuning_runs` must be non-negative, instead got {}.".format(max_tuning_runs)
+            ),
+            error_code=INVALID_PARAMETER_VALUE,
         )
 
     if not _is_supported_version():

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -693,6 +693,11 @@ def autolog(
         MAX_ENTITY_KEY_LENGTH,
     )
 
+    if max_tuning_runs is not None and max_tuning_runs < 0:
+        raise ValueError(
+            "`max_tuning_runs` must be non-negative, instead got {}.".format(max_tuning_runs,)
+        )
+
     if not _is_supported_version():
         warnings.warn(
             "Autologging utilities may not work properly on scikit-learn < {} ".format(

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -656,15 +656,15 @@ def autolog(
                    autologging. If ``False``, show all events and warnings during scikit-learn
                    autologging.
     :param max_tuning_runs: The maximum number of child Mlflow runs created for hyperparameter
-                            search estimators. To create an mlflow child run for the
-                            best k results(based on `rank_test_score` values), set max_tuning_runs
-                            to k. The default value is to track the best 5 search parameter sets.
-                            If `max_tuning_runs=None`, then a child run is created for each search
-                            parameter set. Note: In the case of multi-metric evaluation with a
-                            custom scorer, the first scorer’s `rank_test_score_<scorer_name>` will
-                            be used to select the best k results. To change metric used for
-                            selecting best k results, change ordering of dict passed as `scoring`
-                            parameter for estimator.
+                            search estimators. To create child runs for the best `k` results from
+                            the search, set `max_tuning_runs` to `k`. The default value is to track
+                            the best 5 search parameter sets. If `max_tuning_runs=None`, then
+                            a child run is created for each search parameter set. Note: The best k
+                            results is based on ordering in `rank_test_score`. In the case of
+                            multi-metric evaluation with a custom scorer, the first scorer’s
+                            `rank_test_score_<scorer_name>` will be used to select the best k
+                            results. To change metric used for selecting best k results, change
+                            ordering of dict passed as `scoring` parameter for estimator.
     """
     import pandas as pd
     import sklearn

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -463,6 +463,7 @@ def autolog(
     exclusive=False,
     disable_for_unsupported_versions=False,
     silent=False,
+    max_hyper_param_runs=5,
 ):  # pylint: disable=unused-argument
     """
     Enables (or disables) and configures autologging for scikit-learn estimators.
@@ -654,6 +655,11 @@ def autolog(
     :param silent: If ``True``, suppress all event logs and warnings from MLflow during scikit-learn
                    autologging. If ``False``, show all events and warnings during scikit-learn
                    autologging.
+    :param max_hyper_param_runs: The max number of child mlflow runs to be created for
+                                 hyper parameter search based estimators. If one only cares about
+                                 creating an mlflow child run for the best k results from the
+                                 search, then set max_hyper_param_runs to k. The default value is
+                                 to track the best 5 hyper paramters.
     """
     import pandas as pd
     import sklearn
@@ -824,6 +830,7 @@ def autolog(
                     _create_child_runs_for_parameter_search(
                         cv_estimator=estimator,
                         parent_run=mlflow.active_run(),
+                        max_hyper_param_runs=max_hyper_param_runs,
                         child_tags=child_tags,
                     )
                 except Exception as e:

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -463,7 +463,7 @@ def autolog(
     exclusive=False,
     disable_for_unsupported_versions=False,
     silent=False,
-    max_hyper_param_runs=5,
+    max_tuning_runs=5,
 ):  # pylint: disable=unused-argument
     """
     Enables (or disables) and configures autologging for scikit-learn estimators.
@@ -655,11 +655,17 @@ def autolog(
     :param silent: If ``True``, suppress all event logs and warnings from MLflow during scikit-learn
                    autologging. If ``False``, show all events and warnings during scikit-learn
                    autologging.
-    :param max_hyper_param_runs: The max number of child mlflow runs to be created for
-                                 hyper parameter search based estimators. If one only cares about
-                                 creating an mlflow child run for the best k results from the
-                                 search, then set max_hyper_param_runs to k. The default value is
-                                 to track the best 5 hyper paramters.
+    :param max_tuning_runs: The maximum number of child Mlflow runs to be created for
+                            hyperparameter search estimators. If one only cares about
+                            creating an mlflow child run for the best k results(based on
+                            `rank_test_score` values) from the search, then set max_tuning_runs
+                            to k. The default value is to track the best 5 search parameter sets.
+                            If `None` is passed as a value then a child run is created for each
+                            search parameter set. Note: In the case of multi-metric evaluation with
+                            a custom scorer, the first scorer’s `rank_test_score_<scorer_name>`
+                            will be used to select the best k results. One can change ordering of
+                            dict passed as `scoring` parameter for estimator to change which metric
+                            to use for selecting best k results.
     """
     import pandas as pd
     import sklearn
@@ -830,7 +836,7 @@ def autolog(
                     _create_child_runs_for_parameter_search(
                         cv_estimator=estimator,
                         parent_run=mlflow.active_run(),
-                        max_hyper_param_runs=max_hyper_param_runs,
+                        max_tuning_runs=max_tuning_runs,
                         child_tags=child_tags,
                     )
                 except Exception as e:

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -655,17 +655,16 @@ def autolog(
     :param silent: If ``True``, suppress all event logs and warnings from MLflow during scikit-learn
                    autologging. If ``False``, show all events and warnings during scikit-learn
                    autologging.
-    :param max_tuning_runs: The maximum number of child Mlflow runs to be created for
-                            hyperparameter search estimators. If one only cares about
-                            creating an mlflow child run for the best k results(based on
-                            `rank_test_score` values) from the search, then set max_tuning_runs
+    :param max_tuning_runs: The maximum number of child Mlflow runs created for hyperparameter
+                            search estimators. To create an mlflow child run for the
+                            best k results(based on `rank_test_score` values), set max_tuning_runs
                             to k. The default value is to track the best 5 search parameter sets.
-                            If `None` is passed as a value then a child run is created for each
-                            search parameter set. Note: In the case of multi-metric evaluation with
-                            a custom scorer, the first scorer’s `rank_test_score_<scorer_name>`
-                            will be used to select the best k results. One can change ordering of
-                            dict passed as `scoring` parameter for estimator to change which metric
-                            to use for selecting best k results.
+                            If `max_tuning_runs=None`, then a child run is created for each search
+                            parameter set. Note: In the case of multi-metric evaluation with a
+                            custom scorer, the first scorer’s `rank_test_score_<scorer_name>` will
+                            be used to select the best k results. To change metric used for
+                            selecting best k results, change ordering of dict passed as `scoring`
+                            parameter for estimator.
     """
     import pandas as pd
     import sklearn

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -626,7 +626,7 @@ def _create_child_runs_for_parameter_search(
     base_params = seed_estimator.get_params(deep=should_log_params_deeply)
     cv_results_df = pd.DataFrame.from_dict(cv_estimator.cv_results_)
 
-    if max_tuning_runs == None:
+    if max_tuning_runs is None:
         cv_results_best_n_df = cv_results_df
     else:
         rank_column_name = "rank_test_score"

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -633,13 +633,21 @@ def _create_child_runs_for_parameter_search(
         if rank_column_name not in cv_results_df.columns.values:
             rank_column_name = first_custom_rank_column(cv_results_df)
             warnings.warn(
-                "Top {} child runs will be created based on ordering in {} column. ".format(
+                "Top {} child runs will be created based on ordering in {} column.".format(
                     max_tuning_runs, rank_column_name,
                 )
-                + "You can choose not to limit the number of child runs created by"
+                + " You can choose not to limit the number of child runs created by"
                 + " setting `max_tuning_runs=None`."
             )
         cv_results_best_n_df = cv_results_df.nsmallest(max_tuning_runs, rank_column_name)
+        # Log how many child runs will be created vs omitted.
+        rest = len(cv_results_df) - max_tuning_runs
+        if rest > 0:
+            _logger.info(
+                "Logging the {} best runs, {} others will be omitted.".format(
+                    max_tuning_runs, rest,
+                )
+            )
 
     for _, result_row in cv_results_best_n_df.iterrows():
         tags_to_log = dict(child_tags) if child_tags else {}

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -644,9 +644,9 @@ def _create_child_runs_for_parameter_search(
         rest = len(cv_results_df) - max_tuning_runs
         if rest > 0:
             _logger.info(
-                "Logging the {} best runs, {} others will be omitted.".format(
-                    max_tuning_runs, rest,
-                )
+                "Logging the %s best runs, %s others will be omitted.",
+                max_tuning_runs,
+                rest,
             )
 
     for _, result_row in cv_results_best_n_df.iterrows():

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -644,9 +644,7 @@ def _create_child_runs_for_parameter_search(
         rest = len(cv_results_df) - max_tuning_runs
         if rest > 0:
             _logger.info(
-                "Logging the %s best runs, %s others will be omitted.",
-                max_tuning_runs,
-                rest,
+                "Logging the %s best runs, %s others will be omitted.", max_tuning_runs, rest,
             )
 
     for _, result_row in cv_results_best_n_df.iterrows():

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -637,7 +637,7 @@ def _create_child_runs_for_parameter_search(
                     max_tuning_runs, rank_column_name,
                 )
                 + "You can choose not to limit the number of child runs created by"
-                + "setting `max_tuning_runs=None`."
+                + " setting `max_tuning_runs=None`."
             )
         cv_results_best_n_df = cv_results_df.nsmallest(max_tuning_runs, rank_column_name)
 

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -142,6 +142,11 @@ def test_autolog_preserves_original_function_attributes():
         assert b == a
 
 
+def test_autolog_throws_error_with_negative_max_tuning_runs():
+    with pytest.raises(ValueError, match="`max_tuning_runs` must be non-negative, instead got -1."):
+        mlflow.sklearn.autolog(max_tuning_runs=-1)
+
+
 @pytest.mark.skipif(
     _is_supported_version(), reason="This test fails on supported versions of sklearn"
 )

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -6,7 +6,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import pytest
-import warnings
 
 import sklearn
 import sklearn.base

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -792,7 +792,7 @@ def test_parameter_search_estimators_produce_expected_outputs(
     )
     cv_results = pd.DataFrame.from_dict(cv_model.cv_results_)
     num_total_results = len(cv_results)
-    if max_tuning_runs == None:
+    if max_tuning_runs is None:
         cv_results_best_n_df = cv_results
         cv_results_rest_df = pd.DataFrame()
     else:


### PR DESCRIPTION
Signed-off-by: Mohamad Arabi <mohamad.arabi@databricks.com>

## What changes are proposed in this pull request?
The ability to limit the number of child runs created when running hyper param search with auto-logging. 
The default number of child runs is set to 5.  

## How is this patch tested?
Added pytest unit tests.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

A user can now specify a limit to the number child runs created when training an sklearn hyper parameter search estimator.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
