### PR TITLE
sklearn eval metric autologging: patch `metrics.SCORERS`

### DIFF
--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -30,6 +30,7 @@ from mlflow.models.utils import ModelInputExample, _save_example
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, INTERNAL_ERROR
 from mlflow.protos.databricks_pb2 import RESOURCE_ALREADY_EXISTS
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
+from mlflow.utils import gorilla
 from mlflow.utils import _inspect_original_var_name
 from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import get_instance_method_first_arg_value
@@ -1091,6 +1092,7 @@ def autolog(
     """
     import pandas as pd
     import sklearn
+    import sklearn.metrics
     import sklearn.model_selection
 
     from mlflow.models import infer_signature
@@ -1494,10 +1496,25 @@ def autolog(
                 FLAVOR_NAME, class_def, "score", patched_model_score, manage_run=False,
             )
 
-    from sklearn import metrics
-
     for metric_name in _get_metric_name_list():
-        safe_patch(FLAVOR_NAME, metrics, metric_name, patched_metric_api, manage_run=False)
+        safe_patch(FLAVOR_NAME, sklearn.metrics, metric_name, patched_metric_api, manage_run=False)
+
+    for scorer in sklearn.metrics.SCORERS.values():
+        scorer_fn = scorer._score_func
+        scorer_fn_name = scorer_fn.__name__
+        try:
+            original_metric_fn = gorilla.get_original_attribute(sklearn.metrics, scorer_fn_name)
+        except AttributeError:
+            original_metric_fn = None
+        if scorer_fn is original_metric_fn:
+            scorer._score_func = getattr(sklearn.metrics, scorer_fn_name)
+
+            def finalizer(scorer_, original_score_fn_):
+                scorer_._score_func = original_score_fn_
+
+            gorilla.get_active_patch(sklearn.metrics, scorer_fn_name).set_finalizer(
+                finalizer, scorer, original_metric_fn
+            )
 
     def patched_fn_with_autolog_disabled(original, *args, **kwargs):
         with disable_autologging():

--- a/mlflow/utils/gorilla.py
+++ b/mlflow/utils/gorilla.py
@@ -211,7 +211,6 @@ class Patch(object):
         self.name = name
         self.obj = obj
         self.settings = settings
-        self.finalizer_list = []
 
     def __repr__(self):
         return "%s(destination=%r, name=%r, obj=%r, settings=%r)" % (
@@ -262,13 +261,6 @@ class Patch(object):
                     self.settings = copy.deepcopy(value)
             else:
                 setattr(self, key, value)
-
-    def add_finalizer(self, fn, *args):
-        self.finalizer_list.append(lambda: fn(*args))
-
-
-def get_active_patch(destination, name):
-    return getattr(destination, _ACTIVE_PATCH % (name,))
 
 
 def apply(patch):
@@ -390,9 +382,6 @@ def revert(patch):
     # This is undoing the custom changes to gorilla.py's code in the `apply()`.
     if curr_active_patch in patch.destination.__dict__:
         delattr(patch.destination, curr_active_patch)
-
-    for finalizer in patch.finalizer_list:
-        finalizer()
 
 
 def patch(destination, name=None, settings=None):

--- a/mlflow/utils/gorilla.py
+++ b/mlflow/utils/gorilla.py
@@ -211,7 +211,7 @@ class Patch(object):
         self.name = name
         self.obj = obj
         self.settings = settings
-        self.finalizer = None
+        self.finalizer_list = []
 
     def __repr__(self):
         return "%s(destination=%r, name=%r, obj=%r, settings=%r)" % (
@@ -263,8 +263,8 @@ class Patch(object):
             else:
                 setattr(self, key, value)
 
-    def set_finalizer(self, fn, *args):
-        self.finalizer = lambda: fn(*args)
+    def add_finalizer(self, fn, *args):
+        self.finalizer_list.append(lambda: fn(*args))
 
 
 def get_active_patch(destination, name):
@@ -391,8 +391,8 @@ def revert(patch):
     if curr_active_patch in patch.destination.__dict__:
         delattr(patch.destination, curr_active_patch)
 
-    if patch.finalizer:
-        patch.finalizer()
+    for finalizer in patch.finalizer_list:
+        finalizer()
 
 
 def patch(destination, name=None, settings=None):

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -1511,7 +1511,6 @@ def load_json_artifact(artifact_path):
 def test_basic_post_training_metric_autologging():
     from sklearn import metrics as sklmetrics
 
-    original_recall_score_fn = sklmetrics.recall_score
     mlflow.sklearn.autolog()
 
     model = sklearn.linear_model.LogisticRegression(solver="saga", max_iter=100, random_state=0)
@@ -1589,10 +1588,6 @@ def test_basic_post_training_metric_autologging():
 
     pred1_y_original = model.predict(eval1_X)
     assert np.allclose(pred1_y_original, pred1_y)
-
-    assert sklearn.metrics.recall_score is original_recall_score_fn
-    for score_name in ["recall", "recall_macro", "recall_micro", "recall_samples"]:
-        assert sklearn.metrics.SCORERS[score_name]._score_func is original_recall_score_fn
 
 
 @pytest.mark.parametrize("metric_name", mlflow.sklearn._get_metric_name_list())

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -1535,7 +1535,7 @@ def test_basic_post_training_metric_autologging():
         scorer1 = sklmetrics.make_scorer(sklmetrics.recall_score, average="micro")
         recall_score3_data2 = scorer1(model, eval2_X, eval2_y)
 
-        recall_score4_data2 = sklearn.metrics.SCORERS['recall_macro'](model, eval2_X, eval2_y)
+        recall_score4_data2 = sklearn.metrics.SCORERS["recall_macro"](model, eval2_X, eval2_y)
 
         eval1_X, eval1_y = eval1_X.copy(), eval1_y.copy()
         # In metric key, it will include dataset name as "eval1_X-2"
@@ -1563,8 +1563,9 @@ def test_basic_post_training_metric_autologging():
     }
 
     lor_score_3_cmd = "LogisticRegression.score(X=<ndarray>, y=<ndarray>)"
-    recall_score4_eval2_X_cmd = \
+    recall_score4_eval2_X_cmd = (
         "recall_score(y_true=eval2_y, y_pred=y_pred, pos_label=None, average='macro')"
+    )
     assert metric_info == {
         "LogisticRegression_score-2_eval1_X-2": "LogisticRegression.score(X=eval1_X, y=eval1_y)",
         "LogisticRegression_score-3_unknown_dataset": lor_score_3_cmd,
@@ -1573,7 +1574,7 @@ def test_basic_post_training_metric_autologging():
         "r2_score_eval1_X": "r2_score(y_true=eval1_y, y_pred=pred1_y)",
         "recall_score-2_eval2_X": "recall_score(y_true=eval2_y, y_pred=pred2_y, average='micro')",
         "recall_score-3_eval2_X": "recall_score(y_true=eval2_y, y_pred=y_pred, average='micro')",
-        'recall_score-4_eval2_X': recall_score4_eval2_X_cmd,
+        "recall_score-4_eval2_X": recall_score4_eval2_X_cmd,
         "recall_score_eval1_X": "recall_score(y_true=eval1_y, y_pred=pred1_y, average='macro')",
     }
 
@@ -1590,7 +1591,8 @@ def test_basic_post_training_metric_autologging():
     assert np.allclose(pred1_y_original, pred1_y)
 
     assert sklearn.metrics.recall_score is original_recall_score_fn
-    assert sklearn.metrics.SCORERS['recall_macro']._score_func is original_recall_score_fn
+    for score_name in ["recall", "recall_macro", "recall_micro", "recall_samples"]:
+        assert sklearn.metrics.SCORERS[score_name]._score_func is original_recall_score_fn
 
 
 @pytest.mark.parametrize("metric_name", mlflow.sklearn._get_metric_name_list())

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -1511,6 +1511,7 @@ def load_json_artifact(artifact_path):
 def test_basic_post_training_metric_autologging():
     from sklearn import metrics as sklmetrics
 
+    original_recall_score_fn = sklmetrics.recall_score
     mlflow.sklearn.autolog()
 
     model = sklearn.linear_model.LogisticRegression(solver="saga", max_iter=100, random_state=0)
@@ -1534,6 +1535,8 @@ def test_basic_post_training_metric_autologging():
         scorer1 = sklmetrics.make_scorer(sklmetrics.recall_score, average="micro")
         recall_score3_data2 = scorer1(model, eval2_X, eval2_y)
 
+        recall_score4_data2 = sklearn.metrics.SCORERS['recall_macro'](model, eval2_X, eval2_y)
+
         eval1_X, eval1_y = eval1_X.copy(), eval1_y.copy()
         # In metric key, it will include dataset name as "eval1_X-2"
         lor_score_data1_2 = model.score(eval1_X, eval1_y)
@@ -1554,11 +1557,14 @@ def test_basic_post_training_metric_autologging():
         "LogisticRegression_score_eval1_X": lor_score_data1,
         "recall_score-2_eval2_X": recall_score2_data2,
         "recall_score-3_eval2_X": recall_score3_data2,
+        "recall_score-4_eval2_X": recall_score4_data2,
         "LogisticRegression_score-2_eval1_X-2": lor_score_data1_2,
         "LogisticRegression_score-3_unknown_dataset": lor_score_data1_3,
     }
 
     lor_score_3_cmd = "LogisticRegression.score(X=<ndarray>, y=<ndarray>)"
+    recall_score4_eval2_X_cmd = \
+        "recall_score(y_true=eval2_y, y_pred=y_pred, pos_label=None, average='macro')"
     assert metric_info == {
         "LogisticRegression_score-2_eval1_X-2": "LogisticRegression.score(X=eval1_X, y=eval1_y)",
         "LogisticRegression_score-3_unknown_dataset": lor_score_3_cmd,
@@ -1567,6 +1573,7 @@ def test_basic_post_training_metric_autologging():
         "r2_score_eval1_X": "r2_score(y_true=eval1_y, y_pred=pred1_y)",
         "recall_score-2_eval2_X": "recall_score(y_true=eval2_y, y_pred=pred2_y, average='micro')",
         "recall_score-3_eval2_X": "recall_score(y_true=eval2_y, y_pred=y_pred, average='micro')",
+        'recall_score-4_eval2_X': recall_score4_eval2_X_cmd,
         "recall_score_eval1_X": "recall_score(y_true=eval1_y, y_pred=pred1_y, average='macro')",
     }
 
@@ -1581,6 +1588,9 @@ def test_basic_post_training_metric_autologging():
 
     pred1_y_original = model.predict(eval1_X)
     assert np.allclose(pred1_y_original, pred1_y)
+
+    assert sklearn.metrics.recall_score is original_recall_score_fn
+    assert sklearn.metrics.SCORERS['recall_macro']._score_func is original_recall_score_fn
 
 
 @pytest.mark.parametrize("metric_name", mlflow.sklearn._get_metric_name_list())


### PR DESCRIPTION
## What changes are proposed in this pull request?

sklearn eval metric autologging: patch `metrics.SCORERS`

## How is this patch tested?

Unit tests

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
