### PR TITLE
Missing pandas dependency on examples/sklearn_elasticnet_wine

### DIFF
--- a/examples/sklearn_elasticnet_wine/conda.yaml
+++ b/examples/sklearn_elasticnet_wine/conda.yaml
@@ -7,3 +7,4 @@ dependencies:
   - pip:
     - scikit-learn==0.23.2
     - mlflow>=1.0
+    - pandas


### PR DESCRIPTION
Adding missing pandas dependency on examples/sklearn_elasticnet_wine

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section