### PR TITLE
[`pip_requirements` and `extra_pip_requirements`] Add support for constraints files

### DIFF
--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -255,9 +255,7 @@ def _process_conda_env(conda_env):
     if isinstance(conda_env, str):
         with open(conda_env, "r") as f:
             conda_env = yaml.safe_load(f)
-    elif isinstance(conda_env, dict):
-        pass
-    else:
+    elif not isinstance(conda_env, dict):
         raise TypeError(
             "Expected a string path to a conda env yaml file or a `dict` representing a conda env, "
             "but got `{}`".format(type(conda_env).__name__)

--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -259,8 +259,8 @@ def _process_conda_env(conda_env):
         pass
     else:
         raise TypeError(
-            "Expected a string path to a conda env yaml file or a `dict` representing a conda env "
-            "for `conda_env`, but got `{}`".type(conda_env)
+            "Expected a string path to a conda env yaml file or a `dict` representing a conda env, "
+            "but got `{}`".format(type(conda_env).__name__)
         )
 
     # User-specified `conda_env` may contain requirements/constraints file references

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -4,6 +4,7 @@ This module provides a set of utilities for interpreting and creating requiremen
 """
 import os
 from itertools import filterfalse
+from collections import namedtuple
 
 
 def _is_comment(line):
@@ -20,6 +21,10 @@ def _strip_inline_comment(line):
 
 def _is_requirements_file(line):
     return line.startswith("-r ") or line.startswith("--requirement ")
+
+
+def _is_constraints_file(line):
+    return line.startswith("-c ") or line.startswith("--constraint ")
 
 
 def _join_continued_lines(lines):
@@ -44,9 +49,14 @@ def _join_continued_lines(lines):
         yield "".join(continued_lines)
 
 
-# TODO: Add support for constraint files:
-#       https://github.com/mlflow/mlflow/pull/4519#discussion_r668412179
-def _parse_requirements(requirements_file):
+# Represents a pip requirement.
+#
+# :param req_str: A requirement string (e.g. "scikit-learn == 0.24.2").
+# :param is_constraint: A boolean indicating whether this requirement is a constraint.
+_Requirement = namedtuple("_Requirement", ["req_str", "is_constraint"])
+
+
+def _parse_requirements(requirements_file, is_constraint):
     """
     A simplified version of `pip._internal.req.parse_requirements` which performs the following
     operations on the given requirements file and yields the parsed requirements.
@@ -54,15 +64,19 @@ def _parse_requirements(requirements_file):
     - Remove comments and blank lines
     - Join continued lines
     - Resolve requirements file references (e.g. '-r requirements.txt')
+    - Resolve constraints file references (e.g. '-c constraints.txt')
+
+    :param requirements_file: A string path to a requirements file on the local filesystem.
+    :param is_constraint: Indicates the parsed requirements file is a constraint file.
+    :return: A list of ``_Requirement`` instances.
 
     References:
     - `pip._internal.req.parse_requirements`:
-      https://github.com/pypa/pip/blob/7a77484a492c8f1e1f5ef24eaf71a43df9ea47eb/src/pip/_internal/req/req_file.py#L118
+        https://github.com/pypa/pip/blob/7a77484a492c8f1e1f5ef24eaf71a43df9ea47eb/src/pip/_internal/req/req_file.py#L118
     - Requirements File Format:
-      https://pip.pypa.io/en/stable/cli/pip_install/#requirements-file-format
-
-    :param requirements_file: A string path to a requirements file on the local filesystem.
-    :return: A list of parsed requirements (e.g. ``["scikit-learn==0.24.2", ...]``).
+        https://pip.pypa.io/en/stable/cli/pip_install/#requirements-file-format
+    - Constraints Files:
+        https://pip.pypa.io/en/stable/user_guide/#constraints-files
     """
     with open(requirements_file) as f:
         lines = f.read().splitlines()
@@ -76,11 +90,13 @@ def _parse_requirements(requirements_file):
     for line in lines:
         if _is_requirements_file(line):
             req_file = line.split(maxsplit=1)[1]
-            abs_path = (
-                req_file
-                if os.path.isabs(req_file)
-                else os.path.join(os.path.dirname(requirements_file), req_file)
-            )
-            yield from _parse_requirements(abs_path)
+            # If `req_file` is an absolute path, `os.path.join` returns `req_file`:
+            # https://docs.python.org/3/library/os.path.html#os.path.join
+            abs_path = os.path.join(os.path.dirname(requirements_file), req_file)
+            yield from _parse_requirements(abs_path, is_constraint=False)
+        elif _is_constraints_file(line):
+            req_file = line.split(maxsplit=1)[1]
+            abs_path = os.path.join(os.path.dirname(requirements_file), req_file)
+            yield from _parse_requirements(abs_path, is_constraint=True)
         else:
-            yield line
+            yield _Requirement(line, is_constraint)

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -72,11 +72,11 @@ def _parse_requirements(requirements_file, is_constraint):
 
     References:
     - `pip._internal.req.parse_requirements`:
-        https://github.com/pypa/pip/blob/7a77484a492c8f1e1f5ef24eaf71a43df9ea47eb/src/pip/_internal/req/req_file.py#L118
+      https://github.com/pypa/pip/blob/7a77484a492c8f1e1f5ef24eaf71a43df9ea47eb/src/pip/_internal/req/req_file.py#L118
     - Requirements File Format:
-        https://pip.pypa.io/en/stable/cli/pip_install/#requirements-file-format
+      https://pip.pypa.io/en/stable/cli/pip_install/#requirements-file-format
     - Constraints Files:
-        https://pip.pypa.io/en/stable/user_guide/#constraints-files
+      https://pip.pypa.io/en/stable/user_guide/#constraints-files
     """
     with open(requirements_file) as f:
         lines = f.read().splitlines()

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -189,7 +189,7 @@ def save_model(
 
     conda_env, pip_requirements, pip_constraints = (
         _process_pip_requirements(
-            pip_requirements, extra_pip_requirements, _get_default_pip_requirements(),
+            _get_default_pip_requirements(), pip_requirements, extra_pip_requirements,
         )
         if conda_env is None
         else _process_conda_env(conda_env)

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -202,7 +202,7 @@ def save_model(
 
     # Save `constraints.txt` if necessary
     if pip_constraints:
-        write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME), "\n".join(pip_constraints))
+        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME), "\n".join(pip_constraints))
 
     # Save `requirements.txt`
     write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME), "\n".join(pip_requirements))

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -285,13 +285,14 @@ def log_model(
                             being created and is in ``READY`` status. By default, the function
                             waits for five minutes. Specify 0 or None to skip waiting.
     :param pip_requirements: Either an iterable of pip requirement strings
-        (e.g. ``["scikit-learn", "-r requirements.txt"]``) or the string path to a pip requirements
-        file on the local filesystem (e.g. ``"requirements.txt"``). If provided, this describes the
-        environment this model should be run in. If ``None``, a default list of requirements is
-        inferred from the current software environment. Requirements are automatically parsed and
-        written to a ``requirements.txt`` file that is stored as part of the model. These
-        requirements are also written to the ``pip`` section of the model's conda environment
-        (``conda.yaml``) file.
+        (e.g. ``["scikit-learn", "-r requirements.txt", "-c constrants.txt"]``) or the string path
+        to a pip requirements file on the local filesystem (e.g. ``"requirements.txt"``).
+        If provided, this describes the environment this model should be run in. If ``None``,
+        a default list of requirements is inferred from the current software environment. Both
+        requirements and constraints are automatically parsed and written to ``requirements.txt``
+        and ``constraints.txt`` files, respectively, and stored as part of the model. Requirements
+        are also written to the ``pip`` section of the model's conda environment (``conda.yaml``)
+        file.
     :param extra_pip_requirements: Either an iterable of pip requirement strings
         (e.g. ``["scikit-learn", "-r requirements.txt"]``) or the string path to a pip requirements
         file on the local filesystem (e.g. ``"requirements.txt"``). If provided, this specifies

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -44,6 +44,7 @@ from mlflow.utils.environment import (
 from mlflow.utils.model_utils import _get_flavor_configuration
 from mlflow.exceptions import MlflowException
 from mlflow.utils.annotations import experimental
+from mlflow.utils.file_utils import write_to
 from mlflow.utils.autologging_utils import (
     autologging_integration,
     safe_patch,
@@ -199,13 +200,12 @@ def save_model(
     with open(os.path.join(path, conda_env_subpath), "w") as f:
         yaml.safe_dump(conda_env, stream=f, default_flow_style=False)
 
-    for name, lines in {
-        _REQUIREMENTS_FILE_NAME: pip_requirements,
-        _CONSTRAINTS_FILE_NAME: pip_constraints,
-    }.items():
-        if lines:
-            with open(os.path.join(path, name), "w") as f:
-                f.write("\n".join(lines))
+    # Save `constraints.txt` if necessary
+    if pip_constraints:
+        write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME), "\n".join(pip_constraints))
+
+    # Save `requirements.txt`
+    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME), "\n".join(pip_requirements))
 
     pyfunc.add_to_model(
         mlflow_model, loader_module="mlflow.xgboost", data=model_data_subpath, env=conda_env_subpath

--- a/tests/utils/test_environment.py
+++ b/tests/utils/test_environment.py
@@ -240,7 +240,7 @@ def test_process_pip_requirements(tmpdir):
     assert reqs == ["mlflow", "b"]
     assert cons == []
 
-    # Ensure an mlflow requirement is respected
+    # Ensure a requirement for mlflow is preserved
     conda_env, reqs, cons = _process_pip_requirements(["a"], pip_requirements=["mlflow==1.2.3"])
     assert _get_pip_deps(conda_env) == ["mlflow==1.2.3"]
     assert reqs == ["mlflow==1.2.3"]
@@ -279,6 +279,12 @@ def test_process_conda_env(tmpdir):
     conda_env, reqs, cons = _process_conda_env(conda_env_file.strpath)
     assert _get_pip_deps(conda_env) == ["mlflow", "a"]
     assert reqs == ["mlflow", "a"]
+    assert cons == []
+
+    # Ensure a requirement for mlflow is preserved
+    conda_env, reqs, cons = _process_conda_env(make_conda_env(["mlflow==1.2.3"]))
+    assert _get_pip_deps(conda_env) == ["mlflow==1.2.3"]
+    assert reqs == ["mlflow==1.2.3"]
     assert cons == []
 
     con_file = tmpdir.join("constraints.txt")

--- a/tests/utils/test_environment.py
+++ b/tests/utils/test_environment.py
@@ -287,3 +287,6 @@ def test_process_conda_env(tmpdir):
     assert _get_pip_deps(conda_env) == ["mlflow", "a", "-c constraints.txt"]
     assert reqs == ["mlflow", "a", "-c constraints.txt"]
     assert cons == ["c"]
+
+    with pytest.raises(TypeError, match=r"Expected .+, but got `int`"):
+        _process_conda_env(0)

--- a/tests/utils/test_requirements_utils.py
+++ b/tests/utils/test_requirements_utils.py
@@ -155,7 +155,6 @@ line-cont-eof\
             "rel-req-xxx",
             "rel-req-yyy",
             "abs-req-zzz",
-            *expected_cons,
             "line-cont==1.0",
             "line-cont-space == 1.0",
             "line-cont-blank",
@@ -164,9 +163,9 @@ line-cont-eof\
 
         parsed_reqs = list(_parse_requirements(root_req.basename, is_constraint=False))
         pip_reqs = list(pip_parse_requirements(root_req.basename, session=PipSession()))
-        # Requirements + Constraints
-        assert [r.req_str for r in parsed_reqs] == expected_reqs
-        assert [r.requirement for r in pip_reqs] == expected_reqs
+        # Requirements
+        assert [r.req_str for r in parsed_reqs if not r.is_constraint] == expected_reqs
+        assert [r.requirement for r in pip_reqs if not r.constraint] == expected_reqs
         # Constraints
         assert [r.req_str for r in parsed_reqs if r.is_constraint] == expected_cons
         assert [r.requirement for r in pip_reqs if r.constraint] == expected_cons

--- a/tests/utils/test_requirements_utils.py
+++ b/tests/utils/test_requirements_utils.py
@@ -87,7 +87,7 @@ git+https://github.com/sub/dir#subdirectory=subdir
 -r {relative_req}
 --requirement {absolute_req}
 
-# Constraint files
+# Constraints files
 -c {relative_con}
 --constraint {absolute_con}
 

--- a/tests/utils/test_requirements_utils.py
+++ b/tests/utils/test_requirements_utils.py
@@ -87,6 +87,10 @@ git+https://github.com/sub/dir#subdirectory=subdir
 -r {relative_req}
 --requirement {absolute_req}
 
+# Constraint files
+-c {relative_con}
+--constraint {absolute_con}
+
 # Line continuation
 line-cont\
 ==\
@@ -107,18 +111,36 @@ line-cont-eof\
     try:
         os.chdir(tmpdir)
         root_req = tmpdir.join("requirements.txt")
-        rel_req = tmpdir.join("relative.txt")
-        abs_req = tmpdir.join("absolute.txt")
+        # Requirements files
+        rel_req = tmpdir.join("relative_req.txt")
+        abs_req = tmpdir.join("absolute_req.txt")
+        # Constraints files
+        rel_con = tmpdir.join("relative_con.txt")
+        abs_con = tmpdir.join("absolute_con.txt")
 
         # pip's requirements parser collapses an absolute requirements file path:
         # https://github.com/pypa/pip/issues/10121
         # As a workaround, use a relative path on Windows.
         absolute_req = abs_req.basename if os.name == "nt" else abs_req.strpath
+        absolute_con = abs_con.basename if os.name == "nt" else abs_con.strpath
         root_req.write(
-            root_req_src.format(relative_req=rel_req.basename, absolute_req=absolute_req)
+            root_req_src.format(
+                relative_req=rel_req.basename,
+                absolute_req=absolute_req,
+                relative_con=rel_con.basename,
+                absolute_con=absolute_con,
+            )
         )
-        rel_req.write("rel-xxx\nrel-yyy")
-        abs_req.write("abs-zzz")
+        rel_req.write("rel-req-xxx\nrel-req-yyy")
+        abs_req.write("abs-req-zzz")
+        rel_con.write("rel-con-xxx\nrel-con-yyy")
+        abs_con.write("abs-con-zzz")
+
+        expected_cons = [
+            "rel-con-xxx",
+            "rel-con-yyy",
+            "abs-con-zzz",
+        ]
 
         expected_reqs = [
             "noverspec",
@@ -130,20 +152,23 @@ line-cont-eof\
             "inlinecomm",
             "git+https://github.com/git/uri",
             "git+https://github.com/sub/dir#subdirectory=subdir",
-            "rel-xxx",
-            "rel-yyy",
-            "abs-zzz",
+            "rel-req-xxx",
+            "rel-req-yyy",
+            "abs-req-zzz",
+            *expected_cons,
             "line-cont==1.0",
             "line-cont-space == 1.0",
             "line-cont-blank",
             "line-cont-eof",
         ]
-        parsed_reqs = list(_parse_requirements(root_req.basename))
-        pip_reqs = [
-            req.requirement
-            for req in pip_parse_requirements(root_req.basename, session=PipSession())
-        ]
-        assert pip_reqs == expected_reqs
-        assert parsed_reqs == expected_reqs
+
+        parsed_reqs = list(_parse_requirements(root_req.basename, is_constraint=False))
+        pip_reqs = list(pip_parse_requirements(root_req.basename, session=PipSession()))
+        # Requirements + Constraints
+        assert [r.req_str for r in parsed_reqs] == expected_reqs
+        assert [r.requirement for r in pip_reqs] == expected_reqs
+        # Constraints
+        assert [r.req_str for r in parsed_reqs if r.is_constraint] == expected_cons
+        assert [r.requirement for r in pip_reqs if r.constraint] == expected_cons
     finally:
         os.chdir(request.config.invocation_dir)

--- a/tests/xgboost/test_xgboost_model_export.py
+++ b/tests/xgboost/test_xgboost_model_export.py
@@ -239,6 +239,8 @@ def test_save_model_with_pip_requirements(xgb_model, tmpdir):
 
 @pytest.mark.large
 def test_save_model_with_extra_pip_requirements(xgb_model, tmpdir):
+    default_reqs = mlflow.xgboost._get_default_pip_requirements()
+
     # Path to a requirements file
     tmpdir1 = tmpdir.join("1")
     req_file = tmpdir.join("requirements.txt")
@@ -246,7 +248,6 @@ def test_save_model_with_extra_pip_requirements(xgb_model, tmpdir):
     mlflow.xgboost.save_model(
         xgb_model.model, tmpdir1.strpath, extra_pip_requirements=req_file.strpath
     )
-    default_reqs = mlflow.xgboost._get_default_pip_requirements()
     _assert_pip_requirements(tmpdir1.strpath, ["mlflow", *default_reqs, "a"])
 
     # List of requirements
@@ -268,42 +269,59 @@ def test_save_model_with_extra_pip_requirements(xgb_model, tmpdir):
 
 @pytest.mark.large
 def test_log_model_with_pip_requirements(xgb_model, tmpdir):
-    # TODO: Update tests for `log_model` as well
+    # Path to a requirements file
+    req_file = tmpdir.join("requirements.txt")
+    req_file.write("a")
     with mlflow.start_run():
-        # Path to a requirements file
-        f = tmpdir.join("requirements.txt")
-        f.write("a")
-        mlflow.xgboost.log_model(xgb_model.model, "model", pip_requirements=f.strpath)
+        mlflow.xgboost.log_model(xgb_model.model, "model", pip_requirements=req_file.strpath)
         _assert_pip_requirements(mlflow.get_artifact_uri("model"), ["mlflow", "a"])
 
     # List of requirements
     with mlflow.start_run():
         mlflow.xgboost.log_model(
-            xgb_model.model, "model", pip_requirements=[f"-r {f.strpath}", "b"]
+            xgb_model.model, "model", pip_requirements=[f"-r {req_file.strpath}", "b"]
         )
         _assert_pip_requirements(mlflow.get_artifact_uri("model"), ["mlflow", "a", "b"])
+
+    # Constraints file
+    with mlflow.start_run():
+        mlflow.xgboost.log_model(
+            xgb_model.model, "model", pip_requirements=[f"-c {req_file.strpath}", "b"]
+        )
+        _assert_pip_requirements(
+            mlflow.get_artifact_uri("model"), ["mlflow", "b", "-c constraints.txt"], ["a"]
+        )
 
 
 @pytest.mark.large
 def test_log_model_with_extra_pip_requirements(xgb_model, tmpdir):
+    default_reqs = mlflow.xgboost._get_default_pip_requirements()
+
+    # Path to a requirements file
+    req_file = tmpdir.join("requirements.txt")
+    req_file.write("a")
     with mlflow.start_run():
-        # Path to a requirements file
-        f = tmpdir.join("requirements.txt")
-        f.write("a")
-        mlflow.xgboost.log_model(xgb_model.model, "model", extra_pip_requirements=f.strpath)
-        _assert_pip_requirements(
-            mlflow.get_artifact_uri("model"),
-            ["mlflow", *mlflow.xgboost._get_default_pip_requirements(), "a"],
-        )
+        mlflow.xgboost.log_model(xgb_model.model, "model", extra_pip_requirements=req_file.strpath)
+        _assert_pip_requirements(mlflow.get_artifact_uri("model"), ["mlflow", *default_reqs, "a"])
 
     # List of requirements
     with mlflow.start_run():
         mlflow.xgboost.log_model(
-            xgb_model.model, "model", extra_pip_requirements=[f"-r {f.strpath}", "b"]
+            xgb_model.model, "model", extra_pip_requirements=[f"-r {req_file.strpath}", "b"]
+        )
+        _assert_pip_requirements(
+            mlflow.get_artifact_uri("model"), ["mlflow", *default_reqs, "a", "b"]
+        )
+
+    # Constraints file
+    with mlflow.start_run():
+        mlflow.xgboost.log_model(
+            xgb_model.model, "model", extra_pip_requirements=[f"-c {req_file.strpath}", "b"]
         )
         _assert_pip_requirements(
             mlflow.get_artifact_uri("model"),
-            ["mlflow", *mlflow.xgboost._get_default_pip_requirements(), "a", "b"],
+            ["mlflow", *default_reqs, "b", "-c constraints.txt"],
+            ["a"],
         )
 
 

--- a/tests/xgboost/test_xgboost_model_export.py
+++ b/tests/xgboost/test_xgboost_model_export.py
@@ -217,42 +217,58 @@ def test_model_save_persists_requirements_in_mlflow_model_directory(
 def test_save_model_with_pip_requirements(xgb_model, tmpdir):
     # Path to a requirements file
     tmpdir1 = tmpdir.join("1")
-    f = tmpdir.join("requirements.txt")
-    f.write("a")
-    mlflow.xgboost.save_model(xgb_model.model, tmpdir1.strpath, pip_requirements=f.strpath)
+    req_file = tmpdir.join("requirements.txt")
+    req_file.write("a")
+    mlflow.xgboost.save_model(xgb_model.model, tmpdir1.strpath, pip_requirements=req_file.strpath)
     _assert_pip_requirements(tmpdir1.strpath, ["mlflow", "a"])
 
     # List of requirements
     tmpdir2 = tmpdir.join("2")
     mlflow.xgboost.save_model(
-        xgb_model.model, tmpdir2.strpath, pip_requirements=[f"-r {f.strpath}", "b"]
+        xgb_model.model, tmpdir2.strpath, pip_requirements=[f"-r {req_file.strpath}", "b"]
     )
     _assert_pip_requirements(tmpdir2.strpath, ["mlflow", "a", "b"])
+
+    # Constraints file
+    tmpdir3 = tmpdir.join("3")
+    mlflow.xgboost.save_model(
+        xgb_model.model, tmpdir3.strpath, pip_requirements=[f"-c {req_file.strpath}", "b"]
+    )
+    _assert_pip_requirements(tmpdir3.strpath, ["mlflow", "b", "-c constraints.txt"], ["a"])
 
 
 @pytest.mark.large
 def test_save_model_with_extra_pip_requirements(xgb_model, tmpdir):
     # Path to a requirements file
     tmpdir1 = tmpdir.join("1")
-    f = tmpdir.join("requirements.txt")
-    f.write("a")
-    mlflow.xgboost.save_model(xgb_model.model, tmpdir1.strpath, extra_pip_requirements=f.strpath)
-    _assert_pip_requirements(
-        tmpdir1.strpath, ["mlflow", *mlflow.xgboost._get_default_pip_requirements(), "a"]
+    req_file = tmpdir.join("requirements.txt")
+    req_file.write("a")
+    mlflow.xgboost.save_model(
+        xgb_model.model, tmpdir1.strpath, extra_pip_requirements=req_file.strpath
     )
+    default_reqs = mlflow.xgboost._get_default_pip_requirements()
+    _assert_pip_requirements(tmpdir1.strpath, ["mlflow", *default_reqs, "a"])
 
     # List of requirements
     tmpdir2 = tmpdir.join("2")
     mlflow.xgboost.save_model(
-        xgb_model.model, tmpdir2.strpath, extra_pip_requirements=[f"-r {f.strpath}", "b"]
+        xgb_model.model, tmpdir2.strpath, extra_pip_requirements=[f"-r {req_file.strpath}", "b"]
+    )
+    _assert_pip_requirements(tmpdir2.strpath, ["mlflow", *default_reqs, "a", "b"])
+
+    # Constraints file
+    tmpdir3 = tmpdir.join("3")
+    mlflow.xgboost.save_model(
+        xgb_model.model, tmpdir3.strpath, extra_pip_requirements=[f"-c {req_file.strpath}", "b"]
     )
     _assert_pip_requirements(
-        tmpdir2.strpath, ["mlflow", *mlflow.xgboost._get_default_pip_requirements(), "a", "b"]
+        tmpdir3.strpath, ["mlflow", *default_reqs, "b", "-c constraints.txt"], ["a"]
     )
 
 
 @pytest.mark.large
 def test_log_model_with_pip_requirements(xgb_model, tmpdir):
+    # TODO: Update tests for `log_model` as well
     with mlflow.start_run():
         # Path to a requirements file
         f = tmpdir.join("requirements.txt")


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

- A follow-up PR for #4519 
- Add support for constrains files to `pip_requirements` and `additional_pip_requirements`.
 
## How is this patch tested?

Unit tests

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`log_model` and `save_model` now supports logging constraints files for pip.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
