### PR TITLE
Fix spacy test failure caused by spacy 3.10

### DIFF
--- a/tests/spacy/test_spacy_model_export.py
+++ b/tests/spacy/test_spacy_model_export.py
@@ -84,6 +84,10 @@ def test_model_save_load(spacy_model_with_data, model_path):
     mlflow.spacy.save_model(spacy_model=spacy_model, path=model_path)
     loaded_model = mlflow.spacy.load_model(model_path)
 
+    # Remove a `_sourced_vectors_hashes` field which is added when spaCy loads a model:
+    # https://github.com/explosion/spaCy/blob/e8ef4a46d5dbc9bb6d629ecd0b02721d6bdf2f87/spacy/language.py#L1701
+    loaded_model.meta.pop("_sourced_vectors_hashes")
+
     # Comparing the meta dictionaries for the original and loaded models
     assert spacy_model.meta == loaded_model.meta
 

--- a/tests/spacy/test_spacy_model_export.py
+++ b/tests/spacy/test_spacy_model_export.py
@@ -86,7 +86,7 @@ def test_model_save_load(spacy_model_with_data, model_path):
 
     # Remove a `_sourced_vectors_hashes` field which is added when spaCy loads a model:
     # https://github.com/explosion/spaCy/blob/e8ef4a46d5dbc9bb6d629ecd0b02721d6bdf2f87/spacy/language.py#L1701
-    loaded_model.meta.pop("_sourced_vectors_hashes")
+    loaded_model.meta.pop("_sourced_vectors_hashes", None)
 
     # Comparing the meta dictionaries for the original and loaded models
     assert spacy_model.meta == loaded_model.meta


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Fix a spacy test failure caused by spacy 3.10 to unblock the flavors test.

## How is this patch tested?

Fixed test

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
