### PR TITLE
Add serving tests to all flavors

### DIFF
--- a/tests/catboost/test_catboost_model_export.py
+++ b/tests/catboost/test_catboost_model_export.py
@@ -11,6 +11,7 @@ import sklearn.datasets as datasets
 
 import mlflow.catboost
 from mlflow import pyfunc
+import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 from mlflow.models.utils import _read_example
 from mlflow.models import Model, infer_signature
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
@@ -21,7 +22,11 @@ from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 
 from tests.helper_functions import set_boto_credentials  # pylint: disable=unused-import
 from tests.helper_functions import mock_s3_bucket  # pylint: disable=unused-import
-from tests.helper_functions import _compare_conda_env_requirements, _assert_pip_requirements
+from tests.helper_functions import (
+    pyfunc_serve_and_score_model,
+    _compare_conda_env_requirements,
+    _assert_pip_requirements,
+)
 
 ModelWithData = namedtuple("ModelWithData", ["model", "inference_dataframe"])
 
@@ -367,3 +372,20 @@ def test_model_log_without_specified_conda_env_uses_default_env_with_expected_de
     pyfunc_conf = _get_flavor_configuration(model_path=local_path, flavor_name=pyfunc.FLAVOR_NAME)
     conda_env_path = os.path.join(local_path, pyfunc_conf[pyfunc.ENV])
     assert read_yaml(conda_env_path) == mlflow.catboost.get_default_conda_env()
+
+
+@pytest.mark.large
+def test_pyfunc_serve_and_score(reg_model):
+    model, inference_dataframe = reg_model
+    artifact_path = "model"
+    with mlflow.start_run():
+        mlflow.catboost.log_model(model, artifact_path)
+        model_uri = mlflow.get_artifact_uri(artifact_path)
+
+    resp = pyfunc_serve_and_score_model(
+        model_uri,
+        data=inference_dataframe,
+        content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
+    )
+    scores = pd.read_json(resp.content, orient="records").values.squeeze()
+    np.testing.assert_array_almost_equal(scores, model.predict(inference_dataframe))

--- a/tests/lightgbm/test_lightgbm_model_export.py
+++ b/tests/lightgbm/test_lightgbm_model_export.py
@@ -28,6 +28,7 @@ from tests.helper_functions import set_boto_credentials  # pylint: disable=unuse
 from tests.helper_functions import mock_s3_bucket  # pylint: disable=unused-import
 from tests.helper_functions import (
     score_model_in_sagemaker_docker_container,
+    pyfunc_serve_and_score_model,
     _compare_conda_env_requirements,
     _assert_pip_requirements,
 )
@@ -364,6 +365,23 @@ def test_model_log_without_specified_conda_env_uses_default_env_with_expected_de
         conda_env = yaml.safe_load(f)
 
     assert conda_env == mlflow.lightgbm.get_default_conda_env()
+
+
+@pytest.mark.large
+def test_pyfunc_serve_and_score(lgb_model):
+    model, inference_dataframe = lgb_model
+    artifact_path = "model"
+    with mlflow.start_run():
+        mlflow.lightgbm.log_model(model, artifact_path)
+        model_uri = mlflow.get_artifact_uri(artifact_path)
+
+    resp = pyfunc_serve_and_score_model(
+        model_uri,
+        data=inference_dataframe,
+        content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
+    )
+    scores = pd.read_json(resp.content, orient="records").values.squeeze()
+    np.testing.assert_array_almost_equal(scores, model.predict(inference_dataframe))
 
 
 @pytest.mark.release

--- a/tests/shap/test_log.py
+++ b/tests/shap/test_log.py
@@ -277,7 +277,6 @@ def create_identity_function():
     return identity
 
 
-@pytest.mark.large
 def test_pyfunc_serve_and_score():
     X, y = shap.datasets.boston()
     reg = sklearn.ensemble.RandomForestRegressor(n_estimators=10).fit(X, y)

--- a/tests/shap/test_log.py
+++ b/tests/shap/test_log.py
@@ -285,8 +285,12 @@ def test_pyfunc_serve_and_score():
         reg.predict,
         masker=X,
         algorithm="permutation",
-        # Specify `link` (which defaults to `shap.links.indentity`) to avoid the following error:
+        # `link` defaults to `shap.links.identity` which is decorated by `numba.jit` and causes
+        # the following error when loading the explainer for serving:
+        # ```
         # Exception: The passed link function needs to be callable and have a callable .inverse property!  # noqa
+        # ```
+        # As a workaround, use an identify function that's NOT decorated by `numba.jit`.
         link=create_identity_function(),
     )
     artifact_path = "model"

--- a/tests/shap/test_log.py
+++ b/tests/shap/test_log.py
@@ -4,11 +4,13 @@ import numpy as np
 import pandas as pd
 import sklearn
 import pytest
+
+import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 from mlflow.utils import PYTHON_VERSION
 from mlflow.tracking import MlflowClient
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.model_utils import _get_flavor_configuration
-from tests.helper_functions import _assert_pip_requirements
+from tests.helper_functions import pyfunc_serve_and_score_model, _assert_pip_requirements
 
 
 @pytest.fixture(scope="module")
@@ -261,3 +263,41 @@ def test_log_model_with_extra_pip_requirements(shap_model, tmpdir):
             ["mlflow", *shap_default_reqs, "b", "-c constraints.txt", *sklearn_default_reqs],
             ["a"],
         )
+
+
+def create_identity_function():
+    def identity(x):
+        return x
+
+    def _identity_inverse(x):
+        return x
+
+    identity.inverse = _identity_inverse
+
+    return identity
+
+
+@pytest.mark.large
+def test_pyfunc_serve_and_score():
+    X, y = shap.datasets.boston()
+    reg = sklearn.ensemble.RandomForestRegressor(n_estimators=10).fit(X, y)
+    model = shap.Explainer(
+        reg.predict,
+        masker=X,
+        algorithm="permutation",
+        # Specify `link` (which defaults to `shap.links.indentity`) to avoid the following error:
+        # Exception: The passed link function needs to be callable and have a callable .inverse property!  # noqa
+        link=create_identity_function(),
+    )
+    artifact_path = "model"
+    with mlflow.start_run():
+        mlflow.shap.log_explainer(model, artifact_path)
+        model_uri = mlflow.get_artifact_uri(artifact_path)
+
+    resp = pyfunc_serve_and_score_model(
+        model_uri,
+        data=pd.DataFrame(X[:3]),
+        content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
+    )
+    scores = pd.read_json(resp.content, orient="records").values
+    np.testing.assert_allclose(scores, model(X[:3]).values, rtol=100, atol=100)

--- a/tests/statsmodels/test_statsmodels_model_export.py
+++ b/tests/statsmodels/test_statsmodels_model_export.py
@@ -22,6 +22,7 @@ from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 
 from tests.helper_functions import (
     score_model_in_sagemaker_docker_container,
+    pyfunc_serve_and_score_model,
     _compare_conda_env_requirements,
     _assert_pip_requirements,
 )
@@ -418,6 +419,22 @@ def test_model_log_without_specified_conda_env_uses_default_env_with_expected_de
         conda_env = yaml.safe_load(f)
 
     assert conda_env == mlflow.statsmodels.get_default_conda_env()
+
+
+def test_pyfunc_serve_and_score(ols_model):
+    model, _, inference_dataframe = ols_model
+    artifact_path = "model"
+    with mlflow.start_run():
+        mlflow.statsmodels.log_model(model, artifact_path)
+        model_uri = mlflow.get_artifact_uri(artifact_path)
+
+    resp = pyfunc_serve_and_score_model(
+        model_uri,
+        data=pd.DataFrame(ols_model.inference_dataframe),
+        content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
+    )
+    scores = pd.read_json(resp.content, orient="records").values.squeeze()
+    np.testing.assert_array_almost_equal(scores, model.predict(inference_dataframe))
 
 
 @pytest.mark.release

--- a/tests/statsmodels/test_statsmodels_model_export.py
+++ b/tests/statsmodels/test_statsmodels_model_export.py
@@ -430,7 +430,7 @@ def test_pyfunc_serve_and_score(ols_model):
 
     resp = pyfunc_serve_and_score_model(
         model_uri,
-        data=pd.DataFrame(ols_model.inference_dataframe),
+        data=pd.DataFrame(inference_dataframe),
         content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
     )
     scores = pd.read_json(resp.content, orient="records").values.squeeze()


### PR DESCRIPTION
## What changes are proposed in this pull request?

Some flavors are missing serving tests. This PR adds them (for #4518).

## How is this patch tested?

Unit tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
