### PR TITLE
Mask sensitive information in log

### DIFF
--- a/docs/source/projects.rst
+++ b/docs/source/projects.rst
@@ -231,6 +231,7 @@ Docker container environment
       image: mlflow-docker-example-environment
       volumes: ["/local/path:/container/mount/path"]
       environment: [["NEW_ENV_VAR", "new_var_value"], "VAR_TO_COPY_FROM_HOST_ENVIRONMENT"]
+      mask_log_params: ["NAME_OF_ENV_VAR_TO_MASK_IN_LOG"]      
 
   In this example our docker container will have one additional local volume mounted, and two additional environment variables: one newly-defined, and one copied from the host system.
 

--- a/mlflow/projects/backend/local.py
+++ b/mlflow/projects/backend/local.py
@@ -17,6 +17,8 @@ from mlflow.projects.utils import (
     get_run_env_vars,
     get_databricks_env_vars,
     get_entry_point_command,
+    get_log_command,
+    get_mask_log_params,
     MLFLOW_LOCAL_BACKEND_RUN_ID_CONFIG,
     MLFLOW_DOCKER_WORKDIR_PATH,
     PROJECT_USE_CONDA,
@@ -188,7 +190,10 @@ def _run_entry_point(command, work_dir, experiment_id, run_id):
     env = os.environ.copy()
     env.update(get_run_env_vars(run_id, experiment_id))
     env.update(get_databricks_env_vars(tracking_uri=mlflow.get_tracking_uri()))
-    _logger.info("=== Running command '%s' in run with ID '%s' === ", command, run_id)
+
+    log_command = get_log_command(get_mask_log_params(work_dir), command)
+
+    _logger.info("=== Running command '%s' in run with ID '%s' === ", log_command, run_id)
     # in case os name is not 'nt', we are not running on windows. It introduces
     # bash command otherwise.
     if os.name != "nt":

--- a/mlflow/projects/utils.py
+++ b/mlflow/projects/utils.py
@@ -326,3 +326,23 @@ def get_databricks_env_vars(tracking_uri):
     if config.ignore_tls_verification:
         env_vars["DATABRICKS_INSECURE"] = str(config.ignore_tls_verification)
     return env_vars
+
+
+def get_mask_log_params(work_dir):
+    project = load_project(work_dir)
+    mask_log_params = project.docker_env.get("mask_log_params")
+
+    return mask_log_params
+
+
+def get_log_command(mask_log_params, command):
+    """
+    Returns the string with defined parameters masked with ****.
+    Usage for masking sensitive information in logs
+    """
+    log_command = command
+    for mask_log_param in mask_log_params:
+        pattern = "({0}=)(.*?)( )|({0}=)(.*?)($)".format(mask_log_param)
+        log_command = re.sub(pattern, r"\1****\3", log_command)
+
+    return log_command

--- a/tests/projects/test_utils.py
+++ b/tests/projects/test_utils.py
@@ -13,6 +13,7 @@ from mlflow.projects.utils import (
     _is_zip_uri,
     _fetch_project,
     _parse_subdirectory,
+    get_log_command,
     get_or_create_run,
     fetch_and_validate_project,
     load_project,
@@ -178,3 +179,23 @@ def test_fetch_create_and_log(tmpdir):
             assert entry_point_name == run.data.tags[MLFLOW_PROJECT_ENTRY_POINT]
             assert project_uri == run.data.tags[MLFLOW_SOURCE_NAME]
             assert user_param == run.data.params
+
+
+def test_get_log_command():
+    CMD1 = "docker run -e VAR1=abcd -e VAR2=efgh -P PARAM1=ijklmn test"
+    EXP_CMD1 = "docker run -e VAR1=**** -e VAR2=**** -P PARAM1=**** test"
+    CMD2 = "docker run -e VAR1=abcd -e VAR2=efgh -P PARAM1=ijklmn"
+    EXP_CMD2 = "docker run -e VAR1=**** -e VAR2=**** -P PARAM1=****"
+    CMD3 = "docker run -e VAR1=abcd -e VAR2=efgh PARAM1=ijklmn "
+    EXP_CMD3 = "docker run -e VAR1=**** -e VAR2=**** -P PARAM1=**** "
+
+    mask_log_params1 = ["VAR1", "VAR2", "PARAM1"]
+
+    t_cmd1 = get_log_command(mask_log_params1, CMD1)
+    assert t_cmd1 == EXP_CMD1
+
+    t_cmd2 = get_log_command(mask_log_params1, CMD2)
+    assert t_cmd2 == EXP_CMD2
+
+    t_cmd3 = get_log_command(mask_log_params1, CMD3)
+    assert t_cmd3 == EXP_CMD3


### PR DESCRIPTION
Signed-off-by: Jakub Hettler <jakub.hettler@gmail.com>

## What changes are proposed in this pull request?

Enable masking of parameters in mlflow log AWS S3 secret keys, etc.
from
`mlflow.projects.backend.local: === Running command 'docker run --rm --name advert_distance -e MLFLOW_RUN_ID=ffef -e MLFLOW_TRACKING_URI=http://mlflow.prod -e MLFLOW_EXPERIMENT_ID=5 -e AWS_SECRET_ACCESS_KEY=secr -e AWS_ACCESS_KEY_ID=654a  -e MLFLOW_SNOW_PWD=abcd -e MLFLOW_SNOW_USER=efgh advert_distance:29d3590 python advert_distance/calculate_dist.py --env PROD ' in run with ID 'ffef02009c24474db47db0911880d099' ===
`
to
`mlflow.projects.backend.local: === Running command 'docker run --rm --name advert_distance -e MLFLOW_RUN_ID=ffef -e MLFLOW_TRACKING_URI=http://mlflow.prod -e MLFLOW_EXPERIMENT_ID=5 -e AWS_SECRET_ACCESS_KEY=**** -e AWS_ACCESS_KEY_ID=****  -e MLFLOW_SNOW_PWD=**** -e MLFLOW_SNOW_USER=**** advert_distance:29d3590 python advert_distance/calculate_dist.py --env PROD ' in run with ID 'ffef02009c24474db47db0911880d099' ===
`

## How is this patch tested?

Check the first lines of log after executing mlflow run. It just replaces the defined items in string with command, which is printed to the log and replaces those items with **** and instead of original command it prints the masked one (log_command).

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Enable masking of parameters in mlflow log AWS S3 secret keys, etc. by setting a property in project configuration. 

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [x] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
