### PR TITLE
Run `python-large` test faster

### DIFF
--- a/tests/resources/example_docker_project/Dockerfile
+++ b/tests/resources/example_docker_project/Dockerfile
@@ -1,4 +1,5 @@
 FROM continuumio/miniconda3:4.6.14
 
 RUN apt-get update -y && apt-get install build-essential -y
+RUN conda install python=3.6
 RUN pip install mlflow && pip install sqlalchemy


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

The `python-large` test currently takes 30 ~ 40 min to complete because of the following tests:

https://github.com/mlflow/mlflow/pull/4605/checks?check_run_id=3161011518#step:6:121

```
=========================== slowest 5 test durations ===========================
676.85s setup    tests/projects/test_docker_projects.py::test_docker_project_execution[0]
664.32s setup    tests/projects/test_projects_cli.py::test_run_local_with_docker_args
26.35s call     tests/autologging/test_autologging_client.py::test_client_logs_expected_run_data
26.14s call     tests/projects/test_projects.py::test_use_conda
23.34s call     tests/projects/test_projects_cli.py::test_run_local_conda_env
```

## Result

https://github.com/mlflow/mlflow/pull/4608/checks?check_run_id=3163035745#step:6:120

```
=========================== slowest 5 test durations ===========================
107.44s setup    tests/projects/test_docker_projects.py::test_docker_project_execution[0]
96.09s setup    tests/projects/test_projects_cli.py::test_run_local_with_docker_args
25.00s call     tests/projects/test_projects.py::test_use_conda
24.44s call     tests/autologging/test_autologging_client.py::test_client_logs_expected_run_data
22.80s call     tests/projects/test_projects_cli.py::test_run_local_conda_env
```

`test_docker_project_execution` and `test_run_local_with_docker_args` builds a wheel for pandas from the source, which takes a long time.

## How is this patch tested?

Existing checks

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
