### PR TITLE
Spark datasource autologging: Replace use of replId property with spark session UUID

### DIFF
--- a/mlflow/_spark_autologging.py
+++ b/mlflow/_spark_autologging.py
@@ -160,9 +160,7 @@ def _get_repl_id():
     from pyspark.sql import SparkSession
 
     try:
-        java_active_session = (
-            SparkSession.getActiveSession()._jvm.SparkSession.getActiveSession().get()
-        )
+        java_active_session = SparkSession._instantiatedSession._jsparkSession
         return java_active_session.sessionUUID()
     except Py4JError:
         main_file = sys.argv[0] if len(sys.argv) > 0 else "<console>"

--- a/mlflow/_spark_autologging.py
+++ b/mlflow/_spark_autologging.py
@@ -158,9 +158,12 @@ def _get_repl_id():
     """
     from py4j.protocol import Py4JError
     from pyspark.sql import SparkSession
+
     try:
-        active_session = SparkSession._jvm.SparkSession.getActiveSession().get()
-        return active_session.sessionUUID()
+        java_active_session = (
+            SparkSession.getActiveSession()._jvm.SparkSession.getActiveSession().get()
+        )
+        return java_active_session.sessionUUID()
     except Py4JError:
         main_file = sys.argv[0] if len(sys.argv) > 0 else "<console>"
         return "PythonSubscriber[{filename}][{id}]".format(filename=main_file, id=uuid.uuid4().hex)

--- a/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/MlflowAutologEventPublisher.scala
+++ b/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/MlflowAutologEventPublisher.scala
@@ -44,7 +44,7 @@ private[autologging] trait MlflowAutologEventPublisherImpl {
   }
 
   // Exposed for testing
-  private[autologging] def getSparkSessionUUIDAsReplId: String = {
+  private[autologging] def getSparkSessionUUID: String = {
     spark.getClass().getDeclaredMethod("sessionUUID").invoke(spark).toString
   }
 
@@ -54,11 +54,11 @@ private[autologging] trait MlflowAutologEventPublisherImpl {
     // we log irrespective of REPL ID, but if so, we log conditionally on the REPL ID. We use
     // reflection to determine whether or not the ID is available for runtime compatibility with
     // older Spark versions that do not define this property
-    val resolveReplId = Try {
-      getSparkSessionUUIDAsReplId
+    val getSparkSessionUUIDResult = Try {
+      getSparkSessionUUID
     }
-    resolveReplId match {
-      case Success(replId) => new ReplAwareSparkDataSourceListener(replId, this)
+    getSparkSessionUUIDResult match {
+      case Success(sessionUUID) => new ReplAwareSparkDataSourceListener(sessionUUID, this)
       case Failure(_) => new SparkDataSourceListener(this)
     }
   }

--- a/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/ReplAwareSparkDataSourceListener.scala
+++ b/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/ReplAwareSparkDataSourceListener.scala
@@ -25,6 +25,6 @@ class ReplAwareSparkDataSourceListener(
     // NB: We directly return the Spark Session UUID under the assumption that a data source
     // listener can only be attached to a single Spark Session at a time and that the Spark Session
     // UUID uniquely identifies a REPL
-    return Some(sparkSessionUUID);
+    Some(sparkSessionUUID)
   }
 }

--- a/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/ReplAwareSparkDataSourceListener.scala
+++ b/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/ReplAwareSparkDataSourceListener.scala
@@ -13,7 +13,7 @@ import scala.collection.mutable
  * and notify subscribers. Used in REPL-ID aware environments (e.g. Databricks)
  */
 class ReplAwareSparkDataSourceListener(
-    replId: String,
+    sparkSessionUUID: String,
     publisher: MlflowAutologEventPublisherImpl = MlflowAutologEventPublisher)
   extends SparkDataSourceListener(publisher) {
 
@@ -22,6 +22,9 @@ class ReplAwareSparkDataSourceListener(
   }
 
   override protected def getReplIdOpt(event: SparkListenerSQLExecutionEnd): Option[String] = {
-    return Some(replId);
+    // NB: We directly return the Spark Session UUID under the assumption that a data source
+    // listener can only be attached to a single Spark Session at a time and that the Spark Session
+    // UUID uniquely identifies a REPL
+    return Some(sparkSessionUUID);
   }
 }

--- a/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/ReplAwareSparkDataSourceListener.scala
+++ b/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/ReplAwareSparkDataSourceListener.scala
@@ -21,9 +21,10 @@ class ReplAwareSparkDataSourceListener(
   }
 
   override protected def getReplIdOpt(event: SparkListenerSQLExecutionEnd): Option[String] = {
-    // NB: We compute and return the Spark Session UUID under the assumption that a data source
+    // NB: We fetch and return the Spark Session UUID under the assumption that a data source
     // listener can only be attached to a single Spark Session at a time and that the Spark Session
-    // UUID uniquely identifies a REPL
+    // UUID uniquely identifies a REPL. We fetch the Spark Session UUID each time in case the
+    // active session has changed.
     val sessionUUID = SparkUtils.getSparkSessionUUID(SparkSession.getActiveSession.get)
     Some(sessionUUID)
   }

--- a/mlflow/java/spark/src/test/scala/org/mlflow/spark/autologging/SparkAutologgingIntegrationSuite.scala
+++ b/mlflow/java/spark/src/test/scala/org/mlflow/spark/autologging/SparkAutologgingIntegrationSuite.scala
@@ -266,7 +266,7 @@ class SparkAutologgingSuite extends FunSuite with Matchers with BeforeAndAfterAl
   test("Delegates to repl-ID-aware listener if Session UUID property is set in SparkSession") {
     object MockPublisherNoSessionUUID extends MlflowAutologEventPublisherImpl {
       override def getSparkSessionUUIDAsReplId: String = {
-        throw new NoSuchFieldException("Could not find Session UUID") 
+        throw new NoSuchFieldException("Could not find Session UUID")
       }
     }
     MockPublisherNoSessionUUID.init()

--- a/mlflow/java/spark/src/test/scala/org/mlflow/spark/autologging/SparkAutologgingIntegrationSuite.scala
+++ b/mlflow/java/spark/src/test/scala/org/mlflow/spark/autologging/SparkAutologgingIntegrationSuite.scala
@@ -265,7 +265,7 @@ class SparkAutologgingSuite extends FunSuite with Matchers with BeforeAndAfterAl
 
   test("Delegates to repl-ID-aware listener if Session UUID property is set in SparkSession") {
     object MockPublisherNoSessionUUID extends MlflowAutologEventPublisherImpl {
-      override def getSparkSessionUUIDAsReplId: String = {
+      override def getSparkSessionUUID: String = {
         throw new NoSuchFieldException("Could not find Session UUID")
       }
     }
@@ -276,7 +276,7 @@ class SparkAutologgingSuite extends FunSuite with Matchers with BeforeAndAfterAl
     )
 
     object MockPublisherWithSessionUUID extends MlflowAutologEventPublisherImpl {
-      override def getSparkSessionUUIDAsReplId: String = "123"
+      override def getSparkSessionUUID: String = "123"
     }
     MockPublisherWithSessionUUID.init()
     assert(


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR replaces the use of the `spark.databricks.replId` local spark property for identifying a Spark REPL with the Spark Session UUID field introduced by https://github.com/apache/spark/pull/31839. This improvement is necessary because `spark.databricks.replId` is not always immediately available upon REPL startup and may be populated asynchronously in some cases.

## How is this patch tested?

- Unit / integration tests
- Manual test plan **pending**

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
