### PR TITLE
Fix bug that removes any strings like "git" from source uri.

### DIFF
--- a/mlflow/server/js/src/common/utils/Utils.js
+++ b/mlflow/server/js/src/common/utils/Utils.js
@@ -190,13 +190,13 @@ class Utils {
     if (gitHubMatch || gitLabMatch) {
       const baseUrl = gitHubMatch ? 'https://github.com/' : 'https://gitlab.com/';
       const match = gitHubMatch || gitLabMatch;
-      url = baseUrl + match[1] + '/' + match[2].replace('.git', '');
+      url = baseUrl + match[1] + '/' + match[2].replace(/\.git/g, '');
       if (match[3]) {
         url = url + '/tree/master/' + match[3];
       }
     } else if (bitbucketMatch) {
       const baseUrl = 'https://bitbucket.org/';
-      url = baseUrl + bitbucketMatch[1] + '/' + bitbucketMatch[2].replace('.git', '');
+      url = baseUrl + bitbucketMatch[1] + '/' + bitbucketMatch[2].replace(/\.git/g, '');
       if (bitbucketMatch[3]) {
         url = url + '/src/master/' + bitbucketMatch[3];
       }
@@ -216,7 +216,7 @@ class Utils {
         baseUrl +
         match[1] +
         '/' +
-        match[2].replace('.git', '') +
+        match[2].replace(/\.git/g, '') +
         '/tree/' +
         sourceVersion +
         '/' +
@@ -227,7 +227,7 @@ class Utils {
         baseUrl +
         bitbucketMatch[1] +
         '/' +
-        bitbucketMatch[2].replace('.git', '') +
+        bitbucketMatch[2].replace(/\.git/g, '') +
         '/src/' +
         sourceVersion +
         '/' +

--- a/mlflow/server/js/src/common/utils/Utils.js
+++ b/mlflow/server/js/src/common/utils/Utils.js
@@ -190,13 +190,13 @@ class Utils {
     if (gitHubMatch || gitLabMatch) {
       const baseUrl = gitHubMatch ? 'https://github.com/' : 'https://gitlab.com/';
       const match = gitHubMatch || gitLabMatch;
-      url = baseUrl + match[1] + '/' + match[2].replace(/\.git/g, '');
+      url = baseUrl + match[1] + '/' + match[2].replace(/\.git$/, '');
       if (match[3]) {
         url = url + '/tree/master/' + match[3];
       }
     } else if (bitbucketMatch) {
       const baseUrl = 'https://bitbucket.org/';
-      url = baseUrl + bitbucketMatch[1] + '/' + bitbucketMatch[2].replace(/\.git/g, '');
+      url = baseUrl + bitbucketMatch[1] + '/' + bitbucketMatch[2].replace(/\.git$/, '');
       if (bitbucketMatch[3]) {
         url = url + '/src/master/' + bitbucketMatch[3];
       }
@@ -216,7 +216,7 @@ class Utils {
         baseUrl +
         match[1] +
         '/' +
-        match[2].replace(/\.git/g, '') +
+        match[2].replace(/\.git$/, '') +
         '/tree/' +
         sourceVersion +
         '/' +
@@ -227,7 +227,7 @@ class Utils {
         baseUrl +
         bitbucketMatch[1] +
         '/' +
-        bitbucketMatch[2].replace(/\.git/g, '') +
+        bitbucketMatch[2].replace(/\.git$/, '') +
         '/src/' +
         sourceVersion +
         '/' +

--- a/mlflow/server/js/src/common/utils/Utils.js
+++ b/mlflow/server/js/src/common/utils/Utils.js
@@ -190,13 +190,13 @@ class Utils {
     if (gitHubMatch || gitLabMatch) {
       const baseUrl = gitHubMatch ? 'https://github.com/' : 'https://gitlab.com/';
       const match = gitHubMatch || gitLabMatch;
-      url = baseUrl + match[1] + '/' + match[2].replace(/.git/, '');
+      url = baseUrl + match[1] + '/' + match[2].replace('.git', '');
       if (match[3]) {
         url = url + '/tree/master/' + match[3];
       }
     } else if (bitbucketMatch) {
       const baseUrl = 'https://bitbucket.org/';
-      url = baseUrl + bitbucketMatch[1] + '/' + bitbucketMatch[2].replace(/.git/, '');
+      url = baseUrl + bitbucketMatch[1] + '/' + bitbucketMatch[2].replace('.git', '');
       if (bitbucketMatch[3]) {
         url = url + '/src/master/' + bitbucketMatch[3];
       }
@@ -216,7 +216,7 @@ class Utils {
         baseUrl +
         match[1] +
         '/' +
-        match[2].replace(/.git/, '') +
+        match[2].replace('.git', '') +
         '/tree/' +
         sourceVersion +
         '/' +
@@ -227,7 +227,7 @@ class Utils {
         baseUrl +
         bitbucketMatch[1] +
         '/' +
-        bitbucketMatch[2].replace(/.git/, '') +
+        bitbucketMatch[2].replace('.git', '') +
         '/src/' +
         sourceVersion +
         '/' +

--- a/mlflow/server/js/src/common/utils/Utils.test.js
+++ b/mlflow/server/js/src/common/utils/Utils.test.js
@@ -108,7 +108,8 @@ test('formatSource & renderSource', () => {
   expect(Utils.formatSource(non_project_source)).toEqual('source3');
   expect(Utils.renderSource(non_project_source)).toEqual('source3');
 
-  // formatSource should return a string, renderSource should return an HTML element (with the correct source url).
+  // formatSource should return a string, renderSource should return an HTML element
+  // with the correct source url.
   const github_url = {
     'mlflow.source.name': { value: 'git@github.com:mlflow/mlflow-apps-git.git' },
     'mlflow.source.type': { value: 'PROJECT' },

--- a/mlflow/server/js/src/common/utils/Utils.test.js
+++ b/mlflow/server/js/src/common/utils/Utils.test.js
@@ -362,3 +362,42 @@ test('normalize', () => {
   expect(Utils.normalize('http://mlflow.org///redundant/')).toEqual('http://mlflow.org/redundant');
   expect(Utils.normalize('s3:///bucket/resource/')).toEqual('s3:/bucket/resource');
 });
+
+test('getGitRepoUrl', () => {
+  expect(Utils.getGitRepoUrl('git@github.com:mflow/mflow.git')).toEqual(
+    'https://github.com/mflow/mflow',
+  );
+  expect(Utils.getGitRepoUrl('https://github.com/torvalds/linux.git')).toEqual(
+    'https://github.com/torvalds/linux',
+  );
+  expect(Utils.getGitRepoUrl('https://github.com/takabayashi/test_mlflow_git.git')).toEqual(
+    'https://github.com/takabayashi/test_mlflow_git',
+  );
+  expect(Utils.getGitRepoUrl('git@bitbucket.org:mlflow/mlflow-apps_git.git')).toEqual(
+    'https://bitbucket.org/mlflow/mlflow-apps_git',
+  );
+  expect(Utils.getGitRepoUrl('git@gitlab.com:mlflow/mlflow-apps.git')).toEqual(
+    'https://gitlab.com/mlflow/mlflow-apps',
+  );
+});
+
+test('getGitCommitUrl', () => {
+  expect(Utils.getGitCommitUrl('git@github.com:mflow/mflow.git', 'v001')).toEqual(
+    'https://github.com/mflow/mflow/tree/v001/',
+  );
+  expect(Utils.getGitCommitUrl('git@github.com:mflow/mflow.git')).toEqual(
+    'https://github.com/mflow/mflow/tree/undefined/',
+  );
+  expect(Utils.getGitCommitUrl('https://github.com/torvalds/linux.git', 'v001')).toEqual(
+    'https://github.com/torvalds/linux/tree/v001/',
+  );
+  expect(
+    Utils.getGitCommitUrl('https://github.com/takabayashi/test_mlflow_git.git', 'v001'),
+  ).toEqual('https://github.com/takabayashi/test_mlflow_git/tree/v001/');
+  expect(Utils.getGitCommitUrl('git@bitbucket.org:mlflow/mlflow-apps_git.git', 'v001')).toEqual(
+    'https://bitbucket.org/mlflow/mlflow-apps_git/src/v001/',
+  );
+  expect(Utils.getGitCommitUrl('git@gitlab.com:mlflow/mlflow-apps.git', 'v001')).toEqual(
+    'https://gitlab.com/mlflow/mlflow-apps/tree/v001/',
+  );
+});

--- a/mlflow/server/js/src/common/utils/Utils.test.js
+++ b/mlflow/server/js/src/common/utils/Utils.test.js
@@ -110,14 +110,14 @@ test('formatSource & renderSource', () => {
 
   // formatSource should return a string, renderSource should return an HTML element (with the correct source url).
   const github_url = {
-    'mlflow.source.name': { value: 'git@github.com:mlflow/mlflow-apps_git.git' },
+    'mlflow.source.name': { value: 'git@github.com:mlflow/mlflow-apps-git.git' },
     'mlflow.source.type': { value: 'PROJECT' },
     'mlflow.project.entryPoint': { value: 'entry' },
   };
-  expect(Utils.formatSource(github_url)).toEqual('mlflow-apps_git:entry');
+  expect(Utils.formatSource(github_url)).toEqual('mlflow-apps-git:entry');
   expect(Utils.renderSource(github_url)).toEqual(
-    <a href='https://github.com/mlflow/mlflow-apps_git' target='_top'>
-      mlflow-apps_git:entry
+    <a href='https://github.com/mlflow/mlflow-apps-git' target='_top'>
+      mlflow-apps-git:entry
     </a>,
   );
 
@@ -134,14 +134,14 @@ test('formatSource & renderSource', () => {
   );
 
   const bitbucket_url = {
-    'mlflow.source.name': { value: 'git@bitbucket.org:mlflow/mlflow-apps_git.git' },
+    'mlflow.source.name': { value: 'git@bitbucket.org:mlflow/mlflow-apps-git.git' },
     'mlflow.source.type': { value: 'PROJECT' },
     'mlflow.project.entryPoint': { value: 'entry' },
   };
-  expect(Utils.formatSource(bitbucket_url)).toEqual('mlflow-apps_git:entry');
+  expect(Utils.formatSource(bitbucket_url)).toEqual('mlflow-apps-git:entry');
   expect(Utils.renderSource(bitbucket_url)).toEqual(
-    <a href='https://bitbucket.org/mlflow/mlflow-apps_git' target='_top'>
-      mlflow-apps_git:entry
+    <a href='https://bitbucket.org/mlflow/mlflow-apps-git' target='_top'>
+      mlflow-apps-git:entry
     </a>,
   );
 
@@ -370,11 +370,11 @@ test('getGitRepoUrl', () => {
   expect(Utils.getGitRepoUrl('https://github.com/torvalds/linux.git')).toEqual(
     'https://github.com/torvalds/linux',
   );
-  expect(Utils.getGitRepoUrl('https://github.com/takabayashi/test_mlflow_git.git')).toEqual(
-    'https://github.com/takabayashi/test_mlflow_git',
+  expect(Utils.getGitRepoUrl('https://github.com/mlflow/test_mlflow_git.git')).toEqual(
+    'https://github.com/mlflow/test_mlflow_git',
   );
-  expect(Utils.getGitRepoUrl('git@bitbucket.org:mlflow/mlflow-apps_git.git')).toEqual(
-    'https://bitbucket.org/mlflow/mlflow-apps_git',
+  expect(Utils.getGitRepoUrl('git@bitbucket.org:mlflow/mlflow-apps-git.git')).toEqual(
+    'https://bitbucket.org/mlflow/mlflow-apps-git',
   );
   expect(Utils.getGitRepoUrl('git@gitlab.com:mlflow/mlflow-apps.git')).toEqual(
     'https://gitlab.com/mlflow/mlflow-apps',
@@ -391,11 +391,11 @@ test('getGitCommitUrl', () => {
   expect(Utils.getGitCommitUrl('https://github.com/torvalds/linux.git', 'v001')).toEqual(
     'https://github.com/torvalds/linux/tree/v001/',
   );
-  expect(
-    Utils.getGitCommitUrl('https://github.com/takabayashi/test_mlflow_git.git', 'v001'),
-  ).toEqual('https://github.com/takabayashi/test_mlflow_git/tree/v001/');
-  expect(Utils.getGitCommitUrl('git@bitbucket.org:mlflow/mlflow-apps_git.git', 'v001')).toEqual(
-    'https://bitbucket.org/mlflow/mlflow-apps_git/src/v001/',
+  expect(Utils.getGitCommitUrl('https://github.com/mlflow/test_mlflow_git.git', 'v001')).toEqual(
+    'https://github.com/mlflow/test_mlflow_git/tree/v001/',
+  );
+  expect(Utils.getGitCommitUrl('git@bitbucket.org:mlflow/mlflow-apps-git.git', 'v001')).toEqual(
+    'https://bitbucket.org/mlflow/mlflow-apps-git/src/v001/',
   );
   expect(Utils.getGitCommitUrl('git@gitlab.com:mlflow/mlflow-apps.git', 'v001')).toEqual(
     'https://gitlab.com/mlflow/mlflow-apps/tree/v001/',

--- a/mlflow/server/js/src/common/utils/Utils.test.js
+++ b/mlflow/server/js/src/common/utils/Utils.test.js
@@ -108,16 +108,16 @@ test('formatSource & renderSource', () => {
   expect(Utils.formatSource(non_project_source)).toEqual('source3');
   expect(Utils.renderSource(non_project_source)).toEqual('source3');
 
-  // formatSource should return a string, renderSource should return an HTML element.
+  // formatSource should return a string, renderSource should return an HTML element (with the correct source url).
   const github_url = {
-    'mlflow.source.name': { value: 'git@github.com:mlflow/mlflow-apps.git' },
+    'mlflow.source.name': { value: 'git@github.com:mlflow/mlflow-apps_git.git' },
     'mlflow.source.type': { value: 'PROJECT' },
     'mlflow.project.entryPoint': { value: 'entry' },
   };
-  expect(Utils.formatSource(github_url)).toEqual('mlflow-apps:entry');
+  expect(Utils.formatSource(github_url)).toEqual('mlflow-apps_git:entry');
   expect(Utils.renderSource(github_url)).toEqual(
-    <a href='https://github.com/mlflow/mlflow-apps' target='_top'>
-      mlflow-apps:entry
+    <a href='https://github.com/mlflow/mlflow-apps_git' target='_top'>
+      mlflow-apps_git:entry
     </a>,
   );
 
@@ -134,14 +134,14 @@ test('formatSource & renderSource', () => {
   );
 
   const bitbucket_url = {
-    'mlflow.source.name': { value: 'git@bitbucket.org:mlflow/mlflow-apps.git' },
+    'mlflow.source.name': { value: 'git@bitbucket.org:mlflow/mlflow-apps_git.git' },
     'mlflow.source.type': { value: 'PROJECT' },
     'mlflow.project.entryPoint': { value: 'entry' },
   };
-  expect(Utils.formatSource(bitbucket_url)).toEqual('mlflow-apps:entry');
+  expect(Utils.formatSource(bitbucket_url)).toEqual('mlflow-apps_git:entry');
   expect(Utils.renderSource(bitbucket_url)).toEqual(
-    <a href='https://bitbucket.org/mlflow/mlflow-apps' target='_top'>
-      mlflow-apps:entry
+    <a href='https://bitbucket.org/mlflow/mlflow-apps_git' target='_top'>
+      mlflow-apps_git:entry
     </a>,
   );
 


### PR DESCRIPTION
Signed-off-by: Daniel Takabayashi <daniel.takabayashi@gmail.com>

## What changes are proposed in this pull request?

This is a fix for issue #4395 

The bug that generates this behavior is at this function Utils.getRepomeURL (line 193 and 199) the regex is replacing too much. Just changing the code to `match[2].replace('.git', '')` and `bitbucketMatch[2].replace('.git', '')`. Actually the requirement is so simple here that is not a regex usagee is not needed.

## How is this patch tested?

Running unit tests inside npm test ./src/common/utils/Utils.test.js` before and after the change.
Also, I executed the script created by the author of this bug, navigating throw UI.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [x] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
