### PR TITLE
Skip XGBoost autologging test that no longer applies to XGB > 1.4.2

### DIFF
--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -8,6 +8,7 @@ from sklearn import datasets
 import xgboost as xgb
 import matplotlib as mpl
 import yaml
+from packaging.version import Version
 
 import mlflow
 import mlflow.xgboost
@@ -315,6 +316,13 @@ def test_xgb_autolog_loads_model_from_artifact(bst_params, dtrain):
 
 
 @pytest.mark.large
+@pytest.mark.skipif(
+    Version(xgb.__version__) > Version("1.4.2"),
+    reason=(
+        "In XGBoost <= 1.4.2, linear boosters do not support `get_score()` for importance value"
+        " creation. In XGBoost > 1.4.2, all boosters support `get_score()`."
+    ),
+)
 def test_xgb_autolog_does_not_throw_if_importance_values_not_supported(dtrain):
     # the gblinear booster does not support calling get_score on it,
     #   where get_score is used to create the importance values plot.

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -8,7 +8,6 @@ from sklearn import datasets
 import xgboost as xgb
 import matplotlib as mpl
 import yaml
-from packaging.version import Version
 
 import mlflow
 import mlflow.xgboost


### PR DESCRIPTION
Signed-off-by: dbczumar <corey.zumar@databricks.com>

## What changes are proposed in this pull request?

https://github.com/dmlc/xgboost/pull/7048 introduced support for `get_score()` to linear boosters. We have test coverage for the XGBoost autologging integration to ensure that we don't fail the MLflow run when importance score information is not available for boosters. With 7048 merged into XGBoost, we no longer have to be concerned about this issue in XGBoost > 1.4.2.

## How is this patch tested?

Verified by install XGBoost from dev that this test is skipped:

```
temp_dir=$(mktemp -d)
git clone --recursive https://github.com/dmlc/xgboost.git $temp_dir
git --git-dir=$temp_dir/.git rev-parse HEAD
cd $temp_dir/python-package
python setup.py install
```

```
cd ~/mlflow/tests/xgboost
pytest -k "test_xgb_autolog_does_not_throw_if_importance_values_not_supported" -s --large
================= test session starts =================
platform darwin -- Python 3.8.5, pytest-3.2.1, py-1.9.0, pluggy-0.4.0 -- /Users/corey.zumar/opt/anaconda3/bin/python
cachedir: ../../.cache
rootdir: /Users/corey.zumar/mlflow, inifile: pytest.ini
collected 40 items

test_xgboost_autolog.py::test_xgb_autolog_does_not_throw_if_importance_values_not_supported SKIPPED

============== slowest 5 test durations ===============
0.00s setup    tests/xgboost/test_xgboost_autolog.py::test_xgb_autolog_does_not_throw_if_importance_values_not_supported
0.00s teardown tests/xgboost/test_xgboost_autolog.py::test_xgb_autolog_does_not_throw_if_importance_values_not_supported
================= 39 tests deselected =================
====== 1 skipped, 39 deselected in 0.71 seconds =======
```

We can further verify via cross version tests on this PR that this test case *does* run on XGBoost <= 1.4.2.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
