### PR TITLE
Support dev version of pyspark in autologging in Databricks

### DIFF
--- a/mlflow/utils/autologging_utils/versioning.py
+++ b/mlflow/utils/autologging_utils/versioning.py
@@ -72,7 +72,7 @@ def is_flavor_supported_for_associated_package_versions(flavor_name):
     actual_version = importlib.import_module(module_name).__version__
 
     # In Databricks, treat 'pyspark 3.x.y.dev0' as 'pyspark 3.x.y'
-    if module_name == "pyspark"(is_in_databricks_notebook() or is_in_databricks_job()):
+    if module_name == "pyspark" and (is_in_databricks_notebook() or is_in_databricks_job()):
         actual_version = _strip_dev_prefix(actual_version)
 
     if _violates_pep_440(actual_version) or _is_pre_or_dev_release(actual_version):

--- a/mlflow/utils/autologging_utils/versioning.py
+++ b/mlflow/utils/autologging_utils/versioning.py
@@ -1,8 +1,14 @@
 import importlib
+import re
 import yaml
 
 from packaging.version import Version, InvalidVersion
 from pkg_resources import resource_filename
+
+from mlflow.utils.databricks_utils import (
+    is_in_databricks_job,
+    is_in_databricks_notebook,
+)
 
 
 # A map FLAVOR_NAME -> a tuple of (dependent_module_name, key_in_module_version_info_dict)
@@ -37,6 +43,10 @@ def _is_pre_or_dev_release(ver):
     return v.is_devrelease or v.is_prerelease
 
 
+def _strip_dev_prefix(version):
+    return re.sub(r"(\.?)dev.*", "", version)
+
+
 def _load_version_file_as_dict():
     version_file_path = resource_filename(__name__, "../../ml-package-versions.yml")
     with open(version_file_path) as f:
@@ -60,6 +70,11 @@ def is_flavor_supported_for_associated_package_versions(flavor_name):
     """
     module_name, module_key = FLAVOR_TO_MODULE_NAME_AND_VERSION_INFO_KEY[flavor_name]
     actual_version = importlib.import_module(module_name).__version__
+
+    # In Databricks, treat 'pyspark 3.x.y.dev0' as 'pyspark 3.x.y'
+    if module_name == "pyspark"(is_in_databricks_notebook() or is_in_databricks_job()):
+        actual_version = _strip_dev_prefix(actual_version)
+
     if _violates_pep_440(actual_version) or _is_pre_or_dev_release(actual_version):
         return False
     min_version, max_version, _ = get_min_max_version_and_pip_release(module_key)

--- a/mlflow/utils/autologging_utils/versioning.py
+++ b/mlflow/utils/autologging_utils/versioning.py
@@ -43,7 +43,7 @@ def _is_pre_or_dev_release(ver):
     return v.is_devrelease or v.is_prerelease
 
 
-def _strip_dev_prefix(version):
+def _strip_dev_version_suffix(version):
     return re.sub(r"(\.?)dev.*", "", version)
 
 
@@ -73,7 +73,7 @@ def is_flavor_supported_for_associated_package_versions(flavor_name):
 
     # In Databricks, treat 'pyspark 3.x.y.dev0' as 'pyspark 3.x.y'
     if module_name == "pyspark" and (is_in_databricks_notebook() or is_in_databricks_job()):
-        actual_version = _strip_dev_prefix(actual_version)
+        actual_version = _strip_dev_version_suffix(actual_version)
 
     if _violates_pep_440(actual_version) or _is_pre_or_dev_release(actual_version):
         return False

--- a/tests/autologging/test_autologging_utils.py
+++ b/tests/autologging/test_autologging_utils.py
@@ -807,6 +807,7 @@ def test_dev_version_pyspark_is_supported_in_databricks(flavor, module_version, 
         ) as mock_job:
             assert is_flavor_supported_for_associated_package_versions(flavor) == expected_result
             mock_job.assert_called()
+
         # Not in Databricks
         assert is_flavor_supported_for_associated_package_versions(flavor) is False
 

--- a/tests/autologging/test_autologging_utils.py
+++ b/tests/autologging/test_autologging_utils.py
@@ -27,6 +27,7 @@ from mlflow.utils.autologging_utils.versioning import (
     FLAVOR_TO_MODULE_NAME_AND_VERSION_INFO_KEY,
     _check_version_in_range,
     _is_pre_or_dev_release,
+    _strip_dev_version_suffix,
     _violates_pep_440,
     is_flavor_supported_for_associated_package_versions,
 )
@@ -687,6 +688,13 @@ def test_is_pre_or_dev_release():
     assert _is_pre_or_dev_release("0.24.0rc1")
     assert _is_pre_or_dev_release("0.24.0dev1")
     assert not _is_pre_or_dev_release("0.24.0")
+
+
+def test_strip_dev_version_suffix():
+    assert _strip_dev_version_suffix("1.0.dev0") == "1.0"
+    assert _strip_dev_version_suffix("1.0dev0") == "1.0"
+    assert _strip_dev_version_suffix("1.0.dev") == "1.0"
+    assert _strip_dev_version_suffix("1.0") == "1.0"
 
 
 def test_violates_pep_440():

--- a/tests/autologging/test_autologging_utils.py
+++ b/tests/autologging/test_autologging_utils.py
@@ -808,7 +808,7 @@ def test_dev_version_pyspark_is_supported_in_databricks(flavor, module_version, 
             assert is_flavor_supported_for_associated_package_versions(flavor) == expected_result
             mock_job.assert_called()
         # Not in Databricks
-        assert is_flavor_supported_for_associated_package_versions(flavor) == False
+        assert is_flavor_supported_for_associated_package_versions(flavor) is False
 
 
 @mock.patch(


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

In Databricks, we use dev version of pyspark (e.g `3.1.1.dev0`), but the current autologging implementation considers a dev version as `unsupported`. As a workaround, consider `pyspark 3.x.y.dev0` as `pyspark 3.x.y`.

## How is this patch tested?

Existing checks.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
