### PR TITLE
Remove print statements in pip_requirements example

### DIFF
--- a/examples/pip_requirements/pip_requirements.py
+++ b/examples/pip_requirements/pip_requirements.py
@@ -45,14 +45,12 @@ def main():
         mlflow.xgboost.log_model(model, artifact_path)
         pip_reqs = get_pip_requirements(run_id, artifact_path)
         assert pip_reqs == ["mlflow", xgb_req], pip_reqs
-        print("Model URI:", mlflow.get_artifact_uri(artifact_path))
 
         # Overwrite the default set of pip requirements using `pip_requirements`
         artifact_path = "pip_requirements"
         mlflow.xgboost.log_model(model, artifact_path, pip_requirements=[sklearn_req])
         pip_reqs = get_pip_requirements(run_id, artifact_path)
         assert pip_reqs == ["mlflow", sklearn_req], pip_reqs
-        print("Model URI:", mlflow.get_artifact_uri(artifact_path))
 
         # Add extra pip requirements on top of the default set of pip requirements
         # using `extra_pip_requirements`
@@ -60,7 +58,6 @@ def main():
         mlflow.xgboost.log_model(model, artifact_path, extra_pip_requirements=[sklearn_req])
         pip_reqs = get_pip_requirements(run_id, artifact_path)
         assert pip_reqs == ["mlflow", xgb_req, sklearn_req], pip_reqs
-        print("Model URI:", mlflow.get_artifact_uri(artifact_path))
 
         # Specify pip requirements using a requirements file
         with tempfile.NamedTemporaryFile("w", suffix=".requirements.txt") as f:
@@ -72,7 +69,6 @@ def main():
             mlflow.xgboost.log_model(model, artifact_path, pip_requirements=f.name)
             pip_reqs = get_pip_requirements(run_id, artifact_path)
             assert pip_reqs == ["mlflow", sklearn_req], pip_reqs
-            print("Model URI:", mlflow.get_artifact_uri(artifact_path))
 
             # List of pip requirement strings
             artifact_path = "requirements_file_list"
@@ -81,7 +77,6 @@ def main():
             )
             pip_reqs = get_pip_requirements(run_id, artifact_path)
             assert pip_reqs == ["mlflow", xgb_req, sklearn_req], pip_reqs
-            print("Model URI:", mlflow.get_artifact_uri(artifact_path))
 
         # Using a constraints file
         with tempfile.NamedTemporaryFile("w", suffix=".constraints.txt") as f:
@@ -97,7 +92,6 @@ def main():
             )
             assert pip_reqs == ["mlflow", xgb_req, "-c constraints.txt"], pip_reqs
             assert pip_cons == [sklearn_req], pip_cons
-            print("Model URI:", mlflow.get_artifact_uri(artifact_path))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

- A follow-up for #4564.
- Remove print statements in pip_requirements example because you can see the logging result on MLflow UI.

## How is this patch tested?

Existing checks

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
