### PR TITLE
Revert "Fix dev sklearn build failure due to `scikit-learn requires numpy >= 1.14.6`"

### DIFF
--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -75,8 +75,8 @@ jobs:
           hash=$(echo -n "$INSTALL_COMMAND" | sha256sum)
           echo "::set-output name=key::$ImageOS-$ImageVersion-wheels-$date-$hash"
       - uses: actions/cache@v2
-        # We only cache wheels that take long (> 10 min) to build
-        if: ${{ contains('pyspark, catboost, scikit-learn', matrix.package) && matrix.version == 'dev' }}
+        # We only cache wheels that take long (> 20 min) to build
+        if: ${{ contains('pyspark, catboost', matrix.package) && matrix.version == 'dev' }}
         with:
           path: /home/runner/.cache/wheels
           key: ${{ steps.get-cache-key.outputs.key }}

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -2,10 +2,8 @@ sklearn:
   package_info:
     pip_release: "scikit-learn"
     install_dev: |
-      # TODO: Remove `pip install Cython numpy scipy` and `--no-use-pep517` once
-      #       https://github.com/scikit-learn/scikit-learn/issues/20189 is fixed
-      pip install Cython numpy scipy
-      pip install --no-use-pep517 git+https://github.com/scikit-learn/scikit-learn.git
+      # This installs scikit-learn from the default branch
+      pip install git+https://github.com/scikit-learn/scikit-learn.git
 
   models:
     minimum: "0.20.3"


### PR DESCRIPTION
Reverts mlflow/mlflow#4418