### PR TITLE
Fix release-note category validation workflow

### DIFF
--- a/.github/workflows/release-note-category.js
+++ b/.github/workflows/release-note-category.js
@@ -39,7 +39,7 @@ module.exports = async ({ core, context, github }) => {
   // If no release note category label is applied to this PR, set the action status to "failed"
   if (appliedLabels.length === 0) {
     // Make sure '.github/pull_request_template.md' contains an HTML anchor with this name
-    const anchorName = "release note-category";
+    const anchorName = "release-note-category";
 
     // Fragmented URL to jump to the release note category section in the PR description
     const anchorUrl = `${pr_url}#user-content-${anchorName}`;

--- a/.github/workflows/release-note-category.js
+++ b/.github/workflows/release-note-category.js
@@ -48,7 +48,7 @@ module.exports = async ({ core, context, github }) => {
       `Please select a checkbox in the release note category section: ${anchorUrl} `,
       "or manually apply a release note category label (e.g. 'rn/bug-fix') ",
       "if you're a maintainer of this repository. ",
-      "If this workflow failed when a release note category label has been already applied, ",
+      "If this workflow failed when a release note category label is already applied, ",
       "please re-run it.",
     ].join("");
     core.setFailed(message);

--- a/.github/workflows/release-note-category.js
+++ b/.github/workflows/release-note-category.js
@@ -1,4 +1,4 @@
-module.exports = ({ core, context, github }) => {
+module.exports = async ({ core, context, github }) => {
   const { user, html_url: pr_url } = context.payload.pull_request;
   const { owner, repo } = context.repo;
   const { number: issue_number } = context.issue;

--- a/.github/workflows/release-note-category.js
+++ b/.github/workflows/release-note-category.js
@@ -48,7 +48,7 @@ module.exports = async ({ core, context, github }) => {
       `Please select a checkbox in the release note category section: ${anchorUrl} `,
       "or manually apply a release note category label (e.g. 'rn/bug-fix') ",
       "if you're a maintainer of this repository. ",
-      "If this workflow failed when a release note category label is already applied, ",
+      "If this job failed when a release note category label is already applied, ",
       "please re-run it.",
     ].join("");
     core.setFailed(message);

--- a/.github/workflows/release-note-category.js
+++ b/.github/workflows/release-note-category.js
@@ -1,5 +1,7 @@
-module.exports = ({ core, context }) => {
-  const { body, user, html_url } = context.payload.pull_request;
+module.exports = ({ core, context, github }) => {
+  const { user, html_url: pr_url } = context.payload.pull_request;
+  const { owner, repo } = context.repo;
+  const { number: issue_number } = context.issue;
 
   // Skip validation on pull requests created by the automation bot
   if (user.login === "mlflow-automation") {
@@ -9,42 +11,43 @@ module.exports = ({ core, context }) => {
     return;
   }
 
-  const categories = [
-    "rn/feature",
-    "rn/breaking-change",
-    "rn/bug-fix",
-    "rn/documentation",
-    "rn/none",
-  ];
+  // Fetch release-note category labels
+  const labelsForRepoResp = await github.issues.listLabelsForRepo({
+    owner,
+    repo,
+  });
+  const releaseNoteLabels = labelsForRepoResp.data
+    .map(({ name }) => name)
+    .filter(name => name.startsWith("rn/"));
 
-  // Extract selected release-note categories from the PR description
-  const regexp = /^- \[(?<selected>.*?)\] ?`(?<category>.+?)`/gm;
-  const selectedCategories = [];
-  let match = regexp.exec(body);
-  while (match != null) {
-    const selected = match.groups.selected.trim().toLocaleLowerCase() === "x";
-    const category = match.groups.category.trim();
+  // Fetch release-note category labels applied to this PR
+  const listLabelsOnIssueResp = await github.issues.listLabelsOnIssue({
+    owner,
+    repo,
+    issue_number,
+  });
+  const appliedLabels = listLabelsOnIssueResp.data
+    .map(({ name }) => name)
+    .filter(name => releaseNoteLabels.includes(name));
 
-    if (categories.includes(category) && selected) {
-      selectedCategories.push(category);
-    }
-    match = regexp.exec(body);
-  }
+  console.log(
+    "The following release-note category labels are applied to this PR:"
+  );
+  console.log(appliedLabels);
 
-  console.log("Selected release-note categories:");
-  console.log(selectedCategories);
+  // If no release-note category label is applied to this PR, set the action status to "failed"
+  if (appliedLabels.length === 0) {
+    // Make sure '.github/pull_request_template.md' contains an HTML anchor with this name
+    const anchorName = "release-note-category";
 
-  // ".github/pull_request_template.md" must contain an HTML anchor with this name
-  const anchorName = "release-note-category";
-
-  // GitHub prefixes anchor names in markdown with "user-content-"
-  const anchorUrl = `${html_url}#user-content-${anchorName}`;
-
-  // If no release-note categories is selected, set the action status to "failed"
-  const numSelected = selectedCategories.length;
-  if (numSelected === 0) {
-    core.setFailed(
-      "At least one release-note category must be selected: " + anchorUrl
-    );
+    // Fragmented URL to jump to the release-note category section in the PR description
+    const anchorUrl = `${pr_url}#user-content-${anchorName}`;
+    const message = `
+No release-note category label is applied to this PR.
+Please select a checkbox in the release-note category section: ${anchorUrl},
+or manually apply a release-note category label (e.g. 'rn/bug-fix')
+if you're a maintainer of this repository.
+`;
+    core.setFailed(message);
   }
 };

--- a/.github/workflows/release-note-category.js
+++ b/.github/workflows/release-note-category.js
@@ -19,6 +19,8 @@ module.exports = async ({ core, context, github }) => {
   const releaseNoteLabels = labelsForRepoResp.data
     .map(({ name }) => name)
     .filter(name => name.startsWith("rn/"));
+  console.log("Available release-note category labels:");
+  console.log(releaseNoteLabels);
 
   // Fetch release-note category labels applied to this PR
   const listLabelsOnIssueResp = await github.issues.listLabelsOnIssue({
@@ -30,9 +32,7 @@ module.exports = async ({ core, context, github }) => {
     .map(({ name }) => name)
     .filter(name => releaseNoteLabels.includes(name));
 
-  console.log(
-    "The following release-note category labels are applied to this PR:"
-  );
+  console.log("Release-note category labels applied to this PR:");
   console.log(appliedLabels);
 
   // If no release-note category label is applied to this PR, set the action status to "failed"

--- a/.github/workflows/release-note-category.js
+++ b/.github/workflows/release-note-category.js
@@ -49,7 +49,7 @@ module.exports = async ({ core, context, github }) => {
       "or manually apply a release note category label (e.g. 'rn/bug-fix') ",
       "if you're a maintainer of this repository. ",
       "If this workflow failed when a release note category label has been already applied, ",
-      "please re-run it",
+      "please re-run it.",
     ].join("");
     core.setFailed(message);
   }

--- a/.github/workflows/release-note-category.js
+++ b/.github/workflows/release-note-category.js
@@ -15,6 +15,7 @@ module.exports = async ({ core, context, github }) => {
   const labelsForRepoResp = await github.issues.listLabelsForRepo({
     owner,
     repo,
+    per_page: 100, // the default value is 30, which is too small to fetch all labels
   });
   const releaseNoteLabels = labelsForRepoResp.data
     .map(({ name }) => name)

--- a/.github/workflows/release-note-category.js
+++ b/.github/workflows/release-note-category.js
@@ -33,7 +33,7 @@ module.exports = async ({ core, context, github }) => {
     .map(({ name }) => name)
     .filter(name => releaseNoteLabels.includes(name));
 
-  console.log("release note category labels applied to this PR:");
+  console.log("Release note category labels applied to this PR:");
   console.log(appliedLabels);
 
   // If no release note category label is applied to this PR, set the action status to "failed"
@@ -45,7 +45,7 @@ module.exports = async ({ core, context, github }) => {
     const anchorUrl = `${pr_url}#user-content-${anchorName}`;
     const message = [
       "No release note category label is applied to this PR. ",
-      `Please select a checkbox in the release note category section: ${anchorUrl}, `,
+      `Please select a checkbox in the release note category section: ${anchorUrl} `,
       "or manually apply a release note category label (e.g. 'rn/bug-fix') ",
       "if you're a maintainer of this repository. ",
       "If this workflow failed when a release note category label has been already applied, ",

--- a/.github/workflows/release-note-category.js
+++ b/.github/workflows/release-note-category.js
@@ -11,7 +11,7 @@ module.exports = async ({ core, context, github }) => {
     return;
   }
 
-  // Fetch release-note category labels
+  // Fetch release note category labels
   const labelsForRepoResp = await github.issues.listLabelsForRepo({
     owner,
     repo,
@@ -20,10 +20,10 @@ module.exports = async ({ core, context, github }) => {
   const releaseNoteLabels = labelsForRepoResp.data
     .map(({ name }) => name)
     .filter(name => name.startsWith("rn/"));
-  console.log("Available release-note category labels:");
+  console.log("Available release note category labels:");
   console.log(releaseNoteLabels);
 
-  // Fetch release-note category labels applied to this PR
+  // Fetch release note category labels applied to this PR
   const listLabelsOnIssueResp = await github.issues.listLabelsOnIssue({
     owner,
     repo,
@@ -33,23 +33,24 @@ module.exports = async ({ core, context, github }) => {
     .map(({ name }) => name)
     .filter(name => releaseNoteLabels.includes(name));
 
-  console.log("Release-note category labels applied to this PR:");
+  console.log("release note category labels applied to this PR:");
   console.log(appliedLabels);
 
-  // If no release-note category label is applied to this PR, set the action status to "failed"
+  // If no release note category label is applied to this PR, set the action status to "failed"
   if (appliedLabels.length === 0) {
     // Make sure '.github/pull_request_template.md' contains an HTML anchor with this name
-    const anchorName = "release-note-category";
+    const anchorName = "release note-category";
 
-    // Fragmented URL to jump to the release-note category section in the PR description
+    // Fragmented URL to jump to the release note category section in the PR description
     const anchorUrl = `${pr_url}#user-content-${anchorName}`;
-    const message = `
-No release-note category label is applied to this PR.
-Please select a checkbox in the release-note category section:
-${anchorUrl},
-or manually apply a release-note category label (e.g. 'rn/bug-fix')
-if you're a maintainer of this repository.
-`;
+    const message = [
+      "No release note category label is applied to this PR. ",
+      `Please select a checkbox in the release note category section: ${anchorUrl}, `,
+      "or manually apply a release note category label (e.g. 'rn/bug-fix') ",
+      "if you're a maintainer of this repository. ",
+      "If this workflow failed when a release note category label has been already applied, ",
+      "please re-run it",
+    ].join("");
     core.setFailed(message);
   }
 };

--- a/.github/workflows/release-note-category.js
+++ b/.github/workflows/release-note-category.js
@@ -45,7 +45,8 @@ module.exports = async ({ core, context, github }) => {
     const anchorUrl = `${pr_url}#user-content-${anchorName}`;
     const message = `
 No release-note category label is applied to this PR.
-Please select a checkbox in the release-note category section: ${anchorUrl},
+Please select a checkbox in the release-note category section:
+${anchorUrl},
 or manually apply a release-note category label (e.g. 'rn/bug-fix')
 if you're a maintainer of this repository.
 `;

--- a/.github/workflows/release-note-category.yml
+++ b/.github/workflows/release-note-category.yml
@@ -24,4 +24,4 @@ jobs:
             const script = require(
               `${process.env.GITHUB_WORKSPACE}/.github/workflows/release-note-category.js`
             );
-            script({ core, context });
+            script({ core, context, github });

--- a/.github/workflows/release-note-category.yml
+++ b/.github/workflows/release-note-category.yml
@@ -9,6 +9,8 @@ on:
       - synchronize
       - reopened
       - edited
+      - labeled
+      - unlabeled
 
 jobs:
   validate:

--- a/.github/workflows/release-note-category.yml
+++ b/.github/workflows/release-note-category.yml
@@ -8,7 +8,6 @@ on:
       - opened
       - synchronize
       - reopened
-      - edited
       - labeled
       - unlabeled
 


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

The `release-note-category` workflow should fail when no release-note category label (e.g. `rn/bug-fix`) is applied to a PR, but it actually doesn't because it checks whether a checkbox for a release-note category in the PR description is selected or not. This PR updates the workflow to check labels applied to a PR, not checkboxes in the PR.

## Why do we need to fix the `release-note-category` workflow?

Consider the following scenario:

1. Create a PR
2. Select the checkbox for `rn/none`.
3. The `rn/none` label is automatically applied.
4. **Accidentally remove `rn/none` label.** (the `release-note-category` doesn't fail becase the checkbox for `rn/none` is still checked)
5. Merge the PR

Our internal Jenkins job will complain that no release-note category is selected for this PR.

## How is this patch tested?

Verified the new validation works as expected.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
