### PR TITLE
Fix pytorch-lightning dev testing

### DIFF
--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -108,12 +108,23 @@ def _create_patch_fit(log_every_n_epoch=1, log_models=True):
                     if isinstance(callback, pl.callbacks.early_stopping.EarlyStopping):
                         self._early_stop_check(callback)
 
+            _pl_version = Version(pl.__version__)
+
+            # Related PR: https://github.com/PyTorchLightning/pytorch-lightning/pull/7357
+            if _pl_version >= Version("1.4.0dev"):
+
+                def on_train_epoch_end(
+                    self, trainer, pl_module, *args
+                ):  # pylint: disable=signature-differs,arguments-differ,unused-argument
+
+                    self._log_metrics(trainer, pl_module)
+
             # In pytorch-lightning >= 1.2.0, logging metrics in `on_epoch_end` results in duplicate
             # metrics records because `on_epoch_end` is called after both train and validation
             # epochs (related PR: https://github.com/PyTorchLightning/pytorch-lightning/pull/5986)
             # As a workaround, use `on_train_epoch_end` and `on_validation_epoch_end` instead
             # in pytorch-lightning >= 1.2.0.
-            if Version(pl.__version__) >= Version("1.2.0"):
+            elif _pl_version >= Version("1.2.0"):
 
                 # NB: Override `on_train_epoch_end` with an additional `*args` parameter for
                 # compatibility with versions of pytorch-lightning <= 1.2.0, which required an

--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -110,9 +110,10 @@ def _create_patch_fit(log_every_n_epoch=1, log_models=True):
 
             _pl_version = Version(pl.__version__)
 
-            # In pytorch-lightning >= 1.4.0, `trainer.callback_metrics` contains both training and
-            # validation metrics at the end of a traning epoch because validation is run inside
-            # the traning loop (see https://github.com/PyTorchLightning/pytorch-lightning/pull/7357)
+            # In pytorch-lightning >= 1.4.0, validation is run inside the training epoch and
+            # `trainer.callback_metrics` contains both training and validation metrics of the
+            # current training epoch when `on_train_epoch_end` is called:
+            # https://github.com/PyTorchLightning/pytorch-lightning/pull/7357
             if _pl_version >= Version("1.4.0dev"):
 
                 def on_train_epoch_end(

--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -110,7 +110,9 @@ def _create_patch_fit(log_every_n_epoch=1, log_models=True):
 
             _pl_version = Version(pl.__version__)
 
-            # Related PR: https://github.com/PyTorchLightning/pytorch-lightning/pull/7357
+            # In pytorch-lightning >= 1.4.0, `trainer.callback_metrics` contains both training and
+            # validation metrics at the end of a traning epoch because validation is run inside
+            # the traning loop (see https://github.com/PyTorchLightning/pytorch-lightning/pull/7357)
             if _pl_version >= Version("1.4.0dev"):
 
                 def on_train_epoch_end(

--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -119,7 +119,6 @@ def _create_patch_fit(log_every_n_epoch=1, log_models=True):
                 def on_train_epoch_end(
                     self, trainer, pl_module, *args
                 ):  # pylint: disable=signature-differs,arguments-differ,unused-argument
-
                     self._log_metrics(trainer, pl_module)
 
             # In pytorch-lightning >= 1.2.0, logging metrics in `on_epoch_end` results in duplicate


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Fix for the following error:

https://github.com/mlflow/mlflow/pull/4393/checks?check_run_id=2681467747#step:11:24

```python
___________________ test_pytorch_autolog_logs_expected_data ____________________

pytorch_model = (<pytorch_lightning.trainer.trainer.Trainer object at 0x7f363a4fe9e8>, <Run: data=<RunData: metrics={'loss': 0.5493150...4bc737f', run_uuid='9ca720281ca74cfaa5454d9a44bc737f', start_time=1622089697065, status='FINISHED', user_id='runner'>>)

    def test_pytorch_autolog_logs_expected_data(pytorch_model):
        _, run = pytorch_model
        data = run.data
    
        # Checking if metrics are logged
        client = mlflow.tracking.MlflowClient()
        for metric_key in ["loss", "train_acc", "val_loss", "val_acc"]:
            assert metric_key in run.data.metrics
            metric_history = client.get_metric_history(run.info.run_id, metric_key)
>           assert len(metric_history) == NUM_EPOCHS
E           AssertionError: assert 19 == 20
E            +  where 19 = len([<Metric: key='train_acc', step=1, timestamp=1622089697471, value=0.3243049383163452>, <Metric: key='train_acc', step=... value=0.3384305238723755>, <Metric: key='train_acc', step=6, timestamp=1622089698114, value=0.33845365047454834>, ...])
```

The error log suggests the first step (0) of `train_acc` is not logged.

## What caused the error?

https://github.com/PyTorchLightning/pytorch-lightning/pull/7357 (merged yesterday) changed the training epoch structure and broke one of `pytorch-lightning` autologging tests. This PR fixes it.

## How is this patch tested?

Existing tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
