### PR TITLE
XGBoost autologging: support per-class importance plots

### DIFF
--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -446,15 +446,21 @@ def autolog(
                 # `num_features`-by-`num_classes` matrix structure, we coerce the importance
                 # values to a `num_features`-by-1 matrix
                 indices = np.argsort(importance)
+                # Sort features and importance values by magnitude during transformation to a
+                # `num_features`-by-`num_classes` matrix
                 features = features[indices]
                 importances_per_class_by_feature = np.array(
-                    [[importance] for importance in importances_per_class_by_feature]
+                    [[importance] for importance in importances_per_class_by_feature[indices]]
                 )
                 # In this case, do not include class labels on the feature importance plot because
                 # only one importance value has been provided per feature, rather than an
                 # one importance value for each class per feature
                 label_classes_on_plot = False
             else:
+                importance_value_magnitudes = np.abs(importances_per_class_by_feature).sum(axis=1)
+                indices = np.argsort(importance_value_magnitudes)
+                features = features[indices]
+                importances_per_class_by_feature = importances_per_class_by_feature[indices]
                 label_classes_on_plot = True
 
             num_classes = importances_per_class_by_feature.shape[1]
@@ -489,7 +495,10 @@ def autolog(
                         feature_yloc + offset,
                         class_importance,
                         align="center",
-                        height=(0.5 / num_classes),
+                        # Set the bar height such that importance value bars for a particular
+                        # feature are spaced properly relative to each other (no overlap or gaps)
+                        # and relative to importance value bars for other features
+                        height=(0.5 / max(num_classes - 1, 1)),
                     )
                     if label_classes_on_plot and feature_idx == 0:
                         # Only set a label the first time a bar for a particular class is plotted to

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -478,7 +478,7 @@ def autolog(
             feature_ylocs = np.arange(num_features)
             # Define offsets on the y-axis that are used to evenly space the bars for each class
             # around the y-axis position of each feature
-            offsets_per_yloc = np.linspace(-0.5, 0.5, num_classes) / 2
+            offsets_per_yloc = np.linspace(-0.5, 0.5, num_classes) / 2 if num_classes > 1 else [0]
             for feature_idx, (feature_yloc, importances_per_class) in enumerate(
                 zip(feature_ylocs, importances_per_class_by_feature)
             ):

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -464,6 +464,7 @@ def autolog(
             # from being too dense.
             w, h = [6.4, 4.8]  # matplotlib's default figure size
             h = h + 0.1 * num_features if num_features > 10 else h
+            h = h + 0.1 * num_classes if num_classes > 1 else h
             fig, ax = plt.subplots(figsize=(w, h))
             # When importance values are provided for each class per feature, we want to ensure
             # that the same color is used for all bars in the bar chart that have the same class
@@ -477,10 +478,7 @@ def autolog(
             feature_ylocs = np.arange(num_features)
             # Define offsets on the y-axis that are used to evenly space the bars for each class
             # around the y-axis position of each feature
-            offsets_per_yloc = np.arange((1 - num_classes) / 2, ((num_classes - 1) / 2) + 1)
-            # Ensure that per-class bars for adjacent features do not overlap by reducing the size
-            # of the offsets by a factor proportional to the number of features
-            offsets_per_yloc = offsets_per_yloc / (num_features * 2)
+            offsets_per_yloc = np.linspace(-0.5, 0.5, num_classes) / 2
             for feature_idx, (feature_yloc, importances_per_class) in enumerate(
                 zip(feature_ylocs, importances_per_class_by_feature)
             ):
@@ -491,7 +489,7 @@ def autolog(
                         feature_yloc + offset,
                         class_importance,
                         align="center",
-                        height=(1.0 / (num_features * num_classes)),
+                        height=(0.5 / num_classes),
                     )
                     if label_classes_on_plot and feature_idx == 0:
                         # Only set a label the first time a bar for a particular class is plotted to

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -447,7 +447,9 @@ def autolog(
                 # values to a `num_features`-by-1 matrix
                 indices = np.argsort(importance)
                 features = features[indices]
-                importances_per_class_by_feature = np.array([[importance] for importance in importances_per_class_by_feature])
+                importances_per_class_by_feature = np.array(
+                    [[importance] for importance in importances_per_class_by_feature]
+                )
                 # In this case, do not include class labels on the feature importance plot because
                 # only one importance value has been provided per feature, rather than an
                 # one importance value for each class per feature
@@ -465,7 +467,7 @@ def autolog(
             fig, ax = plt.subplots(figsize=(w, h))
             # When importance values are provided for each class per feature, we want to ensure
             # that the same color is used for all bars in the bar chart that have the same class
-            colors_to_cycle = plt.rcParams['axes.prop_cycle'].by_key()['color'][:num_classes]
+            colors_to_cycle = plt.rcParams["axes.prop_cycle"].by_key()["color"][:num_classes]
             color_cycler = cycler(color=colors_to_cycle)
             ax.set_prop_cycle(color_cycler)
 
@@ -479,9 +481,18 @@ def autolog(
             # Ensure that per-class bars for adjacent features do not overlap by reducing the size
             # of the offsets by a factor proportional to the number of features
             offsets_per_yloc = offsets_per_yloc / (num_features * 2)
-            for feature_idx, (feature_yloc, importances_per_class) in enumerate(zip(feature_ylocs, importances_per_class_by_feature)):
-                for class_idx, (offset, class_importance) in enumerate(zip(offsets_per_yloc, importances_per_class)):
-                    bar, = ax.barh(feature_yloc + offset, class_importance, align="center", height=(1.0 / (num_features * num_classes)))
+            for feature_idx, (feature_yloc, importances_per_class) in enumerate(
+                zip(feature_ylocs, importances_per_class_by_feature)
+            ):
+                for class_idx, (offset, class_importance) in enumerate(
+                    zip(offsets_per_yloc, importances_per_class)
+                ):
+                    (bar,) = ax.barh(
+                        feature_yloc + offset,
+                        class_importance,
+                        align="center",
+                        height=(1.0 / (num_features * num_classes)),
+                    )
                     if label_classes_on_plot and feature_idx == 0:
                         # Only set a label the first time a bar for a particular class is plotted to
                         # avoid duplicate legend entries. If we were to set a label for every bar,

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -434,12 +434,28 @@ def autolog(
             Log feature importance plot.
             """
             import matplotlib.pyplot as plt
+            from cycler import cycler
 
             features = np.array(features)
-            importance = np.array(importance)
-            indices = np.argsort(importance)
-            features = features[indices]
-            importance = importance[indices]
+
+            # Structure the supplied `importance` values as a `num_features`-by-`num_classes` matrix
+            importances_per_class_by_feature = np.array(importance)
+            if importances_per_class_by_feature.ndim <= 1:
+                # In this case, the supplied `importance` values are not given per class. Rather,
+                # one importance value is given per feature. For consistency with the assumed
+                # `num_features`-by-`num_classes` matrix structure, we coerce the importance
+                # values to a `num_features`-by-1 matrix
+                indices = np.argsort(importance)
+                features = features[indices]
+                importances_per_class_by_feature = np.array([[importance] for importance in importances_per_class_by_feature])
+                # In this case, do not include class labels on the feature importance plot because
+                # only one importance value has been provided per feature, rather than an
+                # one importance value for each class per feature
+                label_classes_on_plot = False
+            else:
+                label_classes_on_plot = True
+
+            num_classes = importances_per_class_by_feature.shape[1]
             num_features = len(features)
 
             # If num_features > 10, increase the figure height to prevent the plot
@@ -447,13 +463,37 @@ def autolog(
             w, h = [6.4, 4.8]  # matplotlib's default figure size
             h = h + 0.1 * num_features if num_features > 10 else h
             fig, ax = plt.subplots(figsize=(w, h))
+            # When importance values are provided for each class per feature, we want to ensure
+            # that the same color is used for all bars in the bar chart that have the same class
+            colors_to_cycle = plt.rcParams['axes.prop_cycle'].by_key()['color'][:num_classes]
+            color_cycler = cycler(color=colors_to_cycle)
+            ax.set_prop_cycle(color_cycler)
 
-            yloc = np.arange(num_features)
-            ax.barh(yloc, importance, align="center", height=0.5)
-            ax.set_yticks(yloc)
+            # The following logic operates on one feature at a time, adding a bar to the bar chart
+            # for each class that reflects the importance of the feature to predictions of that
+            # class
+            feature_ylocs = np.arange(num_features)
+            # Define offsets on the y-axis that are used to evenly space the bars for each class
+            # around the y-axis position of each feature
+            offsets_per_yloc = np.arange((1 - num_classes) / 2, ((num_classes - 1) / 2) + 1)
+            # Ensure that per-class bars for adjacent features do not overlap by reducing the size
+            # of the offsets by a factor proportional to the number of features
+            offsets_per_yloc = offsets_per_yloc / (num_features * 2)
+            for feature_idx, (feature_yloc, importances_per_class) in enumerate(zip(feature_ylocs, importances_per_class_by_feature)):
+                for class_idx, (offset, class_importance) in enumerate(zip(offsets_per_yloc, importances_per_class)):
+                    bar, = ax.barh(feature_yloc + offset, class_importance, align="center", height=(1.0 / (num_features * num_classes)))
+                    if label_classes_on_plot and feature_idx == 0:
+                        # Only set a label the first time a bar for a particular class is plotted to
+                        # avoid duplicate legend entries. If we were to set a label for every bar,
+                        # the legend would contain `num_features` labels for each class.
+                        bar.set_label("Class {}".format(class_idx))
+
+            ax.set_yticks(feature_ylocs)
             ax.set_yticklabels(features)
             ax.set_xlabel("Importance")
             ax.set_title("Feature Importance ({})".format(importance_type))
+            if label_classes_on_plot:
+                ax.legend()
             fig.tight_layout()
 
             tmpdir = tempfile.mkdtemp()
@@ -539,15 +579,15 @@ def autolog(
         # logging feature importance as artifacts.
         for imp_type in importance_types:
             imp = None
-            try:
-                imp = model.get_score(importance_type=imp_type)
-                features, importance = zip(*imp.items())
-                log_feature_importance_plot(features, importance, imp_type)
-            except Exception:
-                _logger.exception(
-                    "Failed to log feature importance plot. XGBoost autologging "
-                    "will ignore the failure and continue. Exception: "
-                )
+            # try:
+            imp = model.get_score(importance_type=imp_type)
+            features, importance = zip(*imp.items())
+            log_feature_importance_plot(features, importance, imp_type)
+            # except Exception:
+            #     _logger.exception(
+            #         "Failed to log feature importance plot. XGBoost autologging "
+            #         "will ignore the failure and continue. Exception: "
+            #     )
 
             if imp is not None:
                 tmpdir = tempfile.mkdtemp()

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -588,15 +588,15 @@ def autolog(
         # logging feature importance as artifacts.
         for imp_type in importance_types:
             imp = None
-            # try:
-            imp = model.get_score(importance_type=imp_type)
-            features, importance = zip(*imp.items())
-            log_feature_importance_plot(features, importance, imp_type)
-            # except Exception:
-            #     _logger.exception(
-            #         "Failed to log feature importance plot. XGBoost autologging "
-            #         "will ignore the failure and continue. Exception: "
-            #     )
+            try:
+                imp = model.get_score(importance_type=imp_type)
+                features, importance = zip(*imp.items())
+                log_feature_importance_plot(features, importance, imp_type)
+            except Exception:
+                _logger.exception(
+                    "Failed to log feature importance plot. XGBoost autologging "
+                    "will ignore the failure and continue. Exception: "
+                )
 
             if imp is not None:
                 tmpdir = tempfile.mkdtemp()

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -309,7 +309,7 @@ def test_xgb_autolog_logs_feature_importance_for_linear_boosters(dtrain):
 
     bst_params = {"objective": "multi:softprob", "num_class": 3, "booster": "gblinear"}
     model = xgb.train(bst_params, dtrain)
-    
+
     run = get_latest_run()
     run_id = run.info.run_id
     artifacts_dir = run.info.artifact_uri.replace("file://", "")

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -297,6 +297,40 @@ def test_xgb_autolog_logs_specified_feature_importance(bst_params, dtrain):
 
 
 @pytest.mark.large
+@pytest.mark.skipif(
+    Version(xgb.__version__) <= Version("1.4.2"),
+    reason=(
+        "In XGBoost <= 1.4.2, linear boosters do not support `get_score()` for importance value"
+        " creation."
+    ),
+)
+def test_xgb_autolog_logs_feature_importance_for_linear_boosters(dtrain):
+    mlflow.xgboost.autolog()
+
+    bst_params = {"objective": "multi:softprob", "num_class": 3, "booster": "gblinear"}
+    model = xgb.train(bst_params, dtrain)
+    
+    run = get_latest_run()
+    run_id = run.info.run_id
+    artifacts_dir = run.info.artifact_uri.replace("file://", "")
+    client = mlflow.tracking.MlflowClient()
+    artifacts = [x.path for x in client.list_artifacts(run_id)]
+
+    importance_type = "weight"
+    plot_name = "feature_importance_{}.png".format(importance_type)
+    assert plot_name in artifacts
+
+    json_name = "feature_importance_{}.json".format(importance_type)
+    assert json_name in artifacts
+
+    json_path = os.path.join(artifacts_dir, json_name)
+    with open(json_path, "r") as f:
+        loaded_imp = json.load(f)
+
+    assert loaded_imp == model.get_score(importance_type=importance_type)
+
+
+@pytest.mark.large
 def test_no_figure_is_opened_after_logging(bst_params, dtrain):
     mlflow.xgboost.autolog()
     xgb.train(bst_params, dtrain)


### PR DESCRIPTION
## What changes are proposed in this pull request?

XGBoost 1.15.0-dev introduced support for importance computation on linear estimators. These estimators return importance values for each (feature, class) pair as a `num_features`-by-`num_classes` matrix. This PR introduces extends feature importance plotting support in XGBoost autologging to handle this new importance value format.

## How is this patch tested?

- Unit tests
- Manual tests on XGBoost 1.15.0-dev:

1. Linear booster training on Iris

```python
from sklearn.datasets import load_iris

iris = load_iris()

import mlflow
mlflow.xgboost.autolog()


import xgboost as xgb
dtrain = xgb.DMatrix(iris.data, label=iris.target)

bst_params = {"objective": "multi:softprob", "num_class": 3, "booster": "gblinear"}
model = xgb.train(bst_params, dtrain)
```

![feature_importance_weight](https://user-images.githubusercontent.com/39497902/124195090-8a8a8380-da7e-11eb-9588-cc250aebf3ce.png)

2. Tree booster training on Iris

```python
from sklearn.datasets import load_iris

iris = load_iris()

import mlflow
mlflow.xgboost.autolog()


import xgboost as xgb
dtrain = xgb.DMatrix(iris.data, label=iris.target)

bst_params = {
        "objective": "multi:softprob",
        "num_class": 10,
        "eval_metric": "mlogloss",
        "booster": "gbtree",
    }
model = xgb.train(bst_params, dtrain)
```

![feature_importance_weight](https://user-images.githubusercontent.com/39497902/124196214-ca526a80-da80-11eb-81e4-7e2b68f77e20.png)

3. Linear booster training on MNIST

```python
from sklearn.datasets import load_digits

digits = load_digits()

import mlflow
mlflow.xgboost.autolog()


import xgboost as xgb
dtrain = xgb.DMatrix(digits.data, label=digits.target)

bst_params = {"objective": "multi:softprob", "num_class": 10, "booster": "gblinear"}
model = xgb.train(bst_params, dtrain)

```

![feature_importance_weight](https://user-images.githubusercontent.com/39497902/124194811-14861c80-da7e-11eb-8727-ca1cbbd699a6.png)


4. Tree booster training on MNIST

```
from sklearn.datasets import load_digits

digits = load_digits()

import mlflow
mlflow.xgboost.autolog()


import xgboost as xgb
dtrain = xgb.DMatrix(digits.data, label=digits.target)

bst_params = {
        "objective": "multi:softprob",
        "num_class": 10,
        "eval_metric": "mlogloss",
        "booster": "gbtree",
    }
model = xgb.train(bst_params, dtrain)
```

![feature_importance_weight](https://user-images.githubusercontent.com/39497902/124196344-11d8f680-da81-11eb-8c15-c8a40985e335.png)

## Release Notes

Add XGBoost autologging support for multi-class feature importance plots

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
