### PR TITLE
PyTorch log additional pip requirements in `requirements.txt`

### DIFF
--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -30,7 +30,7 @@ from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST
 from mlflow.pytorch import pickle_module as mlflow_pytorch_pickle_module
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.annotations import experimental
-from mlflow.utils.environment import _mlflow_conda_env
+from mlflow.utils.environment import _mlflow_conda_env, _log_pip_requirements
 from mlflow.utils.file_utils import _copy_file_or_tree, TempDir
 from mlflow.utils.model_utils import _get_flavor_configuration
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
@@ -485,18 +485,6 @@ def save_model(
 
     torchserve_artifacts_config = {}
 
-    if requirements_file:
-        if not isinstance(requirements_file, str):
-            raise TypeError("Path to requirements file should be a string")
-
-        with TempDir() as tmp_requirements_dir:
-            _download_artifact_from_uri(
-                artifact_uri=requirements_file, output_path=tmp_requirements_dir.path()
-            )
-            rel_path = os.path.basename(requirements_file)
-            torchserve_artifacts_config[_REQUIREMENTS_FILE_KEY] = {"path": rel_path}
-            shutil.move(tmp_requirements_dir.path(rel_path), path)
-
     if extra_files:
         torchserve_artifacts_config[_EXTRA_FILES_KEY] = []
         if not isinstance(extra_files, list):
@@ -521,6 +509,20 @@ def save_model(
             conda_env = yaml.safe_load(f)
     with open(os.path.join(path, conda_env_subpath), "w") as f:
         yaml.safe_dump(conda_env, stream=f, default_flow_style=False)
+
+    if requirements_file:
+        if not isinstance(requirements_file, str):
+            raise TypeError("Path to requirements file should be a string")
+
+        with TempDir() as tmp_requirements_dir:
+            _download_artifact_from_uri(
+                artifact_uri=requirements_file, output_path=tmp_requirements_dir.path()
+            )
+            rel_path = os.path.basename(requirements_file)
+            torchserve_artifacts_config[_REQUIREMENTS_FILE_KEY] = {"path": rel_path}
+            shutil.move(tmp_requirements_dir.path(rel_path), path)
+    else:
+        _log_pip_requirements(conda_env, path)
 
     if code_paths is not None:
         code_dir_subpath = "code"

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -950,7 +950,7 @@ def test_requirements_file_save_model(create_requirements_file, sequential_model
             pytorch_model=sequential_model, path=model_path, requirements_file=requirements_file
         )
 
-        # check if the requirements file is different from the default requirements file
+        # Verify that explicitly specified requirements file overrides default requirements file
         conda_env = get_default_conda_env()
         pip_deps = conda_env["dependencies"][-1]["pip"]
         assert _mlflow_additional_pip_env(pip_deps) != content_expected

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -919,7 +919,7 @@ def test_requirements_file_log_model(create_requirements_file, sequential_model)
             run_id=mlflow.active_run().info.run_id, model_path="models"
         )
 
-        # check if the requirements file is different from the default requirements file
+        # Verify that explicitly specified requirements file overrides default requirements file
         conda_env = get_default_conda_env()
         pip_deps = conda_env["dependencies"][-1]["pip"]
         assert _mlflow_additional_pip_env(pip_deps) != content_expected

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -438,6 +438,7 @@ def test_model_log_persists_specified_conda_env_in_mlflow_model_directory(
         saved_conda_env_text = f.read()
     assert saved_conda_env_text == pytorch_custom_env_text
 
+
 @pytest.mark.large
 @pytest.mark.parametrize("scripted_model", [True, False])
 def test_model_log_persists_requirements_in_mlflow_model_directory(


### PR DESCRIPTION
## What changes are proposed in this pull request?

Logging additional pip requirements from the conda_env for pytorch. If requirements_file from torch serve is used, then no the conda_env additional pip requirements are ignored.

## How is this patch tested?

Unit tests for log_model and save_model when a requirements_file is passed and when the default requirements is genereated. 

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Part of #4409 

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
