### PR TITLE
Set `defaults.run.shell` to `bash`

### DIFF
--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - master
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   set-matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -7,6 +7,10 @@ on:
     # Run this action daily at 7:00 UTC
     - cron: "0 7 * * *"
 
+defaults:
+  run:
+    shell: bash
+
 env:
   CONDA_DIR: /usr/share/miniconda
 

--- a/.github/workflows/labeling.yml
+++ b/.github/workflows/labeling.yml
@@ -10,6 +10,10 @@ on:
       - opened
       - edited
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   labeling:
     runs-on: ubuntu-latest

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -10,8 +10,14 @@ on:
       - master
       - branch-[0-9]+.[0-9]+
 
+# Use `bash` by default for all `run` steps in this workflow:
+# https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#defaultsrun
 defaults:
   run:
+    # GitHub Actions runner executes commands specified in a run step via:
+    # $ bash --noprofile --norc -eo pipefail < commands >
+    #
+    # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#using-a-specific-shell
     shell: bash
 
 env:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -13,6 +13,10 @@ on:
 env:
   CONDA_DIR: /usr/share/miniconda
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -10,12 +10,12 @@ on:
       - master
       - branch-[0-9]+.[0-9]+
 
-env:
-  CONDA_DIR: /usr/share/miniconda
-
 defaults:
   run:
     shell: bash
+
+env:
+  CONDA_DIR: /usr/share/miniconda
 
 jobs:
   lint:

--- a/.github/workflows/release-note-category.yml
+++ b/.github/workflows/release-note-category.yml
@@ -11,6 +11,10 @@ on:
       - labeled
       - unlabeled
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-package-build.yml
+++ b/.github/workflows/test-package-build.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master]
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

By default, GitHub Actions runner uses the following command when running a shell command:

```
/usr/bin/bash -e <command>
```

https://github.com/mlflow/mlflow/pull/4545/checks?check_run_id=3084960270#step:9:13

This actually allows a failure in a piped command (e.g. `commands1 | command2 | command3`)

This PR changes the command above to the following by settting `defaults.run.shell` to `bash`:

```
shell: /usr/bin/bash --noprofile --norc -e -o pipefail <command>
```

This command doesn't allow a failure in a pipeline command and makes it easier to debug issues.

## How is this patch tested?

Existing checks.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
