### PR TITLE
Fix docker tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -28,5 +28,3 @@ __pycache__
 ~*
 *.swp
 *.pyc
-
-

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -68,7 +68,8 @@ jobs:
 
     - name: Show disk usage
       run: |
-        df –h
+        which df
+        /bin/df -h
 
     - name: Run docker tests
       if: ${{ github.event_name == 'schedule' || steps.check-diff.outputs.docker_changed == 'true' }}

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -24,7 +24,7 @@ jobs:
 
         REGEXP="tests/examples\|examples"
         CHANGED_FILES=$(git diff --name-only master..HEAD | grep "$REGEXP") || true;
-        EXAMPLES_CHANGED=$([[ "$CHANGED_FILES" == *"examples"* ]] && echo "true" || echo "false")
+        EXAMPLES_CHANGED=$([[ ! -z "$CHANGED_FILES" ]] && echo "true" || echo "false")
 
         echo "CHANGED_FILES:"
         echo "$CHANGED_FILES"
@@ -76,7 +76,7 @@ jobs:
 
         REGEXP="Dockerfile\|\.dockerignore"
         CHANGED_FILES=$(git diff --name-only master..HEAD | grep "$REGEXP") || true;
-        DOCKER_CHANGED=$([[ ("$CHANGED_FILES" == *"Dockerfile"*) || ("$CHANGED_FILES" == *".dockerignore"*) ]] && echo "true" || echo "false")
+        DOCKER_CHANGED=$([[ ! -z "$CHANGED_FILES" ]] && echo "true" || echo "false")
 
         echo "CHANGED_FILES:"
         echo "$CHANGED_FILES"

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -66,6 +66,10 @@ jobs:
         conda remove --all --yes --name test-environment
         ./dev/remove-conda-envs.sh
 
+    - name: Show disk usage
+      run: |
+        df –h
+
     - name: Run docker tests
       if: ${{ github.event_name == 'schedule' || steps.check-diff.outputs.docker_changed == 'true' }}
       run: |

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -62,6 +62,10 @@ jobs:
         conda remove --all --yes --name test-environment
         ./dev/remove-conda-envs.sh
 
+    - name: Show disk usage
+      run: |
+        df -h
+
   docker:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -90,3 +90,7 @@ jobs:
       if: ${{ github.event_name == 'schedule' || steps.check-diff.outputs.docker_changed == 'true' }}
       run: |
         docker build -t mlflow_test_build . && docker images | grep mlflow_test_build
+
+    - name: Show disk usage
+      run: |
+        /bin/df -h

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -15,6 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Increase available disk space
+      run: |
+        # Increase available disk space by removing unnecessary tool chains:
+        # https://github.com/actions/virtual-environments/issues/709#issuecomment-612569242
+        rm -rf "$AGENT_TOOLSDIRECTORY"
+        df -h
+
     - name: Check diff
       id: check-diff
       run: |
@@ -29,13 +36,6 @@ jobs:
         echo -e "CHANGED_FILES:\nCHANGED_FILES"
         echo "EXAMPLES_CHANGED: $EXAMPLES_CHANGED"
         echo "::set-output name=examples_changed::$EXAMPLES_CHANGED"
-
-    - name: Increase available disk space
-      run: |
-        # Increase available disk space by removing unnecessary tool chains:
-        # https://github.com/actions/virtual-environments/issues/709#issuecomment-612569242
-        rm -rf "$AGENT_TOOLSDIRECTORY"
-        /bin/df -h
 
     - name: Enable conda
       run: |
@@ -66,6 +66,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Increase available disk space
+      run: |
+        rm -rf "$AGENT_TOOLSDIRECTORY"
+        df -h
+
     - name: Check diff
       id: check-diff
       run: |
@@ -81,11 +86,6 @@ jobs:
         echo "DOCKER_CHANGED: $DOCKER_CHANGED"
         echo "::set-output name=docker_changed::$DOCKER_CHANGED"
 
-    - name: Increase available disk space
-      run: |
-        rm -rf "$AGENT_TOOLSDIRECTORY"
-        /bin/df -h
-
     - name: Run docker tests
       if: ${{ github.event_name == 'schedule' || steps.check-diff.outputs.docker_changed == 'true' }}
       run: |
@@ -93,4 +93,4 @@ jobs:
 
     - name: Show disk usage
       run: |
-        /bin/df -h
+        df -h

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -26,8 +26,7 @@ jobs:
         CHANGED_FILES=$(git diff --name-only master..HEAD | grep "$REGEXP") || true;
         EXAMPLES_CHANGED=$([[ ! -z "$CHANGED_FILES" ]] && echo "true" || echo "false")
 
-        echo "CHANGED_FILES:"
-        echo "$CHANGED_FILES"
+        echo -e "CHANGED_FILES:\nCHANGED_FILES"
         echo "EXAMPLES_CHANGED: $EXAMPLES_CHANGED"
         echo "::set-output name=examples_changed::$EXAMPLES_CHANGED"
 
@@ -78,8 +77,7 @@ jobs:
         CHANGED_FILES=$(git diff --name-only master..HEAD | grep "$REGEXP") || true;
         DOCKER_CHANGED=$([[ ! -z "$CHANGED_FILES" ]] && echo "true" || echo "false")
 
-        echo "CHANGED_FILES:"
-        echo "$CHANGED_FILES"
+        echo -e "CHANGED_FILES:\nCHANGED_FILES"
         echo "DOCKER_CHANGED: $DOCKER_CHANGED"
         echo "::set-output name=docker_changed::$DOCKER_CHANGED"
 

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -22,24 +22,21 @@ jobs:
           git fetch origin master:master
         fi
 
-        REGEXP="tests/examples\|examples\|Dockerfile\|\.dockerignore\$"
+        REGEXP="tests/examples\|examples"
         CHANGED_FILES=$(git diff --name-only master..HEAD | grep "$REGEXP") || true;
         EXAMPLES_CHANGED=$([[ "$CHANGED_FILES" == *"examples"* ]] && echo "true" || echo "false")
-        DOCKER_CHANGED=$([[ ("$CHANGED_FILES" == *"Dockerfile"*) || ("$CHANGED_FILES" == *".dockerignore"*) ]] && echo "true" || echo "false")
 
         echo "CHANGED_FILES:"
         echo "$CHANGED_FILES"
         echo "EXAMPLES_CHANGED: $EXAMPLES_CHANGED"
-        echo "DOCKER_CHANGED: $DOCKER_CHANGED"
-
         echo "::set-output name=examples_changed::$EXAMPLES_CHANGED"
-        echo "::set-output name=docker_changed::$DOCKER_CHANGED"
 
     - name: Increase available disk space
       run: |
         # Increase available disk space by removing unnecessary tool chains:
         # https://github.com/actions/virtual-environments/issues/709#issuecomment-612569242
         rm -rf "$AGENT_TOOLSDIRECTORY"
+        /bin/df -h
 
     - name: Enable conda
       run: |
@@ -66,9 +63,29 @@ jobs:
         conda remove --all --yes --name test-environment
         ./dev/remove-conda-envs.sh
 
-    - name: Show disk usage
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Check diff
+      id: check-diff
       run: |
-        which df
+        if [ ! "$(git branch --show-current)" == "master" ]; then
+          git fetch origin master:master
+        fi
+
+        REGEXP="Dockerfile\|\.dockerignore"
+        CHANGED_FILES=$(git diff --name-only master..HEAD | grep "$REGEXP") || true;
+        DOCKER_CHANGED=$([[ ("$CHANGED_FILES" == *"Dockerfile"*) || ("$CHANGED_FILES" == *".dockerignore"*) ]] && echo "true" || echo "false")
+
+        echo "CHANGED_FILES:"
+        echo "$CHANGED_FILES"
+        echo "DOCKER_CHANGED: $DOCKER_CHANGED"
+        echo "::set-output name=docker_changed::$DOCKER_CHANGED"
+
+    - name: Increase available disk space
+      run: |
+        rm -rf "$AGENT_TOOLSDIRECTORY"
         /bin/df -h
 
     - name: Run docker tests

--- a/dev/remove-conda-envs.sh
+++ b/dev/remove-conda-envs.sh
@@ -13,9 +13,9 @@ if [ ! -z "$mlflow_envs" ]; then
   do
     conda remove --all --yes --name $env
   done
-
-  conda clean --all --yes
-  conda env list
 fi
+
+conda clean --all --yes
+conda env list
 
 set +ex


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Fix the docker test (which currently fails with a `no space left on device` error).

https://github.com/mlflow/mlflow/runs/2648964303?check_suite_focus=true#step:9:1865

```
ApplyLayer exit status 1 stdout:  stderr: write /opt/conda/lib/python3.8/site-packages/xgboost/lib/libxgboost.so: no space left on device
```

## How is this patch tested?

GitHub Actions

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
