### PR TITLE
Fix json serialization of numpy arrays with object dtype

### DIFF
--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -49,7 +49,7 @@ def parse_dict(js_dict, message):
 
 
 class NumpyEncoder(JSONEncoder):
-    """ Special json encoder for numpy types.
+    """Special json encoder for numpy types.
     Note that some numpy types doesn't have native python equivalence,
     hence json.dumps will raise TypeError.
     In this case, you'll need to convert your numpy types into its closest python equivalence.
@@ -64,7 +64,7 @@ class NumpyEncoder(JSONEncoder):
 
         if isinstance(o, np.ndarray):
             if o.dtype == np.object:
-                return [self.try_convert(x)[0] for x in o.tolist()]
+                return [self.try_convert(x)[0] for x in o.tolist()], True
             elif o.dtype == np.bytes_:
                 return np.vectorize(encode_binary)(o), True
             else:

--- a/tests/models/test_model_input_examples.py
+++ b/tests/models/test_model_input_examples.py
@@ -25,6 +25,7 @@ def pandas_df_with_all_types():
             "boolean_ext": [True, False, True],
             "integer_ext": [1, 2, 3],
             "string_ext": ["a", "b", "c"],
+            "array": np.array(["a", "b", "c"]),
         }
     )
     df["boolean_ext"] = df["boolean_ext"].astype("boolean")


### PR DESCRIPTION
## What changes are proposed in this pull request?
The `NumpyEncoder` in proto json utils does not correctly handle the case of nested numpy array with object type - the try_convert method is expected to return 2 values but is currently returning only one. The values are the 1. converted value and 2. a boolean flag signaling whether there was any conversion done. The code currently returns only 1. This PR updates adds 2. as `True` - this is because we always make at least the conversion of the outer numpy array to list. 

## How is this patch tested?
Extended test for saving examples, which is where this bug popped up. Note that we do not have unit test for NumpyEncoder alone. We should but it is out of scope of this fix.

## Release Notes
n/a

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
