### PR TITLE
[WIP]

### DIFF
--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -39,7 +39,7 @@ jobs:
 
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             REF_VERSIONS_YAML="https://raw.githubusercontent.com/mlflow/mlflow/master/mlflow/ml-package-versions.yml"
-            CHANGED_FILES="$(git diff --name-only ${{ github.head_ref }}...${{ github.base_ref }})"
+            CHANGED_FILES="$(git diff --name-only '${{ github.base_ref }}'...'${{ github.head_ref }}')"
 
             python dev/set_matrix.py --ref-versions-yaml "$REF_VERSIONS_YAML" --changed-files "$CHANGED_FILES"
           else

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -17,7 +17,8 @@ jobs:
       is_matrix_empty: ${{ steps.set-matrix.outputs.is_matrix_empty }}
     steps:
       - uses: actions/checkout@v2
-        fetch-depth: 0
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v2
         with:
           python-version: "3.6"

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -39,7 +39,7 @@ jobs:
 
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             REF_VERSIONS_YAML="https://raw.githubusercontent.com/mlflow/mlflow/master/mlflow/ml-package-versions.yml"
-            CHANGED_FILES="$(git diff --name-only master..HEAD)"
+            CHANGED_FILES="$(git diff --name-only ${{ github.head_ref }}...${{ github.base_ref }})"
 
             python dev/set_matrix.py --ref-versions-yaml "$REF_VERSIONS_YAML" --changed-files "$CHANGED_FILES"
           else

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -39,7 +39,7 @@ jobs:
 
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             REF_VERSIONS_YAML="https://raw.githubusercontent.com/mlflow/mlflow/master/mlflow/ml-package-versions.yml"
-            CHANGED_FILES="$(git diff --name-only '${{ github.base_ref }}'...'${{ github.head_ref }}')"
+            CHANGED_FILES="$(git diff --name-only ${{ github.base_ref }}...remotes/pull/4438/merge)"
 
             python dev/set_matrix.py --ref-versions-yaml "$REF_VERSIONS_YAML" --changed-files "$CHANGED_FILES"
           else

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -34,6 +34,7 @@ jobs:
             git remote -v
             # git checkout master
             git --no-pager log -n 3
+            git --no-pager branch -a
           fi
 
           if [ "${{ github.event_name }}" = "pull_request" ]; then

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -32,6 +32,7 @@ jobs:
           if [ ! "$(git branch --show-current)" == "master" ]; then
             git fetch origin master:master
             git remote -v
+            git checkout master
           fi
 
           if [ "${{ github.event_name }}" = "pull_request" ]; then

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -31,6 +31,7 @@ jobs:
         run: |
           if [ ! "$(git branch --show-current)" == "master" ]; then
             git fetch origin master:master
+            git fetch origin pull/${{ github.event.pull_request.number }}/head:$GITHUB_HEAD_REF
             git remote -v
             # git checkout master
             git --no-pager log -n 3
@@ -39,7 +40,7 @@ jobs:
 
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             REF_VERSIONS_YAML="https://raw.githubusercontent.com/mlflow/mlflow/master/mlflow/ml-package-versions.yml"
-            CHANGED_FILES="$(git diff --name-only ${{ github.base_ref }}...remotes/pull/4438/merge)"
+            CHANGED_FILES="$(git diff --name-only master...$GITHUB_HEAD_REF)"
 
             python dev/set_matrix.py --ref-versions-yaml "$REF_VERSIONS_YAML" --changed-files "$CHANGED_FILES"
           else

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -33,6 +33,7 @@ jobs:
             git fetch origin master:master
             git remote -v
             git checkout master
+            git --no-pager log -n 3
           fi
 
           if [ "${{ github.event_name }}" = "pull_request" ]; then

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -31,6 +31,7 @@ jobs:
         run: |
           if [ ! "$(git branch --show-current)" == "master" ]; then
             git fetch origin master:master
+            git remove -v
           fi
 
           if [ "${{ github.event_name }}" = "pull_request" ]; then

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           if [ ! "$(git branch --show-current)" == "master" ]; then
             git fetch origin master:master
-            git remove -v
+            git remote -v
           fi
 
           if [ "${{ github.event_name }}" = "pull_request" ]; then

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -17,6 +17,7 @@ jobs:
       is_matrix_empty: ${{ steps.set-matrix.outputs.is_matrix_empty }}
     steps:
       - uses: actions/checkout@v2
+        fetch-depth: 0
       - uses: actions/setup-python@v2
         with:
           python-version: "3.6"
@@ -31,16 +32,12 @@ jobs:
         run: |
           if [ ! "$(git branch --show-current)" == "master" ]; then
             git fetch origin master:master
-            git fetch origin pull/${{ github.event.pull_request.number }}/head:$GITHUB_HEAD_REF
-            git remote -v
-            # git checkout master
-            git --no-pager log -n 3
-            git --no-pager branch -a
           fi
 
           if [ "${{ github.event_name }}" = "pull_request" ]; then
+            # git fetch origin pull/${{ github.event.pull_request.number }}/head:${{ github.head_ref }}
             REF_VERSIONS_YAML="https://raw.githubusercontent.com/mlflow/mlflow/master/mlflow/ml-package-versions.yml"
-            CHANGED_FILES="$(git diff --name-only master...$GITHUB_HEAD_REF)"
+            CHANGED_FILES="$(git diff --name-only master...HEAD)"
 
             python dev/set_matrix.py --ref-versions-yaml "$REF_VERSIONS_YAML" --changed-files "$CHANGED_FILES"
           else

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -36,6 +36,7 @@ jobs:
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             REF_VERSIONS_YAML="https://raw.githubusercontent.com/mlflow/mlflow/master/mlflow/ml-package-versions.yml"
             CHANGED_FILES="$(git diff --name-only master..HEAD)"
+
             python dev/set_matrix.py --ref-versions-yaml "$REF_VERSIONS_YAML" --changed-files "$CHANGED_FILES"
           else
             python dev/set_matrix.py

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -32,7 +32,7 @@ jobs:
           if [ ! "$(git branch --show-current)" == "master" ]; then
             git fetch origin master:master
             git remote -v
-            git checkout master
+            # git checkout master
             git --no-pager log -n 3
           fi
 


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
