### PR TITLE
Fetch the latest micro version of python from conda in cross version tests to avoid `ResolvePackageNotFound` error

### DIFF
--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -78,6 +78,7 @@ jobs:
           else
             python_version=3.6
           fi
+          $CONDA/bin/conda search python | grep $python_version
           latest_micro_version=$($CONDA/bin/conda search python | grep $python_version | tail -1 | tr -s ' ' | cut -d' ' -f2)
           echo "::set-output name=python-version::$latest_micro_version"
       - uses: actions/setup-python@v2

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -78,7 +78,8 @@ jobs:
           else
             python_version=3.6
           fi
-          echo "::set-output name=python-version::$python_version"
+          latest_micro_version=$($CONDA/bin/conda search python | grep $python_version | tail -1 | tr -s ' ' | cut -d' ' -f2)
+          echo "::set-output name=python-version::$latest_micro_version"
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ steps.get-python-version.outputs.python-version }}

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -78,6 +78,8 @@ jobs:
           else
             python_version=3.6
           fi
+          # Use a python version that exists on Anaconda to ensure `mlflow serve` can successfully
+          # create a conda environment for serving an MLflow model.
           latest_micro_version=$($CONDA/bin/conda search python | grep -F $python_version | tail -1 | tr -s ' ' | cut -d' ' -f2)
           echo "::set-output name=python-version::$latest_micro_version"
       - uses: actions/setup-python@v2

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -78,8 +78,7 @@ jobs:
           else
             python_version=3.6
           fi
-          $CONDA/bin/conda search python | grep $python_version
-          latest_micro_version=$($CONDA/bin/conda search python | grep $python_version | tail -1 | tr -s ' ' | cut -d' ' -f2)
+          latest_micro_version=$($CONDA/bin/conda search python | grep "$python_version" | tail -1 | tr -s ' ' | cut -d' ' -f2)
           echo "::set-output name=python-version::$latest_micro_version"
       - uses: actions/setup-python@v2
         with:

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -78,7 +78,7 @@ jobs:
           else
             python_version=3.6
           fi
-          latest_micro_version=$($CONDA/bin/conda search python | grep "$python_version" | tail -1 | tr -s ' ' | cut -d' ' -f2)
+          latest_micro_version=$($CONDA/bin/conda search python | grep -F $python_version | tail -1 | tr -s ' ' | cut -d' ' -f2)
           echo "::set-output name=python-version::$latest_micro_version"
       - uses: actions/setup-python@v2
         with:

--- a/mlflow/onnx.py
+++ b/mlflow/onnx.py
@@ -28,6 +28,7 @@ from mlflow.utils.model_utils import _get_flavor_configuration
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 
 FLAVOR_NAME = "onnx"
+# TEMPORARY CHANGE to trigger cross version tests
 
 
 @experimental


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
