### PR TITLE
Migrate to `packaging.version` from `distutils.version`

### DIFF
--- a/examples/spacy/train.py
+++ b/examples/spacy/train.py
@@ -1,14 +1,12 @@
 import random
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 import spacy
 from spacy.util import minibatch, compounding
 
 import mlflow.spacy
 
-IS_SPACY_VERSION_NEWER_THAN_OR_EQUAL_TO_3_0_0 = LooseVersion(spacy.__version__) >= LooseVersion(
-    "3.0.0"
-)
+IS_SPACY_VERSION_NEWER_THAN_OR_EQUAL_TO_3_0_0 = Version(spacy.__version__) >= Version("3.0.0")
 
 # training data
 TRAIN_DATA = [

--- a/mlflow/azureml/__init__.py
+++ b/mlflow/azureml/__init__.py
@@ -8,7 +8,7 @@ import subprocess
 import logging
 import uuid
 
-from distutils.version import StrictVersion
+from packaging.version import Version
 
 from mlflow import get_tracking_uri, get_registry_uri
 from mlflow import pyfunc
@@ -138,9 +138,7 @@ def build_image(
 
     model_pyfunc_conf, _ = _load_pyfunc_conf_with_model(model_path=absolute_model_path)
     model_python_version = model_pyfunc_conf.get(pyfunc.PY_VERSION, None)
-    if model_python_version is not None and StrictVersion(model_python_version) < StrictVersion(
-        "3.0.0"
-    ):
+    if model_python_version is not None and Version(model_python_version) < Version("3.0.0"):
         raise MlflowException(
             message=(
                 "Azure ML can only deploy models trained in Python 3 and above. See"
@@ -351,9 +349,7 @@ def deploy(
         run_id_tag = run_id
     except AttributeError:
         run_id = str(uuid.uuid4())
-    if model_python_version is not None and StrictVersion(model_python_version) < StrictVersion(
-        "3.0.0"
-    ):
+    if model_python_version is not None and Version(model_python_version) < Version("3.0.0"):
         raise MlflowException(
             message=(
                 "Azure ML can only deploy models trained in Python 3 and above. See"

--- a/mlflow/gluon.py
+++ b/mlflow/gluon.py
@@ -1,4 +1,4 @@
-from distutils.version import LooseVersion
+from packaging.version import Version
 import os
 
 import numpy as np
@@ -66,7 +66,7 @@ def load_model(model_uri, ctx):
     symbol = sym.load(model_arch_path)
     inputs = sym.var("data", dtype="float32")
     net = gluon.SymbolBlock(symbol, inputs)
-    if LooseVersion(mxnet.__version__) >= LooseVersion("2.0.0"):
+    if Version(mxnet.__version__) >= Version("2.0.0"):
         net.load_parameters(model_params_path, ctx)
     else:
         net.collect_params().load(model_params_path, ctx)

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -429,8 +429,6 @@ def _load_model(model_path, keras_module, save_format, **kwargs):
     if save_format == "h5":
         model_path = model_path + ".h5"
 
-    from packaging.version import Version
-
     if save_format == "h5" and Version(keras_module.__version__.split("-")[0]) >= Version("2.2.3"):
         # NOTE: Keras 2.2.3 does not work with unicode paths in python2. Pass in h5py.File instead
         # of string to avoid issues.

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -15,7 +15,7 @@ import shutil
 
 import pandas as pd
 
-from distutils.version import LooseVersion
+from packaging.version import Version
 from mlflow import pyfunc
 from mlflow.models import Model
 from mlflow.models.model import MLMODEL_FILE_NAME
@@ -64,7 +64,7 @@ def get_default_conda_env(include_cloudpickle=False, keras_module=None):
         keras_module = keras
     if keras_module.__name__ == "keras":
         # Temporary fix: the created conda environment has issues installing keras >= 2.3.1
-        if LooseVersion(keras_module.__version__) < LooseVersion("2.3.1"):
+        if Version(keras_module.__version__) < Version("2.3.1"):
             conda_deps.append("keras=={}".format(keras_module.__version__))
         else:
             pip_deps.append("keras=={}".format(keras_module.__version__))
@@ -76,14 +76,14 @@ def get_default_conda_env(include_cloudpickle=False, keras_module=None):
     # The Keras pyfunc representation requires the TensorFlow
     # backend for Keras. Therefore, the conda environment must
     # include TensorFlow
-    if LooseVersion(tf.__version__) <= LooseVersion("1.13.2"):
+    if Version(tf.__version__) <= Version("1.13.2"):
         conda_deps.append("tensorflow=={}".format(tf.__version__))
     else:
         pip_deps.append("tensorflow=={}".format(tf.__version__))
 
     # Tensorflow<2.4 does not work with h5py>=3.0.0
     # see https://github.com/tensorflow/tensorflow/issues/44467
-    if LooseVersion(tf.__version__) < LooseVersion("2.4"):
+    if Version(tf.__version__) < Version("2.4"):
         pip_deps.append("h5py<3.0.0")
 
     return _mlflow_conda_env(
@@ -176,7 +176,7 @@ def save_model(
             try:
                 import keras
 
-                if LooseVersion(keras.__version__) < LooseVersion("2.2.0"):
+                if Version(keras.__version__) < Version("2.2.0"):
                     import keras.engine
 
                     return isinstance(model, keras.engine.Model)
@@ -429,11 +429,9 @@ def _load_model(model_path, keras_module, save_format, **kwargs):
     if save_format == "h5":
         model_path = model_path + ".h5"
 
-    from distutils.version import StrictVersion
+    from packaging.version import Version
 
-    if save_format == "h5" and StrictVersion(
-        keras_module.__version__.split("-")[0]
-    ) >= StrictVersion("2.2.3"):
+    if save_format == "h5" and Version(keras_module.__version__.split("-")[0]) >= Version("2.2.3"):
         # NOTE: Keras 2.2.3 does not work with unicode paths in python2. Pass in h5py.File instead
         # of string to avoid issues.
         import h5py
@@ -498,7 +496,7 @@ def _load_pyfunc(path):
     should_compile = save_format == "tf"
     K = importlib.import_module(keras_module.__name__ + ".backend")
     if keras_module.__name__ == "tensorflow.keras" or K.backend() == "tensorflow":
-        if LooseVersion(tf.__version__) < LooseVersion("2.0.0"):
+        if Version(tf.__version__) < Version("2.0.0"):
             graph = tf.Graph()
             sess = tf.Session(graph=graph)
             # By default tf backed models depend on the global graph and session.
@@ -706,9 +704,9 @@ def autolog(
         return __MLflowKerasCallback()
 
     def _early_stop_check(callbacks):
-        if LooseVersion(keras.__version__) < LooseVersion("2.3.0") or LooseVersion(
-            keras.__version__
-        ) >= LooseVersion("2.4.0"):
+        if Version(keras.__version__) < Version("2.3.0") or Version(keras.__version__) >= Version(
+            "2.4.0"
+        ):
             es_callback = keras.callbacks.EarlyStopping
         else:
             es_callback = keras.callbacks.callbacks.EarlyStopping
@@ -803,5 +801,5 @@ def autolog(
     # To avoid unintentional creation of nested MLflow runs caused by a patched
     # `fit_generator()` method calling a patched `fit()` method, we only patch
     # `fit_generator()` in Keras < 2.4.0.
-    if LooseVersion(keras.__version__) < LooseVersion("2.4.0"):
+    if Version(keras.__version__) < Version("2.4.0"):
         safe_patch(FLAVOR_NAME, keras.Model, "fit_generator", fit_generator, manage_run=True)

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -9,6 +9,7 @@ Keras (native) format
 """
 import importlib
 import os
+import re
 import yaml
 import tempfile
 import shutil
@@ -429,7 +430,11 @@ def _load_model(model_path, keras_module, save_format, **kwargs):
     if save_format == "h5":
         model_path = model_path + ".h5"
 
-    if save_format == "h5" and Version(keras_module.__version__.split("-")[0]) >= Version("2.2.3"):
+    # keras in tensorflow used to have a '-tf' suffix in the version:
+    # https://github.com/tensorflow/tensorflow/blob/v2.2.1/tensorflow/python/keras/__init__.py#L36
+    if save_format == "h5" and Version(re.sub(r"-tf$", "", keras_module.__version__)) >= Version(
+        "2.2.3"
+    ):
         # NOTE: Keras 2.2.3 does not work with unicode paths in python2. Pass in h5py.File instead
         # of string to avoid issues.
         import h5py

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -432,9 +432,8 @@ def _load_model(model_path, keras_module, save_format, **kwargs):
 
     # keras in tensorflow used to have a '-tf' suffix in the version:
     # https://github.com/tensorflow/tensorflow/blob/v2.2.1/tensorflow/python/keras/__init__.py#L36
-    if save_format == "h5" and Version(re.sub(r"-tf$", "", keras_module.__version__)) >= Version(
-        "2.2.3"
-    ):
+    unsuffixed_version = re.sub(r"-tf$", "", keras_module.__version__)
+    if save_format == "h5" and Version(unsuffixed_version) >= Version("2.2.3"):
         # NOTE: Keras 2.2.3 does not work with unicode paths in python2. Pass in h5py.File instead
         # of string to avoid issues.
         import h5py

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -15,7 +15,7 @@ import yaml
 import cloudpickle
 import numpy as np
 import pandas as pd
-from distutils.version import LooseVersion
+from packaging.version import Version
 import posixpath
 
 import mlflow
@@ -585,7 +585,7 @@ def _load_model(path, **kwargs):
     else:
         model_path = path
 
-    if LooseVersion(torch.__version__) >= LooseVersion("1.5.0"):
+    if Version(torch.__version__) >= Version("1.5.0"):
         return torch.load(model_path, **kwargs)
     else:
         try:

--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -1,4 +1,4 @@
-from distutils.version import LooseVersion
+from packaging.version import Version
 import logging
 import mlflow.pytorch
 import os
@@ -43,7 +43,7 @@ def _get_optimizer_name(optimizer):
     https://pytorch-lightning.readthedocs.io/en/stable/api/pytorch_lightning.trainer.trainer.html
     #pytorch_lightning.trainer.trainer.Trainer.params.enable_pl_optimizer
     """
-    if LooseVersion(pl.__version__) < LooseVersion("1.1.0"):
+    if Version(pl.__version__) < Version("1.1.0"):
         return optimizer.__class__.__name__
     else:
         from pytorch_lightning.core.optimizer import LightningOptimizer
@@ -113,7 +113,7 @@ def _create_patch_fit(log_every_n_epoch=1, log_models=True):
             # epochs (related PR: https://github.com/PyTorchLightning/pytorch-lightning/pull/5986)
             # As a workaround, use `on_train_epoch_end` and `on_validation_epoch_end` instead
             # in pytorch-lightning >= 1.2.0.
-            if LooseVersion(pl.__version__) >= LooseVersion("1.2.0"):
+            if Version(pl.__version__) >= Version("1.2.0"):
 
                 # NB: Override `on_train_epoch_end` with an additional `*args` parameter for
                 # compatibility with versions of pytorch-lightning <= 1.2.0, which required an

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -1,5 +1,5 @@
 import collections
-from distutils.version import LooseVersion
+from packaging.version import Version
 import inspect
 import logging
 from numbers import Number
@@ -682,7 +682,7 @@ def _create_child_runs_for_parameter_search(cv_estimator, parent_run, child_tags
 def _is_supported_version():
     import sklearn
 
-    return LooseVersion(sklearn.__version__) >= LooseVersion(_MIN_SKLEARN_VERSION)
+    return Version(sklearn.__version__) >= Version(_MIN_SKLEARN_VERSION)
 
 
 # Util function to check whether a metric is able to be computed in given sklearn version
@@ -692,7 +692,7 @@ def _is_metric_supported(metric_name):
     # This dict can be extended to store special metrics' specific supported versions
     _metric_supported_version = {"roc_auc_score": "0.22.2"}
 
-    return LooseVersion(sklearn.__version__) >= LooseVersion(_metric_supported_version[metric_name])
+    return Version(sklearn.__version__) >= Version(_metric_supported_version[metric_name])
 
 
 # Util function to check whether artifact plotting functions are able to be computed
@@ -700,7 +700,7 @@ def _is_metric_supported(metric_name):
 def _is_plotting_supported():
     import sklearn
 
-    return LooseVersion(sklearn.__version__) >= LooseVersion("0.22.0")
+    return Version(sklearn.__version__) >= Version("0.22.0")
 
 
 def _all_estimators():

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -18,7 +18,7 @@ import time
 import tempfile
 from collections import namedtuple
 import pandas
-from distutils.version import LooseVersion
+from packaging.version import Version
 from threading import RLock
 
 import mlflow
@@ -295,7 +295,7 @@ def _validate_saved_model(tf_saved_model_dir, tf_meta_graph_tags, tf_signature_d
     """
     import tensorflow
 
-    if LooseVersion(tensorflow.__version__) < LooseVersion("2.0.0"):
+    if Version(tensorflow.__version__) < Version("2.0.0"):
         validation_tf_graph = tensorflow.Graph()
         validation_tf_sess = tensorflow.Session(graph=validation_tf_graph)
         with validation_tf_graph.as_default():
@@ -361,7 +361,7 @@ def load_model(model_uri, tf_sess=None):
     """
     import tensorflow
 
-    if LooseVersion(tensorflow.__version__) < LooseVersion("2.0.0"):
+    if Version(tensorflow.__version__) < Version("2.0.0"):
         if not tf_sess:
             tf_sess = tensorflow.get_default_session()
             if not tf_sess:
@@ -424,7 +424,7 @@ def _load_tensorflow_saved_model(
     """
     import tensorflow
 
-    if LooseVersion(tensorflow.__version__) < LooseVersion("2.0.0"):
+    if Version(tensorflow.__version__) < Version("2.0.0"):
         loaded = tensorflow.saved_model.loader.load(
             sess=tf_sess, tags=tf_meta_graph_tags, export_dir=tf_saved_model_dir
         )
@@ -477,7 +477,7 @@ def _load_pyfunc(path):
         tf_meta_graph_tags,
         tf_signature_def_key,
     ) = _get_and_parse_flavor_configuration(model_path=path)
-    if LooseVersion(tensorflow.__version__) < LooseVersion("2.0.0"):
+    if Version(tensorflow.__version__) < Version("2.0.0"):
         tf_graph = tensorflow.Graph()
         tf_sess = tensorflow.Session(graph=tf_graph)
         with tf_graph.as_default():
@@ -811,7 +811,7 @@ def _setup_callbacks(lst, log_models, metrics_logger):
     else:
         log_dir = _TensorBoardLogDir(location=tb.log_dir, is_temp=False)
         out_list = lst
-    if LooseVersion(tensorflow.__version__) < LooseVersion("2.0.0"):
+    if Version(tensorflow.__version__) < Version("2.0.0"):
         out_list += [__MLflowTfKerasCallback()]
     else:
         out_list += [__MLflowTfKeras2Callback()]
@@ -901,7 +901,7 @@ def autolog(
 
     atexit.register(_flush_queue)
 
-    if LooseVersion(tensorflow.__version__) < LooseVersion("1.12"):
+    if Version(tensorflow.__version__) < Version("1.12"):
         warnings.warn("Could not log to MLflow. TensorFlow versions below 1.12 are not supported.")
         return
 
@@ -1038,7 +1038,7 @@ def autolog(
                     key: history.history[key][restored_index] for key in history.history.keys()
                 }
                 # Metrics are logged as 'epoch_loss' and 'epoch_acc' in TF 1.X
-                if LooseVersion(tensorflow.__version__) < LooseVersion("2.0.0"):
+                if Version(tensorflow.__version__) < Version("2.0.0"):
                     if "loss" in restored_metrics:
                         restored_metrics["epoch_loss"] = restored_metrics.pop("loss")
                     if "acc" in restored_metrics:
@@ -1195,7 +1195,7 @@ def autolog(
         (tensorflow.keras.Model, "fit", FitPatch),
     ]
 
-    if LooseVersion(tensorflow.__version__) < LooseVersion("2.1.0"):
+    if Version(tensorflow.__version__) < Version("2.1.0"):
         # `fit_generator()` is deprecated in TF >= 2.1.0 and simply wraps `fit()`.
         # To avoid unintentional creation of nested MLflow runs caused by a patched
         # `fit_generator()` method calling a patched `fit()` method, we only patch
@@ -1211,7 +1211,7 @@ def autolog(
     ]
 
     # Add compat.v1 Estimator patching for versions of tensfor that are 2.0+.
-    if LooseVersion(tensorflow.__version__) >= LooseVersion("2.0.0"):
+    if Version(tensorflow.__version__) >= Version("2.0.0"):
         old_estimator_class = tensorflow.compat.v1.estimator.Estimator
         v1_train = (old_estimator_class, "train", train)
         v1_export_saved_model = (old_estimator_class, "export_saved_model", export_saved_model)

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -16,7 +16,7 @@ XGBoost (native) format
 .. _scikit-learn API:
     https://xgboost.readthedocs.io/en/latest/python/python_api.html#module-xgboost.sklearn
 """
-from distutils.version import LooseVersion
+from packaging.version import Version
 import os
 import shutil
 import json
@@ -382,7 +382,11 @@ def autolog(
             Create a callback function that records evaluation results.
             """
 
-            if LooseVersion(xgboost.__version__) >= LooseVersion("1.3.0"):
+            # The dev version of XGBoost (e.g. '1.5.0-SNAPSHOT') doesn't match the scheme
+            # defined in PEP 440 and causes `packaging.version.Version` to fail.
+            # As a workaround, replace 'SNAPSHOT' with 'dev':
+            # https://github.com/dmlc/xgboost/blob/81bdfb835d0d0244c86649e74d2dc3c00beb3942/python-package/xgboost/VERSION#L1  # noqa
+            if Version(xgboost.__version__.replace("SNAPSHOT", "dev")) >= Version("1.3.0"):
                 # In xgboost >= 1.3.0, user-defined callbacks should inherit
                 # `xgboost.callback.TrainingCallback`:
                 # https://xgboost.readthedocs.io/en/latest/python/callbacks.html#defining-your-own-callback  # noqa

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -381,11 +381,8 @@ def autolog(
             """
             Create a callback function that records evaluation results.
             """
-
-            # The dev version of XGBoost (e.g. '1.5.0-SNAPSHOT') doesn't match the scheme
-            # defined in PEP 440 and causes `packaging.version.Version` to fail.
-            # As a workaround, replace 'SNAPSHOT' with 'dev':
-            # https://github.com/dmlc/xgboost/blob/81bdfb835d0d0244c86649e74d2dc3c00beb3942/python-package/xgboost/VERSION#L1  # noqa
+            # TODO: Remove `replace("SNAPSHOT", "dev")` once the following issue is addressed:
+            #       https://github.com/dmlc/xgboost/issues/6984
             if Version(xgboost.__version__.replace("SNAPSHOT", "dev")) >= Version("1.3.0"):
                 # In xgboost >= 1.3.0, user-defined callbacks should inherit
                 # `xgboost.callback.TrainingCallback`:

--- a/tests/gluon/test_gluon_model_export.py
+++ b/tests/gluon/test_gluon_model_export.py
@@ -1,4 +1,4 @@
-from distutils.version import LooseVersion
+from packaging.version import Version
 import os
 import warnings
 import yaml
@@ -28,7 +28,7 @@ from mlflow.utils.model_utils import _get_flavor_configuration
 
 from tests.helper_functions import pyfunc_serve_and_score_model
 
-if LooseVersion(mx.__version__) >= LooseVersion("2.0.0"):
+if Version(mx.__version__) >= Version("2.0.0"):
     from mxnet.gluon.metric import Accuracy  # pylint: disable=import-error
 else:
     from mxnet.metric import Accuracy  # pylint: disable=import-error
@@ -72,9 +72,7 @@ def gluon_model(model_data):
     )
 
     # `metrics` was renamed in mxnet 1.6.0: https://github.com/apache/incubator-mxnet/pull/17048
-    arg_name = (
-        "metrics" if LooseVersion(mx.__version__) < LooseVersion("1.6.0") else "train_metrics"
-    )
+    arg_name = "metrics" if Version(mx.__version__) < Version("1.6.0") else "train_metrics"
     est = estimator.Estimator(
         net=model, loss=SoftmaxCrossEntropyLoss(), trainer=trainer, **{arg_name: Accuracy()}
     )

--- a/tests/gluon_autolog/test_gluon_autolog.py
+++ b/tests/gluon_autolog/test_gluon_autolog.py
@@ -1,4 +1,4 @@
-from distutils.version import LooseVersion
+from packaging.version import Version
 import random
 import warnings
 
@@ -17,7 +17,7 @@ import mlflow.gluon
 from mlflow.utils.autologging_utils import BatchMetricsLogger
 from unittest.mock import patch
 
-if LooseVersion(mx.__version__) >= LooseVersion("2.0.0"):
+if Version(mx.__version__) >= Version("2.0.0"):
     from mxnet.gluon.metric import Accuracy  # pylint: disable=import-error
 else:
     from mxnet.metric import Accuracy  # pylint: disable=import-error
@@ -35,7 +35,7 @@ class LogsDataset(Dataset):
 
 
 def is_mxnet_older_than_1_6_0():
-    return LooseVersion(mx.__version__) < LooseVersion("1.6.0")
+    return Version(mx.__version__) < Version("1.6.0")
 
 
 def get_metrics():

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -1,6 +1,6 @@
 # pep8: disable=E501
 
-from distutils.version import LooseVersion
+from packaging.version import Version
 import h5py
 import os
 import json
@@ -51,7 +51,7 @@ def fix_random_seed():
     random.seed(SEED)
     np.random.seed(SEED)
 
-    if LooseVersion(tf.__version__) >= LooseVersion("2.0.0"):
+    if Version(tf.__version__) >= Version("2.0.0"):
         tf.random.set_seed(SEED)
     else:
         tf.set_random_seed(SEED)
@@ -81,7 +81,7 @@ def model(data):
         # `lr` was renamed to `learning_rate` in keras 2.3.0:
         # https://github.com/keras-team/keras/releases/tag/2.3.0
         {"lr": lr}
-        if LooseVersion(keras.__version__) < LooseVersion("2.3.0")
+        if Version(keras.__version__) < Version("2.3.0")
         else {"learning_rate": lr}
     )
     model.compile(loss="mean_squared_error", optimizer=SGD(**kwargs))
@@ -185,7 +185,7 @@ def test_that_keras_module_arg_works(model_path):
             # pylint: disable=unused-argument
 
             # `Dataset.value` was removed in `h5py == 3.0.0`
-            if LooseVersion(h5py.__version__) >= LooseVersion("3.0.0"):
+            if Version(h5py.__version__) >= Version("3.0.0"):
                 return MyModel(file.get("x")[()].decode("utf-8"))
             else:
                 return MyModel(file.get("x").value)

--- a/tests/pytorch/test_pytorch_autolog.py
+++ b/tests/pytorch/test_pytorch_autolog.py
@@ -1,4 +1,4 @@
-from distutils.version import LooseVersion
+from packaging.version import Version
 import pytest
 import pytorch_lightning as pl
 import torch
@@ -135,7 +135,7 @@ def pytorch_model_with_callback(patience):
     )
 
     with TempDir() as tmp:
-        keyword = "dirpath" if LooseVersion(pl.__version__) >= LooseVersion("1.2.0") else "filepath"
+        keyword = "dirpath" if Version(pl.__version__) >= Version("1.2.0") else "filepath"
         checkpoint_callback = ModelCheckpoint(
             **{keyword: tmp.path()}, save_top_k=1, verbose=True, monitor="val_loss", mode="min",
         )
@@ -184,7 +184,7 @@ def test_pytorch_with_early_stopping_autolog_log_models_configuration_with(log_m
     early_stopping = EarlyStopping(monitor="val_loss", mode="min", patience=patience, verbose=True)
 
     with TempDir() as tmp:
-        keyword = "dirpath" if LooseVersion(pl.__version__) >= LooseVersion("1.2.0") else "filepath"
+        keyword = "dirpath" if Version(pl.__version__) >= Version("1.2.0") else "filepath"
         checkpoint_callback = ModelCheckpoint(
             **{keyword: tmp.path()}, save_top_k=1, verbose=True, monitor="val_loss", mode="min",
         )
@@ -282,7 +282,7 @@ def test_get_optimizer_name():
 
 
 @pytest.mark.skipif(
-    LooseVersion(pl.__version__) < LooseVersion("1.1.0"),
+    Version(pl.__version__) < Version("1.1.0"),
     reason="`LightningOptimizer` doesn't exist in pytorch-lightning < 1.1.0",
 )
 def test_get_optimizer_name_with_lightning_optimizer():

--- a/tests/spacy/test_spacy_model_export.py
+++ b/tests/spacy/test_spacy_model_export.py
@@ -1,7 +1,7 @@
 import os
 import random
 from collections import namedtuple
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 import pandas as pd
 import pytest
@@ -25,9 +25,7 @@ from tests.conftest import tracking_uri_mock  # pylint: disable=unused-import, E
 ModelWithData = namedtuple("ModelWithData", ["model", "inference_data"])
 
 
-IS_SPACY_VERSION_NEWER_THAN_OR_EQUAL_TO_3_0_0 = LooseVersion(spacy.__version__) >= LooseVersion(
-    "3.0.0"
-)
+IS_SPACY_VERSION_NEWER_THAN_OR_EQUAL_TO_3_0_0 = Version(spacy.__version__) >= Version("3.0.0")
 
 
 @pytest.fixture(scope="module")

--- a/tests/spark_autologging/ml/test_pyspark_ml_autologging.py
+++ b/tests/spark_autologging/ml/test_pyspark_ml_autologging.py
@@ -5,7 +5,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from collections import namedtuple
-from distutils.version import LooseVersion
+from packaging.version import Version
 from unittest import mock
 
 import mlflow
@@ -170,8 +170,7 @@ def test_basic_estimator(dataset_binomial):
 
 
 @pytest.mark.skipif(
-    LooseVersion(pyspark.__version__) < LooseVersion("3.1"),
-    reason="This test require spark version >= 3.1",
+    Version(pyspark.__version__) < Version("3.1"), reason="This test require spark version >= 3.1",
 )
 def test_models_in_allowlist_exist(spark_session):  # pylint: disable=unused-argument
     mlflow.pyspark.ml.autolog()  # initialize the variable `mlflow.pyspark.ml._log_model_allowlist`

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -2,7 +2,7 @@
 
 import collections
 import pytest
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 import numpy as np
 import pandas as pd
@@ -828,7 +828,7 @@ def get_text_vec_model(train_samples):
 
 
 @pytest.mark.skipif(
-    LooseVersion(tf.__version__) < LooseVersion("2.3.0"),
+    Version(tf.__version__) < Version("2.3.0"),
     reason=(
         "Deserializing a model with `TextVectorization` and `Embedding`"
         "fails in tensorflow < 2.3.0. See this issue:"

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -75,7 +75,11 @@ def test_xgb_autolog_logs_default_params(bst_params, dtrain):
         #   https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.train
         # In < 1.3.0, it's False:
         #   https://xgboost.readthedocs.io/en/release_1.2.0/python/python_api.html#xgboost.train
-        "maximize": None if Version(xgb.__version__) >= Version("1.3.0") else False,
+        "maximize": (
+            None
+            if Version(xgb.__version__.replace("SNAPSHOT", "dev")) >= Version("1.3.0")
+            else False
+        ),
         "early_stopping_rounds": None,
         "verbose_eval": True,
     }

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -75,6 +75,8 @@ def test_xgb_autolog_logs_default_params(bst_params, dtrain):
         #   https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.train
         # In < 1.3.0, it's False:
         #   https://xgboost.readthedocs.io/en/release_1.2.0/python/python_api.html#xgboost.train
+        # TODO: Remove `replace("SNAPSHOT", "dev")` once the following issue is addressed:
+        #       https://github.com/dmlc/xgboost/issues/6984
         "maximize": (
             None
             if Version(xgb.__version__.replace("SNAPSHOT", "dev")) >= Version("1.3.0")

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -1,4 +1,4 @@
-from distutils.version import LooseVersion
+from packaging.version import Version
 import os
 import json
 import pytest
@@ -75,7 +75,7 @@ def test_xgb_autolog_logs_default_params(bst_params, dtrain):
         #   https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.train
         # In < 1.3.0, it's False:
         #   https://xgboost.readthedocs.io/en/release_1.2.0/python/python_api.html#xgboost.train
-        "maximize": None if LooseVersion(xgb.__version__) >= LooseVersion("1.3.0") else False,
+        "maximize": None if Version(xgb.__version__) >= Version("1.3.0") else False,
         "early_stopping_rounds": None,
         "verbose_eval": True,
     }


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Repalce `distutils` (which has been deprecated in Python 3.10: [PEP632](https://www.python.org/dev/peps/pep-0632/)) with `packaging` to parse package versions more precisely.

```python
>>> from distutils.version import Version as DistVersion
>>> from distutils.version import LooseVersion as DistVersion
>>> DistVersion("1.3.dev") > DistVersion("1.3")
True  # should be False
>>> PkgVersion("1.3.dev") > PkgVersion("1.3")
False
```

Note: `packaging` is included in the MLflow's dependencies (added by https://github.com/mlflow/mlflow/pull/4303).

## How is this patch tested?

Existing tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
