### PR TITLE
[ML-15604] Remove defaults conda channel in MLflow examples

### DIFF
--- a/examples/fastai/conda.yaml
+++ b/examples/fastai/conda.yaml
@@ -1,7 +1,5 @@
 name: fastai-example
 channels:
-  - defaults
-  - anaconda
   - conda-forge
 dependencies:
   - python=3.7.5

--- a/examples/flower_classifier/conda.yaml
+++ b/examples/flower_classifier/conda.yaml
@@ -1,15 +1,13 @@
 name: flower_classifier
 channels:
-  - defaults
-  - anaconda
   - conda-forge
 dependencies:
   - python=3.7
-  - pandas=1.0.3
-  - scikit-learn=0.22.1
-  - tensorflow=1.13.1
-  - keras=2.3.1
-  - pillow=7.0.0
   - pip=20.0.2
   - pip:
     - mlflow>=1.6
+    - pandas==1.0.3
+    - scikit-learn==0.22.1
+    - tensorflow==1.13.1
+    - keras==2.3.1
+    - pillow==7.0.0

--- a/examples/flower_classifier/image_pyfunc.py
+++ b/examples/flower_classifier/image_pyfunc.py
@@ -163,14 +163,13 @@ def _load_pyfunc(path):
 conda_env_template = """
 name: flower_classifier
 channels:
-  - defaults
-  - anaconda
+  - conda-forge
 dependencies:
   - python=={python_version}
-  - keras=={keras_version}
-  - {tf_name}=={tf_version}
   - pip=={pip_version}  
-  - pillow=={pillow_version}
   - pip:
     - mlflow>=1.6
+    - pillow=={pillow_version}
+    - keras=={keras_version}
+    - {tf_name}=={tf_version}
 """

--- a/examples/h2o/conda.yaml
+++ b/examples/h2o/conda.yaml
@@ -1,13 +1,11 @@
 name: h2o_example
 channels:
-  - defaults
-  - anaconda
   - conda-forge
 dependencies:
   - python=3.6
-  - numpy=1.14.2
-  - pandas
   - pip
   - pip:
     - h2o
     - mlflow>=1.0
+    - numpy==1.14.2
+    - pandas

--- a/examples/hyperparam/conda.yaml
+++ b/examples/hyperparam/conda.yaml
@@ -10,9 +10,9 @@ dependencies:
     - pandas==0.22.0
     - scipy
     - scikit-learn==0.19.1
-    - tensorflow==1.15.2
+    - tensorflow==1.13.1
     - matplotlib==2.2.2
-    - keras==2.2.4
+    - keras==2.3.1
     - mlflow>=1.6
     - Gpy==1.9.5
     - GpyOpt==1.2.5

--- a/examples/hyperparam/conda.yaml
+++ b/examples/hyperparam/conda.yaml
@@ -5,7 +5,7 @@ dependencies:
   - python=3.6
   - pip
   - pip:
-    - numpy==1.14.3
+    - numpy==1.19.5
     - click
     - pandas==0.22.0
     - scipy

--- a/examples/hyperparam/conda.yaml
+++ b/examples/hyperparam/conda.yaml
@@ -4,16 +4,17 @@ channels:
 dependencies:
   - python=3.6
   - pip
-  - numpy
   - pip:
+    - numpy==1.14.3
     - click
     - pandas==0.22.0
     - scipy
     - scikit-learn==0.19.1
+    - tensorflow==1.15.2
     - matplotlib==2.2.2
     - keras==2.2.2
     - mlflow>=1.6
-    - Gpy==1.9.2
+    - Gpy==1.9.5
     - GpyOpt==1.2.5
     - pyDOE==0.3.8
     - hyperopt==0.1

--- a/examples/hyperparam/conda.yaml
+++ b/examples/hyperparam/conda.yaml
@@ -5,6 +5,7 @@ dependencies:
   - python=3.6
   - pip
   - pip:
+    - numpy
     - click
     - pandas==0.22.0
     - scipy

--- a/examples/hyperparam/conda.yaml
+++ b/examples/hyperparam/conda.yaml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.6
-  - pip
+  - pip=20.0.2
   - pip:
     - numpy==1.14.3
     - pandas==0.22.0

--- a/examples/hyperparam/conda.yaml
+++ b/examples/hyperparam/conda.yaml
@@ -5,14 +5,14 @@ dependencies:
   - python=3.7
   - pip
   - pip:
-    - numpy==1.14.3
+    - numpy
     - click
     - pandas==0.22.0
     - scipy
     - scikit-learn==0.19.1
     - matplotlib==2.2.2
     - keras==2.2.2
-    - mlflow>=1.0
+    - mlflow>=1.6
     - Gpy==1.9.2
     - GpyOpt==1.2.5
     - pyDOE==0.3.8

--- a/examples/hyperparam/conda.yaml
+++ b/examples/hyperparam/conda.yaml
@@ -1,15 +1,8 @@
 name: hyperparam_example
 channels:
-  - defaults
-  - anaconda
   - conda-forge
 dependencies:
   - python=3.6
-  - numpy=1.14.3
-  - pandas=0.22.0
-  - scikit-learn=0.19.1
-  - matplotlib=2.2.2
-  - keras==2.2.2
   - pip
   - pip:
     - mlflow>=1.0
@@ -17,4 +10,9 @@ dependencies:
     - GpyOpt==1.2.5
     - pyDOE==0.3.8
     - hyperopt==0.1
+    - numpy==1.14.3
+    - pandas==0.22.0
+    - scikit-learn==0.19.1
+    - matplotlib==2.2.2
+    - keras==2.2.2
 

--- a/examples/hyperparam/conda.yaml
+++ b/examples/hyperparam/conda.yaml
@@ -4,13 +4,14 @@ channels:
 dependencies:
   - python=3.6
   - pip=20.0.2
+  - numpy==1.14.3
+  - click
   - pip:
-    - numpy==1.14.3
     - pandas==0.22.0
+    - scipy
     - scikit-learn==0.19.1
     - matplotlib==2.2.2
     - keras==2.2.2
-    - click
     - mlflow>=1.0
     - Gpy==1.9.2
     - GpyOpt==1.2.5

--- a/examples/hyperparam/conda.yaml
+++ b/examples/hyperparam/conda.yaml
@@ -8,7 +8,7 @@ dependencies:
     - numpy==1.19.5
     - click
     - pandas==0.22.0
-    - scipy
+    - scipy==1.4.1
     - scikit-learn==0.19.1
     - tensorflow==1.13.1
     - matplotlib==2.2.2

--- a/examples/hyperparam/conda.yaml
+++ b/examples/hyperparam/conda.yaml
@@ -5,14 +5,14 @@ dependencies:
   - python=3.6
   - pip
   - pip:
-    - mlflow>=1.0
-    - Gpy==1.9.2
-    - GpyOpt==1.2.5
-    - pyDOE==0.3.8
-    - hyperopt==0.1
     - numpy==1.14.3
     - pandas==0.22.0
     - scikit-learn==0.19.1
     - matplotlib==2.2.2
     - keras==2.2.2
-
+    - click
+    - mlflow>=1.0
+    - Gpy==1.9.2
+    - GpyOpt==1.2.5
+    - pyDOE==0.3.8
+    - hyperopt==0.1

--- a/examples/hyperparam/conda.yaml
+++ b/examples/hyperparam/conda.yaml
@@ -12,7 +12,7 @@ dependencies:
     - scikit-learn==0.19.1
     - tensorflow==1.15.2
     - matplotlib==2.2.2
-    - keras==2.2.2
+    - keras==2.2.4
     - mlflow>=1.6
     - Gpy==1.9.5
     - GpyOpt==1.2.5

--- a/examples/hyperparam/conda.yaml
+++ b/examples/hyperparam/conda.yaml
@@ -2,11 +2,11 @@ name: hyperparam_example
 channels:
   - conda-forge
 dependencies:
-  - python=3.6
-  - pip=20.0.2
-  - numpy==1.14.3
-  - click
+  - python=3.7
+  - pip
   - pip:
+    - numpy==1.14.3
+    - click
     - pandas==0.22.0
     - scipy
     - scikit-learn==0.19.1

--- a/examples/hyperparam/conda.yaml
+++ b/examples/hyperparam/conda.yaml
@@ -2,7 +2,7 @@ name: hyperparam_example
 channels:
   - conda-forge
 dependencies:
-  - python=3.7
+  - python=3.6
   - pip
   - pip:
     - click

--- a/examples/hyperparam/conda.yaml
+++ b/examples/hyperparam/conda.yaml
@@ -5,7 +5,6 @@ dependencies:
   - python=3.7
   - pip
   - pip:
-    - numpy
     - click
     - pandas==0.22.0
     - scipy

--- a/examples/hyperparam/conda.yaml
+++ b/examples/hyperparam/conda.yaml
@@ -4,8 +4,8 @@ channels:
 dependencies:
   - python=3.6
   - pip
+  - numpy
   - pip:
-    - numpy
     - click
     - pandas==0.22.0
     - scipy

--- a/examples/lightgbm/conda.yaml
+++ b/examples/lightgbm/conda.yaml
@@ -1,12 +1,10 @@
 name: lightgbm-example
 channels:
-  - defaults
-  - anaconda
   - conda-forge
 dependencies:
   - python=3.6
-  - lightgbm
   - pip
   - pip:
       - mlflow>=1.6.0
       - matplotlib
+      - lightgbm

--- a/examples/multistep_workflow/conda.yaml
+++ b/examples/multistep_workflow/conda.yaml
@@ -1,15 +1,13 @@
 name: multistep
 channels:
-  - defaults
-  - anaconda
   - conda-forge
 dependencies:
   - python=3.6
-  - pyspark
-  - requests
-  - click
   - pip
   - pip:
     - tensorflow==1.15.2
     - keras==2.2.4
     - mlflow>=1.0
+    - pyspark
+    - requests
+    - click

--- a/examples/prophet/conda.yaml
+++ b/examples/prophet/conda.yaml
@@ -1,11 +1,9 @@
 name: tutorial
 channels:
-  - defaults
-  - anaconda
   - conda-forge
 dependencies:
   - python=3.6
-  - fbprophet<=0.7
   - pip
   - pip:
     - mlflow>=1.0
+    - fbprophet<=0.7

--- a/examples/prophet/train.ipynb
+++ b/examples/prophet/train.ipynb
@@ -42,10 +42,12 @@
     "        return self.model.predict(future)\n",
     "\n",
     "conda_env = {\n",
-    "    'channels': ['defaults', 'conda-forge'],\n",
+    "    'channels': ['conda-forge'],\n",
     "    'dependencies': [\n",
-    "      'fbprophet={}'.format(fbprophet.__version__),\n",
-    "      'cloudpickle={}'.format(cloudpickle.__version__),\n",
+    "      {'pip': [\n"
+    "        'fbprophet=={}'.format(fbprophet.__version__),\n",
+    "        'cloudpickle=={}'.format(cloudpickle.__version__),\n",
+    "      ]}"
     "    ],\n",
     "    'name': 'fbp_env'\n",
     "}"

--- a/examples/prophet/train.py
+++ b/examples/prophet/train.py
@@ -41,7 +41,7 @@ conda_env = {
     "channels": ["conda-forge"],
     "dependencies": [
         {
-            'pip': [
+            "pip": [
                 "fbprophet=={}".format(fbprophet.__version__),
                 "cloudpickle=={}".format(cloudpickle.__version__),
             ]

--- a/examples/prophet/train.py
+++ b/examples/prophet/train.py
@@ -38,10 +38,14 @@ class FbProphetWrapper(mlflow.pyfunc.PythonModel):
 
 
 conda_env = {
-    "channels": ["defaults", "conda-forge"],
+    "channels": ["conda-forge"],
     "dependencies": [
-        "fbprophet={}".format(fbprophet.__version__),
-        "cloudpickle={}".format(cloudpickle.__version__),
+        {
+            'pip': [
+                "fbprophet=={}".format(fbprophet.__version__),
+                "cloudpickle=={}".format(cloudpickle.__version__),
+            ]
+        }
     ],
     "name": "fbp_env",
 }

--- a/examples/pytorch/AxHyperOptimizationPTL/conda.yaml
+++ b/examples/pytorch/AxHyperOptimizationPTL/conda.yaml
@@ -7,5 +7,5 @@ dependencies:
   - mlflow
   - pytorch-lightning
   - ax-platform
-  - pytorch>=1.6.0
+  - torch>=1.6.0
   - torchvision

--- a/examples/pytorch/AxHyperOptimizationPTL/conda.yaml
+++ b/examples/pytorch/AxHyperOptimizationPTL/conda.yaml
@@ -1,14 +1,11 @@
 channels:
-- defaults
 - conda-forge
-- pytorch
 dependencies:
 - python=3.8.2
-- pytorch>=1.6.0
-- torchvision
 - pip
 - pip:
   - mlflow
   - pytorch-lightning
   - ax-platform
-
+  - pytorch>=1.6.0
+  - torchvision

--- a/examples/pytorch/BertNewsClassification/conda.yaml
+++ b/examples/pytorch/BertNewsClassification/conda.yaml
@@ -10,7 +10,7 @@ dependencies:
   - boto3
   - transformers>=4.0.0
   - pandas
-  - pytorch==1.6.0
+  - torch==1.6.0
   - torchvision==0.7.0
   - torchtext==0.7.0
   - pytorch-lightning==1.0.2

--- a/examples/pytorch/BertNewsClassification/conda.yaml
+++ b/examples/pytorch/BertNewsClassification/conda.yaml
@@ -1,13 +1,7 @@
 channels:
-- pytorch
 - conda-forge
-- defaults
 dependencies:
 - python=3.8.2
-- pytorch=1.6.0
-- torchvision=0.7.0
-- torchtext==0.7.0
-- pytorch-lightning==1.0.2
 - pip
 - pip:
   - mlflow
@@ -16,3 +10,7 @@ dependencies:
   - boto3
   - transformers>=4.0.0
   - pandas
+  - pytorch==1.6.0
+  - torchvision==0.7.0
+  - torchtext==0.7.0
+  - pytorch-lightning==1.0.2

--- a/examples/pytorch/CaptumExample/conda.yaml
+++ b/examples/pytorch/CaptumExample/conda.yaml
@@ -1,10 +1,7 @@
 channels:
-- pytorch
-- defaults
 - conda-forge
 dependencies:
 - python=3.8.2
-- pytorch
 - pip
 - pip:
   - mlflow
@@ -15,4 +12,4 @@ dependencies:
   - sklearn
   - prettytable
   - ipython
-
+  - pytorch

--- a/examples/pytorch/CaptumExample/conda.yaml
+++ b/examples/pytorch/CaptumExample/conda.yaml
@@ -12,4 +12,4 @@ dependencies:
   - sklearn
   - prettytable
   - ipython
-  - pytorch
+  - torch

--- a/examples/pytorch/IterativePruning/conda.yaml
+++ b/examples/pytorch/IterativePruning/conda.yaml
@@ -1,10 +1,7 @@
 channels:
-- defaults
 - conda-forge
-- pytorch
 dependencies:
 - python=3.8.2
-- pytorch>=1.6.0
 - pip
 - pip:
   - mlflow
@@ -13,3 +10,4 @@ dependencies:
   - pytorch_lightning>=1.0.5
   - ax-platform
   - prettytable
+  - pytorch>=1.6.0

--- a/examples/pytorch/IterativePruning/conda.yaml
+++ b/examples/pytorch/IterativePruning/conda.yaml
@@ -10,4 +10,4 @@ dependencies:
   - pytorch_lightning>=1.0.5
   - ax-platform
   - prettytable
-  - pytorch>=1.6.0
+  - torch>=1.6.0

--- a/examples/pytorch/MNIST/conda.yaml
+++ b/examples/pytorch/MNIST/conda.yaml
@@ -1,12 +1,10 @@
 channels:
-- defaults
 - conda-forge
-- pytorch
 dependencies:
 - python=3.8.2
-- pytorch=1.8.0
-- pytorch-lightning==1.0.2
 - pip
 - pip:
   - mlflow
   - torchvision==0.9.1
+  - pytorch==1.8.0
+  - pytorch-lightning==1.0.2

--- a/examples/pytorch/MNIST/conda.yaml
+++ b/examples/pytorch/MNIST/conda.yaml
@@ -5,6 +5,6 @@ dependencies:
 - pip
 - pip:
   - mlflow
+  - torch==1.8.1
   - torchvision==0.9.1
-  - torch==1.8.0
   - pytorch-lightning==1.0.2

--- a/examples/pytorch/MNIST/conda.yaml
+++ b/examples/pytorch/MNIST/conda.yaml
@@ -6,5 +6,5 @@ dependencies:
 - pip:
   - mlflow
   - torchvision==0.9.1
-  - pytorch==1.8.0
+  - torch==1.8.0
   - pytorch-lightning==1.0.2

--- a/examples/pytorch/MNIST/example2/conda.yaml
+++ b/examples/pytorch/MNIST/example2/conda.yaml
@@ -5,6 +5,6 @@ dependencies:
 - pip
 - pip:
   - mlflow
+  - torch==1.8.0
   - torchvision==0.9.1
-  - pytorch==1.8.0
   - pytorch-lightning==1.0.2

--- a/examples/pytorch/MNIST/example2/conda.yaml
+++ b/examples/pytorch/MNIST/example2/conda.yaml
@@ -1,12 +1,10 @@
 channels:
-- defaults
 - conda-forge
-- pytorch
 dependencies:
 - python=3.8.2
-- pytorch=1.8.0
-- pytorch-lightning==1.0.2
 - pip
 - pip:
   - mlflow
   - torchvision==0.9.1
+  - pytorch==1.8.0
+  - pytorch-lightning==1.0.2

--- a/examples/pytorch/conda.yaml
+++ b/examples/pytorch/conda.yaml
@@ -1,8 +1,5 @@
 name: pytorch_example
 channels:
-  - defaults
-  - pytorch
-  - anaconda
   - conda-forge
 dependencies:
   - python=3.6

--- a/examples/pytorch/torchscript/IrisClassification/conda.yaml
+++ b/examples/pytorch/torchscript/IrisClassification/conda.yaml
@@ -7,5 +7,5 @@ dependencies:
   - sklearn
   - cloudpickle==1.6.0
   - boto3
-  - pytorch==1.6.0
+  - torch==1.6.0
   - torchvision==0.7.0

--- a/examples/pytorch/torchscript/IrisClassification/conda.yaml
+++ b/examples/pytorch/torchscript/IrisClassification/conda.yaml
@@ -1,14 +1,11 @@
 channels:
-- defaults
 - conda-forge
-- pytorch
 dependencies:
 - python=3.8.2
-- pytorch=1.6.0
-- torchvision=0.7.0
 - pip
 - pip:
   - sklearn
   - cloudpickle==1.6.0
   - boto3
-
+  - pytorch==1.6.0
+  - torchvision==0.7.0

--- a/examples/pytorch/torchscript/MNIST/conda.yaml
+++ b/examples/pytorch/torchscript/MNIST/conda.yaml
@@ -1,14 +1,11 @@
 channels:
-- defaults
 - conda-forge
-- pytorch
 dependencies:
 - python=3.8.2
-- pytorch=1.6.0
-- torchvision=0.7.0
 - pip
 - pip:
   - mlflow
   - cloudpickle==1.6.0
   - boto3
-
+  - pytorch==1.6.0
+  - torchvision==0.7.0

--- a/examples/pytorch/torchscript/MNIST/conda.yaml
+++ b/examples/pytorch/torchscript/MNIST/conda.yaml
@@ -7,5 +7,5 @@ dependencies:
   - mlflow
   - cloudpickle==1.6.0
   - boto3
-  - pytorch==1.6.0
+  - torch==1.6.0
   - torchvision==0.7.0

--- a/examples/sklearn_elasticnet_diabetes/linux/conda.yaml
+++ b/examples/sklearn_elasticnet_diabetes/linux/conda.yaml
@@ -1,15 +1,13 @@
 name: tutorial
 channels:
-  - defaults
-  - anaconda
   - conda-forge
 dependencies:
-  - cloudpickle=0.6.1
   - python=3.6
-  - numpy=1.14.3
-  - matplotlib=3.0.2
-  - pandas=0.22.0
-  - scikit-learn=0.19.1
   - pip
   - pip:
     - mlflow
+    - numpy==1.14.3
+    - matplotlib==3.0.2
+    - pandas==0.22.0
+    - scikit-learn==0.19.1
+    - cloudpickle==0.6.1

--- a/examples/sklearn_elasticnet_diabetes/linux/conda.yaml
+++ b/examples/sklearn_elasticnet_diabetes/linux/conda.yaml
@@ -9,5 +9,6 @@ dependencies:
     - numpy==1.14.3
     - matplotlib==3.0.2
     - pandas==0.22.0
+    - scipy
     - scikit-learn==0.19.1
     - cloudpickle==0.6.1

--- a/examples/sklearn_elasticnet_diabetes/osx/conda.yaml
+++ b/examples/sklearn_elasticnet_diabetes/osx/conda.yaml
@@ -1,16 +1,15 @@
 name: tutorial
 channels:
-  - defaults
   - anaconda
   - conda-forge
 dependencies:
-  - cloudpickle=0.6.1
   - python=3.6
-  - numpy=1.14.3
-  - matplotlib=3.0.2
-  - pandas=0.22.0
-  - scikit-learn=0.19.1
   - python.app
   - pip
   - pip:
     - mlflow>=1.0
+    - cloudpickle=0.6.1
+    - numpy==1.14.3
+    - matplotlib==3.0.2
+    - pandas==0.22.0
+    - scikit-learn==0.19.1

--- a/examples/sklearn_elasticnet_wine/conda.yaml
+++ b/examples/sklearn_elasticnet_wine/conda.yaml
@@ -1,6 +1,6 @@
 name: tutorial
 channels:
-  - defaults
+  - conda-forge
 dependencies:
   - python=3.6
   - pip

--- a/examples/sklearn_logistic_regression/conda.yaml
+++ b/examples/sklearn_logistic_regression/conda.yaml
@@ -6,5 +6,6 @@ dependencies:
   - pip
   - pip:
     - mlflow>=1.0
+    - scipy
     - scikit-learn==0.19.1
 

--- a/examples/sklearn_logistic_regression/conda.yaml
+++ b/examples/sklearn_logistic_regression/conda.yaml
@@ -1,12 +1,10 @@
 name: sklearn-example
 channels:
-  - defaults
-  - anaconda
   - conda-forge
 dependencies:
   - python=3.6
-  - scikit-learn=0.19.1
   - pip
   - pip:
     - mlflow>=1.0
+    - scikit-learn==0.19.1
 

--- a/examples/spacy/conda.yaml
+++ b/examples/spacy/conda.yaml
@@ -1,12 +1,9 @@
 name: spacy-example
 channels:
-  - defaults
-  - anaconda
   - conda-forge
 dependencies:
   - python=3.6
-  - spacy=2.2.3
   - pip
   - pip:
     - mlflow>=1.0
-
+    - spacy==2.2.3

--- a/examples/statsmodels/conda.yaml
+++ b/examples/statsmodels/conda.yaml
@@ -1,12 +1,10 @@
 name: statsmodels-example
 channels:
-  - defaults
-  - anaconda
   - conda-forge
 dependencies:
   - python=3.6
-  - statsmodels=0.11.1
-  - scikit-learn=0.22.1
   - pip
   - pip:
       - mlflow>=1.6.0
+      - statsmodels==0.11.1
+      - scikit-learn==0.22.1

--- a/examples/tensorflow/tf1/conda.yaml
+++ b/examples/tensorflow/tf1/conda.yaml
@@ -1,12 +1,9 @@
 name: tensorflow-example
 channels:
-  - defaults
-  - anaconda
   - conda-forge
 dependencies:
   - python=3.6
-  - tensorflow=1.13.1
   - pip
   - pip:
     - mlflow
-
+    - tensorflow==1.13.1

--- a/examples/tensorflow/tf2/conda.yaml
+++ b/examples/tensorflow/tf2/conda.yaml
@@ -1,7 +1,5 @@
 name: tensorflow-example
 channels:
-  - defaults
-  - anaconda
   - conda-forge
 dependencies:
   - python=3.6
@@ -9,4 +7,3 @@ dependencies:
   - pip:
     - mlflow
     - tensorflow==2.0.0
-

--- a/examples/xgboost/conda.yaml
+++ b/examples/xgboost/conda.yaml
@@ -6,5 +6,7 @@ dependencies:
   - pip
   - pip:
       - mlflow>=1.6.0
+      - scipy
+      - scikit-learn==0.19.1
       - matplotlib
       - xgboost

--- a/examples/xgboost/conda.yaml
+++ b/examples/xgboost/conda.yaml
@@ -1,12 +1,10 @@
 name: xgboost-example
 channels:
-  - defaults
-  - anaconda
   - conda-forge
 dependencies:
   - python=3.6
-  - xgboost
   - pip
   - pip:
       - mlflow>=1.6.0
       - matplotlib
+      - xgboost

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -71,7 +71,7 @@ def get_default_conda_env():
         conda env {'name': 'mlflow-env',
                    'channels': ['conda-forge'],
                    'dependencies': ['python=3.7.5',
-                                    {'pip': ['pytorch==1.5.1',
+                                    {'pip': ['torch==1.5.1',
                                              'torchvision==0.6.1',
                                              'mlflow',
                                              'cloudpickle==1.6.0']}]}
@@ -81,7 +81,7 @@ def get_default_conda_env():
 
     return _mlflow_conda_env(
         additional_pip_deps=[
-            "pytorch=={}".format(torch.__version__),
+            "torch=={}".format(torch.__version__),
             "torchvision=={}".format(torchvision.__version__),
             # We include CloudPickle in the default environment because
             # it's required by the default pickle module used by `save_model()`


### PR DESCRIPTION
Signed-off-by: Weichen Xu <weichen.xu@databricks.com>

## What changes are proposed in this pull request?

Remove defaults conda channel in MLflow examples

## How is this patch tested?

N/A

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [x] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
