### PR TITLE
Show HEAD commit hash when installing package from GitHub in cross version tests

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -2,7 +2,8 @@ sklearn:
   package_info:
     pip_release: "scikit-learn"
     install_dev: |
-      pip install git+https://github.com/scikit-learn/scikit-learn.git
+      head_sha=$(git ls-remote https://github.com/scikit-learn/scikit-learn.git HEAD | cut -f1)
+      pip install "git+https://github.com/scikit-learn/scikit-learn.git@$head_sha"
 
   models:
     minimum: "0.20.3"
@@ -34,8 +35,8 @@ pytorch-lightning:
   package_info:
     pip_release: "pytorch-lightning"
     install_dev: |
-      # This installs pytorch-lightning from the default branch
-      pip install git+https://github.com/PytorchLightning/pytorch-lightning.git
+      head_sha=$(git ls-remote https://github.com/PytorchLightning/pytorch-lightning.git HEAD | cut -f1)
+      pip install "git+https://github.com/PytorchLightning/pytorch-lightning.git@$head_sha"
 
   autologging:
     minimum: "1.0.5"
@@ -259,7 +260,8 @@ spacy:
   package_info:
     pip_release: "spacy"
     install_dev: |
-      pip install git+https://github.com/explosion/spaCy
+      head_sha=$(git ls-remote https://github.com/explosion/spaCy.git HEAD | cut -f1)
+      pip install "git+https://github.com/explosion/spaCy.git@$head_sha"
 
   models:
     minimum: "2.2.4"
@@ -272,7 +274,8 @@ statsmodels:
   package_info:
     pip_release: "statsmodels"
     install_dev: |
-      pip install git+https://github.com/statsmodels/statsmodels
+      head_sha=$(git ls-remote https://github.com/statsmodels/statsmodels.git HEAD | cut -f1)
+      pip install "git+https://github.com/statsmodels/statsmodels.git@$head_sha"
 
   models:
     minimum: "0.11.1"

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -3,7 +3,7 @@ sklearn:
     pip_release: "scikit-learn"
     install_dev: |
       head_sha=$(git ls-remote https://github.com/scikit-learn/scikit-learn.git HEAD | cut -f1)
-      pip install "git+https://github.com/scikit-learn/scikit-learn.git@$head_sha"
+      pip install git+https://github.com/scikit-learn/scikit-learn.git@$head_sha
 
   models:
     minimum: "0.20.3"
@@ -36,7 +36,7 @@ pytorch-lightning:
     pip_release: "pytorch-lightning"
     install_dev: |
       head_sha=$(git ls-remote https://github.com/PytorchLightning/pytorch-lightning.git HEAD | cut -f1)
-      pip install "git+https://github.com/PytorchLightning/pytorch-lightning.git@$head_sha"
+      pip install git+https://github.com/PytorchLightning/pytorch-lightning.git@$head_sha
 
   autologging:
     minimum: "1.0.5"
@@ -99,7 +99,8 @@ keras:
     minimum: "2.2.4"
     maximum: "2.4.3"
     requirements:
-      "< 2.3.1": ["tensorflow==1.15.4", "h5py<3.0", "scikit-learn", "pyspark", "pyarrow"]
+      "< 2.3.1":
+        ["tensorflow==1.15.4", "h5py<3.0", "scikit-learn", "pyspark", "pyarrow"]
       "== 2.3.1": ["tensorflow==2.2.1", "scikit-learn", "pyspark", "pyarrow"]
       "> 2.3.1": ["tensorflow<2.5.0", "scikit-learn", "pyspark", "pyarrow"]
     run: |
@@ -261,7 +262,7 @@ spacy:
     pip_release: "spacy"
     install_dev: |
       head_sha=$(git ls-remote https://github.com/explosion/spaCy.git HEAD | cut -f1)
-      pip install "git+https://github.com/explosion/spaCy.git@$head_sha"
+      pip install git+https://github.com/explosion/spaCy.git@$head_sha
 
   models:
     minimum: "2.2.4"
@@ -275,13 +276,13 @@ statsmodels:
     pip_release: "statsmodels"
     install_dev: |
       head_sha=$(git ls-remote https://github.com/statsmodels/statsmodels.git HEAD | cut -f1)
-      pip install "git+https://github.com/statsmodels/statsmodels.git@$head_sha"
+      pip install git+https://github.com/statsmodels/statsmodels.git@$head_sha
 
   models:
     minimum: "0.11.1"
     maximum: "0.12.2"
     run: |
-        pytest tests/statsmodels/test_statsmodels_model_export.py --large
+      pytest tests/statsmodels/test_statsmodels_model_export.py --large
 
   autologging:
     minimum: "0.11.1"

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -99,8 +99,7 @@ keras:
     minimum: "2.2.4"
     maximum: "2.4.3"
     requirements:
-      "< 2.3.1":
-        ["tensorflow==1.15.4", "h5py<3.0", "scikit-learn", "pyspark", "pyarrow"]
+      "< 2.3.1": ["tensorflow==1.15.4", "h5py<3.0", "scikit-learn", "pyspark", "pyarrow"]
       "== 2.3.1": ["tensorflow==2.2.1", "scikit-learn", "pyspark", "pyarrow"]
       "> 2.3.1": ["tensorflow<2.5.0", "scikit-learn", "pyspark", "pyarrow"]
     run: |

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -123,9 +123,9 @@ xgboost:
     pip_release: "xgboost"
     install_dev: |
       temp_dir=$(mktemp -d)
-      git clone --recursive https://github.com/dmlc/xgboost $temp_dir
+      git clone --recursive https://github.com/dmlc/xgboost.git $temp_dir
+      git --git-dir=$temp_dir/.git rev-parse HEAD
       cd $temp_dir/python-package
-      git log -1
       python setup.py install
 
   models:
@@ -148,8 +148,8 @@ lightgbm:
     install_dev: |
       temp_dir=$(mktemp -d)
       git clone --recursive https://github.com/microsoft/LightGBM.git $temp_dir
+      git --git-dir=$temp_dir/.git rev-parse HEAD
       cd $temp_dir/python-package
-      git log -1
       python setup.py install
 
   models:
@@ -176,9 +176,9 @@ catboost:
       else
         # Build wheel from source
         temp_dir=$(mktemp -d)
-        git clone --depth 1 https://github.com/catboost/catboost $temp_dir
+        git clone --depth 1 https://github.com/catboost/catboost.git $temp_dir
+        git --git-dir=$temp_dir/.git rev-parse HEAD
         cd $temp_dir/catboost/python-package
-        git log -1
         python setup.py bdist_wheel
 
         # Copy wheel in cache directory
@@ -245,8 +245,8 @@ onnx:
       sudo apt-get install protobuf-compiler libprotoc-dev
       temp_dir=$(mktemp -d)
       git clone https://github.com/onnx/onnx.git $temp_dir
+      git --git-dir=$temp_dir/.git rev-parse HEAD
       cd $temp_dir
-      git log -1
       git submodule update --init --recursive
       python setup.py install
 
@@ -300,9 +300,9 @@ spark:
       else
         # Build wheel from source
         temp_dir=$(mktemp -d)
-        git clone --depth 1 https://github.com/apache/spark $temp_dir
+        git clone --depth 1 https://github.com/apache/spark.git $temp_dir
+        git --git-dir=$temp_dir/.git rev-parse HEAD
         cd $temp_dir
-        git log -1
         export MAVEN_OPTS="-Xss256m -Xmx2g -XX:ReservedCodeCacheSize=1g"
         ./build/mvn -DskipTests --no-transfer-progress clean package
         cd python

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -123,6 +123,7 @@ xgboost:
       temp_dir=$(mktemp -d)
       git clone --recursive https://github.com/dmlc/xgboost $temp_dir
       cd $temp_dir/python-package
+      git log -1
       python setup.py install
 
   models:
@@ -146,6 +147,7 @@ lightgbm:
       temp_dir=$(mktemp -d)
       git clone --recursive https://github.com/microsoft/LightGBM.git $temp_dir
       cd $temp_dir/python-package
+      git log -1
       python setup.py install
 
   models:
@@ -174,6 +176,7 @@ catboost:
         temp_dir=$(mktemp -d)
         git clone --depth 1 https://github.com/catboost/catboost $temp_dir
         cd $temp_dir/catboost/python-package
+        git log -1
         python setup.py bdist_wheel
 
         # Copy wheel in cache directory
@@ -241,6 +244,7 @@ onnx:
       temp_dir=$(mktemp -d)
       git clone https://github.com/onnx/onnx.git $temp_dir
       cd $temp_dir
+      git log -1
       git submodule update --init --recursive
       python setup.py install
 
@@ -294,6 +298,7 @@ spark:
         temp_dir=$(mktemp -d)
         git clone --depth 1 https://github.com/apache/spark $temp_dir
         cd $temp_dir
+        git log -1
         export MAVEN_OPTS="-Xss256m -Xmx2g -XX:ReservedCodeCacheSize=1g"
         ./build/mvn -DskipTests --no-transfer-progress clean package
         cd python


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Show HEAD commit hash when installing package from GitHub in cross version tests to make it easier to debug.

## How is this patch tested?

Existing checks

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
