### PR TITLE
Add artifact views in the CompareRunView

### DIFF
--- a/hooks/prepare-commit-msg
+++ b/hooks/prepare-commit-msg
@@ -1,3 +1,4 @@
+#!/bin/sh
 # A git hook to block an unsigned-off commit
 
 COMMIT_MSG_FILE=$1

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunView.js
@@ -15,6 +15,7 @@ import CompareRunUtil from './CompareRunUtil';
 import Utils from '../../common/utils/Utils';
 import { Tabs } from 'antd';
 import ParallelCoordinatesPlotPanel from './ParallelCoordinatesPlotPanel';
+import ArtifactPage from './ArtifactPage';
 
 const { TabPane } = Tabs;
 
@@ -181,6 +182,25 @@ export class CompareRunView extends Component {
                 },
                 Utils.formatMetric,
               )}
+              <tr>
+                <th
+                  scope='rowgroup'
+                  className='inter-title'
+                  colSpan={this.props.runInfos.length + 1}
+                >
+                  <h2>Artifacts</h2>
+                </th>
+              </tr>
+              <tr>
+              <td></td>
+              {this.props.runInfos.map((r) => (
+                  <td>
+                  <ArtifactPage
+                    runUuid={r.run_uuid}
+                  />
+                </td>
+                ))}
+              </tr>
             </tbody>
           </table>
         </div>
@@ -227,6 +247,25 @@ export class CompareRunView extends Component {
         </Tabs>
       </div>
     );
+  }
+
+
+  renderArtifacts(runIds){
+    return (
+      <tr>
+                <td></td>
+                <td>
+                  <ArtifactPage
+                    runUuid='201721229e3d487dba15255d6567004c'
+                  />
+                </td>
+                <td>
+                  <ArtifactPage
+                    runUuid='581997d584d14b249cb92d04d21664b6'
+                  />
+                </td>
+              </tr>
+    )
   }
 
   // eslint-disable-next-line no-unused-vars


### PR DESCRIPTION
## What changes are proposed in this pull request?

Show artifacts of multiple runs in the CompareRunView.

Related FRs:

- https://github.com/mlflow/mlflow/issues/2696
- https://github.com/mlflow/mlflow/issues/3843

After opening:

![image](https://user-images.githubusercontent.com/12762439/120230935-a10ba800-c250-11eb-9feb-88b085bd6aa7.png)

After selecting in both runs:

![image](https://user-images.githubusercontent.com/12762439/120230990-bbde1c80-c250-11eb-9dc2-7e2b0f8be6c6.png)
 

## How is this patch tested?

n. a.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
