### PR TITLE
Fix test for dev version of statsmodels

### DIFF
--- a/tests/statsmodels/model_fixtures.py
+++ b/tests/statsmodels/model_fixtures.py
@@ -58,7 +58,13 @@ def get_dataset(name):
     # the v0.12.2 release: https://github.com/statsmodels/statsmodels/pull/7578
     as_pandas_supported = Version(sm.__version__) <= Version("0.12.2")
     dataset_module = getattr(sm.datasets, name)
-    return dataset_module.load(as_pandas=False) if as_pandas_supported else dataset_module.load()
+    if as_pandas_supported:
+        return dataset_module.load(as_pandas=False)
+    else:
+        data = dataset_module.load()
+        data.exog = np.asarray(data.exog)
+        data.endog = np.asarray(data.endog)
+        return data
 
 
 @pytest.fixture(scope="session")

--- a/tests/statsmodels/model_fixtures.py
+++ b/tests/statsmodels/model_fixtures.py
@@ -54,8 +54,9 @@ def failing_logit_model():
 
 
 def get_dataset(name):
-    # `as_pandas` argument for `statsmodel.datasets.*.load` has been removed by this PR after
-    # the v0.12.2 release: https://github.com/statsmodels/statsmodels/pull/7578
+    # `as_pandas` for `statsmodels.datasets.*.load` has been removed by the PR below and is only
+    # available in statsmodels <= 0.12.2:
+    # https://github.com/statsmodels/statsmodels/pull/7578
     as_pandas_supported = Version(sm.__version__) <= Version("0.12.2")
     dataset_module = getattr(sm.datasets, name)
     if as_pandas_supported:

--- a/tests/statsmodels/model_fixtures.py
+++ b/tests/statsmodels/model_fixtures.py
@@ -6,7 +6,6 @@ from collections import namedtuple
 from statsmodels.tsa.arima_process import arma_generate_sample
 from statsmodels.tsa.arima.model import ARIMA
 from scipy.linalg import toeplitz
-from packaging.version import Version
 
 
 ModelWithResults = namedtuple("ModelWithResults", ["model", "alg", "inference_dataframe"])

--- a/tests/statsmodels/model_fixtures.py
+++ b/tests/statsmodels/model_fixtures.py
@@ -54,18 +54,11 @@ def failing_logit_model():
 
 
 def get_dataset(name):
-    # `as_pandas` for `statsmodels.datasets.*.load` has been removed by the PR below and is only
-    # available in statsmodels <= 0.12.2:
-    # https://github.com/statsmodels/statsmodels/pull/7578
-    as_pandas_supported = Version(sm.__version__) <= Version("0.12.2")
     dataset_module = getattr(sm.datasets, name)
-    if as_pandas_supported:
-        return dataset_module.load(as_pandas=False)
-    else:
-        data = dataset_module.load()
-        data.exog = np.asarray(data.exog)
-        data.endog = np.asarray(data.endog)
-        return data
+    data = dataset_module.load()
+    data.exog = np.asarray(data.exog)
+    data.endog = np.asarray(data.endog)
+    return data
 
 
 @pytest.fixture(scope="session")

--- a/tests/statsmodels/model_fixtures.py
+++ b/tests/statsmodels/model_fixtures.py
@@ -203,7 +203,6 @@ def gee_model():
 @pytest.fixture(scope="session")
 def glm_model():
     # Generalized Linear Model (GLM)
-
     data = get_dataset("scotland")
     data.exog = sm.add_constant(data.exog)
     glm = sm.GLM(data.endog, data.exog, family=sm.families.Gamma())


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Fix test for dev version of statsmodels.

## How is this patch tested?

Fixed tests.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
