### PR TITLE
Introdcue `_is_available_on_pypi` and use it to determine whether we need to use `--no-conda` for `pyfunc_serve_and_score_model`

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -314,6 +314,8 @@ jobs:
         run: |
           export PATH="$CONDA_DIR/bin:$PATH"
           source activate test-environment
+          # Install libopenblas-dev for mxnet 1.8.0.post0
+          sudo apt-get install libopenblas-dev
           ./dev/run-python-flavor-tests.sh;
 
   import:

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -187,6 +187,7 @@ gluon:
     maximum: "1.8.0.post0"
     unsupported: ["1.8.0"] # MXNet 1.8.0 is a flawed release that we don't expect to work with
     run: |
+      # Required for mxnet 1.8.0.post0
       sudo apt-get install libopenblas-dev
       pytest tests/gluon/test_gluon_model_export.py --large
 

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -187,7 +187,7 @@ gluon:
     maximum: "1.8.0.post0"
     unsupported: ["1.8.0"] # MXNet 1.8.0 is a flawed release that we don't expect to work with
     run: |
-      # Required for mxnet 1.8.0.post0
+      # Install libopenblas-dev for mxnet 1.8.0.post0
       sudo apt-get install libopenblas-dev
       pytest tests/gluon/test_gluon_model_export.py --large
 

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -31,7 +31,6 @@ pytorch:
     maximum: "1.9.0"
     requirements: ["torchvision", "scikit-learn"]
     run: |
-      python -c "import torch; print(torch.__version__)"
       pytest tests/pytorch/test_pytorch_model_export.py --large
 
 pytorch-lightning:

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -31,6 +31,7 @@ pytorch:
     maximum: "1.9.0"
     requirements: ["torchvision", "scikit-learn"]
     run: |
+      python -c "import torch; print(torch.__version__)"
       pytest tests/pytorch/test_pytorch_model_export.py --large
 
 pytorch-lightning:

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -187,6 +187,7 @@ gluon:
     maximum: "1.8.0.post0"
     unsupported: ["1.8.0"] # MXNet 1.8.0 is a flawed release that we don't expect to work with
     run: |
+      sudo apt-get install libopenblas-dev
       pytest tests/gluon/test_gluon_model_export.py --large
 
   autologging:

--- a/tests/catboost/test_catboost_model_export.py
+++ b/tests/catboost/test_catboost_model_export.py
@@ -26,7 +26,10 @@ from tests.helper_functions import (
     pyfunc_serve_and_score_model,
     _compare_conda_env_requirements,
     _assert_pip_requirements,
+    _is_available_on_pypi,
 )
+
+EXTRA_PYFUNC_SERVING_TEST_ARGS = [] if _is_available_on_pypi("lightgbm") else ["--no-conda"]
 
 ModelWithData = namedtuple("ModelWithData", ["model", "inference_dataframe"])
 

--- a/tests/catboost/test_catboost_model_export.py
+++ b/tests/catboost/test_catboost_model_export.py
@@ -29,7 +29,7 @@ from tests.helper_functions import (
     _is_available_on_pypi,
 )
 
-EXTRA_PYFUNC_SERVING_TEST_ARGS = [] if _is_available_on_pypi("lightgbm") else ["--no-conda"]
+EXTRA_PYFUNC_SERVING_TEST_ARGS = [] if _is_available_on_pypi("catboost") else ["--no-conda"]
 
 ModelWithData = namedtuple("ModelWithData", ["model", "inference_dataframe"])
 

--- a/tests/gluon/test_gluon_model_export.py
+++ b/tests/gluon/test_gluon_model_export.py
@@ -29,6 +29,7 @@ from tests.helper_functions import (
     pyfunc_serve_and_score_model,
     _compare_conda_env_requirements,
     _assert_pip_requirements,
+    _is_available_on_pypi,
 )
 
 if Version(mx.__version__) >= Version("2.0.0"):
@@ -39,6 +40,9 @@ else:
     from mxnet.metric import Accuracy  # pylint: disable=import-error
 
     array_module = mx.nd
+
+
+EXTRA_PYFUNC_SERVING_TEST_ARGS = [] if _is_available_on_pypi("mxnet") else ["--no-conda"]
 
 
 @pytest.fixture
@@ -309,7 +313,7 @@ def test_gluon_model_serving_and_scoring_as_pyfunc(gluon_model, model_data):
         model_uri=model_uri,
         data=pd.DataFrame(test_data.asnumpy()),
         content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
-        extra_args=["--no-conda"],
+        extra_args=EXTRA_PYFUNC_SERVING_TEST_ARGS,
     )
     response_values = pd.read_json(scoring_response.content, orient="records").values.astype(
         np.float32

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -373,5 +373,5 @@ def _is_available_on_pypi(package, version=None, module=None):
     return (
         dist_files is not None  # specified version exists
         and (len(dist_files) > 0)  # at least one distribution file exists
-        and dist_files[0].get("yanked", False)  # specified version is not yanked
+        and not dist_files[0].get("yanked", False)  # specified version is not yanked
     )

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -350,7 +350,7 @@ def _assert_pip_requirements(model_uri, requirements, constraints=None):
         assert cons == constraints
 
 
-def _is_available_on_pypi(package, version=None):
+def _is_available_on_pypi(package, version):
     """
     Returns True if the specified package version is available on PyPI.
     """

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -348,3 +348,19 @@ def _assert_pip_requirements(model_uri, requirements, constraints=None):
         assert f"-c {_CONSTRAINTS_FILE_NAME}" in conda_reqs
         cons = _read_lines(os.path.join(local_path, _CONSTRAINTS_FILE_NAME))
         assert cons == constraints
+
+
+def _is_available_on_pypi(package, version=None):
+    """
+    Returns True if the specified package version is available on PyPI.
+    """
+    resp = requests.get("https://pypi.python.org/pypi/{}/json".format(package))
+    if not resp.ok:
+        return False
+
+    dist_files = resp.json()["releases"].get(version)
+    return (
+        dist_files is not None  # specified version exists
+        and (len(dist_files) > 0)  # at least one distribution file exists
+        and dist_files[0].get("yanked", False)  # specified version is not yanked
+    )

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -41,11 +41,15 @@ from tests.helper_functions import (
     score_model_in_sagemaker_docker_container,
     _compare_conda_env_requirements,
     _assert_pip_requirements,
+    _is_available_on_pypi,
 )
 from tests.helper_functions import set_boto_credentials  # pylint: disable=unused-import
 from tests.helper_functions import mock_s3_bucket  # pylint: disable=unused-import
 from tests.pyfunc.test_spark import score_model_as_udf
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
+
+
+EXTRA_PYFUNC_SERVING_TEST_ARGS = [] if _is_available_on_pypi("keras") else ["--no-conda"]
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -261,7 +265,7 @@ def test_model_save_load(build_model, save_format, model_path, data):
         model_uri=os.path.abspath(model_path),
         data=pd.DataFrame(x),
         content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
-        extra_args=["--no-conda"],
+        extra_args=EXTRA_PYFUNC_SERVING_TEST_ARGS,
     )
     print(scoring_response.content)
     actual_scoring_response = pd.read_json(
@@ -309,7 +313,7 @@ def test_custom_model_save_load(custom_model, custom_layer, data, custom_predict
         model_uri=os.path.abspath(model_path),
         data=pd.DataFrame(x),
         content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
-        extra_args=["--no-conda"],
+        extra_args=EXTRA_PYFUNC_SERVING_TEST_ARGS,
     )
     assert np.allclose(
         pd.read_json(scoring_response.content, orient="records", encoding="utf8").values.astype(

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -48,7 +48,6 @@ from tests.helper_functions import mock_s3_bucket  # pylint: disable=unused-impo
 from tests.pyfunc.test_spark import score_model_as_udf
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 
-
 EXTRA_PYFUNC_SERVING_TEST_ARGS = [] if _is_available_on_pypi("keras") else ["--no-conda"]
 
 

--- a/tests/lightgbm/test_lightgbm_model_export.py
+++ b/tests/lightgbm/test_lightgbm_model_export.py
@@ -31,7 +31,10 @@ from tests.helper_functions import (
     pyfunc_serve_and_score_model,
     _compare_conda_env_requirements,
     _assert_pip_requirements,
+    _is_available_on_pypi,
 )
+
+EXTRA_PYFUNC_SERVING_TEST_ARGS = [] if _is_available_on_pypi("lightgbm") else ["--no-conda"]
 
 ModelWithData = namedtuple("ModelWithData", ["model", "inference_dataframe"])
 
@@ -379,6 +382,7 @@ def test_pyfunc_serve_and_score(lgb_model):
         model_uri,
         data=inference_dataframe,
         content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
+        extra_args=EXTRA_PYFUNC_SERVING_TEST_ARGS,
     )
     scores = pd.read_json(resp.content, orient="records").values.squeeze()
     np.testing.assert_array_almost_equal(scores, model.predict(inference_dataframe))

--- a/tests/onnx/test_onnx_model_export.py
+++ b/tests/onnx/test_onnx_model_export.py
@@ -24,6 +24,7 @@ from tests.helper_functions import (
     pyfunc_serve_and_score_model,
     _compare_conda_env_requirements,
     _assert_pip_requirements,
+    _is_available_on_pypi,
 )
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.environment import _mlflow_conda_env
@@ -36,6 +37,8 @@ TEST_ONNX_RESOURCES_DIR = os.path.join(TEST_DIR, "resources", "onnx")
 pytestmark = pytest.mark.skipif(
     (sys.version_info < (3, 6)), reason="Tests require Python 3 to run!"
 )
+
+EXTRA_PYFUNC_SERVING_TEST_ARGS = [] if _is_available_on_pypi("onnx") else ["--no-conda"]
 
 
 @pytest.fixture(scope="module")
@@ -277,7 +280,7 @@ def test_model_save_load_evaluate_pyfunc_format(onnx_model, model_path, data, pr
         model_uri=os.path.abspath(model_path),
         data=x,
         content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
-        extra_args=["--no-conda"],
+        extra_args=EXTRA_PYFUNC_SERVING_TEST_ARGS,
     )
     assert np.allclose(
         pd.read_json(scoring_response.content, orient="records")
@@ -319,7 +322,7 @@ def test_model_save_load_evaluate_pyfunc_format_multiple_inputs(
         model_uri=os.path.abspath(model_path),
         data=data_multiple_inputs,
         content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
-        extra_args=["--no-conda"],
+        extra_args=EXTRA_PYFUNC_SERVING_TEST_ARGS,
     )
     assert np.allclose(
         pd.read_json(scoring_response.content, orient="records").values,

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -30,7 +30,11 @@ from mlflow.utils.file_utils import TempDir
 from mlflow.utils.model_utils import _get_flavor_configuration
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 
-from tests.helper_functions import _compare_conda_env_requirements, _assert_pip_requirements
+from tests.helper_functions import (
+    _compare_conda_env_requirements,
+    _assert_pip_requirements,
+    _is_available_on_pypi,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -46,6 +50,8 @@ except ImportError:
     _logger.warning(
         "Failed to import test helper functions. Tests depending on these functions may fail!"
     )
+
+EXTRA_ARGS = ["--no-conda"] if _is_available_on_pypi("torch", str(torch.__version__)) else []
 
 
 @pytest.fixture(scope="module")
@@ -604,7 +610,7 @@ def test_pyfunc_model_serving_with_module_scoped_subclassed_model_and_default_co
         model_uri=model_path,
         data=data[0],
         content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
-        extra_args=["--no-conda"],
+        extra_args=EXTRA_ARGS,
     )
     assert scoring_response.status_code == 200
 
@@ -648,7 +654,7 @@ def test_pyfunc_model_serving_with_main_scoped_subclassed_model_and_custom_pickl
         model_uri=model_path,
         data=data[0],
         content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
-        extra_args=["--no-conda"],
+        extra_args=EXTRA_ARGS,
     )
     assert scoring_response.status_code == 200
 
@@ -706,7 +712,7 @@ def test_load_model_succeeds_with_dependencies_specified_via_code_paths(
         model_uri=pyfunc_model_path,
         data=data[0],
         content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
-        extra_args=["--no-conda"],
+        extra_args=EXTRA_ARGS,
     )
     assert scoring_response.status_code == 200
 

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -51,7 +51,9 @@ except ImportError:
         "Failed to import test helper functions. Tests depending on these functions may fail!"
     )
 
-EXTRA_ARGS = ["--no-conda"] if _is_available_on_pypi("torch", str(torch.__version__)) else []
+# Avoid creating a conda environment in `pyfunc_serve_and_score_model` if the installed version of
+# torch is not available on PyPI.
+EXTRA_ARGS = [] if _is_available_on_pypi("torch", str(torch.__version__)) else ["--no-conda"]
 
 
 @pytest.fixture(scope="module")

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -53,7 +53,7 @@ except ImportError:
 
 # Avoid creating a conda environment in `pyfunc_serve_and_score_model` if the installed version of
 # torch is not available on PyPI.
-EXTRA_ARGS = [] if _is_available_on_pypi("torch", str(torch.__version__)) else ["--no-conda"]
+EXTRA_PYFUNC_SERVING_TEST_ARGS = [] if _is_available_on_pypi("torch") else ["--no-conda"]
 
 
 @pytest.fixture(scope="module")
@@ -612,7 +612,7 @@ def test_pyfunc_model_serving_with_module_scoped_subclassed_model_and_default_co
         model_uri=model_path,
         data=data[0],
         content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
-        extra_args=EXTRA_ARGS,
+        extra_args=EXTRA_PYFUNC_SERVING_TEST_ARGS,
     )
     assert scoring_response.status_code == 200
 
@@ -656,7 +656,7 @@ def test_pyfunc_model_serving_with_main_scoped_subclassed_model_and_custom_pickl
         model_uri=model_path,
         data=data[0],
         content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
-        extra_args=EXTRA_ARGS,
+        extra_args=EXTRA_PYFUNC_SERVING_TEST_ARGS,
     )
     assert scoring_response.status_code == 200
 
@@ -714,7 +714,7 @@ def test_load_model_succeeds_with_dependencies_specified_via_code_paths(
         model_uri=pyfunc_model_path,
         data=data[0],
         content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
-        extra_args=EXTRA_ARGS,
+        extra_args=EXTRA_PYFUNC_SERVING_TEST_ARGS,
     )
     assert scoring_response.status_code == 200
 

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -604,7 +604,7 @@ def test_pyfunc_model_serving_with_module_scoped_subclassed_model_and_default_co
     mlflow.pytorch.save_model(
         path=model_path,
         pytorch_model=module_scoped_subclassed_model,
-        conda_env=None,
+        extra_pip_requirements=["pytest"],
         code_paths=[__file__],
     )
 
@@ -678,7 +678,7 @@ def test_load_model_succeeds_with_dependencies_specified_via_code_paths(
     mlflow.pytorch.save_model(
         path=model_path,
         pytorch_model=module_scoped_subclassed_model,
-        conda_env=None,
+        extra_pip_requirements=["pytest"],
         code_paths=[__file__],
     )
 

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -51,8 +51,6 @@ except ImportError:
         "Failed to import test helper functions. Tests depending on these functions may fail!"
     )
 
-# Avoid creating a conda environment in `pyfunc_serve_and_score_model` if the installed version of
-# torch is not available on PyPI.
 EXTRA_PYFUNC_SERVING_TEST_ARGS = [] if _is_available_on_pypi("torch") else ["--no-conda"]
 
 
@@ -602,10 +600,7 @@ def test_pyfunc_model_serving_with_module_scoped_subclassed_model_and_default_co
     module_scoped_subclassed_model, model_path, data
 ):
     mlflow.pytorch.save_model(
-        path=model_path,
-        pytorch_model=module_scoped_subclassed_model,
-        extra_pip_requirements=["pytest"],
-        code_paths=[__file__],
+        path=model_path, pytorch_model=module_scoped_subclassed_model, code_paths=[__file__],
     )
 
     scoring_response = pyfunc_serve_and_score_model(
@@ -676,10 +671,7 @@ def test_load_model_succeeds_with_dependencies_specified_via_code_paths(
     # `tests` module is not available when the model is deployed for local scoring, we include
     # the test suite file as a code dependency
     mlflow.pytorch.save_model(
-        path=model_path,
-        pytorch_model=module_scoped_subclassed_model,
-        extra_pip_requirements=["pytest"],
-        code_paths=[__file__],
+        path=model_path, pytorch_model=module_scoped_subclassed_model, code_paths=[__file__],
     )
 
     # Define a custom pyfunc model that loads a PyTorch model artifact using

--- a/tests/sklearn/test_sklearn_model_export.py
+++ b/tests/sklearn/test_sklearn_model_export.py
@@ -666,6 +666,7 @@ def test_pyfunc_serve_and_score(sklearn_knn_model):
         model_uri,
         data=pd.DataFrame(inference_dataframe),
         content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
+        extra_args=EXTRA_PYFUNC_SERVING_TEST_ARGS,
     )
     scores = pd.read_json(resp.content, orient="records").values.squeeze()
     np.testing.assert_array_almost_equal(scores, model.predict(inference_dataframe))

--- a/tests/sklearn/test_sklearn_model_export.py
+++ b/tests/sklearn/test_sklearn_model_export.py
@@ -38,6 +38,11 @@ from tests.helper_functions import (
     pyfunc_serve_and_score_model,
     _compare_conda_env_requirements,
     _assert_pip_requirements,
+    _is_available_on_pypi,
+)
+
+EXTRA_PYFUNC_SERVING_TEST_ARGS = (
+    [] if _is_available_on_pypi("scikit-learn", module="sklearn") else ["--no-conda"]
 )
 
 ModelWithData = namedtuple("ModelWithData", ["model", "inference_data"])

--- a/tests/spacy/test_spacy_model_export.py
+++ b/tests/spacy/test_spacy_model_export.py
@@ -463,4 +463,3 @@ def _predict(spacy_model, test_x):
     return pd.DataFrame(
         {"predictions": test_x.iloc[:, 0].apply(lambda text: spacy_model(text).cats)}
     )
-

--- a/tests/spacy/test_spacy_model_export.py
+++ b/tests/spacy/test_spacy_model_export.py
@@ -13,6 +13,7 @@ import mlflow.spacy
 from sklearn.datasets import fetch_20newsgroups
 
 from mlflow import pyfunc
+import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model, infer_signature
 from mlflow.models.utils import _read_example
@@ -21,7 +22,14 @@ from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils.model_utils import _get_flavor_configuration
 from tests.conftest import tracking_uri_mock  # pylint: disable=unused-import, E0611
-from tests.helper_functions import _compare_conda_env_requirements, _assert_pip_requirements
+from tests.helper_functions import (
+    pyfunc_serve_and_score_model,
+    _compare_conda_env_requirements,
+    _assert_pip_requirements,
+    _is_available_on_pypi,
+)
+
+EXTRA_PYFUNC_SERVING_TEST_ARGS = [] if _is_available_on_pypi("spacy") else ["--no-conda"]
 
 ModelWithData = namedtuple("ModelWithData", ["model", "inference_data"])
 
@@ -402,6 +410,24 @@ def test_model_log_without_pyfunc_flavor():
         assert loaded_model.flavors.keys() == {"spacy"}
 
 
+@pytest.mark.large
+def test_pyfunc_serve_and_score(spacy_model_with_data):
+    model, inference_dataframe = spacy_model_with_data
+    artifact_path = "model"
+    with mlflow.start_run():
+        mlflow.spacy.log_model(model, artifact_path)
+        model_uri = mlflow.get_artifact_uri(artifact_path)
+
+    resp = pyfunc_serve_and_score_model(
+        model_uri,
+        data=inference_dataframe,
+        content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
+        extra_args=EXTRA_PYFUNC_SERVING_TEST_ARGS,
+    )
+    scores = pd.read_json(resp.content, orient="records")
+    pd.testing.assert_frame_equal(scores, _predict(model, inference_dataframe))
+
+
 def _train_model(nlp, train_data, n_iter=5):
     optimizer = nlp.begin_training()
     batch_sizes = compounding(4.0, 32.0, 1.001)
@@ -437,3 +463,4 @@ def _predict(spacy_model, test_x):
     return pd.DataFrame(
         {"predictions": test_x.iloc[:, 0].apply(lambda text: spacy_model(text).cats)}
     )
+

--- a/tests/statsmodels/test_statsmodels_model_export.py
+++ b/tests/statsmodels/test_statsmodels_model_export.py
@@ -25,6 +25,7 @@ from tests.helper_functions import (
     pyfunc_serve_and_score_model,
     _compare_conda_env_requirements,
     _assert_pip_requirements,
+    _is_available_on_pypi,
 )
 from tests.helper_functions import mock_s3_bucket  # pylint: disable=unused-import
 from tests.helper_functions import set_boto_credentials  # pylint: disable=unused-import
@@ -42,6 +43,7 @@ from tests.statsmodels.model_fixtures import (
     wls_model,
 )
 
+EXTRA_PYFUNC_SERVING_TEST_ARGS = [] if _is_available_on_pypi("statsmodels") else ["--no-conda"]
 
 # The code in this file has been adapted from the test cases of the lightgbm flavor.
 
@@ -432,6 +434,7 @@ def test_pyfunc_serve_and_score(ols_model):
         model_uri,
         data=pd.DataFrame(inference_dataframe),
         content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
+        extra_args=EXTRA_PYFUNC_SERVING_TEST_ARGS,
     )
     scores = pd.read_json(resp.content, orient="records").values.squeeze()
     np.testing.assert_array_almost_equal(scores, model.predict(inference_dataframe))

--- a/tests/tensorflow/test_tensorflow2_model_export.py
+++ b/tests/tensorflow/test_tensorflow2_model_export.py
@@ -32,11 +32,16 @@ from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 
 from tests.helper_functions import (
     score_model_in_sagemaker_docker_container,
+    pyfunc_serve_and_score_model,
     _compare_conda_env_requirements,
     _assert_pip_requirements,
+    _is_available_on_pypi,
 )
 from tests.helper_functions import set_boto_credentials  # pylint: disable=unused-import
 from tests.helper_functions import mock_s3_bucket  # pylint: disable=unused-import
+
+EXTRA_PYFUNC_SERVING_TEST_ARGS = [] if _is_available_on_pypi("tensorflow") else ["--no-conda"]
+
 
 SavedModelInfo = collections.namedtuple(
     "SavedModelInfo",
@@ -740,6 +745,34 @@ def test_categorical_model_can_be_loaded_and_evaluated_as_pyfunc(
         inp_list.append(saved_tf_categorical_model.inference_df[df_col_name].values)
     with pytest.raises(TypeError):
         results = pyfunc_wrapper.predict(inp_list)
+
+
+@pytest.mark.large
+def test_pyfunc_serve_and_score(saved_tf_iris_model):
+    artifact_path = "model"
+
+    with mlflow.start_run():
+        mlflow.tensorflow.log_model(
+            tf_saved_model_dir=saved_tf_iris_model.path,
+            tf_meta_graph_tags=saved_tf_iris_model.meta_graph_tags,
+            tf_signature_def_key=saved_tf_iris_model.signature_def_key,
+            artifact_path=artifact_path,
+        )
+        model_uri = mlflow.get_artifact_uri(artifact_path)
+
+    resp = pyfunc_serve_and_score_model(
+        model_uri=model_uri,
+        data=saved_tf_iris_model.inference_df,
+        content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
+        extra_args=EXTRA_PYFUNC_SERVING_TEST_ARGS,
+    )
+    actual = pd.DataFrame(json.loads(resp.content))["class_ids"].values
+    expected = (
+        saved_tf_iris_model.expected_results_df["predictions"]
+        .map(lambda name: iris_data_utils.SPECIES.index(name))
+        .values
+    )
+    np.testing.assert_array_almost_equal(actual, expected)
 
 
 @pytest.mark.release

--- a/tests/tensorflow/test_tensorflow2_model_export.py
+++ b/tests/tensorflow/test_tensorflow2_model_export.py
@@ -769,7 +769,7 @@ def test_pyfunc_serve_and_score(saved_tf_iris_model):
     actual = pd.DataFrame(json.loads(resp.content))["class_ids"].values
     expected = (
         saved_tf_iris_model.expected_results_df["predictions"]
-        .map(lambda name: iris_data_utils.SPECIES.index(name))
+        .map(iris_data_utils.SPECIES.index)
         .values
     )
     np.testing.assert_array_almost_equal(actual, expected)

--- a/tests/tensorflow/test_tensorflow2_model_export.py
+++ b/tests/tensorflow/test_tensorflow2_model_export.py
@@ -42,7 +42,6 @@ from tests.helper_functions import mock_s3_bucket  # pylint: disable=unused-impo
 
 EXTRA_PYFUNC_SERVING_TEST_ARGS = [] if _is_available_on_pypi("tensorflow") else ["--no-conda"]
 
-
 SavedModelInfo = collections.namedtuple(
     "SavedModelInfo",
     [

--- a/tests/xgboost/test_xgboost_model_export.py
+++ b/tests/xgboost/test_xgboost_model_export.py
@@ -31,7 +31,10 @@ from tests.helper_functions import (
     pyfunc_serve_and_score_model,
     _compare_conda_env_requirements,
     _assert_pip_requirements,
+    _is_available_on_pypi,
 )
+
+EXTRA_PYFUNC_SERVING_TEST_ARGS = [] if _is_available_on_pypi("xgboost") else ["--no-conda"]
 
 ModelWithData = namedtuple("ModelWithData", ["model", "inference_dataframe", "inference_dmatrix"])
 
@@ -431,6 +434,7 @@ def test_pyfunc_serve_and_score(xgb_model):
         model_uri,
         data=inference_dataframe,
         content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
+        extra_args=EXTRA_PYFUNC_SERVING_TEST_ARGS,
     )
     scores = pd.read_json(resp.content, orient="records").values.squeeze()
     np.testing.assert_array_almost_equal(scores, model.predict(inference_dmatrix))


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

Introdcue `_is_available_on_pypi` and use it to determine whether we need to use --no-conda for `pyfunc_serve_and_score_model`.

## Motivation

`_is_available_on_pypi` allows us to do the following:

- If we know conda will fail to create an env due to packages / versions that don't exist on PyPI, use `--no-conda` to ensure the env can be created.
- Otherwise, do no use `--no-conda` to encounter a did-not-find-matching-version error.

This PR should make it easier to test the auto dependency inference proposed in https://github.com/mlflow/mlflow/pull/4518.

## How is this patch tested?

Existing tests

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
