### PR TITLE
Mask sensitive information in log

### DIFF
--- a/docs/source/projects.rst
+++ b/docs/source/projects.rst
@@ -38,7 +38,7 @@ Environment
     The software environment that should be used to execute project entry points. This includes all
     library dependencies required by the project code. See :ref:`project-environments` for more
     information about the software environments supported by MLflow Projects, including
-    :ref:`Conda environments <project-conda-environments>` and 
+    :ref:`Conda environments <project-conda-environments>` and
     :ref:`Docker containers <project-docker-container-environments>`.
 
 You can run any project from a Git URI or from a local directory using the ``mlflow run``
@@ -57,7 +57,7 @@ Specifying Projects
 -------------------
 
 By default, any Git repository or local directory can be treated as an MLflow project; you can
-invoke any bash or Python script contained in the directory as a project entry point. The 
+invoke any bash or Python script contained in the directory as a project entry point. The
 :ref:`project-directories` section describes how MLflow interprets directories as projects.
 
 To provide additional control over a project's attributes, you can also include an :ref:`MLproject
@@ -75,12 +75,12 @@ MLflow currently supports the following project environments: Conda environment,
 .. _project-conda-environments:
 
 Conda environment
-  `Conda <https://conda.io/docs>`_ environments support 
-  both Python packages and native libraries (e.g, CuDNN or Intel MKL). When an MLflow Project 
+  `Conda <https://conda.io/docs>`_ environments support
+  both Python packages and native libraries (e.g, CuDNN or Intel MKL). When an MLflow Project
   specifies a Conda environment, it is activated before project code is run.
 
-  By default, MLflow uses the system path to find and run the ``conda`` binary. You can use a 
-  different Conda installation by setting the ``MLFLOW_CONDA_HOME`` environment variable; in this 
+  By default, MLflow uses the system path to find and run the ``conda`` binary. You can use a
+  different Conda installation by setting the ``MLFLOW_CONDA_HOME`` environment variable; in this
   case, MLflow attempts to run the binary at ``$MLFLOW_CONDA_HOME/bin/conda``.
 
   You can specify a Conda environment for your MLflow project by including a ``conda.yaml``
@@ -90,44 +90,44 @@ Conda environment
 .. _project-docker-container-environments:
 
 Docker container environment
-  `Docker containers <https://www.docker.com/resources/what-container>`_ allow you to capture 
+  `Docker containers <https://www.docker.com/resources/what-container>`_ allow you to capture
   non-Python dependencies such as Java libraries.
 
   When you run an MLflow project that specifies a Docker image, MLflow adds a new Docker layer
-  that copies the project's contents into the ``/mlflow/projects/code`` directory. This step produces 
+  that copies the project's contents into the ``/mlflow/projects/code`` directory. This step produces
   a new image. MLflow then runs the new image and invokes the project entrypoint in the resulting
   container.
- 
-  Environment variables, such as ``MLFLOW_TRACKING_URI``, are propagated inside the Docker container 
-  during project execution. Additionally, :ref:`runs <concepts>` and 
-  :ref:`experiments <organizing_runs_in_experiments>` created by the project are saved to the 
-  tracking server specified by your :ref:`tracking URI <where_runs_are_recorded>`. When running 
+
+  Environment variables, such as ``MLFLOW_TRACKING_URI``, are propagated inside the Docker container
+  during project execution. Additionally, :ref:`runs <concepts>` and
+  :ref:`experiments <organizing_runs_in_experiments>` created by the project are saved to the
+  tracking server specified by your :ref:`tracking URI <where_runs_are_recorded>`. When running
   against a local tracking URI, MLflow mounts the host system's tracking directory
-  (e.g., a local ``mlruns`` directory) inside the container so that metrics, parameters, and 
+  (e.g., a local ``mlruns`` directory) inside the container so that metrics, parameters, and
   artifacts logged during project execution are accessible afterwards.
 
-  See `Dockerized Model Training with MLflow 
-  <https://github.com/mlflow/mlflow/tree/master/examples/docker>`_ for an example of an MLflow 
+  See `Dockerized Model Training with MLflow
+  <https://github.com/mlflow/mlflow/tree/master/examples/docker>`_ for an example of an MLflow
   project with a Docker environment.
 
-  To specify a Docker container environment, you *must* add an 
+  To specify a Docker container environment, you *must* add an
   :ref:`MLproject file <mlproject-file>` to your project. For information about specifying
   a Docker container environment in an ``MLproject`` file, see
   :ref:`mlproject-specify-environment`.
-    
+
 System environment
-  You can also run MLflow Projects directly in your current system environment. All of the 
-  project's dependencies must be installed on your system prior to project execution. The system 
-  environment is supplied at runtime. It is not part of the MLflow Project's directory contents 
-  or ``MLproject`` file. For information about using the system environment when running 
-  a project, see the ``Environment`` parameter description in the :ref:`running-projects` section. 
+  You can also run MLflow Projects directly in your current system environment. All of the
+  project's dependencies must be installed on your system prior to project execution. The system
+  environment is supplied at runtime. It is not part of the MLflow Project's directory contents
+  or ``MLproject`` file. For information about using the system environment when running
+  a project, see the ``Environment`` parameter description in the :ref:`running-projects` section.
 
 .. _project-directories:
 
 Project Directories
 ^^^^^^^^^^^^^^^^^^^
 
-When running an MLflow Project directory or repository that does *not* contain an ``MLproject`` 
+When running an MLflow Project directory or repository that does *not* contain an ``MLproject``
 file, MLflow uses the following conventions to determine the project's attributes:
 
 * The project's name is the name of the directory.
@@ -143,19 +143,19 @@ file, MLflow uses the following conventions to determine the project's attribute
   see :ref:`running-projects`.
 
 * By default, entry points do not have any parameters when an ``MLproject`` file is not included.
-  Parameters can be supplied at runtime via the ``mlflow run`` CLI or the 
-  :py:func:`mlflow.projects.run` Python API. Runtime parameters are passed to the entry point on the 
+  Parameters can be supplied at runtime via the ``mlflow run`` CLI or the
+  :py:func:`mlflow.projects.run` Python API. Runtime parameters are passed to the entry point on the
   command line using ``--key value`` syntax. For more information about running projects and
-  with runtime parameters, see :ref:`running-projects`. 
+  with runtime parameters, see :ref:`running-projects`.
 
-.. _mlproject-file: 
+.. _mlproject-file:
 
 MLproject File
 ^^^^^^^^^^^^^^
 
 You can get more control over an MLflow Project by adding an ``MLproject`` file, which is a text
-file in YAML syntax, to the project's root directory. The following is an example of an 
-``MLproject`` file: 
+file in YAML syntax, to the project's root directory. The following is an example of an
+``MLproject`` file:
 
 .. code-block:: yaml
 
@@ -177,10 +177,10 @@ file in YAML syntax, to the project's root directory. The following is an exampl
           data_file: path
         command: "python validate.py {data_file}"
 
-The file can specify a name and :ref:`a Conda or Docker environment 
-<mlproject-specify-environment>`, as well as more detailed information about each entry point. 
-Specifically, each entry point defines a :ref:`command to run <mlproject-command-syntax>` and 
-:ref:`parameters to pass to the command <project_parameters>` (including data types). 
+The file can specify a name and :ref:`a Conda or Docker environment
+<mlproject-specify-environment>`, as well as more detailed information about each entry point.
+Specifically, each entry point defines a :ref:`command to run <mlproject-command-syntax>` and
+:ref:`parameters to pass to the command <project_parameters>` (including data types).
 
 .. _mlproject-specify-environment:
 
@@ -192,16 +192,16 @@ This section describes how to specify Conda and Docker container environments in
 
 Conda environment
   Include a top-level ``conda_env`` entry in the ``MLproject`` file.
-  The value of this entry must be a *relative* path to a `Conda environment YAML file 
+  The value of this entry must be a *relative* path to a `Conda environment YAML file
   <https://conda.io/docs/user-guide/tasks/manage-environments.html#create-env-file-manually>`_
-  within the MLflow project's directory. In the following example: 
+  within the MLflow project's directory. In the following example:
 
   .. code-block:: yaml
 
     conda_env: files/config/conda_environment.yaml
 
-  ``conda_env`` refers to an environment file located at 
-  ``<MLFLOW_PROJECT_DIRECTORY>/files/config/conda_environment.yaml``, where 
+  ``conda_env`` refers to an environment file located at
+  ``<MLFLOW_PROJECT_DIRECTORY>/files/config/conda_environment.yaml``, where
   ``<MLFLOW_PROJECT_DIRECTORY>`` is the path to the MLflow project's root directory.
 
 Docker container environment
@@ -210,42 +210,43 @@ Docker container environment
   may include a registry path and tags. Here are a couple of examples.
 
   .. rubric:: Example 1: Image without a registry path
-  
+
   .. code-block:: yaml
 
     docker_env:
       image: mlflow-docker-example-environment
 
-  In this example, ``docker_env`` refers to the Docker image with name 
-  ``mlflow-docker-example-environment`` and default tag ``latest``. Because no registry path is 
-  specified, Docker searches for this image on the system that runs the MLflow project. If the 
+  In this example, ``docker_env`` refers to the Docker image with name
+  ``mlflow-docker-example-environment`` and default tag ``latest``. Because no registry path is
+  specified, Docker searches for this image on the system that runs the MLflow project. If the
   image is not found, Docker attempts to pull it from `DockerHub <https://hub.docker.com/>`_.
 
   .. rubric:: Example 2: Mounting volumes and specifying environment variables
 
   You can also specify local volumes to mount in the docker image (as you normally would with Docker's `-v` option), and additional environment variables (as per Docker's `-e` option). Environment variables can either be copied from the host system's environment variables, or specified as new variables for the Docker environment. The `environment` field should be a list. Elements in this list can either be lists of two strings (for defining a new variable) or single strings (for copying variables from the host system). For example:
-  
+
   .. code-block:: yaml
 
     docker_env:
       image: mlflow-docker-example-environment
       volumes: ["/local/path:/container/mount/path"]
       environment: [["NEW_ENV_VAR", "new_var_value"], "VAR_TO_COPY_FROM_HOST_ENVIRONMENT"]
+      mask_log_params: ["NAME_OF_ENV_VAR_TO_MASK_IN_LOG"]
 
   In this example our docker container will have one additional local volume mounted, and two additional environment variables: one newly-defined, and one copied from the host system.
 
   .. rubric:: Example 3: Image in a remote registry
 
   .. code-block:: yaml
-  
+
     docker_env:
       image: 012345678910.dkr.ecr.us-west-2.amazonaws.com/mlflow-docker-example-environment:7.0
 
-  In this example, ``docker_env`` refers to the Docker image with name 
+  In this example, ``docker_env`` refers to the Docker image with name
   ``mlflow-docker-example-environment`` and tag ``7.0`` in the Docker registry with path
-  ``012345678910.dkr.ecr.us-west-2.amazonaws.com``, which corresponds to an 
+  ``012345678910.dkr.ecr.us-west-2.amazonaws.com``, which corresponds to an
   `Amazon ECR registry <https://docs.aws.amazon.com/AmazonECR/latest/userguide/Registries.html>`_.
-  When the MLflow project is run, Docker attempts to pull the image from the specified registry. 
+  When the MLflow project is run, Docker attempts to pull the image from the specified registry.
   The system executing the MLflow project must have credentials to pull this image from  the specified registry.
 
 .. _mlproject-command-syntax:
@@ -261,7 +262,7 @@ string for substitution. If you call the project with additional parameters *not
 ``MLproject`` file to declare types and defaults for just a subset of your parameters.
 
 Before substituting parameters in the command, MLflow escapes them using the Python
-`shlex.quote <https://docs.python.org/3/library/shlex.html#shlex.quote>`_ function, so you don't 
+`shlex.quote <https://docs.python.org/3/library/shlex.html#shlex.quote>`_ function, so you don't
 need to worry about adding quotes inside your command field.
 
 .. _project_parameters:
@@ -297,8 +298,8 @@ float
     A real number. MLflow validates that the parameter is a number.
 
 path
-    A path on the local file system. MLflow converts any relative ``path`` parameters to absolute 
-    paths. MLflow also downloads any paths passed as distributed storage URIs 
+    A path on the local file system. MLflow converts any relative ``path`` parameters to absolute
+    paths. MLflow also downloads any paths passed as distributed storage URIs
     (``s3://``, ``dbfs://``, gs://, etc.) to local files. Use this type for programs that can only read local
     files.
 
@@ -318,7 +319,7 @@ the :py:func:`mlflow.projects.run` Python API. Both tools take the following par
 Project URI
     A directory on the local file system or a Git repository path,
     specified as a URI of the form ``https://<repo>`` (to use HTTPS) or ``user@host:path``
-    (to use Git over SSH). To run against an MLproject file located in a subdirectory of the project, 
+    (to use Git over SSH). To run against an MLproject file located in a subdirectory of the project,
     add a '#' to the end of the URI argument, followed by the relative path from the project's root directory
     to the subdirectory containing the desired project.
 
@@ -381,7 +382,7 @@ Run an MLflow Project on Kubernetes (experimental)
 
 You can run MLflow Projects with :ref:`Docker environments <project-docker-container-environments>`
 on Kubernetes. The following sections provide an overview of the feature, including a simple
-Project execution guide with examples. 
+Project execution guide with examples.
 
 
 To see this feature in action, you can also refer to the

--- a/mlflow/projects/backend/local.py
+++ b/mlflow/projects/backend/local.py
@@ -17,6 +17,8 @@ from mlflow.projects.utils import (
     get_run_env_vars,
     get_databricks_env_vars,
     get_entry_point_command,
+    get_log_command,
+    get_mask_log_params,
     MLFLOW_LOCAL_BACKEND_RUN_ID_CONFIG,
     MLFLOW_DOCKER_WORKDIR_PATH,
     PROJECT_USE_CONDA,
@@ -188,7 +190,10 @@ def _run_entry_point(command, work_dir, experiment_id, run_id):
     env = os.environ.copy()
     env.update(get_run_env_vars(run_id, experiment_id))
     env.update(get_databricks_env_vars(tracking_uri=mlflow.get_tracking_uri()))
-    _logger.info("=== Running command '%s' in run with ID '%s' === ", command, run_id)
+
+    log_command = get_log_command(get_mask_log_params(work_dir), command)
+
+    _logger.info("=== Running command '%s' in run with ID '%s' === ", log_command, run_id)
     # in case os name is not 'nt', we are not running on windows. It introduces
     # bash command otherwise.
     if os.name != "nt":

--- a/mlflow/projects/utils.py
+++ b/mlflow/projects/utils.py
@@ -326,3 +326,23 @@ def get_databricks_env_vars(tracking_uri):
     if config.ignore_tls_verification:
         env_vars["DATABRICKS_INSECURE"] = str(config.ignore_tls_verification)
     return env_vars
+
+
+def get_mask_log_params(work_dir):
+    project = load_project(work_dir)
+    mask_log_params = project.docker_env.get("mask_log_params")
+
+    return mask_log_params
+
+
+def get_log_command(mask_log_params, command):
+    """
+    Returns the string with defined parameters masked with ****.
+    Usage for masking sensitive information in logs
+    """
+    log_command = command
+    for mask_log_param in mask_log_params:
+        pattern = '({0}=)(.*?)( )|({0}=)(.*?)($)'.format(mask_log_param)
+        log_command = re.sub(pattern, r'\1****\3', log_command)
+
+    return log_command

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ _is_mlflow_skinny = bool(os.environ.get(_MLFLOW_SKINNY_ENV_VAR))
 logging.debug("{} env var is set: {}".format(_MLFLOW_SKINNY_ENV_VAR, _is_mlflow_skinny))
 
 setup(
-    name="mlflow" if not _is_mlflow_skinny else "mlflow-skinny",
+    name="lmcmlflow" if not _is_mlflow_skinny else "lmcmlflow-skinny",
     version=version,
     packages=find_packages(exclude=["tests", "tests.*"]),
     package_data={"mlflow": js_files + models_container_server_files + alembic_files + extra_files}

--- a/tests/projects/test_utils.py
+++ b/tests/projects/test_utils.py
@@ -13,6 +13,7 @@ from mlflow.projects.utils import (
     _is_zip_uri,
     _fetch_project,
     _parse_subdirectory,
+    get_log_command,
     get_or_create_run,
     fetch_and_validate_project,
     load_project,
@@ -178,3 +179,23 @@ def test_fetch_create_and_log(tmpdir):
             assert entry_point_name == run.data.tags[MLFLOW_PROJECT_ENTRY_POINT]
             assert project_uri == run.data.tags[MLFLOW_SOURCE_NAME]
             assert user_param == run.data.params
+
+
+def test_get_log_command():
+    CMD1 = "docker run -e VAR1=abcd -e VAR2=efgh -P PARAM1=ijklmn test"
+    EXP_CMD1 = "docker run -e VAR1=**** -e VAR2=**** -P PARAM1=**** test"
+    CMD2 = "docker run -e VAR1=abcd -e VAR2=efgh -P PARAM1=ijklmn"
+    EXP_CMD2 = "docker run -e VAR1=**** -e VAR2=**** -P PARAM1=****"
+    CMD3 = "docker run -e VAR1=abcd -e VAR2=efgh PARAM1=ijklmn "
+    EXP_CMD3 = "docker run -e VAR1=**** -e VAR2=**** -P PARAM1=**** "
+
+    mask_log_params1 = ["VAR1", "VAR2", "PARAM1"]
+
+    t_cmd1 = get_log_command(mask_log_params1, CMD1)
+    assert t_cmd1 == EXP_CMD1
+
+    t_cmd2 = get_log_command(mask_log_params1, CMD2)
+    assert t_cmd2 == EXP_CMD2
+
+    t_cmd3 = get_log_command(mask_log_params1, CMD3)
+    assert t_cmd3 == EXP_CMD3


### PR DESCRIPTION
## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
