### PR TITLE
Redundant word in error message

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -812,7 +812,7 @@ def spark_udf(spark, model_uri, result_type="double"):
     if not any([isinstance(elem_type, x) for x in supported_types]):
         raise MlflowException(
             message="Invalid result_type '{}'. Result type can only be one of or an array of one "
-            "of the following types types: {}".format(str(elem_type), str(supported_types)),
+            "of the following types: {}".format(str(elem_type), str(supported_types)),
             error_code=INVALID_PARAMETER_VALUE,
         )
 


### PR DESCRIPTION
original error message: Result type can only be one of or an array of one of the following types **types**...
proposed error message: Result type can only be one of or an array of one of the following types...

## What changes are proposed in this pull request?
original error message: Result type can only be one of or an array of one of the following types **types**...
proposed error message: Result type can only be one of or an array of one of the following types...
