### PR TITLE
Support setting tags while resuming run

### DIFF
--- a/examples/pytorch/MNIST/mnist_autolog_example.py
+++ b/examples/pytorch/MNIST/mnist_autolog_example.py
@@ -22,7 +22,6 @@ from torch.utils.data import DataLoader, random_split
 from torchvision import datasets, transforms
 
 
-
 class MNISTDataModule(pl.LightningDataModule):
     def __init__(self, **kwargs):
         """

--- a/examples/pytorch/MNIST/mnist_autolog_example.py
+++ b/examples/pytorch/MNIST/mnist_autolog_example.py
@@ -22,6 +22,7 @@ from torch.utils.data import DataLoader, random_split
 from torchvision import datasets, transforms
 
 
+
 class MNISTDataModule(pl.LightningDataModule):
     def __init__(self, **kwargs):
         """

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -146,8 +146,8 @@ def start_run(
                      Used only when ``run_id`` is unspecified.
     :param nested: Controls whether run is nested in parent run. ``True`` creates a nested run.
     :param tags: An optional dictionary of string keys and values to set as tags on the run.
-                 If ``run_id`` is specified, these tags are set on the run with ID ``run_id``.
-                 If ``run_id`` is unspecified, these tags are set on the new run that is created.
+                 If a run is being resumed, these tags are set on the resumed run. If a new run is
+                 being created, these tags are set on the new run.
     :return: :py:class:`mlflow.ActiveRun` object that acts as a context manager wrapping
              the run's state.
 

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -395,7 +395,7 @@ def test_start_run_defaults_databricks_notebook(
 
 
 @pytest.mark.usefixtures(empty_active_run_stack.__name__)
-def test_start_run_with_user_specified_tags():
+def test_start_run_creates_new_run_with_user_specified_tags():
 
     mock_experiment_id = mock.Mock()
     experiment_id_patch = mock.patch(
@@ -441,6 +441,18 @@ def test_start_run_with_user_specified_tags():
             experiment_id=mock_experiment_id, tags=expected_tags
         )
         assert is_from_run(active_run, MlflowClient.create_run.return_value)
+
+
+@pytest.mark.usefixtures(empty_active_run_stack.__name__)
+def test_start_run_resumes_existing_run_and_sets_user_specified_tags():
+    tags_to_set = {
+        "A": "B",
+        "C": "D",
+    }
+    run_id = mlflow.start_run().info.run_id
+    mlflow.end_run()
+    restarted_run = mlflow.start_run(run_id, tags=tags_to_set)
+    assert tags_to_set.items() <= restarted_run.data.tags.items()
 
 
 def test_start_run_with_parent():


### PR DESCRIPTION
Signed-off-by: dbczumar <corey.zumar@databricks.com>

## What changes are proposed in this pull request?

The current behavior of the `tags` argument defined by `mlflow.start_run()` is to only set the supplied tags if a new run is created. Tags are not set on an existing run. This behavior is confusing in the case of MLflow project runs where a run is being resumed by way of `MLFLOW_RUN_ID`: it's hard for Tracking code to know whether it will be run as part of a project, so `start_run(tags=...)` can't currently always be relied on to set required tags.

To simplify the behavior / make it more consistent, this PR extends `start_run()` to set tags on existing runs when they are resumed.

## How is this patch tested?

Unit tests

## Release Notes

Tags passed to the `mlflow.start_run()` API are now set when runs are resumed, in addition to when they are created.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
