### PR TITLE
Introduce `format_docstring` decorator to deduplicate param docs

### DIFF
--- a/mlflow/utils/docstring_utils.py
+++ b/mlflow/utils/docstring_utils.py
@@ -1,0 +1,90 @@
+import textwrap
+import re
+
+
+_leading_whitespace_re = re.compile("(^[ ]*)(?:[^ \n])", re.MULTILINE)
+
+
+def _get_minimum_indentation(text):
+    """
+    Returns the minimum indentation of all non-blank lines in `text`.
+    """
+    indents = _leading_whitespace_re.findall(text)
+    return min(indents, key=len) if indents else ""
+
+
+def _format_param_docs(param_docs):
+    """
+    Returns a decorator that replaces param document placeholders (e.g. '{{ param_name }}') in the
+    docstring of the decorated function.
+
+    :param param_docs: A dict in the form of `{"param_name": "param_doc"}`.
+
+    Examples
+    --------
+    >>> param_docs = {"foo": "bar"}
+    >>> @_format_param_docs(param_docs)
+    ... def func(foo):
+    ...     '''
+    ...     =====================
+    ...     :param foo: {{ foo }}
+    ...     =====================
+    ...     '''
+    >>> print(func.__doc__)
+
+        =====================
+        :param foo:
+            bar
+        =====================
+    """
+
+    def decorator(func):
+        new_doc = func.__doc__
+        min_indent = _get_minimum_indentation(func.__doc__)
+
+        for param_name, param_doc in param_docs.items():
+            placeholder = "{{ " + param_name + " }}"
+            assert placeholder in new_doc
+
+            param_doc = textwrap.indent(param_doc, min_indent + " " * 4)
+            if not param_doc.startswith("\n"):
+                param_doc = "\n" + param_doc
+
+            new_doc = new_doc.replace(placeholder, param_doc)
+
+        func.__doc__ = new_doc
+        return func
+
+    return decorator
+
+
+LOG_MODEL_PARAM_DOCS = {
+    "pip_requirements": """
+Either an iterable of pip requirement strings
+(e.g. ``["scikit-learn", "-r requirements.txt"]``) or the string path to a pip requirements
+file on the local filesystem (e.g. ``"requirements.txt"``). If provided, this describes the
+environment this model should be run in. If ``None``, a default list of requirements is
+inferred from the current software environment. Requirements are automatically parsed and
+written to a ``requirements.txt`` file that is stored as part of the model. These
+requirements are also written to the ``pip`` section of the model's conda environment
+(``conda.yaml``) file.
+""",
+    "extra_pip_requirements": """
+Either an iterable of pip requirement strings
+(e.g. ``["scikit-learn", "-r requirements.txt"]``) or the string path to a pip requirements
+file on the local filesystem (e.g. ``"requirements.txt"``). If provided, this specifies
+additional pip requirements that are appended to a default set of pip requirements generated
+automatically based on the user's current software environment. Requirements are also
+written to the ``pip`` section of the model's conda environment (``conda.yaml``) file.
+
+.. warning::
+    The following arguments can't be specified at the same time:
+
+    - ``conda_env``
+    - ``pip_requirements``
+    - ``extra_pip_requirements``
+
+:ref:`This example<pip-requirements-example>` demonstrates how to specify pip requirements
+using ``pip_requirements`` and ``extra_pip_requirements``.
+""",
+}

--- a/mlflow/utils/docstring_utils.py
+++ b/mlflow/utils/docstring_utils.py
@@ -1,6 +1,5 @@
 import textwrap
 import re
-from functools import reduce
 
 
 def _create_placeholder(key):

--- a/mlflow/utils/docstring_utils.py
+++ b/mlflow/utils/docstring_utils.py
@@ -40,21 +40,23 @@ LOG_MODEL_PARAM_DOCS = ParamDocs(
     {
         "pip_requirements": """
 Either an iterable of pip requirement strings
-(e.g. ``["{{ package_name }}", "-r requirements.txt"]``) or the string path to a pip requirements
-file on the local filesystem (e.g. ``"requirements.txt"``). If provided, this describes the
-environment this model should be run in. If ``None``, a default list of requirements is
-inferred from the current software environment. Requirements are automatically parsed and
-written to a ``requirements.txt`` file that is stored as part of the model. These
-requirements are also written to the ``pip`` section of the model's conda environment
-(``conda.yaml``) file.
+(e.g. ``["{{ package_name }}", "-r requirements.txt", "-c constrants.txt"]``) or the string path to
+a pip requirements file on the local filesystem (e.g. ``"requirements.txt"``). If provided, this
+describes the environment this model should be run in. If ``None``, a default list of requirements
+is inferred from the current software environment. Both requirements and constraints are
+automatically parsed and written to ``requirements.txt`` and ``constraints.txt`` files,
+respectively, and stored as part of the model. Requirements are also written to the ``pip`` section
+of the model's conda environment (``conda.yaml``) file.
 """,
         "extra_pip_requirements": """
 Either an iterable of pip requirement strings
-(e.g. ``["{{ package_name }}", "-r requirements.txt"]``) or the string path to a pip requirements
-file on the local filesystem (e.g. ``"requirements.txt"``). If provided, this specifies
-additional pip requirements that are appended to a default set of pip requirements generated
-automatically based on the user's current software environment. Requirements are also
-written to the ``pip`` section of the model's conda environment (``conda.yaml``) file.
+(e.g. ``["{{ package_name }}", "-r requirements.txt", "-c constrants.txt"]``) or the string path to
+a pip requirements file on the local filesystem (e.g. ``"requirements.txt"``). If provided, this
+describes additional pip requirements that are appended to a default set of pip requirements
+generated automatically based on the user's current software environment. Both requirements and
+constraints are automatically parsed and written to ``requirements.txt`` and ``constraints.txt``
+files, respectively, and stored as part of the model. Requirements are also written to the ``pip``
+section of the model's conda environment (``conda.yaml``) file.
 
 .. warning::
     The following arguments can't be specified at the same time:
@@ -63,8 +65,8 @@ written to the ``pip`` section of the model's conda environment (``conda.yaml``)
     - ``pip_requirements``
     - ``extra_pip_requirements``
 
-:ref:`This example<pip-requirements-example>` demonstrates how to specify pip requirements
-using ``pip_requirements`` and ``extra_pip_requirements``.
+:ref:`This example<pip-requirements-example>` demonstrates how to specify pip requirements using
+``pip_requirements`` and ``extra_pip_requirements``.
 """,
     }
 )

--- a/mlflow/utils/docstring_utils.py
+++ b/mlflow/utils/docstring_utils.py
@@ -70,42 +70,6 @@ class ParamDocs(dict):
         return docstring
 
 
-LOG_MODEL_PARAM_DOCS = ParamDocs(
-    {
-        "pip_requirements": """
-Either an iterable of pip requirement strings
-(e.g. ``["{{ package_name }}", "-r requirements.txt", "-c constraints.txt"]``) or the string path to
-a pip requirements file on the local filesystem (e.g. ``"requirements.txt"``). If provided, this
-describes the environment this model should be run in. If ``None``, a default list of requirements
-is inferred from the current software environment. Both requirements and constraints are
-automatically parsed and written to ``requirements.txt`` and ``constraints.txt`` files,
-respectively, and stored as part of the model. Requirements are also written to the ``pip`` section
-of the model's conda environment (``conda.yaml``) file.
-""",
-        "extra_pip_requirements": """
-Either an iterable of pip requirement strings
-(e.g. ``["{{ package_name }}", "-r requirements.txt", "-c constraints.txt"]``) or the string path to
-a pip requirements file on the local filesystem (e.g. ``"requirements.txt"``). If provided, this
-describes additional pip requirements that are appended to a default set of pip requirements
-generated automatically based on the user's current software environment. Both requirements and
-constraints are automatically parsed and written to ``requirements.txt`` and ``constraints.txt``
-files, respectively, and stored as part of the model. Requirements are also written to the ``pip``
-section of the model's conda environment (``conda.yaml``) file.
-
-.. warning::
-    The following arguments can't be specified at the same time:
-
-    - ``conda_env``
-    - ``pip_requirements``
-    - ``extra_pip_requirements``
-
-:ref:`This example<pip-requirements-example>` demonstrates how to specify pip requirements using
-``pip_requirements`` and ``extra_pip_requirements``.
-""",
-    }
-)
-
-
 _leading_whitespace_re = re.compile("(^[ ]*)(?:[^ \n])", re.MULTILINE)
 
 
@@ -148,3 +112,40 @@ def format_docstring(param_docs):
         return func
 
     return decorator
+
+
+# `{{ ... }}` represents a placeholder.
+LOG_MODEL_PARAM_DOCS = ParamDocs(
+    {
+        "pip_requirements": """
+Either an iterable of pip requirement strings
+(e.g. ``["{{ package_name }}", "-r requirements.txt", "-c constraints.txt"]``) or the string path to
+a pip requirements file on the local filesystem (e.g. ``"requirements.txt"``). If provided, this
+describes the environment this model should be run in. If ``None``, a default list of requirements
+is inferred from the current software environment. Both requirements and constraints are
+automatically parsed and written to ``requirements.txt`` and ``constraints.txt`` files,
+respectively, and stored as part of the model. Requirements are also written to the ``pip`` section
+of the model's conda environment (``conda.yaml``) file.
+""",
+        "extra_pip_requirements": """
+Either an iterable of pip requirement strings
+(e.g. ``["{{ package_name }}", "-r requirements.txt", "-c constraints.txt"]``) or the string path to
+a pip requirements file on the local filesystem (e.g. ``"requirements.txt"``). If provided, this
+describes additional pip requirements that are appended to a default set of pip requirements
+generated automatically based on the user's current software environment. Both requirements and
+constraints are automatically parsed and written to ``requirements.txt`` and ``constraints.txt``
+files, respectively, and stored as part of the model. Requirements are also written to the ``pip``
+section of the model's conda environment (``conda.yaml``) file.
+
+.. warning::
+    The following arguments can't be specified at the same time:
+
+    - ``conda_env``
+    - ``pip_requirements``
+    - ``extra_pip_requirements``
+
+:ref:`This example<pip-requirements-example>` demonstrates how to specify pip requirements using
+``pip_requirements`` and ``extra_pip_requirements``.
+""",
+    }
+)

--- a/mlflow/utils/docstring_utils.py
+++ b/mlflow/utils/docstring_utils.py
@@ -74,7 +74,7 @@ LOG_MODEL_PARAM_DOCS = ParamDocs(
     {
         "pip_requirements": """
 Either an iterable of pip requirement strings
-(e.g. ``["{{ package_name }}", "-r requirements.txt", "-c constrants.txt"]``) or the string path to
+(e.g. ``["{{ package_name }}", "-r requirements.txt", "-c constraints.txt"]``) or the string path to
 a pip requirements file on the local filesystem (e.g. ``"requirements.txt"``). If provided, this
 describes the environment this model should be run in. If ``None``, a default list of requirements
 is inferred from the current software environment. Both requirements and constraints are
@@ -84,7 +84,7 @@ of the model's conda environment (``conda.yaml``) file.
 """,
         "extra_pip_requirements": """
 Either an iterable of pip requirement strings
-(e.g. ``["{{ package_name }}", "-r requirements.txt", "-c constrants.txt"]``) or the string path to
+(e.g. ``["{{ package_name }}", "-r requirements.txt", "-c constraints.txt"]``) or the string path to
 a pip requirements file on the local filesystem (e.g. ``"requirements.txt"``). If provided, this
 describes additional pip requirements that are appended to a default set of pip requirements
 generated automatically based on the user's current software environment. Both requirements and

--- a/mlflow/utils/docstring_utils.py
+++ b/mlflow/utils/docstring_utils.py
@@ -3,6 +3,15 @@ import re
 from functools import reduce
 
 
+def _create_placeholder(key):
+    return "{{ " + key + " }}"
+
+
+def _replace_placeholder(template, key, value):
+    placeholder = _create_placeholder(key)
+    return template.replace(placeholder, value)
+
+
 class ParamDocs(dict):
     """
     Represents a set of parameter documents.
@@ -10,15 +19,6 @@ class ParamDocs(dict):
 
     def __repr__(self):
         return f"ParamDocs({super().__repr__()})"
-
-    @classmethod
-    def _create_placeholder(cls, key):
-        return "{{ " + key + " }}"
-
-    @classmethod
-    def _replace_placeholder(cls, template, key, value):
-        placeholder = ParamDocs._create_placeholder(key)
-        return template.replace(placeholder, value)
 
     def format(self, **kwargs):
         """
@@ -36,7 +36,7 @@ class ParamDocs(dict):
         new_param_docs = {}
         for param_name, param_doc in self.items():
             for key, value in kwargs.items():
-                param_doc = ParamDocs._replace_placeholder(param_doc, key, value)
+                param_doc = _replace_placeholder(param_doc, key, value)
             new_param_docs[param_name] = param_doc
 
         return ParamDocs(new_param_docs)
@@ -66,7 +66,7 @@ class ParamDocs(dict):
             param_doc = textwrap.indent(param_doc, min_indent + " " * 4)
             if not param_doc.startswith("\n"):
                 param_doc = "\n" + param_doc
-            docstring = ParamDocs._replace_placeholder(docstring, param_name, param_doc)
+            docstring = _replace_placeholder(docstring, param_name, param_doc)
 
         return docstring
 

--- a/mlflow/utils/docstring_utils.py
+++ b/mlflow/utils/docstring_utils.py
@@ -2,6 +2,38 @@ import textwrap
 import re
 
 
+LOG_MODEL_PARAM_DOCS = {
+    "pip_requirements": """
+Either an iterable of pip requirement strings
+(e.g. ``["scikit-learn", "-r requirements.txt"]``) or the string path to a pip requirements
+file on the local filesystem (e.g. ``"requirements.txt"``). If provided, this describes the
+environment this model should be run in. If ``None``, a default list of requirements is
+inferred from the current software environment. Requirements are automatically parsed and
+written to a ``requirements.txt`` file that is stored as part of the model. These
+requirements are also written to the ``pip`` section of the model's conda environment
+(``conda.yaml``) file.
+""",
+    "extra_pip_requirements": """
+Either an iterable of pip requirement strings
+(e.g. ``["scikit-learn", "-r requirements.txt"]``) or the string path to a pip requirements
+file on the local filesystem (e.g. ``"requirements.txt"``). If provided, this specifies
+additional pip requirements that are appended to a default set of pip requirements generated
+automatically based on the user's current software environment. Requirements are also
+written to the ``pip`` section of the model's conda environment (``conda.yaml``) file.
+
+.. warning::
+    The following arguments can't be specified at the same time:
+
+    - ``conda_env``
+    - ``pip_requirements``
+    - ``extra_pip_requirements``
+
+:ref:`This example<pip-requirements-example>` demonstrates how to specify pip requirements
+using ``pip_requirements`` and ``extra_pip_requirements``.
+""",
+}
+
+
 _leading_whitespace_re = re.compile("(^[ ]*)(?:[^ \n])", re.MULTILINE)
 
 
@@ -56,35 +88,3 @@ def _format_param_docs(param_docs):
         return func
 
     return decorator
-
-
-LOG_MODEL_PARAM_DOCS = {
-    "pip_requirements": """
-Either an iterable of pip requirement strings
-(e.g. ``["scikit-learn", "-r requirements.txt"]``) or the string path to a pip requirements
-file on the local filesystem (e.g. ``"requirements.txt"``). If provided, this describes the
-environment this model should be run in. If ``None``, a default list of requirements is
-inferred from the current software environment. Requirements are automatically parsed and
-written to a ``requirements.txt`` file that is stored as part of the model. These
-requirements are also written to the ``pip`` section of the model's conda environment
-(``conda.yaml``) file.
-""",
-    "extra_pip_requirements": """
-Either an iterable of pip requirement strings
-(e.g. ``["scikit-learn", "-r requirements.txt"]``) or the string path to a pip requirements
-file on the local filesystem (e.g. ``"requirements.txt"``). If provided, this specifies
-additional pip requirements that are appended to a default set of pip requirements generated
-automatically based on the user's current software environment. Requirements are also
-written to the ``pip`` section of the model's conda environment (``conda.yaml``) file.
-
-.. warning::
-    The following arguments can't be specified at the same time:
-
-    - ``conda_env``
-    - ``pip_requirements``
-    - ``extra_pip_requirements``
-
-:ref:`This example<pip-requirements-example>` demonstrates how to specify pip requirements
-using ``pip_requirements`` and ``extra_pip_requirements``.
-""",
-}

--- a/mlflow/utils/docstring_utils.py
+++ b/mlflow/utils/docstring_utils.py
@@ -13,7 +13,7 @@ def _replace_placeholder(template, key, value):
 
 class ParamDocs(dict):
     """
-    Represents a set of parameter documents.
+    Represents a set of parameter documents in the docstring.
     """
 
     def __repr__(self):
@@ -21,15 +21,15 @@ class ParamDocs(dict):
 
     def format(self, **kwargs):
         """
-        Replaces placeholders in param docs.
+        Formats placeholders in this instance with `kwargs`.
 
         :param kwargs: A `dict` in the form of `{"< placeholder name >": "< value >"}`.
         :return: A new `ParamDocs` instance with the formatted param docs.
 
         Examples
         --------
-        >>> p = ParamDocs(p1="{{ doc1 }}", p2="{{ doc2 }}")
-        >>> p.format(doc1="foo", doc2="bar")
+        >>> pd = ParamDocs(p1="{{ doc1 }}", p2="{{ doc2 }}")
+        >>> pd.format(doc1="foo", doc2="bar")
         ParamDocs({'p1': 'foo', 'p2': 'bar'})
         """
         new_param_docs = {}
@@ -42,19 +42,19 @@ class ParamDocs(dict):
 
     def format_docstring(self, docstring):
         """
-        Replaces param doc placeholders in `docstring`.
+        Formats placeholders in `docstring`.
 
         :param docstring: Docstring to format.
         :return: Formatted docstring.
 
         Examples
         --------
-        >>> p = ParamDocs(p1="doc1", p2="doc2")
+        >>> pd = ParamDocs(p1="doc1", p2="doc2")
         >>> docstring = '''
         ... :param p1: {{ p1 }}
         ... :param p2: {{ p2 }}
         ... '''.strip()
-        >>> print(p.format_docstring(docstring))
+        >>> print(pd.format_docstring(docstring))
         :param p1:
             doc1
         :param p2:

--- a/mlflow/utils/docstring_utils.py
+++ b/mlflow/utils/docstring_utils.py
@@ -129,7 +129,7 @@ of the model's conda environment (``conda.yaml``) file.
 """,
         "extra_pip_requirements": """
 Either an iterable of pip requirement strings
-(e.g. ``["{{ package_name }}", "-r requirements.txt", "-c constraints.txt"]``) or the string path to
+(e.g. ``["pandas", "-r requirements.txt", "-c constraints.txt"]``) or the string path to
 a pip requirements file on the local filesystem (e.g. ``"requirements.txt"``). If provided, this
 describes additional pip requirements that are appended to a default set of pip requirements
 generated automatically based on the user's current software environment. Both requirements and

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -147,7 +147,6 @@ def save_model(
                           base64-encoded.
     :param pip_requirements: {{ pip_requirements }}
     :param extra_pip_requirements: {{ extra_pip_requirements }}
-    :param kwargs: kwargs to pass to `xgboost.Booster.save_model`_ method.
     """
     import xgboost as xgb
 

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -147,6 +147,7 @@ def save_model(
                           base64-encoded.
     :param pip_requirements: {{ pip_requirements }}
     :param extra_pip_requirements: {{ extra_pip_requirements }}
+    :param kwargs: kwargs to pass to `xgboost.Booster.save_model`_ method.
     """
     import xgboost as xgb
 

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -84,7 +84,7 @@ def get_default_conda_env():
     return _mlflow_conda_env(additional_pip_deps=_get_default_pip_requirements())
 
 
-@_format_param_docs(LOG_MODEL_PARAM_DOCS)
+@_format_param_docs(LOG_MODEL_PARAM_DOCS.format(package_name="xgboost"))
 def save_model(
     xgb_model,
     path,

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -42,6 +42,7 @@ from mlflow.utils.environment import (
 from mlflow.utils.model_utils import _get_flavor_configuration
 from mlflow.exceptions import MlflowException
 from mlflow.utils.annotations import experimental
+from mlflow.utils.docstring_utils import _format_param_docs, LOG_MODEL_PARAM_DOCS
 from mlflow.utils.autologging_utils import (
     autologging_integration,
     safe_patch,
@@ -83,6 +84,7 @@ def get_default_conda_env():
     return _mlflow_conda_env(additional_pip_deps=_get_default_pip_requirements())
 
 
+@_format_param_docs(LOG_MODEL_PARAM_DOCS)
 def save_model(
     xgb_model,
     path,
@@ -140,30 +142,8 @@ def save_model(
                           model. The given example will be converted to a Pandas DataFrame and then
                           serialized to json using the Pandas split-oriented format. Bytes are
                           base64-encoded.
-    :param pip_requirements: Either an iterable of pip requirement strings
-        (e.g. ``["scikit-learn", "-r requirements.txt"]``) or the string path to a pip requirements
-        file on the local filesystem (e.g. ``"requirements.txt"``). If provided, this describes the
-        environment this model should be run in. If ``None``, a default list of requirements is
-        inferred from the current software environment. Requirements are automatically parsed and
-        written to a ``requirements.txt`` file that is stored as part of the model. These
-        requirements are also written to the ``pip`` section of the model's conda environment
-        (``conda.yaml``) file.
-    :param extra_pip_requirements: Either an iterable of pip requirement strings
-        (e.g. ``["scikit-learn", "-r requirements.txt"]``) or the string path to a pip requirements
-        file on the local filesystem (e.g. ``"requirements.txt"``). If provided, this specifies
-        additional pip requirements that are appended to a default set of pip requirements generated
-        automatically based on the user's current software environment. Requirements are also
-        written to the ``pip`` section of the model's conda environment (``conda.yaml``) file.
-
-        .. warning::
-            The following arguments can't be specified at the same time:
-
-            - ``conda_env``
-            - ``pip_requirements``
-            - ``extra_pip_requirements``
-
-        :ref:`This example<pip-requirements-example>` demonstrates how to specify pip requirements
-        using ``pip_requirements`` and ``extra_pip_requirements``.
+    :param pip_requirements: {{ pip_requirements }}
+    :param extra_pip_requirements: {{ extra_pip_requirements }}
     """
     import xgboost as xgb
 
@@ -206,6 +186,7 @@ def save_model(
     mlflow_model.save(os.path.join(path, MLMODEL_FILE_NAME))
 
 
+@_format_param_docs(LOG_MODEL_PARAM_DOCS)
 def log_model(
     xgb_model,
     artifact_path,
@@ -269,31 +250,8 @@ def log_model(
     :param await_registration_for: Number of seconds to wait for the model version to finish
                             being created and is in ``READY`` status. By default, the function
                             waits for five minutes. Specify 0 or None to skip waiting.
-    :param pip_requirements: Either an iterable of pip requirement strings
-        (e.g. ``["scikit-learn", "-r requirements.txt"]``) or the string path to a pip requirements
-        file on the local filesystem (e.g. ``"requirements.txt"``). If provided, this describes the
-        environment this model should be run in. If ``None``, a default list of requirements is
-        inferred from the current software environment. Requirements are automatically parsed and
-        written to a ``requirements.txt`` file that is stored as part of the model. These
-        requirements are also written to the ``pip`` section of the model's conda environment
-        (``conda.yaml``) file.
-    :param extra_pip_requirements: Either an iterable of pip requirement strings
-        (e.g. ``["scikit-learn", "-r requirements.txt"]``) or the string path to a pip requirements
-        file on the local filesystem (e.g. ``"requirements.txt"``). If provided, this specifies
-        additional pip requirements that are appended to a default set of pip requirements generated
-        automatically based on the user's current software environment. Requirements are also
-        written to the ``pip`` section of the model's conda environment (``conda.yaml``) file.
-
-        .. warning::
-            The following arguments can't be specified at the same time:
-
-            - ``conda_env``
-            - ``pip_requirements``
-            - ``extra_pip_requirements``
-
-        :ref:`This example<pip-requirements-example>` demonstrates how to specify pip requirements
-        using ``pip_requirements`` and ``extra_pip_requirements``.
-    :param kwargs: kwargs to pass to `xgboost.Booster.save_model`_ method.
+    :param pip_requirements: {{ pip_requirements }}
+    :param extra_pip_requirements: {{ extra_pip_requirements }}
     """
     Model.log(
         artifact_path=artifact_path,

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -44,7 +44,7 @@ from mlflow.utils.environment import (
 from mlflow.utils.model_utils import _get_flavor_configuration
 from mlflow.exceptions import MlflowException
 from mlflow.utils.annotations import experimental
-from mlflow.utils.docstring_utils import _format_param_docs, LOG_MODEL_PARAM_DOCS
+from mlflow.utils.docstring_utils import format_docstring, LOG_MODEL_PARAM_DOCS
 from mlflow.utils.file_utils import write_to
 from mlflow.utils.autologging_utils import (
     autologging_integration,
@@ -87,7 +87,7 @@ def get_default_conda_env():
     return _mlflow_conda_env(additional_pip_deps=_get_default_pip_requirements())
 
 
-@_format_param_docs(LOG_MODEL_PARAM_DOCS.format(package_name="xgboost"))
+@format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name="xgboost"))
 def save_model(
     xgb_model,
     path,
@@ -194,7 +194,7 @@ def save_model(
     mlflow_model.save(os.path.join(path, MLMODEL_FILE_NAME))
 
 
-@_format_param_docs(LOG_MODEL_PARAM_DOCS)
+@format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name="xgboost"))
 def log_model(
     xgb_model,
     artifact_path,

--- a/tests/utils/test_docstring_utils.py
+++ b/tests/utils/test_docstring_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mlflow.utils.docstring_utils import _get_minimum_indentation, _format_param_docs
+from mlflow.utils.docstring_utils import _get_minimum_indentation, format_docstring
 
 
 def test_get_minimum_indentation():
@@ -18,9 +18,9 @@ def test_get_minimum_indentation():
     assert _get_minimum_indentation("") == ""
 
 
-def test_format_param_docs():
+def test_format_docstring():
     # pylint: disable=W
-    @_format_param_docs({"p": "param doc"})
+    @format_docstring({"p": "param doc"})
     def single_param(p):
         """
         :param p:{{ p }}
@@ -34,7 +34,7 @@ def test_format_param_docs():
     assert single_param.__doc__ == expected_doc
     assert single_param.__name__ == "single_param"
 
-    @_format_param_docs({"p1": "param1 doc", "p2": "param2 doc"})
+    @format_docstring({"p1": "param1 doc", "p2": "param2 doc"})
     def multiple_params(p1, p2):
         """
         :param p1:{{ p1 }}
@@ -50,11 +50,3 @@ def test_format_param_docs():
 
     assert multiple_params.__doc__ == expected_doc
     assert multiple_params.__name__ == "multiple_params"
-
-    with pytest.raises(AssertionError):
-
-        @_format_param_docs({"p": "param doc"})
-        def no_placeholder(p):
-            """
-            :param p: param doc
-            """

--- a/tests/utils/test_docstring_utils.py
+++ b/tests/utils/test_docstring_utils.py
@@ -28,7 +28,6 @@ def test_format_docstring():
         :param p:
             param doc
         """
-
     assert single_param.__doc__ == expected_doc
     assert single_param.__name__ == "single_param"
 
@@ -45,6 +44,5 @@ def test_format_docstring():
         :param p2:
             param2 doc
         """
-
     assert multiple_params.__doc__ == expected_doc
     assert multiple_params.__name__ == "multiple_params"

--- a/tests/utils/test_docstring_utils.py
+++ b/tests/utils/test_docstring_utils.py
@@ -1,5 +1,3 @@
-import pytest
-
 from mlflow.utils.docstring_utils import _get_minimum_indentation, format_docstring
 
 

--- a/tests/utils/test_docstring_utils.py
+++ b/tests/utils/test_docstring_utils.py
@@ -1,4 +1,11 @@
-from mlflow.utils.docstring_utils import _get_minimum_indentation, format_docstring
+from mlflow.utils.docstring_utils import ParamDocs, _get_minimum_indentation, format_docstring
+
+
+def test_param_docs_format():
+    pd = ParamDocs({"x": "{{ x }}", "y": "{{ y }}", "z": "{{ x }}, {{ y }}"})
+    formatted = pd.format(x="a", y="b")
+    assert isinstance(formatted, ParamDocs)
+    assert formatted == {"x": "a", "y": "b", "z": "a, b"}
 
 
 def test_get_minimum_indentation():

--- a/tests/utils/test_docstring_utils.py
+++ b/tests/utils/test_docstring_utils.py
@@ -4,26 +4,17 @@ from mlflow.utils.docstring_utils import _get_minimum_indentation, _format_param
 
 
 def test_get_minimum_indentation():
-    assert (
-        _get_minimum_indentation(
-            """
+    text = """
     # 4 spaces
       # 6 spaces
         # 8 spaces
 """
-        )
-        == " " * 4
-    )
+    assert _get_minimum_indentation(text) == " " * 4
 
-    assert (
-        _get_minimum_indentation(
-            """
+    text = """
 # no indent
 """
-        )
-        == ""
-    )
-
+    assert _get_minimum_indentation(text) == ""
     assert _get_minimum_indentation("") == ""
 
 

--- a/tests/utils/test_docstring_utils.py
+++ b/tests/utils/test_docstring_utils.py
@@ -1,0 +1,61 @@
+import pytest
+
+from mlflow.utils.docstring_utils import _get_minimum_indentation, _format_param_docs
+
+
+def test_get_minimum_indentation():
+    _get_minimum_indentation(
+        """
+    # 4 spaces
+      # 6 spaces
+        # 8 spaces
+"""
+    ) == " " * 4
+
+    _get_minimum_indentation(
+        """
+# no indent
+"""
+    ) == ""
+    _get_minimum_indentation("") == ""
+
+
+def test_format_param_docs():
+    @_format_param_docs({"p": "param doc"})
+    def single_param(p):
+        """
+        :param p:{{ p }}
+        """
+
+    expected_doc = """
+        :param p:
+            param doc
+        """
+
+    assert single_param.__doc__ == expected_doc
+    assert single_param.__name__ == "single_param"
+
+    @_format_param_docs({"p1": "param1 doc", "p2": "param2 doc"})
+    def multiple_params(p1, p2):
+        """
+        :param p1:{{ p1 }}
+        :param p2:{{ p2 }}
+        """
+
+    expected_doc = """
+        :param p1:
+            param1 doc
+        :param p2:
+            param2 doc
+        """
+
+    assert multiple_params.__doc__ == expected_doc
+    assert multiple_params.__name__ == "multiple_params"
+
+    with pytest.raises(AssertionError):
+
+        @_format_param_docs({"p": "param doc"})
+        def no_placeholder(p):
+            """
+            :param p: param doc
+            """

--- a/tests/utils/test_docstring_utils.py
+++ b/tests/utils/test_docstring_utils.py
@@ -4,23 +4,31 @@ from mlflow.utils.docstring_utils import _get_minimum_indentation, _format_param
 
 
 def test_get_minimum_indentation():
-    _get_minimum_indentation(
-        """
+    assert (
+        _get_minimum_indentation(
+            """
     # 4 spaces
       # 6 spaces
         # 8 spaces
 """
-    ) == " " * 4
+        )
+        == " " * 4
+    )
 
-    _get_minimum_indentation(
-        """
+    assert (
+        _get_minimum_indentation(
+            """
 # no indent
 """
-    ) == ""
-    _get_minimum_indentation("") == ""
+        )
+        == ""
+    )
+
+    assert _get_minimum_indentation("") == ""
 
 
 def test_format_param_docs():
+    # pylint: disable=W
     @_format_param_docs({"p": "param doc"})
     def single_param(p):
         """


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Introduce `_format_param_docs` to deduplicate param docs.

## Motivation

`save_model` and `log_model` have several common parameters (e.g. `conda_env`). If we want to update their descriptions, we need to update all flavors, which is painful. This PR attempts to fix the issue by introducing `_format_param_docs`.

## How is this patch tested?

- Unit tests
- Manually verify sphinx renderes the docs properly on CircleCI.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
