### PR TITLE
Added commandRunId request header

### DIFF
--- a/mlflow/tracking/request_header/databricks_request_header_provider.py
+++ b/mlflow/tracking/request_header/databricks_request_header_provider.py
@@ -25,7 +25,8 @@ class DatabricksRequestHeaderProvider(RequestHeaderProvider):
             request_headers["job_type"] = databricks_utils.get_job_type()
         if databricks_utils.is_in_cluster():
             request_headers["cluster_id"] = databricks_utils.get_cluster_id()
-        if databricks_utils.get_command_run_id():
-            request_headers["command_run_id"] = databricks_utils.get_command_run_id()
+        command_run_id = databricks_utils.get_command_run_id()
+        if command_run_id is not None:
+            request_headers["command_run_id"] = command_run_id
 
         return request_headers

--- a/mlflow/tracking/request_header/databricks_request_header_provider.py
+++ b/mlflow/tracking/request_header/databricks_request_header_provider.py
@@ -25,6 +25,7 @@ class DatabricksRequestHeaderProvider(RequestHeaderProvider):
             request_headers["job_type"] = databricks_utils.get_job_type()
         if databricks_utils.is_in_cluster():
             request_headers["cluster_id"] = databricks_utils.get_cluster_id()
-        request_headers["command_run_id"] = databricks_utils.get_command_run_id()
+        if databricks_utils.get_command_run_id():
+            request_headers["command_run_id"] = databricks_utils.get_command_run_id()
 
         return request_headers

--- a/mlflow/tracking/request_header/databricks_request_header_provider.py
+++ b/mlflow/tracking/request_header/databricks_request_header_provider.py
@@ -25,5 +25,6 @@ class DatabricksRequestHeaderProvider(RequestHeaderProvider):
             request_headers["job_type"] = databricks_utils.get_job_type()
         if databricks_utils.is_in_cluster():
             request_headers["cluster_id"] = databricks_utils.get_cluster_id()
+        request_headers["command_run_id"] = databricks_utils.get_command_run_id()
 
         return request_headers

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -173,6 +173,13 @@ def get_job_type():
         return _get_context_tag("jobTaskType")
 
 
+def get_command_run_id():
+    try:
+        return _get_command_context().commandRunId().get()
+    except Exception:
+        return _get_context_tag("commandRunId")
+
+
 def get_webapp_url():
     """Should only be called if is_in_databricks_notebook or is_in_databricks_jobs is true"""
     url = _get_property_from_spark_context("spark.databricks.api.url")

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -177,8 +177,8 @@ def get_command_run_id():
     try:
         return _get_command_context().commandRunId().get()
     except Exception:
-        # older runtimes may not have the commandRunId available
-        return "unknown_command_run_id"
+        # Older runtimes may not have the commandRunId available
+        return None
 
 
 def get_webapp_url():

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -177,7 +177,7 @@ def get_command_run_id():
     try:
         return _get_command_context().commandRunId().get()
     except Exception:
-        # old runtimes may not have the commandRunId available
+        # older runtimes may not have the commandRunId available
         return "unknown_command_run_id"
 
 

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -177,7 +177,8 @@ def get_command_run_id():
     try:
         return _get_command_context().commandRunId().get()
     except Exception:
-        return _get_context_tag("commandRunId")
+        # old runtimes may not have the commandRunId available
+        return "unknown_command_run_id"
 
 
 def get_webapp_url():

--- a/some_tracking_uri/0/meta.yaml
+++ b/some_tracking_uri/0/meta.yaml
@@ -1,4 +1,0 @@
-artifact_location: some_tracking_uri/0
-experiment_id: '0'
-lifecycle_stage: active
-name: Default

--- a/some_tracking_uri/0/meta.yaml
+++ b/some_tracking_uri/0/meta.yaml
@@ -1,0 +1,4 @@
+artifact_location: some_tracking_uri/0
+experiment_id: '0'
+lifecycle_stage: active
+name: Default

--- a/tests/tracking/request_header/test_databricks_request_header_provider.py
+++ b/tests/tracking/request_header/test_databricks_request_header_provider.py
@@ -80,4 +80,7 @@ def test_databricks_request_header_provider_request_headers(
         else:
             assert "cluster_id" not in request_headers
 
-        assert request_headers["command_run_id"] == command_run_id_mock.return_value
+        if command_run_id_mock.return_value not None:
+            assert request_headers["command_run_id"] == command_run_id_mock.return_value
+        else:
+            assert "command_run_id" not in request_headers

--- a/tests/tracking/request_header/test_databricks_request_header_provider.py
+++ b/tests/tracking/request_header/test_databricks_request_header_provider.py
@@ -80,4 +80,4 @@ def test_databricks_request_header_provider_request_headers(
         else:
             assert "cluster_id" not in request_headers
 
-        assert "command_run_id" in request_headers
+        assert request_headers["command_run_id"] == command_run_id_mock.return_value

--- a/tests/tracking/request_header/test_databricks_request_header_provider.py
+++ b/tests/tracking/request_header/test_databricks_request_header_provider.py
@@ -56,7 +56,9 @@ def test_databricks_request_header_provider_request_headers(
         "mlflow.utils.databricks_utils.get_job_type"
     ) as job_type_mock, mock.patch(
         "mlflow.utils.databricks_utils.get_cluster_id"
-    ) as cluster_id_mock:
+    ) as cluster_id_mock, mock.patch(
+        "mlflow.utils.databricks_utils.get_command_run_id"
+    ) as command_run_id_mock:
         request_headers = DatabricksRequestHeaderProvider().request_headers()
 
         if is_in_databricks_notebook:
@@ -77,3 +79,5 @@ def test_databricks_request_header_provider_request_headers(
             assert request_headers["cluster_id"] == cluster_id_mock.return_value
         else:
             assert "cluster_id" not in request_headers
+
+        assert "command_run_id" in request_headers

--- a/tests/tracking/request_header/test_databricks_request_header_provider.py
+++ b/tests/tracking/request_header/test_databricks_request_header_provider.py
@@ -80,7 +80,7 @@ def test_databricks_request_header_provider_request_headers(
         else:
             assert "cluster_id" not in request_headers
 
-        if command_run_id_mock.return_value not None:
+        if command_run_id_mock.return_value is not None:
             assert request_headers["command_run_id"] == command_run_id_mock.return_value
         else:
             assert "command_run_id" not in request_headers


### PR DESCRIPTION
## What changes are proposed in this pull request?

Added command run id as a request header created by DatabricksRequestHeaderProvider

## How is this patch tested?

Unit tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [x] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
