### PR TITLE
make patched function still available after autolog disabled

### DIFF
--- a/mlflow/utils/autologging_utils/safety.py
+++ b/mlflow/utils/autologging_utils/safety.py
@@ -310,6 +310,8 @@ def safe_patch(
     else:
         assert callable(patch_function)
 
+    original = gorilla.get_original_attribute(destination, function_name)
+
     def safe_patch_function(*args, **kwargs):
         """
         A safe wrapper around the specified `patch_function` implementation designed to
@@ -358,8 +360,6 @@ def safe_patch(
 
             if is_testing():
                 preexisting_run_for_testing = mlflow.active_run()
-
-            original = gorilla.get_original_attribute(destination, function_name)
 
             # Whether or not to exclude autologged content from user-created fluent runs
             # (i.e. runs created manually via `mlflow.start_run()`)
@@ -633,7 +633,7 @@ def _wrap_patch(destination, name, patch, settings=None):
     if settings is None:
         settings = gorilla.Settings(allow_hit=True, store_hit=True)
 
-    original = getattr(destination, name)
+    original = gorilla.get_original_attribute(destination, name)
     wrapped = update_wrapper_extended(patch, original)
 
     patch = gorilla.Patch(destination, name, wrapped, settings=settings)

--- a/mlflow/utils/gorilla.py
+++ b/mlflow/utils/gorilla.py
@@ -788,7 +788,7 @@ def get_original_attribute(obj, name):
     --------
     :attr:`Settings.allow_hit`.
     """
-    return getattr(obj, _ORIGINAL_NAME % (name,))
+    return getattr(obj, _ORIGINAL_NAME % (name,), getattr(obj, name))
 
 
 def get_decorator_data(obj, set_default=False):


### PR DESCRIPTION
Signed-off-by: Weichen Xu <weichen.xu@databricks.com>

## What changes are proposed in this pull request?

Simple test:

```
import mlflow
mlflow.sklearn.autolog()
from sklearn.metrics import accuracy_score
mlflow.sklearn.autolog(disable=True)
accuracy_score([1,1],[0,1])  # ensure this call still works and behave the same with original function
```

## How is this patch tested?

N/A

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
