### PR TITLE
Enforce updating R documents

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,8 +55,7 @@ jobs:
       - run:
           name: Show diff
           command: |
-            git --no-pager diff
-            git diff --quiet
+            git --no-pager diff --exit-code
 
       - save_cache:
           key: r-cache-{{ checksum ".circleci/R-version" }}-{{ checksum ".circleci/depends.Rds" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,7 @@ jobs:
           name: Show diff
           command: |
             git --no-pager diff
+            git diff --quiet
 
       - save_cache:
           key: r-cache-{{ checksum ".circleci/R-version" }}-{{ checksum ".circleci/depends.Rds" }}

--- a/docs/source/R-api.rst
+++ b/docs/source/R-api.rst
@@ -17,7 +17,7 @@ You can use the R API to `install MLflow <install_mlflow_>`_, start the `user in
 
 Install MLflow
 
-Installs auxiliary dependencies of MLflow (e.g. the MLflow CLI). As a
+Installs auxiliary dependencies of MLflow (e.g. the MLflow CLI). As a
 one-time setup step, you must run install_mlflow() to install these
 dependencies before calling other MLflow APIs.
 
@@ -585,8 +585,8 @@ Arguments
 | Argument                      | Description                          |
 +===============================+======================================+
 | ``flavor``                    | An MLflow flavor object loaded by    |
-|                               | `mlflo                               |
-|                               | w_load_model <#mlflow-load-model>`__ |
+|                               | `mlflow_load_model <#mlflow-load-mod |
+|                               | el>`__                               |
 |                               | , with class loaded from the flavor  |
 |                               | field in an MLmodel file.            |
 +-------------------------------+--------------------------------------+
@@ -639,7 +639,7 @@ Arguments
 Details
 -------
 
-The URI scheme must be supported by MLflow - i.e. there has to be an
+The URI scheme must be supported by MLflow - i.e. there has to be an
 MLflow artifact repository corresponding to the scheme of the URI. The
 content is expected to point to a directory containing MLmodel. The
 following are examples of valid model uris:
@@ -855,7 +855,7 @@ Arguments
 |                               | ``conda_env = /path/to/conda.yaml``  |
 |                               | may be passed to specify a conda     |
 |                               | dependencies file for flavors        |
-|                               | (e.g. keras) that support conda      |
+|                               | (e.g. keras) that support conda      |
 |                               | environments.                        |
 +-------------------------------+--------------------------------------+
 
@@ -929,7 +929,7 @@ Read Command-Line Parameter
 
 Reads a command-line parameter passed to an MLflow project MLflow allows
 you to define named, typed input parameters to your R scripts via the
-mlflow_param API. This is useful for experimentation, e.g. tracking
+mlflow_param API. This is useful for experimentation, e.g. tracking
 multiple invocations of the same script with different parameters.
 
 .. code:: r
@@ -995,16 +995,13 @@ to be used by package authors to extend the supported MLflow models.
 Arguments
 ---------
 
-+-----------+---------------------------------------------------------+
-| Argument  | Description                                             |
-+===========+=========================================================+
-| ``model`` | The loaded MLflow model flavor.                         |
-+-----------+---------------------------------------------------------+
-| ``data``  | A data frame to perform scoring.                        |
-+-----------+---------------------------------------------------------+
-| ``...``   | Optional additional arguments passed to underlying      |
-|           | predict methods.                                        |
-+-----------+---------------------------------------------------------+
+========= ===================================================================
+Argument  Description
+========= ===================================================================
+``model`` The loaded MLflow model flavor.
+``data``  A data frame to perform scoring.
+``...``   Optional additional arguments passed to underlying predict methods.
+========= ===================================================================
 
 ``mlflow_register_external_observer``
 =====================================
@@ -1226,7 +1223,7 @@ Arguments
 Details
 -------
 
-The URI scheme must be supported by MLflow - i.e. there has to be an
+The URI scheme must be supported by MLflow - i.e. there has to be an
 MLflow artifact repository corresponding to the scheme of the URI. The
 content is expected to point to a directory containing MLmodel. The
 following are examples of valid model uris:

--- a/mlflow/R/mlflow/document.R
+++ b/mlflow/R/mlflow/document.R
@@ -21,7 +21,6 @@ markdown_fixed <- gsub("## Usage", "", markdown_fixed)
 last_section <- which(grepl("reexports", markdown_fixed))[[1]]
 markdown_fixed <- markdown_fixed[1:last_section - 1]
 
-
 # Write fixed markdown file
 writeLines(markdown_fixed, "Reference_Manual_mlflow.md")
 

--- a/mlflow/R/mlflow/document.R
+++ b/mlflow/R/mlflow/document.R
@@ -21,6 +21,7 @@ markdown_fixed <- gsub("## Usage", "", markdown_fixed)
 last_section <- which(grepl("reexports", markdown_fixed))[[1]]
 markdown_fixed <- markdown_fixed[1:last_section - 1]
 
+
 # Write fixed markdown file
 writeLines(markdown_fixed, "Reference_Manual_mlflow.md")
 
@@ -48,6 +49,8 @@ You can use the R API to `install MLflow <install_mlflow_>`_, start the `user in
     :depth: 1
 "
 rst_doc <- readLines("../../../docs/source/R-api.rst")
+# Convert non-breaking spaces inserted by pandoc to regular spaces
+rst_doc <- gsub("\302\240", " ", rst_doc)
 rst_doc <- c(rst_header, rst_doc)
 writeLines(rst_doc, "../../../docs/source/R-api.rst")
 


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Enforce updating R documents when R files are changed. This allows us to avoid rebuilding the R documents when we release a new version of MLflow and saves us about **10~15** min (installing R packages without cache takes a long time). After merging this PR, we need to update our internal Jenkins job.

## How is this patch tested?

- Existing tests
- Verify that the `build_doc_r` job fails when `source/R-api.rst` requires updates.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
