### PR TITLE
Fix dev gluon test

### DIFF
--- a/mlflow/gluon.py
+++ b/mlflow/gluon.py
@@ -55,6 +55,7 @@ def load_model(model_uri, ctx):
         model = mlflow.gluon.load_model("runs:/" + gluon_random_data_run.info.run_id + "/model")
         model(nd.array(np.random.rand(1000, 1, 32)))
     """
+    import mxnet as mx
     from mxnet import gluon
     from mxnet import sym
 

--- a/tests/gluon/test_gluon_model_export.py
+++ b/tests/gluon/test_gluon_model_export.py
@@ -4,7 +4,6 @@ import warnings
 import yaml
 
 import mxnet as mx
-import mxnet.ndarray as nd
 import numpy as np
 import pandas as pd
 import pytest

--- a/tests/gluon_autolog/test_gluon_autolog.py
+++ b/tests/gluon_autolog/test_gluon_autolog.py
@@ -1,3 +1,4 @@
+from mxnet.numpy.multiarray import array
 from packaging.version import Version
 import random
 import warnings
@@ -19,8 +20,12 @@ from unittest.mock import patch
 
 if Version(mx.__version__) >= Version("2.0.0"):
     from mxnet.gluon.metric import Accuracy  # pylint: disable=import-error
+
+    array_module = mx.np
 else:
     from mxnet.metric import Accuracy  # pylint: disable=import-error
+
+    array_module = mx.nd
 
 
 class LogsDataset(Dataset):
@@ -28,7 +33,10 @@ class LogsDataset(Dataset):
         self.len = 1000
 
     def __getitem__(self, idx):
-        return nd.array(np.random.rand(1, 32)), nd.full(1, random.randint(0, 10), dtype="float32")
+        return (
+            array_module.array(np.random.rand(1, 32)),
+            array_module.full(1, random.randint(0, 10), dtype="float32"),
+        )
 
     def __len__(self):
         return self.len
@@ -139,7 +147,7 @@ def test_gluon_autolog_model_can_load_from_artifact(gluon_random_data_run):
     assert "model" in artifacts
     ctx = mx.cpu()
     model = mlflow.gluon.load_model("runs:/" + gluon_random_data_run.info.run_id + "/model", ctx)
-    model(nd.array(np.random.rand(1000, 1, 32)))
+    model(array_module.array(np.random.rand(1000, 1, 32)))
 
 
 @pytest.mark.large

--- a/tests/gluon_autolog/test_gluon_autolog.py
+++ b/tests/gluon_autolog/test_gluon_autolog.py
@@ -3,7 +3,6 @@ import random
 import warnings
 
 import mxnet as mx
-import mxnet.ndarray as nd
 import numpy as np
 import pytest
 from mxnet.gluon import Trainer

--- a/tests/gluon_autolog/test_gluon_autolog.py
+++ b/tests/gluon_autolog/test_gluon_autolog.py
@@ -1,4 +1,3 @@
-from mxnet.numpy.multiarray import array
 from packaging.version import Version
 import random
 import warnings


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

Fix dev gluon test

## How is this patch tested?

Fixed tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
