### PR TITLE
Follow-up for #3881

### DIFF
--- a/mlflow/java/client/src/main/java/org/mlflow/api/proto/Service.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/api/proto/Service.java
@@ -34789,7 +34789,10 @@ public final class Service {
 
     /**
      * <pre>
-     * Maximum number of runs desired. Max threshold is 50000
+     * Maximum number of runs desired. If unspecified, defaults to 1000.
+     * All servers are guaranteed to support a `max_results` threshold of at least 50,000
+     * but may support more. Callers of this endpoint are encouraged to pass max_results
+     * explicitly and leverage page_token to iterate through experiments.
      * </pre>
      *
      * <code>optional int32 max_results = 5 [default = 1000];</code>
@@ -34797,7 +34800,10 @@ public final class Service {
     boolean hasMaxResults();
     /**
      * <pre>
-     * Maximum number of runs desired. Max threshold is 50000
+     * Maximum number of runs desired. If unspecified, defaults to 1000.
+     * All servers are guaranteed to support a `max_results` threshold of at least 50,000
+     * but may support more. Callers of this endpoint are encouraged to pass max_results
+     * explicitly and leverage page_token to iterate through experiments.
      * </pre>
      *
      * <code>optional int32 max_results = 5 [default = 1000];</code>
@@ -36210,7 +36216,10 @@ public final class Service {
     private int maxResults_;
     /**
      * <pre>
-     * Maximum number of runs desired. Max threshold is 50000
+     * Maximum number of runs desired. If unspecified, defaults to 1000.
+     * All servers are guaranteed to support a `max_results` threshold of at least 50,000
+     * but may support more. Callers of this endpoint are encouraged to pass max_results
+     * explicitly and leverage page_token to iterate through experiments.
      * </pre>
      *
      * <code>optional int32 max_results = 5 [default = 1000];</code>
@@ -36220,7 +36229,10 @@ public final class Service {
     }
     /**
      * <pre>
-     * Maximum number of runs desired. Max threshold is 50000
+     * Maximum number of runs desired. If unspecified, defaults to 1000.
+     * All servers are guaranteed to support a `max_results` threshold of at least 50,000
+     * but may support more. Callers of this endpoint are encouraged to pass max_results
+     * explicitly and leverage page_token to iterate through experiments.
      * </pre>
      *
      * <code>optional int32 max_results = 5 [default = 1000];</code>
@@ -37116,7 +37128,10 @@ public final class Service {
       private int maxResults_ = 1000;
       /**
        * <pre>
-       * Maximum number of runs desired. Max threshold is 50000
+       * Maximum number of runs desired. If unspecified, defaults to 1000.
+       * All servers are guaranteed to support a `max_results` threshold of at least 50,000
+       * but may support more. Callers of this endpoint are encouraged to pass max_results
+       * explicitly and leverage page_token to iterate through experiments.
        * </pre>
        *
        * <code>optional int32 max_results = 5 [default = 1000];</code>
@@ -37126,7 +37141,10 @@ public final class Service {
       }
       /**
        * <pre>
-       * Maximum number of runs desired. Max threshold is 50000
+       * Maximum number of runs desired. If unspecified, defaults to 1000.
+       * All servers are guaranteed to support a `max_results` threshold of at least 50,000
+       * but may support more. Callers of this endpoint are encouraged to pass max_results
+       * explicitly and leverage page_token to iterate through experiments.
        * </pre>
        *
        * <code>optional int32 max_results = 5 [default = 1000];</code>
@@ -37136,7 +37154,10 @@ public final class Service {
       }
       /**
        * <pre>
-       * Maximum number of runs desired. Max threshold is 50000
+       * Maximum number of runs desired. If unspecified, defaults to 1000.
+       * All servers are guaranteed to support a `max_results` threshold of at least 50,000
+       * but may support more. Callers of this endpoint are encouraged to pass max_results
+       * explicitly and leverage page_token to iterate through experiments.
        * </pre>
        *
        * <code>optional int32 max_results = 5 [default = 1000];</code>
@@ -37149,7 +37170,10 @@ public final class Service {
       }
       /**
        * <pre>
-       * Maximum number of runs desired. Max threshold is 50000
+       * Maximum number of runs desired. If unspecified, defaults to 1000.
+       * All servers are guaranteed to support a `max_results` threshold of at least 50,000
+       * but may support more. Callers of this endpoint are encouraged to pass max_results
+       * explicitly and leverage page_token to iterate through experiments.
        * </pre>
        *
        * <code>optional int32 max_results = 5 [default = 1000];</code>

--- a/mlflow/protos/service.proto
+++ b/mlflow/protos/service.proto
@@ -940,7 +940,10 @@ message SearchRuns {
   // Defaults to only active runs.
   optional ViewType run_view_type = 3 [default = ACTIVE_ONLY];
 
-  // Maximum number of runs desired. Max threshold is 50000
+  // Maximum number of runs desired. If unspecified, defaults to 1000.
+  // Servers may select a desired maximum threshold for `max_results`.
+  // Callers of this endpoint are encouraged to pass max_results explicitly and
+  // leverage page_token to iterate through experiments.
   optional int32 max_results = 5 [default = 1000];
 
   // List of columns to be ordered by, including attributes, params, metrics, and tags with an

--- a/mlflow/protos/service.proto
+++ b/mlflow/protos/service.proto
@@ -941,9 +941,9 @@ message SearchRuns {
   optional ViewType run_view_type = 3 [default = ACTIVE_ONLY];
 
   // Maximum number of runs desired. If unspecified, defaults to 1000.
-  // Servers may select a desired maximum threshold for `max_results`.
-  // Callers of this endpoint are encouraged to pass max_results explicitly and
-  // leverage page_token to iterate through experiments.
+  // All servers are guaranteed to support a `max_results` threshold of at least 50,000
+  // but may support more. Callers of this endpoint are encouraged to pass max_results
+  // explicitly and leverage page_token to iterate through experiments.
   optional int32 max_results = 5 [default = 1000];
 
   // List of columns to be ordered by, including attributes, params, metrics, and tags with an

--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -226,10 +226,12 @@ class AbstractStore:
         :param page_token: Token specifying the next page of results. It should be obtained from
             a ``search_runs`` call.
 
-        :return: A list of :py:class:`mlflow.entities.Run` objects that satisfy the search
-            expressions. The pagination token for the next page can be obtained via the ``token``
-            attribute of the object; however, some store implementations may not support pagination
-            and thus the returned token would not be meaningful in such cases.
+        :return: A :py:class:`PagedList <mlflow.store.entities.PagedList>` of
+            :py:class:`Run <mlflow.entities.Run>` objects that satisfy the search expressions.
+            If the underlying tracking store supports pagination, the token for the next page may
+            be obtained via the ``token`` attribute of the returned object; however, some store
+            implementations may not support pagination and thus the returned token would not be
+            meaningful in such cases.
         """
         runs, token = self._search_runs(
             experiment_ids, filter_string, run_view_type, max_results, order_by, page_token
@@ -272,10 +274,12 @@ class AbstractStore:
         :param page_token: Token specifying the next page of results. It should be obtained from
             a ``list_run_infos`` call.
 
-        :return: A list of :py:class:`mlflow.entities.RunInfo` objects that satisfy the
-            search expressions. The pagination token for the next page can be obtained via the
-            ``token`` attribute of the object; however, some store implementations may not support
-            pagination and thus the returned token would not be meaningful in such cases.
+        :return: A :py:class:`PagedList <mlflow.store.entities.PagedList>` of
+            :py:class:`RunInfo <mlflow.entities.RunInfo>` objects that satisfy the search
+            expressions. If the underlying tracking store supports pagination, the token for the
+            next page may be obtained via the ``token`` attribute of the returned object; however,
+            some store implementations may not support pagination and thus the returned token would
+            not be meaningful in such cases.
         """
         search_result = self.search_runs(
             [experiment_id], None, run_view_type, max_results, order_by, page_token

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -115,9 +115,9 @@ class TrackingServiceClient(object):
             For example, ``order_by=["tag.release ASC", "metric.click_rate DESC"]``.
 
         :return: A :py:class:`PagedList <mlflow.store.entities.PagedList>` of
-            :py:class:`RunInfo <mlflow.entities.RunInfo>` objects that satisfy the search expressions.
-            If the underlying tracking store supports pagination, the token for the next page may
-            be obtained via the ``token`` attribute of the returned object.
+            :py:class:`RunInfo <mlflow.entities.RunInfo>` objects that satisfy the search
+            expressions. If the underlying tracking store supports pagination, the token for the
+            next page may be obtained via the ``token`` attribute of the returned object.
         """
         return self.store.list_run_infos(
             experiment_id, run_view_type, max_results, order_by, page_token

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -104,7 +104,21 @@ class TrackingServiceClient(object):
         order_by=None,
         page_token=None,
     ):
-        """:return: List of :py:class:`mlflow.entities.RunInfo`"""
+        """
+        Return run information for runs which belong to the experiment_id.
+
+        :param experiment_id: The experiment id which to search
+        :param run_view_type: ACTIVE_ONLY, DELETED_ONLY, or ALL runs
+        :param max_results: Maximum number of results desired.
+        :param order_by: List of order_by clauses. Currently supported values are
+            are ``metric.key``, ``parameter.key``, ``tag.key``, ``attribute.key``.
+            For example, ``order_by=["tag.release ASC", "metric.click_rate DESC"]``.
+
+        :return: A :py:class:`PagedList <mlflow.store.entities.PagedList>` of
+            :py:class:`RunInfo <mlflow.entities.RunInfo>` objects that satisfy the search expressions.
+            If the underlying tracking store supports pagination, the token for the next page may
+            be obtained via the ``token`` attribute of the returned object.
+        """
         return self.store.list_run_infos(
             experiment_id, run_view_type, max_results, order_by, page_token
         )
@@ -375,9 +389,10 @@ class TrackingServiceClient(object):
         :param page_token: Token specifying the next page of results. It should be obtained from
             a ``search_runs`` call.
 
-        :return: A list of :py:class:`mlflow.entities.Run` objects that satisfy the search
-            expressions. If the underlying tracking store supports pagination, the token for
-            the next page may be obtained via the ``token`` attribute of the returned object.
+        :return: A :py:class:`PagedList <mlflow.store.entities.PagedList>` of
+            :py:class:`Run <mlflow.entities.Run>` objects that satisfy the search expressions.
+            If the underlying tracking store supports pagination, the token for the next page may
+            be obtained via the ``token`` attribute of the returned object.
         """
         if isinstance(experiment_ids, int) or is_string_type(experiment_ids):
             experiment_ids = [experiment_ids]

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -273,7 +273,20 @@ class MlflowClient(object):
         order_by: Optional[List[str]] = None,
         page_token: Optional[str] = None,
     ) -> PagedList[RunInfo]:
-        """:return: List of :py:class:`mlflow.entities.RunInfo`
+        """
+        Return run information for runs which belong to the experiment_id.
+
+        :param experiment_id: The experiment id which to search
+        :param run_view_type: ACTIVE_ONLY, DELETED_ONLY, or ALL runs
+        :param max_results: Maximum number of results desired.
+        :param order_by: List of order_by clauses. Currently supported values are
+            are ``metric.key``, ``parameter.key``, ``tag.key``, ``attribute.key``.
+            For example, ``order_by=["tag.release ASC", "metric.click_rate DESC"]``.
+
+        :return: A :py:class:`PagedList <mlflow.store.entities.PagedList>` of
+            :py:class:`RunInfo <mlflow.entities.RunInfo>` objects that satisfy the search
+            expressions. If the underlying tracking store supports pagination, the token for the
+            next page may be obtained via the ``token`` attribute of the returned object.
 
         .. code-block:: python
             :caption: Example
@@ -1493,9 +1506,10 @@ class MlflowClient(object):
         :param page_token: Token specifying the next page of results. It should be obtained from
             a ``search_runs`` call.
 
-        :return: A list of :py:class:`mlflow.entities.Run` objects that satisfy the search
-            expressions. If the underlying tracking store supports pagination, the token for
-            the next page may be obtained via the ``token`` attribute of the returned object.
+        :return: A :py:class:`PagedList <mlflow.store.entities.PagedList>` of
+            :py:class:`Run <mlflow.entities.Run>` objects that satisfy the search expressions.
+            If the underlying tracking store supports pagination, the token for the next page may
+            be obtained via the ``token`` attribute of the returned object.
 
         .. code-block:: python
             :caption: Example

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1129,7 +1129,7 @@ def list_run_infos(
            are ``metric.key``, ``parameter.key``, ``tag.key``, ``attribute.key``.
            For example, ``order_by=["tag.release ASC", "metric.click_rate DESC"]``.
 
-    :return: A list of :py:class:`mlflow.entities.RunInfo` objects that satisfy the
+    :return: A list of :py:class:`RunInfo <mlflow.entities.RunInfo>` objects that satisfy the
         search expressions.
 
     .. code-block:: python


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

A follow-up PR for #3881 

- Fix incorrect return descriptions.

## How is this patch tested?

Exisiting checks

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
