### PR TITLE
Migrate all model dependencies from conda to "pip" section

### DIFF
--- a/mlflow/catboost.py
+++ b/mlflow/catboost.py
@@ -47,10 +47,8 @@ def get_default_conda_env():
     import catboost as cb
 
     return _mlflow_conda_env(
-        additional_conda_deps=None,
         # CatBoost is not yet available via the default conda channels, so we install it via pip
-        additional_pip_deps=["catboost=={}".format(cb.__version__)],
-        additional_conda_channels=None,
+        additional_pip_deps=["catboost=={}".format(cb.__version__)]
     )
 
 

--- a/mlflow/fastai.py
+++ b/mlflow/fastai.py
@@ -74,14 +74,12 @@ def get_default_conda_env(include_cloudpickle=False):
 
     import fastai
 
-    pip_deps = None
+    pip_deps = ["fastai={}".format(fastai.__version__)]
     if include_cloudpickle:
         import cloudpickle
-        pip_deps = ["cloudpickle=={}".format(cloudpickle.__version__)]
-    return _mlflow_conda_env(
-        additional_pip_deps=["fastai={}".format(fastai.__version__)] + pip_deps,
-        additional_conda_channels=None,
-    )
+
+        pip_deps.append("cloudpickle=={}".format(cloudpickle.__version__))
+    return _mlflow_conda_env(additional_pip_deps=pip_deps, additional_conda_channels=None,)
 
 
 def save_model(

--- a/mlflow/fastai.py
+++ b/mlflow/fastai.py
@@ -77,11 +77,9 @@ def get_default_conda_env(include_cloudpickle=False):
     pip_deps = None
     if include_cloudpickle:
         import cloudpickle
-
         pip_deps = ["cloudpickle=={}".format(cloudpickle.__version__)]
     return _mlflow_conda_env(
-        additional_conda_deps=["fastai={}".format(fastai.__version__)],
-        additional_pip_deps=pip_deps,
+        additional_pip_deps=["fastai={}".format(fastai.__version__)] + pip_deps,
         additional_conda_channels=None,
     )
 

--- a/mlflow/fastai.py
+++ b/mlflow/fastai.py
@@ -74,7 +74,7 @@ def get_default_conda_env(include_cloudpickle=False):
 
     import fastai
 
-    pip_deps = ["fastai={}".format(fastai.__version__)]
+    pip_deps = ["fastai=={}".format(fastai.__version__)]
     if include_cloudpickle:
         import cloudpickle
 

--- a/mlflow/fastai.py
+++ b/mlflow/fastai.py
@@ -79,7 +79,7 @@ def get_default_conda_env(include_cloudpickle=False):
         import cloudpickle
 
         pip_deps.append("cloudpickle=={}".format(cloudpickle.__version__))
-    return _mlflow_conda_env(additional_pip_deps=pip_deps, additional_conda_channels=None,)
+    return _mlflow_conda_env(additional_pip_deps=pip_deps)
 
 
 def save_model(

--- a/mlflow/h2o.py
+++ b/mlflow/h2o.py
@@ -31,9 +31,7 @@ def get_default_conda_env():
     """
     import h2o
 
-    return _mlflow_conda_env(
-        additional_pip_deps=["h2o=={}".format(h2o.__version__)]
-    )
+    return _mlflow_conda_env(additional_pip_deps=["h2o=={}".format(h2o.__version__)])
 
 
 def save_model(

--- a/mlflow/h2o.py
+++ b/mlflow/h2o.py
@@ -32,9 +32,7 @@ def get_default_conda_env():
     import h2o
 
     return _mlflow_conda_env(
-        additional_conda_deps=None,
-        additional_pip_deps=["h2o=={}".format(h2o.__version__)],
-        additional_conda_channels=None,
+        additional_pip_deps=["h2o=={}".format(h2o.__version__)]
     )
 
 

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -57,7 +57,6 @@ def get_default_conda_env(include_cloudpickle=False, keras_module=None):
     """
     import tensorflow as tf
 
-    conda_deps = []  # if we use tf.keras we only need to declare dependency on tensorflow
     pip_deps = []
     if keras_module is None:
         import keras
@@ -73,14 +72,8 @@ def get_default_conda_env(include_cloudpickle=False, keras_module=None):
         import cloudpickle
 
         pip_deps.append("cloudpickle=={}".format(cloudpickle.__version__))
-    # Temporary fix: conda-forge currently does not have tensorflow > 1.14
-    # The Keras pyfunc representation requires the TensorFlow
-    # backend for Keras. Therefore, the conda environment must
-    # include TensorFlow
-    if Version(tf.__version__) <= Version("1.13.2"):
-        conda_deps.append("tensorflow=={}".format(tf.__version__))
-    else:
-        pip_deps.append("tensorflow=={}".format(tf.__version__))
+
+    pip_deps.append("tensorflow=={}".format(tf.__version__))
 
     # Tensorflow<2.4 does not work with h5py>=3.0.0
     # see https://github.com/tensorflow/tensorflow/issues/44467
@@ -88,7 +81,6 @@ def get_default_conda_env(include_cloudpickle=False, keras_module=None):
         pip_deps.append("h5py<3.0.0")
 
     return _mlflow_conda_env(
-        additional_conda_deps=conda_deps,
         additional_pip_deps=pip_deps,
         additional_conda_channels=None,
     )

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -63,11 +63,7 @@ def get_default_conda_env(include_cloudpickle=False, keras_module=None):
 
         keras_module = keras
     if keras_module.__name__ == "keras":
-        # Temporary fix: the created conda environment has issues installing keras >= 2.3.1
-        if Version(keras_module.__version__) < Version("2.3.1"):
-            conda_deps.append("keras=={}".format(keras_module.__version__))
-        else:
-            pip_deps.append("keras=={}".format(keras_module.__version__))
+        pip_deps.append("keras=={}".format(keras_module.__version__))
     if include_cloudpickle:
         import cloudpickle
 
@@ -80,10 +76,7 @@ def get_default_conda_env(include_cloudpickle=False, keras_module=None):
     if Version(tf.__version__) < Version("2.4"):
         pip_deps.append("h5py<3.0.0")
 
-    return _mlflow_conda_env(
-        additional_pip_deps=pip_deps,
-        additional_conda_channels=None,
-    )
+    return _mlflow_conda_env(additional_pip_deps=pip_deps, additional_conda_channels=None,)
 
 
 def save_model(

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -76,7 +76,7 @@ def get_default_conda_env(include_cloudpickle=False, keras_module=None):
     if Version(tf.__version__) < Version("2.4"):
         pip_deps.append("h5py<3.0.0")
 
-    return _mlflow_conda_env(additional_pip_deps=pip_deps, additional_conda_channels=None,)
+    return _mlflow_conda_env(additional_pip_deps=pip_deps)
 
 
 def save_model(

--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -64,7 +64,6 @@ def get_default_conda_env():
     import lightgbm as lgb
 
     return _mlflow_conda_env(
-        additional_conda_deps=None,
         # LightGBM is not yet available via the default conda channels, so we install it via pip
         additional_pip_deps=["lightgbm=={}".format(lgb.__version__)],
         additional_conda_channels=None,

--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -66,7 +66,6 @@ def get_default_conda_env():
     return _mlflow_conda_env(
         # LightGBM is not yet available via the default conda channels, so we install it via pip
         additional_pip_deps=["lightgbm=={}".format(lgb.__version__)],
-        additional_conda_channels=None,
     )
 
 

--- a/mlflow/onnx.py
+++ b/mlflow/onnx.py
@@ -47,7 +47,6 @@ def get_default_conda_env():
             # include OnnxRuntime
             "onnxruntime=={}".format(onnxruntime.__version__),
         ],
-        additional_conda_channels=None,
     )
 
 

--- a/mlflow/onnx.py
+++ b/mlflow/onnx.py
@@ -40,7 +40,6 @@ def get_default_conda_env():
     import onnxruntime
 
     return _mlflow_conda_env(
-        additional_conda_deps=None,
         additional_pip_deps=[
             "onnx=={}".format(onnx.__version__),
             # The ONNX pyfunc representation requires the OnnxRuntime

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -37,9 +37,7 @@ def get_default_conda_env():
              :class:`PythonModel` is provided.
     """
     return _mlflow_conda_env(
-        additional_conda_deps=None,
         additional_pip_deps=["cloudpickle=={}".format(cloudpickle.__version__)],
-        additional_conda_channels=None,
     )
 
 

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -69,10 +69,12 @@ def get_default_conda_env():
         :caption: Output
 
         conda env {'name': 'mlflow-env',
-                   'channels': ['defaults', 'conda-forge', 'pytorch'],
-                   'dependencies': ['python=3.7.5', 'pytorch=1.5.1',
-                                    'torchvision=0.6.1',
-                                    'pip', {'pip': ['mlflow', 'cloudpickle==1.6.0']}]}
+                   'channels': ['conda-forge'],
+                   'dependencies': ['python=3.7.5',
+                                    {'pip': ['pytorch=1.5.1',
+                                             'torchvision=0.6.1',
+                                             'mlflow',
+                                             'cloudpickle==1.6.0']}]}
     """
     import torch
     import torchvision

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -78,11 +78,9 @@ def get_default_conda_env():
     import torchvision
 
     return _mlflow_conda_env(
-        additional_conda_deps=[
+        additional_pip_deps=[
             "pytorch={}".format(torch.__version__),
             "torchvision={}".format(torchvision.__version__),
-        ],
-        additional_pip_deps=[
             # We include CloudPickle in the default environment because
             # it's required by the default pickle module used by `save_model()`
             # and `log_model()`: `mlflow.pytorch.pickle_module`.

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -85,8 +85,7 @@ def get_default_conda_env():
             # it's required by the default pickle module used by `save_model()`
             # and `log_model()`: `mlflow.pytorch.pickle_module`.
             "cloudpickle=={}".format(cloudpickle.__version__),
-        ],
-        additional_conda_channels=["pytorch"],
+        ]
     )
 
 

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -71,8 +71,8 @@ def get_default_conda_env():
         conda env {'name': 'mlflow-env',
                    'channels': ['conda-forge'],
                    'dependencies': ['python=3.7.5',
-                                    {'pip': ['pytorch=1.5.1',
-                                             'torchvision=0.6.1',
+                                    {'pip': ['pytorch==1.5.1',
+                                             'torchvision==0.6.1',
                                              'mlflow',
                                              'cloudpickle==1.6.0']}]}
     """
@@ -81,8 +81,8 @@ def get_default_conda_env():
 
     return _mlflow_conda_env(
         additional_pip_deps=[
-            "pytorch={}".format(torch.__version__),
-            "torchvision={}".format(torchvision.__version__),
+            "pytorch=={}".format(torch.__version__),
+            "torchvision=={}".format(torchvision.__version__),
             # We include CloudPickle in the default environment because
             # it's required by the default pickle module used by `save_model()`
             # and `log_model()`: `mlflow.pytorch.pickle_module`.

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -84,7 +84,7 @@ def get_default_conda_env():
             # We include CloudPickle in the default environment because
             # it's required by the default pickle module used by `save_model()`
             # and `log_model()`: `mlflow.pytorch.pickle_module`.
-            "cloudpickle=={}".format(cloudpickle.__version__)
+            "cloudpickle=={}".format(cloudpickle.__version__),
         ],
         additional_conda_channels=["pytorch"],
     )

--- a/mlflow/shap.py
+++ b/mlflow/shap.py
@@ -81,9 +81,7 @@ def get_default_conda_env():
 
     pip_deps = ["shap=={}".format(shap.__version__)]
 
-    return _mlflow_conda_env(
-        additional_pip_deps=pip_deps, additional_conda_channels=None,
-    )
+    return _mlflow_conda_env(additional_pip_deps=pip_deps, additional_conda_channels=None,)
 
 
 def _load_pyfunc(path):

--- a/mlflow/shap.py
+++ b/mlflow/shap.py
@@ -82,7 +82,7 @@ def get_default_conda_env():
     pip_deps = ["shap=={}".format(shap.__version__)]
 
     return _mlflow_conda_env(
-        additional_conda_deps=[], additional_pip_deps=pip_deps, additional_conda_channels=None,
+        additional_pip_deps=pip_deps, additional_conda_channels=None,
     )
 
 

--- a/mlflow/shap.py
+++ b/mlflow/shap.py
@@ -512,9 +512,7 @@ def _merge_environments(shap_environment, model_environment):
 
     merged_pip_deps = list(set(shap_pip_deps + model_pip_deps))
 
-    return _mlflow_conda_env(
-        additional_pip_deps=merged_pip_deps,
-    )
+    return _mlflow_conda_env(additional_pip_deps=merged_pip_deps,)
 
 
 @experimental

--- a/mlflow/shap.py
+++ b/mlflow/shap.py
@@ -81,7 +81,7 @@ def get_default_conda_env():
 
     pip_deps = ["shap=={}".format(shap.__version__)]
 
-    return _mlflow_conda_env(additional_pip_deps=pip_deps, additional_conda_channels=None,)
+    return _mlflow_conda_env(additional_pip_deps=pip_deps)
 
 
 def _load_pyfunc(path):
@@ -481,14 +481,13 @@ def save_explainer(
 save_model = save_explainer
 
 
-def _get_conda_and_pip_dependencies(conda_env):
+def _get_pip_dependencies(conda_env):
     """
-    Extract conda and pip dependencies from conda environments
+    Extract pip dependencies from conda environments
 
     :param conda_env: Conda environment
     """
 
-    conda_deps = []
     pip_deps = []
 
     for dependency in conda_env["dependencies"]:
@@ -496,11 +495,8 @@ def _get_conda_and_pip_dependencies(conda_env):
             for pip_dependency in dependency["pip"]:
                 if pip_dependency != "mlflow":
                     pip_deps.append(pip_dependency)
-        else:
-            if dependency.split("=")[0] != "python" and dependency.split("=")[0] != "pip":
-                conda_deps.append(dependency)
 
-    return conda_deps, pip_deps
+    return pip_deps
 
 
 def _merge_environments(shap_environment, model_environment):
@@ -511,24 +507,13 @@ def _merge_environments(shap_environment, model_environment):
     :param model_environment: Underlying model conda environment.
     """
 
-    # merge the channels from the two environments and remove the default conda
-    # channels if present since its added later in `_mlflow_conda_env`
+    shap_pip_deps = _get_pip_dependencies(shap_environment)
+    model_pip_deps = _get_pip_dependencies(model_environment)
 
-    merged_conda_channels = list(
-        set(shap_environment["channels"] + model_environment["channels"])
-        - set(["defaults", "conda-forge"])
-    )
-
-    shap_conda_deps, shap_pip_deps = _get_conda_and_pip_dependencies(shap_environment)
-    model_conda_deps, model_pip_deps = _get_conda_and_pip_dependencies(model_environment)
-
-    merged_conda_deps = list(set(shap_conda_deps + model_conda_deps))
     merged_pip_deps = list(set(shap_pip_deps + model_pip_deps))
 
     return _mlflow_conda_env(
-        additional_conda_deps=merged_conda_deps,
         additional_pip_deps=merged_pip_deps,
-        additional_conda_channels=merged_conda_channels,
     )
 
 

--- a/mlflow/shap.py
+++ b/mlflow/shap.py
@@ -515,8 +515,7 @@ def _merge_environments(shap_environment, model_environment):
     # channels if present since its added later in `_mlflow_conda_env`
 
     merged_conda_channels = list(
-        set(shap_environment["channels"] + model_environment["channels"])
-        - set(["conda-forge"])
+        set(shap_environment["channels"] + model_environment["channels"]) - set(["conda-forge"])
     )
 
     shap_conda_deps, shap_pip_deps = _get_conda_and_pip_dependencies(shap_environment)

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -63,7 +63,7 @@ def get_default_conda_env(include_cloudpickle=False):
         import cloudpickle
 
         pip_deps += ["cloudpickle=={}".format(cloudpickle.__version__)]
-    return _mlflow_conda_env(additional_pip_deps=pip_deps, additional_conda_channels=None)
+    return _mlflow_conda_env(additional_pip_deps=pip_deps)
 
 
 def save_model(

--- a/mlflow/spacy.py
+++ b/mlflow/spacy.py
@@ -38,7 +38,7 @@ def get_default_conda_env():
     import spacy
 
     return _mlflow_conda_env(
-        additional_pip_deps=["spacy=={}".format(spacy.__version__)], additional_conda_channels=None,
+        additional_pip_deps=["spacy=={}".format(spacy.__version__)]
     )
 
 

--- a/mlflow/spacy.py
+++ b/mlflow/spacy.py
@@ -37,9 +37,7 @@ def get_default_conda_env():
     """
     import spacy
 
-    return _mlflow_conda_env(
-        additional_pip_deps=["spacy=={}".format(spacy.__version__)]
-    )
+    return _mlflow_conda_env(additional_pip_deps=["spacy=={}".format(spacy.__version__)])
 
 
 def save_model(

--- a/mlflow/spacy.py
+++ b/mlflow/spacy.py
@@ -38,7 +38,6 @@ def get_default_conda_env():
     import spacy
 
     return _mlflow_conda_env(
-        additional_conda_deps=None,
         additional_pip_deps=["spacy=={}".format(spacy.__version__)],
         additional_conda_channels=None,
     )

--- a/mlflow/spacy.py
+++ b/mlflow/spacy.py
@@ -38,8 +38,7 @@ def get_default_conda_env():
     import spacy
 
     return _mlflow_conda_env(
-        additional_pip_deps=["spacy=={}".format(spacy.__version__)],
-        additional_conda_channels=None,
+        additional_pip_deps=["spacy=={}".format(spacy.__version__)], additional_conda_channels=None,
     )
 
 

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -83,8 +83,7 @@ def get_default_conda_env():
     pyspark_version = re.sub(r"(\.?)dev.*", "", pyspark.__version__)
 
     return _mlflow_conda_env(
-        additional_pip_deps=["pyspark={}".format(pyspark_version)],
-        additional_conda_channels=None,
+        additional_pip_deps=["pyspark={}".format(pyspark_version)], additional_conda_channels=None,
     )
 
 

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -83,7 +83,7 @@ def get_default_conda_env():
     pyspark_version = re.sub(r"(\.?)dev.*", "", pyspark.__version__)
 
     return _mlflow_conda_env(
-        additional_pip_deps=["pyspark=={}".format(pyspark_version)], additional_conda_channels=None,
+        additional_pip_deps=["pyspark=={}".format(pyspark_version)]
     )
 
 

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -83,8 +83,7 @@ def get_default_conda_env():
     pyspark_version = re.sub(r"(\.?)dev.*", "", pyspark.__version__)
 
     return _mlflow_conda_env(
-        additional_conda_deps=["pyspark={}".format(pyspark_version)],
-        additional_pip_deps=None,
+        additional_pip_deps=["pyspark={}".format(pyspark_version)],
         additional_conda_channels=None,
     )
 

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -83,7 +83,7 @@ def get_default_conda_env():
     pyspark_version = re.sub(r"(\.?)dev.*", "", pyspark.__version__)
 
     return _mlflow_conda_env(
-        additional_pip_deps=["pyspark={}".format(pyspark_version)], additional_conda_channels=None,
+        additional_pip_deps=["pyspark=={}".format(pyspark_version)], additional_conda_channels=None,
     )
 
 

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -82,9 +82,7 @@ def get_default_conda_env():
     # available for installation from Anaconda or PyPI
     pyspark_version = re.sub(r"(\.?)dev.*", "", pyspark.__version__)
 
-    return _mlflow_conda_env(
-        additional_pip_deps=["pyspark=={}".format(pyspark_version)]
-    )
+    return _mlflow_conda_env(additional_pip_deps=["pyspark=={}".format(pyspark_version)])
 
 
 def log_model(

--- a/mlflow/statsmodels.py
+++ b/mlflow/statsmodels.py
@@ -56,8 +56,7 @@ def get_default_conda_env():
     import statsmodels
 
     return _mlflow_conda_env(
-        additional_conda_deps=["statsmodels={}".format(statsmodels.__version__)],
-        additional_pip_deps=None,
+        additional_pip_deps=["statsmodels={}".format(statsmodels.__version__)],
         additional_conda_channels=None,
     )
 

--- a/mlflow/statsmodels.py
+++ b/mlflow/statsmodels.py
@@ -55,7 +55,9 @@ def get_default_conda_env():
     """
     import statsmodels
 
-    return _mlflow_conda_env(additional_pip_deps=["statsmodels=={}".format(statsmodels.__version__)])
+    return _mlflow_conda_env(
+        additional_pip_deps=["statsmodels=={}".format(statsmodels.__version__)]
+    )
 
 
 def save_model(

--- a/mlflow/statsmodels.py
+++ b/mlflow/statsmodels.py
@@ -55,9 +55,7 @@ def get_default_conda_env():
     """
     import statsmodels
 
-    return _mlflow_conda_env(
-        additional_pip_deps=["statsmodels={}".format(statsmodels.__version__)]
-    )
+    return _mlflow_conda_env(additional_pip_deps=["statsmodels={}".format(statsmodels.__version__)])
 
 
 def save_model(

--- a/mlflow/statsmodels.py
+++ b/mlflow/statsmodels.py
@@ -56,8 +56,7 @@ def get_default_conda_env():
     import statsmodels
 
     return _mlflow_conda_env(
-        additional_pip_deps=["statsmodels={}".format(statsmodels.__version__)],
-        additional_conda_channels=None,
+        additional_pip_deps=["statsmodels={}".format(statsmodels.__version__)]
     )
 
 

--- a/mlflow/statsmodels.py
+++ b/mlflow/statsmodels.py
@@ -55,7 +55,7 @@ def get_default_conda_env():
     """
     import statsmodels
 
-    return _mlflow_conda_env(additional_pip_deps=["statsmodels={}".format(statsmodels.__version__)])
+    return _mlflow_conda_env(additional_pip_deps=["statsmodels=={}".format(statsmodels.__version__)])
 
 
 def save_model(

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -75,8 +75,7 @@ def get_default_conda_env():
     import tensorflow
 
     return _mlflow_conda_env(
-        additional_conda_deps=["tensorflow={}".format(tensorflow.__version__)],
-        additional_pip_deps=None,
+        additional_pip_deps=["tensorflow={}".format(tensorflow.__version__)],
         additional_conda_channels=None,
     )
 

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -74,7 +74,7 @@ def get_default_conda_env():
     """
     import tensorflow
 
-    return _mlflow_conda_env(additional_pip_deps=["tensorflow={}".format(tensorflow.__version__)])
+    return _mlflow_conda_env(additional_pip_deps=["tensorflow=={}".format(tensorflow.__version__)])
 
 
 @keyword_only

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -74,9 +74,7 @@ def get_default_conda_env():
     """
     import tensorflow
 
-    return _mlflow_conda_env(
-        additional_pip_deps=["tensorflow={}".format(tensorflow.__version__)]
-    )
+    return _mlflow_conda_env(additional_pip_deps=["tensorflow={}".format(tensorflow.__version__)])
 
 
 @keyword_only

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -75,8 +75,7 @@ def get_default_conda_env():
     import tensorflow
 
     return _mlflow_conda_env(
-        additional_pip_deps=["tensorflow={}".format(tensorflow.__version__)],
-        additional_conda_channels=None,
+        additional_pip_deps=["tensorflow={}".format(tensorflow.__version__)]
     )
 
 

--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -5,7 +5,6 @@ from mlflow.utils import PYTHON_VERSION
 _conda_header = """\
 name: mlflow-env
 channels:
-  - defaults
   - conda-forge
 """
 

--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -9,9 +9,7 @@ channels:
 """
 
 
-def _mlflow_conda_env(
-    path=None, additional_pip_deps=None, install_mlflow=True,
-):
+def _mlflow_conda_env(path=None, additional_pip_deps=None, install_mlflow=True, pip_version=None):
     """
     Creates a Conda environment with the specified pip dependencies. If there are
     any pip dependencies, including from the install_mlflow parameter, then pip will be added to
@@ -22,13 +20,19 @@ def _mlflow_conda_env(
                  the conda env will not be written to the filesystem; it will still be returned
                  in dictionary format.
     :param additional_pip_deps: List of additional pip dependencies passed as strings.
+    :param pip_version: specify pip version
     :return: ``None`` if ``path`` is specified. Otherwise, the a dictionary representation of the
              Conda environment.
     """
     pip_deps = (["mlflow"] if install_mlflow else []) + (
         additional_pip_deps if additional_pip_deps else []
     )
-    conda_deps = ["pip"] if pip_deps else []
+
+    if pip_version:
+        pip_package = f"pip=={pip_version}"
+    else:
+        pip_package = "pip"
+    conda_deps = [pip_package] if pip_deps else []
 
     env = yaml.safe_load(_conda_header)
     env["dependencies"] = ["python={}".format(PYTHON_VERSION)]

--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -10,9 +10,7 @@ channels:
 
 
 def _mlflow_conda_env(
-    path=None,
-    additional_pip_deps=None,
-    install_mlflow=True,
+    path=None, additional_pip_deps=None, install_mlflow=True,
 ):
     """
     Creates a Conda environment with the specified package channels and dependencies. If there are
@@ -30,9 +28,7 @@ def _mlflow_conda_env(
     pip_deps = (["mlflow"] if install_mlflow else []) + (
         additional_pip_deps if additional_pip_deps else []
     )
-    conda_deps = (
-        ["pip"] if pip_deps else []
-    )
+    conda_deps = ["pip"] if pip_deps else []
 
     env = yaml.safe_load(_conda_header)
     env["dependencies"] = ["python={}".format(PYTHON_VERSION)]

--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -11,9 +11,7 @@ channels:
 
 def _mlflow_conda_env(
     path=None,
-    additional_conda_deps=None,
     additional_pip_deps=None,
-    additional_conda_channels=None,
     install_mlflow=True,
 ):
     """
@@ -25,17 +23,14 @@ def _mlflow_conda_env(
     :param path: Local filesystem path where the conda env file is to be written. If unspecified,
                  the conda env will not be written to the filesystem; it will still be returned
                  in dictionary format.
-    :param additional_conda_deps: List of additional conda dependencies passed as strings.
     :param additional_pip_deps: List of additional pip dependencies passed as strings.
-    :param additional_conda_channels: List of additional conda channels to search when resolving
-                                      packages.
     :return: ``None`` if ``path`` is specified. Otherwise, the a dictionary representation of the
              Conda environment.
     """
     pip_deps = (["mlflow"] if install_mlflow else []) + (
         additional_pip_deps if additional_pip_deps else []
     )
-    conda_deps = (additional_conda_deps if additional_conda_deps else []) + (
+    conda_deps = (
         ["pip"] if pip_deps else []
     )
 
@@ -44,8 +39,6 @@ def _mlflow_conda_env(
     if conda_deps is not None:
         env["dependencies"] += conda_deps
     env["dependencies"].append({"pip": pip_deps})
-    if additional_conda_channels is not None:
-        env["channels"] += additional_conda_channels
 
     if path is not None:
         with open(path, "w") as out:

--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -9,9 +9,15 @@ channels:
 """
 
 
-def _mlflow_conda_env(path=None, additional_pip_deps=None, install_mlflow=True, pip_version=None):
+def _mlflow_conda_env(
+    path=None,
+    additional_conda_deps=None,
+    additional_pip_deps=None,
+    additional_conda_channels=None,
+    install_mlflow=True,
+):
     """
-    Creates a Conda environment with the specified pip dependencies. If there are
+    Creates a Conda environment with the specified package channels and dependencies. If there are
     any pip dependencies, including from the install_mlflow parameter, then pip will be added to
     the conda dependencies. This is done to ensure that the pip inside the conda environment is
     used to install the pip dependencies.
@@ -19,26 +25,27 @@ def _mlflow_conda_env(path=None, additional_pip_deps=None, install_mlflow=True, 
     :param path: Local filesystem path where the conda env file is to be written. If unspecified,
                  the conda env will not be written to the filesystem; it will still be returned
                  in dictionary format.
+    :param additional_conda_deps: List of additional conda dependencies passed as strings.
     :param additional_pip_deps: List of additional pip dependencies passed as strings.
-    :param pip_version: specify pip version
+    :param additional_conda_channels: List of additional conda channels to search when resolving
+                                      packages.
     :return: ``None`` if ``path`` is specified. Otherwise, the a dictionary representation of the
              Conda environment.
     """
     pip_deps = (["mlflow"] if install_mlflow else []) + (
         additional_pip_deps if additional_pip_deps else []
     )
-
-    if pip_version:
-        pip_package = f"pip=={pip_version}"
-    else:
-        pip_package = "pip"
-    conda_deps = [pip_package] if pip_deps else []
+    conda_deps = (additional_conda_deps if additional_conda_deps else []) + (
+        ["pip"] if pip_deps else []
+    )
 
     env = yaml.safe_load(_conda_header)
     env["dependencies"] = ["python={}".format(PYTHON_VERSION)]
     if conda_deps is not None:
         env["dependencies"] += conda_deps
     env["dependencies"].append({"pip": pip_deps})
+    if additional_conda_channels is not None:
+        env["channels"] += additional_conda_channels
 
     if path is not None:
         with open(path, "w") as out:

--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -13,7 +13,7 @@ def _mlflow_conda_env(
     path=None, additional_pip_deps=None, install_mlflow=True,
 ):
     """
-    Creates a Conda environment with the specified package channels and dependencies. If there are
+    Creates a Conda environment with the specified pip dependencies. If there are
     any pip dependencies, including from the install_mlflow parameter, then pip will be added to
     the conda dependencies. This is done to ensure that the pip inside the conda environment is
     used to install the pip dependencies.

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -72,7 +72,6 @@ def get_default_conda_env():
     import xgboost as xgb
 
     return _mlflow_conda_env(
-        additional_conda_deps=None,
         # XGBoost is not yet available via the default conda channels, so we install it via pip
         additional_pip_deps=["xgboost=={}".format(xgb.__version__)],
         additional_conda_channels=None,

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -73,8 +73,7 @@ def get_default_conda_env():
 
     return _mlflow_conda_env(
         # XGBoost is not yet available via the default conda channels, so we install it via pip
-        additional_pip_deps=["xgboost=={}".format(xgb.__version__)],
-        additional_conda_channels=None,
+        additional_pip_deps=["xgboost=={}".format(xgb.__version__)]
     )
 
 

--- a/tests/gluon/test_gluon_model_export.py
+++ b/tests/gluon/test_gluon_model_export.py
@@ -42,7 +42,7 @@ def model_path(tmpdir):
 @pytest.fixture
 def gluon_custom_env(tmpdir):
     conda_env = os.path.join(str(tmpdir), "conda_env.yml")
-    _mlflow_conda_env(conda_env, additional_conda_deps=["mxnet", "pytest"])
+    _mlflow_conda_env(conda_env, additional_pip_deps=["mxnet", "pytest"])
     return conda_env
 
 

--- a/tests/h2o/test_h2o_model_export.py
+++ b/tests/h2o/test_h2o_model_export.py
@@ -54,7 +54,7 @@ def model_path(tmpdir):
 @pytest.fixture
 def h2o_custom_env(tmpdir):
     conda_env = os.path.join(str(tmpdir), "conda_env.yml")
-    _mlflow_conda_env(conda_env, additional_conda_deps=["pytest"], additional_pip_deps=["h2o"])
+    _mlflow_conda_env(conda_env, additional_pip_deps=["h2o", "pytest"])
     return conda_env
 
 

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -159,7 +159,7 @@ def model_path(tmpdir):
 @pytest.fixture
 def keras_custom_env(tmpdir):
     conda_env = os.path.join(str(tmpdir), "conda_env.yml")
-    _mlflow_conda_env(conda_env, additional_conda_deps=["keras", "tensorflow", "pytest"])
+    _mlflow_conda_env(conda_env, additional_pip_deps=["keras", "tensorflow", "pytest"])
     return conda_env
 
 

--- a/tests/onnx/test_onnx_model_export.py
+++ b/tests/onnx/test_onnx_model_export.py
@@ -220,7 +220,7 @@ def model_path(tmpdir):
 def onnx_custom_env(tmpdir):
     conda_env = os.path.join(str(tmpdir), "conda_env.yml")
     _mlflow_conda_env(
-        conda_env, additional_conda_deps=["pytest", "torch"], additional_pip_deps=["onnx"],
+        conda_env, additional_pip_deps=["onnx", "pytest", "torch"],
     )
     return conda_env
 

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -108,8 +108,12 @@ def pyfunc_custom_env(tmpdir):
     conda_env = os.path.join(str(tmpdir), "conda_env.yml")
     _mlflow_conda_env(
         conda_env,
-        additional_conda_deps=["scikit-learn", "pytest", "cloudpickle"],
-        additional_pip_deps=["-e " + os.path.dirname(mlflow.__path__[0])],
+        additional_pip_deps=[
+            "scikit-learn",
+            "pytest",
+            "cloudpickle",
+            "-e " + os.path.dirname(mlflow.__path__[0]),
+        ],
     )
     return conda_env
 
@@ -122,7 +126,7 @@ def _conda_env():
             "-e " + os.path.dirname(mlflow.__path__[0]),
             "cloudpickle=={}".format(cloudpickle.__version__),
             "scikit-learn=={}".format(sklearn.__version__),
-        ]
+        ],
     )
 
 

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -117,14 +117,12 @@ def pyfunc_custom_env(tmpdir):
 def _conda_env():
     # NB: We need mlflow as a dependency in the environment.
     return _mlflow_conda_env(
-        additional_conda_deps=None,
         install_mlflow=False,
         additional_pip_deps=[
             "-e " + os.path.dirname(mlflow.__path__[0]),
             "cloudpickle=={}".format(cloudpickle.__version__),
             "scikit-learn=={}".format(sklearn.__version__),
-        ],
-        additional_conda_channels=None,
+        ]
     )
 
 

--- a/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
+++ b/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
@@ -40,8 +40,12 @@ def pyfunc_custom_env_file(tmpdir):
     conda_env = os.path.join(str(tmpdir), "conda_env.yml")
     _mlflow_conda_env(
         conda_env,
-        additional_conda_deps=["scikit-learn", "pytest", "cloudpickle"],
-        additional_pip_deps=["-e " + os.path.dirname(mlflow.__path__[0])],
+        additional_pip_deps=[
+            "scikit-learn",
+            "pytest",
+            "cloudpickle",
+            "-e " + os.path.dirname(mlflow.__path__[0]),
+        ],
     )
     return conda_env
 
@@ -49,8 +53,12 @@ def pyfunc_custom_env_file(tmpdir):
 @pytest.fixture
 def pyfunc_custom_env_dict():
     return _mlflow_conda_env(
-        additional_conda_deps=["scikit-learn", "pytest", "cloudpickle"],
-        additional_pip_deps=["-e " + os.path.dirname(mlflow.__path__[0])],
+        additional_pip_deps=[
+            "scikit-learn",
+            "pytest",
+            "cloudpickle",
+            "-e " + os.path.dirname(mlflow.__path__[0]),
+        ],
     )
 
 

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -158,10 +158,7 @@ def model_path(tmpdir):
 @pytest.fixture
 def pytorch_custom_env(tmpdir):
     conda_env = os.path.join(str(tmpdir), "conda_env.yml")
-    _mlflow_conda_env(
-        conda_env,
-        additional_conda_deps=["pytorch", "torchvision", "pytest"]
-    )
+    _mlflow_conda_env(conda_env, additional_pip_deps=["pytorch", "torchvision", "pytest"])
     return conda_env
 
 

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -160,8 +160,7 @@ def pytorch_custom_env(tmpdir):
     conda_env = os.path.join(str(tmpdir), "conda_env.yml")
     _mlflow_conda_env(
         conda_env,
-        additional_conda_deps=["pytorch", "torchvision", "pytest"],
-        additional_conda_channels=["pytorch"],
+        additional_conda_deps=["pytorch", "torchvision", "pytest"]
     )
     return conda_env
 

--- a/tests/shap/test_log.py
+++ b/tests/shap/test_log.py
@@ -126,12 +126,12 @@ def test_load_pyfunc(tmpdir):
 def test_merge_environment():
 
     test_shap_env = {
-        "channels": ["defaults", "conda-forge"],
+        "channels": ["conda-forge"],
         "dependencies": ["python=3.8.5", "pip", {"pip": ["mlflow", "shap==0.38.0"]}],
     }
 
     test_model_env = {
-        "channels": ["defaults", "conda-forge"],
+        "channels": ["conda-forge"],
         "dependencies": [
             "python=3.8.5",
             "pip",
@@ -141,7 +141,7 @@ def test_merge_environment():
 
     expected_merged_env = {
         "name": "mlflow-env",
-        "channels": ["defaults", "conda-forge"],
+        "channels": ["conda-forge"],
         "dependencies": [
             "python={}".format(PYTHON_VERSION),
             "pip",

--- a/tests/shap/test_log.py
+++ b/tests/shap/test_log.py
@@ -153,12 +153,11 @@ def test_merge_environment():
 
     assert sorted(expected_merged_env["channels"]) == sorted(actual_merged_env["channels"])
 
-    expected_conda_deps, expected_pip_deps = mlflow.shap._get_conda_and_pip_dependencies(
+    expected_pip_deps = mlflow.shap._get_pip_dependencies(
         expected_merged_env
     )
-    actual_conda_deps, actual_pip_deps = mlflow.shap._get_conda_and_pip_dependencies(
+    actual_pip_deps = mlflow.shap._get_pip_dependencies(
         actual_merged_env
     )
 
     assert sorted(expected_pip_deps) == sorted(actual_pip_deps)
-    assert sorted(expected_conda_deps) == sorted(actual_conda_deps)

--- a/tests/shap/test_log.py
+++ b/tests/shap/test_log.py
@@ -153,11 +153,7 @@ def test_merge_environment():
 
     assert sorted(expected_merged_env["channels"]) == sorted(actual_merged_env["channels"])
 
-    expected_pip_deps = mlflow.shap._get_pip_dependencies(
-        expected_merged_env
-    )
-    actual_pip_deps = mlflow.shap._get_pip_dependencies(
-        actual_merged_env
-    )
+    expected_pip_deps = mlflow.shap._get_pip_dependencies(expected_merged_env)
+    actual_pip_deps = mlflow.shap._get_pip_dependencies(actual_merged_env)
 
     assert sorted(expected_pip_deps) == sorted(actual_pip_deps)

--- a/tests/shap/test_log.py
+++ b/tests/shap/test_log.py
@@ -153,7 +153,12 @@ def test_merge_environment():
 
     assert sorted(expected_merged_env["channels"]) == sorted(actual_merged_env["channels"])
 
-    expected_pip_deps = mlflow.shap._get_pip_dependencies(expected_merged_env)
-    actual_pip_deps = mlflow.shap._get_pip_dependencies(actual_merged_env)
+    expected_conda_deps, expected_pip_deps = mlflow.shap._get_conda_and_pip_dependencies(
+        expected_merged_env
+    )
+    actual_conda_deps, actual_pip_deps = mlflow.shap._get_conda_and_pip_dependencies(
+        actual_merged_env
+    )
 
     assert sorted(expected_pip_deps) == sorted(actual_pip_deps)
+    assert sorted(expected_conda_deps) == sorted(actual_conda_deps)

--- a/tests/sklearn/test_sklearn_model_export.py
+++ b/tests/sklearn/test_sklearn_model_export.py
@@ -77,7 +77,7 @@ def model_path(tmpdir):
 @pytest.fixture
 def sklearn_custom_env(tmpdir):
     conda_env = os.path.join(str(tmpdir), "conda_env.yml")
-    _mlflow_conda_env(conda_env, additional_conda_deps=["scikit-learn", "pytest"])
+    _mlflow_conda_env(conda_env, additional_pip_deps=["scikit-learn", "pytest"])
     return conda_env
 
 

--- a/tests/spacy/test_spacy_model_export.py
+++ b/tests/spacy/test_spacy_model_export.py
@@ -68,7 +68,7 @@ def spacy_model_with_data():
 @pytest.fixture
 def spacy_custom_env(tmpdir):
     conda_env = os.path.join(str(tmpdir), "conda_env.yml")
-    _mlflow_conda_env(conda_env, additional_conda_deps=["pytest"], additional_pip_deps=["spacy"])
+    _mlflow_conda_env(conda_env, additional_pip_deps=["pytest", "spacy"])
     return conda_env
 
 

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -42,7 +42,7 @@ _logger = logging.getLogger(__name__)
 @pytest.fixture
 def spark_custom_env(tmpdir):
     conda_env = os.path.join(str(tmpdir), "conda_env.yml")
-    _mlflow_conda_env(conda_env, additional_conda_deps=["pyspark", "pytest"])
+    _mlflow_conda_env(conda_env, additional_pip_deps=["pyspark", "pytest"])
     return conda_env
 
 

--- a/tests/statsmodels/test_statsmodels_model_export.py
+++ b/tests/statsmodels/test_statsmodels_model_export.py
@@ -55,9 +55,7 @@ def model_path(tmpdir, subdir="model"):
 @pytest.fixture
 def statsmodels_custom_env(tmpdir):
     conda_env = os.path.join(str(tmpdir), "conda_env.yml")
-    _mlflow_conda_env(
-        conda_env, additional_conda_deps=["statsmodels"], additional_pip_deps=["pytest"]
-    )
+    _mlflow_conda_env(conda_env, additional_pip_deps=["pytest", "statsmodels"])
     return conda_env
 
 
@@ -116,7 +114,7 @@ def _test_model_log(statsmodels_model, model_path, *predict_args):
 
                 artifact_path = "model"
                 conda_env = os.path.join(tmp.path(), "conda_env.yaml")
-                _mlflow_conda_env(conda_env, additional_conda_deps=["statsmodels"])
+                _mlflow_conda_env(conda_env, additional_pip_deps=["statsmodels"])
 
                 mlflow.statsmodels.log_model(
                     statsmodels_model=model, artifact_path=artifact_path, conda_env=conda_env
@@ -197,7 +195,7 @@ def test_log_model_calls_register_model(ols_model):
     register_model_patch = mock.patch("mlflow.register_model")
     with mlflow.start_run(), register_model_patch, TempDir(chdr=True, remove_on_exit=True) as tmp:
         conda_env = os.path.join(tmp.path(), "conda_env.yaml")
-        _mlflow_conda_env(conda_env, additional_conda_deps=["statsmodels"])
+        _mlflow_conda_env(conda_env, additional_pip_deps=["statsmodels"])
         mlflow.statsmodels.log_model(
             statsmodels_model=ols_model.model,
             artifact_path=artifact_path,
@@ -217,7 +215,7 @@ def test_log_model_no_registered_model_name(ols_model):
     register_model_patch = mock.patch("mlflow.register_model")
     with mlflow.start_run(), register_model_patch, TempDir(chdr=True, remove_on_exit=True) as tmp:
         conda_env = os.path.join(tmp.path(), "conda_env.yaml")
-        _mlflow_conda_env(conda_env, additional_conda_deps=["statsmodels"])
+        _mlflow_conda_env(conda_env, additional_pip_deps=["statsmodels"])
         mlflow.statsmodels.log_model(
             statsmodels_model=ols_model.model, artifact_path=artifact_path, conda_env=conda_env
         )

--- a/tests/tensorflow/test_tensorflow2_model_export.py
+++ b/tests/tensorflow/test_tensorflow2_model_export.py
@@ -214,7 +214,7 @@ def saved_tf_categorical_model(tmpdir):
 @pytest.fixture
 def tf_custom_env(tmpdir):
     conda_env = os.path.join(str(tmpdir), "conda_env.yml")
-    _mlflow_conda_env(conda_env, additional_conda_deps=["tensorflow", "pytest"])
+    _mlflow_conda_env(conda_env, additional_pip_deps=["tensorflow", "pytest"])
     return conda_env
 
 

--- a/tests/tensorflow/test_tensorflow_model_export.py
+++ b/tests/tensorflow/test_tensorflow_model_export.py
@@ -151,7 +151,7 @@ def saved_tf_categorical_model(tmpdir):
 @pytest.fixture
 def tf_custom_env(tmpdir):
     conda_env = os.path.join(str(tmpdir), "conda_env.yml")
-    _mlflow_conda_env(conda_env, additional_conda_deps=["tensorflow", "pytest"])
+    _mlflow_conda_env(conda_env, additional_pip_deps=["tensorflow", "pytest"])
     return conda_env
 
 

--- a/tests/utils/test_environment.py
+++ b/tests/utils/test_environment.py
@@ -11,34 +11,42 @@ def conda_env_path(tmpdir):
 
 def test_mlflow_conda_env_returns_none_when_output_path_is_specified(conda_env_path):
     env_creation_output = _mlflow_conda_env(
-        path=conda_env_path, additional_pip_deps=["pip-dep-1", "pip-dep2==0.1.0"],
+        path=conda_env_path,
+        additional_conda_deps=["conda-dep-1=0.0.1", "conda-dep-2"],
+        additional_pip_deps=["pip-dep-1", "pip-dep2==0.1.0"],
     )
 
     assert env_creation_output is None
 
 
 def test_mlflow_conda_env_returns_expected_env_dict_when_output_path_is_not_specified():
-    pip_deps = ["pip-dep-1=0.0.1", "pip-dep-2"]
-    env = _mlflow_conda_env(path=None, additional_pip_deps=pip_deps)
+    conda_deps = ["conda-dep-1=0.0.1", "conda-dep-2"]
+    env = _mlflow_conda_env(path=None, additional_conda_deps=conda_deps)
 
-    for pip_dep in pip_deps:
-        assert pip_dep in env["dependencies"][-1]["pip"]
+    for conda_dep in conda_deps:
+        assert conda_dep in env["dependencies"]
 
 
-def test_mlflow_conda_env_includes_pip_dependencies_but_pip_is_not_specified():
+@pytest.mark.parametrize("conda_deps", [["conda-dep-1=0.0.1", "conda-dep-2"], None])
+def test_mlflow_conda_env_includes_pip_dependencies_but_pip_is_not_specified(conda_deps):
     additional_pip_deps = ["pip-dep==0.0.1"]
-    env = _mlflow_conda_env(path=None, additional_pip_deps=additional_pip_deps)
+    env = _mlflow_conda_env(
+        path=None, additional_conda_deps=conda_deps, additional_pip_deps=additional_pip_deps
+    )
+    if conda_deps is not None:
+        for conda_dep in conda_deps:
+            assert conda_dep in env["dependencies"]
     assert "pip" in env["dependencies"]
 
 
-@pytest.mark.parametrize("pip_version", [None, "20.0.02"])
-def test_mlflow_conda_env_includes_pip_dependencies_and_pip_is_specified(pip_version):
+@pytest.mark.parametrize("pip_specification", ["pip", "pip==20.0.02"])
+def test_mlflow_conda_env_includes_pip_dependencies_and_pip_is_specified(pip_specification):
+    conda_deps = ["conda-dep-1=0.0.1", "conda-dep-2", pip_specification]
     additional_pip_deps = ["pip-dep==0.0.1"]
     env = _mlflow_conda_env(
-        path=None, additional_pip_deps=additional_pip_deps, pip_version=pip_version
+        path=None, additional_conda_deps=conda_deps, additional_pip_deps=additional_pip_deps
     )
-    if pip_version:
-        assert f"pip=={pip_version}" in env["dependencies"]
-    else:
-        assert "pip" in env["dependencies"]
-    assert "pip-dep==0.0.1" in env["dependencies"][-1]["pip"]
+    for conda_dep in conda_deps:
+        assert conda_dep in env["dependencies"]
+    assert pip_specification in env["dependencies"]
+    assert env["dependencies"].count("pip") == (2 if pip_specification == "pip" else 1)

--- a/tests/utils/test_environment.py
+++ b/tests/utils/test_environment.py
@@ -22,7 +22,7 @@ def test_mlflow_conda_env_returns_expected_env_dict_when_output_path_is_not_spec
     env = _mlflow_conda_env(path=None, additional_pip_deps=pip_deps)
 
     for pip_dep in pip_deps:
-        assert pip_dep in env["dependencies"]
+        assert pip_dep in env["dependencies"][-1]["pip"]
 
 
 def test_mlflow_conda_env_includes_pip_dependencies_but_pip_is_not_specified():
@@ -31,9 +31,14 @@ def test_mlflow_conda_env_includes_pip_dependencies_but_pip_is_not_specified():
     assert "pip" in env["dependencies"]
 
 
-@pytest.mark.parametrize("pip_specification", ["pip", "pip==20.0.02"])
-def test_mlflow_conda_env_includes_pip_dependencies_and_pip_is_specified(pip_specification):
+@pytest.mark.parametrize("pip_version", [None, "20.0.02"])
+def test_mlflow_conda_env_includes_pip_dependencies_and_pip_is_specified(pip_version):
     additional_pip_deps = ["pip-dep==0.0.1"]
-    env = _mlflow_conda_env(path=None, additional_pip_deps=additional_pip_deps)
-    assert pip_specification in env["dependencies"]
-    assert env["dependencies"].count("pip") == (2 if pip_specification == "pip" else 1)
+    env = _mlflow_conda_env(
+        path=None, additional_pip_deps=additional_pip_deps, pip_version=pip_version
+    )
+    if pip_version:
+        assert f"pip=={pip_version}" in env["dependencies"]
+    else:
+        assert "pip" in env["dependencies"]
+    assert "pip-dep==0.0.1" in env["dependencies"][-1]["pip"]

--- a/tests/utils/test_environment.py
+++ b/tests/utils/test_environment.py
@@ -11,42 +11,29 @@ def conda_env_path(tmpdir):
 
 def test_mlflow_conda_env_returns_none_when_output_path_is_specified(conda_env_path):
     env_creation_output = _mlflow_conda_env(
-        path=conda_env_path,
-        additional_conda_deps=["conda-dep-1=0.0.1", "conda-dep-2"],
-        additional_pip_deps=["pip-dep-1", "pip-dep2==0.1.0"],
+        path=conda_env_path, additional_pip_deps=["pip-dep-1", "pip-dep2==0.1.0"],
     )
 
     assert env_creation_output is None
 
 
 def test_mlflow_conda_env_returns_expected_env_dict_when_output_path_is_not_specified():
-    conda_deps = ["conda-dep-1=0.0.1", "conda-dep-2"]
-    env = _mlflow_conda_env(path=None, additional_conda_deps=conda_deps)
+    pip_deps = ["pip-dep-1=0.0.1", "pip-dep-2"]
+    env = _mlflow_conda_env(path=None, additional_pip_deps=pip_deps)
 
-    for conda_dep in conda_deps:
-        assert conda_dep in env["dependencies"]
+    for pip_dep in pip_deps:
+        assert pip_dep in env["dependencies"]
 
 
-@pytest.mark.parametrize("conda_deps", [["conda-dep-1=0.0.1", "conda-dep-2"], None])
-def test_mlflow_conda_env_includes_pip_dependencies_but_pip_is_not_specified(conda_deps):
+def test_mlflow_conda_env_includes_pip_dependencies_but_pip_is_not_specified():
     additional_pip_deps = ["pip-dep==0.0.1"]
-    env = _mlflow_conda_env(
-        path=None, additional_conda_deps=conda_deps, additional_pip_deps=additional_pip_deps
-    )
-    if conda_deps is not None:
-        for conda_dep in conda_deps:
-            assert conda_dep in env["dependencies"]
+    env = _mlflow_conda_env(path=None, additional_pip_deps=additional_pip_deps)
     assert "pip" in env["dependencies"]
 
 
 @pytest.mark.parametrize("pip_specification", ["pip", "pip==20.0.02"])
 def test_mlflow_conda_env_includes_pip_dependencies_and_pip_is_specified(pip_specification):
-    conda_deps = ["conda-dep-1=0.0.1", "conda-dep-2", pip_specification]
     additional_pip_deps = ["pip-dep==0.0.1"]
-    env = _mlflow_conda_env(
-        path=None, additional_conda_deps=conda_deps, additional_pip_deps=additional_pip_deps
-    )
-    for conda_dep in conda_deps:
-        assert conda_dep in env["dependencies"]
+    env = _mlflow_conda_env(path=None, additional_pip_deps=additional_pip_deps)
     assert pip_specification in env["dependencies"]
     assert env["dependencies"].count("pip") == (2 if pip_specification == "pip" else 1)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Migrate all model dependencies from conda to "pip" section

## How is this patch tested?

N/A

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
