### PR TITLE
Docs for logging pip requirements and databricks runtime

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -105,7 +105,7 @@ conda.yaml
 requirements.txt
     The requirements file is created from the `pip portion <https://www.anaconda.com/blog/using-pip-in-a-conda-environment>`_ of the ``conda.yaml`` environment specification. Additional pip dependencies can be added to ``requirements.txt`` by including them as a pip dependency in a conda environment and logging the model with the environment. 
 
-The following shows an example of saving a model with a specified conda environment and the corresponding content of the generated ``conda.yaml`` and ``requirements.txt`` files.
+The following shows an example of saving a model with a manually specified conda environment and the corresponding content of the generated ``conda.yaml`` and ``requirements.txt`` files.
 
 .. code-block:: py
 

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -98,7 +98,7 @@ databricks_runtime
 
 Additional Logged Files
 ^^^^^^^^^^^^^^^^^^^^^^^
-For environment recreation, we automatically log ``conda.yaml`` and ``requirements.txt`` files whenever a model is logoged. These files can then be used to reinstall dependencies using either ``conda`` or ``pip``.
+For environment recreation, we automatically log ``conda.yaml`` and ``requirements.txt`` files whenever a model is logged. These files can then be used to reinstall dependencies using either ``conda`` or ``pip``.
 
 conda.yaml
     When saving a model, MLflow provides the option to pass in a conda environment parameter that can contain dependencies used by the model. If no conda environment is provided, a default environment is created based on the flavor of the model. This conda environment is then saved in ``conda.yaml``.

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -91,26 +91,26 @@ input_example
   reference to an artifact with :ref:`input example <input-example>`.
 
 databricks_runtime
-    Databricks runtime version and type, if the model was saved in a Databricks notebook or job.
+    Databricks runtime version and type, if the model was trained in a Databricks notebook or job.
 
 
 
 
 Additional Logged Files
 ^^^^^^^^^^^^^^^^^^^^^^^
-For environment recreation, two additional files are automatically logged whenever a model is saved. These files can then be used to reinstall dependencies through either ``conda`` or ``pip``.
+For environment recreation, we automatically log ``conda.yaml`` and ``requirements.txt`` files whenever a model is logoged. These files can then be used to reinstall dependencies using either ``conda`` or ``pip``.
 
 conda.yaml
     When saving a model, MLflow provides the option to pass in a conda environment parameter that can contain dependencies used by the model. If no conda environment is provided, a default environment is created based on the flavor of the model. This conda environment is then saved in ``conda.yaml``.
 requirements.txt
-    The requirements file is created from the pip dependencies inside of the conda environment. Additional pip dependencies can be added to ``requirements.txt`` by including them as a pip dependency in a conda environment and logging the model with the environment. 
+    The requirements file is created from the `pip portion <https://www.anaconda.com/blog/using-pip-in-a-conda-environment>`_ of the ``conda.yaml`` environment specification. Additional pip dependencies can be added to ``requirements.txt`` by including them as a pip dependency in a conda environment and logging the model with the environment. 
 
 The following shows an example of saving a model with a specified conda environment and the corresponding content of the generated ``conda.yaml`` and ``requirements.txt`` files.
 
 .. code-block:: py
 
     conda_env = {
-        'channels': ['defaults', 'conda-forge'],
+        'channels': ['conda-forge'],
         'dependencies': [
             'python=3.8.8',
             'pip'],
@@ -121,14 +121,13 @@ The following shows an example of saving a model with a specified conda environm
         ],
         'name': 'mlflow-env'
     }
-    mlflow.sklearn.save_model(model, "my_model", conda_env=conda_env)
+    mlflow.sklearn.log_model(model, "my_model", conda_env=conda_env)
 
 The written ``conda.yaml`` file:
 
 .. code-block:: text
 
     channels:
-      - defaults
       - conda-forge
       dependencies:
       - python=3.8.8

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -40,7 +40,10 @@ format. For example, :py:mod:`mlflow.sklearn` outputs models as follows:
     # Directory written by mlflow.sklearn.save_model(model, "my_model")
     my_model/
     ├── MLmodel
-    └── model.pkl
+    ├── model.pkl
+    ├── conda.yaml
+    └── requirements.txt
+    
 
 And its ``MLmodel`` file describes two flavors:
 
@@ -87,6 +90,62 @@ signature
 input_example
   reference to an artifact with :ref:`input example <input-example>`.
 
+databricks_runtime
+    Databricks runtime version and type, if the model was saved in a Databricks notebook or job.
+
+
+
+
+Additional Logged Files
+^^^^^^^^^^^^^^^^^^^^^^^
+For environment recreation, two additional files are automatically logged whenever a model is saved. These files can then be used to reinstall dependencies through either ``conda`` or ``pip``.
+
+conda.yaml
+    When saving a model, MLflow provides the option to pass in a conda environment parameter that can contain dependencies used by the model. If no conda environment is provided, a default environment is created based on the flavor of the model. This conda environment is then saved in ``conda.yaml``.
+requirements.txt
+    The requirements file is created from the pip dependencies inside of the conda environment. Additional pip dependencies can be added to ``requirements.txt`` by including them as a pip dependency in a conda environment and logging the model with the environment. 
+
+The following shows an example of saving a model with a specified conda environment and the corresponding content of the generated ``conda.yaml`` and ``requirements.txt`` files.
+
+.. code-block:: py
+
+    conda_env = {
+        'channels': ['defaults', 'conda-forge'],
+        'dependencies': [
+            'python=3.8.8',
+            'pip'],
+        'pip': [
+            'mlflow',
+            'scikit-learn==0.23.2',
+            'cloudpickle==1.6.0'
+        ],
+        'name': 'mlflow-env'
+    }
+    mlflow.sklearn.save_model(model, "my_model", conda_env=conda_env)
+
+The written ``conda.yaml`` file:
+
+.. code-block:: text
+
+    channels:
+      - defaults
+      - conda-forge
+      dependencies:
+      - python=3.8.8
+      - pip
+      - pip:
+        - mlflow
+        - scikit-learn==0.23.2
+        - cloudpickle==1.6.0
+    name: mlflow-env
+
+The written ``requirements.txt`` file:
+
+.. code-block:: text
+
+    mlflow
+    scikit-learn==0.23.2
+    cloudpickle==1.6.0
 
 .. _model-metadata:
 

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -325,7 +325,7 @@ Here is an example plot of the :ref:`quick start tutorial <quickstart>` with the
 Automatic Logging
 =================
 
-Automatic logging allows you to log metrics, parameters, and models without the need for explicit log statements.
+Automatic logging allows you to log metrics, parameters, and models without the need for explicit log statements. 
 
 There are two ways to use autologging:
 
@@ -337,6 +337,8 @@ The following libraries support autologging:
 .. contents::
   :local:
   :depth: 1
+
+For flavors that automatically save models as an artifact, `additional files <https://mlflow.org/docs/latest/models.html#storage-format>`_ for dependency management are logged.
 
 
 Scikit-learn (experimental)


### PR DESCRIPTION
Signed-off-by: Steven Chen <s.chen@databricks.com>

## What changes are proposed in this pull request?

OSS docs for logging pip requirements and databricks runtime.
![Screen Shot 2021-06-07 at 7 55 43 AM](https://user-images.githubusercontent.com/84401539/121039243-c83d0a80-c765-11eb-9c27-fa81def644f7.png)
![Screen Shot 2021-06-07 at 7 53 19 AM](https://user-images.githubusercontent.com/84401539/121038842-73998f80-c765-11eb-8bbd-5787837a8f40.png)
In Auto-logging:
![Screen Shot 2021-06-08 at 11 15 03 AM](https://user-images.githubusercontent.com/84401539/121236644-095b1a80-c84b-11eb-90db-5c6a21e87cd5.png)

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
