### PR TITLE
Specify `decimal` for `np.testing.assert_array_almost_equal` in PaddlePaddle test to avoid flakiness

### DIFF
--- a/tests/paddle/test_paddle_model_export.py
+++ b/tests/paddle/test_paddle_model_export.py
@@ -369,6 +369,8 @@ def test_model_built_in_high_level_api_load_from_remote_uri_succeeds(
     np.testing.assert_array_almost_equal(
         np.array(model.predict(test_dataset)).squeeze(),
         np.array(reloaded_model(np.array(low_level_test_dataset))).squeeze(),
+        # The default value for `decimal` is 6 which occasionaly causes this test fail
+        decimal=5,
     )
 
 

--- a/tests/paddle/test_paddle_model_export.py
+++ b/tests/paddle/test_paddle_model_export.py
@@ -113,11 +113,13 @@ def test_model_save_load(pd_model, model_path):
     np.testing.assert_array_almost_equal(
         pd_model.model(pd_model.inference_dataframe),
         reloaded_pyfunc.predict(pd_model.inference_dataframe),
+        decimal=5,
     )
 
     np.testing.assert_array_almost_equal(
         reloaded_pd_model(pd_model.inference_dataframe),
         reloaded_pyfunc.predict(pd_model.inference_dataframe),
+        decimal=5,
     )
 
 
@@ -132,7 +134,9 @@ def test_model_load_from_remote_uri_succeeds(pd_model, model_path, mock_s3_bucke
     model_uri = artifact_root + "/" + artifact_path
     reloaded_model = mlflow.paddle.load_model(model_uri=model_uri)
     np.testing.assert_array_almost_equal(
-        pd_model.model(pd_model.inference_dataframe), reloaded_model(pd_model.inference_dataframe)
+        pd_model.model(pd_model.inference_dataframe),
+        reloaded_model(pd_model.inference_dataframe),
+        decimal=5,
     )
 
 
@@ -162,6 +166,7 @@ def test_model_log(pd_model, model_path):
                 np.testing.assert_array_almost_equal(
                     model(pd_model.inference_dataframe),
                     reloaded_pd_model(pd_model.inference_dataframe),
+                    decimal=5,
                 )
 
                 model_path = _download_artifact_from_uri(artifact_uri=model_uri)
@@ -341,11 +346,13 @@ def test_model_save_load_built_in_high_level_api(pd_model_built_in_high_level_ap
     np.testing.assert_array_almost_equal(
         np.array(model.predict(test_dataset)).squeeze(),
         np.array(reloaded_pyfunc.predict(np.array(low_level_test_dataset))).squeeze(),
+        decimal=5,
     )
 
     np.testing.assert_array_almost_equal(
         np.array(reloaded_pd_model(np.array(low_level_test_dataset))).squeeze(),
         np.array(reloaded_pyfunc.predict(np.array(low_level_test_dataset))).squeeze(),
+        decimal=5,
     )
 
 
@@ -369,7 +376,6 @@ def test_model_built_in_high_level_api_load_from_remote_uri_succeeds(
     np.testing.assert_array_almost_equal(
         np.array(model.predict(test_dataset)).squeeze(),
         np.array(reloaded_model(np.array(low_level_test_dataset))).squeeze(),
-        # The default value for `decimal` is 6 which occasionaly causes this test fail
         decimal=5,
     )
 
@@ -404,6 +410,7 @@ def test_model_built_in_high_level_api_log(pd_model_built_in_high_level_api, mod
                 np.testing.assert_array_almost_equal(
                     np.array(model.predict(test_dataset)).squeeze(),
                     np.array(reloaded_pd_model(np.array(low_level_test_dataset))).squeeze(),
+                    decimal=5,
                 )
 
                 model_path = _download_artifact_from_uri(artifact_uri=model_uri)
@@ -461,11 +468,13 @@ def test_model_retrain_built_in_high_level_api(
     np.testing.assert_array_almost_equal(
         np.array(model_retrain.predict(test_dataset)).squeeze(),
         np.array(reloaded_pyfunc.predict(np.array(low_level_test_dataset))).squeeze(),
+        decimal=5,
     )
 
     np.testing.assert_array_almost_equal(
         np.array(reloaded_pd_model(np.array(low_level_test_dataset))).squeeze(),
         np.array(reloaded_pyfunc.predict(np.array(low_level_test_dataset))).squeeze(),
+        decimal=5,
     )
 
 
@@ -504,6 +513,7 @@ def test_log_model_built_in_high_level_api(pd_model_built_in_high_level_api, mod
                 np.testing.assert_array_almost_equal(
                     np.array(model.predict(test_dataset)).squeeze(),
                     np.array(model_retrain.predict(test_dataset)).squeeze(),
+                    decimal=5,
                 )
 
                 model_path = _download_artifact_from_uri(artifact_uri=model_uri)


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Specify `decimal` for `np.testing.assert_array_almost_equal` in PaddlePaddle test to remove flakiness.

- https://github.com/mlflow/mlflow/runs/2845765687#step:6:1265
- https://github.com/mlflow/mlflow/runs/2841128908#step:6:1258

```
        np.testing.assert_array_almost_equal(
            np.array(model.predict(test_dataset)).squeeze(),
>           np.array(reloaded_model(np.array(low_level_test_dataset))).squeeze(),
        )
E       AssertionError: 
E       Arrays are not almost equal to 6 decimals
E       
E       Mismatched elements: 1 / 102 (0.98%)
E       Max absolute difference: 1.9073486e-06
E       Max relative difference: 4.226383e-07
E        x: array([-4.209512, -4.395926, -3.801358, -2.68338 , -3.062791, -3.424096,
E              -5.670746, -4.605403, -6.243965, -4.262145, -7.092348, -5.546641,
E              -5.008991, -5.296614, -6.882115, -4.70855 , -2.73312 , -2.768422,...
E        y: array([-4.209511, -4.395926, -3.801358, -2.68338 , -3.062791, -3.424096,
E              -5.670746, -4.605404, -6.243965, -4.262144, -7.09235 , -5.546641,
E              -5.008991, -5.296614, -6.882115, -4.70855 , -2.73312 , -2.768422,...
```

## How is this patch tested?

Existing unit tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
