### PR TITLE
Add `_get_pinned_requirement` to accurately obtain package versions

### DIFF
--- a/mlflow/catboost.py
+++ b/mlflow/catboost.py
@@ -36,6 +36,7 @@ from mlflow.utils.environment import (
     _REQUIREMENTS_FILE_NAME,
     _CONSTRAINTS_FILE_NAME,
 )
+from mlflow.utils.requirements_utils import _get_pinned_requirement
 from mlflow.utils.file_utils import write_to
 from mlflow.utils.docstring_utils import format_docstring, LOG_MODEL_PARAM_DOCS
 from mlflow.utils.model_utils import _get_flavor_configuration
@@ -55,9 +56,7 @@ def get_default_pip_requirements():
              Calls to :func:`save_model()` and :func:`log_model()` produce a pip environment
              that, at minimum, contains these requirements.
     """
-    import catboost as cb
-
-    return ["catboost=={}".format(cb.__version__)]
+    return [_get_pinned_requirement("catboost")]
 
 
 def get_default_conda_env():

--- a/mlflow/fastai.py
+++ b/mlflow/fastai.py
@@ -35,6 +35,7 @@ from mlflow.utils.environment import (
     _REQUIREMENTS_FILE_NAME,
     _CONSTRAINTS_FILE_NAME,
 )
+from mlflow.utils.requirements_utils import _get_pinned_requirement
 from mlflow.utils.file_utils import write_to
 from mlflow.utils.docstring_utils import format_docstring, LOG_MODEL_PARAM_DOCS
 from mlflow.utils.model_utils import _get_flavor_configuration
@@ -59,13 +60,9 @@ def get_default_pip_requirements(include_cloudpickle=False):
              Calls to :func:`save_model()` and :func:`log_model()` produce a pip environment
              that, at minimum, contains these requirements.
     """
-    import fastai
-
-    pip_deps = ["fastai=={}".format(fastai.__version__)]
+    pip_deps = [_get_pinned_requirement("fastai")]
     if include_cloudpickle:
-        import cloudpickle
-
-        pip_deps.append("cloudpickle=={}".format(cloudpickle.__version__))
+        pip_deps.append(_get_pinned_requirement("cloudpickle"))
 
     return pip_deps
 

--- a/mlflow/gluon.py
+++ b/mlflow/gluon.py
@@ -23,6 +23,7 @@ from mlflow.utils.environment import (
     _REQUIREMENTS_FILE_NAME,
     _CONSTRAINTS_FILE_NAME,
 )
+from mlflow.utils.requirements_utils import _get_pinned_requirement
 from mlflow.utils.docstring_utils import format_docstring, LOG_MODEL_PARAM_DOCS
 from mlflow.utils.file_utils import write_to
 from mlflow.utils.autologging_utils import (
@@ -258,9 +259,7 @@ def get_default_pip_requirements():
              Calls to :func:`save_model()` and :func:`log_model()` produce a pip environment
              that, at minimum, contains these requirements.
     """
-    import mxnet as mx
-
-    return ["mxnet=={}".format(mx.__version__)]
+    return [_get_pinned_requirement("mxnet")]
 
 
 def get_default_conda_env():

--- a/mlflow/h2o.py
+++ b/mlflow/h2o.py
@@ -27,6 +27,7 @@ from mlflow.utils.environment import (
     _REQUIREMENTS_FILE_NAME,
     _CONSTRAINTS_FILE_NAME,
 )
+from mlflow.utils.requirements_utils import _get_pinned_requirement
 from mlflow.utils.file_utils import write_to
 from mlflow.utils.docstring_utils import format_docstring, LOG_MODEL_PARAM_DOCS
 from mlflow.utils.model_utils import _get_flavor_configuration
@@ -40,9 +41,7 @@ def get_default_pip_requirements():
              Calls to :func:`save_model()` and :func:`log_model()` produce a pip environment
              that, at minimum, contains these requirements.
     """
-    import h2o
-
-    return ["h2o=={}".format(h2o.__version__)]
+    return [_get_pinned_requirement("h2o")]
 
 
 def get_default_conda_env():

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -34,6 +34,7 @@ from mlflow.utils.environment import (
     _REQUIREMENTS_FILE_NAME,
     _CONSTRAINTS_FILE_NAME,
 )
+from mlflow.utils.requirements_utils import _get_pinned_requirement
 from mlflow.utils.file_utils import write_to
 from mlflow.utils.docstring_utils import format_docstring, LOG_MODEL_PARAM_DOCS
 from mlflow.utils.model_utils import _get_flavor_configuration
@@ -73,13 +74,11 @@ def get_default_pip_requirements(include_cloudpickle=False, keras_module=None):
 
         keras_module = keras
     if keras_module.__name__ == "keras":
-        pip_deps.append("keras=={}".format(keras_module.__version__))
+        pip_deps.append(_get_pinned_requirement("keras"))
     if include_cloudpickle:
-        import cloudpickle
+        pip_deps.append(_get_pinned_requirement("cloudpickle"))
 
-        pip_deps.append("cloudpickle=={}".format(cloudpickle.__version__))
-
-    pip_deps.append("tensorflow=={}".format(tf.__version__))
+    pip_deps.append(_get_pinned_requirement("tensorflow"))
 
     # Tensorflow<2.4 does not work with h5py>=3.0.0
     # see https://github.com/tensorflow/tensorflow/issues/44467

--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -42,6 +42,7 @@ from mlflow.utils.environment import (
     _REQUIREMENTS_FILE_NAME,
     _CONSTRAINTS_FILE_NAME,
 )
+from mlflow.utils.requirements_utils import _get_pinned_requirement
 from mlflow.utils.file_utils import write_to
 from mlflow.utils.docstring_utils import format_docstring, LOG_MODEL_PARAM_DOCS
 from mlflow.utils.model_utils import _get_flavor_configuration
@@ -72,9 +73,7 @@ def get_default_pip_requirements():
              Calls to :func:`save_model()` and :func:`log_model()` produce a pip environment
              that, at minimum, contains these requirements.
     """
-    import lightgbm as lgb
-
-    return ["lightgbm=={}".format(lgb.__version__)]
+    return [_get_pinned_requirement("lightgbm")]
 
 
 def get_default_conda_env():

--- a/mlflow/onnx.py
+++ b/mlflow/onnx.py
@@ -51,7 +51,7 @@ def get_default_pip_requirements():
         map(
             _get_pinned_requirement,
             [
-                "onnx"
+                "onnx",
                 # The ONNX pyfunc representation requires the OnnxRuntime
                 # inference engine. Therefore, the conda environment must
                 # include OnnxRuntime

--- a/mlflow/onnx.py
+++ b/mlflow/onnx.py
@@ -32,6 +32,7 @@ from mlflow.utils.environment import (
     _REQUIREMENTS_FILE_NAME,
     _CONSTRAINTS_FILE_NAME,
 )
+from mlflow.utils.requirements_utils import _get_pinned_requirement
 from mlflow.utils.file_utils import write_to
 from mlflow.utils.docstring_utils import format_docstring, LOG_MODEL_PARAM_DOCS
 from mlflow.utils.model_utils import _get_flavor_configuration
@@ -46,16 +47,18 @@ def get_default_pip_requirements():
              Calls to :func:`save_model()` and :func:`log_model()` produce a pip environment
              that, at minimum, contains these requirements.
     """
-    import onnx
-    import onnxruntime
-
-    return [
-        "onnx=={}".format(onnx.__version__),
-        # The ONNX pyfunc representation requires the OnnxRuntime
-        # inference engine. Therefore, the conda environment must
-        # include OnnxRuntime
-        "onnxruntime=={}".format(onnxruntime.__version__),
-    ]
+    return list(
+        map(
+            _get_pinned_requirement,
+            [
+                "onnx"
+                # The ONNX pyfunc representation requires the OnnxRuntime
+                # inference engine. Therefore, the conda environment must
+                # include OnnxRuntime
+                "onnxruntime",
+            ],
+        )
+    )
 
 
 @experimental

--- a/mlflow/paddle/__init__.py
+++ b/mlflow/paddle/__init__.py
@@ -33,6 +33,7 @@ from mlflow.utils.environment import (
     _REQUIREMENTS_FILE_NAME,
     _CONSTRAINTS_FILE_NAME,
 )
+from mlflow.utils.requirements_utils import _get_pinned_requirement
 from mlflow.utils.docstring_utils import format_docstring, LOG_MODEL_PARAM_DOCS
 from mlflow.utils.file_utils import write_to
 from mlflow.utils.model_utils import _get_flavor_configuration
@@ -49,9 +50,7 @@ def get_default_pip_requirements():
              Calls to :func:`save_model()` and :func:`log_model()` produce a pip environment
              that, at minimum, contains these requirements.
     """
-    import paddle
-
-    return ["paddlepaddle=={}".format(paddle.__version__)]
+    return [_get_pinned_requirement("paddlepaddle", module="paddle")]
 
 
 def get_default_conda_env():

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -26,6 +26,7 @@ from mlflow.utils.environment import (
     _REQUIREMENTS_FILE_NAME,
     _CONSTRAINTS_FILE_NAME,
 )
+from mlflow.utils.requirements_utils import _get_pinned_requirement
 from mlflow.utils.file_utils import write_to
 from mlflow.utils.model_utils import _get_flavor_configuration
 from mlflow.utils.file_utils import TempDir, _copy_file_or_tree
@@ -43,7 +44,7 @@ def get_default_pip_requirements():
              Calls to :func:`save_model()` and :func:`log_model()` produce a pip environment
              that, at minimum, contains these requirements.
     """
-    return ["cloudpickle=={}".format(cloudpickle.__version__)]
+    return [_get_pinned_requirement("cloudpickle")]
 
 
 def get_default_conda_env():

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -40,7 +40,7 @@ from mlflow.utils.environment import (
     _REQUIREMENTS_FILE_NAME,
     _CONSTRAINTS_FILE_NAME,
 )
-from mlflow.utils.requirements_utils import _strip_local_version_identifier
+from mlflow.utils.requirements_utils import _get_pinned_requirement
 from mlflow.utils.docstring_utils import format_docstring, LOG_MODEL_PARAM_DOCS
 from mlflow.utils.file_utils import _copy_file_or_tree, TempDir, write_to
 from mlflow.utils.model_utils import _get_flavor_configuration
@@ -64,19 +64,19 @@ def get_default_pip_requirements():
              Calls to :func:`save_model()` and :func:`log_model()` produce a pip environment
              that, at minimum, contains these requirements.
     """
-    import torch
-    import torchvision
-
-    return [
-        # `torch.__version__` and `torchvision.__version__`contain a local version identifier
-        # (e.g. "cpu" in "1.9.0+cpu") which causes the installation from PyPI to fail.
-        "torch=={}".format(_strip_local_version_identifier(torch.__version__)),
-        "torchvision=={}".format(_strip_local_version_identifier(torchvision.__version__)),
-        # We include CloudPickle in the default environment because
-        # it's required by the default pickle module used by `save_model()`
-        # and `log_model()`: `mlflow.pytorch.pickle_module`.
-        "cloudpickle=={}".format(cloudpickle.__version__),
-    ]
+    return list(
+        map(
+            _get_pinned_requirement,
+            [
+                "torch",
+                "torchvision",
+                # We include CloudPickle in the default environment because
+                # it's required by the default pickle module used by `save_model()`
+                # and `log_model()`: `mlflow.pytorch.pickle_module`.
+                "cloudpickle",
+            ],
+        )
+    )
 
 
 def get_default_conda_env():

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -13,7 +13,6 @@ import os
 import yaml
 import warnings
 
-import cloudpickle
 import numpy as np
 import pandas as pd
 from packaging.version import Version

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -68,8 +68,8 @@ def get_default_pip_requirements():
     import torchvision
 
     return [
-        # `torch.__version__` and `torchvision.__version__`contains a local version identifier
-        # (e.g. '1.9.0+cu102') which causes the installation from PyPI to fail.
+        # `torch.__version__` and `torchvision.__version__`contain a local version identifier
+        # (e.g. "cpu" in "1.9.0+cpu") which causes the installation from PyPI to fail.
         "torch=={}".format(_strip_local_version_identifier(torch.__version__)),
         "torchvision=={}".format(_strip_local_version_identifier(torchvision.__version__)),
         # We include CloudPickle in the default environment because

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -40,6 +40,7 @@ from mlflow.utils.environment import (
     _REQUIREMENTS_FILE_NAME,
     _CONSTRAINTS_FILE_NAME,
 )
+from mlflow.utils.requirements_utils import _strip_local_version_identifier
 from mlflow.utils.docstring_utils import format_docstring, LOG_MODEL_PARAM_DOCS
 from mlflow.utils.file_utils import _copy_file_or_tree, TempDir, write_to
 from mlflow.utils.model_utils import _get_flavor_configuration
@@ -67,8 +68,10 @@ def get_default_pip_requirements():
     import torchvision
 
     return [
-        "torch=={}".format(torch.__version__),
-        "torchvision=={}".format(torchvision.__version__),
+        # `torch.__version__` and `torchvision.__version__`contains a local version identifier
+        # (e.g. '1.9.0+cu102') which causes the installation from PyPI to fail.
+        "torch=={}".format(_strip_local_version_identifier(torch.__version__)),
+        "torchvision=={}".format(_strip_local_version_identifier(torchvision.__version__)),
         # We include CloudPickle in the default environment because
         # it's required by the default pickle module used by `save_model()`
         # and `log_model()`: `mlflow.pytorch.pickle_module`.

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -42,6 +42,7 @@ from mlflow.utils.environment import (
     _REQUIREMENTS_FILE_NAME,
     _CONSTRAINTS_FILE_NAME,
 )
+from mlflow.utils.requirements_utils import _get_pinned_requirement
 from mlflow.utils.file_utils import write_to
 from mlflow.utils.docstring_utils import format_docstring, LOG_MODEL_PARAM_DOCS
 from mlflow.utils.mlflow_tags import MLFLOW_AUTOLOGGING
@@ -74,13 +75,9 @@ def get_default_pip_requirements(include_cloudpickle=False):
              Calls to :func:`save_model()` and :func:`log_model()` produce a pip environment
              that, at minimum, contains these requirements.
     """
-    import sklearn
-
-    pip_deps = ["scikit-learn=={}".format(sklearn.__version__)]
+    pip_deps = [_get_pinned_requirement("scikit-learn", module="sklearn")]
     if include_cloudpickle:
-        import cloudpickle
-
-        pip_deps += ["cloudpickle=={}".format(cloudpickle.__version__)]
+        pip_deps += [_get_pinned_requirement("cloudpickle")]
 
     return pip_deps
 

--- a/mlflow/spacy.py
+++ b/mlflow/spacy.py
@@ -31,6 +31,7 @@ from mlflow.utils.environment import (
     _REQUIREMENTS_FILE_NAME,
     _CONSTRAINTS_FILE_NAME,
 )
+from mlflow.utils.requirements_utils import _get_pinned_requirement
 from mlflow.utils.docstring_utils import format_docstring, LOG_MODEL_PARAM_DOCS
 from mlflow.utils.file_utils import write_to
 from mlflow.utils.model_utils import _get_flavor_configuration
@@ -46,9 +47,7 @@ def get_default_pip_requirements():
              Calls to :func:`save_model()` and :func:`log_model()` produce a pip environment
              that, at minimum, contains these requirements.
     """
-    import spacy
-
-    return ["spacy=={}".format(spacy.__version__)]
+    return [_get_pinned_requirement("spacy")]
 
 
 def get_default_conda_env():

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -45,6 +45,7 @@ from mlflow.utils.environment import (
     _REQUIREMENTS_FILE_NAME,
     _CONSTRAINTS_FILE_NAME,
 )
+from mlflow.utils.requirements_utils import _get_pinned_requirement
 from mlflow.utils.docstring_utils import format_docstring, LOG_MODEL_PARAM_DOCS
 from mlflow.store.artifact.runs_artifact_repo import RunsArtifactRepository
 from mlflow.store.artifact.models_artifact_repo import ModelsArtifactRepository
@@ -81,13 +82,10 @@ def get_default_pip_requirements():
              Calls to :func:`save_model()` and :func:`log_model()` produce a pip environment
              that, at minimum, contains these requirements.
     """
-    import pyspark
-
     # Strip the suffix from `dev` versions of PySpark, which are not
     # available for installation from Anaconda or PyPI
-    pyspark_version = re.sub(r"(\.?)dev.*", "", pyspark.__version__)
-
-    return ["pyspark=={}".format(pyspark_version)]
+    pyspark_req = re.sub(r"(\.?)dev.*$", "", _get_pinned_requirement("pyspark"))
+    return [pyspark_req]
 
 
 def get_default_conda_env():

--- a/mlflow/statsmodels.py
+++ b/mlflow/statsmodels.py
@@ -33,6 +33,7 @@ from mlflow.utils.environment import (
     _REQUIREMENTS_FILE_NAME,
     _CONSTRAINTS_FILE_NAME,
 )
+from mlflow.utils.requirements_utils import _get_pinned_requirement
 from mlflow.utils.file_utils import write_to
 from mlflow.utils.docstring_utils import format_docstring, LOG_MODEL_PARAM_DOCS
 from mlflow.utils.model_utils import _get_flavor_configuration
@@ -64,9 +65,7 @@ def get_default_pip_requirements():
              Calls to :func:`save_model()` and :func:`log_model()` produce a pip environment
              that, at minimum, contains these requirements.
     """
-    import statsmodels
-
-    return ["statsmodels=={}".format(statsmodels.__version__)]
+    return [_get_pinned_requirement("statsmodels")]
 
 
 def get_default_conda_env():

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -42,6 +42,7 @@ from mlflow.utils.environment import (
     _REQUIREMENTS_FILE_NAME,
     _CONSTRAINTS_FILE_NAME,
 )
+from mlflow.utils.requirements_utils import _get_pinned_requirement
 from mlflow.utils.docstring_utils import format_docstring, LOG_MODEL_PARAM_DOCS
 from mlflow.utils.file_utils import _copy_file_or_tree, TempDir, write_to
 from mlflow.utils.model_utils import _get_flavor_configuration
@@ -82,9 +83,7 @@ def get_default_pip_requirements():
              Calls to :func:`save_model()` and :func:`log_model()` produce a pip environment
              that, at minimum, contains these requirements.
     """
-    import tensorflow
-
-    return ["tensorflow=={}".format(tensorflow.__version__)]
+    return [_get_pinned_requirement("tensorflow")]
 
 
 def get_default_conda_env():

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -120,3 +120,28 @@ def _strip_local_version_identifier(version):
             return None
 
     return str(IgnoreLocal(version))
+
+
+def _get_installed_version(module):
+    """
+    Returns the installed version of the specified module.
+
+    :param module: The name of the module.
+    """
+    return __import__(module).__version__
+
+
+def _get_pinned_requirement(package, version=None, module=None):
+    """
+    Returns a string representing a pinned pip requirement to install the specified package and
+    version (e.g. 'mlflow==1.2.3').
+
+    :param package: The name of the package.
+    :param version: The version of the package. If None, defaults to the installed version.
+    :param module: The name of the top-level module provided by the package . For example,
+                   if `package` is 'scikit-learn', `module` should be 'sklearn'.
+    """
+    module = module or package
+    version = version or _get_installed_version(module)
+    version = _strip_local_version_identifier(version)
+    return f"{package}=={version}"

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -139,7 +139,8 @@ def _get_pinned_requirement(package, version=None, module=None):
     :param package: The name of the package.
     :param version: The version of the package. If None, defaults to the installed version.
     :param module: The name of the top-level module provided by the package . For example,
-                   if `package` is 'scikit-learn', `module` should be 'sklearn'.
+                   if `package` is 'scikit-learn', `module` should be 'sklearn'. If None, defaults
+                   to `package`.
     """
     module = module or package
     version = version or _get_installed_version(module)

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -111,7 +111,7 @@ def _strip_local_version_identifier(version):
     Local version identifiers:
     https://www.python.org/dev/peps/pep-0440/#local-version-identifiers
 
-    :param version: A string package version.
+    :param version: A version string to strip.
     """
 
     class IgnoreLocal(Version):

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -3,8 +3,11 @@ This module provides a set of utilities for interpreting and creating requiremen
 (e.g. pip's `requirements.txt`), which is useful for managing ML software environments.
 """
 import os
+import importlib_metadata
 from itertools import filterfalse
 from collections import namedtuple
+
+from packaging.version import Version
 
 
 def _is_comment(line):
@@ -100,3 +103,21 @@ def _parse_requirements(requirements_file, is_constraint):
             yield from _parse_requirements(abs_path, is_constraint=True)
         else:
             yield _Requirement(line, is_constraint)
+
+
+def _strip_local_version_identifier(version):
+    """
+    Strips a local version identifer in `version`.
+
+    Local version identifiers:
+    https://www.python.org/dev/peps/pep-0440/#local-version-identifiers
+
+    :param version: A string package version.
+    """
+
+    class IgnoreLocal(Version):
+        @property
+        def local(self):
+            return None
+
+    return str(IgnoreLocal(version))

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -3,7 +3,6 @@ This module provides a set of utilities for interpreting and creating requiremen
 (e.g. pip's `requirements.txt`), which is useful for managing ML software environments.
 """
 import os
-import importlib_metadata
 from itertools import filterfalse
 from collections import namedtuple
 

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -6,7 +6,7 @@ import os
 from itertools import filterfalse
 from collections import namedtuple
 
-from packaging.version import Version
+from packaging.version import Version, InvalidVersion
 
 
 def _is_comment(line):
@@ -119,7 +119,10 @@ def _strip_local_version_identifier(version):
         def local(self):
             return None
 
-    return str(IgnoreLocal(version))
+    try:
+        return str(IgnoreLocal(version))
+    except InvalidVersion:
+        return version
 
 
 def _get_installed_version(module):

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -42,6 +42,7 @@ from mlflow.utils.environment import (
     _REQUIREMENTS_FILE_NAME,
     _CONSTRAINTS_FILE_NAME,
 )
+from mlflow.utils.requirements_utils import _get_pinned_requirement
 from mlflow.utils.file_utils import write_to
 from mlflow.utils.model_utils import _get_flavor_configuration
 from mlflow.exceptions import MlflowException
@@ -80,9 +81,7 @@ def get_default_pip_requirements():
              Calls to :func:`save_model()` and :func:`log_model()` produce a pip environment
              that, at minimum, contains these requirements.
     """
-    import xgboost as xgb
-
-    return ["xgboost=={}".format(xgb.__version__)]
+    return [_get_pinned_requirement("xgboost")]
 
 
 def get_default_conda_env():

--- a/tests/utils/test_requirements_utils.py
+++ b/tests/utils/test_requirements_utils.py
@@ -184,6 +184,7 @@ def test_strip_local_version_identifier():
     assert _strip_local_version_identifier("1.2.3rc0+ab") == "1.2.3rc0"
     assert _strip_local_version_identifier("1.2.3.dev0+ab") == "1.2.3.dev0"
     assert _strip_local_version_identifier("1.2.3.post0+ab") == "1.2.3.post0"
+    assert _strip_local_version_identifier("invalid") == "invalid"
 
 
 def test_get_installed_version():

--- a/tests/utils/test_requirements_utils.py
+++ b/tests/utils/test_requirements_utils.py
@@ -7,6 +7,7 @@ from mlflow.utils.requirements_utils import (
     _strip_inline_comment,
     _join_continued_lines,
     _parse_requirements,
+    _strip_local_version_identifier,
 )
 
 
@@ -171,3 +172,11 @@ line-cont-eof\
         assert [r.requirement for r in pip_reqs if r.constraint] == expected_cons
     finally:
         os.chdir(request.config.invocation_dir)
+
+
+def test_strip_local_version_identifier():
+    assert _strip_local_version_identifier("1.2.3") == "1.2.3"
+    assert _strip_local_version_identifier("1.2.3+ab") == "1.2.3"
+    assert _strip_local_version_identifier("1.2.3rc0+ab") == "1.2.3rc0"
+    assert _strip_local_version_identifier("1.2.3.dev0+ab") == "1.2.3.dev0"
+    assert _strip_local_version_identifier("1.2.3.post0+ab") == "1.2.3.post0"

--- a/tests/utils/test_requirements_utils.py
+++ b/tests/utils/test_requirements_utils.py
@@ -1,5 +1,7 @@
 import os
+from unittest import mock
 
+import mlflow
 from mlflow.utils.requirements_utils import (
     _is_comment,
     _is_empty,
@@ -8,6 +10,8 @@ from mlflow.utils.requirements_utils import (
     _join_continued_lines,
     _parse_requirements,
     _strip_local_version_identifier,
+    _get_installed_version,
+    _get_pinned_requirement,
 )
 
 
@@ -180,3 +184,21 @@ def test_strip_local_version_identifier():
     assert _strip_local_version_identifier("1.2.3rc0+ab") == "1.2.3rc0"
     assert _strip_local_version_identifier("1.2.3.dev0+ab") == "1.2.3.dev0"
     assert _strip_local_version_identifier("1.2.3.post0+ab") == "1.2.3.post0"
+
+
+def test_get_installed_version():
+    import numpy as np
+    import pandas as pd
+
+    assert _get_installed_version("mlflow") == mlflow.__version__
+    assert _get_installed_version("numpy") == np.__version__
+    assert _get_installed_version("pandas") == pd.__version__
+
+
+def test_get_pinned_requirement():
+    assert _get_pinned_requirement("mlflow") == f"mlflow=={mlflow.__version__}"
+    assert _get_pinned_requirement("mlflow", version="1.2.3") == "mlflow==1.2.3"
+    assert _get_pinned_requirement("foo", module="mlflow") == f"foo=={mlflow.__version__}"
+
+    with mock.patch("mlflow.__version__", new="1.2.3+abc"):
+        assert _get_pinned_requirement("mlflow") == "mlflow==1.2.3"


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

See https://github.com/mlflow/mlflow/pull/4627#discussion_r680596126

## How is this patch tested?

Unit test

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
