### PR TITLE
Fix docker build error in `test_docker_uri_mode_validation`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,12 @@ RUN apt-get update && \
     apt-get install -y default-libmysqlclient-dev build-essential curl \
     # cmake and protobuf-compiler required for onnx install
     cmake protobuf-compiler &&  \
-    # install required python packages
     conda install python=3.6 && \
+    # install required python packages
     pip install -r dev-requirements.txt --no-cache-dir && \
     pip install -r test-requirements.txt --no-cache-dir && \
     # install mlflow in editable form
-    pip install --no-cache-dir -e .[extras] && \
+    pip install --no-cache-dir -e . && \
     # mkdir required to support install openjdk-11-jre-headless
     mkdir -p /usr/share/man/man1 && apt-get install -y openjdk-11-jre-headless && \
     # install npm for node.js support

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && \
     # cmake and protobuf-compiler required for onnx install
     cmake protobuf-compiler &&  \
     # install required python packages
+    conda install python=3.6 && \
     pip install -r dev-requirements.txt --no-cache-dir && \
     pip install -r test-requirements.txt --no-cache-dir && \
     # install mlflow in editable form

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && \
     pip install -r dev-requirements.txt --no-cache-dir && \
     pip install -r test-requirements.txt --no-cache-dir && \
     # install mlflow in editable form
-    pip install --no-cache-dir -e . && \
+    pip install --no-cache-dir -e .[extras] && \
     # mkdir required to support install openjdk-11-jre-headless
     mkdir -p /usr/share/man/man1 && apt-get install -y openjdk-11-jre-headless && \
     # install npm for node.js support

--- a/dev/lint-requirements.txt
+++ b/dev/lint-requirements.txt
@@ -1,6 +1,5 @@
 prospector[with_pyroma]==0.12.7
 pep8==1.7.1
-pyarrow==0.17.0
 pylint==1.8.2
 rstcheck==3.2
 black==19.10b0

--- a/dev/lint-requirements.txt
+++ b/dev/lint-requirements.txt
@@ -1,5 +1,6 @@
 prospector[with_pyroma]==0.12.7
 pep8==1.7.1
+pyarrow==0.17.0
 pylint==1.8.2
 rstcheck==3.2
 black==19.10b0

--- a/tests/resources/example_docker_project/Dockerfile
+++ b/tests/resources/example_docker_project/Dockerfile
@@ -1,4 +1,4 @@
 FROM continuumio/miniconda3:4.6.14
 
-RUN sudo apt-get update -y && sudo apt-get install build-essential -y
+RUN apt-get update -y && apt-get install build-essential -y
 RUN pip install mlflow && pip install sqlalchemy

--- a/tests/resources/example_docker_project/Dockerfile
+++ b/tests/resources/example_docker_project/Dockerfile
@@ -1,4 +1,4 @@
 FROM continuumio/miniconda3:4.6.14
 
-# RUN sudo apt-get -y && sudo apt-get install build-essential -y
+RUN sudo apt-get update -y && sudo apt-get install build-essential -y
 RUN pip install mlflow && pip install sqlalchemy

--- a/tests/resources/example_docker_project/Dockerfile
+++ b/tests/resources/example_docker_project/Dockerfile
@@ -1,3 +1,3 @@
-FROM continuumio/miniconda3:4.6.14
+FROM continuumio/miniconda3:latest
 
 RUN pip install mlflow && pip install sqlalchemy

--- a/tests/resources/example_docker_project/Dockerfile
+++ b/tests/resources/example_docker_project/Dockerfile
@@ -1,4 +1,4 @@
 FROM continuumio/miniconda3:4.6.14
 
-RUN sudo apt-get -y && sudo apt-get install build-essential -y
+# RUN sudo apt-get -y && sudo apt-get install build-essential -y
 RUN pip install mlflow && pip install sqlalchemy

--- a/tests/resources/example_docker_project/Dockerfile
+++ b/tests/resources/example_docker_project/Dockerfile
@@ -1,3 +1,4 @@
-FROM continuumio/miniconda3:latest
+FROM continuumio/miniconda3:4.6.14
 
+RUN sudo apt-get -y && sudo apt-get install build-essential -y
 RUN pip install mlflow && pip install sqlalchemy


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

`test_docker_uri_mode_validation` fails while building a wheel for `pandas`:

https://github.com/mlflow/mlflow/runs/3156887082#step:4:2132

```
{'stream': "  Building wheel for pandas (PEP 517): finished with status 'error'\n  Complete output from command /opt/conda/bin/python /opt/conda/lib/python3.7/site-packages/pip/_vendor/pep517/_in_process.py build_wheel /tmp/tmpp65lluom:\n"}
...
{'stream': "/_libs/src/skiplist.h -> build/lib.linux-x86_64-3.7/pandas/_libs/src\n  creating build/lib.linux-x86_64-3.7/pandas/_libs/src/headers\n  copying pandas/_libs/src/headers/cmath -> build/lib.linux-x86_64-3.7/pandas/_libs/src/headers\n  copying pandas/_libs/src/headers/ms_inttypes.h -> build/lib.linux-x86_64-3.7/pandas/_libs/src/headers\n  copying pandas/_libs/src/headers/ms_stdint.h -> build/lib.linux-x86_64-3.7/pandas/_libs/src/headers\n  copying pandas/_libs/src/headers/portable.h -> build/lib.linux-x86_64-3.7/pandas/_libs/src/headers\n  copying pandas/_libs/src/headers/stdint.h -> build/lib.linux-x86_64-3.7/pandas/_libs/src/headers\n  creating build/lib.linux-x86_64-3.7/pandas/_libs/src/klib\n  copying pandas/_libs/src/klib/khash.h -> build/lib.linux-x86_64-3.7/pandas/_libs/src/klib\n  copying pandas/_libs/src/klib/khash_python.h -> build/lib.linux-x86_64-3.7/pandas/_libs/src/klib\n  creating build/lib.linux-x86_64-3.7/pandas/_libs/src/parser\n  copying pandas/_libs/src/parser/io.c -> build/lib.linux-x86_64-3.7/pandas/_libs/src/parser\n  copying pandas/_libs/src/parser/io.h -> build/lib.linux-x86_64-3.7/pandas/_libs/src/parser\n  copying pandas/_libs/src/parser/tokenizer.c -> build/lib.linux-x86_64-3.7/pandas/_libs/src/parser\n  copying pandas/_libs/src/parser/tokenizer.h -> build/lib.linux-x86_64-3.7/pandas/_libs/src/parser\n  creating build/lib.linux-x86_64-3.7/pandas/_libs/src/ujson\n  creating build/lib.linux-x86_64-3.7/pandas/_libs/src/ujson/lib\n  copying pandas/_libs/src/ujson/lib/ultrajson.h -> build/lib.linux-x86_64-3.7/pandas/_libs/src/ujson/lib\n  copying pandas/_libs/src/ujson/lib/ultrajsondec.c -> build/lib.linux-x86_64-3.7/pandas/_libs/src/ujson/lib\n  copying pandas/_libs/src/ujson/lib/ultrajsonenc.c -> build/lib.linux-x86_64-3.7/pandas/_libs/src/ujson/lib\n  creating build/lib.linux-x86_64-3.7/pandas/_libs/src/ujson/python\n  copying pandas/_libs/src/ujson/python/JSONtoObj.c -> build/lib.linux-x86_64-3.7/pandas/_libs/src/ujson/python\n  copying pandas/_libs/src/ujson/python/date_conversions.c -> build/lib.linux-x86_64-3.7/pandas/_libs/src/ujson/python\n  copying pandas/_libs/src/ujson/python/date_conversions.h -> build/lib.linux-x86_64-3.7/pandas/_libs/src/ujson/python\n  copying pandas/_libs/src/ujson/python/objToJSON.c -> build/lib.linux-x86_64-3.7/pandas/_libs/src/ujson/python\n  copying pandas/_libs/src/ujson/python/ujson.c -> build/lib.linux-x86_64-3.7/pandas/_libs/src/ujson/python\n  copying pandas/_libs/src/ujson/python/version.h -> build/lib.linux-x86_64-3.7/pandas/_libs/src/ujson/python\n  creating build/lib.linux-x86_64-3.7/pandas/io/formats/templates\n  copying pandas/io/formats/templates/html.tpl -> build/lib.linux-x86_64-3.7/pandas/io/formats/templates\n  copying pandas/io/formats/templates/html_style.tpl -> build/lib.linux-x86_64-3.7/pandas/io/formats/templates\n  copying pandas/io/formats/templates/html_table.tpl -> build/lib.linux-x86_64-3.7/pandas/io/formats/templates\n  copying pandas/io/formats/templates/latex.tpl -> build/lib.linux-x86_64-3.7/pandas/io/formats/templates\n  copying pandas/io/sas/sas.pyx -> build/lib.linux-x86_64-3.7/pandas/io/sas\n  creating build/lib.linux-x86_64-3.7/pandas/tests/io/data\n  copying pandas/tests/io/data/gbq_fake_job.txt -> build/lib.linux-x86_64-3.7/pandas/tests/io/data\n  creating build/lib.linux-x86_64-3.7/pandas/tests/io/data/fixed_width\n  copying pandas/tests/io/data/fixed_width/fixed_width_format.txt -> build/lib.linux-x86_64-3.7/pandas/tests/io/data/fixed_width\n  creating build/lib.linux-x86_64-3.7/pandas/tests/io/data/legacy_pickle\n  creating build/lib.linux-x86_64-3.7/pandas/tests/io/data/legacy_pickle/1.2.4\n  copying pandas/tests/io/data/legacy_pickle/1.2.4/empty_frame_v1_2_4-GH#42345.pkl -> build/lib.linux-x86_64-3.7/pandas/tests/io/data/legacy_pickle/1.2.4\n  creating build/lib.linux-x86_64-3.7/pandas/tests/io/data/parquet\n  copying pandas/tests/io/data/parquet/simple.parquet -> build/lib.linux-x86_64-3.7/pandas/tests/io/data/parquet\n  creating build/lib.linux-x86_64-3.7/pandas/tests/io/data/pickle\n  copying pandas/tests/io/data/pickle/test_mi_py27.pkl -> build/lib.linux-x86_64-3.7/pandas/tests/io/data/pickle\n  copying pandas/tests/io/data/pickle/test_py27.pkl -> build/lib.linux-x86_64-3.7/pandas/tests/io/data/pickle\n  creating build/lib.linux-x86_64-3.7/pandas/tests/io/data/xml\n  copying pandas/tests/io/data/xml/baby_names.xml -> build/lib.linux-x86_64-3.7/pandas/tests/io/data/xml\n  copying pandas/tests/io/data/xml/books.xml -> build/lib.linux-x86_64-3.7/pandas/tests/io/data/xml\n  copying pandas/tests/io/data/xml/cta_rail_lines.kml -> build/lib.linux-x86_64-3.7/pandas/tests/io/data/xml\n  copying pandas/tests/io/data/xml/flatten_doc.xsl -> build/lib.linux-x86_64-3.7/pandas/tests/io/data/xml\n  copying pandas/tests/io/data/xml/row_field_output.xsl -> build/lib.linux-x86_64-3.7/pandas/tests/io/data/xml\n  creating build/lib.linux-x86_64-3.7/pandas/tests/io/xml\n  copying pandas/tests/io/xml/test_to_xml.py -> build/lib.linux-x86_64-3.7/pandas/tests/io/xml\n  copying pandas/tests/io/xml/test_xml.py -> build/lib.linux-x86_64-3.7/pandas/tests/io/xml\n  copying pandas/_libs/window/aggregations.pyi -> build/lib.linux-x86_64-3.7/pandas/_libs/window\n  copying pandas/_libs/window/aggregations.pyx -> build/lib.linux-x86_64-3.7/pandas/_libs/window\n  copying pandas/_libs/window/indexers.pyi -> build/lib.linux-x86_64-3.7/pandas/_libs/window\n  copying pandas/_libs/window/indexers.pyx -> build/lib.linux-x86_64-3.7/pandas/_libs/window\n  copying pandas/_libs/tslibs/base.pxd -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs\n  copying pandas/_libs/tslibs/base.pyx -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs\n  copying pandas/_libs/tslibs/ccalendar.pxd -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs\n  copying pandas/_libs/tslibs/ccalendar.pyi -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs\n  copying pandas/_libs/tslibs/ccalendar.pyx -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs\n  copying pandas/_libs/tslibs/conversion.pxd -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs\n  copying pandas/_libs/tslibs/conversion.pyi -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs\n  copying pandas/_libs/tslibs/conversion.pyx -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs\n  copying pandas/_libs/tslibs/dtypes.pxd -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs\n  copying pandas/_libs/tslibs/dtypes.pyi -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs\n  copying pandas/_libs/tslibs/dtypes.pyx -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs\n  copying pandas/_libs/tslibs/fields.pyi -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs\n  copying pandas/_libs/tslibs/fields.pyx -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs\n  copying pandas/_libs/tslibs/nattype.pxd -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs\n  copying pandas/_libs/tslibs/nattype.pyi -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs\n  copying pandas/_libs/tslibs/nattype.pyx -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs\n  copying pandas/_libs/tslibs/np_datetime.pxd -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs\n  copying pandas/_libs/tslibs/np_datetime.pyx -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs\n  copying pandas/_libs/tslibs/offsets.pxd -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs\n  copying pandas/_libs/tslibs/offsets.pyx -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs\n  copying pandas/_libs/tslibs/parsing.pxd -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs\n  copying pandas/_libs/tslibs/parsing.pyi -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs\n  copying pandas/_libs/tslibs/parsing.pyx -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs\n  copying pandas/_libs/tslibs/period.pxd -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs\n  copying pandas/_libs/tslibs/period.pyi -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs\n  copying pandas/_libs/tslibs/period.pyx -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs\n  copying pandas/_libs/tslibs/strptime.pyi -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs\n  copying pandas/_libs/tslibs/strptime.pyx -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs\n  copying pandas/_libs/tslibs/timedeltas.pxd -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs\n  copying pandas/_libs/tslibs/timedeltas.pyi -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs\n  copying pandas/_libs/tslibs/timedeltas.pyx -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs\n  copying pandas/_libs/tslibs/timestamps.pxd -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs\n  copying pandas/_libs/tslibs/timestamps.pyi -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs\n  copying pandas/_libs/tslibs/timestamps.pyx -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs\n  copying pandas/_libs/tslibs/timezones.pxd -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs\n  copying pandas/_libs/tslibs/timezones.pyi -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs\n  copying pandas/_libs/tslibs/timezones.pyx -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs\n  copying pandas/_libs/tslibs/tzconversion.pxd -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs\n  copying pandas/_libs/tslibs/tzconversion.pyi -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs\n  copying pandas/_libs/tslibs/tzconversion.pyx -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs\n  copying pandas/_libs/tslibs/util.pxd -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs\n  copying pandas/_libs/tslibs/vectorized.pyi -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs\n  copying pandas/_libs/tslibs/vectorized.pyx -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs\n  creating build/lib.linux-x86_64-3.7/pandas/_libs/tslibs/src\n  creating build/lib.linux-x86_64-3.7/pandas/_libs/tslibs/src/datetime\n  copying pandas/_libs/tslibs/src/datetime/np_datetime.c -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs/src/datetime\n  copying pandas/_libs/tslibs/src/datetime/np_datetime.h -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs/src/datetime\n  copying pandas/_libs/tslibs/src/datetime/np_datetime_strings.c -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs/src/datetime\n  copying pandas/_libs/tslibs/src/datetime/np_datetime_strings.h -> build/lib.linux-x86_64-3.7/pandas/_libs/tslibs/src/datetime\n  UPDATING build/lib.linux-x86_64-3.7/pandas/_version.py\n  set build/lib.linux-x86_64-3.7/pandas/_version.py to '1.3.1'\n  running build_ext\n  building 'pandas._libs.algos' extension\n  creating build/temp.linux-x86_64-3.7\n  creating build/temp.linux-x86_64-3.7/pandas\n  creating build/temp.linux-x86_64-3.7/pandas/_libs\n  gcc -pthread -B /opt/conda/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -I./pandas/_libs -Ipandas/_libs/src/klib -I/tmp/pip-build-env-z7j25y5e/overlay/lib/python3.7/site-packages/numpy/core/include -I/opt/conda/include/python3.7m -c pandas/_libs/algos.c -o build/temp.linux-x86_64-3.7/pandas/_libs/algos.o\n  error: command 'gcc' failed with exit status 1\n  \n  ----------------------------------------\n"}
```

We usually don't need to build wheels for pandas because `pandas` provides them:

https://pypi.org/project/pandas/1.3.1/#files

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
