### PR TITLE
Added create/delete registered model to R API

### DIFF
--- a/mlflow/R/mlflow/DESCRIPTION
+++ b/mlflow/R/mlflow/DESCRIPTION
@@ -77,6 +77,7 @@ Collate:
     'model-h2o.R'
     'model-keras.R'
     'model-mleap.R'
+    'model-registry.R'
     'model-serve.R'
     'model-swagger.R'
     'model-xgboost.R'

--- a/mlflow/R/mlflow/R/model-registry.R
+++ b/mlflow/R/mlflow/R/model-registry.R
@@ -15,7 +15,7 @@ mlflow_create_registered_model <- function(name, tags = NULL, description = NULL
     "create",
     client = client,
     verb = "POST",
-    version = "2.0/preview",
+    version = "2.0",
     data = list(
       name = forge::cast_string(name),
       tags = tags,
@@ -41,7 +41,7 @@ mlflow_delete_registered_model <- function(name, client = NULL) {
     "delete",
     client = client,
     verb = "DELETE",
-    version = "2.0/preview",
+    version = "2.0",
     data = list(name = forge::cast_string(name))
   )
 }

--- a/mlflow/R/mlflow/R/model-registry.R
+++ b/mlflow/R/mlflow/R/model-registry.R
@@ -1,0 +1,47 @@
+#' Create registered model
+#'
+#' Creates a new registered model in the model registry
+#'
+#' @param name The name of the model to create.
+#' @param tags Additional metadata for the registered model (Optional).
+#' @param description Description for the registered model (Optional).
+#' @template roxlate-client
+#' @export
+mlflow_create_registered_model <- function(name, tags = NULL, description = NULL, client = NULL) {
+  client <- resolve_client(client)
+
+  response <- mlflow_rest(
+    "registered-models",
+    "create",
+    client = client,
+    verb = "POST",
+    version = "2.0/preview",
+    data = list(
+      name = forge::cast_string(name),
+      tags = tags,
+      description = description
+    )
+  )
+
+  return(response$registered_model)
+}
+
+#' Delete registered model
+#'
+#' Deletes an existing registered model by name
+#'
+#' @param name The name of the model to delete
+#' @template roxlate-client
+#' @export
+mlflow_delete_registered_model <- function(name, client = NULL) {
+  client <- resolve_client(client)
+
+  response <- mlflow_rest(
+    "registered-models",
+    "delete",
+    client = client,
+    verb = "DELETE",
+    version = "2.0/preview",
+    data = list(name = forge::cast_string(name))
+  )
+}

--- a/mlflow/R/mlflow/R/tracking-rest.R
+++ b/mlflow/R/mlflow/R/tracking-rest.R
@@ -1,8 +1,7 @@
 mlflow_rest_path <- function(version) {
   switch(
     version,
-    "2.0" = "api/2.0/mlflow",
-    "2.0/preview" = "api/2.0/preview/mlflow"
+    "2.0" = "api/2.0/mlflow"
   )
 }
 

--- a/mlflow/R/mlflow/R/tracking-rest.R
+++ b/mlflow/R/mlflow/R/tracking-rest.R
@@ -1,7 +1,8 @@
 mlflow_rest_path <- function(version) {
   switch(
     version,
-    "2.0" = "api/2.0/mlflow"
+    "2.0" = "api/2.0/mlflow",
+    "2.0/preview" = "api/2.0/preview/mlflow"
   )
 }
 
@@ -70,6 +71,15 @@ mlflow_rest <- function( ..., client, query = NULL, data = NULL, verb = "GET", v
             mlflow_rest_timeout(),
             config = rest_config$config,
             req_headers
+      )
+    },
+    DELETE = function() {
+      httr::DELETE(api_url,
+              body = if (is.null(data)) NULL else rapply(data, as.character, how = "replace"),
+              encode = "json",
+              mlflow_rest_timeout(),
+              config = rest_config$config,
+              req_headers
       )
     },
     stop("Verb '", verb, "' is unsupported.", call. = FALSE)

--- a/mlflow/R/mlflow/tests/testthat/test-model-registry.R
+++ b/mlflow/R/mlflow/tests/testthat/test-model-registry.R
@@ -6,7 +6,7 @@ teardown({
 
 test_that("mlflow can register a model", {
   with_mock(.env = "mlflow",
-            mlflow_rest = function(..., client) {
+            mlflow_rest = function(...) {
       args <- list(...)
       expect_true(paste(args[1:2], collapse = "/") == "registered-models/create")
 
@@ -23,9 +23,8 @@ test_that("mlflow can register a model", {
       ))
     }, {
     mlflow_clear_test_dir("mlruns")
-    client <- mlflow_client()
 
-    registered_model <- mlflow_create_registered_model("test_model", client = client)
+    registered_model <- mlflow_create_registered_model("test_model")
 
     expect_true("name" %in% names(registered_model))
     expect_true("creation_timestamp" %in% names(registered_model))
@@ -37,7 +36,7 @@ test_that("mlflow can register a model", {
 test_that("mlflow can register a model with tags and description", {
   with_mock(
     .env = "mlflow",
-    mlflow_rest = function(..., client) {
+    mlflow_rest = function(...) {
       args <- list(...)
       expect_true(paste(args[1:2], collapse = "/") == "registered-models/create")
 
@@ -60,13 +59,11 @@ test_that("mlflow can register a model with tags and description", {
     },
     {
       mlflow_clear_test_dir("mlruns")
-      client <- mlflow_client()
 
       registered_model <- mlflow_create_registered_model(
           "test_model",
           tags = list(list(key = "creator", value = "Donald Duck")),
-          description = "Some test model",
-          client = client
+          description = "Some test model"
         )
       expect_equal(length(registered_model$tags), 1)
     }
@@ -75,14 +72,13 @@ test_that("mlflow can register a model with tags and description", {
 
 test_that("mlflow can delete a model", {
   with_mock(.env = "mlflow",
-    mlflow_rest = function(..., client) {
+    mlflow_rest = function(...) {
       args <- list(...)
       expect_true(paste(args[1:2], collapse = "/") == "registered-models/delete")
       expect_equal(args$data$name, "test_model")
   }, {
     mlflow_clear_test_dir("mlruns")
-    client <- mlflow_client()
 
-    mlflow_delete_registered_model("test_model", client = client)
+    mlflow_delete_registered_model("test_model")
   })
 })

--- a/mlflow/R/mlflow/tests/testthat/test-model-registry.R
+++ b/mlflow/R/mlflow/tests/testthat/test-model-registry.R
@@ -1,4 +1,8 @@
-context("Tracking")
+context("Model Registry")
+
+teardown({
+  mlflow_clear_test_dir("mlruns")
+})
 
 test_that("mlflow can register a model", {
   with_mock(.env = "mlflow",
@@ -18,7 +22,10 @@ test_that("mlflow can register a model", {
         )
       ))
     }, {
-    registered_model <- mlflow_create_registered_model("test_model")
+    mlflow_clear_test_dir("mlruns")
+    client <- mlflow_client()
+
+    registered_model <- mlflow_create_registered_model("test_model", client = client)
 
     expect_true("name" %in% names(registered_model))
     expect_true("creation_timestamp" %in% names(registered_model))
@@ -52,10 +59,14 @@ test_that("mlflow can register a model with tags and description", {
       ))
     },
     {
+      mlflow_clear_test_dir("mlruns")
+      client <- mlflow_client()
+
       registered_model <- mlflow_create_registered_model(
           "test_model",
           tags = list(list(key = "creator", value = "Donald Duck")),
-          description = "Some test model"
+          description = "Some test model",
+          client = client
         )
       expect_equal(length(registered_model$tags), 1)
     }
@@ -69,6 +80,9 @@ test_that("mlflow can delete a model", {
       expect_true(paste(args[1:2], collapse = "/") == "registered-models/delete")
       expect_equal(args$data$name, "test_model")
   }, {
-    mlflow_delete_registered_model("test_model")
+    mlflow_clear_test_dir("mlruns")
+    client <- mlflow_client()
+
+    mlflow_delete_registered_model("test_model", client = client)
   })
 })

--- a/mlflow/R/mlflow/tests/testthat/test-model-registry.R
+++ b/mlflow/R/mlflow/tests/testthat/test-model-registry.R
@@ -18,8 +18,7 @@ test_that("mlflow can register a model", {
         )
       ))
     }, {
-    client <- mlflow_client()
-    registered_model <- mlflow_create_registered_model("test_model", client = client)
+    registered_model <- mlflow_create_registered_model("test_model")
 
     expect_true("name" %in% names(registered_model))
     expect_true("creation_timestamp" %in% names(registered_model))
@@ -53,12 +52,10 @@ test_that("mlflow can register a model with tags and description", {
       ))
     },
     {
-      client <- mlflow_client()
       registered_model <- mlflow_create_registered_model(
           "test_model",
           tags = list(list(key = "creator", value = "Donald Duck")),
-          description = "Some test model",
-          client = client
+          description = "Some test model"
         )
       expect_equal(length(registered_model$tags), 1)
     }
@@ -72,7 +69,6 @@ test_that("mlflow can delete a model", {
       expect_true(paste(args[1:2], collapse = "/") == "registered-models/delete")
       expect_equal(args$data$name, "test_model")
   }, {
-    client <- mlflow_client()
-    mlflow_delete_registered_model("test_model", client = client)
+    mlflow_delete_registered_model("test_model")
   })
 })

--- a/mlflow/R/mlflow/tests/testthat/test-model-registry.R
+++ b/mlflow/R/mlflow/tests/testthat/test-model-registry.R
@@ -1,0 +1,78 @@
+context("Tracking")
+
+test_that("mlflow can register a model", {
+  with_mock(.env = "mlflow",
+            mlflow_rest = function(..., client) {
+      args <- list(...)
+      expect_true(paste(args[1:2], collapse = "/") == "registered-models/create")
+
+      data <- args$data
+      expect_equal(data$name, "test_model")
+
+      return(list(
+        registered_model = list(
+          name = "test_model",
+          creation_timestamp = 1.6241e+12,
+          last_updated_timestamp = 1.6241e+12,
+          user_id = "donald.duck"
+        )
+      ))
+    }, {
+    client <- mlflow_client()
+    registered_model <- mlflow_create_registered_model("test_model", client = client)
+
+    expect_true("name" %in% names(registered_model))
+    expect_true("creation_timestamp" %in% names(registered_model))
+    expect_true("last_updated_timestamp" %in% names(registered_model))
+    expect_true("user_id" %in% names(registered_model))
+  })
+})
+
+test_that("mlflow can register a model with tags and description", {
+  with_mock(
+    .env = "mlflow",
+    mlflow_rest = function(..., client) {
+      args <- list(...)
+      expect_true(paste(args[1:2], collapse = "/") == "registered-models/create")
+
+      data <- args$data
+      expect_equal(data$name, "test_model")
+      expect_equal(data$description, "Some test model")
+
+      return(list(
+        registered_model = list(
+          name = "test_model",
+          creation_timestamp = 1.6241e+12,
+          last_updated_timestamp = 1.6241e+12,
+          user_id = "donald.duck",
+          tags = list(list(
+            key = "creator", value = "Donald Duck"
+          )),
+          description = "Some test model"
+        )
+      ))
+    },
+    {
+      client <- mlflow_client()
+      registered_model <- mlflow_create_registered_model(
+          "test_model",
+          tags = list(list(key = "creator", value = "Donald Duck")),
+          description = "Some test model",
+          client = client
+        )
+      expect_equal(length(registered_model$tags), 1)
+    }
+  )
+})
+
+test_that("mlflow can delete a model", {
+  with_mock(.env = "mlflow",
+    mlflow_rest = function(..., client) {
+      args <- list(...)
+      expect_true(paste(args[1:2], collapse = "/") == "registered-models/delete")
+      expect_equal(args$data$name, "test_model")
+  }, {
+    client <- mlflow_client()
+    mlflow_delete_registered_model("test_model", client = client)
+  })
+})

--- a/mlflow/R/mlflow/tests/testthat/test-model-registry.R
+++ b/mlflow/R/mlflow/tests/testthat/test-model-registry.R
@@ -4,6 +4,8 @@ teardown({
   mlflow_clear_test_dir("mlruns")
 })
 
+
+
 test_that("mlflow can register a model", {
   with_mock(.env = "mlflow",
             mlflow_rest = function(...) {
@@ -21,10 +23,16 @@ test_that("mlflow can register a model", {
           user_id = "donald.duck"
         )
       ))
-    }, {
-    mlflow_clear_test_dir("mlruns")
+    },
+    mock_client <- mlflow:::new_mlflow_client_impl(get_host_creds = function() {
+      mlflow:::new_mlflow_host_creds(host = "localhost")
+    })
+    ,{
+    mock_client <- mlflow:::new_mlflow_client_impl(get_host_creds = function() {
+        mlflow:::new_mlflow_host_creds(host = "localhost")
+    })
 
-    registered_model <- mlflow_create_registered_model("test_model")
+    registered_model <- mlflow_create_registered_model("test_model", client = mock_client)
 
     expect_true("name" %in% names(registered_model))
     expect_true("creation_timestamp" %in% names(registered_model))
@@ -58,12 +66,15 @@ test_that("mlflow can register a model with tags and description", {
       ))
     },
     {
-      mlflow_clear_test_dir("mlruns")
+      mock_client <- mlflow:::new_mlflow_client_impl(get_host_creds = function() {
+        mlflow:::new_mlflow_host_creds(host = "localhost")
+      })
 
       registered_model <- mlflow_create_registered_model(
           "test_model",
           tags = list(list(key = "creator", value = "Donald Duck")),
-          description = "Some test model"
+          description = "Some test model",
+          client = mock_client
         )
       expect_equal(length(registered_model$tags), 1)
     }
@@ -77,8 +88,10 @@ test_that("mlflow can delete a model", {
       expect_true(paste(args[1:2], collapse = "/") == "registered-models/delete")
       expect_equal(args$data$name, "test_model")
   }, {
-    mlflow_clear_test_dir("mlruns")
+    mock_client <- mlflow:::new_mlflow_client_impl(get_host_creds = function() {
+      mlflow:::new_mlflow_host_creds(host = "localhost")
+    })
 
-    mlflow_delete_registered_model("test_model")
+    mlflow_delete_registered_model("test_model", client = mock_client)
   })
 })


### PR DESCRIPTION
… Rodenburg <14278376+bramrodenburg@users.noreply.github.com>

## What changes are proposed in this pull request?

Adding basic Model Registry functionality to the R API. This is currently missing in the Python API, and therefore R users have to fall back to the Python API for doing Model Registry related operations. 

In this pull request I've added the functions `mlflow_create_registered_model` and `mlflow_delete_registered_model`. After this PR, my idea is to add the other Model Registry related operations to the R API as well.

## How is this patch tested?

- Added R unit tests

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Added basic model registry functionality to the MLflow R interface. 

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [X] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [X] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
