### PR TITLE
[Cross version tests] Run tests for dev versions when the `enable-dev-tests` label is applied

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -57,4 +57,4 @@ pytest dev/set_matrix.py --doctest-modules
 
 1. Click `Labels` in the right sidebar.
 2. Select the `enable-dev-tests` label.
-3. Push a commit.
+3. Push a commit or re-run the `Cross-version-tests`

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -57,4 +57,4 @@ pytest dev/set_matrix.py --doctest-modules
 
 1. Click `Labels` in the right sidebar.
 2. Select the `enable-dev-tests` label.
-3. Push a commit or re-run the `Cross-version-tests`
+3. Push a commit or re-run the `Cross-version-tests` workflow.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -57,4 +57,4 @@ pytest dev/set_matrix.py --doctest-modules
 
 1. Click `Labels` in the right sidebar.
 2. Select the `enable-dev-tests` label.
-3. Push a commit or re-run the `Cross-version-tests` workflow.
+3. Push a commit or re-run the `Cross version-tests` workflow.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -52,3 +52,9 @@ python dev/set_matrix.py --ref-versions-yaml $REF_VERSIONS_YAML --changed-files 
 ```sh
 pytest dev/set_matrix.py --doctest-modules
 ```
+
+## How to run tests for dev versions on a pull request:
+
+1. Click `Labels` in the right sidebar.
+2. Select the `enable-dev-tests` label.
+3. Push a commit.

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -33,7 +33,6 @@ jobs:
               repo: context.repo.repo,
               issue_number: context.issue.number,
             });
-            console.log(labels);
             return labels.data.some(({ name }) => name === "enable-dev-tests");
       - name: Test set_matrix.py
         run: |
@@ -50,7 +49,7 @@ jobs:
             CHANGED_FILES="$(git diff --name-only master..HEAD)"
             ENABLE_DEV_TESTS="${{ steps.enable-dev-tests.outputs.result }}"
             EXCLUDE_DEV_VERSIONS_FLAG=$([ "$ENABLE_DEV_TESTS" == "true" ] && echo "" || echo "--exclude-dev-versions")
-            python dev/set_matrix.py --ref-versions-yaml "$REF_VERSIONS_YAML" --changed-files "$CHANGED_FILES" "$EXCLUDE_DEV_VERSIONS_FLAG"
+            python dev/set_matrix.py --ref-versions-yaml "$REF_VERSIONS_YAML" --changed-files "$CHANGED_FILES" $EXCLUDE_DEV_VERSIONS_FLAG
           else
             python dev/set_matrix.py
           fi

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -36,7 +36,9 @@ jobs:
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             REF_VERSIONS_YAML="https://raw.githubusercontent.com/mlflow/mlflow/master/mlflow/ml-package-versions.yml"
             CHANGED_FILES="$(git diff --name-only master..HEAD)"
-            python dev/set_matrix.py --ref-versions-yaml "$REF_VERSIONS_YAML" --changed-files "$CHANGED_FILES" --exclude-dev-versions
+            ENABLE_DEV_TESTS="${{ contains(github.event.pull_request.labels.*.name, 'enable-dev-tests' }}"
+            EXCLUDE_DEV_VERSIONS_FLAG=$([ "$ENABLE_DEV_TESTS" == "true" ] && echo "" || echo "--exclude-dev-versions")
+            python dev/set_matrix.py --ref-versions-yaml "$REF_VERSIONS_YAML" --changed-files "$CHANGED_FILES" "$EXCLUDE_DEV_VERSIONS_FLAG"
           else
             python dev/set_matrix.py
           fi

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -25,8 +25,8 @@ jobs:
           pip install packaging pyyaml pytest
       - uses: actions/github-script@v4
         id: enable-dev-tests
-        result-encoding: string
         with:
+          result-encoding: string
           script: |
             const labels = await github.issues.listLabelsOnIssue({
               owner: context.repo.owner,

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -23,8 +23,10 @@ jobs:
       - name: Install dependencies
         run: |
           pip install packaging pyyaml pytest
-      - uses: actions/github-script@v4
+      - name: Check labels
+        uses: actions/github-script@v4
         id: enable-dev-tests
+        if: ${{ github.event_name == 'pull_request' }}
         with:
           result-encoding: string
           script: |

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -23,6 +23,18 @@ jobs:
       - name: Install dependencies
         run: |
           pip install packaging pyyaml pytest
+      - uses: actions/github-script@v4
+        id: enable-dev-tests
+        result-encoding: string
+        with:
+          script: |
+            const labels = await github.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            console.log(labels);
+            return labels.data.some(({ name }) => name === "enable-dev-tests");
       - name: Test set_matrix.py
         run: |
           pytest dev/set_matrix.py --doctest-modules
@@ -36,7 +48,7 @@ jobs:
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             REF_VERSIONS_YAML="https://raw.githubusercontent.com/mlflow/mlflow/master/mlflow/ml-package-versions.yml"
             CHANGED_FILES="$(git diff --name-only master..HEAD)"
-            ENABLE_DEV_TESTS="${{ contains(github.event.pull_request.labels.*.name, 'enable-dev-tests') }}"
+            ENABLE_DEV_TESTS="${{ steps.enable-dev-tests.outputs.result }}"
             EXCLUDE_DEV_VERSIONS_FLAG=$([ "$ENABLE_DEV_TESTS" == "true" ] && echo "" || echo "--exclude-dev-versions")
             python dev/set_matrix.py --ref-versions-yaml "$REF_VERSIONS_YAML" --changed-files "$CHANGED_FILES" "$EXCLUDE_DEV_VERSIONS_FLAG"
           else

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -36,7 +36,7 @@ jobs:
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             REF_VERSIONS_YAML="https://raw.githubusercontent.com/mlflow/mlflow/master/mlflow/ml-package-versions.yml"
             CHANGED_FILES="$(git diff --name-only master..HEAD)"
-            ENABLE_DEV_TESTS="${{ contains(github.event.pull_request.labels.*.name, 'enable-dev-tests' }}"
+            ENABLE_DEV_TESTS="${{ contains(github.event.pull_request.labels.*.name, 'enable-dev-tests') }}"
             EXCLUDE_DEV_VERSIONS_FLAG=$([ "$ENABLE_DEV_TESTS" == "true" ] && echo "" || echo "--exclude-dev-versions")
             python dev/set_matrix.py --ref-versions-yaml "$REF_VERSIONS_YAML" --changed-files "$CHANGED_FILES" "$EXCLUDE_DEV_VERSIONS_FLAG"
           else

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -51,6 +51,7 @@ _logger = logging.getLogger(__name__)
 _SklearnTrainingSession = _get_new_training_session_class()
 
 
+# CHANGE
 def get_default_conda_env(include_cloudpickle=False):
     """
     :return: The default Conda environment for MLflow Models produced by calls to

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -51,7 +51,6 @@ _logger = logging.getLogger(__name__)
 _SklearnTrainingSession = _get_new_training_session_class()
 
 
-# CHANGE
 def get_default_conda_env(include_cloudpickle=False):
     """
     :return: The default Conda environment for MLflow Models produced by calls to


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Run tests for dev versions when the `enable-dev-tests` label is applied on a pull request.

## How is this patch tested?

Verified:

- When `enable-dev-tests` is NOT applied, the dev versions are excluded.
- When `enable-dev-tests` is applied, the dev versions are included.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
