### PR TITLE
Use protobuf 3.7 in protobuf check

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -251,7 +251,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install dependencies
       run: |
-        wget https://github.com/google/protobuf/releases/download/v3.6.0/protoc-3.6.0-linux-x86_64.zip -O $HOME/protoc.zip
+        wget https://github.com/google/protobuf/releases/download/v3.7.0/protoc-3.7.0-linux-x86_64.zip -O $HOME/protoc.zip
         sudo unzip $HOME/protoc.zip -d /usr
     - name: Run tests
       run: |

--- a/generate-protos.sh
+++ b/generate-protos.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -ex
+sudo chmod +x protoc
 PROTOC_VERSION="$(protoc --version)"
 if [[ "$PROTOC_VERSION" != 'libprotoc 3.7.0' ]]; then
 	echo "Required libprotoc versions to be 3.7.0."

--- a/generate-protos.sh
+++ b/generate-protos.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -ex
-sudo chmod +x $(which protoc)
+sudo chmod +x /usr/bin/protoc
 PROTOC_VERSION="$(protoc --version)"
 if [[ "$PROTOC_VERSION" != 'libprotoc 3.7.0' ]]; then
 	echo "Required libprotoc versions to be 3.7.0."

--- a/generate-protos.sh
+++ b/generate-protos.sh
@@ -2,8 +2,8 @@
 
 set -ex
 PROTOC_VERSION="$(protoc --version)"
-if [[ "$PROTOC_VERSION" != 'libprotoc 3.6.0' && "$PROTOC_VERSION" != 'libprotoc 3.6.1' ]]; then
-	echo "Required libprotoc versions to be 3.6.0 or 3.6.1 (preferred)."
+if [[ "$PROTOC_VERSION" != 'libprotoc 3.7.0' ]]; then
+	echo "Required libprotoc versions to be 3.7.0."
 	echo "We found: $PROTOC_VERSION"
 	exit 1
 fi

--- a/generate-protos.sh
+++ b/generate-protos.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -ex
-sudo chmod +x protoc
+sudo chmod +x $(which protoc)
 PROTOC_VERSION="$(protoc --version)"
 if [[ "$PROTOC_VERSION" != 'libprotoc 3.7.0' ]]; then
 	echo "Required libprotoc versions to be 3.7.0."


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
