### PR TITLE
Add support for azure-identity to authenticate with Azure storage accounts

### DIFF
--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -824,10 +824,14 @@ Azure Blob Storage
 
 To store artifacts in Azure Blob Storage, specify a URI of the form
 ``wasbs://<container>@<storage-account>.blob.core.windows.net/<path>``.
-MLflow expects Azure Storage access credentials in the
-``AZURE_STORAGE_CONNECTION_STRING`` or ``AZURE_STORAGE_ACCESS_KEY`` environment variables (preferring
-a connection string if one is set), so you must set one of these variables on both your client
-application and your MLflow tracking server. Finally, you must run ``pip install azure-storage-blob``
+MLflow supports azure-identity `DefaultAzureCredential` (https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/identity/azure-identity). 
+To enable this behavior set MLFLOW_USE_AZURE_IDENTITY to 'true' and add azure-identity as a Python dependency via ``pip install azure-identity``  
+Alternatively Mlflow expects Azure Storage access credentials in the
+``AZURE_STORAGE_CONNECTION_STRING``||``MLFLOW_AZURE_STORAGE_CONNECTION_STRING`` or ``AZURE_STORAGE_ACCESS_KEY`` environment variables (preferring
+a connection string if one is set), so you must set one of these authentication method on both your client
+application and your MLflow tracking server. Those can be different (e.g MLFLOW_USE_AZURE_IDENTITY for tracking server and MLFLOW_AZURE_STORAGE_CONNECTION_STRING 
+for mlflow client). 
+Finally, you must run ``pip install azure-storage-blob``
 separately (on both your client and the server) to access Azure Blob Storage; MLflow does not declare
 a dependency on this package by default.
 

--- a/examples/docker/Dockerfile
+++ b/examples/docker/Dockerfile
@@ -1,7 +1,8 @@
 FROM continuumio/miniconda:4.5.4
 
 RUN pip install mlflow>=1.0 \
-    && pip install azure-storage-blob==12.3.0 \
+    && pip install azure-identity==1.6.0 \
+    && pip install azure-storage-blob==12.8.1 \    
     && pip install numpy==1.14.3 \
     && pip install scipy \
     && pip install pandas==0.22.0 \


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Add support for azure-identity when authenticating with an Azure storage accounts. See https://pypi.org/project/azure-identity/ for more details of the authentication types available. 
- Namespace the environment variable for AZURE_STORAGE_CONNECTION_STRING to MLFLOW_AZURE_STORAGE_CONNECTION_STRING to avoid conflict. 
-  Address  #3483
## How is this patch tested?

Bit week on that front but I'm open to advises. 

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

- Add support for azure-identity credentials when setting MLFLOW_USE_AZURE_IDENTITY environment variable to True. 
- MLFLOW_AZURE_STORAGE_CONNECTION_STRING is also a valid environment variable for AZURE_STORAGE_CONNECTION_STRING 

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [x] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
