### PR TITLE
Updated the examples to use pytorch 1.9.0 and pytorch-lightning 1.3.5

### DIFF
--- a/examples/pytorch/AxHyperOptimizationPTL/conda.yaml
+++ b/examples/pytorch/AxHyperOptimizationPTL/conda.yaml
@@ -7,5 +7,5 @@ dependencies:
   - mlflow
   - pytorch-lightning==1.3.5
   - ax-platform
+  - torchvision>=0.9.1
   - torch==1.9.0
-  - torchvision==0.9.1

--- a/examples/pytorch/AxHyperOptimizationPTL/conda.yaml
+++ b/examples/pytorch/AxHyperOptimizationPTL/conda.yaml
@@ -5,7 +5,7 @@ dependencies:
 - pip
 - pip:
   - mlflow
-  - pytorch-lightning
+  - pytorch-lightning==1.3.5
   - ax-platform
-  - torch>=1.6.0
-  - torchvision
+  - torch==1.9.0
+  - torchvision==0.9.1

--- a/examples/pytorch/BertNewsClassification/MLproject
+++ b/examples/pytorch/BertNewsClassification/MLproject
@@ -11,7 +11,7 @@ entry_points:
       batch_size: {type: int, default: 64}
       num_workers: {type: int, default: 3}
       learning_rate: {type: float, default: 0.001}
-      num_samples: {type: int, default: 15000}
+      num_samples: {type: int, default: 2000}
       dataset: {type: str, default: "20newsgroups"}
 
     command: |

--- a/examples/pytorch/BertNewsClassification/bert_classification.py
+++ b/examples/pytorch/BertNewsClassification/bert_classification.py
@@ -22,7 +22,7 @@ from torch import nn
 from torch.utils.data import Dataset, DataLoader
 from transformers import BertModel, BertTokenizer, AdamW
 from torchtext.utils import download_from_url, extract_archive
-from torchtext.datasets.text_classification import URLS
+import torchtext.datasets as td
 
 
 def get_20newsgroups(num_samples):
@@ -31,15 +31,29 @@ def get_20newsgroups(num_samples):
     return pd.DataFrame(data=X, columns=["description"]).assign(label=y).sample(n=num_samples)
 
 
+def process_label(rating):
+        rating = int(rating)
+        return rating - 1
+
+
 def get_ag_news(num_samples):
-    dataset_tar = download_from_url(URLS["AG_NEWS"], root=".data")
-    extracted_files = extract_archive(dataset_tar)
-    train_csv_path = list(filter(lambda x: x.endswith("train.csv"), extracted_files))[0]
-    return (
-        pd.read_csv(train_csv_path, usecols=[0, 2], names=["label", "description"])
-        .assign(label=lambda df: df["label"] - 1)  # make labels zero-based
-        .sample(n=num_samples)
-    )
+    # reading  the input
+    td.AG_NEWS(root="data", split=("train", "test"))
+    extracted_files = os.listdir("data/AG_NEWS")
+
+    train_csv_path = None
+    for fname in extracted_files:
+        if fname.endswith("train.csv"):
+            train_csv_path = os.path.join(os.getcwd(), "data/AG_NEWS", fname)
+
+    df = pd.read_csv(train_csv_path)
+
+    df.columns = ["label", "title", "description"]
+    df.sample(frac=1)
+    df = df.iloc[: num_samples]
+
+    df["label"] = df.label.apply(process_label)
+    return df
 
 
 class NewsDataset(Dataset):
@@ -401,12 +415,12 @@ if __name__ == "__main__":
     early_stopping = EarlyStopping(monitor="val_loss", mode="min", verbose=True)
 
     checkpoint_callback = ModelCheckpoint(
-        filepath=os.getcwd(), save_top_k=1, verbose=True, monitor="val_loss", mode="min", prefix="",
+        dirpath=os.getcwd(), save_top_k=1, verbose=True, monitor="val_loss", mode="min",
     )
     lr_logger = LearningRateMonitor()
 
     trainer = pl.Trainer.from_argparse_args(
-        args, callbacks=[lr_logger, early_stopping], checkpoint_callback=checkpoint_callback
+        args, callbacks=[lr_logger, early_stopping, checkpoint_callback], checkpoint_callback=True
     )
     trainer.fit(model, dm)
     trainer.test()

--- a/examples/pytorch/BertNewsClassification/bert_classification.py
+++ b/examples/pytorch/BertNewsClassification/bert_classification.py
@@ -21,41 +21,24 @@ from sklearn.datasets import fetch_20newsgroups
 from torch import nn
 from torch.utils.data import Dataset, DataLoader
 from transformers import BertModel, BertTokenizer, AdamW
-from torchtext.utils import download_from_url, extract_archive
 import torchtext.datasets as td
 
 
 def get_20newsgroups(num_samples):
     categories = ["alt.atheism", "talk.religion.misc", "comp.graphics", "sci.space"]
     X, y = fetch_20newsgroups(subset="train", categories=categories, return_X_y=True)
-    return pd.DataFrame(
-        data=X, columns=["description"]).assign(label=y).sample(n=num_samples, replace=True
-        )
-
-
-def process_label(rating):
-        rating = int(rating)
-        return rating - 1
+    return pd.DataFrame(data=X, columns=["description"]).assign(label=y).sample(n=num_samples)
 
 
 def get_ag_news(num_samples):
-    # reading  the input
+    # reading the input
     td.AG_NEWS(root="data", split=("train", "test"))
-    extracted_files = os.listdir("data/AG_NEWS")
-
-    train_csv_path = None
-    for fname in extracted_files:
-        if fname.endswith("train.csv"):
-            train_csv_path = os.path.join(os.getcwd(), "data/AG_NEWS", fname)
-
-    df = pd.read_csv(train_csv_path)
-
-    df.columns = ["label", "title", "description"]
-    df.sample(frac=1)
-    df = df.iloc[: num_samples]
-
-    df["label"] = df.label.apply(process_label)
-    return df
+    train_csv_path = "data/AG_NEWS/train.csv"
+    return (
+        pd.read_csv(train_csv_path, names=["label", "title", "description"])
+        .assign(label=lambda df: df["label"] - 1)
+        .sample(n=num_samples, frac=1)
+    )
 
 
 class NewsDataset(Dataset):

--- a/examples/pytorch/BertNewsClassification/bert_classification.py
+++ b/examples/pytorch/BertNewsClassification/bert_classification.py
@@ -28,7 +28,9 @@ import torchtext.datasets as td
 def get_20newsgroups(num_samples):
     categories = ["alt.atheism", "talk.religion.misc", "comp.graphics", "sci.space"]
     X, y = fetch_20newsgroups(subset="train", categories=categories, return_X_y=True)
-    return pd.DataFrame(data=X, columns=["description"]).assign(label=y).sample(n=num_samples)
+    return pd.DataFrame(
+        data=X, columns=["description"]).assign(label=y).sample(n=num_samples, replace=True
+        )
 
 
 def process_label(rating):

--- a/examples/pytorch/BertNewsClassification/bert_classification.py
+++ b/examples/pytorch/BertNewsClassification/bert_classification.py
@@ -35,9 +35,9 @@ def get_ag_news(num_samples):
     td.AG_NEWS(root="data", split=("train", "test"))
     train_csv_path = "data/AG_NEWS/train.csv"
     return (
-        pd.read_csv(train_csv_path, names=["label", "title", "description"])
-        .assign(label=lambda df: df["label"] - 1)
-        .sample(n=num_samples, frac=1)
+        pd.read_csv(train_csv_path, usecols=[0, 2], names=["label", "description"])
+        .assign(label=lambda df: df["label"] - 1)  # make labels zero-based
+        .sample(n=num_samples)
     )
 
 

--- a/examples/pytorch/BertNewsClassification/conda.yaml
+++ b/examples/pytorch/BertNewsClassification/conda.yaml
@@ -10,7 +10,7 @@ dependencies:
   - boto3
   - transformers>=4.0.0
   - pandas
+  - torchvision>=0.9.1
   - torch==1.9.0
-  - torchvision==0.9.1
   - torchtext==0.10.0
   - pytorch-lightning==1.3.5

--- a/examples/pytorch/BertNewsClassification/conda.yaml
+++ b/examples/pytorch/BertNewsClassification/conda.yaml
@@ -10,7 +10,7 @@ dependencies:
   - boto3
   - transformers>=4.0.0
   - pandas
-  - torch==1.6.0
-  - torchvision==0.7.0
-  - torchtext==0.7.0
-  - pytorch-lightning==1.0.2
+  - torch==1.9.0
+  - torchvision==0.9.1
+  - torchtext==0.10.0
+  - pytorch-lightning==1.3.5

--- a/examples/pytorch/IterativePruning/conda.yaml
+++ b/examples/pytorch/IterativePruning/conda.yaml
@@ -5,7 +5,7 @@ dependencies:
 - pip
 - pip:
   - mlflow
-  - torchvision==0.9.1
+  - torchvision>=0.9.1
   - cloudpickle==1.6.0
   - pytorch_lightning==1.3.5
   - ax-platform

--- a/examples/pytorch/IterativePruning/conda.yaml
+++ b/examples/pytorch/IterativePruning/conda.yaml
@@ -5,9 +5,9 @@ dependencies:
 - pip
 - pip:
   - mlflow
-  - torchvision
+  - torchvision==0.9.1
   - cloudpickle==1.6.0
-  - pytorch_lightning>=1.0.5
+  - pytorch_lightning==1.3.5
   - ax-platform
   - prettytable
-  - torch>=1.6.0
+  - torch==1.9.0

--- a/examples/pytorch/MNIST/conda.yaml
+++ b/examples/pytorch/MNIST/conda.yaml
@@ -5,6 +5,6 @@ dependencies:
 - pip
 - pip:
   - mlflow
+  - torchvision>=0.9.1
   - torch==1.9.0
-  - torchvision==0.9.1
   - pytorch-lightning==1.3.5

--- a/examples/pytorch/MNIST/conda.yaml
+++ b/examples/pytorch/MNIST/conda.yaml
@@ -5,6 +5,6 @@ dependencies:
 - pip
 - pip:
   - mlflow
-  - torch==1.8.1
+  - torch==1.9.0
   - torchvision==0.9.1
-  - pytorch-lightning==1.0.2
+  - pytorch-lightning==1.3.5

--- a/examples/pytorch/MNIST/mnist_autolog_example.py
+++ b/examples/pytorch/MNIST/mnist_autolog_example.py
@@ -283,12 +283,12 @@ if __name__ == "__main__":
     )
 
     checkpoint_callback = ModelCheckpoint(
-        filepath=os.getcwd(), save_top_k=1, verbose=True, monitor="val_loss", mode="min", prefix="",
+        dirpath=os.getcwd(), save_top_k=1, verbose=True, monitor="val_loss", mode="min"
     )
     lr_logger = LearningRateMonitor()
 
     trainer = pl.Trainer.from_argparse_args(
-        args, callbacks=[lr_logger, early_stopping], checkpoint_callback=checkpoint_callback
+        args, callbacks=[lr_logger, early_stopping, checkpoint_callback], checkpoint_callback=True
     )
     trainer.fit(model, dm)
     trainer.test()

--- a/examples/pytorch/torchscript/IrisClassification/conda.yaml
+++ b/examples/pytorch/torchscript/IrisClassification/conda.yaml
@@ -7,5 +7,5 @@ dependencies:
   - sklearn
   - cloudpickle==1.6.0
   - boto3
+  - torchvision>=0.9.1
   - torch==1.9.0
-  - torchvision==0.9.1

--- a/examples/pytorch/torchscript/IrisClassification/conda.yaml
+++ b/examples/pytorch/torchscript/IrisClassification/conda.yaml
@@ -7,5 +7,5 @@ dependencies:
   - sklearn
   - cloudpickle==1.6.0
   - boto3
-  - torch==1.6.0
-  - torchvision==0.7.0
+  - torch==1.9.0
+  - torchvision==0.9.1

--- a/examples/pytorch/torchscript/MNIST/conda.yaml
+++ b/examples/pytorch/torchscript/MNIST/conda.yaml
@@ -7,5 +7,5 @@ dependencies:
   - mlflow
   - cloudpickle==1.6.0
   - boto3
+  - torchvision>=0.9.1
   - torch==1.9.0
-  - torchvision==0.9.1

--- a/examples/pytorch/torchscript/MNIST/conda.yaml
+++ b/examples/pytorch/torchscript/MNIST/conda.yaml
@@ -7,5 +7,5 @@ dependencies:
   - mlflow
   - cloudpickle==1.6.0
   - boto3
-  - torch==1.6.0
-  - torchvision==0.7.0
+  - torch==1.9.0
+  - torchvision==0.9.1

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -807,11 +807,6 @@ def test_load_model_succeeds_when_data_is_model_file_instead_of_directory(
 
 
 @pytest.mark.large
-@pytest.mark.skipif(
-    Version(torch.__version__) >= Version("1.9.0"),
-    reason="From pytorch 1.9.0, torch.load() creates a subclass from the passed Unpickler. "
-           "Refer: https://github.com/pytorch/pytorch/pull/53139",
-)
 def test_load_model_allows_user_to_override_pickle_module_via_keyword_argument(
     module_scoped_subclassed_model, model_path
 ):

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -7,6 +7,7 @@ import json
 import logging
 import pickle
 from unittest import mock
+from packaging.version import Version
 
 import pytest
 import numpy as np

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -807,6 +807,11 @@ def test_load_model_succeeds_when_data_is_model_file_instead_of_directory(
 
 
 @pytest.mark.large
+@pytest.mark.skipif(
+    Version(torch.__version__) >= Version("1.9.0"),
+    reason="From pytorch 1.9.0, torch.load() creates a subclass from the passed Unpickler. "
+           "Refer: https://github.com/pytorch/pytorch/pull/53139",
+)
 def test_load_model_allows_user_to_override_pickle_module_via_keyword_argument(
     module_scoped_subclassed_model, model_path
 ):

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -7,7 +7,6 @@ import json
 import logging
 import pickle
 from unittest import mock
-from packaging.version import Version
 
 import pytest
 import numpy as np


### PR DESCRIPTION
Signed-off-by: KasirajanA <kasirajan.alayappan@ideas2it.com>

## What changes are proposed in this pull request?

Updated the examples to use pytorch 1.9.0 and pytorch-lightning 1.3.5

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [x] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
