### PR TITLE
Update docs for AzureML deployment plugin

### DIFF
--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -315,6 +315,7 @@ for usage instructions and examples.
 - `mlflow-torchserve <https://github.com/mlflow/mlflow-torchserve>`_
 - `mlflow-algorithmia <https://github.com/algorithmiaio/mlflow-algorithmia>`_
 - `mlflow-ray-serve <https://github.com/ray-project/mlflow-ray-serve>`_
+- `mlflow-azureml <https://docs.microsoft.com/en-us/azure/machine-learning/how-to-deploy-mlflow-models>`_
 
 Project Backend Plugins
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/mlflow/azureml/__init__.py
+++ b/mlflow/azureml/__init__.py
@@ -19,7 +19,7 @@ from mlflow.models.model import MLMODEL_FILE_NAME
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils import get_unique_resource_id
-from mlflow.utils.annotations import experimental
+from mlflow.utils.annotations import deprecated
 from mlflow.utils.file_utils import TempDir, _copy_file_or_tree, _copy_project
 from mlflow.version import VERSION as mlflow_version
 from pathlib import Path
@@ -28,7 +28,7 @@ from pathlib import Path
 _logger = logging.getLogger(__name__)
 
 
-@experimental
+@deprecated(since="1.19.0")
 def build_image(
     model_uri,
     workspace,
@@ -237,7 +237,7 @@ def build_image(
         return image, registered_model
 
 
-@experimental
+@deprecated("the azureml deployment plugin", since="1.19.0")
 def deploy(
     model_uri,
     workspace,

--- a/mlflow/azureml/__init__.py
+++ b/mlflow/azureml/__init__.py
@@ -28,7 +28,7 @@ from pathlib import Path
 _logger = logging.getLogger(__name__)
 
 
-@deprecated(since="1.19.0")
+@deprecated("the azureml deployment plugin, https://aka.ms/aml-mlflow-deploy", since="1.19.0")
 def build_image(
     model_uri,
     workspace,

--- a/mlflow/azureml/__init__.py
+++ b/mlflow/azureml/__init__.py
@@ -237,7 +237,7 @@ def build_image(
         return image, registered_model
 
 
-@deprecated("the azureml deployment plugin", since="1.19.0")
+@deprecated("the azureml deployment plugin, https://aka.ms/aml-mlflow-deploy", since="1.19.0")
 def deploy(
     model_uri,
     workspace,

--- a/mlflow/azureml/cli.py
+++ b/mlflow/azureml/cli.py
@@ -7,7 +7,7 @@ import click
 
 import mlflow.azureml
 from mlflow.utils import cli_args
-from mlflow.utils.annotations import experimental
+from mlflow.utils.annotations import deprecated
 
 
 @click.group("azureml")
@@ -79,7 +79,7 @@ def commands():
         " that include the model path, the model run id (if specified), and more."
     ),
 )
-@experimental
+@deprecated(since="1.19.0")
 def build_image(
     model_uri,
     workspace_name,

--- a/mlflow/azureml/cli.py
+++ b/mlflow/azureml/cli.py
@@ -79,7 +79,7 @@ def commands():
         " that include the model path, the model run id (if specified), and more."
     ),
 )
-@deprecated(since="1.19.0")
+@deprecated("the azureml deployment plugin, https://aka.ms/aml-mlflow-deploy", since="1.19.0")
 def build_image(
     model_uri,
     workspace_name,


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adding a docs link to point to the new AzureML deployment plugin, and marking the old AzureML handling as deprecated

## How is this patch tested?

Docs change, no tests

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`mlflow.azureml` package is deprecated in favor of the new AzureML deployment plugin.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [x] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
