### PR TITLE
Fix dev catboost build

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -174,7 +174,7 @@ catboost:
         temp_dir=$(mktemp -d)
         git clone --depth 1 https://github.com/catboost/catboost $temp_dir
         cd $temp_dir/catboost/python-package
-        python mk_wheel.py --build-widget no
+        python mk_wheel.py --build-widget no -DHAVE_CUDA=no
         # python setup.py bdist_wheel
 
         # Copy wheel in cache directory

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -174,7 +174,8 @@ catboost:
         temp_dir=$(mktemp -d)
         git clone --depth 1 https://github.com/catboost/catboost $temp_dir
         cd $temp_dir/catboost/python-package
-        python setup.py bdist_wheel
+        python mk_wheel.py --build-widget no
+        # python setup.py bdist_wheel
 
         # Copy wheel in cache directory
         wheel_path=$(find dist -type f -name "*.whl")

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -174,8 +174,8 @@ catboost:
         temp_dir=$(mktemp -d)
         git clone https://github.com/catboost/catboost $temp_dir
         cd $temp_dir/catboost/python-package
-        git checkout 9b0375cce7f142ef21c586d29721e920d4b3ebb6
-        # git checkout 4059dfa5294c7b7d0220d5312c53e75bba9dd18e
+        # git checkout 9b0375cce7f142ef21c586d29721e920d4b3ebb6
+        git checkout 4059dfa5294c7b7d0220d5312c53e75bba9dd18e
         python setup.py bdist_wheel
 
         # Copy wheel in cache directory

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -172,10 +172,11 @@ catboost:
       else
         # Build wheel from source
         temp_dir=$(mktemp -d)
-        git clone --depth 1 https://github.com/catboost/catboost $temp_dir
+        git clone https://github.com/catboost/catboost $temp_dir
         cd $temp_dir/catboost/python-package
-        python mk_wheel.py --build-widget no -DHAVE_CUDA=no
-        # python setup.py bdist_wheel
+        git checkout 9b0375cce7f142ef21c586d29721e920d4b3ebb6
+        # git checkout 4059dfa5294c7b7d0220d5312c53e75bba9dd18e
+        python setup.py bdist_wheel
 
         # Copy wheel in cache directory
         wheel_path=$(find dist -type f -name "*.whl")


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
