### PR TITLE
Log databricks runtime in MLmodel

### DIFF
--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, Optional
 import mlflow
 from mlflow.exceptions import MlflowException
 from mlflow.utils.file_utils import TempDir
+from mlflow.utils.databricks_utils import get_databricks_runtime
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 
 _logger = logging.getLogger(__name__)
@@ -46,6 +47,10 @@ class Model(object):
         if run_id:
             self.run_id = run_id
             self.artifact_path = artifact_path
+
+        databricks_runtime = get_databricks_runtime()
+        if databricks_runtime:
+            self.databricks_runtime = databricks_runtime
         self.utc_time_created = str(utc_time_created or datetime.utcnow())
         self.flavors = flavors if flavors is not None else {}
         self.signature = signature

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -138,7 +138,9 @@ def get_databricks_runtime():
     if is_in_databricks_notebook() or is_in_databricks_job():
         spark_session = _get_active_spark_session()
         if spark_session is not None:
-            return spark_session.conf.get("spark.databricks.clusterUsageTags.sparkVersion", default=None)
+            return spark_session.conf.get(
+                "spark.databricks.clusterUsageTags.sparkVersion", default=None
+            )
     return None
 
 

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -135,10 +135,15 @@ def get_notebook_path():
 
 
 def get_databricks_runtime():
-    spark_session = _get_active_spark_session()
-    if spark_session is None:
+    try:
+        spark_session = _get_active_spark_session()
+        return (
+            None
+            if spark_session is None
+            else spark_session.conf.get("spark.databricks.clusterUsageTags.sparkVersion")
+        )
+    except Exception:
         return None
-    return spark_session.conf.get("spark.databricks.clusterUsageTags.sparkVersion")
 
 
 def get_cluster_id():

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -135,15 +135,14 @@ def get_notebook_path():
 
 
 def get_databricks_runtime():
-    try:
+    if is_in_databricks_notebook() or is_in_databricks_job():
         spark_session = _get_active_spark_session()
         return (
             None
             if spark_session is None
             else spark_session.conf.get("spark.databricks.clusterUsageTags.sparkVersion")
         )
-    except Exception:
-        return None
+    return None
 
 
 def get_cluster_id():

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -137,11 +137,8 @@ def get_notebook_path():
 def get_databricks_runtime():
     if is_in_databricks_notebook() or is_in_databricks_job():
         spark_session = _get_active_spark_session()
-        return (
-            None
-            if spark_session is None
-            else spark_session.conf.get("spark.databricks.clusterUsageTags.sparkVersion")
-        )
+        if spark_session is not None:
+            return spark_session.conf.get("spark.databricks.clusterUsageTags.sparkVersion", default=None)
     return None
 
 

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -134,6 +134,13 @@ def get_notebook_path():
         return _get_extra_context("notebook_path")
 
 
+def get_databricks_runtime():
+    spark_session = _get_active_spark_session()
+    if spark_session is None:
+        return None
+    return spark_session.conf.get("spark.databricks.clusterUsageTags.sparkVersion")
+
+
 def get_cluster_id():
     spark_session = _get_active_spark_session()
     if spark_session is None:

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -93,6 +93,7 @@ def test_model_log():
         path = os.path.join(local_path, loaded_model.saved_input_example_info["artifact_path"])
         x = _dataframe_from_json(path)
         assert x.to_dict(orient="records")[0] == input_example
+        assert not hasattr(loaded_model, "databricks_runtime")
 
 
 def test_model_log_with_databricks_runtime():

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -69,7 +69,6 @@ class TestFlavor(object):
 
 
 def test_model_log():
-    dbr = "8.3.x-snapshot-gpu-ml-scala2.12"
     with TempDir(chdr=True) as tmp:
         experiment_id = mlflow.create_experiment("test")
         sig = ModelSignature(

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -114,6 +114,16 @@ def test_model_log_with_databricks_runtime():
             "runs:/{}/some/path".format(r.info.run_id), output_path=tmp.path("")
         )
         loaded_model = Model.load(os.path.join(local_path, "MLmodel"))
+        assert loaded_model.run_id == r.info.run_id
+        assert loaded_model.artifact_path == "some/path"
+        assert loaded_model.flavors == {
+            "flavor1": {"a": 1, "b": 2},
+            "flavor2": {"x": 1, "y": 2},
+        }
+        assert loaded_model.signature == sig
+        path = os.path.join(local_path, loaded_model.saved_input_example_info["artifact_path"])
+        x = _dataframe_from_json(path)
+        assert x.to_dict(orient="records")[0] == input_example
         assert loaded_model.databricks_runtime == dbr
 
 

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -489,16 +489,17 @@ def _default_model_version():
 
 
 def test_get_databricks_runtime_nondb(mock_spark_session):
-    get_databricks_runtime()
+    runtime = get_databricks_runtime()
+    assert runtime is None
     mock_spark_session.conf.get.assert_not_called()
 
 
-def test_get_databricks_runtime_no_spark_session(mock_spark_session):
+def test_get_databricks_runtime_no_spark_session():
     with mock.patch(
         "mlflow.utils.databricks_utils._get_active_spark_session", return_value=None
     ), mock.patch("mlflow.utils.databricks_utils.is_in_databricks_notebook", return_value=True):
-        get_databricks_runtime()
-        mock_spark_session.conf.get.assert_not_called()
+        runtime = get_databricks_runtime()
+        assert runtime is None
 
 
 def test_get_databricks_runtime_in_notebook(mock_spark_session):

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -18,7 +18,7 @@ from mlflow.utils.mlflow_tags import (
     MLFLOW_PROJECT_ENTRY_POINT,
 )
 from mlflow.utils.uri import construct_run_url
-from mlflow.utils.databricks_utils import get_databricks_runtime, get_session
+from mlflow.utils.databricks_utils import get_databricks_runtime
 
 
 @pytest.fixture

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -488,18 +488,18 @@ def _default_model_version():
     return ModelVersion("model name", 1, creation_timestamp=123, status="READY")
 
 
-def test_get_databricks_runtime_nondb(mock_spark_session):
-    runtime = get_databricks_runtime()
-    assert runtime is None
-    mock_spark_session.conf.get.assert_not_called()
-
-
 def test_get_databricks_runtime_no_spark_session():
     with mock.patch(
         "mlflow.utils.databricks_utils._get_active_spark_session", return_value=None
     ), mock.patch("mlflow.utils.databricks_utils.is_in_databricks_notebook", return_value=True):
         runtime = get_databricks_runtime()
         assert runtime is None
+
+
+def test_get_databricks_runtime_nondb(mock_spark_session):
+    runtime = get_databricks_runtime()
+    assert runtime is None
+    mock_spark_session.conf.get.assert_not_called()
 
 
 def test_get_databricks_runtime_in_notebook(mock_spark_session):

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -18,6 +18,7 @@ from mlflow.utils.mlflow_tags import (
     MLFLOW_PROJECT_ENTRY_POINT,
 )
 from mlflow.utils.uri import construct_run_url
+from mlflow.utils.databricks_utils import get_databricks_runtime, get_session
 
 
 @pytest.fixture
@@ -30,6 +31,14 @@ def mock_store():
 def mock_registry_store():
     with mock.patch("mlflow.tracking._model_registry.utils._get_store") as mock_get_store:
         yield mock_get_store.return_value
+
+
+@pytest.fixture
+def mock_spark_session():
+    with mock.patch(
+        "mlflow.utils.databricks_utils._get_active_spark_session"
+    ) as mock_spark_session:
+        yield mock_spark_session.return_value
 
 
 @pytest.fixture
@@ -477,3 +486,32 @@ def test_create_model_version_copy_not_called_to_nondb(mock_registry_store):
 
 def _default_model_version():
     return ModelVersion("model name", 1, creation_timestamp=123, status="READY")
+
+
+def test_get_databricks_runtime_nondb(mock_spark_session):
+    get_databricks_runtime()
+    mock_spark_session.conf.get.assert_not_called()
+
+
+def test_get_databricks_runtime_no_spark_session(mock_spark_session):
+    with mock.patch(
+        "mlflow.utils.databricks_utils._get_active_spark_session", return_value=None
+    ), mock.patch("mlflow.utils.databricks_utils.is_in_databricks_notebook", return_value=True):
+        get_databricks_runtime()
+        mock_spark_session.conf.get.assert_not_called()
+
+
+def test_get_databricks_runtime_in_notebook(mock_spark_session):
+    with mock.patch("mlflow.utils.databricks_utils.is_in_databricks_notebook", return_value=True):
+        get_databricks_runtime()
+        mock_spark_session.conf.get.assert_called_once_with(
+            "spark.databricks.clusterUsageTags.sparkVersion", default=None
+        )
+
+
+def test_get_databricks_runtime_in_job(mock_spark_session):
+    with mock.patch("mlflow.utils.databricks_utils.is_in_databricks_job", return_value=True):
+        get_databricks_runtime()
+        mock_spark_session.conf.get.assert_called_once_with(
+            "spark.databricks.clusterUsageTags.sparkVersion", default=None
+        )


### PR DESCRIPTION
Signed-off-by: Steven Chen <s.chen@databricks.com>

## What changes are proposed in this pull request?

Logging databricks runtime information in the MLmodel file. 

## How is this patch tested?
Manual testing of util function in notebook:
![Screen Shot 2021-06-03 at 12 53 55 PM](https://user-images.githubusercontent.com/84401539/120704184-25397780-c46b-11eb-99e8-0ac056ada72b.png)

Manual testing of util function in job:
![Screen Shot 2021-06-03 at 12 53 34 PM](https://user-images.githubusercontent.com/84401539/120704187-266aa480-c46b-11eb-9ab9-e5260fdabd52.png)

Logged MLmodel file:
![Screen Shot 2021-06-03 at 12 49 58 PM](https://user-images.githubusercontent.com/84401539/120704191-28346800-c46b-11eb-9c54-e5580eee4e0b.png)

Manual testing done for notebooks and jobs for the following runtime versions:
- DBR 7.6
- DBR 8.2
- MLR 8.3 CPU
- MLR 8.3 GPU
- MLR 8.x GPU

Wrote unit tests for logging model and `get_databricks_runtime` in notebook and job environments.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Databricks runtime information is now logged in MLmodel when a model is logged in a databricks notebook or job. 

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
