### PR TITLE
Making SQLite as default scheme for backend store fix bug #4415

### DIFF
--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -13,7 +13,7 @@ import mlflow.projects as projects
 import mlflow.runs
 import mlflow.store.artifact.cli
 from mlflow import tracking
-from mlflow.store.tracking import DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH, DEFAULT_STORE_BACKEND_URI
+from mlflow.store.tracking import DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH, DEFAULT_BACKEND_STORE_URI
 from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
 from mlflow.tracking import _get_store
 from mlflow.utils import cli_args
@@ -228,7 +228,7 @@ def _validate_server_args(gunicorn_opts=None, workers=None, waitress_opts=None):
 @click.option(
     "--backend-store-uri",
     metavar="PATH",
-    default=DEFAULT_STORE_BACKEND_URI,
+    default=DEFAULT_BACKEND_STORE_URI,
     help="URI to which to persist experiment and run data. Acceptable URIs are "
     "SQLAlchemy-compatible database connection strings "
     "(e.g. 'sqlite:///path/to/file.db') or local filesystem URIs "
@@ -257,8 +257,6 @@ def ui(backend_store_uri, default_artifact_root, port, host):
     """
     from mlflow.server import _run_server
     from mlflow.server.handlers import initialize_backend_stores
-
-    print(backend_store_uri, default_artifact_root)
 
     try:
         initialize_backend_stores(backend_store_uri, default_artifact_root)
@@ -293,7 +291,7 @@ def _validate_static_prefix(ctx, param, value):  # pylint: disable=unused-argume
 @click.option(
     "--backend-store-uri",
     metavar="PATH",
-    default=DEFAULT_STORE_BACKEND_URI,
+    default=DEFAULT_BACKEND_STORE_URI,
     help="URI to which to persist experiment and run data. Acceptable URIs are "
     "SQLAlchemy-compatible database connection strings "
     "(e.g. 'sqlite:///path/to/file.db') or local filesystem URIs "

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -13,7 +13,7 @@ import mlflow.projects as projects
 import mlflow.runs
 import mlflow.store.artifact.cli
 from mlflow import tracking
-from mlflow.store.tracking import DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH
+from mlflow.store.tracking import DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH, DEFAULT_STORE_BACKEND_URI
 from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
 from mlflow.tracking import _get_store
 from mlflow.utils import cli_args
@@ -228,7 +228,7 @@ def _validate_server_args(gunicorn_opts=None, workers=None, waitress_opts=None):
 @click.option(
     "--backend-store-uri",
     metavar="PATH",
-    default=DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH,
+    default=DEFAULT_STORE_BACKEND_URI,
     help="URI to which to persist experiment and run data. Acceptable URIs are "
     "SQLAlchemy-compatible database connection strings "
     "(e.g. 'sqlite:///path/to/file.db') or local filesystem URIs "
@@ -238,7 +238,7 @@ def _validate_server_args(gunicorn_opts=None, workers=None, waitress_opts=None):
 @click.option(
     "--default-artifact-root",
     metavar="URI",
-    default=None,
+    default=DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH,
     help="Path to local directory to store artifacts, for new experiments. "
     "Note that this flag does not impact already-created experiments. "
     "Default: " + DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH,
@@ -258,15 +258,7 @@ def ui(backend_store_uri, default_artifact_root, port, host):
     from mlflow.server import _run_server
     from mlflow.server.handlers import initialize_backend_stores
 
-    # Ensure that both backend_store_uri and default_artifact_uri are set correctly.
-    if not backend_store_uri:
-        backend_store_uri = DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH
-
-    if not default_artifact_root:
-        if is_local_uri(backend_store_uri):
-            default_artifact_root = backend_store_uri
-        else:
-            default_artifact_root = DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH
+    print(backend_store_uri, default_artifact_root)
 
     try:
         initialize_backend_stores(backend_store_uri, default_artifact_root)
@@ -301,7 +293,7 @@ def _validate_static_prefix(ctx, param, value):  # pylint: disable=unused-argume
 @click.option(
     "--backend-store-uri",
     metavar="PATH",
-    default=DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH,
+    default=DEFAULT_STORE_BACKEND_URI,
     help="URI to which to persist experiment and run data. Acceptable URIs are "
     "SQLAlchemy-compatible database connection strings "
     "(e.g. 'sqlite:///path/to/file.db') or local filesystem URIs "

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -144,9 +144,10 @@ def _get_model_registry_store(backend_store_uri=None):
 def initialize_backend_stores(backend_store_uri=None, default_artifact_root=None):
     _get_tracking_store(backend_store_uri, default_artifact_root)
     try:
+        import ipdb; ipdb.set_trace()
         _get_model_registry_store(backend_store_uri)
-    except UnsupportedModelRegistryStoreURIException:
-        pass
+    except UnsupportedModelRegistryStoreURIException as e:
+        raise e
 
 
 def _get_request_json(flask_request=request):

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -143,11 +143,7 @@ def _get_model_registry_store(backend_store_uri=None):
 
 def initialize_backend_stores(backend_store_uri=None, default_artifact_root=None):
     _get_tracking_store(backend_store_uri, default_artifact_root)
-    try:
-        import ipdb; ipdb.set_trace()
-        _get_model_registry_store(backend_store_uri)
-    except UnsupportedModelRegistryStoreURIException as e:
-        raise e
+    _get_model_registry_store(backend_store_uri)
 
 
 def _get_request_json(flask_request=request):

--- a/mlflow/store/tracking/__init__.py
+++ b/mlflow/store/tracking/__init__.py
@@ -13,6 +13,6 @@ import os
 import mlflow
 
 DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH = "./mlruns"
-DEFAULT_BACKEND_STORE_URI = f"sqlite://{os.path.abspath(os.path.join(mlflow.__path__[0], DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH))}/mlruns.db"
+DEFAULT_BACKEND_STORE_URI = f"sqlite:///{os.path.abspath(os.path.join(mlflow.__path__[0], DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH))}/default.db"
 SEARCH_MAX_RESULTS_DEFAULT = 1000
 SEARCH_MAX_RESULTS_THRESHOLD = 50000

--- a/mlflow/store/tracking/__init__.py
+++ b/mlflow/store/tracking/__init__.py
@@ -9,6 +9,7 @@ Several constants are used by multiple backend store implementations.
 # Path to default location for backend when using local FileStore or ArtifactStore.
 # Also used as default location for artifacts, when not provided, in non local file based backends
 # (eg MySQL)
+DEFAULT_STORE_BACKEND_URI = "sqlite:///./mlruns/mlruns.db"
 DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH = "./mlruns"
 SEARCH_MAX_RESULTS_DEFAULT = 1000
 SEARCH_MAX_RESULTS_THRESHOLD = 50000

--- a/mlflow/store/tracking/__init__.py
+++ b/mlflow/store/tracking/__init__.py
@@ -9,7 +9,10 @@ Several constants are used by multiple backend store implementations.
 # Path to default location for backend when using local FileStore or ArtifactStore.
 # Also used as default location for artifacts, when not provided, in non local file based backends
 # (eg MySQL)
-DEFAULT_STORE_BACKEND_URI = "sqlite:///./mlruns/mlruns.db"
+import os
+import mlflow
+
 DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH = "./mlruns"
+DEFAULT_BACKEND_STORE_URI = f"sqlite://{os.path.abspath(os.path.join(mlflow.__path__[0], DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH))}/mlruns.db"
 SEARCH_MAX_RESULTS_DEFAULT = 1000
 SEARCH_MAX_RESULTS_THRESHOLD = 50000


### PR DESCRIPTION
Signed-off-by: Daniel Takabayashi <daniel.takabayashi@gmail.com>

## What changes are proposed in this pull request?

Making SQLite the default scheme for store backend, also to address the issue #4415.

## How is this patch tested?

 - Unit tests
 - Using the UI interface according to the instruction found [here](https://github.com/mlflow/mlflow/issues/4415)

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
