### PR TITLE
Bug-Fix Issue #2501 Running a MLflow project with docker_env fails to create the docker container

### DIFF
--- a/mlflow/projects/backend/local.py
+++ b/mlflow/projects/backend/local.py
@@ -229,7 +229,8 @@ def _get_docker_command(image, active_run, docker_args=None, volumes=None, user_
         active_run.info.artifact_uri
     )
 
-    cmd += tracking_cmds + artifact_cmds
+    cmd += tracking_cmds 
+    #+ artifact_cmds
     env_vars.update(tracking_envs)
     env_vars.update(artifact_envs)
     if user_env_vars is not None:

--- a/mlflow/projects/docker.py
+++ b/mlflow/projects/docker.py
@@ -99,6 +99,25 @@ def _get_docker_image_uri(repository_uri, work_dir):
     return repository_uri + version_string
 
 
+def onerror(func, path, exc_info):
+    """
+    Error handler for ``shutil.rmtree``.
+
+    If the error is due to an access error (read only file)
+    it attempts to add write permission and then retries.
+
+    If the error is for another reason it re-raises the error.
+
+    Usage : ``shutil.rmtree(path, onerror=onerror)``
+    """
+    import stat
+    if not os.access(path, os.W_OK):
+        # Is the error an access error ?
+        os.chmod(path, stat.S_IWUSR)
+        func(path)
+    else:
+        raise
+
 def _create_docker_build_ctx(work_dir, dockerfile_contents):
     """
     Creates build context tarfile containing Dockerfile and project code, returning path to tarfile
@@ -114,7 +133,7 @@ def _create_docker_build_ctx(work_dir, dockerfile_contents):
             output_filename=result_path, source_dir=dst_path, archive_name=_PROJECT_TAR_ARCHIVE_NAME
         )
     finally:
-        shutil.rmtree(directory)
+        shutil.rmtree(directory, onerror=onerror)
     return result_path
 
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)
As discussed a year ago in #2501, Running a MLflow project with docker_env fails to create the docker container whenever you try to log locally due to having the artifact cmd included in the docker cmd as you can see here https://github.com/mlflow/mlflow/blob/221fedc81679bd23fc68b2cb769b07ce5e8fe9f1/mlflow/projects/backend/local.py#L232

I proposed that we remove the artifact cmd as it tries to include the artifact folder in the container which already included in tracking cmd. as you can see from the log here 
`2021/07/26 12:50:18 INFO mlflow.projects.backend.local: === Running command 'docker run --rm -v C:\Users\mlflow-docker\mlruns:/mlflow/tmp/mlruns -v C:\Users\mlflow-docker\mlruns\0\c0447737c6d94573b93440ca3bcb1ab0\artifacts:C:\Users\r\mlflow-docker\mlruns\0\c0447737c6d94573b93440ca3bcb1ab0\artifacts -e MLFLOW_RUN_ID=c0447737c6d94573b93440ca3bcb1ab0 -e MLFLOW_TRACKING_URI=file:///mlflow/tmp/mlruns -e MLFLOW_EXPERIMENT_ID=0 docker-example:b80c453 python train.py --alpha 0.5 --l1-ratio 0.1' in run with ID 'c0447737c6d94573b93440ca3bcb1ab0' ===`
## How is this patch tested?

(Details)

Followed the docker example and worked successfully

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [x] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
