### PR TITLE
Fix dev spacy testing

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -257,7 +257,7 @@ spacy:
   package_info:
     pip_release: "spacy"
     install_dev: |
-      pip install spacy-nightly
+      pip install git+https://github.com/explosion/spaCy
 
   models:
     minimum: "2.2.4"

--- a/tests/spacy/test_spacy_model_export.py
+++ b/tests/spacy/test_spacy_model_export.py
@@ -34,6 +34,7 @@ IS_SPACY_VERSION_NEWER_THAN_OR_EQUAL_TO_3_0_0 = LooseVersion(spacy.__version__) 
 def spacy_model_with_data():
     # Creating blank model and setting up the spaCy pipeline
     nlp = spacy.blank("en")
+    spacy_version = spacy.__version__
     if IS_SPACY_VERSION_NEWER_THAN_OR_EQUAL_TO_3_0_0:
         from spacy.pipeline.tok2vec import DEFAULT_TOK2VEC_MODEL
 

--- a/tests/spacy/test_spacy_model_export.py
+++ b/tests/spacy/test_spacy_model_export.py
@@ -34,7 +34,6 @@ IS_SPACY_VERSION_NEWER_THAN_OR_EQUAL_TO_3_0_0 = LooseVersion(spacy.__version__) 
 def spacy_model_with_data():
     # Creating blank model and setting up the spaCy pipeline
     nlp = spacy.blank("en")
-    spacy_version = spacy.__version__
     if IS_SPACY_VERSION_NEWER_THAN_OR_EQUAL_TO_3_0_0:
         from spacy.pipeline.tok2vec import DEFAULT_TOK2VEC_MODEL
 


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Fix this error:
https://github.com/mlflow/mlflow/runs/2662168361?check_suite_focus=true


```python
        if IS_SPACY_VERSION_NEWER_THAN_OR_EQUAL_TO_3_0_0:
            from spacy.pipeline.tok2vec import DEFAULT_TOK2VEC_MODEL
    
            model = {
                "@architectures": "spacy.TextCatCNN.v1",
                "exclusive_classes": True,
                "tok2vec": DEFAULT_TOK2VEC_MODEL,
            }
            textcat = nlp.add_pipe("textcat", config={"model": model}, last=True)
        else:
            textcat = nlp.create_pipe(
>               "textcat", config={"exclusive_classes": True, "architecture": "simple_cnn"}
            )

...

E               thinc.config.ConfigValidationError: 
E               
E               Config validation error
E               
E               textcat -> architecture        extra fields not permitted
E               textcat -> exclusive_classes   extra fields not permitted
E               
E               {'nlp': <spacy.lang.en.English object at 0x7f8e9e769898>, 'name': 'textcat', 'architecture': 'simple_cnn', 'exclusive_classes': True, 'model': 
```

The issue is version comparision. In #4386, we migrated to `packaging` (from `distutils`) which can compare dev or post release versions correctly.

```python
# When `spacy.__version__` is `3.0.0rc5`,

# prior to #4386 
IS_SPACY_VERSION_NEWER_THAN_OR_EQUAL_TO_3_0_0 = LooseVersion(spacy.__version__) >= LooseVersion(
    "3.0.0"
)
# -> true (should be False)

# now
IS_SPACY_VERSION_NEWER_THAN_OR_EQUAL_TO_3_0_0 = Version(spacy.__version__) >= Version("3.0.0")
# -> false
```


## How is this patch tested?

Fixed tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
