### PR TITLE
Instantiate `mock.MagicMock`

### DIFF
--- a/tests/store/artifact/test_databricks_models_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_models_artifact_repo.py
@@ -131,7 +131,7 @@ class TestDatabricksModelArtifactRepository(object):
                 DatabricksModelsArtifactRepository(valid_profileless_artifact_uri)
 
     def test_list_artifacts(self, databricks_model_artifact_repo):
-        list_artifact_dir_response_mock = mock.MagicMock
+        list_artifact_dir_response_mock = mock.MagicMock()
         list_artifact_dir_response_mock.status_code = 200
         list_artifact_dir_json_mock = {
             "files": [
@@ -156,7 +156,7 @@ class TestDatabricksModelArtifactRepository(object):
             call_endpoint_mock.assert_called_once_with(ANY, REGISTRY_LIST_ARTIFACTS_ENDPOINT)
 
     def test_list_artifacts_for_single_file(self, databricks_model_artifact_repo):
-        list_artifact_file_response_mock = mock.MagicMock
+        list_artifact_file_response_mock = mock.MagicMock()
         list_artifact_file_response_mock.status_code = 200
         list_artifact_file_json_mock = {
             "files": [{"path": "MLmodel", "is_dir": False, "file_size": 294}]
@@ -180,7 +180,7 @@ class TestDatabricksModelArtifactRepository(object):
         ],
     )
     def test_download_file(self, databricks_model_artifact_repo, remote_file_path, local_path):
-        signed_uri_response_mock = mock.MagicMock
+        signed_uri_response_mock = mock.MagicMock()
         signed_uri_response_mock.status_code = 200
         signed_uri_mock = {
             "signed_uri": "https://my-amazing-signed-uri-to-rule-them-all.com/1234-numbers-yay-567"

--- a/tests/store/model_registry/test_rest_store.py
+++ b/tests/store/model_registry/test_rest_store.py
@@ -44,7 +44,7 @@ def request_fixture():
         yield request_mock
 
 
-def with_mock_http_request(f):
+def mock_http_request(f):
     @functools.wraps(f)
     @mock.patch(
         "mlflow.utils.rest_utils.http_request",
@@ -82,7 +82,7 @@ class TestRestStore(unittest.TestCase):
         json_body = message_to_json(proto_message)
         http_request.assert_any_call(**(self._args(self.creds, endpoint, method, json_body)))
 
-    @with_mock_http_request
+    @mock_http_request
     def test_create_registered_model(self, mock_http):
         tags = [
             RegisteredModelTag(key="key", value="value"),
@@ -99,7 +99,7 @@ class TestRestStore(unittest.TestCase):
             ),
         )
 
-    @with_mock_http_request
+    @mock_http_request
     def test_update_registered_model_name(self, mock_http):
         name = "model_1"
         new_name = "model_2"
@@ -111,7 +111,7 @@ class TestRestStore(unittest.TestCase):
             RenameRegisteredModel(name=name, new_name=new_name),
         )
 
-    @with_mock_http_request
+    @mock_http_request
     def test_update_registered_model_description(self, mock_http):
         name = "model_1"
         description = "test model"
@@ -123,7 +123,7 @@ class TestRestStore(unittest.TestCase):
             UpdateRegisteredModel(name=name, description=description),
         )
 
-    @with_mock_http_request
+    @mock_http_request
     def test_delete_registered_model(self, mock_http):
         name = "model_1"
         self.store.delete_registered_model(name=name)
@@ -131,7 +131,7 @@ class TestRestStore(unittest.TestCase):
             mock_http, "registered-models/delete", "DELETE", DeleteRegisteredModel(name=name)
         )
 
-    @with_mock_http_request
+    @mock_http_request
     def test_list_registered_model(self, mock_http):
         self.store.list_registered_models(max_results=50, page_token=None)
         self._verify_requests(
@@ -141,7 +141,7 @@ class TestRestStore(unittest.TestCase):
             ListRegisteredModels(page_token=None, max_results=50),
         )
 
-    @with_mock_http_request
+    @mock_http_request
     def test_search_registered_model(self, mock_http):
         self.store.search_registered_models()
         self._verify_requests(
@@ -164,7 +164,7 @@ class TestRestStore(unittest.TestCase):
                     mock_http, "registered-models/search", "GET", SearchRegisteredModels(**params)
                 )
 
-    @with_mock_http_request
+    @mock_http_request
     def test_get_registered_model(self, mock_http):
         name = "model_1"
         self.store.get_registered_model(name=name)
@@ -172,7 +172,7 @@ class TestRestStore(unittest.TestCase):
             mock_http, "registered-models/get", "GET", GetRegisteredModel(name=name)
         )
 
-    @with_mock_http_request
+    @mock_http_request
     def test_get_latest_versions(self, mock_http):
         name = "model_1"
         self.store.get_latest_versions(name=name)
@@ -180,7 +180,7 @@ class TestRestStore(unittest.TestCase):
             mock_http, "registered-models/get-latest-versions", "GET", GetLatestVersions(name=name)
         )
 
-    @with_mock_http_request
+    @mock_http_request
     def test_get_latest_versions_with_stages(self, mock_http):
         name = "model_1"
         self.store.get_latest_versions(name=name, stages=["blaah"])
@@ -191,7 +191,7 @@ class TestRestStore(unittest.TestCase):
             GetLatestVersions(name=name, stages=["blaah"]),
         )
 
-    @with_mock_http_request
+    @mock_http_request
     def test_set_registered_model_tag(self, mock_http):
         name = "model_1"
         tag = RegisteredModelTag(key="key", value="value")
@@ -203,7 +203,7 @@ class TestRestStore(unittest.TestCase):
             SetRegisteredModelTag(name=name, key=tag.key, value=tag.value),
         )
 
-    @with_mock_http_request
+    @mock_http_request
     def test_delete_registered_model_tag(self, mock_http):
         name = "model_1"
         self.store.delete_registered_model_tag(name=name, key="key")
@@ -214,7 +214,7 @@ class TestRestStore(unittest.TestCase):
             DeleteRegisteredModelTag(name=name, key="key"),
         )
 
-    @with_mock_http_request
+    @mock_http_request
     def test_create_model_version(self, mock_http):
         self.store.create_model_version("model_1", "path/to/source")
         self._verify_requests(
@@ -248,7 +248,7 @@ class TestRestStore(unittest.TestCase):
             ),
         )
 
-    @with_mock_http_request
+    @mock_http_request
     def test_transition_model_version_stage(self, mock_http):
         name = "model_1"
         version = "5"
@@ -264,7 +264,7 @@ class TestRestStore(unittest.TestCase):
             ),
         )
 
-    @with_mock_http_request
+    @mock_http_request
     def test_update_model_version_decription(self, mock_http):
         name = "model_1"
         version = "5"
@@ -277,7 +277,7 @@ class TestRestStore(unittest.TestCase):
             UpdateModelVersion(name=name, version=version, description="test model version"),
         )
 
-    @with_mock_http_request
+    @mock_http_request
     def test_delete_model_version(self, mock_http):
         name = "model_1"
         version = "12"
@@ -289,7 +289,7 @@ class TestRestStore(unittest.TestCase):
             DeleteModelVersion(name=name, version=version),
         )
 
-    @with_mock_http_request
+    @mock_http_request
     def test_get_model_version_details(self, mock_http):
         name = "model_11"
         version = "8"
@@ -298,7 +298,7 @@ class TestRestStore(unittest.TestCase):
             mock_http, "model-versions/get", "GET", GetModelVersion(name=name, version=version)
         )
 
-    @with_mock_http_request
+    @mock_http_request
     def test_get_model_version_download_uri(self, mock_http):
         name = "model_11"
         version = "8"
@@ -310,14 +310,14 @@ class TestRestStore(unittest.TestCase):
             GetModelVersionDownloadUri(name=name, version=version),
         )
 
-    @with_mock_http_request
+    @mock_http_request
     def test_search_model_versions(self, mock_http):
         self.store.search_model_versions(filter_string="name='model_12'")
         self._verify_requests(
             mock_http, "model-versions/search", "GET", SearchModelVersions(filter="name='model_12'")
         )
 
-    @with_mock_http_request
+    @mock_http_request
     def test_set_model_version_tag(self, mock_http):
         name = "model_1"
         tag = ModelVersionTag(key="key", value="value")
@@ -329,7 +329,7 @@ class TestRestStore(unittest.TestCase):
             SetModelVersionTag(name=name, version="1", key=tag.key, value=tag.value),
         )
 
-    @with_mock_http_request
+    @mock_http_request
     def test_delete_model_version_tag(self, mock_http):
         name = "model_1"
         self.store.delete_model_version_tag(name=name, version="1", key="key")

--- a/tests/store/model_registry/test_rest_store.py
+++ b/tests/store/model_registry/test_rest_store.py
@@ -84,7 +84,6 @@ class TestRestStore(unittest.TestCase):
 
     @with_mock_http_request
     def test_create_registered_model(self, mock_http):
-        print(mock_http.status_code)
         tags = [
             RegisteredModelTag(key="key", value="value"),
             RegisteredModelTag(key="anotherKey", value="some other value"),

--- a/tests/store/model_registry/test_rest_store.py
+++ b/tests/store/model_registry/test_rest_store.py
@@ -36,7 +36,7 @@ from mlflow.utils.rest_utils import MlflowHostCreds
 @pytest.fixture(scope="class")
 def request_fixture():
     with mock.patch("requests.request") as request_mock:
-        response = mock.MagicMock
+        response = mock.MagicMock()
         response.status_code = 200
         response.text = "{}"
         request_mock.return_value = response

--- a/tests/store/tracking/test_rest_store.py
+++ b/tests/store/tracking/test_rest_store.py
@@ -72,7 +72,7 @@ class TestRestStore(object):
                 "headers": _DEFAULT_HEADERS,
                 "verify": True,
             }
-            response = mock.MagicMock
+            response = mock.MagicMock()
             response.status_code = 200
             response.text = '{"experiments": [{"name": "Exp!", "lifecycle_stage": "active"}]}'
             return response
@@ -85,7 +85,7 @@ class TestRestStore(object):
 
     @mock.patch("requests.request")
     def test_failed_http_request(self, request):
-        response = mock.MagicMock
+        response = mock.MagicMock()
         response.status_code = 404
         response.text = '{"error_code": "RESOURCE_DOES_NOT_EXIST", "message": "No experiment"}'
         request.return_value = response
@@ -97,7 +97,7 @@ class TestRestStore(object):
 
     @mock.patch("requests.request")
     def test_failed_http_request_custom_handler(self, request):
-        response = mock.MagicMock
+        response = mock.MagicMock()
         response.status_code = 404
         response.text = '{"error_code": "RESOURCE_DOES_NOT_EXIST", "message": "No experiment"}'
         request.return_value = response
@@ -116,7 +116,7 @@ class TestRestStore(object):
             "OMG_WHAT_IS_THIS_FIELD": "Hooly cow",
         }
 
-        response = mock.MagicMock
+        response = mock.MagicMock()
         response.status_code = 200
         experiments = {"experiments": [experiment_json]}
         response.text = json.dumps(experiments)
@@ -144,7 +144,7 @@ class TestRestStore(object):
 
     @mock.patch("requests.request")
     def test_requestor(self, request):
-        response = mock.MagicMock
+        response = mock.MagicMock()
         response.status_code = 200
         response.text = "{}"
         request.return_value = response
@@ -279,7 +279,7 @@ class TestRestStore(object):
             )
 
         with mock.patch("mlflow.utils.rest_utils.http_request") as mock_http:
-            response = mock.MagicMock
+            response = mock.MagicMock()
             response.text = '{"runs": ["1a", "2b", "3c"], "next_page_token": "67890fghij"}'
             mock_http.return_value = response
             result = store.search_runs(
@@ -318,7 +318,7 @@ class TestRestStore(object):
         creds = MlflowHostCreds("https://hello")
         store = store_class(lambda: creds)
         with mock.patch("mlflow.utils.rest_utils.http_request") as mock_http:
-            response = mock.MagicMock
+            response = mock.MagicMock()
             response.status_code = 200
             experiment = Experiment(
                 experiment_id="123",
@@ -345,7 +345,7 @@ class TestRestStore(object):
             assert result.lifecycle_stage == experiment.lifecycle_stage
             # Test GetExperimentByName against nonexistent experiment
             mock_http.reset_mock()
-            nonexistent_exp_response = mock.MagicMock
+            nonexistent_exp_response = mock.MagicMock()
             nonexistent_exp_response.status_code = 404
             nonexistent_exp_response.text = MlflowException(
                 "Exp doesn't exist!", RESOURCE_DOES_NOT_EXIST
@@ -365,7 +365,7 @@ class TestRestStore(object):
             # Test REST client behavior against a mocked old server, which has handler for
             # ListExperiments but not GetExperimentByName
             mock_http.reset_mock()
-            list_exp_response = mock.MagicMock
+            list_exp_response = mock.MagicMock()
             list_exp_response.text = json.dumps(
                 {"experiments": [json.loads(message_to_json(experiment.to_proto()))]}
             )


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Some tests use `mock.MagicMock` without instantiating it. This PR fixes it.

## How is this patch tested?

- Make sure no lines match `mock.MagicMock$`
- Fixed tests
- Existing tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
