### PR TITLE
Use batch credential fetch APIs for Databricks artifact logging

### DIFF
--- a/mlflow/java/client/src/main/java/com/databricks/api/proto/mlflow/DatabricksArtifacts.java
+++ b/mlflow/java/client/src/main/java/com/databricks/api/proto/mlflow/DatabricksArtifacts.java
@@ -7235,17 +7235,17 @@ public final class DatabricksArtifacts {
       "\342?1\n/com.databricks.mlflow.api.MlflowTra" +
       "ckingMessage*V\n\026ArtifactCredentialType\022\021" +
       "\n\rAZURE_SAS_URI\020\001\022\025\n\021AWS_PRESIGNED_URL\020\002" +
-      "\022\022\n\016GCP_SIGNED_URL\020\0032\342\002\n DatabricksMlflo" +
-      "wArtifactsService\022\233\001\n\025getCredentialsForR" +
+      "\022\022\n\016GCP_SIGNED_URL\020\0032\344\002\n DatabricksMlflo" +
+      "wArtifactsService\022\234\001\n\025getCredentialsForR" +
       "ead\022\035.mlflow.GetCredentialsForRead\032&.mlf" +
-      "low.GetCredentialsForRead.Response\";\362\206\0317" +
-      "\n3\n\003GET\022&/mlflow/artifacts/credentials-f" +
-      "or-read\032\004\010\002\020\000\020\003\022\237\001\n\026getCredentialsForWri" +
-      "te\022\036.mlflow.GetCredentialsForWrite\032\'.mlf" +
-      "low.GetCredentialsForWrite.Response\"<\362\206\031" +
-      "8\n4\n\003GET\022\'/mlflow/artifacts/credentials-" +
-      "for-write\032\004\010\002\020\000\020\003B,\n\037com.databricks.api." +
-      "proto.mlflow\220\001\001\240\001\001\342?\002\020\001"
+      "low.GetCredentialsForRead.Response\"<\362\206\0318" +
+      "\n4\n\004POST\022&/mlflow/artifacts/credentials-" +
+      "for-read\032\004\010\002\020\000\020\003\022\240\001\n\026getCredentialsForWr" +
+      "ite\022\036.mlflow.GetCredentialsForWrite\032\'.ml" +
+      "flow.GetCredentialsForWrite.Response\"=\362\206" +
+      "\0319\n5\n\004POST\022\'/mlflow/artifacts/credential" +
+      "s-for-write\032\004\010\002\020\000\020\003B,\n\037com.databricks.ap" +
+      "i.proto.mlflow\220\001\001\240\001\001\342?\002\020\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {

--- a/mlflow/java/client/src/main/java/com/databricks/api/proto/mlflow/DatabricksArtifacts.java
+++ b/mlflow/java/client/src/main/java/com/databricks/api/proto/mlflow/DatabricksArtifacts.java
@@ -2751,32 +2751,68 @@ public final class DatabricksArtifacts {
 
     /**
      * <pre>
-     * The artifact path, relative to the Run's artifact root location, for which to
+     * The artifact paths, relative to the Run's artifact root location, for which to
      * fetch artifact read credentials
      * </pre>
      *
-     * <code>optional string path = 2 [(.mlflow.validate_required) = true];</code>
+     * <code>repeated string path = 2;</code>
      */
-    boolean hasPath();
+    java.util.List<java.lang.String>
+        getPathList();
     /**
      * <pre>
-     * The artifact path, relative to the Run's artifact root location, for which to
+     * The artifact paths, relative to the Run's artifact root location, for which to
      * fetch artifact read credentials
      * </pre>
      *
-     * <code>optional string path = 2 [(.mlflow.validate_required) = true];</code>
+     * <code>repeated string path = 2;</code>
      */
-    java.lang.String getPath();
+    int getPathCount();
     /**
      * <pre>
-     * The artifact path, relative to the Run's artifact root location, for which to
+     * The artifact paths, relative to the Run's artifact root location, for which to
      * fetch artifact read credentials
      * </pre>
      *
-     * <code>optional string path = 2 [(.mlflow.validate_required) = true];</code>
+     * <code>repeated string path = 2;</code>
+     */
+    java.lang.String getPath(int index);
+    /**
+     * <pre>
+     * The artifact paths, relative to the Run's artifact root location, for which to
+     * fetch artifact read credentials
+     * </pre>
+     *
+     * <code>repeated string path = 2;</code>
      */
     com.google.protobuf.ByteString
-        getPathBytes();
+        getPathBytes(int index);
+
+    /**
+     * <pre>
+     * Token specifying the page of credentials to fetch for large requests that require pagination
+     * </pre>
+     *
+     * <code>optional string page_token = 3;</code>
+     */
+    boolean hasPageToken();
+    /**
+     * <pre>
+     * Token specifying the page of credentials to fetch for large requests that require pagination
+     * </pre>
+     *
+     * <code>optional string page_token = 3;</code>
+     */
+    java.lang.String getPageToken();
+    /**
+     * <pre>
+     * Token specifying the page of credentials to fetch for large requests that require pagination
+     * </pre>
+     *
+     * <code>optional string page_token = 3;</code>
+     */
+    com.google.protobuf.ByteString
+        getPageTokenBytes();
   }
   /**
    * Protobuf type {@code mlflow.GetCredentialsForRead}
@@ -2792,7 +2828,8 @@ public final class DatabricksArtifacts {
     }
     private GetCredentialsForRead() {
       runId_ = "";
-      path_ = "";
+      path_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      pageToken_ = "";
     }
 
     @java.lang.Override
@@ -2827,8 +2864,17 @@ public final class DatabricksArtifacts {
             }
             case 18: {
               com.google.protobuf.ByteString bs = input.readBytes();
+              if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+                path_ = new com.google.protobuf.LazyStringArrayList();
+                mutable_bitField0_ |= 0x00000002;
+              }
+              path_.add(bs);
+              break;
+            }
+            case 26: {
+              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000002;
-              path_ = bs;
+              pageToken_ = bs;
               break;
             }
             default: {
@@ -2846,6 +2892,9 @@ public final class DatabricksArtifacts {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
+        if (((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+          path_ = path_.getUnmodifiableView();
+        }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
       }
@@ -2869,28 +2918,73 @@ public final class DatabricksArtifacts {
 
       /**
        * <pre>
-       * Credentials for reading from the specified artifact location
+       * Credentials for reading from the specified artifact locations
        * </pre>
        *
-       * <code>optional .mlflow.ArtifactCredentialInfo credentials = 1;</code>
+       * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
        */
-      boolean hasCredentials();
+      java.util.List<com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo> 
+          getCredentialInfosList();
       /**
        * <pre>
-       * Credentials for reading from the specified artifact location
+       * Credentials for reading from the specified artifact locations
        * </pre>
        *
-       * <code>optional .mlflow.ArtifactCredentialInfo credentials = 1;</code>
+       * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
        */
-      com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo getCredentials();
+      com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo getCredentialInfos(int index);
       /**
        * <pre>
-       * Credentials for reading from the specified artifact location
+       * Credentials for reading from the specified artifact locations
        * </pre>
        *
-       * <code>optional .mlflow.ArtifactCredentialInfo credentials = 1;</code>
+       * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
        */
-      com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder getCredentialsOrBuilder();
+      int getCredentialInfosCount();
+      /**
+       * <pre>
+       * Credentials for reading from the specified artifact locations
+       * </pre>
+       *
+       * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
+       */
+      java.util.List<? extends com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder> 
+          getCredentialInfosOrBuilderList();
+      /**
+       * <pre>
+       * Credentials for reading from the specified artifact locations
+       * </pre>
+       *
+       * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
+       */
+      com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder getCredentialInfosOrBuilder(
+          int index);
+
+      /**
+       * <pre>
+       * Token used to fetch the next page of credentials for large requests that require pagination
+       * </pre>
+       *
+       * <code>optional string next_page_token = 3;</code>
+       */
+      boolean hasNextPageToken();
+      /**
+       * <pre>
+       * Token used to fetch the next page of credentials for large requests that require pagination
+       * </pre>
+       *
+       * <code>optional string next_page_token = 3;</code>
+       */
+      java.lang.String getNextPageToken();
+      /**
+       * <pre>
+       * Token used to fetch the next page of credentials for large requests that require pagination
+       * </pre>
+       *
+       * <code>optional string next_page_token = 3;</code>
+       */
+      com.google.protobuf.ByteString
+          getNextPageTokenBytes();
     }
     /**
      * Protobuf type {@code mlflow.GetCredentialsForRead.Response}
@@ -2905,6 +2999,8 @@ public final class DatabricksArtifacts {
         super(builder);
       }
       private Response() {
+        credentialInfos_ = java.util.Collections.emptyList();
+        nextPageToken_ = "";
       }
 
       @java.lang.Override
@@ -2931,17 +3027,19 @@ public final class DatabricksArtifacts {
               case 0:
                 done = true;
                 break;
-              case 10: {
-                com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder subBuilder = null;
-                if (((bitField0_ & 0x00000001) == 0x00000001)) {
-                  subBuilder = credentials_.toBuilder();
+              case 18: {
+                if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+                  credentialInfos_ = new java.util.ArrayList<com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo>();
+                  mutable_bitField0_ |= 0x00000001;
                 }
-                credentials_ = input.readMessage(com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.PARSER, extensionRegistry);
-                if (subBuilder != null) {
-                  subBuilder.mergeFrom(credentials_);
-                  credentials_ = subBuilder.buildPartial();
-                }
+                credentialInfos_.add(
+                    input.readMessage(com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.PARSER, extensionRegistry));
+                break;
+              }
+              case 26: {
+                com.google.protobuf.ByteString bs = input.readBytes();
                 bitField0_ |= 0x00000001;
+                nextPageToken_ = bs;
                 break;
               }
               default: {
@@ -2959,6 +3057,9 @@ public final class DatabricksArtifacts {
           throw new com.google.protobuf.InvalidProtocolBufferException(
               e).setUnfinishedMessage(this);
         } finally {
+          if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+            credentialInfos_ = java.util.Collections.unmodifiableList(credentialInfos_);
+          }
           this.unknownFields = unknownFields.build();
           makeExtensionsImmutable();
         }
@@ -2977,37 +3078,113 @@ public final class DatabricksArtifacts {
       }
 
       private int bitField0_;
-      public static final int CREDENTIALS_FIELD_NUMBER = 1;
-      private com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo credentials_;
+      public static final int CREDENTIAL_INFOS_FIELD_NUMBER = 2;
+      private java.util.List<com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo> credentialInfos_;
       /**
        * <pre>
-       * Credentials for reading from the specified artifact location
+       * Credentials for reading from the specified artifact locations
        * </pre>
        *
-       * <code>optional .mlflow.ArtifactCredentialInfo credentials = 1;</code>
+       * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
        */
-      public boolean hasCredentials() {
+      public java.util.List<com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo> getCredentialInfosList() {
+        return credentialInfos_;
+      }
+      /**
+       * <pre>
+       * Credentials for reading from the specified artifact locations
+       * </pre>
+       *
+       * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
+       */
+      public java.util.List<? extends com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder> 
+          getCredentialInfosOrBuilderList() {
+        return credentialInfos_;
+      }
+      /**
+       * <pre>
+       * Credentials for reading from the specified artifact locations
+       * </pre>
+       *
+       * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
+       */
+      public int getCredentialInfosCount() {
+        return credentialInfos_.size();
+      }
+      /**
+       * <pre>
+       * Credentials for reading from the specified artifact locations
+       * </pre>
+       *
+       * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
+       */
+      public com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo getCredentialInfos(int index) {
+        return credentialInfos_.get(index);
+      }
+      /**
+       * <pre>
+       * Credentials for reading from the specified artifact locations
+       * </pre>
+       *
+       * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
+       */
+      public com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder getCredentialInfosOrBuilder(
+          int index) {
+        return credentialInfos_.get(index);
+      }
+
+      public static final int NEXT_PAGE_TOKEN_FIELD_NUMBER = 3;
+      private volatile java.lang.Object nextPageToken_;
+      /**
+       * <pre>
+       * Token used to fetch the next page of credentials for large requests that require pagination
+       * </pre>
+       *
+       * <code>optional string next_page_token = 3;</code>
+       */
+      public boolean hasNextPageToken() {
         return ((bitField0_ & 0x00000001) == 0x00000001);
       }
       /**
        * <pre>
-       * Credentials for reading from the specified artifact location
+       * Token used to fetch the next page of credentials for large requests that require pagination
        * </pre>
        *
-       * <code>optional .mlflow.ArtifactCredentialInfo credentials = 1;</code>
+       * <code>optional string next_page_token = 3;</code>
        */
-      public com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo getCredentials() {
-        return credentials_ == null ? com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.getDefaultInstance() : credentials_;
+      public java.lang.String getNextPageToken() {
+        java.lang.Object ref = nextPageToken_;
+        if (ref instanceof java.lang.String) {
+          return (java.lang.String) ref;
+        } else {
+          com.google.protobuf.ByteString bs = 
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            nextPageToken_ = s;
+          }
+          return s;
+        }
       }
       /**
        * <pre>
-       * Credentials for reading from the specified artifact location
+       * Token used to fetch the next page of credentials for large requests that require pagination
        * </pre>
        *
-       * <code>optional .mlflow.ArtifactCredentialInfo credentials = 1;</code>
+       * <code>optional string next_page_token = 3;</code>
        */
-      public com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder getCredentialsOrBuilder() {
-        return credentials_ == null ? com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.getDefaultInstance() : credentials_;
+      public com.google.protobuf.ByteString
+          getNextPageTokenBytes() {
+        java.lang.Object ref = nextPageToken_;
+        if (ref instanceof java.lang.String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          nextPageToken_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
       }
 
       private byte memoizedIsInitialized = -1;
@@ -3024,8 +3201,11 @@ public final class DatabricksArtifacts {
       @java.lang.Override
       public void writeTo(com.google.protobuf.CodedOutputStream output)
                           throws java.io.IOException {
+        for (int i = 0; i < credentialInfos_.size(); i++) {
+          output.writeMessage(2, credentialInfos_.get(i));
+        }
         if (((bitField0_ & 0x00000001) == 0x00000001)) {
-          output.writeMessage(1, getCredentials());
+          com.google.protobuf.GeneratedMessageV3.writeString(output, 3, nextPageToken_);
         }
         unknownFields.writeTo(output);
       }
@@ -3036,9 +3216,12 @@ public final class DatabricksArtifacts {
         if (size != -1) return size;
 
         size = 0;
-        if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        for (int i = 0; i < credentialInfos_.size(); i++) {
           size += com.google.protobuf.CodedOutputStream
-            .computeMessageSize(1, getCredentials());
+            .computeMessageSize(2, credentialInfos_.get(i));
+        }
+        if (((bitField0_ & 0x00000001) == 0x00000001)) {
+          size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, nextPageToken_);
         }
         size += unknownFields.getSerializedSize();
         memoizedSize = size;
@@ -3056,10 +3239,12 @@ public final class DatabricksArtifacts {
         com.databricks.api.proto.mlflow.DatabricksArtifacts.GetCredentialsForRead.Response other = (com.databricks.api.proto.mlflow.DatabricksArtifacts.GetCredentialsForRead.Response) obj;
 
         boolean result = true;
-        result = result && (hasCredentials() == other.hasCredentials());
-        if (hasCredentials()) {
-          result = result && getCredentials()
-              .equals(other.getCredentials());
+        result = result && getCredentialInfosList()
+            .equals(other.getCredentialInfosList());
+        result = result && (hasNextPageToken() == other.hasNextPageToken());
+        if (hasNextPageToken()) {
+          result = result && getNextPageToken()
+              .equals(other.getNextPageToken());
         }
         result = result && unknownFields.equals(other.unknownFields);
         return result;
@@ -3072,9 +3257,13 @@ public final class DatabricksArtifacts {
         }
         int hash = 41;
         hash = (19 * hash) + getDescriptor().hashCode();
-        if (hasCredentials()) {
-          hash = (37 * hash) + CREDENTIALS_FIELD_NUMBER;
-          hash = (53 * hash) + getCredentials().hashCode();
+        if (getCredentialInfosCount() > 0) {
+          hash = (37 * hash) + CREDENTIAL_INFOS_FIELD_NUMBER;
+          hash = (53 * hash) + getCredentialInfosList().hashCode();
+        }
+        if (hasNextPageToken()) {
+          hash = (37 * hash) + NEXT_PAGE_TOKEN_FIELD_NUMBER;
+          hash = (53 * hash) + getNextPageToken().hashCode();
         }
         hash = (29 * hash) + unknownFields.hashCode();
         memoizedHashCode = hash;
@@ -3204,18 +3393,20 @@ public final class DatabricksArtifacts {
         private void maybeForceBuilderInitialization() {
           if (com.google.protobuf.GeneratedMessageV3
                   .alwaysUseFieldBuilders) {
-            getCredentialsFieldBuilder();
+            getCredentialInfosFieldBuilder();
           }
         }
         @java.lang.Override
         public Builder clear() {
           super.clear();
-          if (credentialsBuilder_ == null) {
-            credentials_ = null;
+          if (credentialInfosBuilder_ == null) {
+            credentialInfos_ = java.util.Collections.emptyList();
+            bitField0_ = (bitField0_ & ~0x00000001);
           } else {
-            credentialsBuilder_.clear();
+            credentialInfosBuilder_.clear();
           }
-          bitField0_ = (bitField0_ & ~0x00000001);
+          nextPageToken_ = "";
+          bitField0_ = (bitField0_ & ~0x00000002);
           return this;
         }
 
@@ -3244,14 +3435,19 @@ public final class DatabricksArtifacts {
           com.databricks.api.proto.mlflow.DatabricksArtifacts.GetCredentialsForRead.Response result = new com.databricks.api.proto.mlflow.DatabricksArtifacts.GetCredentialsForRead.Response(this);
           int from_bitField0_ = bitField0_;
           int to_bitField0_ = 0;
-          if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+          if (credentialInfosBuilder_ == null) {
+            if (((bitField0_ & 0x00000001) == 0x00000001)) {
+              credentialInfos_ = java.util.Collections.unmodifiableList(credentialInfos_);
+              bitField0_ = (bitField0_ & ~0x00000001);
+            }
+            result.credentialInfos_ = credentialInfos_;
+          } else {
+            result.credentialInfos_ = credentialInfosBuilder_.build();
+          }
+          if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
             to_bitField0_ |= 0x00000001;
           }
-          if (credentialsBuilder_ == null) {
-            result.credentials_ = credentials_;
-          } else {
-            result.credentials_ = credentialsBuilder_.build();
-          }
+          result.nextPageToken_ = nextPageToken_;
           result.bitField0_ = to_bitField0_;
           onBuilt();
           return result;
@@ -3301,8 +3497,36 @@ public final class DatabricksArtifacts {
 
         public Builder mergeFrom(com.databricks.api.proto.mlflow.DatabricksArtifacts.GetCredentialsForRead.Response other) {
           if (other == com.databricks.api.proto.mlflow.DatabricksArtifacts.GetCredentialsForRead.Response.getDefaultInstance()) return this;
-          if (other.hasCredentials()) {
-            mergeCredentials(other.getCredentials());
+          if (credentialInfosBuilder_ == null) {
+            if (!other.credentialInfos_.isEmpty()) {
+              if (credentialInfos_.isEmpty()) {
+                credentialInfos_ = other.credentialInfos_;
+                bitField0_ = (bitField0_ & ~0x00000001);
+              } else {
+                ensureCredentialInfosIsMutable();
+                credentialInfos_.addAll(other.credentialInfos_);
+              }
+              onChanged();
+            }
+          } else {
+            if (!other.credentialInfos_.isEmpty()) {
+              if (credentialInfosBuilder_.isEmpty()) {
+                credentialInfosBuilder_.dispose();
+                credentialInfosBuilder_ = null;
+                credentialInfos_ = other.credentialInfos_;
+                bitField0_ = (bitField0_ & ~0x00000001);
+                credentialInfosBuilder_ = 
+                  com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
+                     getCredentialInfosFieldBuilder() : null;
+              } else {
+                credentialInfosBuilder_.addAllMessages(other.credentialInfos_);
+              }
+            }
+          }
+          if (other.hasNextPageToken()) {
+            bitField0_ |= 0x00000002;
+            nextPageToken_ = other.nextPageToken_;
+            onChanged();
           }
           this.mergeUnknownFields(other.unknownFields);
           onChanged();
@@ -3334,158 +3558,416 @@ public final class DatabricksArtifacts {
         }
         private int bitField0_;
 
-        private com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo credentials_ = null;
-        private com.google.protobuf.SingleFieldBuilderV3<
-            com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder> credentialsBuilder_;
-        /**
-         * <pre>
-         * Credentials for reading from the specified artifact location
-         * </pre>
-         *
-         * <code>optional .mlflow.ArtifactCredentialInfo credentials = 1;</code>
-         */
-        public boolean hasCredentials() {
-          return ((bitField0_ & 0x00000001) == 0x00000001);
+        private java.util.List<com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo> credentialInfos_ =
+          java.util.Collections.emptyList();
+        private void ensureCredentialInfosIsMutable() {
+          if (!((bitField0_ & 0x00000001) == 0x00000001)) {
+            credentialInfos_ = new java.util.ArrayList<com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo>(credentialInfos_);
+            bitField0_ |= 0x00000001;
+           }
         }
+
+        private com.google.protobuf.RepeatedFieldBuilderV3<
+            com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder> credentialInfosBuilder_;
+
         /**
          * <pre>
-         * Credentials for reading from the specified artifact location
+         * Credentials for reading from the specified artifact locations
          * </pre>
          *
-         * <code>optional .mlflow.ArtifactCredentialInfo credentials = 1;</code>
+         * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
          */
-        public com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo getCredentials() {
-          if (credentialsBuilder_ == null) {
-            return credentials_ == null ? com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.getDefaultInstance() : credentials_;
+        public java.util.List<com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo> getCredentialInfosList() {
+          if (credentialInfosBuilder_ == null) {
+            return java.util.Collections.unmodifiableList(credentialInfos_);
           } else {
-            return credentialsBuilder_.getMessage();
+            return credentialInfosBuilder_.getMessageList();
           }
         }
         /**
          * <pre>
-         * Credentials for reading from the specified artifact location
+         * Credentials for reading from the specified artifact locations
          * </pre>
          *
-         * <code>optional .mlflow.ArtifactCredentialInfo credentials = 1;</code>
+         * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
          */
-        public Builder setCredentials(com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo value) {
-          if (credentialsBuilder_ == null) {
+        public int getCredentialInfosCount() {
+          if (credentialInfosBuilder_ == null) {
+            return credentialInfos_.size();
+          } else {
+            return credentialInfosBuilder_.getCount();
+          }
+        }
+        /**
+         * <pre>
+         * Credentials for reading from the specified artifact locations
+         * </pre>
+         *
+         * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
+         */
+        public com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo getCredentialInfos(int index) {
+          if (credentialInfosBuilder_ == null) {
+            return credentialInfos_.get(index);
+          } else {
+            return credentialInfosBuilder_.getMessage(index);
+          }
+        }
+        /**
+         * <pre>
+         * Credentials for reading from the specified artifact locations
+         * </pre>
+         *
+         * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
+         */
+        public Builder setCredentialInfos(
+            int index, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo value) {
+          if (credentialInfosBuilder_ == null) {
             if (value == null) {
               throw new NullPointerException();
             }
-            credentials_ = value;
+            ensureCredentialInfosIsMutable();
+            credentialInfos_.set(index, value);
             onChanged();
           } else {
-            credentialsBuilder_.setMessage(value);
+            credentialInfosBuilder_.setMessage(index, value);
           }
-          bitField0_ |= 0x00000001;
           return this;
         }
         /**
          * <pre>
-         * Credentials for reading from the specified artifact location
+         * Credentials for reading from the specified artifact locations
          * </pre>
          *
-         * <code>optional .mlflow.ArtifactCredentialInfo credentials = 1;</code>
+         * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
          */
-        public Builder setCredentials(
-            com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder builderForValue) {
-          if (credentialsBuilder_ == null) {
-            credentials_ = builderForValue.build();
+        public Builder setCredentialInfos(
+            int index, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder builderForValue) {
+          if (credentialInfosBuilder_ == null) {
+            ensureCredentialInfosIsMutable();
+            credentialInfos_.set(index, builderForValue.build());
             onChanged();
           } else {
-            credentialsBuilder_.setMessage(builderForValue.build());
+            credentialInfosBuilder_.setMessage(index, builderForValue.build());
           }
-          bitField0_ |= 0x00000001;
           return this;
         }
         /**
          * <pre>
-         * Credentials for reading from the specified artifact location
+         * Credentials for reading from the specified artifact locations
          * </pre>
          *
-         * <code>optional .mlflow.ArtifactCredentialInfo credentials = 1;</code>
+         * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
          */
-        public Builder mergeCredentials(com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo value) {
-          if (credentialsBuilder_ == null) {
-            if (((bitField0_ & 0x00000001) == 0x00000001) &&
-                credentials_ != null &&
-                credentials_ != com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.getDefaultInstance()) {
-              credentials_ =
-                com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.newBuilder(credentials_).mergeFrom(value).buildPartial();
-            } else {
-              credentials_ = value;
+        public Builder addCredentialInfos(com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo value) {
+          if (credentialInfosBuilder_ == null) {
+            if (value == null) {
+              throw new NullPointerException();
             }
+            ensureCredentialInfosIsMutable();
+            credentialInfos_.add(value);
             onChanged();
           } else {
-            credentialsBuilder_.mergeFrom(value);
+            credentialInfosBuilder_.addMessage(value);
           }
-          bitField0_ |= 0x00000001;
           return this;
         }
         /**
          * <pre>
-         * Credentials for reading from the specified artifact location
+         * Credentials for reading from the specified artifact locations
          * </pre>
          *
-         * <code>optional .mlflow.ArtifactCredentialInfo credentials = 1;</code>
+         * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
          */
-        public Builder clearCredentials() {
-          if (credentialsBuilder_ == null) {
-            credentials_ = null;
+        public Builder addCredentialInfos(
+            int index, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo value) {
+          if (credentialInfosBuilder_ == null) {
+            if (value == null) {
+              throw new NullPointerException();
+            }
+            ensureCredentialInfosIsMutable();
+            credentialInfos_.add(index, value);
             onChanged();
           } else {
-            credentialsBuilder_.clear();
+            credentialInfosBuilder_.addMessage(index, value);
           }
-          bitField0_ = (bitField0_ & ~0x00000001);
           return this;
         }
         /**
          * <pre>
-         * Credentials for reading from the specified artifact location
+         * Credentials for reading from the specified artifact locations
          * </pre>
          *
-         * <code>optional .mlflow.ArtifactCredentialInfo credentials = 1;</code>
+         * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
          */
-        public com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder getCredentialsBuilder() {
-          bitField0_ |= 0x00000001;
-          onChanged();
-          return getCredentialsFieldBuilder().getBuilder();
+        public Builder addCredentialInfos(
+            com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder builderForValue) {
+          if (credentialInfosBuilder_ == null) {
+            ensureCredentialInfosIsMutable();
+            credentialInfos_.add(builderForValue.build());
+            onChanged();
+          } else {
+            credentialInfosBuilder_.addMessage(builderForValue.build());
+          }
+          return this;
         }
         /**
          * <pre>
-         * Credentials for reading from the specified artifact location
+         * Credentials for reading from the specified artifact locations
          * </pre>
          *
-         * <code>optional .mlflow.ArtifactCredentialInfo credentials = 1;</code>
+         * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
          */
-        public com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder getCredentialsOrBuilder() {
-          if (credentialsBuilder_ != null) {
-            return credentialsBuilder_.getMessageOrBuilder();
+        public Builder addCredentialInfos(
+            int index, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder builderForValue) {
+          if (credentialInfosBuilder_ == null) {
+            ensureCredentialInfosIsMutable();
+            credentialInfos_.add(index, builderForValue.build());
+            onChanged();
           } else {
-            return credentials_ == null ?
-                com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.getDefaultInstance() : credentials_;
+            credentialInfosBuilder_.addMessage(index, builderForValue.build());
+          }
+          return this;
+        }
+        /**
+         * <pre>
+         * Credentials for reading from the specified artifact locations
+         * </pre>
+         *
+         * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
+         */
+        public Builder addAllCredentialInfos(
+            java.lang.Iterable<? extends com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo> values) {
+          if (credentialInfosBuilder_ == null) {
+            ensureCredentialInfosIsMutable();
+            com.google.protobuf.AbstractMessageLite.Builder.addAll(
+                values, credentialInfos_);
+            onChanged();
+          } else {
+            credentialInfosBuilder_.addAllMessages(values);
+          }
+          return this;
+        }
+        /**
+         * <pre>
+         * Credentials for reading from the specified artifact locations
+         * </pre>
+         *
+         * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
+         */
+        public Builder clearCredentialInfos() {
+          if (credentialInfosBuilder_ == null) {
+            credentialInfos_ = java.util.Collections.emptyList();
+            bitField0_ = (bitField0_ & ~0x00000001);
+            onChanged();
+          } else {
+            credentialInfosBuilder_.clear();
+          }
+          return this;
+        }
+        /**
+         * <pre>
+         * Credentials for reading from the specified artifact locations
+         * </pre>
+         *
+         * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
+         */
+        public Builder removeCredentialInfos(int index) {
+          if (credentialInfosBuilder_ == null) {
+            ensureCredentialInfosIsMutable();
+            credentialInfos_.remove(index);
+            onChanged();
+          } else {
+            credentialInfosBuilder_.remove(index);
+          }
+          return this;
+        }
+        /**
+         * <pre>
+         * Credentials for reading from the specified artifact locations
+         * </pre>
+         *
+         * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
+         */
+        public com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder getCredentialInfosBuilder(
+            int index) {
+          return getCredentialInfosFieldBuilder().getBuilder(index);
+        }
+        /**
+         * <pre>
+         * Credentials for reading from the specified artifact locations
+         * </pre>
+         *
+         * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
+         */
+        public com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder getCredentialInfosOrBuilder(
+            int index) {
+          if (credentialInfosBuilder_ == null) {
+            return credentialInfos_.get(index);  } else {
+            return credentialInfosBuilder_.getMessageOrBuilder(index);
           }
         }
         /**
          * <pre>
-         * Credentials for reading from the specified artifact location
+         * Credentials for reading from the specified artifact locations
          * </pre>
          *
-         * <code>optional .mlflow.ArtifactCredentialInfo credentials = 1;</code>
+         * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
          */
-        private com.google.protobuf.SingleFieldBuilderV3<
+        public java.util.List<? extends com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder> 
+             getCredentialInfosOrBuilderList() {
+          if (credentialInfosBuilder_ != null) {
+            return credentialInfosBuilder_.getMessageOrBuilderList();
+          } else {
+            return java.util.Collections.unmodifiableList(credentialInfos_);
+          }
+        }
+        /**
+         * <pre>
+         * Credentials for reading from the specified artifact locations
+         * </pre>
+         *
+         * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
+         */
+        public com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder addCredentialInfosBuilder() {
+          return getCredentialInfosFieldBuilder().addBuilder(
+              com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.getDefaultInstance());
+        }
+        /**
+         * <pre>
+         * Credentials for reading from the specified artifact locations
+         * </pre>
+         *
+         * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
+         */
+        public com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder addCredentialInfosBuilder(
+            int index) {
+          return getCredentialInfosFieldBuilder().addBuilder(
+              index, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.getDefaultInstance());
+        }
+        /**
+         * <pre>
+         * Credentials for reading from the specified artifact locations
+         * </pre>
+         *
+         * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
+         */
+        public java.util.List<com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder> 
+             getCredentialInfosBuilderList() {
+          return getCredentialInfosFieldBuilder().getBuilderList();
+        }
+        private com.google.protobuf.RepeatedFieldBuilderV3<
             com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder> 
-            getCredentialsFieldBuilder() {
-          if (credentialsBuilder_ == null) {
-            credentialsBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+            getCredentialInfosFieldBuilder() {
+          if (credentialInfosBuilder_ == null) {
+            credentialInfosBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
                 com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder>(
-                    getCredentials(),
+                    credentialInfos_,
+                    ((bitField0_ & 0x00000001) == 0x00000001),
                     getParentForChildren(),
                     isClean());
-            credentials_ = null;
+            credentialInfos_ = null;
           }
-          return credentialsBuilder_;
+          return credentialInfosBuilder_;
+        }
+
+        private java.lang.Object nextPageToken_ = "";
+        /**
+         * <pre>
+         * Token used to fetch the next page of credentials for large requests that require pagination
+         * </pre>
+         *
+         * <code>optional string next_page_token = 3;</code>
+         */
+        public boolean hasNextPageToken() {
+          return ((bitField0_ & 0x00000002) == 0x00000002);
+        }
+        /**
+         * <pre>
+         * Token used to fetch the next page of credentials for large requests that require pagination
+         * </pre>
+         *
+         * <code>optional string next_page_token = 3;</code>
+         */
+        public java.lang.String getNextPageToken() {
+          java.lang.Object ref = nextPageToken_;
+          if (!(ref instanceof java.lang.String)) {
+            com.google.protobuf.ByteString bs =
+                (com.google.protobuf.ByteString) ref;
+            java.lang.String s = bs.toStringUtf8();
+            if (bs.isValidUtf8()) {
+              nextPageToken_ = s;
+            }
+            return s;
+          } else {
+            return (java.lang.String) ref;
+          }
+        }
+        /**
+         * <pre>
+         * Token used to fetch the next page of credentials for large requests that require pagination
+         * </pre>
+         *
+         * <code>optional string next_page_token = 3;</code>
+         */
+        public com.google.protobuf.ByteString
+            getNextPageTokenBytes() {
+          java.lang.Object ref = nextPageToken_;
+          if (ref instanceof String) {
+            com.google.protobuf.ByteString b = 
+                com.google.protobuf.ByteString.copyFromUtf8(
+                    (java.lang.String) ref);
+            nextPageToken_ = b;
+            return b;
+          } else {
+            return (com.google.protobuf.ByteString) ref;
+          }
+        }
+        /**
+         * <pre>
+         * Token used to fetch the next page of credentials for large requests that require pagination
+         * </pre>
+         *
+         * <code>optional string next_page_token = 3;</code>
+         */
+        public Builder setNextPageToken(
+            java.lang.String value) {
+          if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+          nextPageToken_ = value;
+          onChanged();
+          return this;
+        }
+        /**
+         * <pre>
+         * Token used to fetch the next page of credentials for large requests that require pagination
+         * </pre>
+         *
+         * <code>optional string next_page_token = 3;</code>
+         */
+        public Builder clearNextPageToken() {
+          bitField0_ = (bitField0_ & ~0x00000002);
+          nextPageToken_ = getDefaultInstance().getNextPageToken();
+          onChanged();
+          return this;
+        }
+        /**
+         * <pre>
+         * Token used to fetch the next page of credentials for large requests that require pagination
+         * </pre>
+         *
+         * <code>optional string next_page_token = 3;</code>
+         */
+        public Builder setNextPageTokenBytes(
+            com.google.protobuf.ByteString value) {
+          if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+          nextPageToken_ = value;
+          onChanged();
+          return this;
         }
         @java.lang.Override
         public final Builder setUnknownFields(
@@ -3596,28 +4078,75 @@ public final class DatabricksArtifacts {
     }
 
     public static final int PATH_FIELD_NUMBER = 2;
-    private volatile java.lang.Object path_;
+    private com.google.protobuf.LazyStringList path_;
     /**
      * <pre>
-     * The artifact path, relative to the Run's artifact root location, for which to
+     * The artifact paths, relative to the Run's artifact root location, for which to
      * fetch artifact read credentials
      * </pre>
      *
-     * <code>optional string path = 2 [(.mlflow.validate_required) = true];</code>
+     * <code>repeated string path = 2;</code>
      */
-    public boolean hasPath() {
+    public com.google.protobuf.ProtocolStringList
+        getPathList() {
+      return path_;
+    }
+    /**
+     * <pre>
+     * The artifact paths, relative to the Run's artifact root location, for which to
+     * fetch artifact read credentials
+     * </pre>
+     *
+     * <code>repeated string path = 2;</code>
+     */
+    public int getPathCount() {
+      return path_.size();
+    }
+    /**
+     * <pre>
+     * The artifact paths, relative to the Run's artifact root location, for which to
+     * fetch artifact read credentials
+     * </pre>
+     *
+     * <code>repeated string path = 2;</code>
+     */
+    public java.lang.String getPath(int index) {
+      return path_.get(index);
+    }
+    /**
+     * <pre>
+     * The artifact paths, relative to the Run's artifact root location, for which to
+     * fetch artifact read credentials
+     * </pre>
+     *
+     * <code>repeated string path = 2;</code>
+     */
+    public com.google.protobuf.ByteString
+        getPathBytes(int index) {
+      return path_.getByteString(index);
+    }
+
+    public static final int PAGE_TOKEN_FIELD_NUMBER = 3;
+    private volatile java.lang.Object pageToken_;
+    /**
+     * <pre>
+     * Token specifying the page of credentials to fetch for large requests that require pagination
+     * </pre>
+     *
+     * <code>optional string page_token = 3;</code>
+     */
+    public boolean hasPageToken() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
     }
     /**
      * <pre>
-     * The artifact path, relative to the Run's artifact root location, for which to
-     * fetch artifact read credentials
+     * Token specifying the page of credentials to fetch for large requests that require pagination
      * </pre>
      *
-     * <code>optional string path = 2 [(.mlflow.validate_required) = true];</code>
+     * <code>optional string page_token = 3;</code>
      */
-    public java.lang.String getPath() {
-      java.lang.Object ref = path_;
+    public java.lang.String getPageToken() {
+      java.lang.Object ref = pageToken_;
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
@@ -3625,27 +4154,26 @@ public final class DatabricksArtifacts {
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
-          path_ = s;
+          pageToken_ = s;
         }
         return s;
       }
     }
     /**
      * <pre>
-     * The artifact path, relative to the Run's artifact root location, for which to
-     * fetch artifact read credentials
+     * Token specifying the page of credentials to fetch for large requests that require pagination
      * </pre>
      *
-     * <code>optional string path = 2 [(.mlflow.validate_required) = true];</code>
+     * <code>optional string page_token = 3;</code>
      */
     public com.google.protobuf.ByteString
-        getPathBytes() {
-      java.lang.Object ref = path_;
+        getPageTokenBytes() {
+      java.lang.Object ref = pageToken_;
       if (ref instanceof java.lang.String) {
         com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
-        path_ = b;
+        pageToken_ = b;
         return b;
       } else {
         return (com.google.protobuf.ByteString) ref;
@@ -3669,8 +4197,11 @@ public final class DatabricksArtifacts {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, runId_);
       }
+      for (int i = 0; i < path_.size(); i++) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 2, path_.getRaw(i));
+      }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        com.google.protobuf.GeneratedMessageV3.writeString(output, 2, path_);
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 3, pageToken_);
       }
       unknownFields.writeTo(output);
     }
@@ -3684,8 +4215,16 @@ public final class DatabricksArtifacts {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, runId_);
       }
+      {
+        int dataSize = 0;
+        for (int i = 0; i < path_.size(); i++) {
+          dataSize += computeStringSizeNoTag(path_.getRaw(i));
+        }
+        size += dataSize;
+        size += 1 * getPathList().size();
+      }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, path_);
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, pageToken_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -3708,10 +4247,12 @@ public final class DatabricksArtifacts {
         result = result && getRunId()
             .equals(other.getRunId());
       }
-      result = result && (hasPath() == other.hasPath());
-      if (hasPath()) {
-        result = result && getPath()
-            .equals(other.getPath());
+      result = result && getPathList()
+          .equals(other.getPathList());
+      result = result && (hasPageToken() == other.hasPageToken());
+      if (hasPageToken()) {
+        result = result && getPageToken()
+            .equals(other.getPageToken());
       }
       result = result && unknownFields.equals(other.unknownFields);
       return result;
@@ -3728,9 +4269,13 @@ public final class DatabricksArtifacts {
         hash = (37 * hash) + RUN_ID_FIELD_NUMBER;
         hash = (53 * hash) + getRunId().hashCode();
       }
-      if (hasPath()) {
+      if (getPathCount() > 0) {
         hash = (37 * hash) + PATH_FIELD_NUMBER;
-        hash = (53 * hash) + getPath().hashCode();
+        hash = (53 * hash) + getPathList().hashCode();
+      }
+      if (hasPageToken()) {
+        hash = (37 * hash) + PAGE_TOKEN_FIELD_NUMBER;
+        hash = (53 * hash) + getPageToken().hashCode();
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
@@ -3867,8 +4412,10 @@ public final class DatabricksArtifacts {
         super.clear();
         runId_ = "";
         bitField0_ = (bitField0_ & ~0x00000001);
-        path_ = "";
+        path_ = com.google.protobuf.LazyStringArrayList.EMPTY;
         bitField0_ = (bitField0_ & ~0x00000002);
+        pageToken_ = "";
+        bitField0_ = (bitField0_ & ~0x00000004);
         return this;
       }
 
@@ -3901,10 +4448,15 @@ public final class DatabricksArtifacts {
           to_bitField0_ |= 0x00000001;
         }
         result.runId_ = runId_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-          to_bitField0_ |= 0x00000002;
+        if (((bitField0_ & 0x00000002) == 0x00000002)) {
+          path_ = path_.getUnmodifiableView();
+          bitField0_ = (bitField0_ & ~0x00000002);
         }
         result.path_ = path_;
+        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        result.pageToken_ = pageToken_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -3959,9 +4511,19 @@ public final class DatabricksArtifacts {
           runId_ = other.runId_;
           onChanged();
         }
-        if (other.hasPath()) {
-          bitField0_ |= 0x00000002;
-          path_ = other.path_;
+        if (!other.path_.isEmpty()) {
+          if (path_.isEmpty()) {
+            path_ = other.path_;
+            bitField0_ = (bitField0_ & ~0x00000002);
+          } else {
+            ensurePathIsMutable();
+            path_.addAll(other.path_);
+          }
+          onChanged();
+        }
+        if (other.hasPageToken()) {
+          bitField0_ |= 0x00000004;
+          pageToken_ = other.pageToken_;
           onChanged();
         }
         this.mergeUnknownFields(other.unknownFields);
@@ -4094,34 +4656,170 @@ public final class DatabricksArtifacts {
         return this;
       }
 
-      private java.lang.Object path_ = "";
-      /**
-       * <pre>
-       * The artifact path, relative to the Run's artifact root location, for which to
-       * fetch artifact read credentials
-       * </pre>
-       *
-       * <code>optional string path = 2 [(.mlflow.validate_required) = true];</code>
-       */
-      public boolean hasPath() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+      private com.google.protobuf.LazyStringList path_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      private void ensurePathIsMutable() {
+        if (!((bitField0_ & 0x00000002) == 0x00000002)) {
+          path_ = new com.google.protobuf.LazyStringArrayList(path_);
+          bitField0_ |= 0x00000002;
+         }
       }
       /**
        * <pre>
-       * The artifact path, relative to the Run's artifact root location, for which to
+       * The artifact paths, relative to the Run's artifact root location, for which to
        * fetch artifact read credentials
        * </pre>
        *
-       * <code>optional string path = 2 [(.mlflow.validate_required) = true];</code>
+       * <code>repeated string path = 2;</code>
        */
-      public java.lang.String getPath() {
-        java.lang.Object ref = path_;
+      public com.google.protobuf.ProtocolStringList
+          getPathList() {
+        return path_.getUnmodifiableView();
+      }
+      /**
+       * <pre>
+       * The artifact paths, relative to the Run's artifact root location, for which to
+       * fetch artifact read credentials
+       * </pre>
+       *
+       * <code>repeated string path = 2;</code>
+       */
+      public int getPathCount() {
+        return path_.size();
+      }
+      /**
+       * <pre>
+       * The artifact paths, relative to the Run's artifact root location, for which to
+       * fetch artifact read credentials
+       * </pre>
+       *
+       * <code>repeated string path = 2;</code>
+       */
+      public java.lang.String getPath(int index) {
+        return path_.get(index);
+      }
+      /**
+       * <pre>
+       * The artifact paths, relative to the Run's artifact root location, for which to
+       * fetch artifact read credentials
+       * </pre>
+       *
+       * <code>repeated string path = 2;</code>
+       */
+      public com.google.protobuf.ByteString
+          getPathBytes(int index) {
+        return path_.getByteString(index);
+      }
+      /**
+       * <pre>
+       * The artifact paths, relative to the Run's artifact root location, for which to
+       * fetch artifact read credentials
+       * </pre>
+       *
+       * <code>repeated string path = 2;</code>
+       */
+      public Builder setPath(
+          int index, java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensurePathIsMutable();
+        path_.set(index, value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The artifact paths, relative to the Run's artifact root location, for which to
+       * fetch artifact read credentials
+       * </pre>
+       *
+       * <code>repeated string path = 2;</code>
+       */
+      public Builder addPath(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensurePathIsMutable();
+        path_.add(value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The artifact paths, relative to the Run's artifact root location, for which to
+       * fetch artifact read credentials
+       * </pre>
+       *
+       * <code>repeated string path = 2;</code>
+       */
+      public Builder addAllPath(
+          java.lang.Iterable<java.lang.String> values) {
+        ensurePathIsMutable();
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, path_);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The artifact paths, relative to the Run's artifact root location, for which to
+       * fetch artifact read credentials
+       * </pre>
+       *
+       * <code>repeated string path = 2;</code>
+       */
+      public Builder clearPath() {
+        path_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000002);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The artifact paths, relative to the Run's artifact root location, for which to
+       * fetch artifact read credentials
+       * </pre>
+       *
+       * <code>repeated string path = 2;</code>
+       */
+      public Builder addPathBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensurePathIsMutable();
+        path_.add(value);
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object pageToken_ = "";
+      /**
+       * <pre>
+       * Token specifying the page of credentials to fetch for large requests that require pagination
+       * </pre>
+       *
+       * <code>optional string page_token = 3;</code>
+       */
+      public boolean hasPageToken() {
+        return ((bitField0_ & 0x00000004) == 0x00000004);
+      }
+      /**
+       * <pre>
+       * Token specifying the page of credentials to fetch for large requests that require pagination
+       * </pre>
+       *
+       * <code>optional string page_token = 3;</code>
+       */
+      public java.lang.String getPageToken() {
+        java.lang.Object ref = pageToken_;
         if (!(ref instanceof java.lang.String)) {
           com.google.protobuf.ByteString bs =
               (com.google.protobuf.ByteString) ref;
           java.lang.String s = bs.toStringUtf8();
           if (bs.isValidUtf8()) {
-            path_ = s;
+            pageToken_ = s;
           }
           return s;
         } else {
@@ -4130,20 +4828,19 @@ public final class DatabricksArtifacts {
       }
       /**
        * <pre>
-       * The artifact path, relative to the Run's artifact root location, for which to
-       * fetch artifact read credentials
+       * Token specifying the page of credentials to fetch for large requests that require pagination
        * </pre>
        *
-       * <code>optional string path = 2 [(.mlflow.validate_required) = true];</code>
+       * <code>optional string page_token = 3;</code>
        */
       public com.google.protobuf.ByteString
-          getPathBytes() {
-        java.lang.Object ref = path_;
+          getPageTokenBytes() {
+        java.lang.Object ref = pageToken_;
         if (ref instanceof String) {
           com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
-          path_ = b;
+          pageToken_ = b;
           return b;
         } else {
           return (com.google.protobuf.ByteString) ref;
@@ -4151,51 +4848,48 @@ public final class DatabricksArtifacts {
       }
       /**
        * <pre>
-       * The artifact path, relative to the Run's artifact root location, for which to
-       * fetch artifact read credentials
+       * Token specifying the page of credentials to fetch for large requests that require pagination
        * </pre>
        *
-       * <code>optional string path = 2 [(.mlflow.validate_required) = true];</code>
+       * <code>optional string page_token = 3;</code>
        */
-      public Builder setPath(
+      public Builder setPageToken(
           java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
-  bitField0_ |= 0x00000002;
-        path_ = value;
+  bitField0_ |= 0x00000004;
+        pageToken_ = value;
         onChanged();
         return this;
       }
       /**
        * <pre>
-       * The artifact path, relative to the Run's artifact root location, for which to
-       * fetch artifact read credentials
+       * Token specifying the page of credentials to fetch for large requests that require pagination
        * </pre>
        *
-       * <code>optional string path = 2 [(.mlflow.validate_required) = true];</code>
+       * <code>optional string page_token = 3;</code>
        */
-      public Builder clearPath() {
-        bitField0_ = (bitField0_ & ~0x00000002);
-        path_ = getDefaultInstance().getPath();
+      public Builder clearPageToken() {
+        bitField0_ = (bitField0_ & ~0x00000004);
+        pageToken_ = getDefaultInstance().getPageToken();
         onChanged();
         return this;
       }
       /**
        * <pre>
-       * The artifact path, relative to the Run's artifact root location, for which to
-       * fetch artifact read credentials
+       * Token specifying the page of credentials to fetch for large requests that require pagination
        * </pre>
        *
-       * <code>optional string path = 2 [(.mlflow.validate_required) = true];</code>
+       * <code>optional string page_token = 3;</code>
        */
-      public Builder setPathBytes(
+      public Builder setPageTokenBytes(
           com.google.protobuf.ByteString value) {
         if (value == null) {
     throw new NullPointerException();
   }
-  bitField0_ |= 0x00000002;
-        path_ = value;
+  bitField0_ |= 0x00000004;
+        pageToken_ = value;
         onChanged();
         return this;
       }
@@ -4284,32 +4978,68 @@ public final class DatabricksArtifacts {
 
     /**
      * <pre>
-     * The artifact path, relative to the Run's artifact root location, for which to
+     * The artifact paths, relative to the Run's artifact root location, for which to
      * fetch artifact write credentials
      * </pre>
      *
-     * <code>optional string path = 2 [(.mlflow.validate_required) = true];</code>
+     * <code>repeated string path = 2;</code>
      */
-    boolean hasPath();
+    java.util.List<java.lang.String>
+        getPathList();
     /**
      * <pre>
-     * The artifact path, relative to the Run's artifact root location, for which to
+     * The artifact paths, relative to the Run's artifact root location, for which to
      * fetch artifact write credentials
      * </pre>
      *
-     * <code>optional string path = 2 [(.mlflow.validate_required) = true];</code>
+     * <code>repeated string path = 2;</code>
      */
-    java.lang.String getPath();
+    int getPathCount();
     /**
      * <pre>
-     * The artifact path, relative to the Run's artifact root location, for which to
+     * The artifact paths, relative to the Run's artifact root location, for which to
      * fetch artifact write credentials
      * </pre>
      *
-     * <code>optional string path = 2 [(.mlflow.validate_required) = true];</code>
+     * <code>repeated string path = 2;</code>
+     */
+    java.lang.String getPath(int index);
+    /**
+     * <pre>
+     * The artifact paths, relative to the Run's artifact root location, for which to
+     * fetch artifact write credentials
+     * </pre>
+     *
+     * <code>repeated string path = 2;</code>
      */
     com.google.protobuf.ByteString
-        getPathBytes();
+        getPathBytes(int index);
+
+    /**
+     * <pre>
+     * Token specifying the page of credentials to fetch for large requests that require pagination
+     * </pre>
+     *
+     * <code>optional string page_token = 3;</code>
+     */
+    boolean hasPageToken();
+    /**
+     * <pre>
+     * Token specifying the page of credentials to fetch for large requests that require pagination
+     * </pre>
+     *
+     * <code>optional string page_token = 3;</code>
+     */
+    java.lang.String getPageToken();
+    /**
+     * <pre>
+     * Token specifying the page of credentials to fetch for large requests that require pagination
+     * </pre>
+     *
+     * <code>optional string page_token = 3;</code>
+     */
+    com.google.protobuf.ByteString
+        getPageTokenBytes();
   }
   /**
    * Protobuf type {@code mlflow.GetCredentialsForWrite}
@@ -4325,7 +5055,8 @@ public final class DatabricksArtifacts {
     }
     private GetCredentialsForWrite() {
       runId_ = "";
-      path_ = "";
+      path_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      pageToken_ = "";
     }
 
     @java.lang.Override
@@ -4360,8 +5091,17 @@ public final class DatabricksArtifacts {
             }
             case 18: {
               com.google.protobuf.ByteString bs = input.readBytes();
+              if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+                path_ = new com.google.protobuf.LazyStringArrayList();
+                mutable_bitField0_ |= 0x00000002;
+              }
+              path_.add(bs);
+              break;
+            }
+            case 26: {
+              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000002;
-              path_ = bs;
+              pageToken_ = bs;
               break;
             }
             default: {
@@ -4379,6 +5119,9 @@ public final class DatabricksArtifacts {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
+        if (((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+          path_ = path_.getUnmodifiableView();
+        }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
       }
@@ -4402,28 +5145,73 @@ public final class DatabricksArtifacts {
 
       /**
        * <pre>
-       * Credentials for writing to the specified artifacts location
+       * Credentials for writing to the specified artifact locations
        * </pre>
        *
-       * <code>optional .mlflow.ArtifactCredentialInfo credentials = 1;</code>
+       * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
        */
-      boolean hasCredentials();
+      java.util.List<com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo> 
+          getCredentialInfosList();
       /**
        * <pre>
-       * Credentials for writing to the specified artifacts location
+       * Credentials for writing to the specified artifact locations
        * </pre>
        *
-       * <code>optional .mlflow.ArtifactCredentialInfo credentials = 1;</code>
+       * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
        */
-      com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo getCredentials();
+      com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo getCredentialInfos(int index);
       /**
        * <pre>
-       * Credentials for writing to the specified artifacts location
+       * Credentials for writing to the specified artifact locations
        * </pre>
        *
-       * <code>optional .mlflow.ArtifactCredentialInfo credentials = 1;</code>
+       * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
        */
-      com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder getCredentialsOrBuilder();
+      int getCredentialInfosCount();
+      /**
+       * <pre>
+       * Credentials for writing to the specified artifact locations
+       * </pre>
+       *
+       * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
+       */
+      java.util.List<? extends com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder> 
+          getCredentialInfosOrBuilderList();
+      /**
+       * <pre>
+       * Credentials for writing to the specified artifact locations
+       * </pre>
+       *
+       * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
+       */
+      com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder getCredentialInfosOrBuilder(
+          int index);
+
+      /**
+       * <pre>
+       * Token used to fetch the next page of credentials for large requests that require pagination
+       * </pre>
+       *
+       * <code>optional string next_page_token = 3;</code>
+       */
+      boolean hasNextPageToken();
+      /**
+       * <pre>
+       * Token used to fetch the next page of credentials for large requests that require pagination
+       * </pre>
+       *
+       * <code>optional string next_page_token = 3;</code>
+       */
+      java.lang.String getNextPageToken();
+      /**
+       * <pre>
+       * Token used to fetch the next page of credentials for large requests that require pagination
+       * </pre>
+       *
+       * <code>optional string next_page_token = 3;</code>
+       */
+      com.google.protobuf.ByteString
+          getNextPageTokenBytes();
     }
     /**
      * Protobuf type {@code mlflow.GetCredentialsForWrite.Response}
@@ -4438,6 +5226,8 @@ public final class DatabricksArtifacts {
         super(builder);
       }
       private Response() {
+        credentialInfos_ = java.util.Collections.emptyList();
+        nextPageToken_ = "";
       }
 
       @java.lang.Override
@@ -4464,17 +5254,19 @@ public final class DatabricksArtifacts {
               case 0:
                 done = true;
                 break;
-              case 10: {
-                com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder subBuilder = null;
-                if (((bitField0_ & 0x00000001) == 0x00000001)) {
-                  subBuilder = credentials_.toBuilder();
+              case 18: {
+                if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+                  credentialInfos_ = new java.util.ArrayList<com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo>();
+                  mutable_bitField0_ |= 0x00000001;
                 }
-                credentials_ = input.readMessage(com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.PARSER, extensionRegistry);
-                if (subBuilder != null) {
-                  subBuilder.mergeFrom(credentials_);
-                  credentials_ = subBuilder.buildPartial();
-                }
+                credentialInfos_.add(
+                    input.readMessage(com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.PARSER, extensionRegistry));
+                break;
+              }
+              case 26: {
+                com.google.protobuf.ByteString bs = input.readBytes();
                 bitField0_ |= 0x00000001;
+                nextPageToken_ = bs;
                 break;
               }
               default: {
@@ -4492,6 +5284,9 @@ public final class DatabricksArtifacts {
           throw new com.google.protobuf.InvalidProtocolBufferException(
               e).setUnfinishedMessage(this);
         } finally {
+          if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+            credentialInfos_ = java.util.Collections.unmodifiableList(credentialInfos_);
+          }
           this.unknownFields = unknownFields.build();
           makeExtensionsImmutable();
         }
@@ -4510,37 +5305,113 @@ public final class DatabricksArtifacts {
       }
 
       private int bitField0_;
-      public static final int CREDENTIALS_FIELD_NUMBER = 1;
-      private com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo credentials_;
+      public static final int CREDENTIAL_INFOS_FIELD_NUMBER = 2;
+      private java.util.List<com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo> credentialInfos_;
       /**
        * <pre>
-       * Credentials for writing to the specified artifacts location
+       * Credentials for writing to the specified artifact locations
        * </pre>
        *
-       * <code>optional .mlflow.ArtifactCredentialInfo credentials = 1;</code>
+       * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
        */
-      public boolean hasCredentials() {
+      public java.util.List<com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo> getCredentialInfosList() {
+        return credentialInfos_;
+      }
+      /**
+       * <pre>
+       * Credentials for writing to the specified artifact locations
+       * </pre>
+       *
+       * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
+       */
+      public java.util.List<? extends com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder> 
+          getCredentialInfosOrBuilderList() {
+        return credentialInfos_;
+      }
+      /**
+       * <pre>
+       * Credentials for writing to the specified artifact locations
+       * </pre>
+       *
+       * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
+       */
+      public int getCredentialInfosCount() {
+        return credentialInfos_.size();
+      }
+      /**
+       * <pre>
+       * Credentials for writing to the specified artifact locations
+       * </pre>
+       *
+       * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
+       */
+      public com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo getCredentialInfos(int index) {
+        return credentialInfos_.get(index);
+      }
+      /**
+       * <pre>
+       * Credentials for writing to the specified artifact locations
+       * </pre>
+       *
+       * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
+       */
+      public com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder getCredentialInfosOrBuilder(
+          int index) {
+        return credentialInfos_.get(index);
+      }
+
+      public static final int NEXT_PAGE_TOKEN_FIELD_NUMBER = 3;
+      private volatile java.lang.Object nextPageToken_;
+      /**
+       * <pre>
+       * Token used to fetch the next page of credentials for large requests that require pagination
+       * </pre>
+       *
+       * <code>optional string next_page_token = 3;</code>
+       */
+      public boolean hasNextPageToken() {
         return ((bitField0_ & 0x00000001) == 0x00000001);
       }
       /**
        * <pre>
-       * Credentials for writing to the specified artifacts location
+       * Token used to fetch the next page of credentials for large requests that require pagination
        * </pre>
        *
-       * <code>optional .mlflow.ArtifactCredentialInfo credentials = 1;</code>
+       * <code>optional string next_page_token = 3;</code>
        */
-      public com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo getCredentials() {
-        return credentials_ == null ? com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.getDefaultInstance() : credentials_;
+      public java.lang.String getNextPageToken() {
+        java.lang.Object ref = nextPageToken_;
+        if (ref instanceof java.lang.String) {
+          return (java.lang.String) ref;
+        } else {
+          com.google.protobuf.ByteString bs = 
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            nextPageToken_ = s;
+          }
+          return s;
+        }
       }
       /**
        * <pre>
-       * Credentials for writing to the specified artifacts location
+       * Token used to fetch the next page of credentials for large requests that require pagination
        * </pre>
        *
-       * <code>optional .mlflow.ArtifactCredentialInfo credentials = 1;</code>
+       * <code>optional string next_page_token = 3;</code>
        */
-      public com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder getCredentialsOrBuilder() {
-        return credentials_ == null ? com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.getDefaultInstance() : credentials_;
+      public com.google.protobuf.ByteString
+          getNextPageTokenBytes() {
+        java.lang.Object ref = nextPageToken_;
+        if (ref instanceof java.lang.String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          nextPageToken_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
       }
 
       private byte memoizedIsInitialized = -1;
@@ -4557,8 +5428,11 @@ public final class DatabricksArtifacts {
       @java.lang.Override
       public void writeTo(com.google.protobuf.CodedOutputStream output)
                           throws java.io.IOException {
+        for (int i = 0; i < credentialInfos_.size(); i++) {
+          output.writeMessage(2, credentialInfos_.get(i));
+        }
         if (((bitField0_ & 0x00000001) == 0x00000001)) {
-          output.writeMessage(1, getCredentials());
+          com.google.protobuf.GeneratedMessageV3.writeString(output, 3, nextPageToken_);
         }
         unknownFields.writeTo(output);
       }
@@ -4569,9 +5443,12 @@ public final class DatabricksArtifacts {
         if (size != -1) return size;
 
         size = 0;
-        if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        for (int i = 0; i < credentialInfos_.size(); i++) {
           size += com.google.protobuf.CodedOutputStream
-            .computeMessageSize(1, getCredentials());
+            .computeMessageSize(2, credentialInfos_.get(i));
+        }
+        if (((bitField0_ & 0x00000001) == 0x00000001)) {
+          size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, nextPageToken_);
         }
         size += unknownFields.getSerializedSize();
         memoizedSize = size;
@@ -4589,10 +5466,12 @@ public final class DatabricksArtifacts {
         com.databricks.api.proto.mlflow.DatabricksArtifacts.GetCredentialsForWrite.Response other = (com.databricks.api.proto.mlflow.DatabricksArtifacts.GetCredentialsForWrite.Response) obj;
 
         boolean result = true;
-        result = result && (hasCredentials() == other.hasCredentials());
-        if (hasCredentials()) {
-          result = result && getCredentials()
-              .equals(other.getCredentials());
+        result = result && getCredentialInfosList()
+            .equals(other.getCredentialInfosList());
+        result = result && (hasNextPageToken() == other.hasNextPageToken());
+        if (hasNextPageToken()) {
+          result = result && getNextPageToken()
+              .equals(other.getNextPageToken());
         }
         result = result && unknownFields.equals(other.unknownFields);
         return result;
@@ -4605,9 +5484,13 @@ public final class DatabricksArtifacts {
         }
         int hash = 41;
         hash = (19 * hash) + getDescriptor().hashCode();
-        if (hasCredentials()) {
-          hash = (37 * hash) + CREDENTIALS_FIELD_NUMBER;
-          hash = (53 * hash) + getCredentials().hashCode();
+        if (getCredentialInfosCount() > 0) {
+          hash = (37 * hash) + CREDENTIAL_INFOS_FIELD_NUMBER;
+          hash = (53 * hash) + getCredentialInfosList().hashCode();
+        }
+        if (hasNextPageToken()) {
+          hash = (37 * hash) + NEXT_PAGE_TOKEN_FIELD_NUMBER;
+          hash = (53 * hash) + getNextPageToken().hashCode();
         }
         hash = (29 * hash) + unknownFields.hashCode();
         memoizedHashCode = hash;
@@ -4737,18 +5620,20 @@ public final class DatabricksArtifacts {
         private void maybeForceBuilderInitialization() {
           if (com.google.protobuf.GeneratedMessageV3
                   .alwaysUseFieldBuilders) {
-            getCredentialsFieldBuilder();
+            getCredentialInfosFieldBuilder();
           }
         }
         @java.lang.Override
         public Builder clear() {
           super.clear();
-          if (credentialsBuilder_ == null) {
-            credentials_ = null;
+          if (credentialInfosBuilder_ == null) {
+            credentialInfos_ = java.util.Collections.emptyList();
+            bitField0_ = (bitField0_ & ~0x00000001);
           } else {
-            credentialsBuilder_.clear();
+            credentialInfosBuilder_.clear();
           }
-          bitField0_ = (bitField0_ & ~0x00000001);
+          nextPageToken_ = "";
+          bitField0_ = (bitField0_ & ~0x00000002);
           return this;
         }
 
@@ -4777,14 +5662,19 @@ public final class DatabricksArtifacts {
           com.databricks.api.proto.mlflow.DatabricksArtifacts.GetCredentialsForWrite.Response result = new com.databricks.api.proto.mlflow.DatabricksArtifacts.GetCredentialsForWrite.Response(this);
           int from_bitField0_ = bitField0_;
           int to_bitField0_ = 0;
-          if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+          if (credentialInfosBuilder_ == null) {
+            if (((bitField0_ & 0x00000001) == 0x00000001)) {
+              credentialInfos_ = java.util.Collections.unmodifiableList(credentialInfos_);
+              bitField0_ = (bitField0_ & ~0x00000001);
+            }
+            result.credentialInfos_ = credentialInfos_;
+          } else {
+            result.credentialInfos_ = credentialInfosBuilder_.build();
+          }
+          if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
             to_bitField0_ |= 0x00000001;
           }
-          if (credentialsBuilder_ == null) {
-            result.credentials_ = credentials_;
-          } else {
-            result.credentials_ = credentialsBuilder_.build();
-          }
+          result.nextPageToken_ = nextPageToken_;
           result.bitField0_ = to_bitField0_;
           onBuilt();
           return result;
@@ -4834,8 +5724,36 @@ public final class DatabricksArtifacts {
 
         public Builder mergeFrom(com.databricks.api.proto.mlflow.DatabricksArtifacts.GetCredentialsForWrite.Response other) {
           if (other == com.databricks.api.proto.mlflow.DatabricksArtifacts.GetCredentialsForWrite.Response.getDefaultInstance()) return this;
-          if (other.hasCredentials()) {
-            mergeCredentials(other.getCredentials());
+          if (credentialInfosBuilder_ == null) {
+            if (!other.credentialInfos_.isEmpty()) {
+              if (credentialInfos_.isEmpty()) {
+                credentialInfos_ = other.credentialInfos_;
+                bitField0_ = (bitField0_ & ~0x00000001);
+              } else {
+                ensureCredentialInfosIsMutable();
+                credentialInfos_.addAll(other.credentialInfos_);
+              }
+              onChanged();
+            }
+          } else {
+            if (!other.credentialInfos_.isEmpty()) {
+              if (credentialInfosBuilder_.isEmpty()) {
+                credentialInfosBuilder_.dispose();
+                credentialInfosBuilder_ = null;
+                credentialInfos_ = other.credentialInfos_;
+                bitField0_ = (bitField0_ & ~0x00000001);
+                credentialInfosBuilder_ = 
+                  com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
+                     getCredentialInfosFieldBuilder() : null;
+              } else {
+                credentialInfosBuilder_.addAllMessages(other.credentialInfos_);
+              }
+            }
+          }
+          if (other.hasNextPageToken()) {
+            bitField0_ |= 0x00000002;
+            nextPageToken_ = other.nextPageToken_;
+            onChanged();
           }
           this.mergeUnknownFields(other.unknownFields);
           onChanged();
@@ -4867,158 +5785,416 @@ public final class DatabricksArtifacts {
         }
         private int bitField0_;
 
-        private com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo credentials_ = null;
-        private com.google.protobuf.SingleFieldBuilderV3<
-            com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder> credentialsBuilder_;
-        /**
-         * <pre>
-         * Credentials for writing to the specified artifacts location
-         * </pre>
-         *
-         * <code>optional .mlflow.ArtifactCredentialInfo credentials = 1;</code>
-         */
-        public boolean hasCredentials() {
-          return ((bitField0_ & 0x00000001) == 0x00000001);
+        private java.util.List<com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo> credentialInfos_ =
+          java.util.Collections.emptyList();
+        private void ensureCredentialInfosIsMutable() {
+          if (!((bitField0_ & 0x00000001) == 0x00000001)) {
+            credentialInfos_ = new java.util.ArrayList<com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo>(credentialInfos_);
+            bitField0_ |= 0x00000001;
+           }
         }
+
+        private com.google.protobuf.RepeatedFieldBuilderV3<
+            com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder> credentialInfosBuilder_;
+
         /**
          * <pre>
-         * Credentials for writing to the specified artifacts location
+         * Credentials for writing to the specified artifact locations
          * </pre>
          *
-         * <code>optional .mlflow.ArtifactCredentialInfo credentials = 1;</code>
+         * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
          */
-        public com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo getCredentials() {
-          if (credentialsBuilder_ == null) {
-            return credentials_ == null ? com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.getDefaultInstance() : credentials_;
+        public java.util.List<com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo> getCredentialInfosList() {
+          if (credentialInfosBuilder_ == null) {
+            return java.util.Collections.unmodifiableList(credentialInfos_);
           } else {
-            return credentialsBuilder_.getMessage();
+            return credentialInfosBuilder_.getMessageList();
           }
         }
         /**
          * <pre>
-         * Credentials for writing to the specified artifacts location
+         * Credentials for writing to the specified artifact locations
          * </pre>
          *
-         * <code>optional .mlflow.ArtifactCredentialInfo credentials = 1;</code>
+         * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
          */
-        public Builder setCredentials(com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo value) {
-          if (credentialsBuilder_ == null) {
+        public int getCredentialInfosCount() {
+          if (credentialInfosBuilder_ == null) {
+            return credentialInfos_.size();
+          } else {
+            return credentialInfosBuilder_.getCount();
+          }
+        }
+        /**
+         * <pre>
+         * Credentials for writing to the specified artifact locations
+         * </pre>
+         *
+         * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
+         */
+        public com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo getCredentialInfos(int index) {
+          if (credentialInfosBuilder_ == null) {
+            return credentialInfos_.get(index);
+          } else {
+            return credentialInfosBuilder_.getMessage(index);
+          }
+        }
+        /**
+         * <pre>
+         * Credentials for writing to the specified artifact locations
+         * </pre>
+         *
+         * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
+         */
+        public Builder setCredentialInfos(
+            int index, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo value) {
+          if (credentialInfosBuilder_ == null) {
             if (value == null) {
               throw new NullPointerException();
             }
-            credentials_ = value;
+            ensureCredentialInfosIsMutable();
+            credentialInfos_.set(index, value);
             onChanged();
           } else {
-            credentialsBuilder_.setMessage(value);
+            credentialInfosBuilder_.setMessage(index, value);
           }
-          bitField0_ |= 0x00000001;
           return this;
         }
         /**
          * <pre>
-         * Credentials for writing to the specified artifacts location
+         * Credentials for writing to the specified artifact locations
          * </pre>
          *
-         * <code>optional .mlflow.ArtifactCredentialInfo credentials = 1;</code>
+         * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
          */
-        public Builder setCredentials(
-            com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder builderForValue) {
-          if (credentialsBuilder_ == null) {
-            credentials_ = builderForValue.build();
+        public Builder setCredentialInfos(
+            int index, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder builderForValue) {
+          if (credentialInfosBuilder_ == null) {
+            ensureCredentialInfosIsMutable();
+            credentialInfos_.set(index, builderForValue.build());
             onChanged();
           } else {
-            credentialsBuilder_.setMessage(builderForValue.build());
+            credentialInfosBuilder_.setMessage(index, builderForValue.build());
           }
-          bitField0_ |= 0x00000001;
           return this;
         }
         /**
          * <pre>
-         * Credentials for writing to the specified artifacts location
+         * Credentials for writing to the specified artifact locations
          * </pre>
          *
-         * <code>optional .mlflow.ArtifactCredentialInfo credentials = 1;</code>
+         * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
          */
-        public Builder mergeCredentials(com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo value) {
-          if (credentialsBuilder_ == null) {
-            if (((bitField0_ & 0x00000001) == 0x00000001) &&
-                credentials_ != null &&
-                credentials_ != com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.getDefaultInstance()) {
-              credentials_ =
-                com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.newBuilder(credentials_).mergeFrom(value).buildPartial();
-            } else {
-              credentials_ = value;
+        public Builder addCredentialInfos(com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo value) {
+          if (credentialInfosBuilder_ == null) {
+            if (value == null) {
+              throw new NullPointerException();
             }
+            ensureCredentialInfosIsMutable();
+            credentialInfos_.add(value);
             onChanged();
           } else {
-            credentialsBuilder_.mergeFrom(value);
+            credentialInfosBuilder_.addMessage(value);
           }
-          bitField0_ |= 0x00000001;
           return this;
         }
         /**
          * <pre>
-         * Credentials for writing to the specified artifacts location
+         * Credentials for writing to the specified artifact locations
          * </pre>
          *
-         * <code>optional .mlflow.ArtifactCredentialInfo credentials = 1;</code>
+         * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
          */
-        public Builder clearCredentials() {
-          if (credentialsBuilder_ == null) {
-            credentials_ = null;
+        public Builder addCredentialInfos(
+            int index, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo value) {
+          if (credentialInfosBuilder_ == null) {
+            if (value == null) {
+              throw new NullPointerException();
+            }
+            ensureCredentialInfosIsMutable();
+            credentialInfos_.add(index, value);
             onChanged();
           } else {
-            credentialsBuilder_.clear();
+            credentialInfosBuilder_.addMessage(index, value);
           }
-          bitField0_ = (bitField0_ & ~0x00000001);
           return this;
         }
         /**
          * <pre>
-         * Credentials for writing to the specified artifacts location
+         * Credentials for writing to the specified artifact locations
          * </pre>
          *
-         * <code>optional .mlflow.ArtifactCredentialInfo credentials = 1;</code>
+         * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
          */
-        public com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder getCredentialsBuilder() {
-          bitField0_ |= 0x00000001;
-          onChanged();
-          return getCredentialsFieldBuilder().getBuilder();
+        public Builder addCredentialInfos(
+            com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder builderForValue) {
+          if (credentialInfosBuilder_ == null) {
+            ensureCredentialInfosIsMutable();
+            credentialInfos_.add(builderForValue.build());
+            onChanged();
+          } else {
+            credentialInfosBuilder_.addMessage(builderForValue.build());
+          }
+          return this;
         }
         /**
          * <pre>
-         * Credentials for writing to the specified artifacts location
+         * Credentials for writing to the specified artifact locations
          * </pre>
          *
-         * <code>optional .mlflow.ArtifactCredentialInfo credentials = 1;</code>
+         * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
          */
-        public com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder getCredentialsOrBuilder() {
-          if (credentialsBuilder_ != null) {
-            return credentialsBuilder_.getMessageOrBuilder();
+        public Builder addCredentialInfos(
+            int index, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder builderForValue) {
+          if (credentialInfosBuilder_ == null) {
+            ensureCredentialInfosIsMutable();
+            credentialInfos_.add(index, builderForValue.build());
+            onChanged();
           } else {
-            return credentials_ == null ?
-                com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.getDefaultInstance() : credentials_;
+            credentialInfosBuilder_.addMessage(index, builderForValue.build());
+          }
+          return this;
+        }
+        /**
+         * <pre>
+         * Credentials for writing to the specified artifact locations
+         * </pre>
+         *
+         * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
+         */
+        public Builder addAllCredentialInfos(
+            java.lang.Iterable<? extends com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo> values) {
+          if (credentialInfosBuilder_ == null) {
+            ensureCredentialInfosIsMutable();
+            com.google.protobuf.AbstractMessageLite.Builder.addAll(
+                values, credentialInfos_);
+            onChanged();
+          } else {
+            credentialInfosBuilder_.addAllMessages(values);
+          }
+          return this;
+        }
+        /**
+         * <pre>
+         * Credentials for writing to the specified artifact locations
+         * </pre>
+         *
+         * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
+         */
+        public Builder clearCredentialInfos() {
+          if (credentialInfosBuilder_ == null) {
+            credentialInfos_ = java.util.Collections.emptyList();
+            bitField0_ = (bitField0_ & ~0x00000001);
+            onChanged();
+          } else {
+            credentialInfosBuilder_.clear();
+          }
+          return this;
+        }
+        /**
+         * <pre>
+         * Credentials for writing to the specified artifact locations
+         * </pre>
+         *
+         * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
+         */
+        public Builder removeCredentialInfos(int index) {
+          if (credentialInfosBuilder_ == null) {
+            ensureCredentialInfosIsMutable();
+            credentialInfos_.remove(index);
+            onChanged();
+          } else {
+            credentialInfosBuilder_.remove(index);
+          }
+          return this;
+        }
+        /**
+         * <pre>
+         * Credentials for writing to the specified artifact locations
+         * </pre>
+         *
+         * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
+         */
+        public com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder getCredentialInfosBuilder(
+            int index) {
+          return getCredentialInfosFieldBuilder().getBuilder(index);
+        }
+        /**
+         * <pre>
+         * Credentials for writing to the specified artifact locations
+         * </pre>
+         *
+         * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
+         */
+        public com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder getCredentialInfosOrBuilder(
+            int index) {
+          if (credentialInfosBuilder_ == null) {
+            return credentialInfos_.get(index);  } else {
+            return credentialInfosBuilder_.getMessageOrBuilder(index);
           }
         }
         /**
          * <pre>
-         * Credentials for writing to the specified artifacts location
+         * Credentials for writing to the specified artifact locations
          * </pre>
          *
-         * <code>optional .mlflow.ArtifactCredentialInfo credentials = 1;</code>
+         * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
          */
-        private com.google.protobuf.SingleFieldBuilderV3<
+        public java.util.List<? extends com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder> 
+             getCredentialInfosOrBuilderList() {
+          if (credentialInfosBuilder_ != null) {
+            return credentialInfosBuilder_.getMessageOrBuilderList();
+          } else {
+            return java.util.Collections.unmodifiableList(credentialInfos_);
+          }
+        }
+        /**
+         * <pre>
+         * Credentials for writing to the specified artifact locations
+         * </pre>
+         *
+         * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
+         */
+        public com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder addCredentialInfosBuilder() {
+          return getCredentialInfosFieldBuilder().addBuilder(
+              com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.getDefaultInstance());
+        }
+        /**
+         * <pre>
+         * Credentials for writing to the specified artifact locations
+         * </pre>
+         *
+         * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
+         */
+        public com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder addCredentialInfosBuilder(
+            int index) {
+          return getCredentialInfosFieldBuilder().addBuilder(
+              index, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.getDefaultInstance());
+        }
+        /**
+         * <pre>
+         * Credentials for writing to the specified artifact locations
+         * </pre>
+         *
+         * <code>repeated .mlflow.ArtifactCredentialInfo credential_infos = 2;</code>
+         */
+        public java.util.List<com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder> 
+             getCredentialInfosBuilderList() {
+          return getCredentialInfosFieldBuilder().getBuilderList();
+        }
+        private com.google.protobuf.RepeatedFieldBuilderV3<
             com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder> 
-            getCredentialsFieldBuilder() {
-          if (credentialsBuilder_ == null) {
-            credentialsBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+            getCredentialInfosFieldBuilder() {
+          if (credentialInfosBuilder_ == null) {
+            credentialInfosBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
                 com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder>(
-                    getCredentials(),
+                    credentialInfos_,
+                    ((bitField0_ & 0x00000001) == 0x00000001),
                     getParentForChildren(),
                     isClean());
-            credentials_ = null;
+            credentialInfos_ = null;
           }
-          return credentialsBuilder_;
+          return credentialInfosBuilder_;
+        }
+
+        private java.lang.Object nextPageToken_ = "";
+        /**
+         * <pre>
+         * Token used to fetch the next page of credentials for large requests that require pagination
+         * </pre>
+         *
+         * <code>optional string next_page_token = 3;</code>
+         */
+        public boolean hasNextPageToken() {
+          return ((bitField0_ & 0x00000002) == 0x00000002);
+        }
+        /**
+         * <pre>
+         * Token used to fetch the next page of credentials for large requests that require pagination
+         * </pre>
+         *
+         * <code>optional string next_page_token = 3;</code>
+         */
+        public java.lang.String getNextPageToken() {
+          java.lang.Object ref = nextPageToken_;
+          if (!(ref instanceof java.lang.String)) {
+            com.google.protobuf.ByteString bs =
+                (com.google.protobuf.ByteString) ref;
+            java.lang.String s = bs.toStringUtf8();
+            if (bs.isValidUtf8()) {
+              nextPageToken_ = s;
+            }
+            return s;
+          } else {
+            return (java.lang.String) ref;
+          }
+        }
+        /**
+         * <pre>
+         * Token used to fetch the next page of credentials for large requests that require pagination
+         * </pre>
+         *
+         * <code>optional string next_page_token = 3;</code>
+         */
+        public com.google.protobuf.ByteString
+            getNextPageTokenBytes() {
+          java.lang.Object ref = nextPageToken_;
+          if (ref instanceof String) {
+            com.google.protobuf.ByteString b = 
+                com.google.protobuf.ByteString.copyFromUtf8(
+                    (java.lang.String) ref);
+            nextPageToken_ = b;
+            return b;
+          } else {
+            return (com.google.protobuf.ByteString) ref;
+          }
+        }
+        /**
+         * <pre>
+         * Token used to fetch the next page of credentials for large requests that require pagination
+         * </pre>
+         *
+         * <code>optional string next_page_token = 3;</code>
+         */
+        public Builder setNextPageToken(
+            java.lang.String value) {
+          if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+          nextPageToken_ = value;
+          onChanged();
+          return this;
+        }
+        /**
+         * <pre>
+         * Token used to fetch the next page of credentials for large requests that require pagination
+         * </pre>
+         *
+         * <code>optional string next_page_token = 3;</code>
+         */
+        public Builder clearNextPageToken() {
+          bitField0_ = (bitField0_ & ~0x00000002);
+          nextPageToken_ = getDefaultInstance().getNextPageToken();
+          onChanged();
+          return this;
+        }
+        /**
+         * <pre>
+         * Token used to fetch the next page of credentials for large requests that require pagination
+         * </pre>
+         *
+         * <code>optional string next_page_token = 3;</code>
+         */
+        public Builder setNextPageTokenBytes(
+            com.google.protobuf.ByteString value) {
+          if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+          nextPageToken_ = value;
+          onChanged();
+          return this;
         }
         @java.lang.Override
         public final Builder setUnknownFields(
@@ -5129,28 +6305,75 @@ public final class DatabricksArtifacts {
     }
 
     public static final int PATH_FIELD_NUMBER = 2;
-    private volatile java.lang.Object path_;
+    private com.google.protobuf.LazyStringList path_;
     /**
      * <pre>
-     * The artifact path, relative to the Run's artifact root location, for which to
+     * The artifact paths, relative to the Run's artifact root location, for which to
      * fetch artifact write credentials
      * </pre>
      *
-     * <code>optional string path = 2 [(.mlflow.validate_required) = true];</code>
+     * <code>repeated string path = 2;</code>
      */
-    public boolean hasPath() {
+    public com.google.protobuf.ProtocolStringList
+        getPathList() {
+      return path_;
+    }
+    /**
+     * <pre>
+     * The artifact paths, relative to the Run's artifact root location, for which to
+     * fetch artifact write credentials
+     * </pre>
+     *
+     * <code>repeated string path = 2;</code>
+     */
+    public int getPathCount() {
+      return path_.size();
+    }
+    /**
+     * <pre>
+     * The artifact paths, relative to the Run's artifact root location, for which to
+     * fetch artifact write credentials
+     * </pre>
+     *
+     * <code>repeated string path = 2;</code>
+     */
+    public java.lang.String getPath(int index) {
+      return path_.get(index);
+    }
+    /**
+     * <pre>
+     * The artifact paths, relative to the Run's artifact root location, for which to
+     * fetch artifact write credentials
+     * </pre>
+     *
+     * <code>repeated string path = 2;</code>
+     */
+    public com.google.protobuf.ByteString
+        getPathBytes(int index) {
+      return path_.getByteString(index);
+    }
+
+    public static final int PAGE_TOKEN_FIELD_NUMBER = 3;
+    private volatile java.lang.Object pageToken_;
+    /**
+     * <pre>
+     * Token specifying the page of credentials to fetch for large requests that require pagination
+     * </pre>
+     *
+     * <code>optional string page_token = 3;</code>
+     */
+    public boolean hasPageToken() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
     }
     /**
      * <pre>
-     * The artifact path, relative to the Run's artifact root location, for which to
-     * fetch artifact write credentials
+     * Token specifying the page of credentials to fetch for large requests that require pagination
      * </pre>
      *
-     * <code>optional string path = 2 [(.mlflow.validate_required) = true];</code>
+     * <code>optional string page_token = 3;</code>
      */
-    public java.lang.String getPath() {
-      java.lang.Object ref = path_;
+    public java.lang.String getPageToken() {
+      java.lang.Object ref = pageToken_;
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
@@ -5158,27 +6381,26 @@ public final class DatabricksArtifacts {
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
-          path_ = s;
+          pageToken_ = s;
         }
         return s;
       }
     }
     /**
      * <pre>
-     * The artifact path, relative to the Run's artifact root location, for which to
-     * fetch artifact write credentials
+     * Token specifying the page of credentials to fetch for large requests that require pagination
      * </pre>
      *
-     * <code>optional string path = 2 [(.mlflow.validate_required) = true];</code>
+     * <code>optional string page_token = 3;</code>
      */
     public com.google.protobuf.ByteString
-        getPathBytes() {
-      java.lang.Object ref = path_;
+        getPageTokenBytes() {
+      java.lang.Object ref = pageToken_;
       if (ref instanceof java.lang.String) {
         com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
-        path_ = b;
+        pageToken_ = b;
         return b;
       } else {
         return (com.google.protobuf.ByteString) ref;
@@ -5202,8 +6424,11 @@ public final class DatabricksArtifacts {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, runId_);
       }
+      for (int i = 0; i < path_.size(); i++) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 2, path_.getRaw(i));
+      }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        com.google.protobuf.GeneratedMessageV3.writeString(output, 2, path_);
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 3, pageToken_);
       }
       unknownFields.writeTo(output);
     }
@@ -5217,8 +6442,16 @@ public final class DatabricksArtifacts {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, runId_);
       }
+      {
+        int dataSize = 0;
+        for (int i = 0; i < path_.size(); i++) {
+          dataSize += computeStringSizeNoTag(path_.getRaw(i));
+        }
+        size += dataSize;
+        size += 1 * getPathList().size();
+      }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, path_);
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, pageToken_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -5241,10 +6474,12 @@ public final class DatabricksArtifacts {
         result = result && getRunId()
             .equals(other.getRunId());
       }
-      result = result && (hasPath() == other.hasPath());
-      if (hasPath()) {
-        result = result && getPath()
-            .equals(other.getPath());
+      result = result && getPathList()
+          .equals(other.getPathList());
+      result = result && (hasPageToken() == other.hasPageToken());
+      if (hasPageToken()) {
+        result = result && getPageToken()
+            .equals(other.getPageToken());
       }
       result = result && unknownFields.equals(other.unknownFields);
       return result;
@@ -5261,9 +6496,13 @@ public final class DatabricksArtifacts {
         hash = (37 * hash) + RUN_ID_FIELD_NUMBER;
         hash = (53 * hash) + getRunId().hashCode();
       }
-      if (hasPath()) {
+      if (getPathCount() > 0) {
         hash = (37 * hash) + PATH_FIELD_NUMBER;
-        hash = (53 * hash) + getPath().hashCode();
+        hash = (53 * hash) + getPathList().hashCode();
+      }
+      if (hasPageToken()) {
+        hash = (37 * hash) + PAGE_TOKEN_FIELD_NUMBER;
+        hash = (53 * hash) + getPageToken().hashCode();
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
@@ -5400,8 +6639,10 @@ public final class DatabricksArtifacts {
         super.clear();
         runId_ = "";
         bitField0_ = (bitField0_ & ~0x00000001);
-        path_ = "";
+        path_ = com.google.protobuf.LazyStringArrayList.EMPTY;
         bitField0_ = (bitField0_ & ~0x00000002);
+        pageToken_ = "";
+        bitField0_ = (bitField0_ & ~0x00000004);
         return this;
       }
 
@@ -5434,10 +6675,15 @@ public final class DatabricksArtifacts {
           to_bitField0_ |= 0x00000001;
         }
         result.runId_ = runId_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-          to_bitField0_ |= 0x00000002;
+        if (((bitField0_ & 0x00000002) == 0x00000002)) {
+          path_ = path_.getUnmodifiableView();
+          bitField0_ = (bitField0_ & ~0x00000002);
         }
         result.path_ = path_;
+        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        result.pageToken_ = pageToken_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -5492,9 +6738,19 @@ public final class DatabricksArtifacts {
           runId_ = other.runId_;
           onChanged();
         }
-        if (other.hasPath()) {
-          bitField0_ |= 0x00000002;
-          path_ = other.path_;
+        if (!other.path_.isEmpty()) {
+          if (path_.isEmpty()) {
+            path_ = other.path_;
+            bitField0_ = (bitField0_ & ~0x00000002);
+          } else {
+            ensurePathIsMutable();
+            path_.addAll(other.path_);
+          }
+          onChanged();
+        }
+        if (other.hasPageToken()) {
+          bitField0_ |= 0x00000004;
+          pageToken_ = other.pageToken_;
           onChanged();
         }
         this.mergeUnknownFields(other.unknownFields);
@@ -5627,34 +6883,170 @@ public final class DatabricksArtifacts {
         return this;
       }
 
-      private java.lang.Object path_ = "";
-      /**
-       * <pre>
-       * The artifact path, relative to the Run's artifact root location, for which to
-       * fetch artifact write credentials
-       * </pre>
-       *
-       * <code>optional string path = 2 [(.mlflow.validate_required) = true];</code>
-       */
-      public boolean hasPath() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+      private com.google.protobuf.LazyStringList path_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      private void ensurePathIsMutable() {
+        if (!((bitField0_ & 0x00000002) == 0x00000002)) {
+          path_ = new com.google.protobuf.LazyStringArrayList(path_);
+          bitField0_ |= 0x00000002;
+         }
       }
       /**
        * <pre>
-       * The artifact path, relative to the Run's artifact root location, for which to
+       * The artifact paths, relative to the Run's artifact root location, for which to
        * fetch artifact write credentials
        * </pre>
        *
-       * <code>optional string path = 2 [(.mlflow.validate_required) = true];</code>
+       * <code>repeated string path = 2;</code>
        */
-      public java.lang.String getPath() {
-        java.lang.Object ref = path_;
+      public com.google.protobuf.ProtocolStringList
+          getPathList() {
+        return path_.getUnmodifiableView();
+      }
+      /**
+       * <pre>
+       * The artifact paths, relative to the Run's artifact root location, for which to
+       * fetch artifact write credentials
+       * </pre>
+       *
+       * <code>repeated string path = 2;</code>
+       */
+      public int getPathCount() {
+        return path_.size();
+      }
+      /**
+       * <pre>
+       * The artifact paths, relative to the Run's artifact root location, for which to
+       * fetch artifact write credentials
+       * </pre>
+       *
+       * <code>repeated string path = 2;</code>
+       */
+      public java.lang.String getPath(int index) {
+        return path_.get(index);
+      }
+      /**
+       * <pre>
+       * The artifact paths, relative to the Run's artifact root location, for which to
+       * fetch artifact write credentials
+       * </pre>
+       *
+       * <code>repeated string path = 2;</code>
+       */
+      public com.google.protobuf.ByteString
+          getPathBytes(int index) {
+        return path_.getByteString(index);
+      }
+      /**
+       * <pre>
+       * The artifact paths, relative to the Run's artifact root location, for which to
+       * fetch artifact write credentials
+       * </pre>
+       *
+       * <code>repeated string path = 2;</code>
+       */
+      public Builder setPath(
+          int index, java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensurePathIsMutable();
+        path_.set(index, value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The artifact paths, relative to the Run's artifact root location, for which to
+       * fetch artifact write credentials
+       * </pre>
+       *
+       * <code>repeated string path = 2;</code>
+       */
+      public Builder addPath(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensurePathIsMutable();
+        path_.add(value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The artifact paths, relative to the Run's artifact root location, for which to
+       * fetch artifact write credentials
+       * </pre>
+       *
+       * <code>repeated string path = 2;</code>
+       */
+      public Builder addAllPath(
+          java.lang.Iterable<java.lang.String> values) {
+        ensurePathIsMutable();
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, path_);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The artifact paths, relative to the Run's artifact root location, for which to
+       * fetch artifact write credentials
+       * </pre>
+       *
+       * <code>repeated string path = 2;</code>
+       */
+      public Builder clearPath() {
+        path_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000002);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The artifact paths, relative to the Run's artifact root location, for which to
+       * fetch artifact write credentials
+       * </pre>
+       *
+       * <code>repeated string path = 2;</code>
+       */
+      public Builder addPathBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensurePathIsMutable();
+        path_.add(value);
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object pageToken_ = "";
+      /**
+       * <pre>
+       * Token specifying the page of credentials to fetch for large requests that require pagination
+       * </pre>
+       *
+       * <code>optional string page_token = 3;</code>
+       */
+      public boolean hasPageToken() {
+        return ((bitField0_ & 0x00000004) == 0x00000004);
+      }
+      /**
+       * <pre>
+       * Token specifying the page of credentials to fetch for large requests that require pagination
+       * </pre>
+       *
+       * <code>optional string page_token = 3;</code>
+       */
+      public java.lang.String getPageToken() {
+        java.lang.Object ref = pageToken_;
         if (!(ref instanceof java.lang.String)) {
           com.google.protobuf.ByteString bs =
               (com.google.protobuf.ByteString) ref;
           java.lang.String s = bs.toStringUtf8();
           if (bs.isValidUtf8()) {
-            path_ = s;
+            pageToken_ = s;
           }
           return s;
         } else {
@@ -5663,20 +7055,19 @@ public final class DatabricksArtifacts {
       }
       /**
        * <pre>
-       * The artifact path, relative to the Run's artifact root location, for which to
-       * fetch artifact write credentials
+       * Token specifying the page of credentials to fetch for large requests that require pagination
        * </pre>
        *
-       * <code>optional string path = 2 [(.mlflow.validate_required) = true];</code>
+       * <code>optional string page_token = 3;</code>
        */
       public com.google.protobuf.ByteString
-          getPathBytes() {
-        java.lang.Object ref = path_;
+          getPageTokenBytes() {
+        java.lang.Object ref = pageToken_;
         if (ref instanceof String) {
           com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
-          path_ = b;
+          pageToken_ = b;
           return b;
         } else {
           return (com.google.protobuf.ByteString) ref;
@@ -5684,51 +7075,48 @@ public final class DatabricksArtifacts {
       }
       /**
        * <pre>
-       * The artifact path, relative to the Run's artifact root location, for which to
-       * fetch artifact write credentials
+       * Token specifying the page of credentials to fetch for large requests that require pagination
        * </pre>
        *
-       * <code>optional string path = 2 [(.mlflow.validate_required) = true];</code>
+       * <code>optional string page_token = 3;</code>
        */
-      public Builder setPath(
+      public Builder setPageToken(
           java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
-  bitField0_ |= 0x00000002;
-        path_ = value;
+  bitField0_ |= 0x00000004;
+        pageToken_ = value;
         onChanged();
         return this;
       }
       /**
        * <pre>
-       * The artifact path, relative to the Run's artifact root location, for which to
-       * fetch artifact write credentials
+       * Token specifying the page of credentials to fetch for large requests that require pagination
        * </pre>
        *
-       * <code>optional string path = 2 [(.mlflow.validate_required) = true];</code>
+       * <code>optional string page_token = 3;</code>
        */
-      public Builder clearPath() {
-        bitField0_ = (bitField0_ & ~0x00000002);
-        path_ = getDefaultInstance().getPath();
+      public Builder clearPageToken() {
+        bitField0_ = (bitField0_ & ~0x00000004);
+        pageToken_ = getDefaultInstance().getPageToken();
         onChanged();
         return this;
       }
       /**
        * <pre>
-       * The artifact path, relative to the Run's artifact root location, for which to
-       * fetch artifact write credentials
+       * Token specifying the page of credentials to fetch for large requests that require pagination
        * </pre>
        *
-       * <code>optional string path = 2 [(.mlflow.validate_required) = true];</code>
+       * <code>optional string page_token = 3;</code>
        */
-      public Builder setPathBytes(
+      public Builder setPageTokenBytes(
           com.google.protobuf.ByteString value) {
         if (value == null) {
     throw new NullPointerException();
   }
-  bitField0_ |= 0x00000002;
-        path_ = value;
+  bitField0_ |= 0x00000004;
+        pageToken_ = value;
         onChanged();
         return this;
       }
@@ -5831,31 +7219,33 @@ public final class DatabricksArtifacts {
       "aders\030\004 \003(\0132).mlflow.ArtifactCredentialI" +
       "nfo.HttpHeader\022,\n\004type\030\005 \001(\0162\036.mlflow.Ar" +
       "tifactCredentialType\032)\n\nHttpHeader\022\014\n\004na" +
-      "me\030\001 \001(\t\022\r\n\005value\030\002 \001(\t\"\343\001\n\025GetCredentia" +
-      "lsForRead\022\024\n\006run_id\030\001 \001(\tB\004\370\206\031\001\022\022\n\004path\030" +
-      "\002 \001(\tB\004\370\206\031\001\032?\n\010Response\0223\n\013credentials\030\001" +
-      " \001(\0132\036.mlflow.ArtifactCredentialInfo:_\342?" +
-      "(\n&com.databricks.rpc.RPC[$this.Response" +
-      "]\342?1\n/com.databricks.mlflow.api.MlflowTr" +
-      "ackingMessage\"\344\001\n\026GetCredentialsForWrite" +
-      "\022\024\n\006run_id\030\001 \001(\tB\004\370\206\031\001\022\022\n\004path\030\002 \001(\tB\004\370\206" +
-      "\031\001\032?\n\010Response\0223\n\013credentials\030\001 \001(\0132\036.ml" +
-      "flow.ArtifactCredentialInfo:_\342?(\n&com.da" +
-      "tabricks.rpc.RPC[$this.Response]\342?1\n/com" +
-      ".databricks.mlflow.api.MlflowTrackingMes" +
-      "sage*V\n\026ArtifactCredentialType\022\021\n\rAZURE_" +
-      "SAS_URI\020\001\022\025\n\021AWS_PRESIGNED_URL\020\002\022\022\n\016GCP_" +
-      "SIGNED_URL\020\0032\342\002\n DatabricksMlflowArtifac" +
-      "tsService\022\233\001\n\025getCredentialsForRead\022\035.ml" +
-      "flow.GetCredentialsForRead\032&.mlflow.GetC" +
-      "redentialsForRead.Response\";\362\206\0317\n3\n\003GET\022" +
-      "&/mlflow/artifacts/credentials-for-read\032" +
-      "\004\010\002\020\000\020\003\022\237\001\n\026getCredentialsForWrite\022\036.mlf" +
-      "low.GetCredentialsForWrite\032\'.mlflow.GetC" +
-      "redentialsForWrite.Response\"<\362\206\0318\n4\n\003GET" +
-      "\022\'/mlflow/artifacts/credentials-for-writ" +
-      "e\032\004\010\002\020\000\020\003B,\n\037com.databricks.api.proto.ml" +
-      "flow\220\001\001\240\001\001\342?\002\020\001"
+      "me\030\001 \001(\t\022\r\n\005value\030\002 \001(\t\"\217\002\n\025GetCredentia" +
+      "lsForRead\022\024\n\006run_id\030\001 \001(\tB\004\370\206\031\001\022\014\n\004path\030" +
+      "\002 \003(\t\022\022\n\npage_token\030\003 \001(\t\032]\n\010Response\0228\n" +
+      "\020credential_infos\030\002 \003(\0132\036.mlflow.Artifac" +
+      "tCredentialInfo\022\027\n\017next_page_token\030\003 \001(\t" +
+      ":_\342?(\n&com.databricks.rpc.RPC[$this.Resp" +
+      "onse]\342?1\n/com.databricks.mlflow.api.Mlfl" +
+      "owTrackingMessage\"\220\002\n\026GetCredentialsForW" +
+      "rite\022\024\n\006run_id\030\001 \001(\tB\004\370\206\031\001\022\014\n\004path\030\002 \003(\t" +
+      "\022\022\n\npage_token\030\003 \001(\t\032]\n\010Response\0228\n\020cred" +
+      "ential_infos\030\002 \003(\0132\036.mlflow.ArtifactCred" +
+      "entialInfo\022\027\n\017next_page_token\030\003 \001(\t:_\342?(" +
+      "\n&com.databricks.rpc.RPC[$this.Response]" +
+      "\342?1\n/com.databricks.mlflow.api.MlflowTra" +
+      "ckingMessage*V\n\026ArtifactCredentialType\022\021" +
+      "\n\rAZURE_SAS_URI\020\001\022\025\n\021AWS_PRESIGNED_URL\020\002" +
+      "\022\022\n\016GCP_SIGNED_URL\020\0032\342\002\n DatabricksMlflo" +
+      "wArtifactsService\022\233\001\n\025getCredentialsForR" +
+      "ead\022\035.mlflow.GetCredentialsForRead\032&.mlf" +
+      "low.GetCredentialsForRead.Response\";\362\206\0317" +
+      "\n3\n\003GET\022&/mlflow/artifacts/credentials-f" +
+      "or-read\032\004\010\002\020\000\020\003\022\237\001\n\026getCredentialsForWri" +
+      "te\022\036.mlflow.GetCredentialsForWrite\032\'.mlf" +
+      "low.GetCredentialsForWrite.Response\"<\362\206\031" +
+      "8\n4\n\003GET\022\'/mlflow/artifacts/credentials-" +
+      "for-write\032\004\010\002\020\000\020\003B,\n\037com.databricks.api." +
+      "proto.mlflow\220\001\001\240\001\001\342?\002\020\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -5888,25 +7278,25 @@ public final class DatabricksArtifacts {
     internal_static_mlflow_GetCredentialsForRead_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_GetCredentialsForRead_descriptor,
-        new java.lang.String[] { "RunId", "Path", });
+        new java.lang.String[] { "RunId", "Path", "PageToken", });
     internal_static_mlflow_GetCredentialsForRead_Response_descriptor =
       internal_static_mlflow_GetCredentialsForRead_descriptor.getNestedTypes().get(0);
     internal_static_mlflow_GetCredentialsForRead_Response_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_GetCredentialsForRead_Response_descriptor,
-        new java.lang.String[] { "Credentials", });
+        new java.lang.String[] { "CredentialInfos", "NextPageToken", });
     internal_static_mlflow_GetCredentialsForWrite_descriptor =
       getDescriptor().getMessageTypes().get(2);
     internal_static_mlflow_GetCredentialsForWrite_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_GetCredentialsForWrite_descriptor,
-        new java.lang.String[] { "RunId", "Path", });
+        new java.lang.String[] { "RunId", "Path", "PageToken", });
     internal_static_mlflow_GetCredentialsForWrite_Response_descriptor =
       internal_static_mlflow_GetCredentialsForWrite_descriptor.getNestedTypes().get(0);
     internal_static_mlflow_GetCredentialsForWrite_Response_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_GetCredentialsForWrite_Response_descriptor,
-        new java.lang.String[] { "Credentials", });
+        new java.lang.String[] { "CredentialInfos", "NextPageToken", });
     com.google.protobuf.ExtensionRegistry registry =
         com.google.protobuf.ExtensionRegistry.newInstance();
     registry.add(com.databricks.api.proto.databricks.Databricks.rpc);

--- a/mlflow/java/client/src/main/java/com/databricks/api/proto/mlflow/DatabricksArtifacts.java
+++ b/mlflow/java/client/src/main/java/com/databricks/api/proto/mlflow/DatabricksArtifacts.java
@@ -2752,7 +2752,7 @@ public final class DatabricksArtifacts {
     /**
      * <pre>
      * The artifact paths, relative to the Run's artifact root location, for which to
-     * fetch artifact read credentials
+     * fetch artifact read credentials. Must not be empty.
      * </pre>
      *
      * <code>repeated string path = 2;</code>
@@ -2762,7 +2762,7 @@ public final class DatabricksArtifacts {
     /**
      * <pre>
      * The artifact paths, relative to the Run's artifact root location, for which to
-     * fetch artifact read credentials
+     * fetch artifact read credentials. Must not be empty.
      * </pre>
      *
      * <code>repeated string path = 2;</code>
@@ -2771,7 +2771,7 @@ public final class DatabricksArtifacts {
     /**
      * <pre>
      * The artifact paths, relative to the Run's artifact root location, for which to
-     * fetch artifact read credentials
+     * fetch artifact read credentials. Must not be empty.
      * </pre>
      *
      * <code>repeated string path = 2;</code>
@@ -2780,7 +2780,7 @@ public final class DatabricksArtifacts {
     /**
      * <pre>
      * The artifact paths, relative to the Run's artifact root location, for which to
-     * fetch artifact read credentials
+     * fetch artifact read credentials. Must not be empty.
      * </pre>
      *
      * <code>repeated string path = 2;</code>
@@ -4082,7 +4082,7 @@ public final class DatabricksArtifacts {
     /**
      * <pre>
      * The artifact paths, relative to the Run's artifact root location, for which to
-     * fetch artifact read credentials
+     * fetch artifact read credentials. Must not be empty.
      * </pre>
      *
      * <code>repeated string path = 2;</code>
@@ -4094,7 +4094,7 @@ public final class DatabricksArtifacts {
     /**
      * <pre>
      * The artifact paths, relative to the Run's artifact root location, for which to
-     * fetch artifact read credentials
+     * fetch artifact read credentials. Must not be empty.
      * </pre>
      *
      * <code>repeated string path = 2;</code>
@@ -4105,7 +4105,7 @@ public final class DatabricksArtifacts {
     /**
      * <pre>
      * The artifact paths, relative to the Run's artifact root location, for which to
-     * fetch artifact read credentials
+     * fetch artifact read credentials. Must not be empty.
      * </pre>
      *
      * <code>repeated string path = 2;</code>
@@ -4116,7 +4116,7 @@ public final class DatabricksArtifacts {
     /**
      * <pre>
      * The artifact paths, relative to the Run's artifact root location, for which to
-     * fetch artifact read credentials
+     * fetch artifact read credentials. Must not be empty.
      * </pre>
      *
      * <code>repeated string path = 2;</code>
@@ -4666,7 +4666,7 @@ public final class DatabricksArtifacts {
       /**
        * <pre>
        * The artifact paths, relative to the Run's artifact root location, for which to
-       * fetch artifact read credentials
+       * fetch artifact read credentials. Must not be empty.
        * </pre>
        *
        * <code>repeated string path = 2;</code>
@@ -4678,7 +4678,7 @@ public final class DatabricksArtifacts {
       /**
        * <pre>
        * The artifact paths, relative to the Run's artifact root location, for which to
-       * fetch artifact read credentials
+       * fetch artifact read credentials. Must not be empty.
        * </pre>
        *
        * <code>repeated string path = 2;</code>
@@ -4689,7 +4689,7 @@ public final class DatabricksArtifacts {
       /**
        * <pre>
        * The artifact paths, relative to the Run's artifact root location, for which to
-       * fetch artifact read credentials
+       * fetch artifact read credentials. Must not be empty.
        * </pre>
        *
        * <code>repeated string path = 2;</code>
@@ -4700,7 +4700,7 @@ public final class DatabricksArtifacts {
       /**
        * <pre>
        * The artifact paths, relative to the Run's artifact root location, for which to
-       * fetch artifact read credentials
+       * fetch artifact read credentials. Must not be empty.
        * </pre>
        *
        * <code>repeated string path = 2;</code>
@@ -4712,7 +4712,7 @@ public final class DatabricksArtifacts {
       /**
        * <pre>
        * The artifact paths, relative to the Run's artifact root location, for which to
-       * fetch artifact read credentials
+       * fetch artifact read credentials. Must not be empty.
        * </pre>
        *
        * <code>repeated string path = 2;</code>
@@ -4730,7 +4730,7 @@ public final class DatabricksArtifacts {
       /**
        * <pre>
        * The artifact paths, relative to the Run's artifact root location, for which to
-       * fetch artifact read credentials
+       * fetch artifact read credentials. Must not be empty.
        * </pre>
        *
        * <code>repeated string path = 2;</code>
@@ -4748,7 +4748,7 @@ public final class DatabricksArtifacts {
       /**
        * <pre>
        * The artifact paths, relative to the Run's artifact root location, for which to
-       * fetch artifact read credentials
+       * fetch artifact read credentials. Must not be empty.
        * </pre>
        *
        * <code>repeated string path = 2;</code>
@@ -4764,7 +4764,7 @@ public final class DatabricksArtifacts {
       /**
        * <pre>
        * The artifact paths, relative to the Run's artifact root location, for which to
-       * fetch artifact read credentials
+       * fetch artifact read credentials. Must not be empty.
        * </pre>
        *
        * <code>repeated string path = 2;</code>
@@ -4778,7 +4778,7 @@ public final class DatabricksArtifacts {
       /**
        * <pre>
        * The artifact paths, relative to the Run's artifact root location, for which to
-       * fetch artifact read credentials
+       * fetch artifact read credentials. Must not be empty.
        * </pre>
        *
        * <code>repeated string path = 2;</code>
@@ -4979,7 +4979,7 @@ public final class DatabricksArtifacts {
     /**
      * <pre>
      * The artifact paths, relative to the Run's artifact root location, for which to
-     * fetch artifact write credentials
+     * fetch artifact write credentials. Must not be empty.
      * </pre>
      *
      * <code>repeated string path = 2;</code>
@@ -4989,7 +4989,7 @@ public final class DatabricksArtifacts {
     /**
      * <pre>
      * The artifact paths, relative to the Run's artifact root location, for which to
-     * fetch artifact write credentials
+     * fetch artifact write credentials. Must not be empty.
      * </pre>
      *
      * <code>repeated string path = 2;</code>
@@ -4998,7 +4998,7 @@ public final class DatabricksArtifacts {
     /**
      * <pre>
      * The artifact paths, relative to the Run's artifact root location, for which to
-     * fetch artifact write credentials
+     * fetch artifact write credentials. Must not be empty.
      * </pre>
      *
      * <code>repeated string path = 2;</code>
@@ -5007,7 +5007,7 @@ public final class DatabricksArtifacts {
     /**
      * <pre>
      * The artifact paths, relative to the Run's artifact root location, for which to
-     * fetch artifact write credentials
+     * fetch artifact write credentials. Must not be empty.
      * </pre>
      *
      * <code>repeated string path = 2;</code>
@@ -6309,7 +6309,7 @@ public final class DatabricksArtifacts {
     /**
      * <pre>
      * The artifact paths, relative to the Run's artifact root location, for which to
-     * fetch artifact write credentials
+     * fetch artifact write credentials. Must not be empty.
      * </pre>
      *
      * <code>repeated string path = 2;</code>
@@ -6321,7 +6321,7 @@ public final class DatabricksArtifacts {
     /**
      * <pre>
      * The artifact paths, relative to the Run's artifact root location, for which to
-     * fetch artifact write credentials
+     * fetch artifact write credentials. Must not be empty.
      * </pre>
      *
      * <code>repeated string path = 2;</code>
@@ -6332,7 +6332,7 @@ public final class DatabricksArtifacts {
     /**
      * <pre>
      * The artifact paths, relative to the Run's artifact root location, for which to
-     * fetch artifact write credentials
+     * fetch artifact write credentials. Must not be empty.
      * </pre>
      *
      * <code>repeated string path = 2;</code>
@@ -6343,7 +6343,7 @@ public final class DatabricksArtifacts {
     /**
      * <pre>
      * The artifact paths, relative to the Run's artifact root location, for which to
-     * fetch artifact write credentials
+     * fetch artifact write credentials. Must not be empty.
      * </pre>
      *
      * <code>repeated string path = 2;</code>
@@ -6893,7 +6893,7 @@ public final class DatabricksArtifacts {
       /**
        * <pre>
        * The artifact paths, relative to the Run's artifact root location, for which to
-       * fetch artifact write credentials
+       * fetch artifact write credentials. Must not be empty.
        * </pre>
        *
        * <code>repeated string path = 2;</code>
@@ -6905,7 +6905,7 @@ public final class DatabricksArtifacts {
       /**
        * <pre>
        * The artifact paths, relative to the Run's artifact root location, for which to
-       * fetch artifact write credentials
+       * fetch artifact write credentials. Must not be empty.
        * </pre>
        *
        * <code>repeated string path = 2;</code>
@@ -6916,7 +6916,7 @@ public final class DatabricksArtifacts {
       /**
        * <pre>
        * The artifact paths, relative to the Run's artifact root location, for which to
-       * fetch artifact write credentials
+       * fetch artifact write credentials. Must not be empty.
        * </pre>
        *
        * <code>repeated string path = 2;</code>
@@ -6927,7 +6927,7 @@ public final class DatabricksArtifacts {
       /**
        * <pre>
        * The artifact paths, relative to the Run's artifact root location, for which to
-       * fetch artifact write credentials
+       * fetch artifact write credentials. Must not be empty.
        * </pre>
        *
        * <code>repeated string path = 2;</code>
@@ -6939,7 +6939,7 @@ public final class DatabricksArtifacts {
       /**
        * <pre>
        * The artifact paths, relative to the Run's artifact root location, for which to
-       * fetch artifact write credentials
+       * fetch artifact write credentials. Must not be empty.
        * </pre>
        *
        * <code>repeated string path = 2;</code>
@@ -6957,7 +6957,7 @@ public final class DatabricksArtifacts {
       /**
        * <pre>
        * The artifact paths, relative to the Run's artifact root location, for which to
-       * fetch artifact write credentials
+       * fetch artifact write credentials. Must not be empty.
        * </pre>
        *
        * <code>repeated string path = 2;</code>
@@ -6975,7 +6975,7 @@ public final class DatabricksArtifacts {
       /**
        * <pre>
        * The artifact paths, relative to the Run's artifact root location, for which to
-       * fetch artifact write credentials
+       * fetch artifact write credentials. Must not be empty.
        * </pre>
        *
        * <code>repeated string path = 2;</code>
@@ -6991,7 +6991,7 @@ public final class DatabricksArtifacts {
       /**
        * <pre>
        * The artifact paths, relative to the Run's artifact root location, for which to
-       * fetch artifact write credentials
+       * fetch artifact write credentials. Must not be empty.
        * </pre>
        *
        * <code>repeated string path = 2;</code>
@@ -7005,7 +7005,7 @@ public final class DatabricksArtifacts {
       /**
        * <pre>
        * The artifact paths, relative to the Run's artifact root location, for which to
-       * fetch artifact write credentials
+       * fetch artifact write credentials. Must not be empty.
        * </pre>
        *
        * <code>repeated string path = 2;</code>
@@ -7219,33 +7219,33 @@ public final class DatabricksArtifacts {
       "aders\030\004 \003(\0132).mlflow.ArtifactCredentialI" +
       "nfo.HttpHeader\022,\n\004type\030\005 \001(\0162\036.mlflow.Ar" +
       "tifactCredentialType\032)\n\nHttpHeader\022\014\n\004na" +
-      "me\030\001 \001(\t\022\r\n\005value\030\002 \001(\t\"\217\002\n\025GetCredentia" +
+      "me\030\001 \001(\t\022\r\n\005value\030\002 \001(\t\"\225\002\n\025GetCredentia" +
       "lsForRead\022\024\n\006run_id\030\001 \001(\tB\004\370\206\031\001\022\014\n\004path\030" +
-      "\002 \003(\t\022\022\n\npage_token\030\003 \001(\t\032]\n\010Response\0228\n" +
+      "\002 \003(\t\022\022\n\npage_token\030\003 \001(\t\032c\n\010Response\0228\n" +
       "\020credential_infos\030\002 \003(\0132\036.mlflow.Artifac" +
       "tCredentialInfo\022\027\n\017next_page_token\030\003 \001(\t" +
-      ":_\342?(\n&com.databricks.rpc.RPC[$this.Resp" +
-      "onse]\342?1\n/com.databricks.mlflow.api.Mlfl" +
-      "owTrackingMessage\"\220\002\n\026GetCredentialsForW" +
-      "rite\022\024\n\006run_id\030\001 \001(\tB\004\370\206\031\001\022\014\n\004path\030\002 \003(\t" +
-      "\022\022\n\npage_token\030\003 \001(\t\032]\n\010Response\0228\n\020cred" +
-      "ential_infos\030\002 \003(\0132\036.mlflow.ArtifactCred" +
-      "entialInfo\022\027\n\017next_page_token\030\003 \001(\t:_\342?(" +
-      "\n&com.databricks.rpc.RPC[$this.Response]" +
-      "\342?1\n/com.databricks.mlflow.api.MlflowTra" +
-      "ckingMessage*V\n\026ArtifactCredentialType\022\021" +
-      "\n\rAZURE_SAS_URI\020\001\022\025\n\021AWS_PRESIGNED_URL\020\002" +
-      "\022\022\n\016GCP_SIGNED_URL\020\0032\344\002\n DatabricksMlflo" +
-      "wArtifactsService\022\234\001\n\025getCredentialsForR" +
-      "ead\022\035.mlflow.GetCredentialsForRead\032&.mlf" +
-      "low.GetCredentialsForRead.Response\"<\362\206\0318" +
-      "\n4\n\004POST\022&/mlflow/artifacts/credentials-" +
-      "for-read\032\004\010\002\020\000\020\003\022\240\001\n\026getCredentialsForWr" +
-      "ite\022\036.mlflow.GetCredentialsForWrite\032\'.ml" +
-      "flow.GetCredentialsForWrite.Response\"=\362\206" +
-      "\0319\n5\n\004POST\022\'/mlflow/artifacts/credential" +
-      "s-for-write\032\004\010\002\020\000\020\003B,\n\037com.databricks.ap" +
-      "i.proto.mlflow\220\001\001\240\001\001\342?\002\020\001"
+      "J\004\010\001\020\002:_\342?(\n&com.databricks.rpc.RPC[$thi" +
+      "s.Response]\342?1\n/com.databricks.mlflow.ap" +
+      "i.MlflowTrackingMessage\"\226\002\n\026GetCredentia" +
+      "lsForWrite\022\024\n\006run_id\030\001 \001(\tB\004\370\206\031\001\022\014\n\004path" +
+      "\030\002 \003(\t\022\022\n\npage_token\030\003 \001(\t\032c\n\010Response\0228" +
+      "\n\020credential_infos\030\002 \003(\0132\036.mlflow.Artifa" +
+      "ctCredentialInfo\022\027\n\017next_page_token\030\003 \001(" +
+      "\tJ\004\010\001\020\002:_\342?(\n&com.databricks.rpc.RPC[$th" +
+      "is.Response]\342?1\n/com.databricks.mlflow.a" +
+      "pi.MlflowTrackingMessage*V\n\026ArtifactCred" +
+      "entialType\022\021\n\rAZURE_SAS_URI\020\001\022\025\n\021AWS_PRE" +
+      "SIGNED_URL\020\002\022\022\n\016GCP_SIGNED_URL\020\0032\344\002\n Dat" +
+      "abricksMlflowArtifactsService\022\234\001\n\025getCre" +
+      "dentialsForRead\022\035.mlflow.GetCredentialsF" +
+      "orRead\032&.mlflow.GetCredentialsForRead.Re" +
+      "sponse\"<\362\206\0318\n4\n\004POST\022&/mlflow/artifacts/" +
+      "credentials-for-read\032\004\010\002\020\000\020\003\022\240\001\n\026getCred" +
+      "entialsForWrite\022\036.mlflow.GetCredentialsF" +
+      "orWrite\032\'.mlflow.GetCredentialsForWrite." +
+      "Response\"=\362\206\0319\n5\n\004POST\022\'/mlflow/artifact" +
+      "s/credentials-for-write\032\004\010\002\020\000\020\003B,\n\037com.d" +
+      "atabricks.api.proto.mlflow\220\001\001\240\001\001\342?\002\020\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {

--- a/mlflow/protos/databricks_artifacts.proto
+++ b/mlflow/protos/databricks_artifacts.proto
@@ -101,7 +101,7 @@ message GetCredentialsForRead {
   optional string run_id = 1 [(validate_required) = true];
 
   // The artifact paths, relative to the Run's artifact root location, for which to
-  // fetch artifact read credentials
+  // fetch artifact read credentials. Must not be empty.
   repeated string path = 2;
 
   // Token specifying the page of credentials to fetch for large requests that require pagination
@@ -109,16 +109,14 @@ message GetCredentialsForRead {
 
   message Response {
 
-    // DEPRECATED: Credentials for reading from a single specified artifact location.
-    // Older versions of the MLflow client use this field to retrieve credentials via point fetches.
-    // This field is populated with the first element of the new `credential_infos` field
-    // optional ArtifactCredentialInfo credentials = 1 [deprecated = true];
-
     // Credentials for reading from the specified artifact locations
     repeated ArtifactCredentialInfo credential_infos = 2;
 
     // Token used to fetch the next page of credentials for large requests that require pagination
     optional string next_page_token = 3;
+
+    // Older versions of the MLflow client use this field to retrieve credentials via point fetches.
+    reserved 1;
 
   }
 }
@@ -131,7 +129,7 @@ message GetCredentialsForWrite {
   optional string run_id = 1 [(validate_required) = true];
 
   // The artifact paths, relative to the Run's artifact root location, for which to
-  // fetch artifact write credentials
+  // fetch artifact write credentials. Must not be empty.
   repeated string path = 2;
 
   // Token specifying the page of credentials to fetch for large requests that require pagination
@@ -139,16 +137,14 @@ message GetCredentialsForWrite {
 
   message Response {
 
-    // DEPRECATED: Credentials for writing to a single specified artifact location.
-    // Older versions of the MLflow client use this field to retrieve credentials via point fetches.
-    // This field is populated with the first element of the new `credential_infos` field
-    // optional ArtifactCredentialInfo credentials = 1 [deprecated = true];
-
     // Credentials for writing to the specified artifact locations
     repeated ArtifactCredentialInfo credential_infos = 2;
 
     // Token used to fetch the next page of credentials for large requests that require pagination
     optional string next_page_token = 3;
+
+    // Older versions of the MLflow client use this field to retrieve credentials via point fetches.
+    reserved 1;
 
   }
 }

--- a/mlflow/protos/databricks_artifacts.proto
+++ b/mlflow/protos/databricks_artifacts.proto
@@ -100,14 +100,25 @@ message GetCredentialsForRead {
   // The ID of the MLflow Run for which to fetch artifact read credentials
   optional string run_id = 1 [(validate_required) = true];
 
-  // The artifact path, relative to the Run's artifact root location, for which to
+  // The artifact paths, relative to the Run's artifact root location, for which to
   // fetch artifact read credentials
-  optional string path = 2 [(validate_required) = true];
+  repeated string path = 2;
+
+  // Token specifying the page of credentials to fetch for large requests that require pagination
+  optional string page_token = 3;
 
   message Response {
 
-    // Credentials for reading from the specified artifact location
-    optional ArtifactCredentialInfo credentials = 1;
+    // DEPRECATED: Credentials for reading from a single specified artifact location.
+    // Older versions of the MLflow client use this field to retrieve credentials via point fetches.
+    // This field is populated with the first element of the new `credential_infos` field
+    // optional ArtifactCredentialInfo credentials = 1 [deprecated = true];
+
+    // Credentials for reading from the specified artifact locations
+    repeated ArtifactCredentialInfo credential_infos = 2;
+
+    // Token used to fetch the next page of credentials for large requests that require pagination
+    optional string next_page_token = 3;
 
   }
 }
@@ -119,14 +130,25 @@ message GetCredentialsForWrite {
   // The ID of the MLflow Run for which to fetch artifact write credentials
   optional string run_id = 1 [(validate_required) = true];
 
-  // The artifact path, relative to the Run's artifact root location, for which to
+  // The artifact paths, relative to the Run's artifact root location, for which to
   // fetch artifact write credentials
-  optional string path = 2 [(validate_required) = true];
+  repeated string path = 2;
+
+  // Token specifying the page of credentials to fetch for large requests that require pagination
+  optional string page_token = 3;
 
   message Response {
 
-    // Credentials for writing to the specified artifacts location
-    optional ArtifactCredentialInfo credentials = 1;
+    // DEPRECATED: Credentials for writing to a single specified artifact location.
+    // Older versions of the MLflow client use this field to retrieve credentials via point fetches.
+    // This field is populated with the first element of the new `credential_infos` field
+    // optional ArtifactCredentialInfo credentials = 1 [deprecated = true];
+
+    // Credentials for writing to the specified artifact locations
+    repeated ArtifactCredentialInfo credential_infos = 2;
+
+    // Token used to fetch the next page of credentials for large requests that require pagination
+    optional string next_page_token = 3;
 
   }
 }

--- a/mlflow/protos/databricks_artifacts.proto
+++ b/mlflow/protos/databricks_artifacts.proto
@@ -23,7 +23,7 @@ service DatabricksMlflowArtifactsService {
   rpc getCredentialsForRead (GetCredentialsForRead) returns (GetCredentialsForRead.Response) {
     option (rpc) = {
       endpoints: [{
-        method: "GET",
+        method: "POST",
         path: "/mlflow/artifacts/credentials-for-read"
         since { major: 2, minor: 0 },
       }],
@@ -35,7 +35,7 @@ service DatabricksMlflowArtifactsService {
   rpc getCredentialsForWrite (GetCredentialsForWrite) returns (GetCredentialsForWrite.Response) {
     option (rpc) = {
       endpoints: [{
-        method: "GET",
+        method: "POST",
         path: "/mlflow/artifacts/credentials-for-write"
         since { major: 2, minor: 0 },
       }],

--- a/mlflow/protos/databricks_artifacts_pb2.py
+++ b/mlflow/protos/databricks_artifacts_pb2.py
@@ -24,7 +24,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='mlflow',
   syntax='proto2',
   serialized_options=_b('\n\037com.databricks.api.proto.mlflow\220\001\001\240\001\001\342?\002\020\001'),
-  serialized_pb=_b('\n\x1a\x64\x61tabricks_artifacts.proto\x12\x06mlflow\x1a\x15scalapb/scalapb.proto\x1a\x10\x64\x61tabricks.proto\"\xdf\x01\n\x16\x41rtifactCredentialInfo\x12\x0e\n\x06run_id\x18\x01 \x01(\t\x12\x0c\n\x04path\x18\x02 \x01(\t\x12\x12\n\nsigned_uri\x18\x03 \x01(\t\x12:\n\x07headers\x18\x04 \x03(\x0b\x32).mlflow.ArtifactCredentialInfo.HttpHeader\x12,\n\x04type\x18\x05 \x01(\x0e\x32\x1e.mlflow.ArtifactCredentialType\x1a)\n\nHttpHeader\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"\x8f\x02\n\x15GetCredentialsForRead\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0c\n\x04path\x18\x02 \x03(\t\x12\x12\n\npage_token\x18\x03 \x01(\t\x1a]\n\x08Response\x12\x38\n\x10\x63redential_infos\x18\x02 \x03(\x0b\x32\x1e.mlflow.ArtifactCredentialInfo\x12\x17\n\x0fnext_page_token\x18\x03 \x01(\t:_\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\xe2?1\n/com.databricks.mlflow.api.MlflowTrackingMessage\"\x90\x02\n\x16GetCredentialsForWrite\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0c\n\x04path\x18\x02 \x03(\t\x12\x12\n\npage_token\x18\x03 \x01(\t\x1a]\n\x08Response\x12\x38\n\x10\x63redential_infos\x18\x02 \x03(\x0b\x32\x1e.mlflow.ArtifactCredentialInfo\x12\x17\n\x0fnext_page_token\x18\x03 \x01(\t:_\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\xe2?1\n/com.databricks.mlflow.api.MlflowTrackingMessage*V\n\x16\x41rtifactCredentialType\x12\x11\n\rAZURE_SAS_URI\x10\x01\x12\x15\n\x11\x41WS_PRESIGNED_URL\x10\x02\x12\x12\n\x0eGCP_SIGNED_URL\x10\x03\x32\xe2\x02\n DatabricksMlflowArtifactsService\x12\x9b\x01\n\x15getCredentialsForRead\x12\x1d.mlflow.GetCredentialsForRead\x1a&.mlflow.GetCredentialsForRead.Response\";\xf2\x86\x19\x37\n3\n\x03GET\x12&/mlflow/artifacts/credentials-for-read\x1a\x04\x08\x02\x10\x00\x10\x03\x12\x9f\x01\n\x16getCredentialsForWrite\x12\x1e.mlflow.GetCredentialsForWrite\x1a\'.mlflow.GetCredentialsForWrite.Response\"<\xf2\x86\x19\x38\n4\n\x03GET\x12\'/mlflow/artifacts/credentials-for-write\x1a\x04\x08\x02\x10\x00\x10\x03\x42,\n\x1f\x63om.databricks.api.proto.mlflow\x90\x01\x01\xa0\x01\x01\xe2?\x02\x10\x01')
+  serialized_pb=_b('\n\x1a\x64\x61tabricks_artifacts.proto\x12\x06mlflow\x1a\x15scalapb/scalapb.proto\x1a\x10\x64\x61tabricks.proto\"\xdf\x01\n\x16\x41rtifactCredentialInfo\x12\x0e\n\x06run_id\x18\x01 \x01(\t\x12\x0c\n\x04path\x18\x02 \x01(\t\x12\x12\n\nsigned_uri\x18\x03 \x01(\t\x12:\n\x07headers\x18\x04 \x03(\x0b\x32).mlflow.ArtifactCredentialInfo.HttpHeader\x12,\n\x04type\x18\x05 \x01(\x0e\x32\x1e.mlflow.ArtifactCredentialType\x1a)\n\nHttpHeader\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"\x8f\x02\n\x15GetCredentialsForRead\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0c\n\x04path\x18\x02 \x03(\t\x12\x12\n\npage_token\x18\x03 \x01(\t\x1a]\n\x08Response\x12\x38\n\x10\x63redential_infos\x18\x02 \x03(\x0b\x32\x1e.mlflow.ArtifactCredentialInfo\x12\x17\n\x0fnext_page_token\x18\x03 \x01(\t:_\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\xe2?1\n/com.databricks.mlflow.api.MlflowTrackingMessage\"\x90\x02\n\x16GetCredentialsForWrite\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0c\n\x04path\x18\x02 \x03(\t\x12\x12\n\npage_token\x18\x03 \x01(\t\x1a]\n\x08Response\x12\x38\n\x10\x63redential_infos\x18\x02 \x03(\x0b\x32\x1e.mlflow.ArtifactCredentialInfo\x12\x17\n\x0fnext_page_token\x18\x03 \x01(\t:_\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\xe2?1\n/com.databricks.mlflow.api.MlflowTrackingMessage*V\n\x16\x41rtifactCredentialType\x12\x11\n\rAZURE_SAS_URI\x10\x01\x12\x15\n\x11\x41WS_PRESIGNED_URL\x10\x02\x12\x12\n\x0eGCP_SIGNED_URL\x10\x03\x32\xe4\x02\n DatabricksMlflowArtifactsService\x12\x9c\x01\n\x15getCredentialsForRead\x12\x1d.mlflow.GetCredentialsForRead\x1a&.mlflow.GetCredentialsForRead.Response\"<\xf2\x86\x19\x38\n4\n\x04POST\x12&/mlflow/artifacts/credentials-for-read\x1a\x04\x08\x02\x10\x00\x10\x03\x12\xa0\x01\n\x16getCredentialsForWrite\x12\x1e.mlflow.GetCredentialsForWrite\x1a\'.mlflow.GetCredentialsForWrite.Response\"=\xf2\x86\x19\x39\n5\n\x04POST\x12\'/mlflow/artifacts/credentials-for-write\x1a\x04\x08\x02\x10\x00\x10\x03\x42,\n\x1f\x63om.databricks.api.proto.mlflow\x90\x01\x01\xa0\x01\x01\xe2?\x02\x10\x01')
   ,
   dependencies=[scalapb_dot_scalapb__pb2.DESCRIPTOR,databricks__pb2.DESCRIPTOR,])
 
@@ -392,7 +392,7 @@ _DATABRICKSMLFLOWARTIFACTSSERVICE = _descriptor.ServiceDescriptor(
   index=0,
   serialized_options=None,
   serialized_start=943,
-  serialized_end=1297,
+  serialized_end=1299,
   methods=[
   _descriptor.MethodDescriptor(
     name='getCredentialsForRead',
@@ -401,7 +401,7 @@ _DATABRICKSMLFLOWARTIFACTSSERVICE = _descriptor.ServiceDescriptor(
     containing_service=None,
     input_type=_GETCREDENTIALSFORREAD,
     output_type=_GETCREDENTIALSFORREAD_RESPONSE,
-    serialized_options=_b('\362\206\0317\n3\n\003GET\022&/mlflow/artifacts/credentials-for-read\032\004\010\002\020\000\020\003'),
+    serialized_options=_b('\362\206\0318\n4\n\004POST\022&/mlflow/artifacts/credentials-for-read\032\004\010\002\020\000\020\003'),
   ),
   _descriptor.MethodDescriptor(
     name='getCredentialsForWrite',
@@ -410,7 +410,7 @@ _DATABRICKSMLFLOWARTIFACTSSERVICE = _descriptor.ServiceDescriptor(
     containing_service=None,
     input_type=_GETCREDENTIALSFORWRITE,
     output_type=_GETCREDENTIALSFORWRITE_RESPONSE,
-    serialized_options=_b('\362\206\0318\n4\n\003GET\022\'/mlflow/artifacts/credentials-for-write\032\004\010\002\020\000\020\003'),
+    serialized_options=_b('\362\206\0319\n5\n\004POST\022\'/mlflow/artifacts/credentials-for-write\032\004\010\002\020\000\020\003'),
   ),
 ])
 _sym_db.RegisterServiceDescriptor(_DATABRICKSMLFLOWARTIFACTSSERVICE)

--- a/mlflow/protos/databricks_artifacts_pb2.py
+++ b/mlflow/protos/databricks_artifacts_pb2.py
@@ -24,7 +24,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='mlflow',
   syntax='proto2',
   serialized_options=_b('\n\037com.databricks.api.proto.mlflow\220\001\001\240\001\001\342?\002\020\001'),
-  serialized_pb=_b('\n\x1a\x64\x61tabricks_artifacts.proto\x12\x06mlflow\x1a\x15scalapb/scalapb.proto\x1a\x10\x64\x61tabricks.proto\"\xdf\x01\n\x16\x41rtifactCredentialInfo\x12\x0e\n\x06run_id\x18\x01 \x01(\t\x12\x0c\n\x04path\x18\x02 \x01(\t\x12\x12\n\nsigned_uri\x18\x03 \x01(\t\x12:\n\x07headers\x18\x04 \x03(\x0b\x32).mlflow.ArtifactCredentialInfo.HttpHeader\x12,\n\x04type\x18\x05 \x01(\x0e\x32\x1e.mlflow.ArtifactCredentialType\x1a)\n\nHttpHeader\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"\xe3\x01\n\x15GetCredentialsForRead\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x12\n\x04path\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a?\n\x08Response\x12\x33\n\x0b\x63redentials\x18\x01 \x01(\x0b\x32\x1e.mlflow.ArtifactCredentialInfo:_\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\xe2?1\n/com.databricks.mlflow.api.MlflowTrackingMessage\"\xe4\x01\n\x16GetCredentialsForWrite\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x12\n\x04path\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a?\n\x08Response\x12\x33\n\x0b\x63redentials\x18\x01 \x01(\x0b\x32\x1e.mlflow.ArtifactCredentialInfo:_\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\xe2?1\n/com.databricks.mlflow.api.MlflowTrackingMessage*V\n\x16\x41rtifactCredentialType\x12\x11\n\rAZURE_SAS_URI\x10\x01\x12\x15\n\x11\x41WS_PRESIGNED_URL\x10\x02\x12\x12\n\x0eGCP_SIGNED_URL\x10\x03\x32\xe2\x02\n DatabricksMlflowArtifactsService\x12\x9b\x01\n\x15getCredentialsForRead\x12\x1d.mlflow.GetCredentialsForRead\x1a&.mlflow.GetCredentialsForRead.Response\";\xf2\x86\x19\x37\n3\n\x03GET\x12&/mlflow/artifacts/credentials-for-read\x1a\x04\x08\x02\x10\x00\x10\x03\x12\x9f\x01\n\x16getCredentialsForWrite\x12\x1e.mlflow.GetCredentialsForWrite\x1a\'.mlflow.GetCredentialsForWrite.Response\"<\xf2\x86\x19\x38\n4\n\x03GET\x12\'/mlflow/artifacts/credentials-for-write\x1a\x04\x08\x02\x10\x00\x10\x03\x42,\n\x1f\x63om.databricks.api.proto.mlflow\x90\x01\x01\xa0\x01\x01\xe2?\x02\x10\x01')
+  serialized_pb=_b('\n\x1a\x64\x61tabricks_artifacts.proto\x12\x06mlflow\x1a\x15scalapb/scalapb.proto\x1a\x10\x64\x61tabricks.proto\"\xdf\x01\n\x16\x41rtifactCredentialInfo\x12\x0e\n\x06run_id\x18\x01 \x01(\t\x12\x0c\n\x04path\x18\x02 \x01(\t\x12\x12\n\nsigned_uri\x18\x03 \x01(\t\x12:\n\x07headers\x18\x04 \x03(\x0b\x32).mlflow.ArtifactCredentialInfo.HttpHeader\x12,\n\x04type\x18\x05 \x01(\x0e\x32\x1e.mlflow.ArtifactCredentialType\x1a)\n\nHttpHeader\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"\x8f\x02\n\x15GetCredentialsForRead\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0c\n\x04path\x18\x02 \x03(\t\x12\x12\n\npage_token\x18\x03 \x01(\t\x1a]\n\x08Response\x12\x38\n\x10\x63redential_infos\x18\x02 \x03(\x0b\x32\x1e.mlflow.ArtifactCredentialInfo\x12\x17\n\x0fnext_page_token\x18\x03 \x01(\t:_\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\xe2?1\n/com.databricks.mlflow.api.MlflowTrackingMessage\"\x90\x02\n\x16GetCredentialsForWrite\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0c\n\x04path\x18\x02 \x03(\t\x12\x12\n\npage_token\x18\x03 \x01(\t\x1a]\n\x08Response\x12\x38\n\x10\x63redential_infos\x18\x02 \x03(\x0b\x32\x1e.mlflow.ArtifactCredentialInfo\x12\x17\n\x0fnext_page_token\x18\x03 \x01(\t:_\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\xe2?1\n/com.databricks.mlflow.api.MlflowTrackingMessage*V\n\x16\x41rtifactCredentialType\x12\x11\n\rAZURE_SAS_URI\x10\x01\x12\x15\n\x11\x41WS_PRESIGNED_URL\x10\x02\x12\x12\n\x0eGCP_SIGNED_URL\x10\x03\x32\xe2\x02\n DatabricksMlflowArtifactsService\x12\x9b\x01\n\x15getCredentialsForRead\x12\x1d.mlflow.GetCredentialsForRead\x1a&.mlflow.GetCredentialsForRead.Response\";\xf2\x86\x19\x37\n3\n\x03GET\x12&/mlflow/artifacts/credentials-for-read\x1a\x04\x08\x02\x10\x00\x10\x03\x12\x9f\x01\n\x16getCredentialsForWrite\x12\x1e.mlflow.GetCredentialsForWrite\x1a\'.mlflow.GetCredentialsForWrite.Response\"<\xf2\x86\x19\x38\n4\n\x03GET\x12\'/mlflow/artifacts/credentials-for-write\x1a\x04\x08\x02\x10\x00\x10\x03\x42,\n\x1f\x63om.databricks.api.proto.mlflow\x90\x01\x01\xa0\x01\x01\xe2?\x02\x10\x01')
   ,
   dependencies=[scalapb_dot_scalapb__pb2.DESCRIPTOR,databricks__pb2.DESCRIPTOR,])
 
@@ -49,8 +49,8 @@ _ARTIFACTCREDENTIALTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=766,
-  serialized_end=852,
+  serialized_start=854,
+  serialized_end=940,
 )
 _sym_db.RegisterEnumDescriptor(_ARTIFACTCREDENTIALTYPE)
 
@@ -165,9 +165,16 @@ _GETCREDENTIALSFORREAD_RESPONSE = _descriptor.Descriptor(
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='credentials', full_name='mlflow.GetCredentialsForRead.Response.credentials', index=0,
-      number=1, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
+      name='credential_infos', full_name='mlflow.GetCredentialsForRead.Response.credential_infos', index=0,
+      number=2, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='next_page_token', full_name='mlflow.GetCredentialsForRead.Response.next_page_token', index=1,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
@@ -183,8 +190,8 @@ _GETCREDENTIALSFORREAD_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=373,
-  serialized_end=436,
+  serialized_start=387,
+  serialized_end=480,
 )
 
 _GETCREDENTIALSFORREAD = _descriptor.Descriptor(
@@ -203,11 +210,18 @@ _GETCREDENTIALSFORREAD = _descriptor.Descriptor(
       serialized_options=_b('\370\206\031\001'), file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='path', full_name='mlflow.GetCredentialsForRead.path', index=1,
-      number=2, type=9, cpp_type=9, label=1,
+      number=2, type=9, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='page_token', full_name='mlflow.GetCredentialsForRead.page_token', index=2,
+      number=3, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      serialized_options=_b('\370\206\031\001'), file=DESCRIPTOR),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
@@ -221,7 +235,7 @@ _GETCREDENTIALSFORREAD = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=306,
-  serialized_end=533,
+  serialized_end=577,
 )
 
 
@@ -233,9 +247,16 @@ _GETCREDENTIALSFORWRITE_RESPONSE = _descriptor.Descriptor(
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='credentials', full_name='mlflow.GetCredentialsForWrite.Response.credentials', index=0,
-      number=1, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
+      name='credential_infos', full_name='mlflow.GetCredentialsForWrite.Response.credential_infos', index=0,
+      number=2, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='next_page_token', full_name='mlflow.GetCredentialsForWrite.Response.next_page_token', index=1,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
@@ -251,8 +272,8 @@ _GETCREDENTIALSFORWRITE_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=373,
-  serialized_end=436,
+  serialized_start=387,
+  serialized_end=480,
 )
 
 _GETCREDENTIALSFORWRITE = _descriptor.Descriptor(
@@ -271,11 +292,18 @@ _GETCREDENTIALSFORWRITE = _descriptor.Descriptor(
       serialized_options=_b('\370\206\031\001'), file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='path', full_name='mlflow.GetCredentialsForWrite.path', index=1,
-      number=2, type=9, cpp_type=9, label=1,
+      number=2, type=9, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='page_token', full_name='mlflow.GetCredentialsForWrite.page_token', index=2,
+      number=3, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      serialized_options=_b('\370\206\031\001'), file=DESCRIPTOR),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
@@ -288,16 +316,16 @@ _GETCREDENTIALSFORWRITE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=536,
-  serialized_end=764,
+  serialized_start=580,
+  serialized_end=852,
 )
 
 _ARTIFACTCREDENTIALINFO_HTTPHEADER.containing_type = _ARTIFACTCREDENTIALINFO
 _ARTIFACTCREDENTIALINFO.fields_by_name['headers'].message_type = _ARTIFACTCREDENTIALINFO_HTTPHEADER
 _ARTIFACTCREDENTIALINFO.fields_by_name['type'].enum_type = _ARTIFACTCREDENTIALTYPE
-_GETCREDENTIALSFORREAD_RESPONSE.fields_by_name['credentials'].message_type = _ARTIFACTCREDENTIALINFO
+_GETCREDENTIALSFORREAD_RESPONSE.fields_by_name['credential_infos'].message_type = _ARTIFACTCREDENTIALINFO
 _GETCREDENTIALSFORREAD_RESPONSE.containing_type = _GETCREDENTIALSFORREAD
-_GETCREDENTIALSFORWRITE_RESPONSE.fields_by_name['credentials'].message_type = _ARTIFACTCREDENTIALINFO
+_GETCREDENTIALSFORWRITE_RESPONSE.fields_by_name['credential_infos'].message_type = _ARTIFACTCREDENTIALINFO
 _GETCREDENTIALSFORWRITE_RESPONSE.containing_type = _GETCREDENTIALSFORWRITE
 DESCRIPTOR.message_types_by_name['ArtifactCredentialInfo'] = _ARTIFACTCREDENTIALINFO
 DESCRIPTOR.message_types_by_name['GetCredentialsForRead'] = _GETCREDENTIALSFORREAD
@@ -353,10 +381,8 @@ _sym_db.RegisterMessage(GetCredentialsForWrite.Response)
 
 DESCRIPTOR._options = None
 _GETCREDENTIALSFORREAD.fields_by_name['run_id']._options = None
-_GETCREDENTIALSFORREAD.fields_by_name['path']._options = None
 _GETCREDENTIALSFORREAD._options = None
 _GETCREDENTIALSFORWRITE.fields_by_name['run_id']._options = None
-_GETCREDENTIALSFORWRITE.fields_by_name['path']._options = None
 _GETCREDENTIALSFORWRITE._options = None
 
 _DATABRICKSMLFLOWARTIFACTSSERVICE = _descriptor.ServiceDescriptor(
@@ -365,8 +391,8 @@ _DATABRICKSMLFLOWARTIFACTSSERVICE = _descriptor.ServiceDescriptor(
   file=DESCRIPTOR,
   index=0,
   serialized_options=None,
-  serialized_start=855,
-  serialized_end=1209,
+  serialized_start=943,
+  serialized_end=1297,
   methods=[
   _descriptor.MethodDescriptor(
     name='getCredentialsForRead',

--- a/mlflow/protos/databricks_artifacts_pb2.py
+++ b/mlflow/protos/databricks_artifacts_pb2.py
@@ -24,7 +24,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='mlflow',
   syntax='proto2',
   serialized_options=_b('\n\037com.databricks.api.proto.mlflow\220\001\001\240\001\001\342?\002\020\001'),
-  serialized_pb=_b('\n\x1a\x64\x61tabricks_artifacts.proto\x12\x06mlflow\x1a\x15scalapb/scalapb.proto\x1a\x10\x64\x61tabricks.proto\"\xdf\x01\n\x16\x41rtifactCredentialInfo\x12\x0e\n\x06run_id\x18\x01 \x01(\t\x12\x0c\n\x04path\x18\x02 \x01(\t\x12\x12\n\nsigned_uri\x18\x03 \x01(\t\x12:\n\x07headers\x18\x04 \x03(\x0b\x32).mlflow.ArtifactCredentialInfo.HttpHeader\x12,\n\x04type\x18\x05 \x01(\x0e\x32\x1e.mlflow.ArtifactCredentialType\x1a)\n\nHttpHeader\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"\x8f\x02\n\x15GetCredentialsForRead\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0c\n\x04path\x18\x02 \x03(\t\x12\x12\n\npage_token\x18\x03 \x01(\t\x1a]\n\x08Response\x12\x38\n\x10\x63redential_infos\x18\x02 \x03(\x0b\x32\x1e.mlflow.ArtifactCredentialInfo\x12\x17\n\x0fnext_page_token\x18\x03 \x01(\t:_\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\xe2?1\n/com.databricks.mlflow.api.MlflowTrackingMessage\"\x90\x02\n\x16GetCredentialsForWrite\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0c\n\x04path\x18\x02 \x03(\t\x12\x12\n\npage_token\x18\x03 \x01(\t\x1a]\n\x08Response\x12\x38\n\x10\x63redential_infos\x18\x02 \x03(\x0b\x32\x1e.mlflow.ArtifactCredentialInfo\x12\x17\n\x0fnext_page_token\x18\x03 \x01(\t:_\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\xe2?1\n/com.databricks.mlflow.api.MlflowTrackingMessage*V\n\x16\x41rtifactCredentialType\x12\x11\n\rAZURE_SAS_URI\x10\x01\x12\x15\n\x11\x41WS_PRESIGNED_URL\x10\x02\x12\x12\n\x0eGCP_SIGNED_URL\x10\x03\x32\xe4\x02\n DatabricksMlflowArtifactsService\x12\x9c\x01\n\x15getCredentialsForRead\x12\x1d.mlflow.GetCredentialsForRead\x1a&.mlflow.GetCredentialsForRead.Response\"<\xf2\x86\x19\x38\n4\n\x04POST\x12&/mlflow/artifacts/credentials-for-read\x1a\x04\x08\x02\x10\x00\x10\x03\x12\xa0\x01\n\x16getCredentialsForWrite\x12\x1e.mlflow.GetCredentialsForWrite\x1a\'.mlflow.GetCredentialsForWrite.Response\"=\xf2\x86\x19\x39\n5\n\x04POST\x12\'/mlflow/artifacts/credentials-for-write\x1a\x04\x08\x02\x10\x00\x10\x03\x42,\n\x1f\x63om.databricks.api.proto.mlflow\x90\x01\x01\xa0\x01\x01\xe2?\x02\x10\x01')
+  serialized_pb=_b('\n\x1a\x64\x61tabricks_artifacts.proto\x12\x06mlflow\x1a\x15scalapb/scalapb.proto\x1a\x10\x64\x61tabricks.proto\"\xdf\x01\n\x16\x41rtifactCredentialInfo\x12\x0e\n\x06run_id\x18\x01 \x01(\t\x12\x0c\n\x04path\x18\x02 \x01(\t\x12\x12\n\nsigned_uri\x18\x03 \x01(\t\x12:\n\x07headers\x18\x04 \x03(\x0b\x32).mlflow.ArtifactCredentialInfo.HttpHeader\x12,\n\x04type\x18\x05 \x01(\x0e\x32\x1e.mlflow.ArtifactCredentialType\x1a)\n\nHttpHeader\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"\x95\x02\n\x15GetCredentialsForRead\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0c\n\x04path\x18\x02 \x03(\t\x12\x12\n\npage_token\x18\x03 \x01(\t\x1a\x63\n\x08Response\x12\x38\n\x10\x63redential_infos\x18\x02 \x03(\x0b\x32\x1e.mlflow.ArtifactCredentialInfo\x12\x17\n\x0fnext_page_token\x18\x03 \x01(\tJ\x04\x08\x01\x10\x02:_\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\xe2?1\n/com.databricks.mlflow.api.MlflowTrackingMessage\"\x96\x02\n\x16GetCredentialsForWrite\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0c\n\x04path\x18\x02 \x03(\t\x12\x12\n\npage_token\x18\x03 \x01(\t\x1a\x63\n\x08Response\x12\x38\n\x10\x63redential_infos\x18\x02 \x03(\x0b\x32\x1e.mlflow.ArtifactCredentialInfo\x12\x17\n\x0fnext_page_token\x18\x03 \x01(\tJ\x04\x08\x01\x10\x02:_\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\xe2?1\n/com.databricks.mlflow.api.MlflowTrackingMessage*V\n\x16\x41rtifactCredentialType\x12\x11\n\rAZURE_SAS_URI\x10\x01\x12\x15\n\x11\x41WS_PRESIGNED_URL\x10\x02\x12\x12\n\x0eGCP_SIGNED_URL\x10\x03\x32\xe4\x02\n DatabricksMlflowArtifactsService\x12\x9c\x01\n\x15getCredentialsForRead\x12\x1d.mlflow.GetCredentialsForRead\x1a&.mlflow.GetCredentialsForRead.Response\"<\xf2\x86\x19\x38\n4\n\x04POST\x12&/mlflow/artifacts/credentials-for-read\x1a\x04\x08\x02\x10\x00\x10\x03\x12\xa0\x01\n\x16getCredentialsForWrite\x12\x1e.mlflow.GetCredentialsForWrite\x1a\'.mlflow.GetCredentialsForWrite.Response\"=\xf2\x86\x19\x39\n5\n\x04POST\x12\'/mlflow/artifacts/credentials-for-write\x1a\x04\x08\x02\x10\x00\x10\x03\x42,\n\x1f\x63om.databricks.api.proto.mlflow\x90\x01\x01\xa0\x01\x01\xe2?\x02\x10\x01')
   ,
   dependencies=[scalapb_dot_scalapb__pb2.DESCRIPTOR,databricks__pb2.DESCRIPTOR,])
 
@@ -49,8 +49,8 @@ _ARTIFACTCREDENTIALTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=854,
-  serialized_end=940,
+  serialized_start=866,
+  serialized_end=952,
 )
 _sym_db.RegisterEnumDescriptor(_ARTIFACTCREDENTIALTYPE)
 
@@ -191,7 +191,7 @@ _GETCREDENTIALSFORREAD_RESPONSE = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=387,
-  serialized_end=480,
+  serialized_end=486,
 )
 
 _GETCREDENTIALSFORREAD = _descriptor.Descriptor(
@@ -235,7 +235,7 @@ _GETCREDENTIALSFORREAD = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=306,
-  serialized_end=577,
+  serialized_end=583,
 )
 
 
@@ -273,7 +273,7 @@ _GETCREDENTIALSFORWRITE_RESPONSE = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=387,
-  serialized_end=480,
+  serialized_end=486,
 )
 
 _GETCREDENTIALSFORWRITE = _descriptor.Descriptor(
@@ -316,8 +316,8 @@ _GETCREDENTIALSFORWRITE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=580,
-  serialized_end=852,
+  serialized_start=586,
+  serialized_end=864,
 )
 
 _ARTIFACTCREDENTIALINFO_HTTPHEADER.containing_type = _ARTIFACTCREDENTIALINFO
@@ -391,8 +391,8 @@ _DATABRICKSMLFLOWARTIFACTSSERVICE = _descriptor.ServiceDescriptor(
   file=DESCRIPTOR,
   index=0,
   serialized_options=None,
-  serialized_start=943,
-  serialized_end=1299,
+  serialized_start=955,
+  serialized_end=1311,
   methods=[
   _descriptor.MethodDescriptor(
     name='getCredentialsForRead',

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -442,6 +442,12 @@ class DatabricksArtifactRepository(ArtifactRepository):
             page_token = response.next_page_token
         return infos
 
+    def _download_file(self, remote_file_path, local_path):
+        """
+        _download_file is unused in this repository's implementation and is only defined out
+        of necessity because it is an abstract method in the `ArtifactRepository` base class
+        """
+
     def download_artifacts(self, artifact_path, dst_path=None):
         """
         Parallelized implementation of `download_artifacts` for Databricks.

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -555,7 +555,6 @@ class DatabricksArtifactRepository(ArtifactRepository):
                 for file_info in self.list_artifacts(src_artifact_dir_path)
                 if file_info.path != "." and file_info.path != src_artifact_dir_path
             ]
-
             if not dir_content:  # empty dir
                 if not os.path.exists(local_dir):
                     os.makedirs(local_dir, exist_ok=True)

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -145,7 +145,7 @@ class DatabricksArtifactRepository(ArtifactRepository):
         """
         Issue one or more requests for artifact credentials, providing read or write
         access to the specified run-relative artifact `paths` within the MLflow Run specified
-        by `run_id`. The type of access credentials, read or write, is specified by 
+        by `run_id`. The type of access credentials, read or write, is specified by
         `request_message_class`.
 
         :return: A list of `ArtifactCredentialInfo` objects providing read access to the specified

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -142,6 +142,15 @@ class DatabricksArtifactRepository(ArtifactRepository):
         return run_response.run.info.artifact_uri
 
     def _get_credential_infos(self, request_message_class, run_id, paths):
+        """
+        Issue one or more requests for artifact credentials, providing read or write
+        access to the specified run-relative artifact `paths` within the MLflow Run specified
+        by `run_id`. The type of access credentials, read or write, is specified by 
+        `request_message_class`.
+
+        :return: A list of `ArtifactCredentialInfo` objects providing read access to the specified
+                 run-relative artifact `paths` within the MLflow Run specified by `run_id`.
+        """
         credential_infos = []
         page_token = None
 
@@ -170,9 +179,17 @@ class DatabricksArtifactRepository(ArtifactRepository):
         return credential_infos
 
     def _get_write_credential_infos(self, run_id, paths):
+        """
+        :return: A list of `ArtifactCredentialInfo` objects providing write access to the specified
+                 run-relative artifact `paths` within the MLflow Run specified by `run_id`.
+        """
         return self._get_credential_infos(GetCredentialsForWrite, run_id, paths)
 
     def _get_read_credential_infos(self, run_id, paths):
+        """
+        :return: A list of `ArtifactCredentialInfo` objects providing read access to the specified
+                 run-relative artifact `paths` within the MLflow Run specified by `run_id`.
+        """
         return self._get_credential_infos(GetCredentialsForRead, run_id, paths)
 
     def _extract_headers_from_credentials(self, headers):

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -157,9 +157,7 @@ class DatabricksArtifactRepository(ArtifactRepository):
         for paths_chunk in chunk_list(paths, _MAX_CREDENTIALS_REQUEST_SIZE):
             while True:
                 json_body = message_to_json(
-                    request_message_class(
-                        run_id=run_id, path=paths_chunk, page_token=page_token
-                    )
+                    request_message_class(run_id=run_id, path=paths_chunk, page_token=page_token)
                 )
                 response = self._call_endpoint(
                     DatabricksMlflowArtifactsService, request_message_class, json_body
@@ -232,7 +230,9 @@ class DatabricksArtifactRepository(ArtifactRepository):
                     credential_info = self._get_write_credential_infos(
                         run_id=self.run_id, paths=[artifact_path]
                     )[0]
-                    put_block_list(credential_info.signed_uri, uploading_block_list, headers=headers)
+                    put_block_list(
+                        credential_info.signed_uri, uploading_block_list, headers=headers
+                    )
                 else:
                     raise e
         except Exception as err:

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -144,7 +144,9 @@ class DatabricksArtifactRepository(ArtifactRepository):
         page_token = None
         while True:
             if page_token:
-                json_body = message_to_json(GetCredentialsForWrite(run_id=run_id, path=paths, page_token=page_token))
+                json_body = message_to_json(
+                    GetCredentialsForWrite(run_id=run_id, path=paths, page_token=page_token)
+                )
             else:
                 json_body = message_to_json(GetCredentialsForWrite(run_id=run_id, path=paths))
 
@@ -164,7 +166,9 @@ class DatabricksArtifactRepository(ArtifactRepository):
         page_token = None
         while True:
             if page_token:
-                json_body = message_to_json(GetCredentialsForRead(run_id=run_id, path=paths, page_token=page_token))
+                json_body = message_to_json(
+                    GetCredentialsForRead(run_id=run_id, path=paths, page_token=page_token)
+                )
             else:
                 json_body = message_to_json(GetCredentialsForRead(run_id=run_id, path=paths))
 
@@ -251,13 +255,17 @@ class DatabricksArtifactRepository(ArtifactRepository):
         except Exception as err:
             raise MlflowException(err)
 
-    def _upload_to_cloud(self, cloud_credential_info, src_file_path, dst_run_relative_artifact_path):
+    def _upload_to_cloud(
+        self, cloud_credential_info, src_file_path, dst_run_relative_artifact_path
+    ):
         """
         Upload a local file to the specified run-relative `dst_run_relative_artifact_path` using
         the supplied `cloud_credential_info`.
         """
         if cloud_credential_info.type == ArtifactCredentialType.AZURE_SAS_URI:
-            self._azure_upload_file(cloud_credential_info, src_file_path, dst_run_relative_artifact_path)
+            self._azure_upload_file(
+                cloud_credential_info, src_file_path, dst_run_relative_artifact_path
+            )
         elif cloud_credential_info.type in [
             ArtifactCredentialType.AWS_PRESIGNED_URL,
             ArtifactCredentialType.GCP_SIGNED_URL,
@@ -281,7 +289,9 @@ class DatabricksArtifactRepository(ArtifactRepository):
                 message="Cloud provider not supported.", error_code=INTERNAL_ERROR
             )
         try:
-            download_file_using_http_uri(cloud_credential_info.signed_uri, dst_local_file_path, _DOWNLOAD_CHUNK_SIZE)
+            download_file_using_http_uri(
+                cloud_credential_info.signed_uri, dst_local_file_path, _DOWNLOAD_CHUNK_SIZE
+            )
         except Exception as err:
             raise MlflowException(err)
 
@@ -313,14 +323,15 @@ class DatabricksArtifactRepository(ArtifactRepository):
 
     def log_artifact(self, local_file, artifact_path=None):
         run_relative_artifact_path = self._get_run_relative_artifact_path_for_upload(
-            src_file_path=local_file,
-            dst_artifact_dir=artifact_path,
+            src_file_path=local_file, dst_artifact_dir=artifact_path,
         )
-        write_credential_info = self._get_write_credential_infos(run_id=self.run_id, paths=[run_relative_artifact_path])[0]
+        write_credential_info = self._get_write_credential_infos(
+            run_id=self.run_id, paths=[run_relative_artifact_path]
+        )[0]
         self._upload_to_cloud(
             cloud_credential_info=write_credential_info,
             src_file_path=local_file,
-            dst_run_relative_artifact_path=run_relative_artifact_path
+            dst_run_relative_artifact_path=run_relative_artifact_path,
         )
 
     def log_artifacts(self, local_dir, artifact_path=None):
@@ -349,8 +360,7 @@ class DatabricksArtifactRepository(ArtifactRepository):
             for name in filenames:
                 file_path = os.path.join(dirpath, name)
                 dst_run_relative_artifact_path = self._get_run_relative_artifact_path_for_upload(
-                    src_file_path=file_path,
-                    dst_artifact_dir=artifact_subdir,
+                    src_file_path=file_path, dst_artifact_dir=artifact_subdir,
                 )
                 staged_uploads.append(
                     StagedArtifactUpload(
@@ -361,7 +371,9 @@ class DatabricksArtifactRepository(ArtifactRepository):
 
         write_credential_infos = self._get_write_credential_infos(
             run_id=self.run_id,
-            paths=[staged_upload.dst_run_relative_artifact_path for staged_upload in staged_uploads],
+            paths=[
+                staged_upload.dst_run_relative_artifact_path for staged_upload in staged_uploads
+            ],
         )
 
         inflight_uploads = {}
@@ -476,7 +488,9 @@ class DatabricksArtifactRepository(ArtifactRepository):
             )
 
             inflight_downloads = []
-            for src_artifact_path, read_credential_info in zip(src_artifact_paths, read_credential_infos):
+            for src_artifact_path, read_credential_info in zip(
+                src_artifact_paths, read_credential_infos
+            ):
                 dst_local_path = self._create_download_destination(
                     src_artifact_path=src_artifact_path, dst_local_dir_path=dst_local_dir_path
                 )
@@ -533,7 +547,8 @@ class DatabricksArtifactRepository(ArtifactRepository):
             else:
                 inflight_downloads += async_download_file_artifacts_from_paths(
                     src_artifact_paths=[
-                        artifact_info.path for artifact_info in dir_content
+                        artifact_info.path
+                        for artifact_info in dir_content
                         if not artifact_info.is_dir
                     ],
                     dst_local_dir_path=dst_local_dir_path,
@@ -578,7 +593,11 @@ class DatabricksArtifactRepository(ArtifactRepository):
             inflight_downloads = async_download_file_artifacts_from_paths(
                 src_artifact_paths=[artifact_path], dst_local_dir_path=dst_path
             )
-            assert len(inflight_downloads) == 1, "Expected one inflight download for a file artifact, got {} downloads".format(len(inflight_downloads))
+            assert (
+                len(inflight_downloads) == 1
+            ), "Expected one inflight download for a file artifact, got {} downloads".format(
+                len(inflight_downloads)
+            )
             dst_local_path = inflight_downloads[0].dst_local_path
 
         # Join futures to ensure that all artifacts have been downloaded prior to returning

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -152,9 +152,9 @@ class DatabricksArtifactRepository(ArtifactRepository):
                  run-relative artifact `paths` within the MLflow Run specified by `run_id`.
         """
         credential_infos = []
-        page_token = None
 
         for paths_chunk in chunk_list(paths, _MAX_CREDENTIALS_REQUEST_SIZE):
+            page_token = None
             while True:
                 json_body = message_to_json(
                     request_message_class(run_id=run_id, path=paths_chunk, page_token=page_token)

--- a/mlflow/utils/__init__.py
+++ b/mlflow/utils/__init__.py
@@ -63,6 +63,11 @@ def reraise(tp, value, tb=None):
         tb = None
 
 
+def chunk_list(l, chunk_size):
+    for i in range(0, len(l), chunk_size):
+        yield l[i : i + chunk_size]
+
+
 def _chunk_dict(d, chunk_size):
     """
     Splits a dictionary into chunks of the specified size.

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -723,9 +723,9 @@ class TestDatabricksArtifactRepository(object):
 
     def test_get_write_credential_infos_respects_max_request_size(self, databricks_artifact_repo):
         """
-        Verifies that the `_get_write_credential_infos` method, which is used to resolve write access
-        credentials for a collection of artifacts, batches requests according to a maximum request
-        size configured by the backend
+        Verifies that the `_get_write_credential_infos` method, which is used to resolve write
+        access credentials for a collection of artifacts, batches requests according to a maximum
+        request size configured by the backend
         """
         # Create 3 chunks of paths, two of which have the maximum request size and one of which
         # is smaller than the maximum chunk size. Aggregate and pass these to

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -655,7 +655,8 @@ class TestDatabricksArtifactRepository(object):
             databricks_artifact_repo._get_read_credential_infos(
                 MOCK_RUN_ID, paths_chunk_1 + paths_chunk_2 + paths_chunk_3,
             )
-            assert call_endpoint_mock.call_count == message_mock.call_count == 3
+            assert call_endpoint_mock.call_count == 3
+            assert message_mock.call_count == 3
             message_mock.assert_has_calls(
                 [
                     mock.call(GetCredentialsForRead(run_id=MOCK_RUN_ID, path=paths_chunk_1)),

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -18,7 +18,7 @@ from mlflow.protos.databricks_artifacts_pb2 import (
 )
 from mlflow.protos.service_pb2 import ListArtifacts, FileInfo
 from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
-from mlflow.store.artifact.dbfs_artifact_repo import (
+from mlflow.store.artifact.databricks_artifact_repo import (
     DatabricksArtifactRepository,
     _MAX_CREDENTIALS_REQUEST_SIZE,
 )

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -207,7 +207,9 @@ class TestDatabricksArtifactRepository(object):
             write_credential_infos_mock.return_value = [mock_credential_info]
             azure_upload_mock.return_value = None
             databricks_artifact_repo.log_artifact(test_file.strpath, artifact_path)
-            write_credential_infos_mock.assert_called_with(run_id=MOCK_RUN_ID, paths=[expected_location])
+            write_credential_infos_mock.assert_called_with(
+                run_id=MOCK_RUN_ID, paths=[expected_location]
+            )
             azure_upload_mock.assert_called_with(
                 mock_credential_info, test_file.strpath, expected_location
             )
@@ -244,7 +246,9 @@ class TestDatabricksArtifactRepository(object):
             write_credential_infos_mock.return_value = [mock_credential_info]
             request_mock.return_value = mock_response
             databricks_artifact_repo.log_artifact(test_file.strpath, artifact_path)
-            write_credential_infos_mock.assert_called_with(run_id=MOCK_RUN_ID, paths=[expected_location])
+            write_credential_infos_mock.assert_called_with(
+                run_id=MOCK_RUN_ID, paths=[expected_location]
+            )
             request_mock.assert_called_with(
                 "put",
                 MOCK_AZURE_SIGNED_URI + "?comp=blocklist",
@@ -285,7 +289,9 @@ class TestDatabricksArtifactRepository(object):
             write_credential_infos_mock.return_value = [mock_credential_info]
             request_mock.return_value = mock_response
             databricks_artifact_repo.log_artifact(test_file.strpath, artifact_path)
-            write_credential_infos_mock.assert_called_with(run_id=MOCK_RUN_ID, paths=[expected_location])
+            write_credential_infos_mock.assert_called_with(
+                run_id=MOCK_RUN_ID, paths=[expected_location]
+            )
             request_mock.assert_called_with("put", MOCK_AWS_SIGNED_URI, ANY, headers={})
 
     @pytest.mark.parametrize("artifact_path,expected_location", [(None, "test.txt")])
@@ -309,7 +315,9 @@ class TestDatabricksArtifactRepository(object):
             write_credential_infos_mock.return_value = [mock_credential_info]
             request_mock.return_value = mock_response
             databricks_artifact_repo.log_artifact(test_file.strpath, artifact_path)
-            write_credential_infos_mock.assert_called_with(run_id=MOCK_RUN_ID, paths=[expected_location])
+            write_credential_infos_mock.assert_called_with(
+                run_id=MOCK_RUN_ID, paths=[expected_location]
+            )
             request_mock.assert_called_with(
                 "put", MOCK_AWS_SIGNED_URI, ANY, headers=expected_headers
             )
@@ -347,7 +355,9 @@ class TestDatabricksArtifactRepository(object):
             write_credential_infos_mock.return_value = [mock_credential_info]
             request_mock.return_value = mock_response
             databricks_artifact_repo.log_artifact(test_file.strpath, artifact_path)
-            write_credential_infos_mock.assert_called_with(run_id=MOCK_RUN_ID, paths=[expected_location])
+            write_credential_infos_mock.assert_called_with(
+                run_id=MOCK_RUN_ID, paths=[expected_location]
+            )
             request_mock.assert_called_with("put", MOCK_GCP_SIGNED_URL, ANY, headers={})
 
     @pytest.mark.parametrize("artifact_path,expected_location", [(None, "test.txt")])
@@ -371,7 +381,9 @@ class TestDatabricksArtifactRepository(object):
             write_credential_infos_mock.return_value = [mock_credential_info]
             request_mock.return_value = mock_response
             databricks_artifact_repo.log_artifact(test_file.strpath, artifact_path)
-            write_credential_infos_mock.assert_called_with(run_id=MOCK_RUN_ID, paths=[expected_location])
+            write_credential_infos_mock.assert_called_with(
+                run_id=MOCK_RUN_ID, paths=[expected_location]
+            )
             request_mock.assert_called_with(
                 "put", MOCK_GCP_SIGNED_URL, ANY, headers=expected_headers
             )
@@ -414,7 +426,9 @@ class TestDatabricksArtifactRepository(object):
             write_credential_infos_mock.return_value = [mock_credential_info]
             upload_mock.return_value = None
             databricks_artifact_repo.log_artifact(test_file.strpath, artifact_path)
-            write_credential_infos_mock.assert_called_with(run_id=MOCK_RUN_ID, paths=[expected_location])
+            write_credential_infos_mock.assert_called_with(
+                run_id=MOCK_RUN_ID, paths=[expected_location]
+            )
             upload_mock.assert_called_with(
                 cloud_credential_info=mock_credential_info,
                 src_file_path=test_file.strpath,
@@ -570,18 +584,18 @@ class TestDatabricksArtifactRepository(object):
                 GetCredentialsForRead.Response(
                     credential_infos=credential_infos_mock_2, next_page_token="3"
                 ),
-                GetCredentialsForRead.Response(
-                    credential_infos=credential_infos_mock_3,
-                ),
+                GetCredentialsForRead.Response(credential_infos=credential_infos_mock_3,),
             ]
             call_endpoint_mock.side_effect = get_credentials_for_read_responses
             read_credential_infos = databricks_artifact_repo._get_read_credential_infos(MOCK_RUN_ID)
             assert read_credential_infos == credential_infos_mock_1 + credential_infos_mock_2
-            message_mock.assert_has_calls([
-                mock.call(GetCredentialsForRead(run_id=MOCK_RUN_ID, path="")),
-                mock.call(GetCredentialsForRead(run_id=MOCK_RUN_ID, path="", page_token="2")),
-                mock.call(GetCredentialsForRead(run_id=MOCK_RUN_ID, path="", page_token="3")),
-            ])
+            message_mock.assert_has_calls(
+                [
+                    mock.call(GetCredentialsForRead(run_id=MOCK_RUN_ID, path="")),
+                    mock.call(GetCredentialsForRead(run_id=MOCK_RUN_ID, path="", page_token="2")),
+                    mock.call(GetCredentialsForRead(run_id=MOCK_RUN_ID, path="", page_token="3")),
+                ]
+            )
             assert call_endpoint_mock.call_count == 3
 
     def test_paginated_get_credentials_for_write(self, databricks_artifact_repo):
@@ -612,18 +626,20 @@ class TestDatabricksArtifactRepository(object):
                 GetCredentialsForWrite.Response(
                     credential_infos=credential_infos_mock_2, next_page_token="3"
                 ),
-                GetCredentialsForWrite.Response(
-                    credential_infos=credential_infos_mock_3,
-                ),
+                GetCredentialsForWrite.Response(credential_infos=credential_infos_mock_3,),
             ]
             call_endpoint_mock.side_effect = get_credentials_for_write_responses
-            write_credential_infos = databricks_artifact_repo._get_write_credential_infos(MOCK_RUN_ID)
+            write_credential_infos = databricks_artifact_repo._get_write_credential_infos(
+                MOCK_RUN_ID
+            )
             assert write_credential_infos == credential_infos_mock_1 + credential_infos_mock_2
-            message_mock.assert_has_calls([
-                mock.call(GetCredentialsForWrite(run_id=MOCK_RUN_ID, path="")),
-                mock.call(GetCredentialsForWrite(run_id=MOCK_RUN_ID, path="", page_token="2")),
-                mock.call(GetCredentialsForWrite(run_id=MOCK_RUN_ID, path="", page_token="3")),
-            ])
+            message_mock.assert_has_calls(
+                [
+                    mock.call(GetCredentialsForWrite(run_id=MOCK_RUN_ID, path="")),
+                    mock.call(GetCredentialsForWrite(run_id=MOCK_RUN_ID, path="", page_token="2")),
+                    mock.call(GetCredentialsForWrite(run_id=MOCK_RUN_ID, path="", page_token="3")),
+                ]
+            )
             assert call_endpoint_mock.call_count == 3
 
     @pytest.mark.parametrize(
@@ -653,10 +669,11 @@ class TestDatabricksArtifactRepository(object):
             download_mock.return_value = None
             get_list_mock.return_value = []
             databricks_artifact_repo.download_artifacts(remote_file_path, local_path)
-            read_credential_infos_mock.assert_called_with(run_id=MOCK_RUN_ID, paths=[remote_file_path])
+            read_credential_infos_mock.assert_called_with(
+                run_id=MOCK_RUN_ID, paths=[remote_file_path]
+            )
             download_mock.assert_called_with(
-                cloud_credential_info=mock_credential_info,
-                dst_local_file_path=ANY,
+                cloud_credential_info=mock_credential_info, dst_local_file_path=ANY,
             )
 
     @pytest.mark.parametrize(
@@ -685,8 +702,7 @@ class TestDatabricksArtifactRepository(object):
                 run_id=MOCK_RUN_ID, paths=[posixpath.join(MOCK_SUBDIR, remote_file_path)]
             )
             download_mock.assert_called_with(
-                cloud_credential_info=mock_credential_info,
-                dst_local_file_path=ANY,
+                cloud_credential_info=mock_credential_info, dst_local_file_path=ANY,
             )
 
     def test_databricks_download_file_get_request_fail(self, databricks_artifact_repo, test_file):
@@ -705,7 +721,9 @@ class TestDatabricksArtifactRepository(object):
             request_mock.return_value = MlflowException("MOCK ERROR")
             with pytest.raises(MlflowException):
                 databricks_artifact_repo.download_artifacts(test_file.strpath)
-            read_credential_infos_mock.assert_called_with(run_id=MOCK_RUN_ID, paths=[test_file.strpath])
+            read_credential_infos_mock.assert_called_with(
+                run_id=MOCK_RUN_ID, paths=[test_file.strpath]
+            )
 
     def test_download_artifacts_awaits_download_completion(self, databricks_artifact_repo, tmpdir):
         """
@@ -790,7 +808,9 @@ class TestDatabricksArtifactRepository(object):
             ):  # pylint: disable=unused-argument
                 # Sleep in order to simulate a longer-running asynchronous upload
                 time.sleep(2)
-                dst_run_relative_artifact_path = os.path.join(dst_dir, dst_run_relative_artifact_path)
+                dst_run_relative_artifact_path = os.path.join(
+                    dst_dir, dst_run_relative_artifact_path
+                )
                 os.makedirs(os.path.dirname(dst_run_relative_artifact_path), exist_ok=True)
                 shutil.copyfile(src=src_file_path, dst=dst_run_relative_artifact_path)
 
@@ -832,7 +852,7 @@ class TestDatabricksArtifactRepository(object):
                 ),
                 ArtifactCredentialInfo(
                     signed_uri=MOCK_AZURE_SIGNED_URI, type=ArtifactCredentialType.AZURE_SAS_URI
-                )
+                ),
             ]
             download_mock.side_effect = [
                 MlflowException("MOCK ERROR 1"),
@@ -867,7 +887,7 @@ class TestDatabricksArtifactRepository(object):
                 ),
                 ArtifactCredentialInfo(
                     signed_uri=MOCK_AZURE_SIGNED_URI, type=ArtifactCredentialType.AZURE_SAS_URI
-                )
+                ),
             ]
             upload_mock.side_effect = [
                 MlflowException("MOCK ERROR 1"),

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -197,22 +197,19 @@ class TestDatabricksArtifactRepository(object):
         self, databricks_artifact_repo, test_file, artifact_path, expected_location
     ):
         with mock.patch(
-            DATABRICKS_ARTIFACT_REPOSITORY + "._get_write_credentials"
-        ) as write_credentials_mock, mock.patch(
+            DATABRICKS_ARTIFACT_REPOSITORY + "._get_write_credential_infos"
+        ) as write_credential_infos_mock, mock.patch(
             DATABRICKS_ARTIFACT_REPOSITORY + "._azure_upload_file"
         ) as azure_upload_mock:
-            mock_credentials = ArtifactCredentialInfo(
+            mock_credential_info = ArtifactCredentialInfo(
                 signed_uri=MOCK_AZURE_SIGNED_URI, type=ArtifactCredentialType.AZURE_SAS_URI
             )
-            write_credentials_response_proto = GetCredentialsForWrite.Response(
-                credentials=mock_credentials
-            )
-            write_credentials_mock.return_value = write_credentials_response_proto
+            write_credential_infos_mock.return_value = [mock_credential_info]
             azure_upload_mock.return_value = None
             databricks_artifact_repo.log_artifact(test_file.strpath, artifact_path)
-            write_credentials_mock.assert_called_with(MOCK_RUN_ID, expected_location)
+            write_credential_infos_mock.assert_called_with(run_id=MOCK_RUN_ID, paths=[expected_location])
             azure_upload_mock.assert_called_with(
-                mock_credentials, test_file.strpath, expected_location
+                mock_credential_info, test_file.strpath, expected_location
             )
 
     @pytest.mark.parametrize("artifact_path, expected_location", [(None, "test.txt")])
@@ -232,11 +229,11 @@ class TestDatabricksArtifactRepository(object):
         mock_response.status_code = 200
         mock_response.close = lambda: None
         with mock.patch(
-            DATABRICKS_ARTIFACT_REPOSITORY + "._get_write_credentials"
-        ) as write_credentials_mock, mock.patch(
+            DATABRICKS_ARTIFACT_REPOSITORY + "._get_write_credential_infos"
+        ) as write_credential_infos_mock, mock.patch(
             "mlflow.utils.rest_utils.cloud_storage_http_request"
         ) as request_mock:
-            mock_credentials = ArtifactCredentialInfo(
+            mock_credential_info = ArtifactCredentialInfo(
                 signed_uri=MOCK_AZURE_SIGNED_URI,
                 type=ArtifactCredentialType.AZURE_SAS_URI,
                 headers=[
@@ -244,13 +241,10 @@ class TestDatabricksArtifactRepository(object):
                     for header_name, header_value in mock_azure_headers.items()
                 ],
             )
-            write_credentials_response_proto = GetCredentialsForWrite.Response(
-                credentials=mock_credentials
-            )
-            write_credentials_mock.return_value = write_credentials_response_proto
+            write_credential_infos_mock.return_value = [mock_credential_info]
             request_mock.return_value = mock_response
             databricks_artifact_repo.log_artifact(test_file.strpath, artifact_path)
-            write_credentials_mock.assert_called_with(MOCK_RUN_ID, expected_location)
+            write_credential_infos_mock.assert_called_with(run_id=MOCK_RUN_ID, paths=[expected_location])
             request_mock.assert_called_with(
                 "put",
                 MOCK_AZURE_SIGNED_URI + "?comp=blocklist",
@@ -260,21 +254,18 @@ class TestDatabricksArtifactRepository(object):
 
     def test_log_artifact_azure_blob_client_sas_error(self, databricks_artifact_repo, test_file):
         with mock.patch(
-            DATABRICKS_ARTIFACT_REPOSITORY + "._get_write_credentials"
-        ) as write_credentials_mock, mock.patch(
+            DATABRICKS_ARTIFACT_REPOSITORY + "._get_write_credential_infos"
+        ) as write_credential_infos_mock, mock.patch(
             "azure.storage.blob.BlobClient.from_blob_url"
         ) as mock_create_blob_client:
-            mock_credentials = ArtifactCredentialInfo(
+            mock_credential_info = ArtifactCredentialInfo(
                 signed_uri=MOCK_AZURE_SIGNED_URI, type=ArtifactCredentialType.AZURE_SAS_URI
             )
-            write_credentials_response_proto = GetCredentialsForWrite.Response(
-                credentials=mock_credentials
-            )
-            write_credentials_mock.return_value = write_credentials_response_proto
+            write_credential_infos_mock.return_value = [mock_credential_info]
             mock_create_blob_client.side_effect = MlflowException("MOCK ERROR")
             with pytest.raises(MlflowException):
                 databricks_artifact_repo.log_artifact(test_file.strpath)
-            write_credentials_mock.assert_called_with(MOCK_RUN_ID, ANY)
+            write_credential_infos_mock.assert_called_with(run_id=MOCK_RUN_ID, paths=ANY)
 
     @pytest.mark.parametrize("artifact_path,expected_location", [(None, "test.txt")])
     def test_log_artifact_aws(
@@ -284,20 +275,17 @@ class TestDatabricksArtifactRepository(object):
         mock_response.status_code = 200
         mock_response.close = lambda: None
         with mock.patch(
-            DATABRICKS_ARTIFACT_REPOSITORY + "._get_write_credentials"
-        ) as write_credentials_mock, mock.patch(
+            DATABRICKS_ARTIFACT_REPOSITORY + "._get_write_credential_infos"
+        ) as write_credential_infos_mock, mock.patch(
             "mlflow.utils.rest_utils.cloud_storage_http_request"
         ) as request_mock:
-            mock_credentials = ArtifactCredentialInfo(
+            mock_credential_info = ArtifactCredentialInfo(
                 signed_uri=MOCK_AWS_SIGNED_URI, type=ArtifactCredentialType.AWS_PRESIGNED_URL
             )
-            write_credentials_response_proto = GetCredentialsForWrite.Response(
-                credentials=mock_credentials
-            )
-            write_credentials_mock.return_value = write_credentials_response_proto
+            write_credential_infos_mock.return_value = [mock_credential_info]
             request_mock.return_value = mock_response
             databricks_artifact_repo.log_artifact(test_file.strpath, artifact_path)
-            write_credentials_mock.assert_called_with(MOCK_RUN_ID, expected_location)
+            write_credential_infos_mock.assert_called_with(run_id=MOCK_RUN_ID, paths=[expected_location])
             request_mock.assert_called_with("put", MOCK_AWS_SIGNED_URI, ANY, headers={})
 
     @pytest.mark.parametrize("artifact_path,expected_location", [(None, "test.txt")])
@@ -309,43 +297,37 @@ class TestDatabricksArtifactRepository(object):
         mock_response.status_code = 200
         mock_response.close = lambda: None
         with mock.patch(
-            DATABRICKS_ARTIFACT_REPOSITORY + "._get_write_credentials"
-        ) as write_credentials_mock, mock.patch(
+            DATABRICKS_ARTIFACT_REPOSITORY + "._get_write_credential_infos"
+        ) as write_credential_infos_mock, mock.patch(
             "mlflow.utils.rest_utils.cloud_storage_http_request"
         ) as request_mock:
-            mock_credentials = ArtifactCredentialInfo(
+            mock_credential_info = ArtifactCredentialInfo(
                 signed_uri=MOCK_AWS_SIGNED_URI,
                 type=ArtifactCredentialType.AWS_PRESIGNED_URL,
                 headers=MOCK_HEADERS,
             )
-            write_credentials_response_proto = GetCredentialsForWrite.Response(
-                credentials=mock_credentials
-            )
-            write_credentials_mock.return_value = write_credentials_response_proto
+            write_credential_infos_mock.return_value = [mock_credential_info]
             request_mock.return_value = mock_response
             databricks_artifact_repo.log_artifact(test_file.strpath, artifact_path)
-            write_credentials_mock.assert_called_with(MOCK_RUN_ID, expected_location)
+            write_credential_infos_mock.assert_called_with(run_id=MOCK_RUN_ID, paths=[expected_location])
             request_mock.assert_called_with(
                 "put", MOCK_AWS_SIGNED_URI, ANY, headers=expected_headers
             )
 
     def test_log_artifact_aws_presigned_url_error(self, databricks_artifact_repo, test_file):
         with mock.patch(
-            DATABRICKS_ARTIFACT_REPOSITORY + "._get_write_credentials"
-        ) as write_credentials_mock, mock.patch(
+            DATABRICKS_ARTIFACT_REPOSITORY + "._get_write_credential_infos"
+        ) as write_credential_infos_mock, mock.patch(
             "mlflow.utils.rest_utils.cloud_storage_http_request"
         ) as request_mock:
-            mock_credentials = ArtifactCredentialInfo(
+            mock_credential_info = ArtifactCredentialInfo(
                 signed_uri=MOCK_AWS_SIGNED_URI, type=ArtifactCredentialType.AWS_PRESIGNED_URL
             )
-            write_credentials_response_proto = GetCredentialsForWrite.Response(
-                credentials=mock_credentials
-            )
-            write_credentials_mock.return_value = write_credentials_response_proto
+            write_credential_infos_mock.return_value = [mock_credential_info]
             request_mock.side_effect = MlflowException("MOCK ERROR")
             with pytest.raises(MlflowException):
                 databricks_artifact_repo.log_artifact(test_file.strpath)
-            write_credentials_mock.assert_called_with(MOCK_RUN_ID, ANY)
+            write_credential_infos_mock.assert_called_with(run_id=MOCK_RUN_ID, paths=ANY)
 
     @pytest.mark.parametrize("artifact_path,expected_location", [(None, "test.txt")])
     def test_log_artifact_gcp(
@@ -355,20 +337,17 @@ class TestDatabricksArtifactRepository(object):
         mock_response.status_code = 200
         mock_response.close = lambda: None
         with mock.patch(
-            DATABRICKS_ARTIFACT_REPOSITORY + "._get_write_credentials"
-        ) as write_credentials_mock, mock.patch(
+            DATABRICKS_ARTIFACT_REPOSITORY + "._get_write_credential_infos"
+        ) as write_credential_infos_mock, mock.patch(
             "mlflow.utils.rest_utils.cloud_storage_http_request"
         ) as request_mock:
-            mock_credentials = ArtifactCredentialInfo(
+            mock_credential_info = ArtifactCredentialInfo(
                 signed_uri=MOCK_GCP_SIGNED_URL, type=ArtifactCredentialType.GCP_SIGNED_URL
             )
-            write_credentials_response_proto = GetCredentialsForWrite.Response(
-                credentials=mock_credentials
-            )
-            write_credentials_mock.return_value = write_credentials_response_proto
+            write_credential_infos_mock.return_value = [mock_credential_info]
             request_mock.return_value = mock_response
             databricks_artifact_repo.log_artifact(test_file.strpath, artifact_path)
-            write_credentials_mock.assert_called_with(MOCK_RUN_ID, expected_location)
+            write_credential_infos_mock.assert_called_with(run_id=MOCK_RUN_ID, paths=[expected_location])
             request_mock.assert_called_with("put", MOCK_GCP_SIGNED_URL, ANY, headers={})
 
     @pytest.mark.parametrize("artifact_path,expected_location", [(None, "test.txt")])
@@ -380,43 +359,37 @@ class TestDatabricksArtifactRepository(object):
         mock_response.status_code = 200
         mock_response.close = lambda: None
         with mock.patch(
-            DATABRICKS_ARTIFACT_REPOSITORY + "._get_write_credentials"
-        ) as write_credentials_mock, mock.patch(
+            DATABRICKS_ARTIFACT_REPOSITORY + "._get_write_credential_infos"
+        ) as write_credential_infos_mock, mock.patch(
             "mlflow.utils.rest_utils.cloud_storage_http_request"
         ) as request_mock:
-            mock_credentials = ArtifactCredentialInfo(
+            mock_credential_info = ArtifactCredentialInfo(
                 signed_uri=MOCK_GCP_SIGNED_URL,
                 type=ArtifactCredentialType.GCP_SIGNED_URL,
                 headers=MOCK_HEADERS,
             )
-            write_credentials_response_proto = GetCredentialsForWrite.Response(
-                credentials=mock_credentials
-            )
-            write_credentials_mock.return_value = write_credentials_response_proto
+            write_credential_infos_mock.return_value = [mock_credential_info]
             request_mock.return_value = mock_response
             databricks_artifact_repo.log_artifact(test_file.strpath, artifact_path)
-            write_credentials_mock.assert_called_with(MOCK_RUN_ID, expected_location)
+            write_credential_infos_mock.assert_called_with(run_id=MOCK_RUN_ID, paths=[expected_location])
             request_mock.assert_called_with(
                 "put", MOCK_GCP_SIGNED_URL, ANY, headers=expected_headers
             )
 
     def test_log_artifact_gcp_presigned_url_error(self, databricks_artifact_repo, test_file):
         with mock.patch(
-            DATABRICKS_ARTIFACT_REPOSITORY + "._get_write_credentials"
-        ) as write_credentials_mock, mock.patch(
+            DATABRICKS_ARTIFACT_REPOSITORY + "._get_write_credential_infos"
+        ) as write_credential_infos_mock, mock.patch(
             "mlflow.utils.rest_utils.cloud_storage_http_request"
         ) as request_mock:
-            mock_credentials = ArtifactCredentialInfo(
+            mock_credential_info = ArtifactCredentialInfo(
                 signed_uri=MOCK_GCP_SIGNED_URL, type=ArtifactCredentialType.GCP_SIGNED_URL
             )
-            write_credentials_response_proto = GetCredentialsForWrite.Response(
-                credentials=mock_credentials
-            )
-            write_credentials_mock.return_value = write_credentials_response_proto
+            write_credential_infos_mock.return_value = [mock_credential_info]
             request_mock.side_effect = MlflowException("MOCK ERROR")
             with pytest.raises(MlflowException):
                 databricks_artifact_repo.log_artifact(test_file.strpath)
-            write_credentials_mock.assert_called_with(MOCK_RUN_ID, ANY)
+            write_credential_infos_mock.assert_called_with(run_id=MOCK_RUN_ID, paths=ANY)
 
     @pytest.mark.parametrize(
         "artifact_path, expected_location",
@@ -429,46 +402,24 @@ class TestDatabricksArtifactRepository(object):
         with mock.patch(
             DATABRICKS_ARTIFACT_REPOSITORY + "._get_run_artifact_root"
         ) as get_run_artifact_root_mock, mock.patch(
-            DATABRICKS_ARTIFACT_REPOSITORY + "._get_write_credentials"
-        ) as write_credentials_mock, mock.patch(
+            DATABRICKS_ARTIFACT_REPOSITORY + "._get_write_credential_infos"
+        ) as write_credential_infos_mock, mock.patch(
             DATABRICKS_ARTIFACT_REPOSITORY + "._upload_to_cloud"
         ) as upload_mock:
             get_run_artifact_root_mock.return_value = MOCK_RUN_ROOT_URI
             databricks_artifact_repo = get_artifact_repository(MOCK_SUBDIR_ROOT_URI)
-            mock_credentials = ArtifactCredentialInfo(
+            mock_credential_info = ArtifactCredentialInfo(
                 signed_uri=MOCK_AZURE_SIGNED_URI, type=ArtifactCredentialType.AZURE_SAS_URI
             )
-            write_credentials_response_proto = GetCredentialsForWrite.Response(
-                credentials=mock_credentials
-            )
-            write_credentials_mock.return_value = write_credentials_response_proto
+            write_credential_infos_mock.return_value = [mock_credential_info]
             upload_mock.return_value = None
             databricks_artifact_repo.log_artifact(test_file.strpath, artifact_path)
-            write_credentials_mock.assert_called_with(MOCK_RUN_ID, expected_location)
+            write_credential_infos_mock.assert_called_with(run_id=MOCK_RUN_ID, paths=[expected_location])
             upload_mock.assert_called_with(
-                write_credentials_response_proto, test_file.strpath, expected_location
+                cloud_credential_info=mock_credential_info,
+                src_file_path=test_file.strpath,
+                dst_run_relative_artifact_path=expected_location,
             )
-
-    @pytest.mark.parametrize("artifact_path", [None, "output/", ""])
-    def test_log_artifacts(self, databricks_artifact_repo, test_dir, artifact_path):
-        with mock.patch(DATABRICKS_ARTIFACT_REPOSITORY + ".log_artifact") as log_artifact_mock:
-            log_artifact_mock.return_value = None
-            databricks_artifact_repo.log_artifacts(test_dir.strpath, artifact_path)
-            artifact_path = artifact_path or ""
-            expected_calls = [
-                mock.call(
-                    os.path.join(test_dir.strpath, "empty-file.txt"),
-                    os.path.join(artifact_path, ""),
-                ),
-                mock.call(
-                    os.path.join(test_dir.strpath, "test.txt"), os.path.join(artifact_path, "")
-                ),
-                mock.call(
-                    os.path.join(test_dir.strpath, os.path.join("subdir", "test.txt")),
-                    os.path.join(artifact_path, "subdir"),
-                ),
-            ]
-            log_artifact_mock.assert_has_calls(expected_calls, any_order=True)
 
     def test_list_artifacts(self, databricks_artifact_repo):
         list_artifact_file_proto_mock = [FileInfo(path="a.txt", is_dir=False, file_size=0)]
@@ -591,6 +542,90 @@ class TestDatabricksArtifactRepository(object):
             ]
             message_mock.assert_has_calls(calls)
 
+    def test_paginated_get_credentials_for_read(self, databricks_artifact_repo):
+        credential_infos_mock_1 = [
+            ArtifactCredentialInfo(
+                signed_uri="http://mock_url_1", type=ArtifactCredentialType.AWS_PRESIGNED_URL
+            ),
+            ArtifactCredentialInfo(
+                signed_uri="http://mock_url_2", type=ArtifactCredentialType.AWS_PRESIGNED_URL
+            ),
+        ]
+        credential_infos_mock_2 = [
+            ArtifactCredentialInfo(
+                signed_uri="http://mock_url_3", type=ArtifactCredentialType.AWS_PRESIGNED_URL
+            )
+        ]
+        credential_infos_mock_3 = []
+
+        with mock.patch(
+            DATABRICKS_ARTIFACT_REPOSITORY_PACKAGE + ".message_to_json"
+        ) as message_mock, mock.patch(
+            DATABRICKS_ARTIFACT_REPOSITORY + "._call_endpoint"
+        ) as call_endpoint_mock:
+            get_credentials_for_read_responses = [
+                GetCredentialsForRead.Response(
+                    credential_infos=credential_infos_mock_1, next_page_token="2"
+                ),
+                GetCredentialsForRead.Response(
+                    credential_infos=credential_infos_mock_2, next_page_token="3"
+                ),
+                GetCredentialsForRead.Response(
+                    credential_infos=credential_infos_mock_3,
+                ),
+            ]
+            call_endpoint_mock.side_effect = get_credentials_for_read_responses
+            read_credential_infos = databricks_artifact_repo._get_read_credential_infos(MOCK_RUN_ID)
+            assert read_credential_infos == credential_infos_mock_1 + credential_infos_mock_2
+            message_mock.assert_has_calls([
+                mock.call(GetCredentialsForRead(run_id=MOCK_RUN_ID, path="")),
+                mock.call(GetCredentialsForRead(run_id=MOCK_RUN_ID, path="", page_token="2")),
+                mock.call(GetCredentialsForRead(run_id=MOCK_RUN_ID, path="", page_token="3")),
+            ])
+            assert call_endpoint_mock.call_count == 3
+
+    def test_paginated_get_credentials_for_write(self, databricks_artifact_repo):
+        credential_infos_mock_1 = [
+            ArtifactCredentialInfo(
+                signed_uri="http://mock_url_1", type=ArtifactCredentialType.AWS_PRESIGNED_URL
+            ),
+            ArtifactCredentialInfo(
+                signed_uri="http://mock_url_2", type=ArtifactCredentialType.AWS_PRESIGNED_URL
+            ),
+        ]
+        credential_infos_mock_2 = [
+            ArtifactCredentialInfo(
+                signed_uri="http://mock_url_3", type=ArtifactCredentialType.AWS_PRESIGNED_URL
+            )
+        ]
+        credential_infos_mock_3 = []
+
+        with mock.patch(
+            DATABRICKS_ARTIFACT_REPOSITORY_PACKAGE + ".message_to_json"
+        ) as message_mock, mock.patch(
+            DATABRICKS_ARTIFACT_REPOSITORY + "._call_endpoint"
+        ) as call_endpoint_mock:
+            get_credentials_for_write_responses = [
+                GetCredentialsForWrite.Response(
+                    credential_infos=credential_infos_mock_1, next_page_token="2"
+                ),
+                GetCredentialsForWrite.Response(
+                    credential_infos=credential_infos_mock_2, next_page_token="3"
+                ),
+                GetCredentialsForWrite.Response(
+                    credential_infos=credential_infos_mock_3,
+                ),
+            ]
+            call_endpoint_mock.side_effect = get_credentials_for_write_responses
+            write_credential_infos = databricks_artifact_repo._get_write_credential_infos(MOCK_RUN_ID)
+            assert write_credential_infos == credential_infos_mock_1 + credential_infos_mock_2
+            message_mock.assert_has_calls([
+                mock.call(GetCredentialsForWrite(run_id=MOCK_RUN_ID, path="")),
+                mock.call(GetCredentialsForWrite(run_id=MOCK_RUN_ID, path="", page_token="2")),
+                mock.call(GetCredentialsForWrite(run_id=MOCK_RUN_ID, path="", page_token="3")),
+            ])
+            assert call_endpoint_mock.call_count == 3
+
     @pytest.mark.parametrize(
         "remote_file_path, local_path, cloud_credential_type",
         [
@@ -605,24 +640,24 @@ class TestDatabricksArtifactRepository(object):
         self, databricks_artifact_repo, remote_file_path, local_path, cloud_credential_type
     ):
         with mock.patch(
-            DATABRICKS_ARTIFACT_REPOSITORY + "._get_read_credentials"
-        ) as read_credentials_mock, mock.patch(
+            DATABRICKS_ARTIFACT_REPOSITORY + "._get_read_credential_infos"
+        ) as read_credential_infos_mock, mock.patch(
             DATABRICKS_ARTIFACT_REPOSITORY + ".list_artifacts"
         ) as get_list_mock, mock.patch(
             DATABRICKS_ARTIFACT_REPOSITORY + "._download_from_cloud"
         ) as download_mock:
-            mock_credentials = ArtifactCredentialInfo(
+            mock_credential_info = ArtifactCredentialInfo(
                 signed_uri=MOCK_AZURE_SIGNED_URI, type=cloud_credential_type
             )
-            read_credentials_response_proto = GetCredentialsForRead.Response(
-                credentials=mock_credentials
-            )
-            read_credentials_mock.return_value = read_credentials_response_proto
+            read_credential_infos_mock.return_value = [mock_credential_info]
             download_mock.return_value = None
             get_list_mock.return_value = []
             databricks_artifact_repo.download_artifacts(remote_file_path, local_path)
-            read_credentials_mock.assert_called_with(MOCK_RUN_ID, remote_file_path)
-            download_mock.assert_called_with(mock_credentials, ANY)
+            read_credential_infos_mock.assert_called_with(run_id=MOCK_RUN_ID, paths=[remote_file_path])
+            download_mock.assert_called_with(
+                cloud_credential_info=mock_credential_info,
+                dst_local_file_path=ANY,
+            )
 
     @pytest.mark.parametrize(
         "remote_file_path, local_path", [("test_file.txt", ""), ("test_file.txt", None)]
@@ -631,49 +666,46 @@ class TestDatabricksArtifactRepository(object):
         with mock.patch(
             DATABRICKS_ARTIFACT_REPOSITORY + "._get_run_artifact_root"
         ) as get_run_artifact_root_mock, mock.patch(
-            DATABRICKS_ARTIFACT_REPOSITORY + "._get_read_credentials"
-        ) as read_credentials_mock, mock.patch(
+            DATABRICKS_ARTIFACT_REPOSITORY + "._get_read_credential_infos"
+        ) as read_credential_infos_mock, mock.patch(
             DATABRICKS_ARTIFACT_REPOSITORY + ".list_artifacts"
         ) as get_list_mock, mock.patch(
             DATABRICKS_ARTIFACT_REPOSITORY + "._download_from_cloud"
         ) as download_mock:
             get_run_artifact_root_mock.return_value = MOCK_RUN_ROOT_URI
-            mock_credentials = ArtifactCredentialInfo(
+            mock_credential_info = ArtifactCredentialInfo(
                 signed_uri=MOCK_AZURE_SIGNED_URI, type=ArtifactCredentialType.AZURE_SAS_URI
             )
-            read_credentials_response_proto = GetCredentialsForRead.Response(
-                credentials=mock_credentials
-            )
-            read_credentials_mock.return_value = read_credentials_response_proto
+            read_credential_infos_mock.return_value = [mock_credential_info]
             download_mock.return_value = None
             get_list_mock.return_value = []
             databricks_artifact_repo = get_artifact_repository(MOCK_SUBDIR_ROOT_URI)
             databricks_artifact_repo.download_artifacts(remote_file_path, local_path)
-            read_credentials_mock.assert_called_with(
-                MOCK_RUN_ID, posixpath.join(MOCK_SUBDIR, remote_file_path)
+            read_credential_infos_mock.assert_called_with(
+                run_id=MOCK_RUN_ID, paths=[posixpath.join(MOCK_SUBDIR, remote_file_path)]
             )
-            download_mock.assert_called_with(mock_credentials, ANY)
+            download_mock.assert_called_with(
+                cloud_credential_info=mock_credential_info,
+                dst_local_file_path=ANY,
+            )
 
     def test_databricks_download_file_get_request_fail(self, databricks_artifact_repo, test_file):
         with mock.patch(
-            DATABRICKS_ARTIFACT_REPOSITORY + "._get_read_credentials"
-        ) as read_credentials_mock, mock.patch(
+            DATABRICKS_ARTIFACT_REPOSITORY + "._get_read_credential_infos"
+        ) as read_credential_infos_mock, mock.patch(
             DATABRICKS_ARTIFACT_REPOSITORY + ".list_artifacts"
         ) as get_list_mock, mock.patch(
             "requests.get"
         ) as request_mock:
-            mock_credentials = ArtifactCredentialInfo(
+            mock_credential_info = ArtifactCredentialInfo(
                 signed_uri=MOCK_AZURE_SIGNED_URI, type=ArtifactCredentialType.AZURE_SAS_URI
             )
-            read_credentials_response_proto = GetCredentialsForRead.Response(
-                credentials=mock_credentials
-            )
-            read_credentials_mock.return_value = read_credentials_response_proto
+            read_credential_infos_mock.return_value = [mock_credential_info]
             get_list_mock.return_value = []
             request_mock.return_value = MlflowException("MOCK ERROR")
             with pytest.raises(MlflowException):
                 databricks_artifact_repo.download_artifacts(test_file.strpath)
-            read_credentials_mock.assert_called_with(MOCK_RUN_ID, test_file.strpath)
+            read_credential_infos_mock.assert_called_with(run_id=MOCK_RUN_ID, paths=[test_file.strpath])
 
     def test_download_artifacts_awaits_download_completion(self, databricks_artifact_repo, tmpdir):
         """
@@ -681,30 +713,34 @@ class TestDatabricksArtifactRepository(object):
         returns a result to the caller
         """
         with mock.patch(
-            DATABRICKS_ARTIFACT_REPOSITORY + "._get_read_credentials"
-        ) as read_credentials_mock, mock.patch(
+            DATABRICKS_ARTIFACT_REPOSITORY + "._get_read_credential_infos"
+        ) as read_credential_infos_mock, mock.patch(
             DATABRICKS_ARTIFACT_REPOSITORY + ".list_artifacts"
         ) as get_list_mock, mock.patch(
             DATABRICKS_ARTIFACT_REPOSITORY + "._download_from_cloud"
         ) as download_mock:
-            mock_credentials = ArtifactCredentialInfo(
+            ArtifactCredentialInfo(
                 signed_uri=MOCK_AZURE_SIGNED_URI, type=ArtifactCredentialType.AZURE_SAS_URI
             )
-            read_credentials_response_proto = GetCredentialsForRead.Response(
-                credentials=mock_credentials
-            )
-            read_credentials_mock.return_value = read_credentials_response_proto
+            read_credential_infos_mock.return_value = [
+                ArtifactCredentialInfo(
+                    signed_uri=MOCK_AZURE_SIGNED_URI, type=ArtifactCredentialType.AZURE_SAS_URI
+                ),
+                ArtifactCredentialInfo(
+                    signed_uri=MOCK_AZURE_SIGNED_URI, type=ArtifactCredentialType.AZURE_SAS_URI
+                ),
+            ]
             get_list_mock.return_value = [
                 FileInfo(path="file_1.txt", is_dir=False, file_size=100),
                 FileInfo(path="file_2.txt", is_dir=False, file_size=0),
             ]
 
             def mock_download_from_cloud(
-                cloud_credential, local_file_path
+                cloud_credential_info, dst_local_file_path
             ):  # pylint: disable=unused-argument
                 # Sleep in order to simulate a longer-running asynchronous download
                 time.sleep(2)
-                with open(local_file_path, "w") as f:
+                with open(dst_local_file_path, "w") as f:
                     f.write("content")
 
             download_mock.side_effect = mock_download_from_cloud
@@ -718,10 +754,10 @@ class TestDatabricksArtifactRepository(object):
                 with open(path, "r") as f:
                     assert f.read() == "content"
 
-    def test_artifact_logging_awaits_upload_completion(self, databricks_artifact_repo, tmpdir):
+    def test_artifact_logging(self, databricks_artifact_repo, tmpdir):
         """
-        Verifies that all asynchronous artifact uploads initiated by `log_artifact()` and
-        `log_artifacts()` are joined before these methods return a result to the caller
+        Verifies that `log_artifact()` and `log_artifacts()` initiate all expected asynchronous
+        artifact uploads and await their completion before returning results to the caller
         """
         src_dir = os.path.join(str(tmpdir), "src")
         os.makedirs(src_dir)
@@ -736,26 +772,27 @@ class TestDatabricksArtifactRepository(object):
         os.makedirs(dst_dir)
 
         with mock.patch(
-            DATABRICKS_ARTIFACT_REPOSITORY + "._get_write_credentials"
-        ) as write_credentials_mock, mock.patch(
+            DATABRICKS_ARTIFACT_REPOSITORY + "._get_write_credential_infos"
+        ) as write_credential_infos_mock, mock.patch(
             DATABRICKS_ARTIFACT_REPOSITORY + "._upload_to_cloud"
         ) as upload_mock:
-            mock_credentials = ArtifactCredentialInfo(
-                signed_uri=MOCK_AZURE_SIGNED_URI, type=ArtifactCredentialType.AZURE_SAS_URI
-            )
-            write_credentials_response_proto = GetCredentialsForWrite.Response(
-                credentials=mock_credentials
-            )
-            write_credentials_mock.return_value = write_credentials_response_proto
+            write_credential_infos_mock.return_value = [
+                ArtifactCredentialInfo(
+                    signed_uri=MOCK_AZURE_SIGNED_URI, type=ArtifactCredentialType.AZURE_SAS_URI
+                ),
+                ArtifactCredentialInfo(
+                    signed_uri=MOCK_AZURE_SIGNED_URI, type=ArtifactCredentialType.AZURE_SAS_URI
+                ),
+            ]
 
             def mock_upload_to_cloud(
-                cloud_credentials, local_file_path, artifact_path
+                cloud_credential_info, src_file_path, dst_run_relative_artifact_path
             ):  # pylint: disable=unused-argument
                 # Sleep in order to simulate a longer-running asynchronous upload
                 time.sleep(2)
-                dst_path = os.path.join(dst_dir, artifact_path)
-                os.makedirs(os.path.dirname(dst_path), exist_ok=True)
-                shutil.copyfile(src=local_file_path, dst=dst_path)
+                dst_run_relative_artifact_path = os.path.join(dst_dir, dst_run_relative_artifact_path)
+                os.makedirs(os.path.dirname(dst_run_relative_artifact_path), exist_ok=True)
+                shutil.copyfile(src=src_file_path, dst=dst_run_relative_artifact_path)
 
             upload_mock.side_effect = mock_upload_to_cloud
 
@@ -779,22 +816,23 @@ class TestDatabricksArtifactRepository(object):
 
     def test_download_artifacts_provides_failure_info(self, databricks_artifact_repo):
         with mock.patch(
-            DATABRICKS_ARTIFACT_REPOSITORY + "._get_read_credentials"
+            DATABRICKS_ARTIFACT_REPOSITORY + "._get_read_credential_infos"
         ) as read_credentials_mock, mock.patch(
             DATABRICKS_ARTIFACT_REPOSITORY + ".list_artifacts"
         ) as get_list_mock, mock.patch(
             DATABRICKS_ARTIFACT_REPOSITORY + "._download_from_cloud"
         ) as download_mock:
-            mock_credentials = ArtifactCredentialInfo(
-                signed_uri=MOCK_AZURE_SIGNED_URI, type=ArtifactCredentialType.AZURE_SAS_URI
-            )
-            read_credentials_response_proto = GetCredentialsForRead.Response(
-                credentials=mock_credentials
-            )
-            read_credentials_mock.return_value = read_credentials_response_proto
             get_list_mock.return_value = [
                 FileInfo(path="file_1.txt", is_dir=False, file_size=100),
                 FileInfo(path="file_2.txt", is_dir=False, file_size=0),
+            ]
+            read_credentials_mock.return_value = [
+                ArtifactCredentialInfo(
+                    signed_uri=MOCK_AZURE_SIGNED_URI, type=ArtifactCredentialType.AZURE_SAS_URI
+                ),
+                ArtifactCredentialInfo(
+                    signed_uri=MOCK_AZURE_SIGNED_URI, type=ArtifactCredentialType.AZURE_SAS_URI
+                )
             ]
             download_mock.side_effect = [
                 MlflowException("MOCK ERROR 1"),
@@ -819,18 +857,18 @@ class TestDatabricksArtifactRepository(object):
             f.write("file2")
 
         with mock.patch(
-            DATABRICKS_ARTIFACT_REPOSITORY + "._get_write_credentials"
+            DATABRICKS_ARTIFACT_REPOSITORY + "._get_write_credential_infos"
         ) as write_credentials_mock, mock.patch(
             DATABRICKS_ARTIFACT_REPOSITORY + "._upload_to_cloud"
         ) as upload_mock:
-            mock_credentials = ArtifactCredentialInfo(
-                signed_uri=MOCK_AZURE_SIGNED_URI, type=ArtifactCredentialType.AZURE_SAS_URI
-            )
-            write_credentials_response_proto = GetCredentialsForWrite.Response(
-                credentials=mock_credentials
-            )
-            write_credentials_mock.return_value = write_credentials_response_proto
-
+            write_credentials_mock.return_value = [
+                ArtifactCredentialInfo(
+                    signed_uri=MOCK_AZURE_SIGNED_URI, type=ArtifactCredentialType.AZURE_SAS_URI
+                ),
+                ArtifactCredentialInfo(
+                    signed_uri=MOCK_AZURE_SIGNED_URI, type=ArtifactCredentialType.AZURE_SAS_URI
+                )
+            ]
             upload_mock.side_effect = [
                 MlflowException("MOCK ERROR 1"),
                 MlflowException("MOCK ERROR 2"),


### PR DESCRIPTION
## What changes are proposed in this pull request?

Use batch credential fetch APIs for Databricks artifact logging

## How is this patch tested?

- Unit tests
- Manual testing on Databricks to ensure that uploads / downloads work properly in the context of logging / loading models and logging / loading directories containing hundreds of files

## Release Notes

Improved artifact logging performance on Databricks

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
