### PR TITLE
Spark datasource autologging: Improve fidelity of REPL ID / context information

### DIFF
--- a/mlflow/_spark_autologging.py
+++ b/mlflow/_spark_autologging.py
@@ -16,6 +16,7 @@ from mlflow.utils.autologging_utils import (
     autologging_is_disabled,
     ExceptionSafeClass,
 )
+from mlflow.utils.databricks_utils import get_repl_id as get_databricks_repl_id 
 from mlflow.spark import FLAVOR_NAME
 
 _JAVA_PACKAGE = "org.mlflow.spark.autologging"
@@ -156,7 +157,7 @@ def _get_repl_id():
     local properties, and expect that the PythonSubscriber for the current Python process only
     receives events for datasource reads triggered by the current process.
     """
-    repl_id = SparkContext.getOrCreate().getLocalProperty("spark.databricks.replId")
+    repl_id = get_databricks_repl_id()
     if repl_id:
         return repl_id
     main_file = sys.argv[0] if len(sys.argv) > 0 else "<console>"

--- a/mlflow/_spark_autologging.py
+++ b/mlflow/_spark_autologging.py
@@ -16,7 +16,7 @@ from mlflow.utils.autologging_utils import (
     autologging_is_disabled,
     ExceptionSafeClass,
 )
-from mlflow.utils.databricks_utils import get_repl_id as get_databricks_repl_id 
+from mlflow.utils.databricks_utils import get_repl_id as get_databricks_repl_id
 from mlflow.spark import FLAVOR_NAME
 
 _JAVA_PACKAGE = "org.mlflow.spark.autologging"

--- a/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/MlflowAutologEventPublisher.scala
+++ b/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/MlflowAutologEventPublisher.scala
@@ -43,10 +43,6 @@ private[autologging] trait MlflowAutologEventPublisherImpl {
       "autologging."))
   }
 
-  // Exposed for testing
-  private[autologging] val databricksConfigProviderClassName =
-    "com.databricks.config.DatabricksClientSettingsProvider"
-
   /**
    * @returns True if Spark is running in a REPL-aware context. False otherwise.
    */
@@ -60,15 +56,14 @@ private[autologging] trait MlflowAutologEventPublisherImpl {
     }
 
     // If the `spark.databricks.replId` is absent, we may still be in a Databricks environment,
-    // which is REPL-aware. To check, we look for the presence of a Databricks-specific
-    // configuration class on the classpath
-    val configProviderFetchResult = Try {
-      Class.forName(databricksConfigProviderClassName);
+    // which is REPL-aware. To check, we look for the presence of a Databricks-specific cluster ID
+    // tag in the Spark configuration
+    val clusterId = spark.conf.getOption("spark.databricks.clusterUsageTags.clusterId")
+    if (clusterId.isDefined) {
+      return true
     }
-    configProviderFetchResult match {
-      case Success(_) => true
-      case Failure(_) => false
-    }
+
+    false
   }
 
   // Exposed for testing

--- a/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/MlflowAutologEventPublisher.scala
+++ b/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/MlflowAutologEventPublisher.scala
@@ -44,10 +44,13 @@ private[autologging] trait MlflowAutologEventPublisherImpl {
   }
 
   // Exposed for testing
+  private[autologging] val databricksConfigProviderClassName =
+    "com.databricks.config.DatabricksClientSettingsProvider"
+
   /**
    * @returns True if Spark is running in a REPL-aware context. False otherwise.
    */
-  private[autologging] def isInReplAwareContext: Boolean = {
+  private def isInReplAwareContext: Boolean = {
     // Attempt to fetch the `spark.databricks.replId` property from the Spark Context.
     // The presence of this ID is a clear indication that we are in a REPL-aware environment
     val sc = spark.sparkContext
@@ -59,7 +62,6 @@ private[autologging] trait MlflowAutologEventPublisherImpl {
     // If the `spark.databricks.replId` is absent, we may still be in a Databricks environment,
     // which is REPL-aware. To check, we look for the presence of a Databricks-specific
     // configuration class on the classpath
-    val databricksConfigProviderClassName = "com.databricks.config.DatabricksClientSettingsProvider"
     val configProviderFetchResult = Try {
       Class.forName(databricksConfigProviderClassName);
     }

--- a/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/MlflowAutologEventPublisher.scala
+++ b/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/MlflowAutologEventPublisher.scala
@@ -9,6 +9,7 @@ import scala.collection.JavaConverters._
 import org.apache.spark.sql.SparkSession
 import org.slf4j.LoggerFactory
 
+import scala.util.{Try, Success, Failure}
 import scala.util.control.NonFatal
 
 /**
@@ -43,14 +44,37 @@ private[autologging] trait MlflowAutologEventPublisherImpl {
   }
 
   // Exposed for testing
-  private[autologging] def getSparkDataSourceListener: SparkListener = {
-    // Get SparkContext & determine if REPL id is set - if not, then we log irrespective of repl
-    // ID, but if so, we log conditionally on repl ID
+  /**
+   * @returns True if Spark is running in a REPL-aware context. False otherwise.
+   */
+  private[autologging] def isInReplAwareContext: Boolean = {
+    // Attempt to fetch the `spark.databricks.replId` property from the Spark Context.
+    // The presence of this ID is a clear indication that we are in a REPL-aware environment
     val sc = spark.sparkContext
     val replId = Option(sc.getLocalProperty("spark.databricks.replId"))
-    replId match {
-      case None => new SparkDataSourceListener(this)
-      case Some(_) => new ReplAwareSparkDataSourceListener(this)
+    if (replId.isDefined) {
+      return true 
+    }
+
+    // If the `spark.databricks.replId` is absent, we may still be in a Databricks environment,
+    // which is REPL-aware. To check, we look for the presence of a Databricks-specific
+    // configuration class on the classpath
+    val databricksConfigProviderClassName = "com.databricks.config.DatabricksClientSettingsProvider"
+    val configProviderFetchResult = Try {
+      Class.forName(databricksConfigProviderClassName);
+    }
+    configProviderFetchResult match {
+      case Success(_) => true
+      case Failure(_) => false
+    }
+  }
+
+  // Exposed for testing
+  private[autologging] def getSparkDataSourceListener: SparkListener = {
+    if (isInReplAwareContext) {
+      new ReplAwareSparkDataSourceListener(this)
+    } else {
+      new SparkDataSourceListener(this)
     }
   }
 

--- a/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/MlflowAutologEventPublisher.scala
+++ b/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/MlflowAutologEventPublisher.scala
@@ -56,7 +56,7 @@ private[autologging] trait MlflowAutologEventPublisherImpl {
     val sc = spark.sparkContext
     val replId = Option(sc.getLocalProperty("spark.databricks.replId"))
     if (replId.isDefined) {
-      return true 
+      return true
     }
 
     // If the `spark.databricks.replId` is absent, we may still be in a Databricks environment,

--- a/mlflow/java/spark/src/test/scala/org/mlflow/spark/autologging/SparkAutologgingIntegrationSuite.scala
+++ b/mlflow/java/spark/src/test/scala/org/mlflow/spark/autologging/SparkAutologgingIntegrationSuite.scala
@@ -281,4 +281,18 @@ class SparkAutologgingSuite extends FunSuite with Matchers with BeforeAndAfterAl
     assert(MlflowAutologEventPublisher.sparkQueryListener.isInstanceOf[SparkDataSourceListener])
   }
 
+  test("Delegates to repl-ID-aware listener if Databricks environment is detected via classpath") {
+    // Verify instance created by init() in beforeEach is not REPL-ID-aware
+    assert(MlflowAutologEventPublisher.sparkQueryListener.isInstanceOf[SparkDataSourceListener])
+    assert(!MlflowAutologEventPublisher.sparkQueryListener.isInstanceOf[ReplAwareSparkDataSourceListener])
+    MlflowAutologEventPublisher.stop()
+
+    object MockPublisher extends MlflowAutologEventPublisherImpl {
+      // Mock the Databricks-specific class name that is checked on the classpath, replacing
+      // it with a Java-native class that is guaranteed to be resolvable 
+      override val databricksConfigProviderClassName = "java.io.File"
+    }
+    MockPublisher.init()
+    assert(MockPublisher.sparkQueryListener.isInstanceOf[ReplAwareSparkDataSourceListener])
+  }
 }

--- a/mlflow/java/spark/src/test/scala/org/mlflow/spark/autologging/SparkAutologgingIntegrationSuite.scala
+++ b/mlflow/java/spark/src/test/scala/org/mlflow/spark/autologging/SparkAutologgingIntegrationSuite.scala
@@ -289,7 +289,7 @@ class SparkAutologgingSuite extends FunSuite with Matchers with BeforeAndAfterAl
 
     object MockPublisher extends MlflowAutologEventPublisherImpl {
       // Mock the Databricks-specific class name that is checked on the classpath, replacing
-      // it with a Java-native class that is guaranteed to be resolvable 
+      // it with a Java-native class that is guaranteed to be resolvable
       override val databricksConfigProviderClassName = "java.io.File"
     }
     MockPublisher.init()

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -171,6 +171,27 @@ def get_job_group_id():
         return None
 
 
+def get_repl_id():
+    """
+    :return: The ID of the current Databricks Python REPL
+    """
+    try:
+        from pyspark import SparkContext
+        repl_id = SparkContext.getOrCreate().getLocalProperty("spark.databricks.replId")
+        if repl_id is not None:
+            return repl_id
+    except Exception:
+        pass
+
+    try:
+        dbutils = _get_dbutils()
+        repl_id = dbutils.entry_point.getReplId()
+        if repl_id is not None:
+            return repl_id
+    except Exception:
+        pass
+
+
 def get_job_id():
     try:
         return _get_command_context().jobId().get()

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -177,6 +177,7 @@ def get_repl_id():
     """
     try:
         from pyspark import SparkContext
+
         repl_id = SparkContext.getOrCreate().getLocalProperty("spark.databricks.replId")
         if repl_id is not None:
             return repl_id

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -175,18 +175,23 @@ def get_repl_id():
     """
     :return: The ID of the current Databricks Python REPL
     """
+    # Attempt to fetch the REPL ID from the Python REPL's entrypoint object. This REPL ID
+    # is guaranteed to be set upon REPL startup in DBR / MLR 9.0
     try:
-        from pyspark import SparkContext
-
-        repl_id = SparkContext.getOrCreate().getLocalProperty("spark.databricks.replId")
+        dbutils = _get_dbutils()
+        repl_id = dbutils.entry_point.getReplId()
         if repl_id is not None:
             return repl_id
     except Exception:
         pass
 
+    # If the REPL ID entrypoint property is unavailable due to an older runtime version (< 9.0),
+    # attempt to fetch the REPL ID from the Spark Context. This property may not be available
+    # until several seconds after REPL startup
     try:
-        dbutils = _get_dbutils()
-        repl_id = dbutils.entry_point.getReplId()
+        from pyspark import SparkContext
+
+        repl_id = SparkContext.getOrCreate().getLocalProperty("spark.databricks.replId")
         if repl_id is not None:
             return repl_id
     except Exception:

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -225,18 +225,29 @@ def test_get_repl_id():
     # Outside of Databricks environments, the Databricks REPL ID should be absent
     assert databricks_utils.get_repl_id() is None
 
+    mock_dbutils = mock.MagicMock()
+    mock_dbutils.entry_point.getReplId.return_value = "testReplId1"
+    with mock.patch("mlflow.utils.databricks_utils._get_dbutils", return_value=mock_dbutils):
+        assert databricks_utils.get_repl_id() == "testReplId1"
+
     mock_sparkcontext_inst = mock.MagicMock()
-    mock_sparkcontext_inst.getLocalProperty.return_value = "testReplId1"
+    mock_sparkcontext_inst.getLocalProperty.return_value = "testReplId2"
     mock_sparkcontext_class = mock.MagicMock()
     mock_sparkcontext_class.getOrCreate.return_value = mock_sparkcontext_inst
     mock_spark = mock.MagicMock()
     mock_spark.SparkContext = mock_sparkcontext_class
-    with mock.patch(
-        "builtins.__import__", side_effect=lambda *args, **kwargs: mock_spark,
-    ):
-        assert databricks_utils.get_repl_id() == "testReplId1"
 
-    mock_dbutils = mock.MagicMock()
-    mock_dbutils.entry_point.getReplId.return_value = "testReplId2"
-    with mock.patch("mlflow.utils.databricks_utils._get_dbutils", return_value=mock_dbutils):
+    import builtins
+
+    original_import = builtins.__import__
+
+    def mock_import(name, *args, **kwargs):
+        if name == "pyspark":
+            return mock_spark
+        else:
+            return original_import(name, *args, **kwargs)
+
+    with mock.patch(
+        "builtins.__import__", side_effect=mock_import,
+    ):
         assert databricks_utils.get_repl_id() == "testReplId2"

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -224,7 +224,7 @@ def test_is_in_databricks_runtime():
 def test_get_repl_id():
     # Outside of Databricks environments, the Databricks REPL ID should be absent
     assert databricks_utils.get_repl_id() is None
-   
+
     mock_sparkcontext_inst = mock.MagicMock()
     mock_sparkcontext_inst.getLocalProperty.return_value = "testReplId1"
     mock_sparkcontext_class = mock.MagicMock()


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR accomplishes the following goals related to Spark Datasource autologging in Databricks REPL-aware environments:

1. Ensure that Python subscribers resolve a REPL ID reliably, even when `spark.databricks.replId` is not immediately available due to asynchronous population

2. Ensure that a correct (REPL-aware) Java datasource publisher is configured reliably, even when `spark.databricks.replId` is not immediately available due to asynchronous population

## How is this patch tested?

- Included new unit tests
- Manually tested Spark autologging on Databricks in an environment where `dbutils.entry_point.getReplId()` is available. Manual test used the following code:

```
import mlflow.spark
import os
import shutil
from pyspark.sql import SparkSession
df = spark.createDataFrame([
        (4, "spark i j k"),
        (5, "l m n"),
        (6, "spark hadoop spark"),
        (7, "apache hadoop")], ["id", "text"])

import tempfile
csv_dir = os.path.join(tempfile.mkdtemp(), "NOTEBOOK1")
df.write.csv(csv_dir, header=True)

mlflow.spark.autolog()

loaded_df = spark.read.csv(csv_dir, header=True, inferSchema=True)
with mlflow.start_run() as active_run:
  # Call toPandas() to trigger a read of the Spark datasource. Datasource info
  # (path and format) is logged to the current active run, or the
  # next-created MLflow run if no run is currently active
  pandas_df = loaded_df.toPandas()
  import time
  time.sleep(5)
```

and produced the following results:

<img width="792" alt="Screen Shot 2021-07-13 at 12 48 31 AM" src="https://user-images.githubusercontent.com/39497902/125412778-10a6a400-e374-11eb-8e13-d3e3fb7d4cb7.png">

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
