### PR TITLE
Deprecate  `requriements_file` argument for pytorch flavor

### DIFF
--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -11,6 +11,7 @@ import importlib
 import logging
 import os
 import yaml
+import warnings
 
 import cloudpickle
 import numpy as np
@@ -193,15 +194,21 @@ def log_model(
                             being created and is in ``READY`` status. By default, the function
                             waits for five minutes. Specify 0 or None to skip waiting.
 
-    :param requirements_file: A string containing the path to requirements file. Remote URIs
-                      are resolved to absolute filesystem paths.
-                      For example, consider the following ``requirements_file`` string -
+    :param requirements_file:
 
-                      requirements_file = "s3://my-bucket/path/to/my_file"
+        .. warning::
 
-                      In this case, the ``"my_file"`` requirements file is downloaded from S3.
+            ``requirements_file`` has been deprecated. Please use ``pip_requirements`` instead.
 
-                      If ``None``, no requirements file is added to the model.
+        A string containing the path to requirements file. Remote URIs are resolved to absolute
+        filesystem paths. For example, consider the following ``requirements_file`` string:
+
+        .. code-block:: python
+
+            requirements_file = "s3://my-bucket/path/to/my_file"
+
+        In this case, the ``"my_file"`` requirements file is downloaded from S3. If ``None``,
+        no requirements file is added to the model.
 
     :param extra_files: A list containing the paths to corresponding extra files. Remote URIs
                       are resolved to absolute filesystem paths.
@@ -319,7 +326,6 @@ def save_model(
     pickle_module=None,
     signature: ModelSignature = None,
     input_example: ModelInputExample = None,
-    # TODO: Deprecate `requirements_file` and recommend using `pip_requirements` instead.
     requirements_file=None,
     extra_files=None,
     pip_requirements=None,
@@ -391,15 +397,21 @@ def save_model(
                           format, or a numpy array where the example will be serialized to json
                           by converting it to a list. Bytes are base64-encoded.
 
-    :param requirements_file: A string containing the path to requirements file. Remote URIs
-                      are resolved to absolute filesystem paths.
-                      For example, consider the following ``requirements_file`` string -
+    :param requirements_file:
 
-                      requirements_file = "s3://my-bucket/path/to/my_file"
+        .. warning::
 
-                      In this case, the ``"my_file"`` requirements file is downloaded from S3.
+            ``requirements_file`` has been deprecated. Please use ``pip_requirements`` instead.
 
-                      If ``None``, no requirements file is added to the model.
+        A string containing the path to requirements file. Remote URIs are resolved to absolute
+        filesystem paths. For example, consider the following ``requirements_file`` string:
+
+        .. code-block:: python
+
+            requirements_file = "s3://my-bucket/path/to/my_file"
+
+        In this case, the ``"my_file"`` requirements file is downloaded from S3. If ``None``,
+        no requirements file is added to the model.
 
     :param extra_files: A list containing the paths to corresponding extra files. Remote URIs
                       are resolved to absolute filesystem paths.
@@ -546,6 +558,13 @@ def save_model(
         write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME), "\n".join(pip_constraints))
 
     if requirements_file:
+
+        warnings.warn(
+            "`requirements_file` has been deprecated. Please use `pip_requirements` instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
+
         if not isinstance(requirements_file, str):
             raise TypeError("Path to requirements file should be a string")
 

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -1026,6 +1026,15 @@ def test_log_model_invalid_requirement_file_type(sequential_model):
         )
 
 
+def test_save_model_emits_deprecation_warning_for_requirements_file(tmpdir):
+    reqs_file = tmpdir.join("requirements.txt")
+    reqs_file.write("torch")
+    with pytest.warns(FutureWarning, match="`requirements_file` has been deprecated"):
+        mlflow.pytorch.save_model(
+            get_sequential_model(), tmpdir.join("model"), requirements_file=reqs_file.strpath,
+        )
+
+
 @pytest.fixture
 def create_extra_files(tmpdir):
     fp1 = tmpdir.join("extra1.txt")


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

- A follow-up for #4602 
- Deprecate  `requriements_file` argument for pytorch flavor.

## How is this patch tested?

Unit test

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`requirements_file` in `mlflow.pytorch.log_model` and `mlflow.pytorch.save_model` has been deprecated. It's recommended to use `pip_requirements` instead for specifying pip requirements.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
