### PR TITLE
Revert patched code when disabling autolog

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -28,5 +28,3 @@ __pycache__
 ~*
 *.swp
 *.pyc
-
-

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -15,6 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Increase available disk space
+      run: |
+        # Increase available disk space by removing unnecessary tool chains:
+        # https://github.com/actions/virtual-environments/issues/709#issuecomment-612569242
+        rm -rf "$AGENT_TOOLSDIRECTORY"
+        df -h
+
     - name: Check diff
       id: check-diff
       run: |
@@ -22,24 +29,13 @@ jobs:
           git fetch origin master:master
         fi
 
-        REGEXP="tests/examples\|examples\|Dockerfile\|\.dockerignore\$"
+        REGEXP="tests/examples\|examples"
         CHANGED_FILES=$(git diff --name-only master..HEAD | grep "$REGEXP") || true;
-        EXAMPLES_CHANGED=$([[ "$CHANGED_FILES" == *"examples"* ]] && echo "true" || echo "false")
-        DOCKER_CHANGED=$([[ ("$CHANGED_FILES" == *"Dockerfile"*) || ("$CHANGED_FILES" == *".dockerignore"*) ]] && echo "true" || echo "false")
+        EXAMPLES_CHANGED=$([[ ! -z "$CHANGED_FILES" ]] && echo "true" || echo "false")
 
-        echo "CHANGED_FILES:"
-        echo "$CHANGED_FILES"
+        echo -e "CHANGED_FILES:\nCHANGED_FILES"
         echo "EXAMPLES_CHANGED: $EXAMPLES_CHANGED"
-        echo "DOCKER_CHANGED: $DOCKER_CHANGED"
-
         echo "::set-output name=examples_changed::$EXAMPLES_CHANGED"
-        echo "::set-output name=docker_changed::$DOCKER_CHANGED"
-
-    - name: Increase available disk space
-      run: |
-        # Increase available disk space by removing unnecessary tool chains:
-        # https://github.com/actions/virtual-environments/issues/709#issuecomment-612569242
-        rm -rf "$AGENT_TOOLSDIRECTORY"
 
     - name: Enable conda
       run: |
@@ -66,7 +62,39 @@ jobs:
         conda remove --all --yes --name test-environment
         ./dev/remove-conda-envs.sh
 
+    - name: Show disk usage
+      run: |
+        df -h
+
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Increase available disk space
+      run: |
+        rm -rf "$AGENT_TOOLSDIRECTORY"
+        df -h
+
+    - name: Check diff
+      id: check-diff
+      run: |
+        if [ ! "$(git branch --show-current)" == "master" ]; then
+          git fetch origin master:master
+        fi
+
+        REGEXP="Dockerfile\|\.dockerignore"
+        CHANGED_FILES=$(git diff --name-only master..HEAD | grep "$REGEXP") || true;
+        DOCKER_CHANGED=$([[ ! -z "$CHANGED_FILES" ]] && echo "true" || echo "false")
+
+        echo -e "CHANGED_FILES:\nCHANGED_FILES"
+        echo "DOCKER_CHANGED: $DOCKER_CHANGED"
+        echo "::set-output name=docker_changed::$DOCKER_CHANGED"
+
     - name: Run docker tests
       if: ${{ github.event_name == 'schedule' || steps.check-diff.outputs.docker_changed == 'true' }}
       run: |
         docker build -t mlflow_test_build . && docker images | grep mlflow_test_build
+
+    - name: Show disk usage
+      run: |
+        df -h

--- a/dev/remove-conda-envs.sh
+++ b/dev/remove-conda-envs.sh
@@ -13,9 +13,9 @@ if [ ! -z "$mlflow_envs" ]; then
   do
     conda remove --all --yes --name $env
   done
-
-  conda clean --all --yes
-  conda env list
 fi
+
+conda clean --all --yes
+conda env list
 
 set +ex

--- a/examples/spacy/train.py
+++ b/examples/spacy/train.py
@@ -1,14 +1,12 @@
 import random
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 import spacy
 from spacy.util import minibatch, compounding
 
 import mlflow.spacy
 
-IS_SPACY_VERSION_NEWER_THAN_OR_EQUAL_TO_3_0_0 = LooseVersion(spacy.__version__) >= LooseVersion(
-    "3.0.0"
-)
+IS_SPACY_VERSION_NEWER_THAN_OR_EQUAL_TO_3_0_0 = Version(spacy.__version__) >= Version("3.0.0")
 
 # training data
 TRAIN_DATA = [

--- a/mlflow/azureml/__init__.py
+++ b/mlflow/azureml/__init__.py
@@ -8,7 +8,7 @@ import subprocess
 import logging
 import uuid
 
-from distutils.version import StrictVersion
+from packaging.version import Version
 
 from mlflow import get_tracking_uri, get_registry_uri
 from mlflow import pyfunc
@@ -138,9 +138,7 @@ def build_image(
 
     model_pyfunc_conf, _ = _load_pyfunc_conf_with_model(model_path=absolute_model_path)
     model_python_version = model_pyfunc_conf.get(pyfunc.PY_VERSION, None)
-    if model_python_version is not None and StrictVersion(model_python_version) < StrictVersion(
-        "3.0.0"
-    ):
+    if model_python_version is not None and Version(model_python_version) < Version("3.0.0"):
         raise MlflowException(
             message=(
                 "Azure ML can only deploy models trained in Python 3 and above. See"
@@ -351,9 +349,7 @@ def deploy(
         run_id_tag = run_id
     except AttributeError:
         run_id = str(uuid.uuid4())
-    if model_python_version is not None and StrictVersion(model_python_version) < StrictVersion(
-        "3.0.0"
-    ):
+    if model_python_version is not None and Version(model_python_version) < Version("3.0.0"):
         raise MlflowException(
             message=(
                 "Azure ML can only deploy models trained in Python 3 and above. See"

--- a/mlflow/gluon.py
+++ b/mlflow/gluon.py
@@ -1,4 +1,4 @@
-from distutils.version import LooseVersion
+from packaging.version import Version
 import os
 
 import numpy as np
@@ -66,7 +66,7 @@ def load_model(model_uri, ctx):
     symbol = sym.load(model_arch_path)
     inputs = sym.var("data", dtype="float32")
     net = gluon.SymbolBlock(symbol, inputs)
-    if LooseVersion(mxnet.__version__) >= LooseVersion("2.0.0"):
+    if Version(mxnet.__version__) >= Version("2.0.0"):
         net.load_parameters(model_params_path, ctx)
     else:
         net.collect_params().load(model_params_path, ctx)

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -15,7 +15,7 @@ import yaml
 import cloudpickle
 import numpy as np
 import pandas as pd
-from distutils.version import LooseVersion
+from packaging.version import Version
 import posixpath
 
 import mlflow
@@ -585,7 +585,7 @@ def _load_model(path, **kwargs):
     else:
         model_path = path
 
-    if LooseVersion(torch.__version__) >= LooseVersion("1.5.0"):
+    if Version(torch.__version__) >= Version("1.5.0"):
         return torch.load(model_path, **kwargs)
     else:
         try:

--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -1,4 +1,4 @@
-from distutils.version import LooseVersion
+from packaging.version import Version
 import logging
 import mlflow.pytorch
 import os
@@ -43,7 +43,7 @@ def _get_optimizer_name(optimizer):
     https://pytorch-lightning.readthedocs.io/en/stable/api/pytorch_lightning.trainer.trainer.html
     #pytorch_lightning.trainer.trainer.Trainer.params.enable_pl_optimizer
     """
-    if LooseVersion(pl.__version__) < LooseVersion("1.1.0"):
+    if Version(pl.__version__) < Version("1.1.0"):
         return optimizer.__class__.__name__
     else:
         from pytorch_lightning.core.optimizer import LightningOptimizer
@@ -113,7 +113,7 @@ def _create_patch_fit(log_every_n_epoch=1, log_models=True):
             # epochs (related PR: https://github.com/PyTorchLightning/pytorch-lightning/pull/5986)
             # As a workaround, use `on_train_epoch_end` and `on_validation_epoch_end` instead
             # in pytorch-lightning >= 1.2.0.
-            if LooseVersion(pl.__version__) >= LooseVersion("1.2.0"):
+            if Version(pl.__version__) >= Version("1.2.0"):
 
                 # NB: Override `on_train_epoch_end` with an additional `*args` parameter for
                 # compatibility with versions of pytorch-lightning <= 1.2.0, which required an

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -1,5 +1,5 @@
 import collections
-from distutils.version import LooseVersion
+from packaging.version import Version
 import inspect
 import logging
 from numbers import Number
@@ -682,7 +682,7 @@ def _create_child_runs_for_parameter_search(cv_estimator, parent_run, child_tags
 def _is_supported_version():
     import sklearn
 
-    return LooseVersion(sklearn.__version__) >= LooseVersion(_MIN_SKLEARN_VERSION)
+    return Version(sklearn.__version__) >= Version(_MIN_SKLEARN_VERSION)
 
 
 # Util function to check whether a metric is able to be computed in given sklearn version
@@ -692,7 +692,7 @@ def _is_metric_supported(metric_name):
     # This dict can be extended to store special metrics' specific supported versions
     _metric_supported_version = {"roc_auc_score": "0.22.2"}
 
-    return LooseVersion(sklearn.__version__) >= LooseVersion(_metric_supported_version[metric_name])
+    return Version(sklearn.__version__) >= Version(_metric_supported_version[metric_name])
 
 
 # Util function to check whether artifact plotting functions are able to be computed
@@ -700,7 +700,7 @@ def _is_metric_supported(metric_name):
 def _is_plotting_supported():
     import sklearn
 
-    return LooseVersion(sklearn.__version__) >= LooseVersion("0.22.0")
+    return Version(sklearn.__version__) >= Version("0.22.0")
 
 
 def _all_estimators():

--- a/mlflow/store/artifact/artifact_repo.py
+++ b/mlflow/store/artifact/artifact_repo.py
@@ -62,6 +62,34 @@ class ArtifactRepository:
         listing = self.list_artifacts(artifact_path)
         return len(listing) > 0
 
+    def _create_download_destination(self, src_artifact_path, dst_local_dir_path=None):
+        """
+        Creates a local filesystem location to be used as a destination for downloading the artifact
+        specified by `src_artifact_path`. The destination location is a subdirectory of the
+        specified `dst_local_dir_path`, which is determined according to the structure of
+        `src_artifact_path`. For example, if `src_artifact_path` is `dir1/file1.txt`, then the
+        resulting destination path is `<dst_local_dir_path>/dir1/file1.txt`. Local directories are
+        created for the resulting destination location if they do not exist.
+
+        :param src_artifact_path: A relative, POSIX-style path referring to an artifact stored
+                                  within the repository's artifact root location.
+                                  `src_artifact_path` should be specified relative to the
+                                  repository's artifact root location.
+        :param dst_local_dir_path: The absolute path to a local filesystem directory in which the
+                                   local destination path will be contained. The local destination
+                                   path may be contained in a subdirectory of `dst_root_dir` if
+                                   `src_artifact_path` contains subdirectories.
+        :return: The absolute path to a local filesystem location to be used as a destination
+                 for downloading the artifact specified by `src_artifact_path`.
+        """
+        src_artifact_path = src_artifact_path.rstrip("/")  # Ensure correct dirname for trailing '/'
+        dirpath = posixpath.dirname(src_artifact_path)
+        local_dir_path = os.path.join(dst_local_dir_path, dirpath)
+        local_file_path = os.path.join(dst_local_dir_path, src_artifact_path)
+        if not os.path.exists(local_dir_path):
+            os.makedirs(local_dir_path, exist_ok=True)
+        return local_file_path
+
     def download_artifacts(self, artifact_path, dst_path=None):
         """
         Download an artifact file or directory to a local directory if applicable, and return a
@@ -80,32 +108,51 @@ class ArtifactRepository:
 
         # TODO: Probably need to add a more efficient method to stream just a single artifact
         #       without downloading it, or to get a pre-signed URL for cloud storage.
-        def download_file(fullpath):
-            fullpath = fullpath.rstrip("/")  # Prevents incorrect split if fullpath ends with a '/'
-            dirpath, _ = posixpath.split(fullpath)
-            local_dir_path = os.path.join(dst_path, dirpath)
-            local_file_path = os.path.join(dst_path, fullpath)
-            if not os.path.exists(local_dir_path):
-                os.makedirs(local_dir_path)
-            self._download_file(remote_file_path=fullpath, local_path=local_file_path)
-            return local_file_path
+        def download_artifact(src_artifact_path, dst_local_dir_path):
+            """
+            Download the file artifact specified by `src_artifact_path` to the local filesystem
+            directory specified by `dst_local_dir_path`.
 
-        def download_artifact_dir(dir_path):
-            local_dir = os.path.join(dst_path, dir_path)
+            :param src_artifact_path: A relative, POSIX-style path referring to a file artifact
+                                      stored within the repository's artifact root location.
+                                      `src_artifact_path` should be specified relative to the
+                                      repository's artifact root location.
+            :param dst_local_dir_path: Absolute path of the local filesystem destination directory
+                                       to which to download the specified artifact. The downloaded
+                                       artifact may be written to a subdirectory of
+                                       `dst_local_dir_path` if `src_artifact_path` contains
+                                       subdirectories.
+            :return: A local filesystem path referring to the downloaded file.
+            """
+            local_destination_file_path = self._create_download_destination(
+                src_artifact_path=src_artifact_path, dst_local_dir_path=dst_local_dir_path
+            )
+            self._download_file(
+                remote_file_path=src_artifact_path, local_path=local_destination_file_path
+            )
+            return local_destination_file_path
+
+        def download_artifact_dir(src_artifact_dir_path, dst_local_dir_path):
+            local_dir = os.path.join(dst_local_dir_path, src_artifact_dir_path)
             dir_content = [  # prevent infinite loop, sometimes the dir is recursively included
                 file_info
-                for file_info in self.list_artifacts(dir_path)
-                if file_info.path != "." and file_info.path != dir_path
+                for file_info in self.list_artifacts(src_artifact_dir_path)
+                if file_info.path != "." and file_info.path != src_artifact_dir_path
             ]
             if not dir_content:  # empty dir
                 if not os.path.exists(local_dir):
-                    os.makedirs(local_dir)
+                    os.makedirs(local_dir, exist_ok=True)
             else:
                 for file_info in dir_content:
                     if file_info.is_dir:
-                        download_artifact_dir(dir_path=file_info.path)
+                        download_artifact_dir(
+                            src_artifact_dir_path=file_info.path,
+                            dst_local_dir_path=dst_local_dir_path,
+                        )
                     else:
-                        download_file(file_info.path)
+                        download_artifact(
+                            src_artifact_path=file_info.path, dst_local_dir_path=dst_local_dir_path
+                        )
             return local_dir
 
         if dst_path is None:
@@ -131,9 +178,11 @@ class ArtifactRepository:
 
         # Check if the artifacts points to a directory
         if self._is_directory(artifact_path):
-            return download_artifact_dir(artifact_path)
+            return download_artifact_dir(
+                src_artifact_dir_path=artifact_path, dst_local_dir_path=dst_path
+            )
         else:
-            return download_file(artifact_path)
+            return download_artifact(src_artifact_path=artifact_path, dst_local_dir_path=dst_path)
 
     @abstractmethod
     def _download_file(self, remote_file_path, local_path):

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -18,7 +18,7 @@ import time
 import tempfile
 from collections import namedtuple
 import pandas
-from distutils.version import LooseVersion
+from packaging.version import Version
 from threading import RLock
 
 import mlflow
@@ -295,7 +295,7 @@ def _validate_saved_model(tf_saved_model_dir, tf_meta_graph_tags, tf_signature_d
     """
     import tensorflow
 
-    if LooseVersion(tensorflow.__version__) < LooseVersion("2.0.0"):
+    if Version(tensorflow.__version__) < Version("2.0.0"):
         validation_tf_graph = tensorflow.Graph()
         validation_tf_sess = tensorflow.Session(graph=validation_tf_graph)
         with validation_tf_graph.as_default():
@@ -361,7 +361,7 @@ def load_model(model_uri, tf_sess=None):
     """
     import tensorflow
 
-    if LooseVersion(tensorflow.__version__) < LooseVersion("2.0.0"):
+    if Version(tensorflow.__version__) < Version("2.0.0"):
         if not tf_sess:
             tf_sess = tensorflow.get_default_session()
             if not tf_sess:
@@ -424,7 +424,7 @@ def _load_tensorflow_saved_model(
     """
     import tensorflow
 
-    if LooseVersion(tensorflow.__version__) < LooseVersion("2.0.0"):
+    if Version(tensorflow.__version__) < Version("2.0.0"):
         loaded = tensorflow.saved_model.loader.load(
             sess=tf_sess, tags=tf_meta_graph_tags, export_dir=tf_saved_model_dir
         )
@@ -477,7 +477,7 @@ def _load_pyfunc(path):
         tf_meta_graph_tags,
         tf_signature_def_key,
     ) = _get_and_parse_flavor_configuration(model_path=path)
-    if LooseVersion(tensorflow.__version__) < LooseVersion("2.0.0"):
+    if Version(tensorflow.__version__) < Version("2.0.0"):
         tf_graph = tensorflow.Graph()
         tf_sess = tensorflow.Session(graph=tf_graph)
         with tf_graph.as_default():
@@ -811,7 +811,7 @@ def _setup_callbacks(lst, log_models, metrics_logger):
     else:
         log_dir = _TensorBoardLogDir(location=tb.log_dir, is_temp=False)
         out_list = lst
-    if LooseVersion(tensorflow.__version__) < LooseVersion("2.0.0"):
+    if Version(tensorflow.__version__) < Version("2.0.0"):
         out_list += [__MLflowTfKerasCallback()]
     else:
         out_list += [__MLflowTfKeras2Callback()]
@@ -901,7 +901,7 @@ def autolog(
 
     atexit.register(_flush_queue)
 
-    if LooseVersion(tensorflow.__version__) < LooseVersion("1.12"):
+    if Version(tensorflow.__version__) < Version("1.12"):
         warnings.warn("Could not log to MLflow. TensorFlow versions below 1.12 are not supported.")
         return
 
@@ -1038,7 +1038,7 @@ def autolog(
                     key: history.history[key][restored_index] for key in history.history.keys()
                 }
                 # Metrics are logged as 'epoch_loss' and 'epoch_acc' in TF 1.X
-                if LooseVersion(tensorflow.__version__) < LooseVersion("2.0.0"):
+                if Version(tensorflow.__version__) < Version("2.0.0"):
                     if "loss" in restored_metrics:
                         restored_metrics["epoch_loss"] = restored_metrics.pop("loss")
                     if "acc" in restored_metrics:
@@ -1195,7 +1195,7 @@ def autolog(
         (tensorflow.keras.Model, "fit", FitPatch),
     ]
 
-    if LooseVersion(tensorflow.__version__) < LooseVersion("2.1.0"):
+    if Version(tensorflow.__version__) < Version("2.1.0"):
         # `fit_generator()` is deprecated in TF >= 2.1.0 and simply wraps `fit()`.
         # To avoid unintentional creation of nested MLflow runs caused by a patched
         # `fit_generator()` method calling a patched `fit()` method, we only patch
@@ -1211,7 +1211,7 @@ def autolog(
     ]
 
     # Add compat.v1 Estimator patching for versions of tensfor that are 2.0+.
-    if LooseVersion(tensorflow.__version__) >= LooseVersion("2.0.0"):
+    if Version(tensorflow.__version__) >= Version("2.0.0"):
         old_estimator_class = tensorflow.compat.v1.estimator.Estimator
         v1_train = (old_estimator_class, "train", train)
         v1_export_saved_model = (old_estimator_class, "export_saved_model", export_saved_model)

--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -23,6 +23,7 @@ from mlflow.utils.autologging_utils.logging_and_warnings import (  # noqa: E402
 from mlflow.utils.autologging_utils.safety import (  # noqa: E402
     try_mlflow_log,
     update_wrapper_extended,
+    revert_patches,
 )
 from mlflow.utils.autologging_utils.versioning import (  # noqa: E402
     FLAVOR_TO_MODULE_NAME_AND_VERSION_INFO_KEY,
@@ -342,6 +343,10 @@ def autologging_integration(name):
             )
             config_to_store.update(kwargs)
             AUTOLOGGING_INTEGRATIONS[name] = config_to_store
+
+            if get_autologging_config(name, "disable", True):
+                revert_patches(name)
+                return
 
             is_silent_mode = get_autologging_config(name, "silent", False)
             # Reroute non-MLflow warnings encountered during autologging enablement to an

--- a/mlflow/utils/autologging_utils/safety.py
+++ b/mlflow/utils/autologging_utils/safety.py
@@ -546,7 +546,7 @@ def safe_patch(
 
 
 def revert_patches(autologging_integration):
-    print("len: ", len(_AUTOLOGGING_PATCHES))
+    # print("len: ", len(_AUTOLOGGING_PATCHES))
     if autologging_integration in _AUTOLOGGING_PATCHES:
         for patch in _AUTOLOGGING_PATCHES.get(autologging_integration):
             gorilla.revert(patch)

--- a/mlflow/utils/autologging_utils/safety.py
+++ b/mlflow/utils/autologging_utils/safety.py
@@ -546,10 +546,12 @@ def safe_patch(
 
 
 def revert_patches(autologging_integration):
-    for patch in _AUTOLOGGING_PATCHES.get(autologging_integration):
-        gorilla.revert(patch)
+    print("len: ", len(_AUTOLOGGING_PATCHES))
+    if autologging_integration in _AUTOLOGGING_PATCHES:
+        for patch in _AUTOLOGGING_PATCHES.get(autologging_integration):
+            gorilla.revert(patch)
 
-    _AUTOLOGGING_PATCHES.pop(autologging_integration, None)
+        _AUTOLOGGING_PATCHES.pop(autologging_integration, None)
 
 
 # Represents an active autologging session using two fields:

--- a/mlflow/utils/autologging_utils/safety.py
+++ b/mlflow/utils/autologging_utils/safety.py
@@ -635,7 +635,7 @@ def _store_patch(autologging_integration, patch):
     if autologging_integration in _AUTOLOGGING_PATCHES:
         _AUTOLOGGING_PATCHES[autologging_integration].add(patch)
     else:
-        _AUTOLOGGING_PATCHES[autologging_integration] = set(patch)
+        _AUTOLOGGING_PATCHES[autologging_integration] = set([patch])
 
 
 def _validate_autologging_run(autologging_integration, run_id):

--- a/mlflow/utils/autologging_utils/safety.py
+++ b/mlflow/utils/autologging_utils/safety.py
@@ -22,6 +22,8 @@ from mlflow.utils.mlflow_tags import MLFLOW_AUTOLOGGING
 
 _AUTOLOGGING_TEST_MODE_ENV_VAR = "MLFLOW_AUTOLOGGING_TESTING"
 
+_AUTOLOGGING_PATCHES = {}
+
 
 def try_mlflow_log(fn, *args, **kwargs):
     """
@@ -539,7 +541,15 @@ def safe_patch(
                 else:
                     return original(*args, **kwargs)
 
-    _wrap_patch(destination, function_name, safe_patch_function)
+    new_patch = _wrap_patch(destination, function_name, safe_patch_function)
+    _store_patch(autologging_integration, new_patch)
+
+
+def revert_patches(autologging_integration):
+    for patch in _AUTOLOGGING_PATCHES.get(autologging_integration):
+        gorilla.revert(patch)
+
+    _AUTOLOGGING_PATCHES.pop(autologging_integration, None)
 
 
 # Represents an active autologging session using two fields:
@@ -618,6 +628,14 @@ def _wrap_patch(destination, name, patch, settings=None):
 
     patch = gorilla.Patch(destination, name, wrapped, settings=settings)
     gorilla.apply(patch)
+    return patch
+
+
+def _store_patch(autologging_integration, patch):
+    if autologging_integration in _AUTOLOGGING_PATCHES:
+        _AUTOLOGGING_PATCHES[autologging_integration].add(patch)
+    else:
+        _AUTOLOGGING_PATCHES[autologging_integration] = set(patch)
 
 
 def _validate_autologging_run(autologging_integration, run_id):

--- a/mlflow/utils/gorilla.py
+++ b/mlflow/utils/gorilla.py
@@ -331,6 +331,34 @@ def apply(patch):
     setattr(patch.destination, _ACTIVE_PATCH, patch)
 
 
+def revert(patch):
+    """Revert a patch.
+    Parameters
+    ----------
+    patch : gorilla.Patch
+        Patch.
+    Note
+    ----
+    This is only possible if the attribute :attr:`Settings.store_hit` was set
+    to ``True`` when applying the patch and overriding an existing attribute.
+    """
+    if getattr(patch.destination, _ACTIVE_PATCH, None) != patch:
+        return
+
+    try:
+        original = get_original_attribute(patch.destination, patch.name)
+    except AttributeError:
+        raise RuntimeError(
+                "Cannot revert the attribute named '%s' since the setting "
+                "'store_hit' was not set to True when applying the patch."
+                % (patch.destination.__name__,))
+
+    original_name = _ORIGINAL_NAME % (patch.name,)
+    setattr(patch.destination, patch.name, original)
+    delattr(patch.destination, original_name)
+    delattr(patch.destination, _ACTIVE_PATCH)
+
+
 def patch(destination, name=None, settings=None):
     """Decorator to create a patch.
 

--- a/mlflow/utils/gorilla.py
+++ b/mlflow/utils/gorilla.py
@@ -231,6 +231,9 @@ class Patch(object):
         is_equal = self.__eq__(other)
         return is_equal if is_equal is NotImplemented else not is_equal
 
+    def __hash__(self):
+        return super().__hash__()
+
     def _update(self, **kwargs):
         """Update some attributes.
 
@@ -343,6 +346,7 @@ def revert(patch):
     to ``True`` when applying the patch and overriding an existing attribute.
     """
     if getattr(patch.destination, _ACTIVE_PATCH, None) != patch:
+        # print("SKIPPING")
         return
 
     try:
@@ -354,7 +358,13 @@ def revert(patch):
                 % (patch.destination.__name__,))
 
     original_name = _ORIGINAL_NAME % (patch.name,)
+    if not getattr(patch.destination, original_name):
+        return
+
+
     setattr(patch.destination, patch.name, original)
+    # print(patch.destination, patch.name, hasattr(patch.destination, original_name))
+    # print(getattr(patch.destination, _ACTIVE_PATCH), patch)
     delattr(patch.destination, original_name)
     delattr(patch.destination, _ACTIVE_PATCH)
 

--- a/mlflow/utils/gorilla.py
+++ b/mlflow/utils/gorilla.py
@@ -331,7 +331,7 @@ def apply(patch):
                 setattr(patch.destination, original_name, target)
 
     setattr(patch.destination, patch.name, patch.obj)
-    setattr(patch.destination, _ACTIVE_PATCH, patch)
+    # setattr(patch.destination, _ACTIVE_PATCH, patch)
 
 
 def revert(patch):
@@ -346,7 +346,6 @@ def revert(patch):
     to ``True`` when applying the patch and overriding an existing attribute.
     """
     if getattr(patch.destination, _ACTIVE_PATCH, None) != patch:
-        # print("SKIPPING")
         return
 
     try:
@@ -358,6 +357,7 @@ def revert(patch):
                 % (patch.destination.__name__,))
 
     original_name = _ORIGINAL_NAME % (patch.name,)
+    # print('atoof: ', original, patch.destination, patch.name, original_name)
     if not getattr(patch.destination, original_name):
         return
 
@@ -366,7 +366,7 @@ def revert(patch):
     # print(patch.destination, patch.name, hasattr(patch.destination, original_name))
     # print(getattr(patch.destination, _ACTIVE_PATCH), patch)
     delattr(patch.destination, original_name)
-    delattr(patch.destination, _ACTIVE_PATCH)
+    # delattr(patch.destination, _ACTIVE_PATCH)
 
 
 def patch(destination, name=None, settings=None):

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -16,7 +16,7 @@ XGBoost (native) format
 .. _scikit-learn API:
     https://xgboost.readthedocs.io/en/latest/python/python_api.html#module-xgboost.sklearn
 """
-from distutils.version import LooseVersion
+from packaging.version import Version
 import os
 import shutil
 import json
@@ -381,8 +381,9 @@ def autolog(
             """
             Create a callback function that records evaluation results.
             """
-
-            if LooseVersion(xgboost.__version__) >= LooseVersion("1.3.0"):
+            # TODO: Remove `replace("SNAPSHOT", "dev")` once the following issue is addressed:
+            #       https://github.com/dmlc/xgboost/issues/6984
+            if Version(xgboost.__version__.replace("SNAPSHOT", "dev")) >= Version("1.3.0"):
                 # In xgboost >= 1.3.0, user-defined callbacks should inherit
                 # `xgboost.callback.TrainingCallback`:
                 # https://xgboost.readthedocs.io/en/latest/python/callbacks.html#defining-your-own-callback  # noqa

--- a/tests/gluon/test_gluon_model_export.py
+++ b/tests/gluon/test_gluon_model_export.py
@@ -1,4 +1,4 @@
-from distutils.version import LooseVersion
+from packaging.version import Version
 import os
 import warnings
 import yaml
@@ -28,7 +28,7 @@ from mlflow.utils.model_utils import _get_flavor_configuration
 
 from tests.helper_functions import pyfunc_serve_and_score_model
 
-if LooseVersion(mx.__version__) >= LooseVersion("2.0.0"):
+if Version(mx.__version__) >= Version("2.0.0"):
     from mxnet.gluon.metric import Accuracy  # pylint: disable=import-error
 else:
     from mxnet.metric import Accuracy  # pylint: disable=import-error
@@ -72,9 +72,7 @@ def gluon_model(model_data):
     )
 
     # `metrics` was renamed in mxnet 1.6.0: https://github.com/apache/incubator-mxnet/pull/17048
-    arg_name = (
-        "metrics" if LooseVersion(mx.__version__) < LooseVersion("1.6.0") else "train_metrics"
-    )
+    arg_name = "metrics" if Version(mx.__version__) < Version("1.6.0") else "train_metrics"
     est = estimator.Estimator(
         net=model, loss=SoftmaxCrossEntropyLoss(), trainer=trainer, **{arg_name: Accuracy()}
     )

--- a/tests/gluon_autolog/test_gluon_autolog.py
+++ b/tests/gluon_autolog/test_gluon_autolog.py
@@ -1,4 +1,4 @@
-from distutils.version import LooseVersion
+from packaging.version import Version
 import random
 import warnings
 
@@ -17,7 +17,7 @@ import mlflow.gluon
 from mlflow.utils.autologging_utils import BatchMetricsLogger
 from unittest.mock import patch
 
-if LooseVersion(mx.__version__) >= LooseVersion("2.0.0"):
+if Version(mx.__version__) >= Version("2.0.0"):
     from mxnet.gluon.metric import Accuracy  # pylint: disable=import-error
 else:
     from mxnet.metric import Accuracy  # pylint: disable=import-error
@@ -35,7 +35,7 @@ class LogsDataset(Dataset):
 
 
 def is_mxnet_older_than_1_6_0():
-    return LooseVersion(mx.__version__) < LooseVersion("1.6.0")
+    return Version(mx.__version__) < Version("1.6.0")
 
 
 def get_metrics():

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -1,6 +1,6 @@
 # pep8: disable=E501
 
-from distutils.version import LooseVersion
+from packaging.version import Version
 import h5py
 import os
 import json
@@ -51,7 +51,7 @@ def fix_random_seed():
     random.seed(SEED)
     np.random.seed(SEED)
 
-    if LooseVersion(tf.__version__) >= LooseVersion("2.0.0"):
+    if Version(tf.__version__) >= Version("2.0.0"):
         tf.random.set_seed(SEED)
     else:
         tf.set_random_seed(SEED)
@@ -81,7 +81,7 @@ def model(data):
         # `lr` was renamed to `learning_rate` in keras 2.3.0:
         # https://github.com/keras-team/keras/releases/tag/2.3.0
         {"lr": lr}
-        if LooseVersion(keras.__version__) < LooseVersion("2.3.0")
+        if Version(keras.__version__) < Version("2.3.0")
         else {"learning_rate": lr}
     )
     model.compile(loss="mean_squared_error", optimizer=SGD(**kwargs))
@@ -185,7 +185,7 @@ def test_that_keras_module_arg_works(model_path):
             # pylint: disable=unused-argument
 
             # `Dataset.value` was removed in `h5py == 3.0.0`
-            if LooseVersion(h5py.__version__) >= LooseVersion("3.0.0"):
+            if Version(h5py.__version__) >= Version("3.0.0"):
                 return MyModel(file.get("x")[()].decode("utf-8"))
             else:
                 return MyModel(file.get("x").value)

--- a/tests/pytorch/test_pytorch_autolog.py
+++ b/tests/pytorch/test_pytorch_autolog.py
@@ -1,4 +1,4 @@
-from distutils.version import LooseVersion
+from packaging.version import Version
 import pytest
 import pytorch_lightning as pl
 import torch
@@ -135,7 +135,7 @@ def pytorch_model_with_callback(patience):
     )
 
     with TempDir() as tmp:
-        keyword = "dirpath" if LooseVersion(pl.__version__) >= LooseVersion("1.2.0") else "filepath"
+        keyword = "dirpath" if Version(pl.__version__) >= Version("1.2.0") else "filepath"
         checkpoint_callback = ModelCheckpoint(
             **{keyword: tmp.path()}, save_top_k=1, verbose=True, monitor="val_loss", mode="min",
         )
@@ -184,7 +184,7 @@ def test_pytorch_with_early_stopping_autolog_log_models_configuration_with(log_m
     early_stopping = EarlyStopping(monitor="val_loss", mode="min", patience=patience, verbose=True)
 
     with TempDir() as tmp:
-        keyword = "dirpath" if LooseVersion(pl.__version__) >= LooseVersion("1.2.0") else "filepath"
+        keyword = "dirpath" if Version(pl.__version__) >= Version("1.2.0") else "filepath"
         checkpoint_callback = ModelCheckpoint(
             **{keyword: tmp.path()}, save_top_k=1, verbose=True, monitor="val_loss", mode="min",
         )
@@ -282,7 +282,7 @@ def test_get_optimizer_name():
 
 
 @pytest.mark.skipif(
-    LooseVersion(pl.__version__) < LooseVersion("1.1.0"),
+    Version(pl.__version__) < Version("1.1.0"),
     reason="`LightningOptimizer` doesn't exist in pytorch-lightning < 1.1.0",
 )
 def test_get_optimizer_name_with_lightning_optimizer():

--- a/tests/spacy/test_spacy_model_export.py
+++ b/tests/spacy/test_spacy_model_export.py
@@ -1,7 +1,7 @@
 import os
 import random
 from collections import namedtuple
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 import pandas as pd
 import pytest
@@ -25,9 +25,7 @@ from tests.conftest import tracking_uri_mock  # pylint: disable=unused-import, E
 ModelWithData = namedtuple("ModelWithData", ["model", "inference_data"])
 
 
-IS_SPACY_VERSION_NEWER_THAN_OR_EQUAL_TO_3_0_0 = LooseVersion(spacy.__version__) >= LooseVersion(
-    "3.0.0"
-)
+IS_SPACY_VERSION_NEWER_THAN_OR_EQUAL_TO_3_0_0 = Version(spacy.__version__) >= Version("3.0.0")
 
 
 @pytest.fixture(scope="module")

--- a/tests/spark_autologging/ml/test_pyspark_ml_autologging.py
+++ b/tests/spark_autologging/ml/test_pyspark_ml_autologging.py
@@ -5,7 +5,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from collections import namedtuple
-from distutils.version import LooseVersion
+from packaging.version import Version
 from unittest import mock
 
 import mlflow
@@ -170,8 +170,7 @@ def test_basic_estimator(dataset_binomial):
 
 
 @pytest.mark.skipif(
-    LooseVersion(pyspark.__version__) < LooseVersion("3.1"),
-    reason="This test require spark version >= 3.1",
+    Version(pyspark.__version__) < Version("3.1"), reason="This test require spark version >= 3.1",
 )
 def test_models_in_allowlist_exist(spark_session):  # pylint: disable=unused-argument
     mlflow.pyspark.ml.autolog()  # initialize the variable `mlflow.pyspark.ml._log_model_allowlist`

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -1,4 +1,6 @@
 import os
+import time
+import shutil
 
 import pytest
 import posixpath
@@ -672,3 +674,173 @@ class TestDatabricksArtifactRepository(object):
             with pytest.raises(MlflowException):
                 databricks_artifact_repo.download_artifacts(test_file.strpath)
             read_credentials_mock.assert_called_with(MOCK_RUN_ID, test_file.strpath)
+
+    def test_download_artifacts_awaits_download_completion(self, databricks_artifact_repo, tmpdir):
+        """
+        Verifies that all asynchronous artifact downloads are joined before `download_artifacts()`
+        returns a result to the caller
+        """
+        with mock.patch(
+            DATABRICKS_ARTIFACT_REPOSITORY + "._get_read_credentials"
+        ) as read_credentials_mock, mock.patch(
+            DATABRICKS_ARTIFACT_REPOSITORY + ".list_artifacts"
+        ) as get_list_mock, mock.patch(
+            DATABRICKS_ARTIFACT_REPOSITORY + "._download_from_cloud"
+        ) as download_mock:
+            mock_credentials = ArtifactCredentialInfo(
+                signed_uri=MOCK_AZURE_SIGNED_URI, type=ArtifactCredentialType.AZURE_SAS_URI
+            )
+            read_credentials_response_proto = GetCredentialsForRead.Response(
+                credentials=mock_credentials
+            )
+            read_credentials_mock.return_value = read_credentials_response_proto
+            get_list_mock.return_value = [
+                FileInfo(path="file_1.txt", is_dir=False, file_size=100),
+                FileInfo(path="file_2.txt", is_dir=False, file_size=0),
+            ]
+
+            def mock_download_from_cloud(
+                cloud_credential, local_file_path
+            ):  # pylint: disable=unused-argument
+                # Sleep in order to simulate a longer-running asynchronous download
+                time.sleep(2)
+                with open(local_file_path, "w") as f:
+                    f.write("content")
+
+            download_mock.side_effect = mock_download_from_cloud
+
+            databricks_artifact_repo.download_artifacts("test_path", str(tmpdir))
+
+            expected_file1_path = os.path.join(str(tmpdir), "file_1.txt")
+            expected_file2_path = os.path.join(str(tmpdir), "file_2.txt")
+            for path in [expected_file1_path, expected_file2_path]:
+                assert os.path.exists(path)
+                with open(path, "r") as f:
+                    assert f.read() == "content"
+
+    def test_artifact_logging_awaits_upload_completion(self, databricks_artifact_repo, tmpdir):
+        """
+        Verifies that all asynchronous artifact uploads initiated by `log_artifact()` and
+        `log_artifacts()` are joined before these methods return a result to the caller
+        """
+        src_dir = os.path.join(str(tmpdir), "src")
+        os.makedirs(src_dir)
+        src_file1_path = os.path.join(src_dir, "file_1.txt")
+        with open(src_file1_path, "w") as f:
+            f.write("file1")
+        src_file2_path = os.path.join(src_dir, "file_2.txt")
+        with open(src_file2_path, "w") as f:
+            f.write("file2")
+
+        dst_dir = os.path.join(str(tmpdir), "dst")
+        os.makedirs(dst_dir)
+
+        with mock.patch(
+            DATABRICKS_ARTIFACT_REPOSITORY + "._get_write_credentials"
+        ) as write_credentials_mock, mock.patch(
+            DATABRICKS_ARTIFACT_REPOSITORY + "._upload_to_cloud"
+        ) as upload_mock:
+            mock_credentials = ArtifactCredentialInfo(
+                signed_uri=MOCK_AZURE_SIGNED_URI, type=ArtifactCredentialType.AZURE_SAS_URI
+            )
+            write_credentials_response_proto = GetCredentialsForWrite.Response(
+                credentials=mock_credentials
+            )
+            write_credentials_mock.return_value = write_credentials_response_proto
+
+            def mock_upload_to_cloud(
+                cloud_credentials, local_file_path, artifact_path
+            ):  # pylint: disable=unused-argument
+                # Sleep in order to simulate a longer-running asynchronous upload
+                time.sleep(2)
+                dst_path = os.path.join(dst_dir, artifact_path)
+                os.makedirs(os.path.dirname(dst_path), exist_ok=True)
+                shutil.copyfile(src=local_file_path, dst=dst_path)
+
+            upload_mock.side_effect = mock_upload_to_cloud
+
+            databricks_artifact_repo.log_artifacts(src_dir, "dir_artifact")
+
+            expected_dst_dir_file1_path = os.path.join(dst_dir, "dir_artifact", "file_1.txt")
+            expected_dst_dir_file2_path = os.path.join(dst_dir, "dir_artifact", "file_2.txt")
+            assert os.path.exists(expected_dst_dir_file1_path)
+            assert os.path.exists(expected_dst_dir_file2_path)
+            with open(expected_dst_dir_file1_path, "r") as f:
+                assert f.read() == "file1"
+            with open(expected_dst_dir_file2_path, "r") as f:
+                assert f.read() == "file2"
+
+            databricks_artifact_repo.log_artifact(src_file1_path)
+
+            expected_dst_file_path = os.path.join(dst_dir, "file_1.txt")
+            assert os.path.exists(expected_dst_file_path)
+            with open(expected_dst_file_path, "r") as f:
+                assert f.read() == "file1"
+
+    def test_download_artifacts_provides_failure_info(self, databricks_artifact_repo):
+        with mock.patch(
+            DATABRICKS_ARTIFACT_REPOSITORY + "._get_read_credentials"
+        ) as read_credentials_mock, mock.patch(
+            DATABRICKS_ARTIFACT_REPOSITORY + ".list_artifacts"
+        ) as get_list_mock, mock.patch(
+            DATABRICKS_ARTIFACT_REPOSITORY + "._download_from_cloud"
+        ) as download_mock:
+            mock_credentials = ArtifactCredentialInfo(
+                signed_uri=MOCK_AZURE_SIGNED_URI, type=ArtifactCredentialType.AZURE_SAS_URI
+            )
+            read_credentials_response_proto = GetCredentialsForRead.Response(
+                credentials=mock_credentials
+            )
+            read_credentials_mock.return_value = read_credentials_response_proto
+            get_list_mock.return_value = [
+                FileInfo(path="file_1.txt", is_dir=False, file_size=100),
+                FileInfo(path="file_2.txt", is_dir=False, file_size=0),
+            ]
+            download_mock.side_effect = [
+                MlflowException("MOCK ERROR 1"),
+                MlflowException("MOCK ERROR 2"),
+            ]
+
+            with pytest.raises(MlflowException) as exc:
+                databricks_artifact_repo.download_artifacts("test_path")
+
+            assert MOCK_RUN_ROOT_URI in str(exc)
+            assert "file_1.txt" in str(exc)
+            assert "MOCK ERROR 1" in str(exc)
+            assert "file_2.txt" in str(exc)
+            assert "MOCK ERROR 2" in str(exc)
+
+    def test_log_artifacts_provides_failure_info(self, databricks_artifact_repo, tmpdir):
+        src_file1_path = os.path.join(str(tmpdir), "file_1.txt")
+        with open(src_file1_path, "w") as f:
+            f.write("file1")
+        src_file2_path = os.path.join(str(tmpdir), "file_2.txt")
+        with open(src_file2_path, "w") as f:
+            f.write("file2")
+
+        with mock.patch(
+            DATABRICKS_ARTIFACT_REPOSITORY + "._get_write_credentials"
+        ) as write_credentials_mock, mock.patch(
+            DATABRICKS_ARTIFACT_REPOSITORY + "._upload_to_cloud"
+        ) as upload_mock:
+            mock_credentials = ArtifactCredentialInfo(
+                signed_uri=MOCK_AZURE_SIGNED_URI, type=ArtifactCredentialType.AZURE_SAS_URI
+            )
+            write_credentials_response_proto = GetCredentialsForWrite.Response(
+                credentials=mock_credentials
+            )
+            write_credentials_mock.return_value = write_credentials_response_proto
+
+            upload_mock.side_effect = [
+                MlflowException("MOCK ERROR 1"),
+                MlflowException("MOCK ERROR 2"),
+            ]
+
+            with pytest.raises(MlflowException) as exc:
+                databricks_artifact_repo.log_artifacts(str(tmpdir), "test_artifacts")
+
+            assert MOCK_RUN_ROOT_URI in str(exc)
+            assert "file_1.txt" in str(exc)
+            assert "MOCK ERROR 1" in str(exc)
+            assert "file_2.txt" in str(exc)
+            assert "MOCK ERROR 2" in str(exc)

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -2,7 +2,7 @@
 
 import collections
 import pytest
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 import numpy as np
 import pandas as pd
@@ -828,7 +828,7 @@ def get_text_vec_model(train_samples):
 
 
 @pytest.mark.skipif(
-    LooseVersion(tf.__version__) < LooseVersion("2.3.0"),
+    Version(tf.__version__) < Version("2.3.0"),
     reason=(
         "Deserializing a model with `TextVectorization` and `Embedding`"
         "fails in tensorflow < 2.3.0. See this issue:"

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -1,4 +1,4 @@
-from distutils.version import LooseVersion
+from packaging.version import Version
 import os
 import json
 import pytest
@@ -75,7 +75,13 @@ def test_xgb_autolog_logs_default_params(bst_params, dtrain):
         #   https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.train
         # In < 1.3.0, it's False:
         #   https://xgboost.readthedocs.io/en/release_1.2.0/python/python_api.html#xgboost.train
-        "maximize": None if LooseVersion(xgb.__version__) >= LooseVersion("1.3.0") else False,
+        # TODO: Remove `replace("SNAPSHOT", "dev")` once the following issue is addressed:
+        #       https://github.com/dmlc/xgboost/issues/6984
+        "maximize": (
+            None
+            if Version(xgb.__version__.replace("SNAPSHOT", "dev")) >= Version("1.3.0")
+            else False
+        ),
         "early_stopping_rounds": None,
         "verbose_eval": True,
     }


### PR DESCRIPTION
## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
