### PR TITLE
[cross version tests] Clean up commands for installing dev versions

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -57,4 +57,4 @@ pytest dev/set_matrix.py --doctest-modules
 
 1. Click `Labels` in the right sidebar.
 2. Select the `enable-dev-tests` label.
-3. Push a commit or re-run the `Cross version-tests` workflow.
+3. Push a commit or re-run the `Cross version tests` workflow.

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -115,7 +115,6 @@ jobs:
         run: |
           set -x
           pip freeze
-          pip freeze | grep ${{ matrix.package }}
       - name: Run tests
         env:
           MLFLOW_CONDA_HOME: /usr/share/miniconda

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -113,7 +113,6 @@ jobs:
           ${{ matrix.install }}
       - name: Check package versions
         run: |
-          set -x
           pip freeze
       - name: Run tests
         env:

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -113,7 +113,9 @@ jobs:
           ${{ matrix.install }}
       - name: Check package versions
         run: |
+          set -x
           pip freeze
+          pip freeze | grep ${{ matrix.package }}
       - name: Run tests
         env:
           MLFLOW_CONDA_HOME: /usr/share/miniconda

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -161,7 +161,9 @@ catboost:
     install_dev: |
       # The cross-version-tests workflow runs this command with the environment variable `CACHE_DIR`
       if [ ! -d "$CACHE_DIR" ] || [ -z $(find $CACHE_DIR -type f -name "catboost-*.whl") ]; then
-        pip wheel --no-deps --wheel-dir $CACHE_DIR git+https://github.com/catboost/catboost.git#subdirectory=catboost/python-package
+        head_sha=$(git ls-remote https://github.com/catboost/catboost.git HEAD | cut -f1)
+        pip wheel --no-deps --wheel-dir $CACHE_DIR \
+          git+https://github.com/catboost/catboost.git@head_sha#subdirectory=catboost/python-package
       fi
       pip install $(find $CACHE_DIR -type f -name "catboost-*.whl")
 

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -163,7 +163,7 @@ catboost:
       if [ ! -d "$CACHE_DIR" ] || [ -z $(find $CACHE_DIR -type f -name "catboost-*.whl") ]; then
         head_sha=$(git ls-remote https://github.com/catboost/catboost.git HEAD | cut -f1)
         pip wheel --no-deps --wheel-dir $CACHE_DIR \
-          git+https://github.com/catboost/catboost.git@head_sha#subdirectory=catboost/python-package
+          git+https://github.com/catboost/catboost.git@$head_sha#subdirectory=catboost/python-package
       fi
       pip install $(find $CACHE_DIR -type f -name "catboost-*.whl")
 

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -2,8 +2,7 @@ sklearn:
   package_info:
     pip_release: "scikit-learn"
     install_dev: |
-      head_sha=$(git ls-remote https://github.com/scikit-learn/scikit-learn.git HEAD | cut -f1)
-      pip install git+https://github.com/scikit-learn/scikit-learn.git@$head_sha
+      pip install git+https://github.com/scikit-learn/scikit-learn.git
 
   models:
     minimum: "0.20.3"
@@ -35,8 +34,7 @@ pytorch-lightning:
   package_info:
     pip_release: "pytorch-lightning"
     install_dev: |
-      head_sha=$(git ls-remote https://github.com/PytorchLightning/pytorch-lightning.git HEAD | cut -f1)
-      pip install git+https://github.com/PytorchLightning/pytorch-lightning.git@$head_sha
+      pip install git+https://github.com/PytorchLightning/pytorch-lightning.git
 
   autologging:
     minimum: "1.0.5"
@@ -121,11 +119,7 @@ xgboost:
   package_info:
     pip_release: "xgboost"
     install_dev: |
-      temp_dir=$(mktemp -d)
-      git clone --recursive https://github.com/dmlc/xgboost.git $temp_dir
-      git --git-dir=$temp_dir/.git rev-parse HEAD
-      cd $temp_dir/python-package
-      python setup.py install
+      pip install git+https://github.com/dmlc/xgboost.git#subdirectory=python-package
 
   models:
     minimum: "0.90"
@@ -145,11 +139,7 @@ lightgbm:
   package_info:
     pip_release: "lightgbm"
     install_dev: |
-      temp_dir=$(mktemp -d)
-      git clone --recursive https://github.com/microsoft/LightGBM.git $temp_dir
-      git --git-dir=$temp_dir/.git rev-parse HEAD
-      cd $temp_dir/python-package
-      python setup.py install
+      pip install git+https://github.com/microsoft/LightGBM.git#subdirectory=python-package
 
   models:
     minimum: "2.3.1"
@@ -170,24 +160,10 @@ catboost:
     pip_release: "catboost"
     install_dev: |
       # The cross-version-tests workflow runs this command with the environment variable `CACHE_DIR`
-      if [ -d "$CACHE_DIR" ] && [ ! -z $(find $CACHE_DIR -type f -name "catboost-*.whl") ]; then
-        pip install $(find $CACHE_DIR -type f -name "catboost-*.whl")
-      else
-        # Build wheel from source
-        temp_dir=$(mktemp -d)
-        git clone --depth 1 https://github.com/catboost/catboost.git $temp_dir
-        git --git-dir=$temp_dir/.git rev-parse HEAD
-        cd $temp_dir/catboost/python-package
-        python setup.py bdist_wheel
-
-        # Copy wheel in cache directory
-        wheel_path=$(find dist -type f -name "*.whl")
-        mkdir -p $CACHE_DIR
-        cp $wheel_path $CACHE_DIR
-
-        # Install wheel
-        pip install $wheel_path
+      if [ ! -d "$CACHE_DIR" ] || [ -z $(find $CACHE_DIR -type f -name "catboost-*.whl") ]; then
+        pip wheel --no-deps --wheel-dir $CACHE_DIR git+https://github.com/catboost/catboost.git#subdirectory=catboost/python-package
       fi
+      pip install $(find $CACHE_DIR -type f -name "catboost-*.whl")
 
   models:
     minimum: "0.23.1"
@@ -242,12 +218,7 @@ onnx:
     pip_release: "onnx"
     install_dev: |
       sudo apt-get install protobuf-compiler libprotoc-dev
-      temp_dir=$(mktemp -d)
-      git clone https://github.com/onnx/onnx.git $temp_dir
-      git --git-dir=$temp_dir/.git rev-parse HEAD
-      cd $temp_dir
-      git submodule update --init --recursive
-      python setup.py install
+      pip install git+https://github.com/onnx/onnx.git
 
   models:
     minimum: "1.5.0"
@@ -260,8 +231,7 @@ spacy:
   package_info:
     pip_release: "spacy"
     install_dev: |
-      head_sha=$(git ls-remote https://github.com/explosion/spaCy.git HEAD | cut -f1)
-      pip install git+https://github.com/explosion/spaCy.git@$head_sha
+      pip install git+https://github.com/explosion/spaCy.git
 
   models:
     minimum: "2.2.4"
@@ -274,8 +244,7 @@ statsmodels:
   package_info:
     pip_release: "statsmodels"
     install_dev: |
-      head_sha=$(git ls-remote https://github.com/statsmodels/statsmodels.git HEAD | cut -f1)
-      pip install git+https://github.com/statsmodels/statsmodels.git@$head_sha
+      pip install git+https://github.com/statsmodels/statsmodels.git
 
   models:
     minimum: "0.11.1"
@@ -294,9 +263,7 @@ spark:
     pip_release: "pyspark"
     install_dev: |
       # The cross-version-tests workflow runs this command with the environment variable `CACHE_DIR`
-      if [ -d "$CACHE_DIR" ] && [ ! -z $(find $CACHE_DIR -type f -name "pyspark-*.whl") ]; then
-        pip install $(find $CACHE_DIR -type f -name "pyspark-*.whl")
-      else
+      if [ ! -d "$CACHE_DIR" ] || [ -z $(find $CACHE_DIR -type f -name "pyspark-*.whl") ]; then
         # Build wheel from source
         temp_dir=$(mktemp -d)
         git clone --depth 1 https://github.com/apache/spark.git $temp_dir
@@ -305,16 +272,9 @@ spark:
         export MAVEN_OPTS="-Xss256m -Xmx2g -XX:ReservedCodeCacheSize=1g"
         ./build/mvn -DskipTests --no-transfer-progress clean package
         cd python
-        python setup.py bdist_wheel
-
-        # Copy wheel in cache directory
-        wheel_path=$(find dist -type f -name "*.whl")
-        mkdir -p $CACHE_DIR
-        cp $wheel_path $CACHE_DIR
-
-        # Install wheel
-        pip install $wheel_path
+        pip wheel --no-deps --wheel-dir $CACHE_DIR .
       fi
+      pip install $(find $CACHE_DIR -type f -name "pyspark-*.whl")
 
   models:
     minimum: "3.0.0"

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -272,7 +272,12 @@ spark:
         export MAVEN_OPTS="-Xss256m -Xmx2g -XX:ReservedCodeCacheSize=1g"
         ./build/mvn -DskipTests --no-transfer-progress clean package
         cd python
-        pip wheel --no-deps --wheel-dir $CACHE_DIR .
+        python setup.py bdist_wheel
+
+        # Copy wheel in cache directory
+        wheel_path=$(find dist -type f -name "pyspark-*.whl")
+        mkdir -p $CACHE_DIR
+        cp $wheel_path $CACHE_DIR
       fi
       pip install $(find $CACHE_DIR -type f -name "pyspark-*.whl")
 


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Clean up commands for installing dev versions.

## How is this patch tested?

Existing checks

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
