### PR TITLE
PyTorch Examples - PTL 1.4.0 Fixes

### DIFF
--- a/examples/pytorch/AxHyperOptimizationPTL/conda.yaml
+++ b/examples/pytorch/AxHyperOptimizationPTL/conda.yaml
@@ -5,7 +5,7 @@ dependencies:
 - pip
 - pip:
   - mlflow
-  - pytorch-lightning==1.3.5
+  - pytorch-lightning==1.4.0
   - ax-platform
   - torchvision>=0.9.1
   - torch==1.9.0

--- a/examples/pytorch/BertNewsClassification/conda.yaml
+++ b/examples/pytorch/BertNewsClassification/conda.yaml
@@ -13,4 +13,4 @@ dependencies:
   - torchvision>=0.9.1
   - torch==1.9.0
   - torchtext==0.10.0
-  - pytorch-lightning==1.3.5
+  - pytorch-lightning==1.4.0

--- a/examples/pytorch/IterativePruning/conda.yaml
+++ b/examples/pytorch/IterativePruning/conda.yaml
@@ -7,7 +7,7 @@ dependencies:
   - mlflow
   - torchvision>=0.9.1
   - cloudpickle==1.6.0
-  - pytorch_lightning==1.3.5
+  - pytorch_lightning==1.4.0
   - ax-platform
   - prettytable
   - torch==1.9.0

--- a/examples/pytorch/IterativePruning/iterative_prune_mnist.py
+++ b/examples/pytorch/IterativePruning/iterative_prune_mnist.py
@@ -41,7 +41,7 @@ class IterativePrune:
         trainer.test()
         if os.path.exists(self.base_model_path):
             shutil.rmtree(self.base_model_path)
-        mlflow.pytorch.save_model(trainer.get_model(), self.base_model_path)
+        mlflow.pytorch.save_model(trainer.lightning_module, self.base_model_path)
         return trainer
 
     def load_base_model(self):

--- a/examples/pytorch/MNIST/conda.yaml
+++ b/examples/pytorch/MNIST/conda.yaml
@@ -7,4 +7,4 @@ dependencies:
   - mlflow
   - torchvision>=0.9.1
   - torch==1.9.0
-  - pytorch-lightning==1.3.5
+  - pytorch-lightning==1.4.0


### PR DESCRIPTION
Signed-off-by: Shrinath Suresh <shrinath@ideas2it.com>

## What changes are proposed in this pull request?

https://pypi.org/project/pytorch-lightning/ - Pytorch Lightning major release happened recently. Updated the examples to run with PTL 1.4.0

## How is this patch tested?

Existing Unit tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [x] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
