### PR TITLE
Fix autologging event logger log_autolog_called with disable=True

### DIFF
--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -372,9 +372,7 @@ def autologging_integration(name):
                 # event loggers to more easily identify important configuration parameters
                 # (e.g., `disable`) without examining positional arguments. Passing positional
                 # arguments to `log_autolog_called` is deprecated in MLflow > 1.13.1
-                AutologgingEventLogger.get_logger().log_autolog_called(
-                    name, (), config_to_store
-                )
+                AutologgingEventLogger.get_logger().log_autolog_called(name, (), config_to_store)
             except Exception:
                 pass
 

--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -367,6 +367,17 @@ def autologging_integration(name):
             config_to_store.update(kwargs)
             AUTOLOGGING_INTEGRATIONS[name] = config_to_store
 
+            try:
+                # Pass `autolog()` arguments to `log_autolog_called` in keyword format to enable
+                # event loggers to more easily identify important configuration parameters
+                # (e.g., `disable`) without examining positional arguments. Passing positional
+                # arguments to `log_autolog_called` is deprecated in MLflow > 1.13.1
+                AutologgingEventLogger.get_logger().log_autolog_called(
+                    name, (), config_to_store
+                )
+            except Exception:
+                pass
+
             # If disabling autologging using fluent api, then every active integration's autolog
             # needs to be called with disable=True. So do not short circuit and let
             # `mlflow.autolog()` invoke all active integrations with disable=True.
@@ -395,18 +406,6 @@ def autologging_integration(name):
                 reroute_warnings=True,
                 disable_warnings=is_silent_mode,
             ):
-
-                try:
-                    # Pass `autolog()` arguments to `log_autolog_called` in keyword format to enable
-                    # event loggers to more easily identify important configuration parameters
-                    # (e.g., `disable`) without examining positional arguments. Passing positional
-                    # arguments to `log_autolog_called` is deprecated in MLflow > 1.13.1
-                    AutologgingEventLogger.get_logger().log_autolog_called(
-                        name, (), config_to_store
-                    )
-                except Exception:
-                    pass
-
                 _check_and_log_warning_for_unsupported_package_versions(name)
 
                 return _autolog(*args, **kwargs)

--- a/tests/autologging/test_autologging_utils.py
+++ b/tests/autologging/test_autologging_utils.py
@@ -515,7 +515,16 @@ def test_autologging_integration_makes_expected_event_logging_calls():
     AutologgingEventLogger.set_logger(logger)
 
     autolog_success("a", bar=9, disable=True)
-    assert len(logger.calls) == 0
+    assert len(logger.calls) == 1
+    call = logger.calls[0]
+    assert call.integration == "test_success"
+    # NB: In MLflow > 1.13.1, the `call_args` argument to `log_autolog_called` is deprecated.
+    # Positional arguments passed to `autolog()` should be forwarded to `log_autolog_called`
+    # in keyword format
+    assert call.call_args == ()
+    assert call.call_kwargs == {"foo": "a", "bar": 9, "disable": True, "silent": False}
+
+    logger.reset()
 
     with pytest.raises(Exception, match="autolog failed"):
         autolog_failure(82, disable=False, silent=True)


### PR DESCRIPTION
## What changes are proposed in this pull request?

https://github.com/mlflow/mlflow/pull/4405 erroneously prevented the `log_autolog_called` event from firing when an autologging API was called with the `disable=True` argument. This PR fixes the issue and restores the preexisting test.

## How is this patch tested?

Unit tests

## Release Notes

Fix a bug in the autologging event logger that prevented the `log_autolog_called` instrumentation hook from firing when autologging APIs were called with `disable=True`.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
