### PR TITLE
Add is_in_databricks_runtime method

### DIFF
--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -30,7 +30,8 @@ from mlflow.tracking.artifact_utils import _upload_artifacts_to_databricks
 from mlflow.tracking.registry import UnsupportedModelRegistryStoreURIException
 from mlflow.utils.databricks_utils import (
     is_databricks_default_tracking_uri,
-    is_in_databricks_runtime,
+    is_in_databricks_job,
+    is_in_databricks_notebook,
     get_workspace_info_from_dbutils,
     get_workspace_info_from_databricks_secrets,
 )
@@ -2230,7 +2231,9 @@ class MlflowClient(object):
     def _get_run_link(self, tracking_uri, run_id):
         # if using the default Databricks tracking URI and in a notebook, we can automatically
         # figure out the run-link.
-        if is_databricks_default_tracking_uri(tracking_uri) and is_in_databricks_runtime():
+        if is_databricks_default_tracking_uri(tracking_uri) and (
+            is_in_databricks_notebook() or is_in_databricks_job()
+        ):
             # use DBUtils to determine workspace information.
             workspace_host, workspace_id = get_workspace_info_from_dbutils()
         else:

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -30,8 +30,7 @@ from mlflow.tracking.artifact_utils import _upload_artifacts_to_databricks
 from mlflow.tracking.registry import UnsupportedModelRegistryStoreURIException
 from mlflow.utils.databricks_utils import (
     is_databricks_default_tracking_uri,
-    is_in_databricks_job,
-    is_in_databricks_notebook,
+    is_in_databricks_runtime,
     get_workspace_info_from_dbutils,
     get_workspace_info_from_databricks_secrets,
 )
@@ -2231,9 +2230,7 @@ class MlflowClient(object):
     def _get_run_link(self, tracking_uri, run_id):
         # if using the default Databricks tracking URI and in a notebook, we can automatically
         # figure out the run-link.
-        if is_databricks_default_tracking_uri(tracking_uri) and (
-            is_in_databricks_notebook() or is_in_databricks_job()
-        ):
+        if is_databricks_default_tracking_uri(tracking_uri) and is_in_databricks_runtime():
             # use DBUtils to determine workspace information.
             workspace_host, workspace_id = get_workspace_info_from_dbutils()
         else:

--- a/mlflow/utils/autologging_utils/versioning.py
+++ b/mlflow/utils/autologging_utils/versioning.py
@@ -5,10 +5,7 @@ import yaml
 from packaging.version import Version, InvalidVersion
 from pkg_resources import resource_filename
 
-from mlflow.utils.databricks_utils import (
-    is_in_databricks_job,
-    is_in_databricks_notebook,
-)
+from mlflow.utils.databricks_utils import is_in_databricks_runtime
 
 
 # A map FLAVOR_NAME -> a tuple of (dependent_module_name, key_in_module_version_info_dict)
@@ -72,7 +69,7 @@ def is_flavor_supported_for_associated_package_versions(flavor_name):
     actual_version = importlib.import_module(module_name).__version__
 
     # In Databricks, treat 'pyspark 3.x.y.dev0' as 'pyspark 3.x.y'
-    if module_name == "pyspark" and (is_in_databricks_notebook() or is_in_databricks_job()):
+    if module_name == "pyspark" and is_in_databricks_runtime():
         actual_version = _strip_dev_version_suffix(actual_version)
 
     if _violates_pep_440(actual_version) or _is_pre_or_dev_release(actual_version):

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -91,6 +91,7 @@ def is_in_databricks_job():
 def is_in_databricks_runtime():
     try:
         import pyspark.databricks
+
         return True
     except ModuleNotFoundError:
         return False

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -88,6 +88,14 @@ def is_in_databricks_job():
         return False
 
 
+def is_in_databricks_runtime():
+    try:
+        import pyspark.databricks
+        return True
+    except ModuleNotFoundError:
+        return False
+
+
 def is_dbfs_fuse_available():
     with open(os.devnull, "w") as devnull_stderr, open(os.devnull, "w") as devnull_stdout:
         try:
@@ -135,7 +143,7 @@ def get_notebook_path():
 
 
 def get_databricks_runtime():
-    if is_in_databricks_notebook() or is_in_databricks_job():
+    if is_in_databricks_runtime():
         spark_session = _get_active_spark_session()
         if spark_session is not None:
             return spark_session.conf.get(

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -90,8 +90,8 @@ def is_in_databricks_job():
 
 def is_in_databricks_runtime():
     try:
-        # pylint: disable=unused-import,import-error,no-name-in-module
-        import pyspark.databricks  # noqa
+        # pylint: disable=unused-import,import-error,no-name-in-module,unused-variable
+        import pyspark.databricks
 
         return True
     except ModuleNotFoundError:

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -90,7 +90,8 @@ def is_in_databricks_job():
 
 def is_in_databricks_runtime():
     try:
-        import pyspark.databricks
+        # pylint: disable=unused-import,import-error,no-name-in-module
+        import pyspark.databricks  # noqa
 
         return True
     except ModuleNotFoundError:

--- a/tests/autologging/test_autologging_utils.py
+++ b/tests/autologging/test_autologging_utils.py
@@ -841,17 +841,11 @@ def test_dev_version_pyspark_is_supported_in_databricks(flavor, module_version, 
     with mock.patch(module_name + ".__version__", module_version):
         # In Databricks
         with mock.patch(
-            "mlflow.utils.autologging_utils.versioning.is_in_databricks_notebook",
+            "mlflow.utils.autologging_utils.versioning.is_in_databricks_runtime",
             return_value=True,
-        ) as mock_notebook:
+        ) as mock_runtime:
             assert is_flavor_supported_for_associated_package_versions(flavor) == expected_result
-            mock_notebook.assert_called()
-
-        with mock.patch(
-            "mlflow.utils.autologging_utils.versioning.is_in_databricks_job", return_value=True,
-        ) as mock_job:
-            assert is_flavor_supported_for_associated_package_versions(flavor) == expected_result
-            mock_job.assert_called()
+            mock_runtime.assert_called()
 
         # Not in Databricks
         assert is_flavor_supported_for_associated_package_versions(flavor) is False

--- a/tests/autologging/test_autologging_utils.py
+++ b/tests/autologging/test_autologging_utils.py
@@ -841,8 +841,7 @@ def test_dev_version_pyspark_is_supported_in_databricks(flavor, module_version, 
     with mock.patch(module_name + ".__version__", module_version):
         # In Databricks
         with mock.patch(
-            "mlflow.utils.autologging_utils.versioning.is_in_databricks_runtime",
-            return_value=True,
+            "mlflow.utils.autologging_utils.versioning.is_in_databricks_runtime", return_value=True,
         ) as mock_runtime:
             assert is_flavor_supported_for_associated_package_versions(flavor) == expected_result
             mock_runtime.assert_called()

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -344,7 +344,7 @@ def test_create_model_version_explicitly_set_run_link(mock_registry_store):
     )
     # mocks to make sure that even if you're in a notebook, this setting is respected.
     with mock.patch(
-        "mlflow.tracking.client.is_in_databricks_notebook", return_value=True
+        "mlflow.tracking.client.is_in_databricks_runtime", return_value=True
     ), mock.patch(
         "mlflow.tracking.client.get_workspace_info_from_dbutils",
         return_value=(hostname, workspace_id),
@@ -369,7 +369,7 @@ def test_create_model_version_run_link_in_notebook_with_default_profile(mock_reg
         RunInfo(run_id, experiment_id, "userid", "status", 0, 1, None), None
     )
     with mock.patch(
-        "mlflow.tracking.client.is_in_databricks_notebook", return_value=True
+        "mlflow.tracking.client.is_in_databricks_runtime", return_value=True
     ), mock.patch(
         "mlflow.tracking.client.get_workspace_info_from_dbutils",
         return_value=(hostname, workspace_id),
@@ -415,7 +415,7 @@ def test_create_model_version_run_link_with_configured_profile(mock_registry_sto
         RunInfo(run_id, experiment_id, "userid", "status", 0, 1, None), None
     )
     with mock.patch(
-        "mlflow.tracking.client.is_in_databricks_notebook", return_value=False
+        "mlflow.tracking.client.is_in_databricks_runtime", return_value=False
     ), mock.patch(
         "mlflow.tracking.client.get_workspace_info_from_databricks_secrets",
         return_value=(hostname, workspace_id),

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -344,7 +344,7 @@ def test_create_model_version_explicitly_set_run_link(mock_registry_store):
     )
     # mocks to make sure that even if you're in a notebook, this setting is respected.
     with mock.patch(
-        "mlflow.tracking.client.is_in_databricks_runtime", return_value=True
+        "mlflow.tracking.client.is_in_databricks_notebook", return_value=True
     ), mock.patch(
         "mlflow.tracking.client.get_workspace_info_from_dbutils",
         return_value=(hostname, workspace_id),
@@ -369,7 +369,7 @@ def test_create_model_version_run_link_in_notebook_with_default_profile(mock_reg
         RunInfo(run_id, experiment_id, "userid", "status", 0, 1, None), None
     )
     with mock.patch(
-        "mlflow.tracking.client.is_in_databricks_runtime", return_value=True
+        "mlflow.tracking.client.is_in_databricks_notebook", return_value=True
     ), mock.patch(
         "mlflow.tracking.client.get_workspace_info_from_dbutils",
         return_value=(hostname, workspace_id),
@@ -415,7 +415,7 @@ def test_create_model_version_run_link_with_configured_profile(mock_registry_sto
         RunInfo(run_id, experiment_id, "userid", "status", 0, 1, None), None
     )
     with mock.patch(
-        "mlflow.tracking.client.is_in_databricks_runtime", return_value=False
+        "mlflow.tracking.client.is_in_databricks_notebook", return_value=False
     ), mock.patch(
         "mlflow.tracking.client.get_workspace_info_from_databricks_secrets",
         return_value=(hostname, workspace_id),
@@ -491,7 +491,7 @@ def _default_model_version():
 def test_get_databricks_runtime_no_spark_session():
     with mock.patch(
         "mlflow.utils.databricks_utils._get_active_spark_session", return_value=None
-    ), mock.patch("mlflow.utils.databricks_utils.is_in_databricks_runtime", return_value=True):
+    ), mock.patch("mlflow.utils.databricks_utils.is_in_databricks_notebook", return_value=True):
         runtime = get_databricks_runtime()
         assert runtime is None
 
@@ -501,18 +501,3 @@ def test_get_databricks_runtime_nondb(mock_spark_session):
     assert runtime is None
     mock_spark_session.conf.get.assert_not_called()
 
-
-def test_get_databricks_runtime_in_notebook(mock_spark_session):
-    with mock.patch("mlflow.utils.databricks_utils.is_in_databricks_runtime", return_value=True):
-        get_databricks_runtime()
-        mock_spark_session.conf.get.assert_called_once_with(
-            "spark.databricks.clusterUsageTags.sparkVersion", default=None
-        )
-
-
-def test_get_databricks_runtime_in_job(mock_spark_session):
-    with mock.patch("mlflow.utils.databricks_utils.is_in_databricks_runtime", return_value=True):
-        get_databricks_runtime()
-        mock_spark_session.conf.get.assert_called_once_with(
-            "spark.databricks.clusterUsageTags.sparkVersion", default=None
-        )

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -491,7 +491,7 @@ def _default_model_version():
 def test_get_databricks_runtime_no_spark_session():
     with mock.patch(
         "mlflow.utils.databricks_utils._get_active_spark_session", return_value=None
-    ), mock.patch("mlflow.utils.databricks_utils.is_in_databricks_notebook", return_value=True):
+    ), mock.patch("mlflow.utils.databricks_utils.is_in_databricks_runtime", return_value=True):
         runtime = get_databricks_runtime()
         assert runtime is None
 
@@ -503,7 +503,7 @@ def test_get_databricks_runtime_nondb(mock_spark_session):
 
 
 def test_get_databricks_runtime_in_notebook(mock_spark_session):
-    with mock.patch("mlflow.utils.databricks_utils.is_in_databricks_notebook", return_value=True):
+    with mock.patch("mlflow.utils.databricks_utils.is_in_databricks_runtime", return_value=True):
         get_databricks_runtime()
         mock_spark_session.conf.get.assert_called_once_with(
             "spark.databricks.clusterUsageTags.sparkVersion", default=None
@@ -511,7 +511,7 @@ def test_get_databricks_runtime_in_notebook(mock_spark_session):
 
 
 def test_get_databricks_runtime_in_job(mock_spark_session):
-    with mock.patch("mlflow.utils.databricks_utils.is_in_databricks_job", return_value=True):
+    with mock.patch("mlflow.utils.databricks_utils.is_in_databricks_runtime", return_value=True):
         get_databricks_runtime()
         mock_spark_session.conf.get.assert_called_once_with(
             "spark.databricks.clusterUsageTags.sparkVersion", default=None

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -500,4 +500,3 @@ def test_get_databricks_runtime_nondb(mock_spark_session):
     runtime = get_databricks_runtime()
     assert runtime is None
     mock_spark_session.conf.get.assert_not_called()
-

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -205,14 +205,12 @@ def test_databricks_params_throws_errors(ProfileConfigProvider):
 
 
 def test_is_in_databricks_runtime(tmpdir):
-    import sys
-
     with mock.patch("sys.modules", new={**sys.modules, "pyspark.databricks": mock.MagicMock()}):
-        # pylint: disable=unused-import
+        # pylint: disable=unused-import,import-error,no-name-in-module
         import pyspark.databricks  # noqa
 
         assert databricks_utils.is_in_databricks_runtime()
     with pytest.raises(ModuleNotFoundError):
-        # pylint: disable=unused-import
+        # pylint: disable=unused-import,import-error,no-name-in-module
         import pyspark.databricks  # noqa
     assert not databricks_utils.is_in_databricks_runtime()

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -205,12 +205,16 @@ def test_databricks_params_throws_errors(ProfileConfigProvider):
 
 
 def test_is_in_databricks_runtime():
-    with mock.patch("sys.modules", new={**sys.modules, "pyspark": mock.MagicMock()}):
-        with mock.patch("sys.modules", new={**sys.modules, "pyspark.databricks": mock.MagicMock()}):
-            # pylint: disable=unused-import,import-error,no-name-in-module,unused-variable
-            import pyspark.databricks
+    with mock.patch(
+        "sys.modules",
+        new={**sys.modules, "pyspark": mock.MagicMock(), "pyspark.databricks": mock.MagicMock()},
+    ):
+        # pylint: disable=unused-import,import-error,no-name-in-module,unused-variable
+        import pyspark.databricks
 
-            assert databricks_utils.is_in_databricks_runtime()
+        assert databricks_utils.is_in_databricks_runtime()
+
+    with mock.patch("sys.modules", new={**sys.modules, "pyspark": mock.MagicMock()}):
         with pytest.raises(ModuleNotFoundError, match="No module named 'pyspark.databricks'"):
             # pylint: disable=unused-import,import-error,no-name-in-module,unused-variable
             import pyspark.databricks

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -207,10 +207,10 @@ def test_databricks_params_throws_errors(ProfileConfigProvider):
 def test_is_in_databricks_runtime():
     with mock.patch("sys.modules", new={**sys.modules, "pyspark.databricks": mock.MagicMock()}):
         # pylint: disable=unused-import,import-error,no-name-in-module,unused-variable
-        import pyspark.databricks  # noqa
+        import pyspark.databricks
 
         assert databricks_utils.is_in_databricks_runtime()
     with pytest.raises(ModuleNotFoundError, match="No module named 'pyspark.databricks'"):
         # pylint: disable=unused-import,import-error,no-name-in-module,unused-variable
-        import pyspark.databricks  # noqa
+        import pyspark.databricks
     assert not databricks_utils.is_in_databricks_runtime()

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -205,12 +205,13 @@ def test_databricks_params_throws_errors(ProfileConfigProvider):
 
 
 def test_is_in_databricks_runtime():
-    with mock.patch("sys.modules", new={**sys.modules, "pyspark.databricks": mock.MagicMock()}):
-        # pylint: disable=unused-import,import-error,no-name-in-module,unused-variable
-        import pyspark.databricks
+    with mock.patch("sys.modules", new={**sys.modules, "pyspark": mock.MagicMock()}):
+        with mock.patch("sys.modules", new={**sys.modules, "pyspark.databricks": mock.MagicMock()}):
+            # pylint: disable=unused-import,import-error,no-name-in-module,unused-variable
+            import pyspark.databricks
 
-        assert databricks_utils.is_in_databricks_runtime()
-    with pytest.raises(ModuleNotFoundError, match="No module named 'pyspark.databricks'"):
-        # pylint: disable=unused-import,import-error,no-name-in-module,unused-variable
-        import pyspark.databricks
-    assert not databricks_utils.is_in_databricks_runtime()
+            assert databricks_utils.is_in_databricks_runtime()
+        with pytest.raises(ModuleNotFoundError, match="No module named 'pyspark.databricks'"):
+            # pylint: disable=unused-import,import-error,no-name-in-module,unused-variable
+            import pyspark.databricks
+        assert not databricks_utils.is_in_databricks_runtime()

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -205,21 +205,14 @@ def test_databricks_params_throws_errors(ProfileConfigProvider):
 
 
 def test_is_in_databricks_runtime(tmpdir):
-    import importlib
+    import sys
 
-    fake_databricks_runtime = tmpdir.mkdir("pyspark")
-    fake_databricks_runtime.join("__init__.py").write("")
-    fake_databricks_runtime.join("databricks.py").write("")
-
-    with mock.patch("sys.path", new=[tmpdir.strpath, *sys.path]):
-        importlib.reload(sys.modules["pyspark"])
-        import pyspark.databricks  # pylint: disable=unused-import
+    with mock.patch("sys.modules", new={**sys.modules, "pyspark.databricks": mock.MagicMock()}):
+        # pylint: disable=unused-import
+        import pyspark.databricks  # noqa
 
         assert databricks_utils.is_in_databricks_runtime()
-
-    sys.modules.pop("pyspark")
-    sys.modules.pop("pyspark.databricks")
     with pytest.raises(ModuleNotFoundError):
-        import pyspark.databricks  # pylint: disable=unused-import
-
+        # pylint: disable=unused-import
+        import pyspark.databricks  # noqa
     assert not databricks_utils.is_in_databricks_runtime()

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -20,6 +20,7 @@ def test_no_throw():
     assert not databricks_utils.is_in_databricks_notebook()
     assert not databricks_utils.is_in_databricks_job()
     assert not databricks_utils.is_dbfs_fuse_available()
+    assert not databricks_utils.is_in_databricks_runtime()
 
 
 @mock.patch("databricks_cli.configure.provider.get_config")

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -204,13 +204,13 @@ def test_databricks_params_throws_errors(ProfileConfigProvider):
         databricks_utils.get_databricks_host_creds()
 
 
-def test_is_in_databricks_runtime(tmpdir):
+def test_is_in_databricks_runtime(tmpdir):  # pylint: disable==unused-argument
     with mock.patch("sys.modules", new={**sys.modules, "pyspark.databricks": mock.MagicMock()}):
-        # pylint: disable=unused-import,import-error,no-name-in-module
-        import pyspark.databricks  # noqa
+        # pylint: disable=unused-import,import-error,no-name-in-module,unused-variable
+        import pyspark.databricks
 
         assert databricks_utils.is_in_databricks_runtime()
-    with pytest.raises(ModuleNotFoundError):
-        # pylint: disable=unused-import,import-error,no-name-in-module
-        import pyspark.databricks  # noqa
+    with pytest.raises(ModuleNotFoundError, match="No module named 'pyspark.databricks'"):
+        # pylint: disable=unused-import,import-error,no-name-in-module,unused-variable
+        import pyspark.databricks
     assert not databricks_utils.is_in_databricks_runtime()

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -204,13 +204,13 @@ def test_databricks_params_throws_errors(ProfileConfigProvider):
         databricks_utils.get_databricks_host_creds()
 
 
-def test_is_in_databricks_runtime(tmpdir):  # pylint: disable==unused-argument
+def test_is_in_databricks_runtime():
     with mock.patch("sys.modules", new={**sys.modules, "pyspark.databricks": mock.MagicMock()}):
         # pylint: disable=unused-import,import-error,no-name-in-module,unused-variable
-        import pyspark.databricks
+        import pyspark.databricks  # noqa
 
         assert databricks_utils.is_in_databricks_runtime()
     with pytest.raises(ModuleNotFoundError, match="No module named 'pyspark.databricks'"):
         # pylint: disable=unused-import,import-error,no-name-in-module,unused-variable
-        import pyspark.databricks
+        import pyspark.databricks  # noqa
     assert not databricks_utils.is_in_databricks_runtime()


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add is_in_databricks_runtime method

## How is this patch tested?

N/A

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
