### PR TITLE
Set `_R_CHECK_SYSTEM_CLOCK_` to false to skip the system clock check in `devtools::check_built`

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -102,10 +102,10 @@ jobs:
         # Hack to get around this issue:
         # https://stat.ethz.ch/pipermail/r-package-devel/2020q3/005930.html
         #
-        # By setting this environment variable to false, we can skip the system clock check
-        # that relies on two external web APIs and fails when they are unavailable:
+        # The system clock check during `R CMD check` relies on two external web APIs and fails
+        # when they are unavailable. By setting `_R_CHECK_SYSTEM_CLOCK_` to FALSE, we can skip it:
         # https://github.com/wch/r-source/blob/59a1965239143ca6242b9cc948d8834e1194e84a/src/library/tools/R/check.R#L511
-        _R_CHECK_SYSTEM_CLOCK_: false
+        _R_CHECK_SYSTEM_CLOCK_: FALSE
       run: |
         export LINTR_COMMENT_BOT=false
         cd mlflow/R/mlflow/tests

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -98,6 +98,10 @@ jobs:
         cd tests
         Rscript ../.create-test-env.R
     - name: Run tests
+      env:
+        # Hack to get around this issue:
+        # https://stat.ethz.ch/pipermail/r-package-devel/2020q3/005930.html
+        _R_CHECK_SYSTEM_CLOCK_: false
       run: |
         export LINTR_COMMENT_BOT=false
         cd mlflow/R/mlflow/tests

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -101,6 +101,10 @@ jobs:
       env:
         # Hack to get around this issue:
         # https://stat.ethz.ch/pipermail/r-package-devel/2020q3/005930.html
+        #
+        # By setting this environment variable to false, we can skip the system clock check
+        # that relies on two external web APIs and fails when they are unavailable:
+        # https://github.com/wch/r-source/blob/59a1965239143ca6242b9cc948d8834e1194e84a/src/library/tools/R/check.R#L511
         _R_CHECK_SYSTEM_CLOCK_: false
       run: |
         export LINTR_COMMENT_BOT=false


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

- Set `_R_CHECK_SYSTEM_CLOCK_` to false to skip the system clock check in `devtools::check_built` which occasionally fails.
- The same approach is used in [microsoft/LightGBM](https://github.com/microsoft/LightGBM/blob/48257d45e577df69abbc86542d0515159e524eb2/.github/workflows/r_package.yml#L14) (Just because LightGBM uses this approach doesn't necessarily mean it's safe to do this though).

## How is this patch tested?

Existing checks

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
