### PR TITLE
Implemented Sagemaker Batch Transform integration with MLflow

### DIFF
--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -542,9 +542,12 @@ def deploy_transform_job(
     :param compression_type: The compression type of the transform data.
     :param split_type: The method to split the transform job's data files into smaller batches.
     :param accept: The multipurpose internet mail extension (MIME) type of the output data.
-    :param assemble_with: The method to assemble the results of the transform job as a single S3 object.
-    :param input_filter: A JSONPath expression used to select a portion of the input data for the transform job.
-    :param output_filter: A JSONPath expression used to select a portion of the output data from the transform job.
+    :param assemble_with: The method to assemble the results of the transform job as
+            a single S3 object.
+    :param input_filter: A JSONPath expression used to select a portion of the input data for
+            the transform job.
+    :param output_filter: A JSONPath expression used to select a portion of the output data from
+            the transform job.
     :param join_resource: The source of the data to join with the transformed data.
 
     :param execution_role_arn: The name of an IAM role granting the SageMaker service permissions to
@@ -569,9 +572,9 @@ def deploy_transform_job(
                           https://aws.amazon.com/sagemaker/pricing/instance-types/.
     :param instance_count: The number of SageMaker ML instances on which to deploy the model.
     :param vpc_config: A dictionary specifying the VPC configuration to use when creating the
-                       new SageMaker model associated with this batch transform job. The acceptable values
-                       for this parameter are identical to those of the ``VpcConfig`` parameter in
-                       the `SageMaker boto3 client's create_model method
+                       new SageMaker model associated with this batch transform job. The acceptable
+                       values for this parameter are identical to those of the ``VpcConfig``
+                       parameter in the `SageMaker boto3 client's create_model method
                        <https://boto3.readthedocs.io/en/latest/reference/services/sagemaker.html
                        #SageMaker.Client.create_model>`_. For more information, see
                        https://docs.aws.amazon.com/sagemaker/latest/dg/API_VpcConfig.html.
@@ -712,26 +715,28 @@ def terminate_transform_job(
     :param archive: If ``True``, resources associated with the specified batch transform job,
                     such as its associated models and model artifacts, are preserved.
                     If ``False``, these resources are deleted. In order to use ``archive=False``,
-                    ``terminate_transform_job()`` must be executed synchronously with ``synchronous=True``.
+                    ``terminate_transform_job()`` must be executed synchronously
+                    with ``synchronous=True``.
     :param synchronous: If `True`, this function blocks until the termination process succeeds
                         or encounters an irrecoverable failure. If `False`, this function
-                        returns immediately after starting the termination process. It will not wait
-                        for the termination process to complete; in this case, the caller is
+                        returns immediately after starting the termination process. It will not
+                        wait for the termination process to complete; in this case, the caller is
                         responsible for monitoring the status of the termination process via native
                         SageMaker APIs or the AWS console.
     :param timeout_seconds: If `synchronous` is `True`, the termination process returns after the
                             specified number of seconds if no definitive result (success or failure)
                             is achieved. Once the function returns, the caller is responsible
-                            for monitoring the status of the termination process via native SageMaker
-                            APIs or the AWS console. If `synchronous` is False, this parameter
-                            is ignored.
+                            for monitoring the status of the termination process via native
+                            SageMaker APIs or the AWS console. If `synchronous` is False, this
+                            parameter is ignored.
     """
     import boto3
 
     if (not archive) and (not synchronous):
         raise MlflowException(
             message=(
-                "Resources must be archived when `terminate_transform_job()` is executed in non-synchronous mode."
+                "Resources must be archived when `terminate_transform_job()`\
+                    is executed in non-synchronous mode."
                 " Either set `synchronous=True` or `archive=True`."
             ),
             error_code=INVALID_PARAMETER_VALUE,
@@ -751,7 +756,8 @@ def terminate_transform_job(
 
         if transform_job_info["TransformJobStatus"] == "Stopping":
             return _SageMakerOperationStatus.in_progress(
-                "Termination is still in progress. Current batch transform job status: {transform_job_status}".format(
+                "Termination is still in progress. Current batch transform job status:\
+                    {transform_job_status}".format(
                     transform_job_status=transform_job_info["TransformJobStatus"]
                 )
             )
@@ -1008,7 +1014,8 @@ def _create_sagemaker_transform_job(
     :param model_name: The name to assign the new SageMaker model that will be associated with the
                        specified batch transform job.
     :param model_s3_path: S3 path where we stored the model artifacts.
-    :param model_uri: URI of the MLflow model to associate with the specified SageMaker batch transform job.
+    :param model_uri: URI of the MLflow model to associate with the specified SageMaker batch
+                        transform job.
     :param image_url: URL of the ECR-hosted docker image the model is being deployed into.
     :param flavor: The name of the flavor of the model to use for deployment.
     :param vpc_config: A dictionary specifying the VPC configuration to use when creating the
@@ -1024,9 +1031,12 @@ def _create_sagemaker_transform_job(
     :param split_type: The method to split the transform job's data files into smaller batches.
     :param s3_output_path: The S3 path to store the output results of the Sagemaker transform job.
     :param accept: The multipurpose internet mail extension (MIME) type of the output data.
-    :param assemble_with: The method to assemble the results of the transform job as a single S3 object.
-    :param input_filter: A JSONPath expression used to select a portion of the input data for the transform job.
-    :param output_filter: A JSONPath expression used to select a portion of the output data from the transform job.
+    :param assemble_with: The method to assemble the results of the transform job as a single
+                        S3 object.
+    :param input_filter: A JSONPath expression used to select a portion of the input data for the
+                        transform job.
+    :param output_filter: A JSONPath expression used to select a portion of the output data from
+                        the transform job.
     :param join_resource: The source of the data to join with the transformed data.
     """
     _logger.info("Creating new batch transform job with name: %s ...", job_name)
@@ -1088,7 +1098,8 @@ def _create_sagemaker_transform_job(
         transform_job_status = transform_job_info["TransformJobStatus"]
         if transform_job_status == "InProgress":
             return _SageMakerOperationStatus.in_progress(
-                'Waiting for batch transform job to reach the "Completed" state. Current batch transform job status:'
+                'Waiting for batch transform job to reach the "Completed" state. \
+                    Current batch transform job status:'
                 ' "{transform_job_status}"'.format(transform_job_status=transform_job_status)
             )
         elif transform_job_status == "Completed":
@@ -1317,7 +1328,8 @@ def _update_sagemaker_endpoint(
             failure_reason = endpoint_info.get(
                 "FailureReason",
                 (
-                    "An unknown SageMaker failure occurred. Please see the SageMaker console logs for"  # noqa
+                    "An unknown SageMaker failure occurred. \
+                    Please see the SageMaker console logs for"  # noqa
                     " more information."
                 ),
             )
@@ -1442,8 +1454,8 @@ def _find_endpoint(endpoint_name, sage_client):
 
 def _find_transform_job(job_name, sage_client):
     """
-    Finds a SageMaker batch transform job with the specified name in the caller's AWS account, returning a
-    NoneType if the endpoint is not found.
+    Finds a SageMaker batch transform job with the specified name in the caller's AWS account,
+    returning a NoneType if the endpoint is not found.
 
     :param sage_client: A boto3 client for SageMaker.
     :return: If the endpoint exists, a dictionary of endpoint attributes. If the endpoint does not

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -491,6 +491,300 @@ def delete(app_name, region_name="us-west-2", archive=False, synchronous=True, t
             delete_operation.clean_up()
 
 
+def deploy_transform_job(
+    job_name,
+    model_uri,
+    s3_input_data_type,
+    s3_input_uri,
+    content_type,
+    s3_output_path,
+    compression_type="None",
+    split_type="Line",
+    accept="text/csv",
+    assemble_with="Line",
+    input_filter="$",
+    output_filter="$",
+    join_resource="None",
+    execution_role_arn=None,
+    bucket=None,
+    image_url=None,
+    region_name="us-west-2",
+    instance_type=DEFAULT_SAGEMAKER_INSTANCE_TYPE,
+    instance_count=DEFAULT_SAGEMAKER_INSTANCE_COUNT,
+    vpc_config=None,
+    flavor=None,
+    synchronous=True,
+    timeout_seconds=1200,
+):
+    """
+    Deploy an MLflow model on AWS SageMaker and create the corresponding batch transform job.
+    The currently active AWS account must have correct permissions set up.
+
+    :param job_name: Name of the deployed Sagemaker batch transform job.
+    :param model_uri: The location, in URI format, of the MLflow model to deploy to SageMaker.
+                      For example:
+
+                      - ``/Users/me/path/to/local/model``
+                      - ``relative/path/to/local/model``
+                      - ``s3://my_bucket/path/to/model``
+                      - ``runs:/<mlflow_run_id>/run-relative/path/to/model``
+                      - ``models:/<model_name>/<model_version>``
+                      - ``models:/<model_name>/<stage>``
+
+                      For more information about supported URI schemes, see
+                      `Referencing Artifacts <https://www.mlflow.org/docs/latest/concepts.html#
+                      artifact-locations>`_.
+
+    :param s3_input_data_type: Input data type for the transform job.
+    :param s3_input_uri: S3 key name prefix or a manifest of the input data.
+    :param content_type: The multipurpose internet mail extension (MIME) type of the data.
+    :param s3_output_path: The S3 path to store the output results of the Sagemaker transform job.
+    :param compression_type: The compression type of the transform data.
+    :param split_type: The method to split the transform job's data files into smaller batches.
+    :param accept: The multipurpose internet mail extension (MIME) type of the output data.
+    :param assemble_with: The method to assemble the results of the transform job as a single S3 object.
+    :param input_filter: A JSONPath expression used to select a portion of the input data for the transform job.
+    :param output_filter: A JSONPath expression used to select a portion of the output data from the transform job.
+    :param join_resource: The source of the data to join with the transformed data.
+
+    :param execution_role_arn: The name of an IAM role granting the SageMaker service permissions to
+                               access the specified Docker image and S3 bucket containing MLflow
+                               model artifacts. If unspecified, the currently-assumed role will be
+                               used. This execution role is passed to the SageMaker service when
+                               creating a SageMaker model from the specified MLflow model. It is
+                               passed as the ``ExecutionRoleArn`` parameter of the `SageMaker
+                               CreateModel API call <https://docs.aws.amazon.com/sagemaker/latest/
+                               dg/API_CreateModel.html>`_. This role is *not* assumed for any other
+                               call. For more information about SageMaker execution roles for model
+                               creation, see
+                               https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-roles.html.
+    :param bucket: S3 bucket where model artifacts will be stored. Defaults to a
+                   SageMaker-compatible bucket name.
+    :param image_url: URL of the ECR-hosted Docker image the model should be deployed into, produced
+                      by ``mlflow sagemaker build-and-push-container``. This parameter can also
+                      be specified by the environment variable ``MLFLOW_SAGEMAKER_DEPLOY_IMG_URL``.
+    :param region_name: Name of the AWS region to which to deploy the application.
+    :param instance_type: The type of SageMaker ML instance on which to deploy the model. For a list
+                          of supported instance types, see
+                          https://aws.amazon.com/sagemaker/pricing/instance-types/.
+    :param instance_count: The number of SageMaker ML instances on which to deploy the model.
+    :param vpc_config: A dictionary specifying the VPC configuration to use when creating the
+                       new SageMaker model associated with this batch transform job. The acceptable values
+                       for this parameter are identical to those of the ``VpcConfig`` parameter in
+                       the `SageMaker boto3 client's create_model method
+                       <https://boto3.readthedocs.io/en/latest/reference/services/sagemaker.html
+                       #SageMaker.Client.create_model>`_. For more information, see
+                       https://docs.aws.amazon.com/sagemaker/latest/dg/API_VpcConfig.html.
+
+    .. code-block:: python
+        :caption: Example
+
+        import mlflow.sagemaker as mfs
+        vpc_config = {
+                        'SecurityGroupIds': [
+                            'sg-123456abc',
+                        ],
+                        'Subnets': [
+                            'subnet-123456abc',
+                        ]
+                     }
+        mfs.deploy_transform_job(..., vpc_config=vpc_config)
+
+    :param flavor: The name of the flavor of the model to use for deployment. Must be either
+                   ``None`` or one of mlflow.sagemaker.SUPPORTED_DEPLOYMENT_FLAVORS. If ``None``,
+                   a flavor is automatically selected from the model's available flavors. If the
+                   specified flavor is not present or not supported for deployment, an exception
+                   will be thrown.
+    :param synchronous: If ``True``, this function will block until the deployment process succeeds
+                        or encounters an irrecoverable failure. If ``False``, this function will
+                        return immediately after starting the deployment process. It will not wait
+                        for the deployment process to complete; in this case, the caller is
+                        responsible for monitoring the health and status of the pending deployment
+                        via native SageMaker APIs or the AWS console.
+    :param timeout_seconds: If ``synchronous`` is ``True``, the deployment process will return after
+                            the specified number of seconds if no definitive result (success or
+                            failure) is achieved. Once the function returns, the caller is
+                            responsible for monitoring the health and status of the pending
+                            deployment using native SageMaker APIs or the AWS console. If
+                            ``synchronous`` is ``False``, this parameter is ignored.
+    """
+    import boto3
+
+    model_path = _download_artifact_from_uri(model_uri)
+    model_config_path = os.path.join(model_path, MLMODEL_FILE_NAME)
+    if not os.path.exists(model_config_path):
+        raise MlflowException(
+            message=(
+                "Failed to find {} configuration within the specified model's" " root directory."
+            ).format(MLMODEL_FILE_NAME),
+            error_code=INVALID_PARAMETER_VALUE,
+        )
+    model_config = Model.load(model_config_path)
+
+    if flavor is None:
+        flavor = _get_preferred_deployment_flavor(model_config)
+    else:
+        _validate_deployment_flavor(model_config, flavor)
+    _logger.info("Using the %s flavor for deployment!", flavor)
+
+    sage_client = boto3.client("sagemaker", region_name=region_name)
+    s3_client = boto3.client("s3", region_name=region_name)
+
+    transform_job_exists = (
+        _find_transform_job(job_name=job_name, sage_client=sage_client) is not None
+    )
+    if transform_job_exists:
+        raise MlflowException(
+            message=(
+                "You are attempting to deploy a batch transform job with name: {job_name}."
+                "However, a batch transform job with the same name already exists.".format(
+                    job_name=job_name
+                )
+            ),
+            error_code=INVALID_PARAMETER_VALUE,
+        )
+
+    model_name = _get_sagemaker_transform_model_name(job_name=job_name)
+    if not image_url:
+        image_url = _get_default_image_url(region_name=region_name)
+    if not execution_role_arn:
+        execution_role_arn = _get_assumed_role_arn()
+    if not bucket:
+        _logger.info("No model data bucket specified, using the default bucket")
+        bucket = _get_default_s3_bucket(region_name)
+
+    model_s3_path = _upload_s3(
+        local_model_path=model_path,
+        bucket=bucket,
+        prefix=model_name,
+        region_name=region_name,
+        s3_client=s3_client,
+    )
+
+    deployment_operation = _create_sagemaker_transform_job(
+        job_name=job_name,
+        model_name=model_name,
+        model_s3_path=model_s3_path,
+        model_uri=model_uri,
+        image_url=image_url,
+        flavor=flavor,
+        vpc_config=vpc_config,
+        role=execution_role_arn,
+        sage_client=sage_client,
+        instance_type=instance_type,
+        instance_count=instance_count,
+        s3_input_data_type=s3_input_data_type,
+        s3_input_uri=s3_input_uri,
+        content_type=content_type,
+        compression_type=compression_type,
+        split_type=split_type,
+        s3_output_path=s3_output_path,
+        accept=accept,
+        assemble_with=assemble_with,
+        input_filter=input_filter,
+        output_filter=output_filter,
+        join_resource=join_resource,
+    )
+
+    if synchronous:
+        _logger.info("Waiting for the batch transform job to complete...")
+        operation_status = deployment_operation.await_completion(timeout_seconds=timeout_seconds)
+        if operation_status.state == _SageMakerOperationStatus.STATE_SUCCEEDED:
+            _logger.info(
+                'The batch transform job completed successfully with message: "%s"',
+                operation_status.message,
+            )
+        else:
+            raise MlflowException(
+                "The batch transform job failed with the following error message:"
+                ' "{error_message}"'.format(error_message=operation_status.message)
+            )
+
+
+def terminate_transform_job(
+    job_name, region_name="us-west-2", archive=True, synchronous=True, timeout_seconds=300,
+):
+    """
+    Terminate a SageMaker batch transform job.
+
+    :param job_name: Name of the deployed Sagemaker batch transform job.
+    :param region_name: Name of the AWS region in which the batch transform job is deployed.
+    :param archive: If ``True``, resources associated with the specified batch transform job,
+                    such as its associated models and model artifacts, are preserved.
+                    If ``False``, these resources are deleted. In order to use ``archive=False``,
+                    ``terminate_transform_job()`` must be executed synchronously with ``synchronous=True``.
+    :param synchronous: If `True`, this function blocks until the termination process succeeds
+                        or encounters an irrecoverable failure. If `False`, this function
+                        returns immediately after starting the termination process. It will not wait
+                        for the termination process to complete; in this case, the caller is
+                        responsible for monitoring the status of the termination process via native
+                        SageMaker APIs or the AWS console.
+    :param timeout_seconds: If `synchronous` is `True`, the termination process returns after the
+                            specified number of seconds if no definitive result (success or failure)
+                            is achieved. Once the function returns, the caller is responsible
+                            for monitoring the status of the termination process via native SageMaker
+                            APIs or the AWS console. If `synchronous` is False, this parameter
+                            is ignored.
+    """
+    import boto3
+
+    if (not archive) and (not synchronous):
+        raise MlflowException(
+            message=(
+                "Resources must be archived when `terminate_transform_job()` is executed in non-synchronous mode."
+                " Either set `synchronous=True` or `archive=True`."
+            ),
+            error_code=INVALID_PARAMETER_VALUE,
+        )
+
+    s3_client = boto3.client("s3", region_name=region_name)
+    sage_client = boto3.client("sagemaker", region_name=region_name)
+
+    transform_job_info = sage_client.describe_transform_job(TransformJobName=job_name)
+    transform_job_arn = transform_job_info["TransformJobArn"]
+
+    sage_client.stop_transform_job(TransformJobName=job_name)
+    _logger.info("Terminated batch transform job with arn: %s", transform_job_arn)
+
+    def status_check_fn():
+        transform_job_info = _find_transform_job(job_name=job_name, sage_client=sage_client)
+
+        if transform_job_info["TransformJobStatus"] == "Stopping":
+            return _SageMakerOperationStatus.in_progress(
+                "Termination is still in progress. Current batch transform job status: {transform_job_status}".format(
+                    transform_job_status=transform_job_info["TransformJobStatus"]
+                )
+            )
+        elif transform_job_info["TransformJobStatus"] == "Stopped":
+            return _SageMakerOperationStatus.succeeded(
+                "The SageMaker batch transform job was terminated successfully."
+            )
+
+    def cleanup_fn():
+        _logger.info("Cleaning up unused resources...")
+        model_name = transform_job_info["ModelName"]
+        model_arn = _delete_sagemaker_model(model_name, sage_client, s3_client)
+        _logger.info("Deleted associated model with arn: %s", model_arn)
+
+    stop_operation = _SageMakerOperation(status_check_fn=status_check_fn, cleanup_fn=cleanup_fn)
+
+    if synchronous:
+        _logger.info("Waiting for the termination operation to complete...")
+        operation_status = stop_operation.await_completion(timeout_seconds=timeout_seconds)
+        if operation_status.state == _SageMakerOperationStatus.STATE_SUCCEEDED:
+            _logger.info(
+                'The termination operation completed successfully with message: "%s"',
+                operation_status.message,
+            )
+        else:
+            raise MlflowException(
+                "The termination operation failed with the following error message:"
+                ' "{error_message}"'.format(error_message=operation_status.message)
+            )
+        if not archive:
+            stop_operation.clean_up()
+
+
 def run_local(model_uri, port=5000, image=DEFAULT_IMAGE_NAME, flavor=None):
     """
     Serve model locally in a SageMaker compatible Docker container.
@@ -677,8 +971,144 @@ def _get_sagemaker_model_name(endpoint_name):
     return "{en}-model-{uid}".format(en=endpoint_name, uid=get_unique_resource_id())
 
 
+def _get_sagemaker_transform_model_name(job_name):
+    return "{bn}-model-{uid}".format(bn=job_name, uid=get_unique_resource_id())
+
+
 def _get_sagemaker_config_name(endpoint_name):
     return "{en}-config-{uid}".format(en=endpoint_name, uid=get_unique_resource_id())
+
+
+def _create_sagemaker_transform_job(
+    job_name,
+    model_name,
+    model_s3_path,
+    model_uri,
+    image_url,
+    flavor,
+    vpc_config,
+    role,
+    sage_client,
+    instance_type,
+    instance_count,
+    s3_input_data_type,
+    s3_input_uri,
+    content_type,
+    compression_type,
+    split_type,
+    s3_output_path,
+    accept,
+    assemble_with,
+    input_filter,
+    output_filter,
+    join_resource,
+):
+    """
+    :param job_name: Name of the deployed Sagemaker batch transform job.
+    :param model_name: The name to assign the new SageMaker model that will be associated with the
+                       specified batch transform job.
+    :param model_s3_path: S3 path where we stored the model artifacts.
+    :param model_uri: URI of the MLflow model to associate with the specified SageMaker batch transform job.
+    :param image_url: URL of the ECR-hosted docker image the model is being deployed into.
+    :param flavor: The name of the flavor of the model to use for deployment.
+    :param vpc_config: A dictionary specifying the VPC configuration to use when creating the
+                       new SageMaker model associated with this SageMaker batch transform job.
+    :param role: SageMaker execution ARN role.
+    :param sage_client: A boto3 client for SageMaker.
+    :param instance_type: The type of SageMaker ML instance on which to deploy the model.
+    :param instance_count: The number of SageMaker ML instances on which to deploy the model.
+    :param s3_input_data_type: Input data type for the transform job.
+    :param s3_input_uri: S3 key name prefix or a manifest of the input data.
+    :param content_type: The multipurpose internet mail extension (MIME) type of the data.
+    :param compression_type: The compression type of the transform data.
+    :param split_type: The method to split the transform job's data files into smaller batches.
+    :param s3_output_path: The S3 path to store the output results of the Sagemaker transform job.
+    :param accept: The multipurpose internet mail extension (MIME) type of the output data.
+    :param assemble_with: The method to assemble the results of the transform job as a single S3 object.
+    :param input_filter: A JSONPath expression used to select a portion of the input data for the transform job.
+    :param output_filter: A JSONPath expression used to select a portion of the output data from the transform job.
+    :param join_resource: The source of the data to join with the transformed data.
+    """
+    _logger.info("Creating new batch transform job with name: %s ...", job_name)
+
+    model_response = _create_sagemaker_model(
+        model_name=model_name,
+        model_s3_path=model_s3_path,
+        model_uri=model_uri,
+        flavor=flavor,
+        vpc_config=vpc_config,
+        image_url=image_url,
+        execution_role=role,
+        sage_client=sage_client,
+    )
+    _logger.info("Created model with arn: %s", model_response["ModelArn"])
+
+    transform_input = {
+        "DataSource": {"S3DataSource": {"S3DataType": s3_input_data_type, "S3Uri": s3_input_uri}},
+        "ContentType": content_type,
+        "CompressionType": compression_type,
+        "SplitType": split_type,
+    }
+
+    transform_output = {
+        "S3OutputPath": s3_output_path,
+        "Accept": accept,
+        "AssembleWith": assemble_with,
+    }
+
+    transform_resources = {"InstanceType": instance_type, "InstanceCount": instance_count}
+
+    data_processing = {
+        "InputFilter": input_filter,
+        "OutputFilter": output_filter,
+        "JoinSource": join_resource,
+    }
+
+    transform_job_response = sage_client.create_transform_job(
+        TransformJobName=job_name,
+        ModelName=model_name,
+        TransformInput=transform_input,
+        TransformOutput=transform_output,
+        TransformResources=transform_resources,
+        DataProcessing=data_processing,
+        Tags=[{"Key": "model_name", "Value": model_name}],
+    )
+    _logger.info(
+        "Created batch transform job with arn: %s", transform_job_response["TransformJobArn"]
+    )
+
+    def status_check_fn():
+        transform_job_info = sage_client.describe_transform_job(TransformJobName=job_name)
+
+        if transform_job_info is None:
+            return _SageMakerOperationStatus.in_progress(
+                "Waiting for batch transform job to be created..."
+            )
+
+        transform_job_status = transform_job_info["TransformJobStatus"]
+        if transform_job_status == "InProgress":
+            return _SageMakerOperationStatus.in_progress(
+                'Waiting for batch transform job to reach the "Completed" state. Current batch transform job status:'
+                ' "{transform_job_status}"'.format(transform_job_status=transform_job_status)
+            )
+        elif transform_job_status == "Completed":
+            return _SageMakerOperationStatus.succeeded(
+                "The SageMaker batch transform job was processed successfully."
+            )
+        else:
+            failure_reason = transform_job_info.get(
+                "FailureReason",
+                (
+                    "An unknown SageMaker failure occurred. Please see the SageMaker console logs"
+                    " for more information."
+                ),
+            )
+            return _SageMakerOperationStatus.failed(failure_reason)
+
+    def cleanup_fn():
+        pass
+
+    return _SageMakerOperation(status_check_fn=status_check_fn, cleanup_fn=cleanup_fn)
 
 
 def _create_sagemaker_endpoint(
@@ -1005,6 +1435,30 @@ def _find_endpoint(endpoint_name, sage_client):
         if "NextToken" in endpoints_page:
             endpoints_page = sage_client.list_endpoints(
                 MaxResults=100, NextToken=endpoints_page["NextToken"], NameContains=endpoint_name
+            )
+        else:
+            return None
+
+
+def _find_transform_job(job_name, sage_client):
+    """
+    Finds a SageMaker batch transform job with the specified name in the caller's AWS account, returning a
+    NoneType if the endpoint is not found.
+
+    :param sage_client: A boto3 client for SageMaker.
+    :return: If the endpoint exists, a dictionary of endpoint attributes. If the endpoint does not
+             exist, ``None``.
+    """
+    transform_jobs_page = sage_client.list_transform_jobs(MaxResults=100, NameContains=job_name)
+
+    while True:
+        for transform_job in transform_jobs_page["TransformJobSummaries"]:
+            if transform_job["TransformJobName"] == job_name:
+                return transform_job
+
+        if "NextToken" in transform_jobs_page:
+            transform_jobs_page = sage_client.list_transform_jobs(
+                MaxResults=100, NextToken=transform_jobs_page["NextToken"], NameContains=job_name,
             )
         else:
             return None

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -19,6 +19,7 @@ from mlflow.models.model import MLMODEL_FILE_NAME
 from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST, INVALID_PARAMETER_VALUE
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils import get_unique_resource_id
+from mlflow.utils.annotations import experimental
 from mlflow.utils.file_utils import TempDir
 from mlflow.models.container import SUPPORTED_FLAVORS as SUPPORTED_DEPLOYMENT_FLAVORS
 from mlflow.models.container import DEPLOYMENT_CONFIG_KEY_FLAVOR_NAME
@@ -491,6 +492,7 @@ def delete(app_name, region_name="us-west-2", archive=False, synchronous=True, t
             delete_operation.clean_up()
 
 
+@experimental
 def deploy_transform_job(
     job_name,
     model_uri,
@@ -704,6 +706,7 @@ def deploy_transform_job(
             )
 
 
+@experimental
 def terminate_transform_job(
     job_name, region_name="us-west-2", archive=True, synchronous=True, timeout_seconds=300,
 ):

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -735,8 +735,8 @@ def terminate_transform_job(
     if (not archive) and (not synchronous):
         raise MlflowException(
             message=(
-                "Resources must be archived when `terminate_transform_job()`\
-                    is executed in non-synchronous mode."
+                "Resources must be archived when `terminate_transform_job()`"
+                " is executed in non-synchronous mode."
                 " Either set `synchronous=True` or `archive=True`."
             ),
             error_code=INVALID_PARAMETER_VALUE,

--- a/mlflow/sagemaker/cli.py
+++ b/mlflow/sagemaker/cli.py
@@ -220,6 +220,254 @@ def delete(app_name, region_name, archive, asynchronous, timeout):
     )
 
 
+@commands.command("deploy-transform-job")
+@click.option("--job-name", "-n", help="Transform job name", required=True)
+@cli_args.MODEL_URI
+@click.option(
+    "--input-data-type", "-dt", help="Input data type for the transform job", required=True
+)
+@click.option(
+    "--input-uri", "-in", help="S3 key name prefix or manifest of the input data", required=True
+)
+@click.option(
+    "--content-type",
+    help="The multipurpose internet mail extension (MIME) type of the data",
+    required=True,
+)
+@click.option(
+    "--output-path",
+    "-out",
+    help="The S3 path to store the output results of the Sagemaker transform job",
+    required=True,
+)
+@click.option(
+    "--compression-type", default="None", help="The compression type of the transform data"
+)
+@click.option(
+    "--split-type",
+    "-st",
+    default="Line",
+    help="The method to split the transform job's data files into smaller batches",
+)
+@click.option(
+    "--accept",
+    "-a",
+    default="text/csv",
+    help="The multipurpose internet mail extension (MIME) type of the output data",
+)
+@click.option(
+    "--assemble-with",
+    "-aw",
+    default="Line",
+    help="The method to assemble the results of the transform job as a single S3 object",
+)
+@click.option(
+    "--input-filter",
+    "-if",
+    default="$",
+    help="A JSONPath expression used to select a portion of the input data for the transform job",
+)
+@click.option(
+    "--output-filter",
+    "-of",
+    default="$",
+    help="A JSONPath expression used to select a portion of the output data from the transform job",
+)
+@click.option(
+    "--join-resource",
+    "-jr",
+    default="None",
+    help="The source of the data to join with the transformed data",
+)
+@click.option("--execution-role-arn", "-e", default=None, help="SageMaker execution role")
+@click.option("--bucket", "-b", default=None, help="S3 bucket to store model artifacts")
+@click.option("--image-url", "-i", default=None, help="ECR URL for the Docker image")
+@click.option(
+    "--region-name",
+    default="us-west-2",
+    help="Name of the AWS region in which to deploy the transform job",
+)
+@click.option(
+    "--instance-type",
+    "-t",
+    default=mlflow.sagemaker.DEFAULT_SAGEMAKER_INSTANCE_TYPE,
+    help="The type of SageMaker ML instance on which to perform the batch transform job. For a list of"
+    " supported instance types, see"
+    " https://aws.amazon.com/sagemaker/pricing/instance-types/.",
+)
+@click.option(
+    "--instance-count",
+    "-c",
+    default=mlflow.sagemaker.DEFAULT_SAGEMAKER_INSTANCE_COUNT,
+    help="The number of SageMaker ML instances on which to perform the batch transform job",
+)
+@click.option(
+    "--vpc-config",
+    "-v",
+    help="Path to a file containing a JSON-formatted VPC configuration. This"
+    " configuration will be used when creating the new SageMaker model associated"
+    " with this application. For more information, see"
+    " https://docs.aws.amazon.com/sagemaker/latest/dg/API_VpcConfig.html",
+)
+@click.option(
+    "--flavor",
+    "-f",
+    default=None,
+    help=(
+        "The name of the flavor to use for deployment. Must be one of the following:"
+        " {supported_flavors}. If unspecified, a flavor will be automatically selected"
+        " from the model's available flavors.".format(
+            supported_flavors=mlflow.sagemaker.SUPPORTED_DEPLOYMENT_FLAVORS
+        )
+    ),
+)
+@click.option(
+    "--async",
+    "asynchronous",
+    is_flag=True,
+    help=(
+        "If specified, this command will return immediately after starting the"
+        " deployment process. It will not wait for the deployment process to complete."
+        " The caller is responsible for monitoring the deployment process via native"
+        " SageMaker APIs or the AWS console."
+    ),
+)
+@click.option(
+    "--timeout",
+    default=1200,
+    help=(
+        "If the command is executed synchronously, the deployment process will return"
+        " after the specified number of seconds if no definitive result (success or"
+        " failure) is achieved. Once the function returns, the caller is responsible"
+        " for monitoring the health and status of the pending deployment via"
+        " native SageMaker APIs or the AWS console. If the command is executed"
+        " asynchronously using the `--async` flag, this value is ignored."
+    ),
+)
+def deploy_transform_job(
+    job_name,
+    model_uri,
+    input_data_type,
+    input_uri,
+    content_type,
+    output_path,
+    compression_type,
+    split_type,
+    accept,
+    assemble_with,
+    input_filter,
+    output_filter,
+    join_resource,
+    execution_role_arn,
+    bucket,
+    image_url,
+    region_name,
+    instance_type,
+    instance_count,
+    vpc_config,
+    flavor,
+    asynchronous,
+    timeout,
+):
+    """
+    Deploy model on Sagemaker as a batch transform job. Current active AWS account needs to have
+    correct permissions setup.
+
+    By default, unless the ``--async`` flag is specified, this command will block until
+    either the batch transform job completes (definitively succeeds or fails) or the specified
+    timeout elapses.
+    """
+    if vpc_config is not None:
+        with open(vpc_config, "r") as f:
+            vpc_config = json.load(f)
+
+    mlflow.sagemaker.deploy_transform_job(
+        job_name=job_name,
+        model_uri=model_uri,
+        s3_input_data_type=input_data_type,
+        s3_input_uri=input_uri,
+        content_type=content_type,
+        s3_output_path=output_path,
+        compression_type=compression_type,
+        split_type=split_type,
+        accept=accept,
+        assemble_with=assemble_with,
+        input_filter=input_filter,
+        output_filter=output_filter,
+        join_resource=join_resource,
+        execution_role_arn=execution_role_arn,
+        bucket=bucket,
+        image_url=image_url,
+        region_name=region_name,
+        instance_type=instance_type,
+        instance_count=instance_count,
+        vpc_config=vpc_config,
+        flavor=flavor,
+        synchronous=(not asynchronous),
+        timeout_seconds=timeout,
+    )
+
+
+@commands.command("terminate-transform-job")
+@click.option("--job-name", "-n", help="Transform job name", required=True)
+@click.option(
+    "--region-name",
+    "-r",
+    default="us-west-2",
+    help="Name of the AWS region in which to deploy the transform job",
+)
+@click.option(
+    "--archive",
+    "-ar",
+    is_flag=True,
+    help=(
+        "If specified, resources associated with the application are preserved."
+        " These resources may include unused SageMaker models and model artifacts."
+        " Otherwise, if `--archive` is unspecified, these resources are deleted."
+        " `--archive` must be specified when deleting asynchronously with `--async`."
+    ),
+)
+@click.option(
+    "--async",
+    "asynchronous",
+    is_flag=True,
+    help=(
+        "If specified, this command will return immediately after starting the"
+        " termination process. It will not wait for the termination process to complete."
+        " The caller is responsible for monitoring the termination process via native"
+        " SageMaker APIs or the AWS console."
+    ),
+)
+@click.option(
+    "--timeout",
+    default=1200,
+    help=(
+        "If the command is executed synchronously, the termination process will return"
+        " after the specified number of seconds if no definitive result (success or"
+        " failure) is achieved. Once the function returns, the caller is responsible"
+        " for monitoring the health and status of the pending termination via"
+        " native SageMaker APIs or the AWS console. If the command is executed"
+        " asynchronously using the `--async` flag, this value is ignored."
+    ),
+)
+def terminate_transform_job(job_name, region_name, archive, asynchronous, timeout):
+    """
+    Terminate the specified Sagemaker batch transform job. Unless ``--archive`` is specified, all SageMaker resources
+    associated with the batch transform job are deleted as well.
+
+    By default, unless the ``--async`` flag is specified, this command will block until
+    either the termination process completes (definitively succeeds or fails) or the specified timeout
+    elapses.
+    """
+    mlflow.sagemaker.terminate_transform_job(
+        job_name=job_name,
+        region_name=region_name,
+        archive=archive,
+        synchronous=(not asynchronous),
+        timeout_seconds=timeout,
+    )
+
+
 @commands.command("run-local")
 @cli_args.MODEL_URI
 @click.option("--port", "-p", default=5000, help="Server port. [default: 5000]")

--- a/mlflow/sagemaker/cli.py
+++ b/mlflow/sagemaker/cli.py
@@ -291,8 +291,8 @@ def delete(app_name, region_name, archive, asynchronous, timeout):
     "--instance-type",
     "-t",
     default=mlflow.sagemaker.DEFAULT_SAGEMAKER_INSTANCE_TYPE,
-    help="The type of SageMaker ML instance on which to perform the batch transform job. For a list of"
-    " supported instance types, see"
+    help="The type of SageMaker ML instance on which to perform the batch transform job."
+    " For a list of supported instance types, see"
     " https://aws.amazon.com/sagemaker/pricing/instance-types/.",
 )
 @click.option(
@@ -452,12 +452,12 @@ def deploy_transform_job(
 )
 def terminate_transform_job(job_name, region_name, archive, asynchronous, timeout):
     """
-    Terminate the specified Sagemaker batch transform job. Unless ``--archive`` is specified, all SageMaker resources
-    associated with the batch transform job are deleted as well.
+    Terminate the specified Sagemaker batch transform job. Unless ``--archive`` is specified,
+    all SageMaker resources associated with the batch transform job are deleted as well.
 
     By default, unless the ``--async`` flag is specified, this command will block until
-    either the termination process completes (definitively succeeds or fails) or the specified timeout
-    elapses.
+    either the termination process completes (definitively succeeds or fails) or the specified
+    timeout elapses.
     """
     mlflow.sagemaker.terminate_transform_job(
         job_name=job_name,

--- a/mlflow/sagemaker/cli.py
+++ b/mlflow/sagemaker/cli.py
@@ -7,6 +7,7 @@ import mlflow
 import mlflow.sagemaker
 from mlflow.sagemaker import DEFAULT_IMAGE_NAME as IMAGE
 from mlflow.utils import cli_args
+from mlflow.utils.annotations import experimental
 import mlflow.models.docker_utils
 
 
@@ -224,10 +225,10 @@ def delete(app_name, region_name, archive, asynchronous, timeout):
 @click.option("--job-name", "-n", help="Transform job name", required=True)
 @cli_args.MODEL_URI
 @click.option(
-    "--input-data-type", "-dt", help="Input data type for the transform job", required=True
+    "--input-data-type", help="Input data type for the transform job", required=True
 )
 @click.option(
-    "--input-uri", "-in", help="S3 key name prefix or manifest of the input data", required=True
+    "--input-uri", "-u", help="S3 key name prefix or manifest of the input data", required=True
 )
 @click.option(
     "--content-type",
@@ -236,7 +237,7 @@ def delete(app_name, region_name, archive, asynchronous, timeout):
 )
 @click.option(
     "--output-path",
-    "-out",
+    "-o",
     help="The S3 path to store the output results of the Sagemaker transform job",
     required=True,
 )
@@ -245,7 +246,7 @@ def delete(app_name, region_name, archive, asynchronous, timeout):
 )
 @click.option(
     "--split-type",
-    "-st",
+    "-s",
     default="Line",
     help="The method to split the transform job's data files into smaller batches",
 )
@@ -257,25 +258,22 @@ def delete(app_name, region_name, archive, asynchronous, timeout):
 )
 @click.option(
     "--assemble-with",
-    "-aw",
     default="Line",
     help="The method to assemble the results of the transform job as a single S3 object",
 )
 @click.option(
     "--input-filter",
-    "-if",
     default="$",
     help="A JSONPath expression used to select a portion of the input data for the transform job",
 )
 @click.option(
     "--output-filter",
-    "-of",
     default="$",
     help="A JSONPath expression used to select a portion of the output data from the transform job",
 )
 @click.option(
     "--join-resource",
-    "-jr",
+    "-j",
     default="None",
     help="The source of the data to join with the transformed data",
 )
@@ -344,6 +342,7 @@ def delete(app_name, region_name, archive, asynchronous, timeout):
         " asynchronously using the `--async` flag, this value is ignored."
     ),
 )
+@experimental
 def deploy_transform_job(
     job_name,
     model_uri,
@@ -414,11 +413,10 @@ def deploy_transform_job(
     "--region-name",
     "-r",
     default="us-west-2",
-    help="Name of the AWS region in which to deploy the transform job",
+    help="Name of the AWS region in which the transform job is deployed",
 )
 @click.option(
     "--archive",
-    "-ar",
     is_flag=True,
     help=(
         "If specified, resources associated with the application are preserved."
@@ -450,6 +448,7 @@ def deploy_transform_job(
         " asynchronously using the `--async` flag, this value is ignored."
     ),
 )
+@experimental
 def terminate_transform_job(job_name, region_name, archive, asynchronous, timeout):
     """
     Terminate the specified Sagemaker batch transform job. Unless ``--archive`` is specified,

--- a/mlflow/sagemaker/cli.py
+++ b/mlflow/sagemaker/cli.py
@@ -224,9 +224,7 @@ def delete(app_name, region_name, archive, asynchronous, timeout):
 @commands.command("deploy-transform-job")
 @click.option("--job-name", "-n", help="Transform job name", required=True)
 @cli_args.MODEL_URI
-@click.option(
-    "--input-data-type", help="Input data type for the transform job", required=True
-)
+@click.option("--input-data-type", help="Input data type for the transform job", required=True)
 @click.option(
     "--input-uri", "-u", help="S3 key name prefix or manifest of the input data", required=True
 )

--- a/tests/sagemaker/mock/__init__.py
+++ b/tests/sagemaker/mock/__init__.py
@@ -183,6 +183,65 @@ class SageMakerResponse(BaseResponse):
         self.sagemaker_backend.delete_model(model_name)
         return ""
 
+    def create_transform_job(self):
+        """
+        Handler for the SageMaker "CreateTransformJob" API call documented here:
+        https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateTransformJob.html.
+        """
+        job_name = self.request_params["TransformJobName"]
+        model_name = self.request_params.get("ModelName")
+        transform_input = self.request_params.get("TransformInput")
+        transform_output = self.request_params.get("TransformOutput")
+        transform_resources = self.request_params.get("TransformResources")
+        data_processing = self.request_params.get("DataProcessing")
+        tags = self.request_params.get("Tags", [])
+        new_job = self.sagemaker_backend.create_transform_job(
+            job_name=job_name,
+            model_name=model_name,
+            transform_input=transform_input,
+            transform_output=transform_output,
+            transform_resources=transform_resources,
+            data_processing=data_processing,
+            tags=tags,
+            region_name=self.region,
+        )
+        return json.dumps({"TransformJobArn": new_job.arn})
+
+    def stop_transform_job(self):
+        """
+        Handler for the SageMaker "StopTransformJob" API call documented here:
+        https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_StopTransformJob.html.
+        """
+        job_name = self.request_params["TransformJobName"]
+        self.sagemaker_backend.stop_transform_job(job_name)
+        return ""
+
+    def describe_transform_job(self):
+        """
+        Handler for the SageMaker "DescribeTransformJob" API call documented here:
+        https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_DescribeTransformJob.html.
+        """
+        job_name = self.request_params["TransformJobName"]
+        transform_job_description = self.sagemaker_backend.describe_transform_job(job_name)
+        return json.dumps(transform_job_description.response_object)
+
+    def list_transform_jobs(self):
+        """
+        Handler for the SageMaker "ListTransformJobs" API call documented here:
+        https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_ListTransformJobs.html.
+
+        This function does not support pagination. All transform jobs are returned in a
+        single response.
+        """
+        transform_job_summaries = self.sagemaker_backend.list_transform_jobs()
+        return json.dumps(
+            {
+                "TransformJobSummaries": [
+                    summary.response_object for summary in transform_job_summaries
+                ]
+            }
+        )
+
 
 class SageMakerBackend(BaseBackend):
     """
@@ -195,7 +254,9 @@ class SageMakerBackend(BaseBackend):
         self.models = {}
         self.endpoints = {}
         self.endpoint_configs = {}
+        self.transform_jobs = {}
         self._endpoint_update_latency_seconds = 0
+        self._transform_job_update_latency_seconds = 0
 
     def set_endpoint_update_latency(self, latency_seconds):
         """
@@ -205,6 +266,14 @@ class SageMakerBackend(BaseBackend):
         """
         self._endpoint_update_latency_seconds = latency_seconds
 
+    def set_transform_job_update_latency(self, latency_seconds):
+        """
+        Sets the latency for the following operations that update transform job state:
+        - "create_transform_job"
+        - "terminate_transform_job"
+        """
+        self._transform_job_update_latency_seconds = latency_seconds
+
     def set_endpoint_latest_operation(self, endpoint_name, operation):
         if endpoint_name not in self.endpoints:
             raise ValueError(
@@ -212,6 +281,14 @@ class SageMakerBackend(BaseBackend):
                 " that does not exist!"
             )
         self.endpoints[endpoint_name].resource.latest_operation = operation
+
+    def set_transform_job_latest_operation(self, transform_job_name, operation):
+        if transform_job_name not in self.transform_jobs:
+            raise ValueError(
+                "Attempted to manually set the latest operation for a transform job"
+                " that does not exist!"
+            )
+        self.transform_jobs[transform_job_name].resource.latest_operation = operation
 
     @property
     def _url_module(self):
@@ -475,9 +552,101 @@ class SageMakerBackend(BaseBackend):
 
         del self.models[model_name]
 
+    def create_transform_job(
+        self,
+        job_name,
+        model_name,
+        transform_input,
+        transform_output,
+        transform_resources,
+        data_processing,
+        tags,
+        region_name,
+    ):
+        """
+        Modifies backend state during calls to the SageMaker "CreateTransformJob" API
+        documented here:
+        https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateTransformJob.html.
+        """
+        if job_name in self.transform_jobs:
+            raise ValueError(
+                "Attempted to create a transform job with name:"
+                " {job_name}, but a transform job with this"
+                " name already exists.".format(job_name=job_name)
+            )
+
+        if model_name not in self.models:
+            raise ValueError(
+                "Attempted to create a transform job with a model named:"
+                " `{model_name}` However, this model does not exist.".format(model_name=model_name)
+            )
+
+        new_job = TransformJob(
+            job_name=job_name,
+            model_name=model_name,
+            transform_input=transform_input,
+            transform_output=transform_output,
+            transform_resources=transform_resources,
+            data_processing=data_processing,
+            tags=tags,
+            latest_operation=TransformJobOperation.create_successful(
+                latency_seconds=self._transform_job_update_latency_seconds
+            ),
+        )
+        new_job_arn = self._get_base_arn(region_name=region_name) + new_job.arn_descriptor
+        new_resource = SageMakerResourceWithArn(resource=new_job, arn=new_job_arn)
+        self.transform_jobs[job_name] = new_resource
+        return new_resource
+
+    def describe_transform_job(self, job_name):
+        """
+        Modifies backend state during calls to the SageMaker "DescribeTransformJob" API
+        documented here:
+        https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_DescribeTransformJob.html.
+        """
+        if job_name not in self.transform_jobs:
+            raise ValueError(
+                "Attempted to describe a transform job with name: `{job_name}`"
+                " that does not exist.".format(job_name=job_name)
+            )
+
+        transform_job = self.transform_jobs[job_name]
+        return TransformJobDescription(transform_job=transform_job.resource, arn=transform_job.arn)
+
+    def stop_transform_job(self, job_name):
+        """
+        Modifies backend state during calls to the SageMaker "StopTransformJob" API
+        documented here:
+        https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_StopTransformJob.html.
+        """
+        if job_name not in self.transform_jobs:
+            raise ValueError(
+                "Attempted to stop a transform job with name: `{job_name}`"
+                " that does not exist.".format(job_name=job_name)
+            )
+
+        self.transform_jobs[
+            job_name
+        ].resource.latest_operation = TransformJobOperation.stop_successful(
+            latency_seconds=self._transform_job_update_latency_seconds
+        )
+
+    def list_transform_jobs(self):
+        """
+        Modifies backend state during calls to the SageMaker "ListTransformJobs" API
+        documented here:
+        https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_ListTransformJobs.html.
+        """
+        summaries = []
+        for _, transform_job in self.transform_jobs.items():
+            summary = TransformJobSummary(
+                transform_job=transform_job.resource, arn=transform_job.arn
+            )
+            summaries.append(summary)
+        return summaries
+
 
 class TimestampedResource(BaseModel):
-
     TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 
     def __init__(self):
@@ -514,6 +683,61 @@ class Endpoint(TimestampedResource):
     @property
     def arn_descriptor(self):
         return ":endpoint/{endpoint_name}".format(endpoint_name=self.endpoint_name)
+
+    @property
+    def status(self):
+        return self.latest_operation.status()
+
+
+class TransformJob(TimestampedResource):
+
+    """
+    Object representing a SageMaker transform job. The SageMakerBackend will create
+    and manage transform jobs.
+    """
+
+    STATUS_IN_PROGRESS = "InProgress"
+    STATUS_FAILED = "Failed"
+    STATUS_COMPLETED = "Completed"
+    STATUS_STOPPING = "Stopping"
+    STATUS_STOPPED = "Stopped"
+
+    def __init__(
+        self,
+        job_name,
+        model_name,
+        transform_input,
+        transform_output,
+        transform_resources,
+        data_processing,
+        tags,
+        latest_operation,
+    ):
+        """
+        :param job_name: The name of the TransformJob.
+        :param model_name: The name of the model to associate with the TransformJob.
+        :param transform_input: The input data source and the way transform job consumes it.
+        :param transform_output: The output results of the transform job.
+        :param transform_resources: The ML instance types and instance count to use for the transform job.
+        :param data_processing: The data structure to specify the inference data and associate data to the
+                                prediction results.
+        :param tags: Arbitrary tags to associate with the transform job.
+        :param latest_operation: The most recent operation that was invoked on the transform job,
+                                 represented as an TransformJobOperation object.
+        """
+        super().__init__()
+        self.job_name = job_name
+        self.model_name = model_name
+        self.transform_input = transform_input
+        self.transform_output = transform_output
+        self.transform_resources = transform_resources
+        self.data_processing = data_processing
+        self.tags = tags
+        self.latest_operation = latest_operation
+
+    @property
+    def arn_descriptor(self):
+        return ":transform-job/{job_name}".format(job_name=self.job_name)
 
     @property
     def status(self):
@@ -578,6 +802,59 @@ class EndpointOperation:
             latency_seconds=latency_seconds,
             pending_status=Endpoint.STATUS_UPDATING,
             completed_status=Endpoint.STATUS_FAILED,
+        )
+
+
+class TransformJobOperation:
+    """
+    Object representing a SageMaker transform job operation ("create" or "stop"). Every
+    transform job is associated with the operation that was most recently invoked on it.
+    """
+
+    def __init__(self, latency_seconds, pending_status, completed_status):
+        """
+        :param latency_seconds: The latency of the operation, in seconds. Before the time window specified
+                        by this latency elapses, the operation will have the status specified by
+                        ``pending_status``. After the time window elapses, the operation will
+                        have the status  specified by ``completed_status``.
+        :param pending_status: The status that the operation should reflect *before* the latency
+                               window has elapsed.
+        :param completed_status: The status that the operation should reflect *after* the latency
+                                 window has elapsed.
+        """
+        self.latency_seconds = latency_seconds
+        self.pending_status = pending_status
+        self.completed_status = completed_status
+        self.start_time = time.time()
+
+    def status(self):
+        if time.time() - self.start_time < self.latency_seconds:
+            return self.pending_status
+        else:
+            return self.completed_status
+
+    @classmethod
+    def create_successful(cls, latency_seconds):
+        return cls(
+            latency_seconds=latency_seconds,
+            pending_status=TransformJob.STATUS_IN_PROGRESS,
+            completed_status=TransformJob.STATUS_COMPLETED,
+        )
+
+    @classmethod
+    def create_unsuccessful(cls, latency_seconds):
+        return cls(
+            latency_seconds=latency_seconds,
+            pending_status=TransformJob.STATUS_IN_PROGRESS,
+            completed_status=TransformJob.STATUS_FAILED,
+        )
+
+    @classmethod
+    def stop_successful(cls, latency_seconds):
+        return cls(
+            latency_seconds=latency_seconds,
+            pending_status=TransformJob.STATUS_STOPPING,
+            completed_status=TransformJob.STATUS_STOPPED,
         )
 
 
@@ -747,6 +1024,53 @@ class ModelDescription:
             "ExecutionRoleArn": self.model.execution_role_arn,
             "VpcConfig": self.model.vpc_config if self.model.vpc_config else {},
             "CreationTime": self.model.creation_time,
+        }
+        return response
+
+
+class TransformJobSummary:
+    """
+    Object representing a TransformJobSummary entry in the TransformJobSummaries list returned by
+    SageMaker's "ListTransformJobs" API:
+    https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_ListTransformJobs.html.
+    """
+
+    def __init__(self, transform_job, arn):
+        self.transform_job = transform_job
+        self.arn = arn
+
+    @property
+    def response_object(self):
+        response = {
+            "TransformJobName": self.transform_job.job_name,
+            "TransformJobArn": self.arn,
+            "CreationTime": self.transform_job.creation_time,
+            "LastModifiedTime": self.transform_job.last_modified_time,
+            "TransformJobStatus": self.transform_job.status,
+        }
+        return response
+
+
+class TransformJobDescription:
+    """
+    Object representing a transform job description returned by SageMaker's
+    "DescribeTransformJob" API:
+    https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_DescribeTransformJob.html.
+    """
+
+    def __init__(self, transform_job, arn):
+        self.transform_job = transform_job
+        self.arn = arn
+
+    @property
+    def response_object(self):
+        response = {
+            "TransformJobName": self.transform_job.job_name,
+            "TransformJobArn": self.arn,
+            "CreationTime": self.transform_job.creation_time,
+            "LastModifiedTime": self.transform_job.last_modified_time,
+            "TransformJobStatus": self.transform_job.status,
+            "ModelName": self.transform_job.model_name,
         }
         return response
 

--- a/tests/sagemaker/mock/__init__.py
+++ b/tests/sagemaker/mock/__init__.py
@@ -718,9 +718,10 @@ class TransformJob(TimestampedResource):
         :param model_name: The name of the model to associate with the TransformJob.
         :param transform_input: The input data source and the way transform job consumes it.
         :param transform_output: The output results of the transform job.
-        :param transform_resources: The ML instance types and instance count to use for the transform job.
-        :param data_processing: The data structure to specify the inference data and associate data to the
-                                prediction results.
+        :param transform_resources: The ML instance types and instance count to use for the
+                                    transform job.
+        :param data_processing: The data structure to specify the inference data and associate data
+                                to the prediction results.
         :param tags: Arbitrary tags to associate with the transform job.
         :param latest_operation: The most recent operation that was invoked on the transform job,
                                  represented as an TransformJobOperation object.
@@ -813,10 +814,10 @@ class TransformJobOperation:
 
     def __init__(self, latency_seconds, pending_status, completed_status):
         """
-        :param latency_seconds: The latency of the operation, in seconds. Before the time window specified
-                        by this latency elapses, the operation will have the status specified by
-                        ``pending_status``. After the time window elapses, the operation will
-                        have the status  specified by ``completed_status``.
+        :param latency_seconds: The latency of the operation, in seconds. Before the time window
+                        specified by this latency elapses, the operation will have the status
+                        specified by ``pending_status``. After the time window elapses, the
+                        operation will have the status  specified by ``completed_status``.
         :param pending_status: The status that the operation should reflect *before* the latency
                                window has elapsed.
         :param completed_status: The status that the operation should reflect *after* the latency

--- a/tests/sagemaker/test_batch_deployment.py
+++ b/tests/sagemaker/test_batch_deployment.py
@@ -1,0 +1,530 @@
+import os
+import pytest
+import time
+from collections import namedtuple
+from unittest import mock
+
+import boto3
+import botocore
+import numpy as np
+from click.testing import CliRunner
+from sklearn.linear_model import LogisticRegression
+
+import mlflow
+import mlflow.pyfunc
+import mlflow.sklearn
+import mlflow.sagemaker as mfs
+import mlflow.sagemaker.cli as mfscli
+from mlflow.exceptions import MlflowException
+from mlflow.models import Model
+from mlflow.protos.databricks_pb2 import (
+    ErrorCode,
+    RESOURCE_DOES_NOT_EXIST,
+    INVALID_PARAMETER_VALUE,
+    INTERNAL_ERROR,
+)
+from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
+from mlflow.tracking.artifact_utils import _download_artifact_from_uri
+
+from tests.helper_functions import set_boto_credentials  # pylint: disable=unused-import
+from tests.sagemaker.mock import mock_sagemaker, TransformJob, TransformJobOperation
+
+TrainedModel = namedtuple("TrainedModel", ["model_path", "run_id", "model_uri"])
+
+
+@pytest.fixture
+def pretrained_model():
+    model_path = "model"
+    with mlflow.start_run():
+        X = np.array([-2, -1, 0, 1, 2, 1]).reshape(-1, 1)
+        y = np.array([0, 0, 1, 1, 1, 0])
+        lr = LogisticRegression(solver="lbfgs")
+        lr.fit(X, y)
+        mlflow.sklearn.log_model(lr, model_path)
+        run_id = mlflow.active_run().info.run_id
+        model_uri = "runs:/" + run_id + "/" + model_path
+        return TrainedModel(model_path, run_id, model_uri)
+
+
+@pytest.fixture
+def sagemaker_client():
+    return boto3.client("sagemaker", region_name="us-west-2")
+
+
+def get_sagemaker_backend(region_name):
+    return mock_sagemaker.backends[region_name]
+
+
+def mock_sagemaker_aws_services(fn):
+    from functools import wraps
+    from moto import mock_s3, mock_ecr, mock_sts, mock_iam
+
+    @mock_ecr
+    @mock_iam
+    @mock_s3
+    @mock_sagemaker
+    @mock_sts
+    @wraps(fn)
+    def mock_wrapper(*args, **kwargs):
+        # Create an ECR repository for the `mlflow-pyfunc` SageMaker docker image
+        ecr_client = boto3.client("ecr", region_name="us-west-2")
+        ecr_client.create_repository(repositoryName=mfs.DEFAULT_IMAGE_NAME)
+
+        # Create the moto IAM role
+        role_policy = """
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": "*",
+                    "Resource": "*"
+                }
+            ]
+        }
+        """
+        iam_client = boto3.client("iam", region_name="us-west-2")
+        iam_client.create_role(RoleName="moto", AssumeRolePolicyDocument=role_policy)
+
+        return fn(*args, **kwargs)
+
+    return mock_wrapper
+
+
+@pytest.mark.large
+def test_batch_deployment_with_unsupported_flavor_raises_exception(pretrained_model):
+    unsupported_flavor = "this is not a valid flavor"
+    with pytest.raises(MlflowException) as exc:
+        mfs.deploy_transform_job(
+            job_name="bad_flavor",
+            model_uri=pretrained_model.model_uri,
+            s3_input_data_type="Some Data Type",
+            s3_input_uri="Some Input Uri",
+            content_type="Some Content Type",
+            s3_output_path="Some Output Path",
+            flavor=unsupported_flavor,
+        )
+
+    assert exc.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+
+
+@pytest.mark.large
+def test_batch_deployment_with_missing_flavor_raises_exception(pretrained_model):
+    missing_flavor = "mleap"
+    with pytest.raises(MlflowException) as exc:
+        mfs.deploy_transform_job(
+            job_name="missing-flavor",
+            model_uri=pretrained_model.model_uri,
+            s3_input_data_type="Some Data Type",
+            s3_input_uri="Some Input Uri",
+            content_type="Some Content Type",
+            s3_output_path="Some Output Path",
+            flavor=missing_flavor,
+        )
+
+    assert exc.value.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
+
+
+@pytest.mark.large
+def test_batch_deployment_of_model_with_no_supported_flavors_raises_exception(pretrained_model):
+    logged_model_path = _download_artifact_from_uri(pretrained_model.model_uri)
+    model_config_path = os.path.join(logged_model_path, "MLmodel")
+    model_config = Model.load(model_config_path)
+    del model_config.flavors[mlflow.pyfunc.FLAVOR_NAME]
+    model_config.save(path=model_config_path)
+
+    with pytest.raises(MlflowException) as exc:
+        mfs.deploy_transform_job(
+            job_name="missing-flavor",
+            model_uri=logged_model_path,
+            s3_input_data_type="Some Data Type",
+            s3_input_uri="Some Input Uri",
+            content_type="Some Content Type",
+            s3_output_path="Some Output Path",
+            flavor=None,
+        )
+
+    assert exc.value.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
+
+
+@pytest.mark.large
+@mock_sagemaker_aws_services
+def test_deploy_creates_sagemaker_transform_job_and_s3_resources_with_expected_names_from_local(
+    pretrained_model, sagemaker_client
+):
+    job_name = "test-job"
+    mfs.deploy_transform_job(
+        job_name=job_name,
+        model_uri=pretrained_model.model_uri,
+        s3_input_data_type="Some Data Type",
+        s3_input_uri="Some Input Uri",
+        content_type="Some Content Type",
+        s3_output_path="Some Output Path",
+    )
+
+    region_name = sagemaker_client.meta.region_name
+    s3_client = boto3.client("s3", region_name=region_name)
+    default_bucket = mfs._get_default_s3_bucket(region_name)
+    transform_job_description = sagemaker_client.describe_transform_job(TransformJobName=job_name)
+    model_name = transform_job_description["ModelName"]
+    assert model_name in [model["ModelName"] for model in sagemaker_client.list_models()["Models"]]
+    object_names = [
+        entry["Key"] for entry in s3_client.list_objects(Bucket=default_bucket)["Contents"]
+    ]
+    assert any([model_name in object_name for object_name in object_names])
+    assert job_name in [
+        transform_job["TransformJobName"]
+        for transform_job in sagemaker_client.list_transform_jobs()["TransformJobSummaries"]
+    ]
+
+
+@pytest.mark.large
+@mock_sagemaker_aws_services
+def test_deploy_cli_creates_sagemaker_transform_job_and_s3_resources_with_expected_names_from_local(
+    pretrained_model, sagemaker_client
+):
+    job_name = "test-job"
+    result = CliRunner(env={"LC_ALL": "en_US.UTF-8", "LANG": "en_US.UTF-8"}).invoke(
+        mfscli.commands,
+        [
+            "deploy-transform-job",
+            "--job-name",
+            job_name,
+            "--model-uri",
+            pretrained_model.model_uri,
+            "--input-data-type",
+            "Some Data Type",
+            "--input-uri",
+            "Some Input Uri",
+            "--content-type",
+            "Some Content Type",
+            "--output-path",
+            "Some Output Path",
+        ],
+    )
+    assert result.exit_code == 0
+
+    region_name = sagemaker_client.meta.region_name
+    s3_client = boto3.client("s3", region_name=region_name)
+    default_bucket = mfs._get_default_s3_bucket(region_name)
+    transform_job_description = sagemaker_client.describe_transform_job(TransformJobName=job_name)
+    model_name = transform_job_description["ModelName"]
+    assert model_name in [model["ModelName"] for model in sagemaker_client.list_models()["Models"]]
+    object_names = [
+        entry["Key"] for entry in s3_client.list_objects(Bucket=default_bucket)["Contents"]
+    ]
+    assert any([model_name in object_name for object_name in object_names])
+    assert job_name in [
+        transform_job["TransformJobName"]
+        for transform_job in sagemaker_client.list_transform_jobs()["TransformJobSummaries"]
+    ]
+
+
+@pytest.mark.large
+@mock_sagemaker_aws_services
+def test_deploy_creates_sagemaker_transform_job_and_s3_resources_with_expected_names_from_s3(
+    pretrained_model, sagemaker_client
+):
+    local_model_path = _download_artifact_from_uri(pretrained_model.model_uri)
+    artifact_path = "model"
+    region_name = sagemaker_client.meta.region_name
+    default_bucket = mfs._get_default_s3_bucket(region_name)
+    s3_artifact_repo = S3ArtifactRepository("s3://{}".format(default_bucket))
+    s3_artifact_repo.log_artifacts(local_model_path, artifact_path=artifact_path)
+    model_s3_uri = "s3://{bucket_name}/{artifact_path}".format(
+        bucket_name=default_bucket, artifact_path=pretrained_model.model_path
+    )
+
+    job_name = "test-job"
+    mfs.deploy_transform_job(
+        job_name=job_name,
+        model_uri=model_s3_uri,
+        s3_input_data_type="Some Data Type",
+        s3_input_uri="Some Input Uri",
+        content_type="Some Content Type",
+        s3_output_path="Some Output Path",
+    )
+
+    transform_job_description = sagemaker_client.describe_transform_job(TransformJobName=job_name)
+    model_name = transform_job_description["ModelName"]
+    assert model_name in [model["ModelName"] for model in sagemaker_client.list_models()["Models"]]
+
+    s3_client = boto3.client("s3", region_name=region_name)
+    object_names = [
+        entry["Key"] for entry in s3_client.list_objects(Bucket=default_bucket)["Contents"]
+    ]
+    assert any([model_name in object_name for object_name in object_names])
+    assert job_name in [
+        transform_job["TransformJobName"]
+        for transform_job in sagemaker_client.list_transform_jobs()["TransformJobSummaries"]
+    ]
+
+
+@pytest.mark.large
+@mock_sagemaker_aws_services
+def test_deploy_cli_creates_sagemaker_transform_job_and_s3_resources_with_expected_names_from_s3(
+    pretrained_model, sagemaker_client
+):
+    local_model_path = _download_artifact_from_uri(pretrained_model.model_uri)
+    artifact_path = "model"
+    region_name = sagemaker_client.meta.region_name
+    default_bucket = mfs._get_default_s3_bucket(region_name)
+    s3_artifact_repo = S3ArtifactRepository("s3://{}".format(default_bucket))
+    s3_artifact_repo.log_artifacts(local_model_path, artifact_path=artifact_path)
+    model_s3_uri = "s3://{bucket_name}/{artifact_path}".format(
+        bucket_name=default_bucket, artifact_path=pretrained_model.model_path
+    )
+
+    job_name = "test-job"
+    result = CliRunner(env={"LC_ALL": "en_US.UTF-8", "LANG": "en_US.UTF-8"}).invoke(
+        mfscli.commands,
+        [
+            "deploy-transform-job",
+            "--job-name",
+            job_name,
+            "--model-uri",
+            model_s3_uri,
+            "--input-data-type",
+            "Some Data Type",
+            "--input-uri",
+            "Some Input Uri",
+            "--content-type",
+            "Some Content Type",
+            "--output-path",
+            "Some Output Path",
+        ],
+    )
+    assert result.exit_code == 0
+
+    region_name = sagemaker_client.meta.region_name
+    s3_client = boto3.client("s3", region_name=region_name)
+    default_bucket = mfs._get_default_s3_bucket(region_name)
+    transform_job_description = sagemaker_client.describe_transform_job(TransformJobName=job_name)
+    model_name = transform_job_description["ModelName"]
+    assert model_name in [model["ModelName"] for model in sagemaker_client.list_models()["Models"]]
+    object_names = [
+        entry["Key"] for entry in s3_client.list_objects(Bucket=default_bucket)["Contents"]
+    ]
+    assert any([model_name in object_name for object_name in object_names])
+    assert job_name in [
+        transform_job["TransformJobName"]
+        for transform_job in sagemaker_client.list_transform_jobs()["TransformJobSummaries"]
+    ]
+
+
+@pytest.mark.large
+@mock_sagemaker_aws_services
+def test_deploying_sagemaker_transform_job_with_preexisting_name_in_create_mode_throws_exception(
+    pretrained_model,
+):
+    job_name = "test-job"
+    mfs.deploy_transform_job(
+        job_name=job_name,
+        model_uri=pretrained_model.model_uri,
+        s3_input_data_type="Some Data Type",
+        s3_input_uri="Some Input Uri",
+        content_type="Some Content Type",
+        s3_output_path="Some Output Path",
+    )
+
+    with pytest.raises(MlflowException) as exc:
+        mfs.deploy_transform_job(
+            job_name=job_name,
+            model_uri=pretrained_model.model_uri,
+            s3_input_data_type="Some Data Type",
+            s3_input_uri="Some Input Uri",
+            content_type="Some Content Type",
+            s3_output_path="Some Output Path",
+        )
+
+    assert "a batch transform job with the same name already exists" in exc.value.message
+    assert exc.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+
+
+@pytest.mark.large
+@mock_sagemaker_aws_services
+def test_deploy_in_synchronous_mode_waits_for_transform_job_creation_to_complete_before_returning(
+    pretrained_model, sagemaker_client
+):
+    transform_job_creation_latency = 10
+    get_sagemaker_backend(sagemaker_client.meta.region_name).set_transform_job_update_latency(
+        transform_job_creation_latency
+    )
+
+    job_name = "test-job"
+    deployment_start_time = time.time()
+    mfs.deploy_transform_job(
+        job_name=job_name,
+        model_uri=pretrained_model.model_uri,
+        s3_input_data_type="Some Data Type",
+        s3_input_uri="Some Input Uri",
+        content_type="Some Content Type",
+        s3_output_path="Some Output Path",
+        synchronous=True,
+    )
+    deployment_end_time = time.time()
+
+    assert (deployment_end_time - deployment_start_time) >= transform_job_creation_latency
+    transform_job_description = sagemaker_client.describe_transform_job(TransformJobName=job_name)
+    assert transform_job_description["TransformJobStatus"] == TransformJob.STATUS_COMPLETED
+
+
+@pytest.mark.large
+@mock_sagemaker_aws_services
+def test_deploy_create_in_asynchronous_mode_returns_before_transform_job_creation_completes(
+    pretrained_model, sagemaker_client
+):
+    transform_job_creation_latency = 10
+    get_sagemaker_backend(sagemaker_client.meta.region_name).set_transform_job_update_latency(
+        transform_job_creation_latency
+    )
+
+    job_name = "test-job"
+    deployment_start_time = time.time()
+    mfs.deploy_transform_job(
+        job_name=job_name,
+        model_uri=pretrained_model.model_uri,
+        s3_input_data_type="Some Data Type",
+        s3_input_uri="Some Input Uri",
+        content_type="Some Content Type",
+        s3_output_path="Some Output Path",
+        synchronous=False,
+    )
+    deployment_end_time = time.time()
+
+    assert (deployment_end_time - deployment_start_time) < transform_job_creation_latency
+    transform_job_description = sagemaker_client.describe_transform_job(TransformJobName=job_name)
+    assert transform_job_description["TransformJobStatus"] == TransformJob.STATUS_IN_PROGRESS
+
+
+@pytest.mark.large
+@mock_sagemaker_aws_services
+def test_deploy_in_throw_exception_after_transform_job_creation_fails(
+    pretrained_model, sagemaker_client
+):
+    transform_job_creation_latency = 10
+    sagemaker_backend = get_sagemaker_backend(sagemaker_client.meta.region_name)
+    sagemaker_backend.set_transform_job_update_latency(transform_job_creation_latency)
+
+    boto_caller = botocore.client.BaseClient._make_api_call
+
+    def fail_transform_job_creations(self, operation_name, operation_kwargs):
+        """
+        Processes all boto3 client operations according to the following rules:
+        - If the operation is a transform job creation, create the transform job and set its status to
+          ``TransformJob.STATUS_FAILED``.
+        - Else, execute the client operation as normal
+        """
+        result = boto_caller(self, operation_name, operation_kwargs)
+        if operation_name == "CreateTransformJob":
+            transform_job_name = operation_kwargs["TransformJobName"]
+            sagemaker_backend.set_transform_job_latest_operation(
+                transform_job_name=transform_job_name,
+                operation=TransformJobOperation.create_unsuccessful(
+                    latency_seconds=transform_job_creation_latency
+                ),
+            )
+        return result
+
+    with mock.patch(
+        "botocore.client.BaseClient._make_api_call", new=fail_transform_job_creations
+    ), pytest.raises(MlflowException) as exc:
+        mfs.deploy_transform_job(
+            job_name="test-job",
+            model_uri=pretrained_model.model_uri,
+            s3_input_data_type="Some Data Type",
+            s3_input_uri="Some Input Uri",
+            content_type="Some Content Type",
+            s3_output_path="Some Output Path",
+        )
+
+    assert "batch transform job failed" in exc.value.message
+    assert exc.value.error_code == ErrorCode.Name(INTERNAL_ERROR)
+
+
+@pytest.mark.large
+@mock_sagemaker_aws_services
+def test_attempting_to_terminate_in_asynchronous_mode_without_archiving_throws_exception(
+    pretrained_model,
+):
+    job_name = "test-job"
+    mfs.deploy_transform_job(
+        job_name=job_name,
+        model_uri=pretrained_model.model_uri,
+        s3_input_data_type="Some Data Type",
+        s3_input_uri="Some Input Uri",
+        content_type="Some Content Type",
+        s3_output_path="Some Output Path",
+    )
+
+    with pytest.raises(MlflowException) as exc:
+        mfs.terminate_transform_job(
+            job_name=job_name, archive=False, synchronous=False,
+        )
+
+    assert "Resources must be archived" in exc.value.message
+    assert exc.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+
+
+@pytest.mark.large
+@mock_sagemaker_aws_services
+def test_terminate_in_synchronous_mode_waits_for_transform_job_termination_to_complete_before_returning(
+    pretrained_model, sagemaker_client
+):
+    transform_job_termination_latency = 10
+    get_sagemaker_backend(sagemaker_client.meta.region_name).set_transform_job_update_latency(
+        transform_job_termination_latency
+    )
+
+    job_name = "test-job"
+    termination_start_time = time.time()
+    mfs.deploy_transform_job(
+        job_name=job_name,
+        model_uri=pretrained_model.model_uri,
+        s3_input_data_type="Some Data Type",
+        s3_input_uri="Some Input Uri",
+        content_type="Some Content Type",
+        s3_output_path="Some Output Path",
+        synchronous=True,
+    )
+
+    mfs.terminate_transform_job(
+        job_name=job_name, synchronous=True,
+    )
+    termination_end_time = time.time()
+
+    assert (termination_end_time - termination_start_time) >= transform_job_termination_latency
+    transform_job_description = sagemaker_client.describe_transform_job(TransformJobName=job_name)
+    assert transform_job_description["TransformJobStatus"] == TransformJob.STATUS_STOPPED
+
+
+@pytest.mark.large
+@mock_sagemaker_aws_services
+def test_terminate_in_asynchronous_mode_returns_before_transform_job_termination_completes(
+    pretrained_model, sagemaker_client
+):
+    transform_job_termination_latency = 10
+    get_sagemaker_backend(sagemaker_client.meta.region_name).set_transform_job_update_latency(
+        transform_job_termination_latency
+    )
+
+    job_name = "test-job"
+    termination_start_time = time.time()
+    mfs.deploy_transform_job(
+        job_name=job_name,
+        model_uri=pretrained_model.model_uri,
+        s3_input_data_type="Some Data Type",
+        s3_input_uri="Some Input Uri",
+        content_type="Some Content Type",
+        s3_output_path="Some Output Path",
+        synchronous=False,
+    )
+
+    mfs.terminate_transform_job(
+        job_name=job_name, synchronous=False,
+    )
+    termination_end_time = time.time()
+
+    assert (termination_end_time - termination_start_time) < transform_job_termination_latency
+    transform_job_description = sagemaker_client.describe_transform_job(TransformJobName=job_name)
+    assert transform_job_description["TransformJobStatus"] == TransformJob.STATUS_STOPPING

--- a/tests/sagemaker/test_batch_deployment.py
+++ b/tests/sagemaker/test_batch_deployment.py
@@ -411,8 +411,8 @@ def test_deploy_in_throw_exception_after_transform_job_creation_fails(
     def fail_transform_job_creations(self, operation_name, operation_kwargs):
         """
         Processes all boto3 client operations according to the following rules:
-        - If the operation is a transform job creation, create the transform job and set its status to
-          ``TransformJob.STATUS_FAILED``.
+        - If the operation is a transform job creation, create the transform job and
+          set its status to ``TransformJob.STATUS_FAILED``.
         - Else, execute the client operation as normal
         """
         result = boto_caller(self, operation_name, operation_kwargs)
@@ -468,7 +468,7 @@ def test_attempting_to_terminate_in_asynchronous_mode_without_archiving_throws_e
 
 @pytest.mark.large
 @mock_sagemaker_aws_services
-def test_terminate_in_synchronous_mode_waits_for_transform_job_termination_to_complete_before_returning(
+def test_terminate_in_sync_mode_waits_for_transform_job_termination_to_complete_before_returning(
     pretrained_model, sagemaker_client
 ):
     transform_job_termination_latency = 10


### PR DESCRIPTION
## What changes are proposed in this pull request?
Implemented the Python APIs and the CLI supports to integrate Sagemaker Batch Transform with MLflow.
https://docs.aws.amazon.com/sagemaker/latest/dg/batch-transform.html

`deploy_transform_job()` is used to deploy the model from the MLflow model registry as a Sagemaker Batch Transform job.
`terminate_transform_job()` is used to terminate the in-progress Sagemaker Batch Transform job.

## How is this patch tested?
- Unit tests
- Checked linter by running lint.sh
- Manually used the API to deploy a model as a Sagemaker Batch Transform job and checked it from the AWS Console
- Manually used the API to terminate the deployed Sagemaker Batch Transform job and checked it from the AWS Console
- Generated the docs and checked it.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The model can be deployed as a Sagemaker Batch Transform job using Pythons APIs and CLIs.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [x] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
