### PR TITLE
Fix some issues in gorillar patch

### DIFF
--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -376,11 +376,12 @@ def autologging_integration(name):
             except Exception:
                 pass
 
+            revert_patches(name)
+
             # If disabling autologging using fluent api, then every active integration's autolog
             # needs to be called with disable=True. So do not short circuit and let
             # `mlflow.autolog()` invoke all active integrations with disable=True.
             if name != "mlflow" and get_autologging_config(name, "disable", True):
-                revert_patches(name)
                 return
 
             is_silent_mode = get_autologging_config(name, "silent", False)

--- a/mlflow/utils/autologging_utils/safety.py
+++ b/mlflow/utils/autologging_utils/safety.py
@@ -633,7 +633,7 @@ def _wrap_patch(destination, name, patch, settings=None):
     if settings is None:
         settings = gorilla.Settings(allow_hit=True, store_hit=True)
 
-    original = getattr(destination, name)
+    original = gorilla.get_original_attribute(destination, name)
     wrapped = update_wrapper_extended(patch, original)
 
     patch = gorilla.Patch(destination, name, wrapped, settings=settings)

--- a/mlflow/utils/autologging_utils/safety.py
+++ b/mlflow/utils/autologging_utils/safety.py
@@ -310,6 +310,8 @@ def safe_patch(
     else:
         assert callable(patch_function)
 
+    original = gorilla.get_original_attribute(destination, function_name)
+
     def safe_patch_function(*args, **kwargs):
         """
         A safe wrapper around the specified `patch_function` implementation designed to
@@ -358,8 +360,6 @@ def safe_patch(
 
             if is_testing():
                 preexisting_run_for_testing = mlflow.active_run()
-
-            original = gorilla.get_original_attribute(destination, function_name)
 
             # Whether or not to exclude autologged content from user-created fluent runs
             # (i.e. runs created manually via `mlflow.start_run()`)

--- a/mlflow/utils/autologging_utils/safety.py
+++ b/mlflow/utils/autologging_utils/safety.py
@@ -310,8 +310,6 @@ def safe_patch(
     else:
         assert callable(patch_function)
 
-    original = gorilla.get_original_attribute(destination, function_name)
-
     def safe_patch_function(*args, **kwargs):
         """
         A safe wrapper around the specified `patch_function` implementation designed to
@@ -360,6 +358,8 @@ def safe_patch(
 
             if is_testing():
                 preexisting_run_for_testing = mlflow.active_run()
+
+            original = gorilla.get_original_attribute(destination, function_name)
 
             # Whether or not to exclude autologged content from user-created fluent runs
             # (i.e. runs created manually via `mlflow.start_run()`)

--- a/mlflow/utils/gorilla.py
+++ b/mlflow/utils/gorilla.py
@@ -357,17 +357,13 @@ def revert(patch):
             % (patch.destination.__name__,)
         )
 
-    original = get_original_attribute(
-        patch.destination, patch.name, bypass_descriptor_protocal=True)
+    # get original attribute bypassing descriptor protocal
+    original = object.__getattribute__(patch.destination, original_name)
 
     if patch.is_inplace_patch:
         setattr(patch.destination, patch.name, original)
 
-    # We are only deleting the attribute if it is defined on the
-    # destination class as opposed to being inherited from parent class.
-    if original_name in patch.destination.__dict__:
-        delattr(patch.destination, original_name)
-
+    delattr(patch.destination, original_name)
     delattr(patch.destination, curr_active_patch)
 
 

--- a/mlflow/utils/gorilla.py
+++ b/mlflow/utils/gorilla.py
@@ -41,7 +41,6 @@ import logging
 import pkgutil
 import sys
 import types
-import warnings
 
 __version__ = "0.3.0"
 _logger = logging.getLogger(__name__)

--- a/mlflow/utils/gorilla.py
+++ b/mlflow/utils/gorilla.py
@@ -349,7 +349,8 @@ def revert(patch):
     # then there is no patching exist.
     curr_active_patch = _ACTIVE_PATCH % (patch.name,)
     if curr_active_patch not in patch.destination.__dict__:
-        raise RuntimeError(f"The patch does not exist or has been reverted.")
+        # already reverted.
+        return
 
     original_name = _ORIGINAL_NAME % (patch.name,)
     if original_name not in patch.destination.__dict__:

--- a/mlflow/utils/gorilla.py
+++ b/mlflow/utils/gorilla.py
@@ -326,7 +326,8 @@ def apply(patch):
             original_name = _ORIGINAL_NAME % (patch.name,)
             setattr(patch.destination, original_name, target)
 
-    setattr(patch.destination, patch.name, patch.obj)
+    patch_obj = object.__getattribute__(patch, 'obj')  # bypass descriptor protocol
+    setattr(patch.destination, patch.name, patch_obj)
     setattr(patch.destination, curr_active_patch, patch)
 
 

--- a/mlflow/utils/gorilla.py
+++ b/mlflow/utils/gorilla.py
@@ -325,8 +325,7 @@ def apply(patch):
             original_name = _ORIGINAL_NAME % (patch.name,)
             setattr(patch.destination, original_name, target)
 
-    patch_obj = object.__getattribute__(patch, "obj")  # bypass descriptor protocol
-    setattr(patch.destination, patch.name, patch_obj)
+    setattr(patch.destination, patch.name, patch.obj)
     setattr(patch.destination, curr_active_patch, patch)
 
 
@@ -357,7 +356,7 @@ def revert(patch):
 
     # check whether original_name is in destination. We cannot use hasattr because it will
     # try to get attribute from parent classes if attribute not found in destination class.
-    if original_name not in patch.destination.__dict__:
+    if original_name not in patch.destination.__dict__ and not patch.is_inplace_patch:
         raise RuntimeError(
             "Cannot revert the attribute named '%s' since the setting "
             "'store_hit' was not set to True when applying the patch."

--- a/mlflow/utils/gorilla.py
+++ b/mlflow/utils/gorilla.py
@@ -356,16 +356,15 @@ def revert(patch):
 
     original_name = _ORIGINAL_NAME % (patch.name,)
 
-    # check whether original_name is in destination. We cannot use hasattr because it will
-    # try to get attribute from parent classes if attribute not found in destination class.
-    if original_name not in patch.destination.__dict__ and patch.is_inplace_patch:
-        raise RuntimeError(
-            "Cannot revert the attribute named '%s' since the setting "
-            "'store_hit' was not set to True when applying the patch."
-            % (patch.destination.__name__,)
-        )
-
     if patch.is_inplace_patch:
+        # check whether original_name is in destination. We cannot use hasattr because it will
+        # try to get attribute from parent classes if attribute not found in destination class.
+        if original_name not in patch.destination.__dict__:
+            raise RuntimeError(
+                "Cannot revert the attribute named '%s' since the setting "
+                "'store_hit' was not set to True when applying the patch."
+                % (patch.destination.__name__,)
+            )
         # restore original method
         # during reverting patch, we need restore the raw attribute to the patch point
         # so get original attribute bypassing descriptor protocal

--- a/mlflow/utils/gorilla.py
+++ b/mlflow/utils/gorilla.py
@@ -374,7 +374,8 @@ def revert(patch):
         # delete patched method
         delattr(patch.destination, patch.name)
 
-    delattr(patch.destination, original_name)
+    if original_name in patch.destination.__dict__:
+        delattr(patch.destination, original_name)
     delattr(patch.destination, curr_active_patch)
 
 

--- a/mlflow/utils/gorilla.py
+++ b/mlflow/utils/gorilla.py
@@ -28,6 +28,7 @@ import inspect
 import pkgutil
 import sys
 import types
+import warnings
 
 __version__ = "0.3.0"
 
@@ -296,9 +297,8 @@ def apply(patch):
     curr_active_patch = _ACTIVE_PATCH % (patch.name,)
     if curr_active_patch in patch.destination.__dict__:
         # safe guarding checking.
-        raise RuntimeError(
-            f"Patch {patch.name} on {destination.__name__} already existed."
-            f"Revert old patch first if you want to patch it again."
+        warnings.warn(
+            f"Patch {patch.name} on {destination.__name__} already existed. Overwrite old patch."
         )
 
     # When a hit occurs due to an attribute at the destination already existing

--- a/mlflow/utils/gorilla.py
+++ b/mlflow/utils/gorilla.py
@@ -777,14 +777,21 @@ def get_original_attribute(obj, name, bypass_descriptor_protocal=False):
         if bypass_descriptor_protocal:
             return object.__getattribute__(obj_, name_)
         else:
-            return getattr(obj_, name)
+            return getattr(obj_, name_)
 
     objs = inspect.getmro(obj) if inspect.isclass(obj) else [obj]
     original_name = _ORIGINAL_NAME % (name,)
+    curr_active_patch = _ACTIVE_PATCH % (name,)
+
     for obj_ in objs:
         if original_name in obj_.__dict__:
             return _get_attr(obj_, original_name)
         elif name in obj_.__dict__:
+            if curr_active_patch in obj_.__dict__:
+                # safety guarding check
+                raise RuntimeError(
+                    f'{obj_.__name__}.{name} has been patched, but original methods was not '
+                    f'stored. Turn on setting `allow_hit` when patching to address this.')
             return _get_attr(obj_, name)
         else:
             continue

--- a/mlflow/utils/gorilla.py
+++ b/mlflow/utils/gorilla.py
@@ -8,10 +8,22 @@
 """
 NOTE: The contents of this file have been inlined from the gorilla package's source code
 https://github.com/christophercrouzet/gorilla/blob/v0.3.0/gorilla.py
+
+This module has fixes / adaptations for MLflow use cases that make it different from the original
+gorilla library
+
 The following modifications have been made:
-    - When a patch is applied to a method `foo` on parent class `A` and a subsequent
-      patch is applied to `foo` on one of its children `B`, `get_original_attribute(B, "foo")`
-      will now refer to `B.foo`, rather than `A.foo`.
+    - Modify `get_original_attribute` logic, search from children classes to parent classes,
+      and for each class check "_gorilla_original_{attr_name}" attribute first.
+      first. This will ensure get the correct original attribute in any cases, e.g.,
+      the case some classes in the hierarchy haven't been patched, but some others are
+      patched, this case the previous code is risky to get wrong original attribute.
+    - Make `get_original_attribute` support bypassing descriptor protocol.
+    - remove `get_attribute` method, use `get_original_attribute` with
+      `bypass_descriptor_protocol=True` instead of calling it.
+    - After reverting patch, there will be no side-effect, restore object to be exactly the
+      original status.
+    - Remove `create_patches` and `patches` methods.
 
 gorilla
 ~~~~~~~
@@ -25,34 +37,23 @@ Convenient approach to monkey patching.
 import collections
 import copy
 import inspect
+import logging
 import pkgutil
 import sys
 import types
 import warnings
 
 __version__ = "0.3.0"
+_logger = logging.getLogger(__name__)
 
 
-if sys.version_info[0] == 2:
-    _CLASS_TYPES = (type, types.ClassType)
-
-    def _iteritems(d, **kwargs):
-        return d.iteritems(**kwargs)
-
-    def _load_module(finder, name):
-        loader = finder.find_module(name)
-        return loader.load_module(name)
+def _iteritems(d, **kwargs):
+    return iter(d.items(**kwargs))
 
 
-else:
-    _CLASS_TYPES = (type,)
-
-    def _iteritems(d, **kwargs):
-        return iter(d.items(**kwargs))
-
-    def _load_module(finder, name):
-        loader, _ = finder.find_loader(name)
-        return loader.load_module()
+def _load_module(finder, name):
+    loader, _ = finder.find_loader(name)
+    return loader.load_module()
 
 
 # Pattern for each internal attribute name.
@@ -212,7 +213,7 @@ class Patch(object):
         self.name = name
         self.obj = obj
         self.settings = settings
-        self.is_inplace_patch = self.name in self.destination.__dict__
+        self.is_inplace_patch = None
 
     def __repr__(self):
         return "%s(destination=%r, name=%r, obj=%r, settings=%r)" % (
@@ -292,12 +293,12 @@ def apply(patch):
     to have already been stored, then it won't be stored again to avoid losing
     the original attribute that was stored the first time around.
     """
+    patch.is_inplace_patch = patch.name in patch.destination.__dict__
     settings = Settings() if patch.settings is None else patch.settings
 
     curr_active_patch = _ACTIVE_PATCH % (patch.name,)
     if curr_active_patch in patch.destination.__dict__:
-        # safe guarding checking.
-        warnings.warn(
+        _logger.debug(
             f"Patch {patch.name} on {destination.__name__} already existed. Overwrite old patch."
         )
 
@@ -305,7 +306,7 @@ def apply(patch):
     # with the patch's name, the existing attribute is referred to as 'target'.
     try:
         target = get_original_attribute(
-            patch.destination, patch.name, bypass_descriptor_protocal=True
+            patch.destination, patch.name, bypass_descriptor_protocol=True
         )
     except AttributeError:
         pass
@@ -346,13 +347,16 @@ def revert(patch):
     with modifictions for autologging disablement purposes.
     """
     # If an curr_active_patch has not been set on destination class for the current patch,
-    # then there is no patching exist.
+    # then the patch has not been applied and we do not need to revert anything.
     curr_active_patch = _ACTIVE_PATCH % (patch.name,)
     if curr_active_patch not in patch.destination.__dict__:
         # already reverted.
         return
 
     original_name = _ORIGINAL_NAME % (patch.name,)
+
+    # check whether original_name is in destination. We cannot use hasattr because it will
+    # try to get attribute from parent classes if attribute not found in destination class.
     if original_name not in patch.destination.__dict__:
         raise RuntimeError(
             "Cannot revert the attribute named '%s' since the setting "
@@ -360,7 +364,8 @@ def revert(patch):
             % (patch.destination.__name__,)
         )
 
-    # get original attribute bypassing descriptor protocal
+    # during reverting patch, we need restore the raw attribute to the patch point
+    # so get original attribute bypassing descriptor protocal
     original = object.__getattribute__(patch.destination, original_name)
 
     if patch.is_inplace_patch:
@@ -406,71 +411,6 @@ def patch(destination, name=None, settings=None):
         patch = Patch(destination, name_, wrapped, settings=settings_)
         data = get_decorator_data(base, set_default=True)
         data.patches.append(patch)
-        return wrapped
-
-    return decorator
-
-
-def patches(
-    destination,
-    settings=None,
-    traverse_bases=True,
-    filter=default_filter,
-    recursive=True,
-    use_decorators=True,
-):
-    """Decorator to create a patch for each member of a module or a class.
-
-    Parameters
-    ----------
-    destination : object
-        Patch destination.
-    settings : gorilla.Settings
-        Settings.
-    traverse_bases : bool
-        If the object is a class, the base classes are also traversed.
-    filter : function
-        Attributes for which the function returns ``False`` are skipped. The
-        function needs to define two parameters: ``name``, the attribute name,
-        and ``obj``, the attribute value. If ``None``, no attribute is skipped.
-    recursive : bool
-        If ``True``, and a hit occurs due to an attribute at the destination
-        already existing with the given name, and both the member and the
-        target attributes are classes, then instead of creating a patch
-        directly with the member attribute value as is, a patch for each of its
-        own members is created with the target as new destination.
-    use_decorators : bool
-        Allows to take any modifier decorator into consideration to allow for
-        more granular customizations.
-
-    Returns
-    -------
-    object
-        The decorated object.
-
-    Note
-    ----
-    A 'target' differs from a 'destination' in that a target represents an
-    existing attribute at the destination about to be hit by a patch.
-
-    See Also
-    --------
-    :class:`Patch`, :func:`create_patches`.
-    """
-
-    def decorator(wrapped):
-        settings_ = copy.deepcopy(settings)
-        patches = create_patches(
-            destination,
-            wrapped,
-            settings=settings_,
-            traverse_bases=traverse_bases,
-            filter=filter,
-            recursive=recursive,
-            use_decorators=use_decorators,
-        )
-        data = get_decorator_data(_get_base(wrapped), set_default=True)
-        data.patches.extend(patches)
         return wrapped
 
     return decorator
@@ -582,100 +522,6 @@ def filter(value):  # pylint: disable=W0622
     return decorator
 
 
-def create_patches(
-    destination,
-    root,
-    settings=None,
-    traverse_bases=True,
-    filter=default_filter,
-    recursive=True,
-    use_decorators=True,
-):
-    """Create a patch for each member of a module or a class.
-
-    Parameters
-    ----------
-    destination : object
-        Patch destination.
-    root : object
-        Root object, either a module or a class.
-    settings : gorilla.Settings
-        Settings.
-    traverse_bases : bool
-        If the object is a class, the base classes are also traversed.
-    filter : function
-        Attributes for which the function returns ``False`` are skipped. The
-        function needs to define two parameters: ``name``, the attribute name,
-        and ``obj``, the attribute value. If ``None``, no attribute is skipped.
-    recursive : bool
-        If ``True``, and a hit occurs due to an attribute at the destination
-        already existing with the given name, and both the member and the
-        target attributes are classes, then instead of creating a patch
-        directly with the member attribute value as is, a patch for each of its
-        own members is created with the target as new destination.
-    use_decorators : bool
-        ``True`` to take any modifier decorator into consideration to allow for
-        more granular customizations.
-
-    Returns
-    -------
-    list of gorilla.Patch
-        The patches.
-
-    Note
-    ----
-    A 'target' differs from a 'destination' in that a target represents an
-    existing attribute at the destination about to be hit by a patch.
-
-    See Also
-    --------
-    :func:`patches`.
-    """
-    if filter is None:
-        filter = _true
-
-    out = []
-    root_patch = Patch(destination, "", root, settings=settings)
-    stack = collections.deque((root_patch,))
-    while stack:
-        parent_patch = stack.popleft()
-        members = _get_members(
-            parent_patch.obj, traverse_bases=traverse_bases, filter=None, recursive=False
-        )
-        for name, value in members:
-            patch = Patch(
-                parent_patch.destination, name, value, settings=copy.deepcopy(parent_patch.settings)
-            )
-            if use_decorators:
-                base = _get_base(value)
-                decorator_data = get_decorator_data(base)
-                filter_override = None if decorator_data is None else decorator_data.filter
-                if (
-                    filter_override is None and not filter(name, value)
-                ) or filter_override is False:
-                    continue
-
-                if decorator_data is not None:
-                    patch._update(**decorator_data.override)
-            elif not filter(name, value):
-                continue
-
-            if recursive and isinstance(value, _CLASS_TYPES):
-                try:
-                    target = get_attribute(patch.destination, patch.name)
-                except AttributeError:
-                    pass
-                else:
-                    if isinstance(target, _CLASS_TYPES):
-                        patch.destination = target
-                        stack.append(patch)
-                        continue
-
-            out.append(patch)
-
-    return out
-
-
 def find_patches(modules, recursive=True):
     """Find all the patches created through decorators.
 
@@ -717,44 +563,7 @@ def find_patches(modules, recursive=True):
     return out
 
 
-def get_attribute(obj, name):
-    """Retrieve an attribute while bypassing the descriptor protocol.
-
-    As per the built-in |getattr()|_ function, if the input object is a class
-    then its base classes might also be searched until the attribute is found.
-
-    Parameters
-    ----------
-    obj : object
-        Object to search the attribute in.
-    name : str
-        Name of the attribute.
-
-    Returns
-    -------
-    object
-        The attribute found.
-
-    Raises
-    ------
-    AttributeError
-        The attribute couldn't be found.
-
-
-    .. |getattr()| replace:: ``getattr()``
-    .. _getattr(): https://docs.python.org/library/functions.html#getattr
-    """
-    objs = inspect.getmro(obj) if isinstance(obj, _CLASS_TYPES) else [obj]
-    for obj_ in objs:
-        try:
-            return object.__getattribute__(obj_, name)
-        except AttributeError:
-            pass
-
-    raise AttributeError("'%s' object has no attribute '%s'" % (type(obj), name))
-
-
-def get_original_attribute(obj, name, bypass_descriptor_protocal=False):
+def get_original_attribute(obj, name, bypass_descriptor_protocol=False):
     """Retrieve an overriden attribute that has been stored.
 
     Parameters
@@ -763,8 +572,10 @@ def get_original_attribute(obj, name, bypass_descriptor_protocal=False):
         Object to search the attribute in.
     name : str
         Name of the attribute.
-    bypass_descriptor_protocal: boolean
-        bypassing descriptor protocal if true.
+    bypass_descriptor_protocol: boolean
+        bypassing descriptor protocol if true. When storing original method during patching or
+        restoring original method during reverting patch, we need set bypass_descriptor_protocol
+        to be True to ensure get the raw attribute object.
 
     Returns
     -------
@@ -775,6 +586,11 @@ def get_original_attribute(obj, name, bypass_descriptor_protocal=False):
     ------
     AttributeError
         The attribute couldn't be found.
+
+    Note
+    ----
+    if setting store_hit=False, then after patch applied, this methods may return patched
+    attribute instead of original attribute in specific cases.
 
     See Also
     --------
@@ -784,12 +600,16 @@ def get_original_attribute(obj, name, bypass_descriptor_protocal=False):
     original_name = _ORIGINAL_NAME % (name,)
 
     def _get_attr(obj_, name_):
-        if bypass_descriptor_protocal:
-            return get_attribute(obj_, name_)
+        if bypass_descriptor_protocol:
+            return object.__getattribute__(obj_, name_)
         else:
             return getattr(obj_, name_)
 
     if inspect.isclass(obj):
+        # Search from children classes to parent classes, and check "original_name" attribute
+        # first. This will ensure get the correct original attribute in any cases, e.g.,
+        # the case some classes in the hierarchy haven't been patched, but some others are
+        # patched, this case the previous code is risky to get wrong original attribute.
         for obj_ in inspect.getmro(obj):
             if original_name in obj_.__dict__:
                 return _get_attr(obj_, original_name)
@@ -822,7 +642,7 @@ def get_decorator_data(obj, set_default=False):
     gorilla.DecoratorData
         The decorator data or ``None``.
     """
-    if isinstance(obj, _CLASS_TYPES):
+    if inspect.isclass(obj):
         datas = getattr(obj, _DECORATOR_DATA, {})
         data = datas.setdefault(obj, None)
         if data is None and set_default:
@@ -896,7 +716,7 @@ def _get_members(obj, traverse_bases=True, filter=default_filter, recursive=True
     stack = collections.deque((obj,))
     while stack:
         obj = stack.popleft()
-        if traverse_bases and isinstance(obj, _CLASS_TYPES):
+        if traverse_bases and inspect.isclass(obj):
             roots = [base for base in inspect.getmro(obj) if base not in (type, object)]
         else:
             roots = [obj]
@@ -912,7 +732,7 @@ def _get_members(obj, traverse_bases=True, filter=default_filter, recursive=True
 
         members = sorted(members)
         for _, value in members:
-            if recursive and isinstance(value, _CLASS_TYPES):
+            if recursive and inspect.isclass(value):
                 stack.append(value)
 
         out.extend(members)

--- a/mlflow/utils/gorilla.py
+++ b/mlflow/utils/gorilla.py
@@ -598,12 +598,18 @@ def get_original_attribute(obj, name, bypass_descriptor_protocol=False):
     """
 
     original_name = _ORIGINAL_NAME % (name,)
+    curr_active_patch = _ACTIVE_PATCH % (name,)
 
     def _get_attr(obj_, name_):
         if bypass_descriptor_protocol:
             return object.__getattribute__(obj_, name_)
         else:
             return getattr(obj_, name_)
+
+    no_original_stored_err = (
+        "Original attribute %s was not stored when patching, set "
+        "store_hit=True will address this."
+    )
 
     if inspect.isclass(obj):
         # Search from children classes to parent classes, and check "original_name" attribute
@@ -614,6 +620,14 @@ def get_original_attribute(obj, name, bypass_descriptor_protocol=False):
             if original_name in obj_.__dict__:
                 return _get_attr(obj_, original_name)
             elif name in obj_.__dict__:
+                if curr_active_patch in obj_.__dict__:
+                    patch = getattr(obj, curr_active_patch)
+                    if patch.is_inplace_patch:
+                        raise RuntimeError(no_original_stored_err % (f"{obj_.__name__}.{name}",))
+                    else:
+                        # non inplace patch, we can get original methods in parent classes.
+                        # so go on checking parent classes
+                        continue
                 return _get_attr(obj_, name)
             else:
                 # go on checking parent classes
@@ -623,6 +637,8 @@ def get_original_attribute(obj, name, bypass_descriptor_protocol=False):
         try:
             return _get_attr(obj, original_name)
         except AttributeError:
+            if curr_active_patch in obj.__dict__:
+                raise RuntimeError(no_original_stored_err % (f"{type(obj).__name__}.{name}",))
             return _get_attr(obj, name)
 
 

--- a/mlflow/utils/gorilla.py
+++ b/mlflow/utils/gorilla.py
@@ -326,7 +326,7 @@ def apply(patch):
             original_name = _ORIGINAL_NAME % (patch.name,)
             setattr(patch.destination, original_name, target)
 
-    patch_obj = object.__getattribute__(patch, 'obj')  # bypass descriptor protocol
+    patch_obj = object.__getattribute__(patch, "obj")  # bypass descriptor protocol
     setattr(patch.destination, patch.name, patch_obj)
     setattr(patch.destination, curr_active_patch, patch)
 

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -933,11 +933,12 @@ def test_autolog_logs_signature_only_when_estimator_defines_predict():
 def test_autolog_does_not_throw_when_predict_fails():
     X, y = get_iris()
 
+    mlflow.sklearn.autolog(log_input_examples=True, log_model_signatures=True)
+
     # Note that `mock_warning` will be called twice because if `predict` throws, `score` also throws
     with mlflow.start_run() as run, mock.patch(
         "sklearn.linear_model.LinearRegression.predict", side_effect=Exception("Failed")
     ), mock.patch("mlflow.sklearn._logger.warning") as mock_warning:
-        mlflow.sklearn.autolog(log_input_examples=True, log_model_signatures=True)
         model = sklearn.linear_model.LinearRegression()
         model.fit(X, y)
 

--- a/tests/tracking/fluent/test_fluent_autolog.py
+++ b/tests/tracking/fluent/test_fluent_autolog.py
@@ -291,17 +291,6 @@ def test_autolog_obeys_silent_mode(
     stream = StringIO()
     sys.stderr = stream
 
-    if (
-        disable
-        and not disable_for_unsupported_versions
-        and not exclusive
-        and library is keras
-        and not log_input_examples
-        and not log_model_signatures
-        and not log_models
-    ):
-        print("DBG1")
-
     mlflow.autolog(
         silent=True,
         disable=disable,

--- a/tests/tracking/fluent/test_fluent_autolog.py
+++ b/tests/tracking/fluent/test_fluent_autolog.py
@@ -291,6 +291,17 @@ def test_autolog_obeys_silent_mode(
     stream = StringIO()
     sys.stderr = stream
 
+    if (
+        disable
+        and not disable_for_unsupported_versions
+        and not exclusive
+        and library is keras
+        and not log_input_examples
+        and not log_model_signatures
+        and not log_models
+    ):
+        print("DBG1")
+
     mlflow.autolog(
         silent=True,
         disable=disable,

--- a/tests/utils/test_gorilla.py
+++ b/tests/utils/test_gorilla.py
@@ -170,3 +170,19 @@ def test_patch_on_inherit_method(store_hit):
     assert B.f2 is original_A_f2
     assert gorilla.get_original_attribute(B, "f2") is original_A_f2
     assert "f2" not in B.__dict__  # assert no side effect after reverting
+
+
+@pytest.mark.parametrize("store_hit", [True, False])
+def test_patch_on_attribute_not_exist(store_hit):
+    A, _ = gen_class_A_B()
+
+    def patched_fx(self):
+        return 101
+
+    gorilla_setting = gorilla.Settings(allow_hit=True, store_hit=store_hit)
+    fx_patch = gorilla.Patch(A, "fx", patched_fx, gorilla_setting)
+    gorilla.apply(fx_patch)
+    a1 = A()
+    assert a1.fx() == 101
+    gorilla.revert(fx_patch)
+    assert not hasattr(A, "fx")

--- a/tests/utils/test_gorilla.py
+++ b/tests/utils/test_gorilla.py
@@ -164,8 +164,7 @@ def test_patch_on_inherit_method(store_hit):
 
     assert B.f2 is patched_B_f2
 
-    if store_hit:
-        assert gorilla.get_original_attribute(B, "f2") is original_A_f2
+    assert gorilla.get_original_attribute(B, "f2") is original_A_f2
 
     gorilla.revert(patch_B_f2)
     assert B.f2 is original_A_f2

--- a/tests/utils/test_gorilla.py
+++ b/tests/utils/test_gorilla.py
@@ -49,13 +49,13 @@ def test_basic_patch_for_class(gorilla_setting):
     original_A_f2 = A.f2
     original_B_f1 = B.f1
 
-    def patched_A_f1(self):
+    def patched_A_f1(self):  # pylint: disable=unused-argument
         pass
 
-    def patched_A_f2(self):
+    def patched_A_f2(self):  # pylint: disable=unused-argument
         pass
 
-    def patched_B_f1(self):
+    def patched_B_f1(self):  # pylint: disable=unused-argument
         pass
 
     patch_A_f1 = gorilla.Patch(A, "f1", patched_A_f1, gorilla_setting)
@@ -107,7 +107,7 @@ def test_patch_for_descriptor(gorilla_setting):
 
     original_A_f3_raw = object.__getattribute__(A, "f3")
 
-    def patched_A_f3(self):
+    def patched_A_f3(self):  # pylint: disable=unused-argument
         pass
 
     patch_A_f3 = gorilla.Patch(A, "f3", patched_A_f3, gorilla_setting)
@@ -136,7 +136,7 @@ def test_patch_for_descriptor(gorilla_setting):
 
     # test patch a descriptor
     @delegate(patched_A_f3)
-    def new_patched_A_f3(self):
+    def new_patched_A_f3(self):  # pylint: disable=unused-argument
         pass
 
     new_patch_A_f3 = gorilla.Patch(A, "f3", new_patched_A_f3, gorilla_setting)
@@ -155,7 +155,7 @@ def test_patch_on_inherit_method(gorilla_setting):
 
     original_A_f2 = A.f2
 
-    def patched_B_f2(self):
+    def patched_B_f2(self):  # pylint: disable=unused-argument
         pass
 
     patch_B_f2 = gorilla.Patch(B, "f2", patched_B_f2, gorilla_setting)

--- a/tests/utils/test_gorilla.py
+++ b/tests/utils/test_gorilla.py
@@ -16,7 +16,6 @@ def delegate(delegated_fn):
 
 
 def gen_class_A_B():
-
     class A:
         def f1(self):
             pass
@@ -59,92 +58,96 @@ def test_basic_patch_for_class(gorilla_setting):
     def patched_B_f1(self):
         pass
 
-    patch_A_f1 = gorilla.Patch(A, 'f1', patched_A_f1, gorilla_setting)
-    patch_A_f2 = gorilla.Patch(A, 'f2', patched_A_f2, gorilla_setting)
-    patch_B_f1 = gorilla.Patch(B, 'f1', patched_B_f1, gorilla_setting)
+    patch_A_f1 = gorilla.Patch(A, "f1", patched_A_f1, gorilla_setting)
+    patch_A_f2 = gorilla.Patch(A, "f2", patched_A_f2, gorilla_setting)
+    patch_B_f1 = gorilla.Patch(B, "f1", patched_B_f1, gorilla_setting)
 
-    assert gorilla.get_original_attribute(A, 'f1') is original_A_f1
-    assert gorilla.get_original_attribute(B, 'f1') is original_B_f1
-    assert gorilla.get_original_attribute(B, 'f2') is original_A_f2
+    assert gorilla.get_original_attribute(A, "f1") is original_A_f1
+    assert gorilla.get_original_attribute(B, "f1") is original_B_f1
+    assert gorilla.get_original_attribute(B, "f2") is original_A_f2
 
     gorilla.apply(patch_A_f1)
     assert A.f1 is patched_A_f1
-    assert gorilla.get_original_attribute(A, 'f1') is original_A_f1
-    assert gorilla.get_original_attribute(B, 'f1') is original_B_f1
+    assert gorilla.get_original_attribute(A, "f1") is original_A_f1
+    assert gorilla.get_original_attribute(B, "f1") is original_B_f1
 
     gorilla.apply(patch_B_f1)
     assert A.f1 is patched_A_f1
     assert B.f1 is patched_B_f1
-    assert gorilla.get_original_attribute(A, 'f1') is original_A_f1
-    assert gorilla.get_original_attribute(B, 'f1') is original_B_f1
+    assert gorilla.get_original_attribute(A, "f1") is original_A_f1
+    assert gorilla.get_original_attribute(B, "f1") is original_B_f1
 
     gorilla.apply(patch_A_f2)
     assert A.f2 is patched_A_f2
     assert B.f2 is patched_A_f2
-    assert gorilla.get_original_attribute(A, 'f2') is original_A_f2
-    assert gorilla.get_original_attribute(B, 'f2') is original_A_f2
+    assert gorilla.get_original_attribute(A, "f2") is original_A_f2
+    assert gorilla.get_original_attribute(B, "f2") is original_A_f2
 
     gorilla.revert(patch_A_f2)
     assert A.f2 is original_A_f2
     assert B.f2 is original_A_f2
-    assert gorilla.get_original_attribute(A, 'f2') == original_A_f2
-    assert gorilla.get_original_attribute(B, 'f2') == original_A_f2
+    assert gorilla.get_original_attribute(A, "f2") == original_A_f2
+    assert gorilla.get_original_attribute(B, "f2") == original_A_f2
 
     gorilla.revert(patch_B_f1)
     assert A.f1 is patched_A_f1
     assert B.f1 is original_B_f1
-    assert gorilla.get_original_attribute(A, 'f1') == original_A_f1
-    assert gorilla.get_original_attribute(B, 'f1') == original_B_f1
+    assert gorilla.get_original_attribute(A, "f1") == original_A_f1
+    assert gorilla.get_original_attribute(B, "f1") == original_B_f1
 
     gorilla.revert(patch_A_f1)
     assert A.f1 is original_A_f1
     assert B.f1 is original_B_f1
-    assert gorilla.get_original_attribute(A, 'f1') == original_A_f1
-    assert gorilla.get_original_attribute(B, 'f1') == original_B_f1
+    assert gorilla.get_original_attribute(A, "f1") == original_A_f1
+    assert gorilla.get_original_attribute(B, "f1") == original_B_f1
 
 
 def test_patch_for_descriptor(gorilla_setting):
-    A,_ = gen_class_A_B()
+    A, _ = gen_class_A_B()
 
-    original_A_f3_raw = object.__getattribute__(A, 'f3')
+    original_A_f3_raw = object.__getattribute__(A, "f3")
 
     def patched_A_f3(self):
         pass
 
-    patch_A_f3 = gorilla.Patch(A, 'f3', patched_A_f3, gorilla_setting)
+    patch_A_f3 = gorilla.Patch(A, "f3", patched_A_f3, gorilla_setting)
 
-    assert gorilla.get_original_attribute(A, 'f3') is A.delegated_f3
-    assert gorilla.get_original_attribute(
-        A, 'f3', bypass_descriptor_protocol=True
-    ) is original_A_f3_raw
+    assert gorilla.get_original_attribute(A, "f3") is A.delegated_f3
+    assert (
+        gorilla.get_original_attribute(A, "f3", bypass_descriptor_protocol=True)
+        is original_A_f3_raw
+    )
 
     gorilla.apply(patch_A_f3)
     assert A.f3 is patched_A_f3
-    assert gorilla.get_original_attribute(A, 'f3') is A.delegated_f3
-    assert gorilla.get_original_attribute(
-        A, 'f3', bypass_descriptor_protocol=True
-    ) is original_A_f3_raw
+    assert gorilla.get_original_attribute(A, "f3") is A.delegated_f3
+    assert (
+        gorilla.get_original_attribute(A, "f3", bypass_descriptor_protocol=True)
+        is original_A_f3_raw
+    )
 
     gorilla.revert(patch_A_f3)
     assert A.f3 is A.delegated_f3
-    assert gorilla.get_original_attribute(A, 'f3') is A.delegated_f3
-    assert gorilla.get_original_attribute(
-        A, 'f3', bypass_descriptor_protocol=True
-    ) is original_A_f3_raw
+    assert gorilla.get_original_attribute(A, "f3") is A.delegated_f3
+    assert (
+        gorilla.get_original_attribute(A, "f3", bypass_descriptor_protocol=True)
+        is original_A_f3_raw
+    )
 
     # test patch a descriptor
     @delegate(patched_A_f3)
     def new_patched_A_f3(self):
         pass
 
-    new_patch_A_f3 = gorilla.Patch(A, 'f3', new_patched_A_f3, gorilla_setting)
+    new_patch_A_f3 = gorilla.Patch(A, "f3", new_patched_A_f3, gorilla_setting)
     gorilla.apply(new_patch_A_f3)
     assert A.f3 is patched_A_f3
-    assert object.__getattribute__(A, 'f3') is new_patched_A_f3
-    assert gorilla.get_original_attribute(A, 'f3') is A.delegated_f3
-    assert gorilla.get_original_attribute(
-        A, 'f3', bypass_descriptor_protocol=True
-    ) is original_A_f3_raw
+    assert object.__getattribute__(A, "f3") is new_patched_A_f3
+    assert gorilla.get_original_attribute(A, "f3") is A.delegated_f3
+    assert (
+        gorilla.get_original_attribute(A, "f3", bypass_descriptor_protocol=True)
+        is original_A_f3_raw
+    )
 
 
 def test_patch_on_inherit_method(gorilla_setting):
@@ -155,15 +158,13 @@ def test_patch_on_inherit_method(gorilla_setting):
     def patched_B_f2(self):
         pass
 
-    patch_B_f2 = gorilla.Patch(B, 'f2', patched_B_f2, gorilla_setting)
+    patch_B_f2 = gorilla.Patch(B, "f2", patched_B_f2, gorilla_setting)
     gorilla.apply(patch_B_f2)
 
     assert B.f2 is patched_B_f2
-    assert gorilla.get_original_attribute(B, 'f2') is original_A_f2
+    assert gorilla.get_original_attribute(B, "f2") is original_A_f2
 
     gorilla.revert(patch_B_f2)
     assert B.f2 is original_A_f2
-    assert gorilla.get_original_attribute(B, 'f2') is original_A_f2
-    assert 'f2' not in B.__dict__  # assert no side effect after reverting
-
-
+    assert gorilla.get_original_attribute(B, "f2") is original_A_f2
+    assert "f2" not in B.__dict__  # assert no side effect after reverting

--- a/tests/utils/test_gorilla.py
+++ b/tests/utils/test_gorilla.py
@@ -176,7 +176,7 @@ def test_patch_on_inherit_method(store_hit):
 def test_patch_on_attribute_not_exist(store_hit):
     A, _ = gen_class_A_B()
 
-    def patched_fx(self):
+    def patched_fx(self):  # pylint: disable=unused-argument
         return 101
 
     gorilla_setting = gorilla.Settings(allow_hit=True, store_hit=store_hit)

--- a/tests/utils/test_gorilla.py
+++ b/tests/utils/test_gorilla.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python
+import pytest
+from mlflow.utils import gorilla
+
+
+class Delegator:
+    def __init__(self, delegated_fn):
+        self.delegated_fn = delegated_fn
+
+    def __get__(self, instance, owner):
+        return self.delegated_fn
+
+
+def delegate(delegated_fn):
+    return lambda fn: Delegator(delegated_fn)
+
+
+def gen_class_A_B():
+
+    class A:
+        def f1(self):
+            pass
+
+        def f2(self):
+            pass
+
+        def delegated_f3(self):
+            pass
+
+        @delegate(delegated_f3)
+        def f3(self):
+            pass
+
+    class B(A):
+        def f1(self):
+            pass
+
+    return A, B
+
+
+@pytest.fixture
+def gorilla_setting():
+    return gorilla.Settings(allow_hit=True, store_hit=True)
+
+
+def test_basic_patch_for_class(gorilla_setting):
+    A, B = gen_class_A_B()
+
+    original_A_f1 = A.f1
+    original_A_f2 = A.f2
+    original_B_f1 = B.f1
+
+    def patched_A_f1(self):
+        pass
+
+    def patched_A_f2(self):
+        pass
+
+    def patched_B_f1(self):
+        pass
+
+    patch_A_f1 = gorilla.Patch(A, 'f1', patched_A_f1, gorilla_setting)
+    patch_A_f2 = gorilla.Patch(A, 'f2', patched_A_f2, gorilla_setting)
+    patch_B_f1 = gorilla.Patch(B, 'f1', patched_B_f1, gorilla_setting)
+
+    assert gorilla.get_original_attribute(A, 'f1') is original_A_f1
+    assert gorilla.get_original_attribute(B, 'f1') is original_B_f1
+    assert gorilla.get_original_attribute(B, 'f2') is original_A_f2
+
+    gorilla.apply(patch_A_f1)
+    assert A.f1 is patched_A_f1
+    assert gorilla.get_original_attribute(A, 'f1') is original_A_f1
+    assert gorilla.get_original_attribute(B, 'f1') is original_B_f1
+
+    gorilla.apply(patch_B_f1)
+    assert A.f1 is patched_A_f1
+    assert B.f1 is patched_B_f1
+    assert gorilla.get_original_attribute(A, 'f1') is original_A_f1
+    assert gorilla.get_original_attribute(B, 'f1') is original_B_f1
+
+    gorilla.apply(patch_A_f2)
+    assert A.f2 is patched_A_f2
+    assert B.f2 is patched_A_f2
+    assert gorilla.get_original_attribute(A, 'f2') is original_A_f2
+    assert gorilla.get_original_attribute(B, 'f2') is original_A_f2
+
+    gorilla.revert(patch_A_f2)
+    assert A.f2 is original_A_f2
+    assert B.f2 is original_A_f2
+    assert gorilla.get_original_attribute(A, 'f2') == original_A_f2
+    assert gorilla.get_original_attribute(B, 'f2') == original_A_f2
+
+    gorilla.revert(patch_B_f1)
+    assert A.f1 is patched_A_f1
+    assert B.f1 is original_B_f1
+    assert gorilla.get_original_attribute(A, 'f1') == original_A_f1
+    assert gorilla.get_original_attribute(B, 'f1') == original_B_f1
+
+    gorilla.revert(patch_A_f1)
+    assert A.f1 is original_A_f1
+    assert B.f1 is original_B_f1
+    assert gorilla.get_original_attribute(A, 'f1') == original_A_f1
+    assert gorilla.get_original_attribute(B, 'f1') == original_B_f1
+
+
+def test_patch_for_descriptor(gorilla_setting):
+    A,_ = gen_class_A_B()
+
+    original_A_f3_raw = object.__getattribute__(A, 'f3')
+
+    def patched_A_f3(self):
+        pass
+
+    patch_A_f3 = gorilla.Patch(A, 'f3', patched_A_f3, gorilla_setting)
+
+    assert gorilla.get_original_attribute(A, 'f3') is A.delegated_f3
+    assert gorilla.get_original_attribute(
+        A, 'f3', bypass_descriptor_protocol=True
+    ) is original_A_f3_raw
+
+    gorilla.apply(patch_A_f3)
+    assert A.f3 is patched_A_f3
+    assert gorilla.get_original_attribute(A, 'f3') is A.delegated_f3
+    assert gorilla.get_original_attribute(
+        A, 'f3', bypass_descriptor_protocol=True
+    ) is original_A_f3_raw
+
+    gorilla.revert(patch_A_f3)
+    assert A.f3 is A.delegated_f3
+    assert gorilla.get_original_attribute(A, 'f3') is A.delegated_f3
+    assert gorilla.get_original_attribute(
+        A, 'f3', bypass_descriptor_protocol=True
+    ) is original_A_f3_raw
+
+    # test patch a descriptor
+    @delegate(patched_A_f3)
+    def new_patched_A_f3(self):
+        pass
+
+    new_patch_A_f3 = gorilla.Patch(A, 'f3', new_patched_A_f3, gorilla_setting)
+    gorilla.apply(new_patch_A_f3)
+    assert A.f3 is patched_A_f3
+    assert object.__getattribute__(A, 'f3') is new_patched_A_f3
+    assert gorilla.get_original_attribute(A, 'f3') is A.delegated_f3
+    assert gorilla.get_original_attribute(
+        A, 'f3', bypass_descriptor_protocol=True
+    ) is original_A_f3_raw
+
+
+def test_patch_on_inherit_method(gorilla_setting):
+    A, B = gen_class_A_B()
+
+    original_A_f2 = A.f2
+
+    def patched_B_f2(self):
+        pass
+
+    patch_B_f2 = gorilla.Patch(B, 'f2', patched_B_f2, gorilla_setting)
+    gorilla.apply(patch_B_f2)
+
+    assert B.f2 is patched_B_f2
+    assert gorilla.get_original_attribute(B, 'f2') is original_A_f2
+
+    gorilla.revert(patch_B_f2)
+    assert B.f2 is original_A_f2
+    assert gorilla.get_original_attribute(B, 'f2') is original_A_f2
+    assert 'f2' not in B.__dict__  # assert no side effect after reverting
+
+

--- a/tests/utils/test_gorilla.py
+++ b/tests/utils/test_gorilla.py
@@ -149,7 +149,8 @@ def test_patch_for_descriptor(gorilla_setting):
     )
 
 
-def test_patch_on_inherit_method(gorilla_setting):
+@pytest.mark.parametrize("store_hit", [True, False])
+def test_patch_on_inherit_method(store_hit):
     A, B = gen_class_A_B()
 
     original_A_f2 = A.f2
@@ -157,11 +158,14 @@ def test_patch_on_inherit_method(gorilla_setting):
     def patched_B_f2(self):  # pylint: disable=unused-argument
         pass
 
+    gorilla_setting = gorilla.Settings(allow_hit=True, store_hit=store_hit)
     patch_B_f2 = gorilla.Patch(B, "f2", patched_B_f2, gorilla_setting)
     gorilla.apply(patch_B_f2)
 
     assert B.f2 is patched_B_f2
-    assert gorilla.get_original_attribute(B, "f2") is original_A_f2
+
+    if store_hit:
+        assert gorilla.get_original_attribute(B, "f2") is original_A_f2
 
     gorilla.revert(patch_B_f2)
     assert B.f2 is original_A_f2

--- a/tests/utils/test_gorilla.py
+++ b/tests/utils/test_gorilla.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import pytest
 from mlflow.utils import gorilla
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Modify `get_original_attribute` logic, search from children classes to parent classes,
  and for each class check "_gorilla_original_{attr_name}" attribute first.
  first. This will ensure get the correct original attribute in any cases, e.g.,
  the case some classes in the hierarchy haven't been patched, but some others are
  patched, this case the previous code is risky to get wrong original attribute.
- Make `get_original_attribute` support bypassing descriptor protocol.
- remove `get_attribute` method, use `get_original_attribute` with
  `bypass_descriptor_protocol=True` instead of calling it.
- After reverting patch, there will be no side-effect, restore object to be exactly the
  original status.
- Remove `create_patches` and `patches` methods.

## How is this patch tested?

Unit tests.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
