### PR TITLE
[WIP][ML-16201] Deprecate the use of `conda_env` argument in `log_model`

### DIFF
--- a/mlflow/utils/annotations.py
+++ b/mlflow/utils/annotations.py
@@ -1,3 +1,4 @@
+import inspect
 import warnings
 from functools import wraps
 
@@ -62,4 +63,26 @@ def keyword_only(func):
 
     notice = ".. Note:: This method requires all argument be specified by keyword.\n"
     wrapper.__doc__ = notice + wrapper.__doc__
+    return wrapper
+
+
+def deprecate_conda_env(f):
+    conda_env_var_name = "conda_env"
+    spec = inspect.getfullargspec(f)
+    conda_env_index = spec.args.index(conda_env_var_name)
+
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        is_conda_env_supplied = len(args) > conda_env_index or conda_env_var_name in kwargs
+        if is_conda_env_supplied:
+            warnings.warn(
+                (
+                    "The `conda_env` argument has been deprecated, "
+                    "please use `pip_requirements` instead"
+                ),
+                FutureWarning,
+                stacklevel=2,
+            )
+        return f(*args, **kwargs)
+
     return wrapper

--- a/mlflow/utils/annotations.py
+++ b/mlflow/utils/annotations.py
@@ -73,7 +73,9 @@ def deprecate_conda_env(f):
     """
     conda_env_var_name = "conda_env"
     spec = inspect.getfullargspec(f)
-    conda_env_index = spec.args.index(conda_env_var_name)
+    # Note `spec.args` contains positional, positional-only (introduced in Python 3.8),
+    # and keyword arguments.
+    conda_env_index = (spec.args + spec.kwonlyargs).index(conda_env_var_name)
 
     @wraps(f)
     def wrapper(*args, **kwargs):

--- a/mlflow/utils/annotations.py
+++ b/mlflow/utils/annotations.py
@@ -77,8 +77,8 @@ def deprecate_conda_env(f):
         if is_conda_env_supplied:
             warnings.warn(
                 (
-                    "The `conda_env` argument has been deprecated, "
-                    "please use `pip_requirements` instead"
+                    "`conda_env` has been deprecated, please use `pip_requirements` or "
+                    "`additional_pip_requirements` instead"
                 ),
                 FutureWarning,
                 stacklevel=2,

--- a/mlflow/utils/annotations.py
+++ b/mlflow/utils/annotations.py
@@ -67,6 +67,10 @@ def keyword_only(func):
 
 
 def deprecate_conda_env(f):
+    """
+    Wraps the given function to raise a deprecation warning when the `conda_env` argument is
+    supplied.
+    """
     conda_env_var_name = "conda_env"
     spec = inspect.getfullargspec(f)
     conda_env_index = spec.args.index(conda_env_var_name)
@@ -78,7 +82,7 @@ def deprecate_conda_env(f):
             warnings.warn(
                 (
                     "`conda_env` has been deprecated, please use `pip_requirements` or "
-                    "`additional_pip_requirements` instead"
+                    "`additional_pip_requirements` instead."
                 ),
                 FutureWarning,
                 stacklevel=2,

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -36,7 +36,7 @@ from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.environment import _mlflow_conda_env, _log_pip_requirements
 from mlflow.utils.model_utils import _get_flavor_configuration
 from mlflow.exceptions import MlflowException
-from mlflow.utils.annotations import experimental
+from mlflow.utils.annotations import experimental, deprecate_conda_env
 from mlflow.utils.autologging_utils import (
     autologging_integration,
     safe_patch,
@@ -77,6 +77,7 @@ def get_default_conda_env():
     )
 
 
+@deprecate_conda_env
 def save_model(
     xgb_model,
     path,
@@ -168,6 +169,7 @@ def save_model(
     mlflow_model.save(os.path.join(path, MLMODEL_FILE_NAME))
 
 
+@deprecate_conda_env
 def log_model(
     xgb_model,
     artifact_path,

--- a/tests/utils/test_annotations.py
+++ b/tests/utils/test_annotations.py
@@ -1,0 +1,26 @@
+import pytest
+from unittest import mock
+
+from mlflow.utils.annotations import deprecate_conda_env
+
+
+def test_deprecate_conda_env():
+    @deprecate_conda_env
+    def f(a, conda_env=None):
+        """docstring"""
+
+    assert f.__name__ == "f"
+    assert f.__doc__ == "docstring"
+
+    with pytest.warns(FutureWarning, match="`conda_env` has been deprecated"):
+        f(0, {})
+
+    with pytest.warns(FutureWarning, match="`conda_env` has been deprecated"):
+        f(0, conda_env={})
+
+    with pytest.warns(FutureWarning, match="`conda_env` has been deprecated"):
+        f(0, conda_env=None)
+
+    with mock.patch("warnings.warn") as mock_warn:
+        f(0)
+        mock_warn.assert_not_called()

--- a/tests/utils/test_annotations.py
+++ b/tests/utils/test_annotations.py
@@ -16,9 +16,6 @@ def keyword_only_arg(a, *, conda_env=None):
     """keyword_only"""
 
 
-# Only Python 3.8 and newer support positional-only arguments
-# def positional_only_arg(a, conda_env, /):
-#     """positional_only"""
 
 
 @pytest.mark.parametrize("original", [_positional_arg, _keyword_arg, keyword_only_arg])

--- a/tests/utils/test_annotations.py
+++ b/tests/utils/test_annotations.py
@@ -16,8 +16,6 @@ def keyword_only_arg(a, *, conda_env=None):
     """keyword_only"""
 
 
-
-
 @pytest.mark.parametrize("original", [_positional_arg, _keyword_arg, keyword_only_arg])
 def test_deprecate_conda_env(original):
     wrapped = deprecate_conda_env(original)

--- a/tests/utils/test_annotations.py
+++ b/tests/utils/test_annotations.py
@@ -4,35 +4,44 @@ from unittest import mock
 from mlflow.utils.annotations import deprecate_conda_env
 
 
-def _positional_arg(a, conda_env):
-    """positional"""
-
-
-def _keyword_arg(a, conda_env=None):
+def _keyword_arg(a, conda_env=None, b=0):
     """keyword"""
 
 
-def keyword_only_arg(a, *, conda_env=None):
+def _keyword_only_arg(a, *, conda_env=None, b=0):
     """keyword_only"""
 
 
-@pytest.mark.parametrize("original", [_positional_arg, _keyword_arg, keyword_only_arg])
-def test_deprecate_conda_env(original):
-    wrapped = deprecate_conda_env(original)
-    assert wrapped.__name__ == original.__name__
-    assert wrapped.__doc__ == original.__doc__
+def test_deprecate_conda_env_preserves_function_attributes():
+    wrapped = deprecate_conda_env(_keyword_arg)
+    assert wrapped.__name__ == _keyword_arg.__name__
+    assert wrapped.__doc__ == _keyword_arg.__doc__
 
-    if original != keyword_only_arg:
-        with pytest.warns(FutureWarning, match="`conda_env` has been deprecated"):
-            wrapped(0, {})
+
+def test_deprecate_conda_env_keyword_arg():
+    wrapped = deprecate_conda_env(_keyword_arg)
+
+    with pytest.warns(FutureWarning, match="`conda_env` has been deprecated"):
+        wrapped(0, {})
 
     with pytest.warns(FutureWarning, match="`conda_env` has been deprecated"):
         wrapped(0, conda_env={})
 
-    with pytest.warns(FutureWarning, match="`conda_env` has been deprecated"):
-        wrapped(0, conda_env=None)
+    with mock.patch("warnings.warn") as mock_warn:
+        wrapped(0, None)
+        mock_warn.assert_not_called()
 
-    if original != _positional_arg:
-        with mock.patch("warnings.warn") as mock_warn:
-            wrapped(0)
-            mock_warn.assert_not_called()
+        mock_warn.reset_mock()
+        wrapped(0, conda_env=None)
+        mock_warn.assert_not_called()
+
+
+def test_deprecate_conda_env_keyword_only_arg():
+    wrapped = deprecate_conda_env(_keyword_only_arg)
+
+    with pytest.warns(FutureWarning, match="`conda_env` has been deprecated"):
+        wrapped(0, conda_env={})
+
+    with mock.patch("warnings.warn") as mock_warn:
+        wrapped(0, conda_env=None)
+        mock_warn.assert_not_called()


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

[WIP][ML-16201] Deprecate the use of `conda_env` argument in `log_model`.

## How is this patch tested?

Unit tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
