### PR TITLE
Allow specifying flavors and versions when manually running cross-version tests

### DIFF
--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       flavors:
-        description: "[Optional] Comma-separated string specifying which flavors to test (e.g. 'keras, scikit-learn'). If unspecified, all flavors are tested."
+        description: "[Optional] Comma-separated string specifying which flavors to test (e.g. 'sklearn, xgboost'). If unspecified, all flavors are tested."
         required: false
         default: ""
       versions:

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -2,6 +2,15 @@ name: Cross version tests
 
 on:
   workflow_dispatch:
+    inputs:
+      flavors:
+        description: "[Optional] Comma-separated string specifying which flavors to test (e.g. 'keras, scikit-learn'). If unspecified, all flavors are tested."
+        required: false
+        default: ""
+      versions:
+        description: "[Optional] Comma-separated string specifying which versions to test (e.g. '1.2.3, 4.5.6'). If unspecified, all versions are tested."
+        required: false
+        default: ""
   schedule:
     # Run this workflow daily at 7:00 UTC
     - cron: "0 7 * * *"
@@ -50,12 +59,15 @@ jobs:
             git fetch origin master:master
           fi
 
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
+          EVENT_NAME="${{ github.event_name }}"
+          if [ "$EVENT_NAME" = "pull_request" ]; then
             REF_VERSIONS_YAML="https://raw.githubusercontent.com/mlflow/mlflow/master/mlflow/ml-package-versions.yml"
             CHANGED_FILES="$(git diff --name-only master..HEAD)"
             ENABLE_DEV_TESTS="${{ steps.enable-dev-tests.outputs.result }}"
             EXCLUDE_DEV_VERSIONS_FLAG=$([ "$ENABLE_DEV_TESTS" == "true" ] && echo "" || echo "--exclude-dev-versions")
             python dev/set_matrix.py --ref-versions-yaml "$REF_VERSIONS_YAML" --changed-files "$CHANGED_FILES" $EXCLUDE_DEV_VERSIONS_FLAG
+          elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            python dev/set_matrix.py --flavors "${{ github.event.inputs.flavors }}" --versions "${{ github.event.inputs.versions }}"
           else
             python dev/set_matrix.py
           fi

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -357,6 +357,11 @@ def divider(title, length=None):
     return "\n{} {} {}".format("=" * left, title, "=" * (rest - left))
 
 
+def split_by_comma(x):
+    stripped = x.strip()
+    return list(map(str.strip, stripped.split(","))) if stripped != "" else []
+
+
 def parse_args():
     parser = argparse.ArgumentParser(description="Set a test matrix for the cross version tests")
     parser.add_argument(
@@ -374,6 +379,19 @@ def parse_args():
         required=False,
         default=None,
         help=("A string that represents a list of changed files"),
+    )
+
+    parser.add_argument(
+        "--flavors",
+        required=False,
+        type=split_by_comma,
+        help="Comma-separated string specifying which flavors to test (e.g. 'keras, scikit-learn')",
+    )
+    parser.add_argument(
+        "--versions",
+        required=False,
+        type=split_by_comma,
+        help="Comma-separated string specifying which versions to test (e.g. '1.2.3, 4.5.6')",
     )
 
     parser.add_argument(
@@ -484,6 +502,13 @@ def main():
 
     # If this file contains changes, re-run all the tests, otherwise re-run the affected tests.
     include = matrix if (__file__ in changed_files) else diff_config.union(diff_flavor)
+
+    if args.flavors:
+        include = filter(lambda x: x["flavor"] in args.flavors, include)
+
+    if args.versions:
+        include = filter(lambda x: x["version"] in args.versions, include)
+
     include = sorted(include, key=lambda x: x["job_name"])
     job_names = [x["job_name"] for x in include]
 

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -373,7 +373,7 @@ def parse_args(args):
         default="mlflow/ml-package-versions.yml",
         help=(
             "URL or local file path of the config yaml. Defaults to "
-            "'mlflow/ml-package-versions.yml' on the branch where this script is running",
+            "'mlflow/ml-package-versions.yml' on the branch where this script is running."
         ),
     )
     parser.add_argument(
@@ -382,7 +382,7 @@ def parse_args(args):
         default=None,
         help=(
             "URL or local file path of the reference config yaml which will be compared with the "
-            "config specified by `--versions-yaml` in order to identify the config updates"
+            "config specified by `--versions-yaml` in order to identify the config updates."
         ),
     )
     parser.add_argument(
@@ -397,13 +397,19 @@ def parse_args(args):
         "--flavors",
         required=False,
         type=split_by_comma,
-        help="Comma-separated string specifying which flavors to test (e.g. 'keras, scikit-learn')",
+        help=(
+            "Comma-separated string specifying which flavors to test (e.g. 'sklearn, xgboost'). "
+            "If unspecified, all flavors are tested."
+        ),
     )
     parser.add_argument(
         "--versions",
         required=False,
         type=split_by_comma,
-        help="Comma-separated string specifying which versions to test (e.g. '1.2.3, 4.5.6')",
+        help=(
+            "Comma-separated string specifying which versions to test (e.g. '1.2.3, 4.5.6'). "
+            "If unspecified, all versions are tested."
+        ),
     )
 
     parser.add_argument(
@@ -411,7 +417,7 @@ def parse_args(args):
         action="store_true",
         required=False,
         default=False,
-        help="If True, exclude dev versions from the test matrix",
+        help="If True, exclude dev versions from the test matrix.",
     )
 
     return parser.parse_args(args)

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -496,7 +496,7 @@ def process_changed_files(changed_files, matrix_base):
     if changed_files is None:
         return set()
 
-    flavors = set(x["flavors"] for x in matrix_base)
+    flavors = set(x["flavor"] for x in matrix_base)
     changed_flavors = (
         # If this file (`dev/set_matrix.py`) has been changed, re-run all tests
         flavors

--- a/tests/dev/test_set_matrix.py
+++ b/tests/dev/test_set_matrix.py
@@ -32,7 +32,7 @@ class MockResponse:
 
 
 def mock_pypi_api(mock_responses):
-    def urlopen_patch(url, *args, **kwargs):
+    def urlopen_patch(url, *args, **kwargs):  # pylint: disable=unused-argument
         package_name = re.search(r"https://pypi.python.org/pypi/(.+)/json", url).group(1)
         return mock_responses[package_name]
 
@@ -107,7 +107,7 @@ def test_flavors(flavors, expected):
 @pytest.mark.parametrize(
     "versions, expected",
     [
-        ("1.0.0", {"1.0.0",}),
+        ("1.0.0", {"1.0.0"}),
         ("1.0.0,1.1.1", {"1.0.0", "1.1.1"}),
         ("1.3, 1.4", {"1.3", "1.4"}),  # Contains a space after a comma
         ("", {"1.0.0", "1.1.1", "1.2.0", "1.3", "1.4", "dev"}),

--- a/tests/dev/test_set_matrix.py
+++ b/tests/dev/test_set_matrix.py
@@ -1,0 +1,133 @@
+import json
+import re
+from unittest import mock
+import tempfile
+from contextlib import contextmanager
+import functools
+import pytest
+
+from dev.set_matrix import generate_matrix
+
+
+class MockResponse:
+    def __init__(self, body):
+        self.body = body
+
+    def read(self):
+        return json.dumps(self.body).encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        pass
+
+    @classmethod
+    def from_versions(cls, versions):
+        return cls(
+            {"releases": {v: [{"filename": v + ".whl", "upload_time": v}] for v in versions}}
+        )
+
+
+def mock_pypi_api(mock_responses):
+    def urlopen_patch(url, *args, **kwargs):
+        package_name = re.search(r"https://pypi.python.org/pypi/(.+)/json", url).group(1)
+        return mock_responses[package_name]
+
+    def decorotor(test_func):
+        @functools.wraps(test_func)
+        def wrapper(*args, **kwargs):
+            with mock.patch("urllib.request.urlopen", new=urlopen_patch):
+                return test_func(*args, **kwargs)
+
+        return wrapper
+
+    return decorotor
+
+
+@contextmanager
+def mock_ml_package_versions_yml(src, src_ref):
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yml") as yml, tempfile.NamedTemporaryFile(
+        mode="w", suffix=".yml"
+    ) as yml_ref:
+        yml.write(src)
+        yml.flush()
+        yml_ref.write(src_ref)
+        yml_ref.flush()
+        yield ["--versions-yaml", yml.name, "--ref-versions-yaml", yml_ref.name]
+
+
+MOCK_YAML_SOURCE = """
+foo:
+  package_info:
+    pip_release: foo
+    install_dev: "pip install git+https://github.com/foo/foo.git"
+
+  autologging:
+    minimum: "1.0.0"
+    maximum: "1.2.0"
+    run: pytest tests/foo
+
+bar:
+  package_info:
+    pip_release: bar
+    install_dev: "pip install git+https://github.com/bar/bar.git"
+
+  autologging:
+    minimum: "1.3"
+    maximum: "1.4"
+    run: pytest/tests bar
+"""
+
+MOCK_PYPI_API_RESPONSES = {
+    "foo": MockResponse.from_versions(["1.0.0", "1.1.0", "1.1.1", "1.2.0"]),
+    "bar": MockResponse.from_versions(["1.3", "1.4"]),
+}
+
+
+@pytest.mark.parametrize(
+    "flavors, expected",
+    [
+        ("foo", {"foo"}),
+        ("foo,bar", {"foo", "bar"}),
+        ("foo, bar", {"foo", "bar"}),  # Contains a space after a comma
+        ("", {"foo", "bar"}),
+        (None, {"foo", "bar"}),
+    ],
+)
+@mock_pypi_api(MOCK_PYPI_API_RESPONSES)
+def test_flavors(flavors, expected):
+    with mock_ml_package_versions_yml(MOCK_YAML_SOURCE, "{}") as path_args:
+        flavors_args = [] if flavors is None else ["--flavors", flavors]
+        matrix = generate_matrix([*path_args, *flavors_args])
+        flavors = set(x["flavor"] for x in matrix)
+        assert flavors == expected
+
+
+@pytest.mark.parametrize(
+    "versions, expected",
+    [
+        ("1.0.0", {"1.0.0",}),
+        ("1.0.0,1.1.1", {"1.0.0", "1.1.1"}),
+        ("1.3, 1.4", {"1.3", "1.4"}),  # Contains a space after a comma
+        ("", {"1.0.0", "1.1.1", "1.2.0", "1.3", "1.4", "dev"}),
+        (None, {"1.0.0", "1.1.1", "1.2.0", "1.3", "1.4", "dev"}),
+    ],
+)
+@mock_pypi_api(MOCK_PYPI_API_RESPONSES)
+def test_versions(versions, expected):
+    with mock_ml_package_versions_yml(MOCK_YAML_SOURCE, "{}") as path_args:
+        versions_args = [] if versions is None else ["--versions", versions]
+        matrix = generate_matrix([*path_args, *versions_args])
+        versions = set(x["version"] for x in matrix)
+        assert versions == expected
+
+
+@mock_pypi_api(MOCK_PYPI_API_RESPONSES)
+def test_flavors_and_versions():
+    with mock_ml_package_versions_yml(MOCK_YAML_SOURCE, "{}") as path_args:
+        matrix = generate_matrix([*path_args, "--flavors", "foo,bar", "--versions", "dev"])
+        flavors = set(x["flavor"] for x in matrix)
+        versions = set(x["version"] for x in matrix)
+        assert set(flavors) == {"foo", "bar"}
+        assert set(versions) == {"dev"}

--- a/tests/dev/test_set_matrix.py
+++ b/tests/dev/test_set_matrix.py
@@ -4,6 +4,8 @@ from unittest import mock
 import tempfile
 from contextlib import contextmanager
 import functools
+from pathlib import Path
+
 import pytest
 
 from dev.set_matrix import generate_matrix
@@ -46,15 +48,13 @@ def mock_pypi_api(mock_responses):
 
 
 @contextmanager
-def mock_ml_package_versions_yml(src, src_ref):
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".yml") as yml, tempfile.NamedTemporaryFile(
-        mode="w", suffix=".yml"
-    ) as yml_ref:
-        yml.write(src)
-        yml.flush()
-        yml_ref.write(src_ref)
-        yml_ref.flush()
-        yield ["--versions-yaml", yml.name, "--ref-versions-yaml", yml_ref.name]
+def mock_ml_package_versions_yml(src_base, src_ref):
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        yml_base = Path(tmp_dir).joinpath("base.yml")
+        yml_ref = Path(tmp_dir).joinpath("ref.yml")
+        yml_base.write_text(src_base)
+        yml_ref.write_text(src_ref)
+        yield ["--versions-yaml", str(yml_base), "--ref-versions-yaml", str(yml_ref)]
 
 
 MOCK_YAML_SOURCE = """


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Allow specifying flavors and versions when manually running cross-version tests to avoid running all tests when we want to only test a specific version in a specific flavor.
- Make `set_matrix.py` testable for faster development and preventing regressions.
- Refactoring.

## How is this patch tested?

Manually verified the proposed changes work as expected.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
