### PR TITLE
Lazily obtain Databricks runtime version in `Model` to avoid importing pyspark when loading MLflow model

### DIFF
--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -94,9 +94,6 @@ class Model(object):
         databricks_runtime = get_databricks_runtime()
         if databricks_runtime:
             res["databricks_runtime"] = databricks_runtime
-
-        if not res.get("databricks_runtime"):
-            res.pop("databricks_runtime")
         if self.signature is not None:
             res["signature"] = self.signature.to_dict()
         if self.saved_input_example_info is not None:

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -48,9 +48,6 @@ class Model(object):
             self.run_id = run_id
             self.artifact_path = artifact_path
 
-        databricks_runtime = get_databricks_runtime()
-        if databricks_runtime:
-            self.databricks_runtime = databricks_runtime
         self.utc_time_created = str(utc_time_created or datetime.utcnow())
         self.flavors = flavors if flavors is not None else {}
         self.signature = signature
@@ -94,6 +91,12 @@ class Model(object):
     def to_dict(self):
         """Serialize the model to a dictionary."""
         res = {k: v for k, v in self.__dict__.items() if not k.startswith("_")}
+        databricks_runtime = get_databricks_runtime()
+        if databricks_runtime:
+            res["databricks_runtime"] = databricks_runtime
+
+        if not res.get("databricks_runtime"):
+            res.pop("databricks_runtime")
         if self.signature is not None:
             res["signature"] = self.signature.to_dict()
         if self.saved_input_example_info is not None:


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Lazily obtain Databricks runtime version in `Model` to avoid importing pyspark when loanding MLflow model.

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
