### PR TITLE
Update file_utils to support writing to YAML file without sorting.

### DIFF
--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -124,7 +124,7 @@ def make_containing_dirs(path):
         os.makedirs(dir_name)
 
 
-def write_yaml(root, file_name, data, overwrite=False):
+def write_yaml(root, file_name, data, overwrite=False, sort_keys=True):
     """
     Write dictionary data in yaml format.
 
@@ -145,7 +145,12 @@ def write_yaml(root, file_name, data, overwrite=False):
     try:
         with codecs.open(yaml_file_name, mode="w", encoding=ENCODING) as yaml_file:
             yaml.dump(
-                data, yaml_file, default_flow_style=False, allow_unicode=True, Dumper=YamlSafeDumper
+                data,
+                yaml_file,
+                default_flow_style=False,
+                allow_unicode=True,
+                sort_keys=sort_keys,
+                Dumper=YamlSafeDumper,
             )
     except Exception as e:
         raise e

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ SKINNY_REQUIREMENTS = [
     "databricks-cli>=0.8.7",
     "entrypoints",
     "gitpython>=2.1.0",
-    "pyyaml",
+    "pyyaml>=5.1",
     "protobuf>=3.7.0",
     "pytz",
     "requests>=2.17.3",

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -49,24 +49,35 @@ def test_yaml_read_and_write(tmpdir):
     assert "more_text" not in file_utils.read_yaml(temp_dir, yaml_file)
 
 
-def test_yaml_write_unsorted(tmpdir):
+def test_yaml_write_sorting(tmpdir):
     temp_dir = str(tmpdir)
-    yaml_file = random_file("yaml")
     data = {
         "a": 1,
         "c": 2,
         "b": 3,
     }
-    file_utils.write_yaml(temp_dir, yaml_file, data, sort_keys=True)
 
-    expected = """a: 1
+    sorted_yaml_file = random_file("yaml")
+    file_utils.write_yaml(temp_dir, sorted_yaml_file, data, sort_keys=True)
+    expected_sorted = """a: 1
 b: 3
 c: 2
 """
-    with open(os.path.join(temp_dir, yaml_file), "r") as f:
-        actual = f.read()
+    with open(os.path.join(temp_dir, sorted_yaml_file), "r") as f:
+        actual_sorted = f.read()
 
-    assert actual == expected
+    assert actual_sorted == expected_sorted
+
+    unsorted_yaml_file = random_file("yaml")
+    file_utils.write_yaml(temp_dir, unsorted_yaml_file, data, sort_keys=False)
+    expected_unsorted = """a: 1
+c: 2
+b: 3
+"""
+    with open(os.path.join(temp_dir, unsorted_yaml_file), "r") as f:
+        actual_unsorted = f.read()
+
+    assert actual_unsorted == expected_unsorted
 
 
 def test_mkdir(tmpdir):

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -49,6 +49,26 @@ def test_yaml_read_and_write(tmpdir):
     assert "more_text" not in file_utils.read_yaml(temp_dir, yaml_file)
 
 
+def test_yaml_write_unsorted(tmpdir):
+    temp_dir = str(tmpdir)
+    yaml_file = random_file("yaml")
+    data = {
+        "a": 1,
+        "c": 2,
+        "b": 3,
+    }
+    file_utils.write_yaml(temp_dir, yaml_file, data, sort_keys=True)
+
+    expected = """a: 1
+b: 3
+c: 2
+"""
+    with open(os.path.join(temp_dir, yaml_file), "r") as f:
+        actual = f.read()
+
+    assert actual == expected
+
+
 def test_mkdir(tmpdir):
     temp_dir = str(tmpdir)
     new_dir_name = "mkdir_test_%d" % random_int()


### PR DESCRIPTION
Signed-off-by: Avesh Singh <aveshcsingh@gmail.com>

## What changes are proposed in this pull request?

Enables file_utils to write a YAML file in the order provided in the `data` dictionary.

PyYaml version 5.1 introduces this functionality ([see release notes](https://github.com/yaml/pyyaml/blob/ee37f4653c08fc07aecff69cfd92848e6b1a540e/CHANGES#L93)), which is controlled by the [sort_keys](https://pyyaml.docsforge.com/master/api/yaml/dumper/SafeDumper/) parameter. 

Python versions >=3.7 specify that dictionaries must be insertion ordered. In Python 3.6, the behavior is not specified, however, CPython implements dictionaries that are sorted by insertion order.

## How is this patch tested?

Unit tests

## Release Notes

N/A

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
