### PR TITLE
Fix dev sklearn build failure due to `scikit-learn requires numpy >= 1.14.6`

### DIFF
--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -75,8 +75,8 @@ jobs:
           hash=$(echo -n "$INSTALL_COMMAND" | sha256sum)
           echo "::set-output name=key::$ImageOS-$ImageVersion-wheels-$date-$hash"
       - uses: actions/cache@v2
-        # We only cache wheels that take long (> 20 min) to build
-        if: ${{ contains('pyspark, catboost', matrix.package) && matrix.version == 'dev' }}
+        # We only cache wheels that take long (> 10 min) to build
+        if: ${{ contains('pyspark, catboost, scikit-learn', matrix.package) && matrix.version == 'dev' }}
         with:
           path: /home/runner/.cache/wheels
           key: ${{ steps.get-cache-key.outputs.key }}

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -2,8 +2,10 @@ sklearn:
   package_info:
     pip_release: "scikit-learn"
     install_dev: |
-      # This installs scikit-learn from the default branch
-      pip install git+https://github.com/scikit-learn/scikit-learn.git
+      # TODO: Remove `pip install Cython numpy scipy` and `--no-use-pep517` once
+      #       https://github.com/scikit-learn/scikit-learn/issues/20189 is fixed
+      pip install Cython numpy scipy
+      pip install --no-use-pep517 git+https://github.com/scikit-learn/scikit-learn.git
 
   models:
     minimum: "0.20.3"


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Fix dev sklearn build failure in the cross version testing:

https://github.com/mlflow/mlflow/runs/2727082788?check_suite_focus=true#step:9:10

```diff
+ >>> pip install git+https://github.com/scikit-learn/scikit-learn.git
Collecting git+https://github.com/scikit-learn/scikit-learn.git
  Running command git clone -q https://github.com/scikit-learn/scikit-learn.git /tmp/pip-req-build-_oyusy6y
  Cloning https://github.com/scikit-learn/scikit-learn.git to /tmp/pip-req-build-_oyusy6y
  Installing build dependencies: started
  Installing build dependencies: still running...
  Installing build dependencies: still running...
  Installing build dependencies: still running...
  Installing build dependencies: still running...
  Installing build dependencies: still running...
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
    Preparing wheel metadata: started
    Preparing wheel metadata: finished with status 'error'
    ERROR: Command errored out with exit status 1:
     command: /usr/share/miniconda/bin/python /usr/share/miniconda/lib/python3.7/site-packages/pip/_vendor/pep517/in_process/_in_process.py prepare_metadata_for_build_wheel /tmp/tmp3848g2m9
         cwd: /tmp/pip-req-build-_oyusy6y
    Complete output (24 lines):
    Partial import of sklearn during the build process.
    Traceback (most recent call last):
      File "/usr/share/miniconda/lib/python3.7/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 280, in <module>
        main()
      File "/usr/share/miniconda/lib/python3.7/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 263, in main
        json_out['return_val'] = hook(**hook_input['kwargs'])
      File "/usr/share/miniconda/lib/python3.7/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 133, in prepare_metadata_for_build_wheel
        return hook(metadata_directory, config_settings)
      File "/tmp/pip-build-env-30qbzflz/overlay/lib/python3.7/site-packages/setuptools/build_meta.py", line 166, in prepare_metadata_for_build_wheel
        self.run_setup()
      File "/tmp/pip-build-env-30qbzflz/overlay/lib/python3.7/site-packages/setuptools/build_meta.py", line 259, in run_setup
        self).run_setup(setup_script=setup_script)
      File "/tmp/pip-build-env-30qbzflz/overlay/lib/python3.7/site-packages/setuptools/build_meta.py", line 150, in run_setup
        exec(compile(code, __file__, 'exec'), locals())
      File "setup.py", line 300, in <module>
        setup_package()
      File "setup.py", line 286, in setup_package
        check_package_status('numpy', min_deps.NUMPY_MIN_VERSION)
      File "setup.py", line 223, in check_package_status
        req_str, instructions))
    ImportError: Your installation of numpy 1.14.5 is out-of-date.
+    scikit-learn requires numpy >= 1.14.6.
    Installation instructions are available on the scikit-learn website: http://scikit-learn.org/stable/install.html
```

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
