### PR TITLE
Created command context provider to set job group ID as part of run tags

### DIFF
--- a/mlflow/tracking/context/databricks_command_context.py
+++ b/mlflow/tracking/context/databricks_command_context.py
@@ -1,0 +1,15 @@
+from mlflow.tracking.context.abstract_context import RunContextProvider
+from mlflow.utils import databricks_utils
+from mlflow.utils.mlflow_tags import MLFLOW_DATABRICKS_COMMAND_ID
+
+
+class DatabricksCommandRunContext(RunContextProvider):
+    def in_context(self):
+        return databricks_utils.get_job_group_id() is not None
+
+    def tags(self):
+        job_group_id = databricks_utils.get_job_group_id()
+        tags = {}
+        if job_group_id is not None:
+            tags[MLFLOW_DATABRICKS_COMMAND_ID] = job_group_id
+        return tags

--- a/mlflow/tracking/context/databricks_command_context.py
+++ b/mlflow/tracking/context/databricks_command_context.py
@@ -1,6 +1,6 @@
 from mlflow.tracking.context.abstract_context import RunContextProvider
 from mlflow.utils import databricks_utils
-from mlflow.utils.mlflow_tags import MLFLOW_DATABRICKS_COMMAND_ID
+from mlflow.utils.mlflow_tags import MLFLOW_DATABRICKS_NOTEBOOK_COMMAND_ID
 
 
 class DatabricksCommandRunContext(RunContextProvider):
@@ -11,5 +11,5 @@ class DatabricksCommandRunContext(RunContextProvider):
         job_group_id = databricks_utils.get_job_group_id()
         tags = {}
         if job_group_id is not None:
-            tags[MLFLOW_DATABRICKS_COMMAND_ID] = job_group_id
+            tags[MLFLOW_DATABRICKS_NOTEBOOK_COMMAND_ID] = job_group_id
         return tags

--- a/mlflow/tracking/context/registry.py
+++ b/mlflow/tracking/context/registry.py
@@ -7,6 +7,7 @@ from mlflow.tracking.context.git_context import GitRunContext
 from mlflow.tracking.context.databricks_notebook_context import DatabricksNotebookRunContext
 from mlflow.tracking.context.databricks_job_context import DatabricksJobRunContext
 from mlflow.tracking.context.databricks_cluster_context import DatabricksClusterRunContext
+from mlflow.tracking.context.databricks_command_context import DatabricksCommandRunContext
 
 
 _logger = logging.getLogger(__name__)
@@ -53,6 +54,7 @@ _run_context_provider_registry.register(GitRunContext)
 _run_context_provider_registry.register(DatabricksNotebookRunContext)
 _run_context_provider_registry.register(DatabricksJobRunContext)
 _run_context_provider_registry.register(DatabricksClusterRunContext)
+_run_context_provider_registry.register(DatabricksCommandRunContext)
 
 _run_context_provider_registry.register_entrypoints()
 

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -151,6 +151,16 @@ def get_cluster_id():
     return spark_session.conf.get("spark.databricks.clusterUsageTags.clusterId")
 
 
+def get_job_group_id():
+    try:
+        dbutils = _get_dbutils()
+        job_group_id = dbutils.entry_point.getJobGroupId()
+        if job_group_id is not None:
+            return job_group_id
+    except Exception:
+        return None
+
+
 def get_job_id():
     try:
         return _get_command_context().jobId().get()

--- a/mlflow/utils/mlflow_tags.py
+++ b/mlflow/utils/mlflow_tags.py
@@ -27,6 +27,7 @@ MLFLOW_DATABRICKS_NOTEBOOK_PATH = "mlflow.databricks.notebookPath"
 MLFLOW_DATABRICKS_WEBAPP_URL = "mlflow.databricks.webappURL"
 MLFLOW_DATABRICKS_RUN_URL = "mlflow.databricks.runURL"
 MLFLOW_DATABRICKS_CLUSTER_ID = "mlflow.databricks.cluster.id"
+MLFLOW_DATABRICKS_COMMAND_ID = "mlflow.databricks.commandID"
 # The SHELL_JOB_ID and SHELL_JOB_RUN_ID tags are used for tracking the
 # Databricks Job ID and Databricks Job Run ID associated with an MLflow Project run
 MLFLOW_DATABRICKS_SHELL_JOB_ID = "mlflow.databricks.shellJobID"

--- a/mlflow/utils/mlflow_tags.py
+++ b/mlflow/utils/mlflow_tags.py
@@ -27,7 +27,8 @@ MLFLOW_DATABRICKS_NOTEBOOK_PATH = "mlflow.databricks.notebookPath"
 MLFLOW_DATABRICKS_WEBAPP_URL = "mlflow.databricks.webappURL"
 MLFLOW_DATABRICKS_RUN_URL = "mlflow.databricks.runURL"
 MLFLOW_DATABRICKS_CLUSTER_ID = "mlflow.databricks.cluster.id"
-MLFLOW_DATABRICKS_COMMAND_ID = "mlflow.databricks.commandID"
+# The unique ID of a command execution in a Databricks notebook
+MLFLOW_DATABRICKS_NOTEBOOK_COMMAND_ID = "mlflow.databricks.notebook.commandID"
 # The SHELL_JOB_ID and SHELL_JOB_RUN_ID tags are used for tracking the
 # Databricks Job ID and Databricks Job Run ID associated with an MLflow Project run
 MLFLOW_DATABRICKS_SHELL_JOB_ID = "mlflow.databricks.shellJobID"

--- a/tests/tracking/context/test_databricks_command_context.py
+++ b/tests/tracking/context/test_databricks_command_context.py
@@ -19,7 +19,5 @@ def test_databricks_command_run_context_tags():
 
 
 def test_databricks_command_run_context_tags_nones():
-    with mock.patch(
-        "mlflow.utils.databricks_utils.get_job_group_id", return_value=None
-    ) as job_group_id_mock:
+    with mock.patch("mlflow.utils.databricks_utils.get_job_group_id", return_value=None) as _:
         assert DatabricksCommandRunContext().tags() == {}

--- a/tests/tracking/context/test_databricks_command_context.py
+++ b/tests/tracking/context/test_databricks_command_context.py
@@ -1,0 +1,25 @@
+from unittest import mock
+
+from mlflow.utils.mlflow_tags import MLFLOW_DATABRICKS_COMMAND_ID
+from mlflow.tracking.context.databricks_command_context import DatabricksCommandRunContext
+
+
+def test_databricks_command_run_context_in_context():
+    with mock.patch("mlflow.utils.databricks_utils.get_job_group_id") as job_group_id_mock:
+        assert DatabricksCommandRunContext().in_context() == (
+            job_group_id_mock.return_value is not None
+        )
+
+
+def test_databricks_command_run_context_tags():
+    with mock.patch("mlflow.utils.databricks_utils.get_job_group_id") as job_group_id_mock:
+        assert DatabricksCommandRunContext().tags() == {
+            MLFLOW_DATABRICKS_COMMAND_ID: job_group_id_mock.return_value
+        }
+
+
+def test_databricks_command_run_context_tags_nones():
+    with mock.patch(
+        "mlflow.utils.databricks_utils.get_job_group_id", return_value=None
+    ) as job_group_id_mock:
+        assert DatabricksCommandRunContext().tags() == {}

--- a/tests/tracking/context/test_databricks_command_context.py
+++ b/tests/tracking/context/test_databricks_command_context.py
@@ -5,10 +5,8 @@ from mlflow.tracking.context.databricks_command_context import DatabricksCommand
 
 
 def test_databricks_command_run_context_in_context():
-    with mock.patch("mlflow.utils.databricks_utils.get_job_group_id") as job_group_id_mock:
-        assert DatabricksCommandRunContext().in_context() == (
-            job_group_id_mock.return_value is not None
-        )
+    with mock.patch("mlflow.utils.databricks_utils.get_job_group_id", return_value="1"):
+        assert DatabricksCommandRunContext().in_context()
 
 
 def test_databricks_command_run_context_tags():
@@ -19,5 +17,5 @@ def test_databricks_command_run_context_tags():
 
 
 def test_databricks_command_run_context_tags_nones():
-    with mock.patch("mlflow.utils.databricks_utils.get_job_group_id", return_value=None) as _:
+    with mock.patch("mlflow.utils.databricks_utils.get_job_group_id", return_value=None):
         assert DatabricksCommandRunContext().tags() == {}

--- a/tests/tracking/context/test_databricks_command_context.py
+++ b/tests/tracking/context/test_databricks_command_context.py
@@ -1,6 +1,6 @@
 from unittest import mock
 
-from mlflow.utils.mlflow_tags import MLFLOW_DATABRICKS_COMMAND_ID
+from mlflow.utils.mlflow_tags import MLFLOW_DATABRICKS_NOTEBOOK_COMMAND_ID
 from mlflow.tracking.context.databricks_command_context import DatabricksCommandRunContext
 
 
@@ -14,7 +14,7 @@ def test_databricks_command_run_context_in_context():
 def test_databricks_command_run_context_tags():
     with mock.patch("mlflow.utils.databricks_utils.get_job_group_id") as job_group_id_mock:
         assert DatabricksCommandRunContext().tags() == {
-            MLFLOW_DATABRICKS_COMMAND_ID: job_group_id_mock.return_value
+            MLFLOW_DATABRICKS_NOTEBOOK_COMMAND_ID: job_group_id_mock.return_value
         }
 
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Created command context provider to set job group ID as part of run tags. We use the job group ID as the command ID because it is set for every command in Databricks.

## How is this patch tested?

Unit tests were added for the new run context.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
