### PR TITLE
Remove tests marked by `pytest.mark.release`

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -19,13 +19,6 @@ def pytest_addoption(parser):
         help="Run tests decorated with 'large' annotation",
     )
     parser.addoption(
-        "--release",
-        action="store_true",
-        dest="release",
-        default=False,
-        help="Run tests decorated with 'release' annotation",
-    )
-    parser.addoption(
         "--requires-ssh",
         action="store_true",
         dest="requires_ssh",

--- a/conftest.py
+++ b/conftest.py
@@ -56,8 +56,6 @@ def pytest_configure(config):
         markexpr.append("large")
     if not config.option.lazy_import:
         markexpr.append("not lazy_import")
-    if not config.option.release:
-        markexpr.append("not release")
     if not config.option.requires_ssh:
         markexpr.append("not requires_ssh")
     if len(markexpr) > 0:

--- a/tests/h2o/test_h2o_model_export.py
+++ b/tests/h2o/test_h2o_model_export.py
@@ -3,9 +3,7 @@
 import os
 import pytest
 import yaml
-import json
 import pandas as pd
-import pandas.testing
 from collections import namedtuple
 
 import numpy as np

--- a/tests/h2o/test_h2o_model_export.py
+++ b/tests/h2o/test_h2o_model_export.py
@@ -25,7 +25,6 @@ from mlflow.utils.file_utils import TempDir
 from mlflow.utils.model_utils import _get_flavor_configuration
 
 from tests.helper_functions import (
-    score_model_in_sagemaker_docker_container,
     pyfunc_serve_and_score_model,
     _compare_conda_env_requirements,
     _assert_pip_requirements,
@@ -350,26 +349,3 @@ def test_pyfunc_serve_and_score(h2o_iris_model):
     scores = pd.read_json(resp.content, orient="records").drop("predict", axis=1)
     preds = model.predict(inference_dataframe).as_data_frame().drop("predict", axis=1)
     np.testing.assert_array_almost_equal(scores, preds)
-
-
-@pytest.mark.release
-def test_sagemaker_docker_model_scoring_with_default_conda_env(h2o_iris_model, model_path):
-    mlflow.h2o.save_model(h2o_model=h2o_iris_model.model, path=model_path, conda_env=None)
-    reloaded_h2o_pyfunc = mlflow.pyfunc.load_pyfunc(model_path)
-
-    scoring_response = score_model_in_sagemaker_docker_container(
-        model_uri=model_path,
-        data=h2o_iris_model.inference_data.as_data_frame(),
-        content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
-        flavor=mlflow.pyfunc.FLAVOR_NAME,
-    )
-    deployed_model_preds = pd.DataFrame(json.loads(scoring_response.content))
-
-    pandas.testing.assert_frame_equal(
-        deployed_model_preds["predict"].to_frame(),
-        reloaded_h2o_pyfunc.predict(h2o_iris_model.inference_data.as_data_frame())[
-            "predict"
-        ].to_frame(),
-        check_dtype=False,
-        check_less_precise=6,
-    )

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -3,7 +3,6 @@
 from packaging.version import Version
 import h5py
 import os
-import json
 import pytest
 import shutil
 import importlib

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -38,7 +38,6 @@ from mlflow.utils.file_utils import TempDir
 from mlflow.utils.model_utils import _get_flavor_configuration
 from tests.helper_functions import pyfunc_serve_and_score_model
 from tests.helper_functions import (
-    score_model_in_sagemaker_docker_container,
     _compare_conda_env_requirements,
     _assert_pip_requirements,
 )
@@ -600,22 +599,6 @@ def test_model_load_succeeds_with_missing_data_key_when_data_exists_at_default_p
 
     model_loaded = mlflow.keras.load_model(model_path)
     assert all(model_loaded.predict(data[0].values) == tf_keras_model.predict(data[0].values))
-
-
-@pytest.mark.release
-def test_sagemaker_docker_model_scoring_with_default_conda_env(model, model_path, data, predicted):
-    mlflow.keras.save_model(keras_model=model, path=model_path, conda_env=None)
-
-    scoring_response = score_model_in_sagemaker_docker_container(
-        model_uri=model_path,
-        data=data[0],
-        content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
-        flavor=mlflow.pyfunc.FLAVOR_NAME,
-        activity_polling_timeout_seconds=500,
-    )
-    deployed_model_preds = pd.DataFrame(json.loads(scoring_response.content))
-
-    np.testing.assert_array_almost_equal(deployed_model_preds.values, predicted, decimal=4)
 
 
 def test_save_model_with_tf_save_format(model_path):

--- a/tests/lightgbm/test_lightgbm_model_export.py
+++ b/tests/lightgbm/test_lightgbm_model_export.py
@@ -1,13 +1,11 @@
 import os
 import pytest
 import yaml
-import json
 from collections import namedtuple
 from unittest import mock
 
 import numpy as np
 import pandas as pd
-import pandas.testing
 import sklearn.datasets as datasets
 import lightgbm as lgb
 

--- a/tests/lightgbm/test_lightgbm_model_export.py
+++ b/tests/lightgbm/test_lightgbm_model_export.py
@@ -27,7 +27,6 @@ from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from tests.helper_functions import set_boto_credentials  # pylint: disable=unused-import
 from tests.helper_functions import mock_s3_bucket  # pylint: disable=unused-import
 from tests.helper_functions import (
-    score_model_in_sagemaker_docker_container,
     pyfunc_serve_and_score_model,
     _compare_conda_env_requirements,
     _assert_pip_requirements,
@@ -382,24 +381,3 @@ def test_pyfunc_serve_and_score(lgb_model):
     )
     scores = pd.read_json(resp.content, orient="records").values.squeeze()
     np.testing.assert_array_almost_equal(scores, model.predict(inference_dataframe))
-
-
-@pytest.mark.release
-def test_sagemaker_docker_model_scoring_with_default_conda_env(lgb_model, model_path):
-    mlflow.lightgbm.save_model(lgb_model=lgb_model.model, path=model_path, conda_env=None)
-    reloaded_pyfunc = pyfunc.load_pyfunc(model_uri=model_path)
-
-    scoring_response = score_model_in_sagemaker_docker_container(
-        model_uri=model_path,
-        data=lgb_model.inference_dataframe,
-        content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
-        flavor=mlflow.pyfunc.FLAVOR_NAME,
-    )
-    deployed_model_preds = pd.DataFrame(json.loads(scoring_response.content))
-
-    pandas.testing.assert_frame_equal(
-        deployed_model_preds,
-        pd.DataFrame(reloaded_pyfunc.predict(lgb_model.inference_dataframe)),
-        check_dtype=False,
-        check_less_precise=6,
-    )

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -34,7 +34,6 @@ from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 import tests
 from tests.helper_functions import pyfunc_serve_and_score_model
 from tests.helper_functions import (
-    score_model_in_sagemaker_docker_container,
     _compare_conda_env_requirements,
     _assert_pip_requirements,
 )
@@ -1039,43 +1038,4 @@ def test_load_model_with_missing_cloudpickle_version_logs_warning(model_path):
             in log_message
             for log_message in log_messages
         ]
-    )
-
-
-# TODO(czumar) Re-mark this test as "large" instead of "release" after SageMaker docker container
-# build issues have been debugged
-# @pytest.mark.large
-@pytest.mark.release
-def test_sagemaker_docker_model_scoring_with_default_conda_env(
-    sklearn_logreg_model, main_scoped_model_class, iris_data, tmpdir
-):
-    sklearn_model_path = os.path.join(str(tmpdir), "sklearn_model")
-    mlflow.sklearn.save_model(sk_model=sklearn_logreg_model, path=sklearn_model_path)
-
-    def test_predict(sk_model, model_input):
-        return sk_model.predict(model_input) * 2
-
-    pyfunc_model_path = os.path.join(str(tmpdir), "pyfunc_model")
-    mlflow.pyfunc.save_model(
-        path=pyfunc_model_path,
-        artifacts={"sk_model": sklearn_model_path},
-        python_model=main_scoped_model_class(test_predict),
-        conda_env=_conda_env(),
-    )
-    reloaded_pyfunc = mlflow.pyfunc.load_pyfunc(model_uri=pyfunc_model_path)
-
-    inference_df = pd.DataFrame(iris_data[0])
-    scoring_response = score_model_in_sagemaker_docker_container(
-        model_uri=pyfunc_model_path,
-        data=inference_df,
-        content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
-        flavor=mlflow.pyfunc.FLAVOR_NAME,
-    )
-    deployed_model_preds = pd.DataFrame(json.loads(scoring_response.content))
-
-    pandas.testing.assert_frame_equal(
-        deployed_model_preds,
-        pd.DataFrame(reloaded_pyfunc.predict(inference_df)),
-        check_dtype=False,
-        check_less_precise=6,
     )

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -39,7 +39,6 @@ _logger = logging.getLogger(__name__)
 # Therefore, we attempt to import from `tests` and gracefully emit a warning if it's unavailable.
 try:
     from tests.helper_functions import pyfunc_serve_and_score_model
-    from tests.helper_functions import score_model_in_sagemaker_docker_container
     from tests.helper_functions import set_boto_credentials  # pylint: disable=unused-import
     from tests.helper_functions import mock_s3_bucket  # pylint: disable=unused-import
 except ImportError:
@@ -905,26 +904,6 @@ def test_load_model_raises_exception_when_pickle_module_cannot_be_imported(
 
     assert "Failed to import the pickle module" in str(exc_info)
     assert bad_pickle_module_name in str(exc_info)
-
-
-@pytest.mark.release
-def test_sagemaker_docker_model_scoring_with_sequential_model_and_default_conda_env(
-    model, model_path, data, sequential_predicted
-):
-    mlflow.pytorch.save_model(pytorch_model=model, path=model_path, conda_env=None)
-
-    scoring_response = score_model_in_sagemaker_docker_container(
-        model_uri=model_path,
-        data=data[0],
-        content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
-        flavor=mlflow.pyfunc.FLAVOR_NAME,
-        activity_polling_timeout_seconds=360,
-    )
-    deployed_model_preds = pd.DataFrame(json.loads(scoring_response.content))
-
-    np.testing.assert_array_almost_equal(
-        deployed_model_preds.values[:, 0], sequential_predicted, decimal=4
-    )
 
 
 @pytest.fixture

--- a/tests/sklearn/test_sklearn_model_export.py
+++ b/tests/sklearn/test_sklearn_model_export.py
@@ -34,7 +34,6 @@ from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from tests.helper_functions import set_boto_credentials  # pylint: disable=unused-import
 from tests.helper_functions import mock_s3_bucket  # pylint: disable=unused-import
 from tests.helper_functions import (
-    score_model_in_sagemaker_docker_container,
     pyfunc_serve_and_score_model,
     _compare_conda_env_requirements,
     _assert_pip_requirements,
@@ -577,28 +576,6 @@ def test_model_save_without_cloudpickle_format_does_not_add_cloudpickle_to_conda
                 for dependency in saved_conda_env_parsed["dependencies"]
             ]
         )
-
-
-@pytest.mark.release
-def test_sagemaker_docker_model_scoring_with_default_conda_env(sklearn_knn_model, model_path):
-    mlflow.sklearn.save_model(sk_model=sklearn_knn_model.model, path=model_path, conda_env=None)
-    reloaded_knn_pyfunc = pyfunc.load_pyfunc(model_uri=model_path)
-
-    inference_df = pd.DataFrame(sklearn_knn_model.inference_data)
-    scoring_response = score_model_in_sagemaker_docker_container(
-        model_uri=model_path,
-        data=inference_df,
-        content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
-        flavor=mlflow.pyfunc.FLAVOR_NAME,
-    )
-    deployed_model_preds = pd.DataFrame(json.loads(scoring_response.content))
-
-    pandas.testing.assert_frame_equal(
-        deployed_model_preds,
-        pd.DataFrame(reloaded_knn_pyfunc.predict(inference_df)),
-        check_dtype=False,
-        check_less_precise=6,
-    )
 
 
 @pytest.mark.large

--- a/tests/sklearn/test_sklearn_model_export.py
+++ b/tests/sklearn/test_sklearn_model_export.py
@@ -4,12 +4,10 @@ import os
 import pickle
 import pytest
 import yaml
-import json
 from collections import namedtuple
 
 import numpy as np
 import pandas as pd
-import pandas.testing
 import sklearn.datasets as datasets
 import sklearn.linear_model as glm
 import sklearn.neighbors as knn

--- a/tests/statsmodels/test_statsmodels_model_export.py
+++ b/tests/statsmodels/test_statsmodels_model_export.py
@@ -4,8 +4,6 @@ import pandas as pd
 from unittest import mock
 import os
 import yaml
-import json
-import pandas.testing
 
 import mlflow.statsmodels
 import mlflow.utils

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -28,8 +28,6 @@ from mlflow.store.tracking import SEARCH_MAX_RESULTS_DEFAULT
 from mlflow.store.db.utils import (
     _get_schema_version,
     _get_latest_schema_revision,
-    MLFLOW_SQLALCHEMYSTORE_MAX_OVERFLOW,
-    MLFLOW_SQLALCHEMYSTORE_POOL_SIZE,
 )
 from mlflow.store.tracking.dbmodels import models
 from mlflow.store.db.db_types import MYSQL, MSSQL

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -1937,55 +1937,6 @@ class TestSqlAlchemyStoreSqliteMigratedDB(TestSqlAlchemyStoreSqlite):
         os.remove(self.temp_dbfile)
 
 
-@pytest.mark.release
-class TestSqlAlchemyStoreMysqlDb(TestSqlAlchemyStoreSqlite):
-    """
-    Run tests against a MySQL database
-    """
-
-    DEFAULT_MYSQL_PORT = 3306
-
-    def setUp(self):
-        os.environ[MLFLOW_SQLALCHEMYSTORE_POOL_SIZE] = "2"
-        os.environ[MLFLOW_SQLALCHEMYSTORE_MAX_OVERFLOW] = "1"
-        db_username = os.environ.get("MYSQL_TEST_USERNAME")
-        db_password = os.environ.get("MYSQL_TEST_PASSWORD")
-        db_port = (
-            int(os.environ["MYSQL_TEST_PORT"])
-            if "MYSQL_TEST_PORT" in os.environ
-            else TestSqlAlchemyStoreMysqlDb.DEFAULT_MYSQL_PORT
-        )
-        if db_username is None or db_password is None:
-            raise Exception(
-                "Username and password for database tests must be specified via the "
-                "MYSQL_TEST_USERNAME and MYSQL_TEST_PASSWORD environment variables. "
-                "environment variable. In posix shells, you can rerun your test command "
-                "with the environment variables set, e.g: MYSQL_TEST_USERNAME=your_username "
-                "MYSQL_TEST_PASSWORD=your_password <your-test-command>. You may optionally "
-                "specify a database port via MYSQL_TEST_PORT (default is 3306)."
-            )
-        self._db_name = "test_sqlalchemy_store_%s" % uuid.uuid4().hex[:5]
-        db_server_url = "mysql://%s:%s@localhost:%s" % (db_username, db_password, db_port)
-        self._engine = sqlalchemy.create_engine(db_server_url)
-        self._engine.execute("CREATE DATABASE %s" % self._db_name)
-        self.db_url = "%s/%s" % (db_server_url, self._db_name)
-        self.store = self._get_store(self.db_url)
-
-    def tearDown(self):
-        self._engine.execute("DROP DATABASE %s" % self._db_name)
-
-    def test_log_many_entities(self):
-        """
-        Sanity check: verify that we can log a reasonable number of entities without failures due
-        to connection leaks etc.
-        """
-        run = self._run_factory()
-        for i in range(100):
-            self.store.log_metric(run.info.run_id, entities.Metric("key", i, i * 2, i * 3))
-            self.store.log_param(run.info.run_id, entities.Param("pkey-%s" % i, "pval-%s" % i))
-            self.store.set_tag(run.info.run_id, entities.RunTag("tkey-%s" % i, "tval-%s" % i))
-
-
 @mock.patch("sqlalchemy.orm.session.Session", spec=True)
 class TestZeroValueInsertion(unittest.TestCase):
     def test_set_zero_value_insertion_for_autoincrement_column_MYSQL(self, mock_session):

--- a/tests/tensorflow/test_tensorflow_model_export.py
+++ b/tests/tensorflow/test_tensorflow_model_export.py
@@ -5,7 +5,6 @@ import os
 import shutil
 import pytest
 import yaml
-import json
 from unittest import mock
 
 import numpy as np
@@ -16,7 +15,6 @@ import tensorflow as tf
 
 import mlflow
 import mlflow.tensorflow
-import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 from mlflow.exceptions import MlflowException
 from mlflow import pyfunc
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -854,3 +854,36 @@ def test_autolog_text_vec_model(tmpdir):
 
     loaded_model = mlflow.keras.load_model("runs:/" + run.info.run_id + "/model")
     np.testing.assert_array_equal(loaded_model.predict(train_samples), model.predict(train_samples))
+
+
+@pytest.mark.large
+def test_tf_saved_model_model_with_tf_keras_api(tmpdir):
+    tf.random.set_seed(1337)
+
+    mlflow_model_path = os.path.join(str(tmpdir), "mlflow_model")
+    tf_model_path = os.path.join(str(tmpdir), "tf_model")
+
+    # Build TensorFlow model.
+    inputs = tf.keras.layers.Input(shape=1, name="feature1", dtype=tf.float32)
+    outputs = tf.keras.layers.Dense(1)(inputs)
+    model = tf.keras.Model(inputs=inputs, outputs=[outputs])
+
+    # Save model in TensorFlow SavedModel format.
+    tf.saved_model.save(model, tf_model_path)
+
+    # Save TensorFlow SavedModel as MLflow model.
+    mlflow.tensorflow.save_model(
+        tf_saved_model_dir=tf_model_path,
+        tf_meta_graph_tags=["serve"],
+        tf_signature_def_key="serving_default",
+        path=mlflow_model_path,
+    )
+
+    def load_and_predict():
+        model_uri = mlflow_model_path
+        mlflow_model = mlflow.pyfunc.load_model(model_uri)
+        feed_dict = {"feature1": tf.constant([[2.0]])}
+        predictions = mlflow_model.predict(feed_dict)
+        assert np.allclose(predictions["dense"], np.asarray([-0.09599352]))
+
+    load_and_predict()

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -854,36 +854,3 @@ def test_autolog_text_vec_model(tmpdir):
 
     loaded_model = mlflow.keras.load_model("runs:/" + run.info.run_id + "/model")
     np.testing.assert_array_equal(loaded_model.predict(train_samples), model.predict(train_samples))
-
-
-@pytest.mark.large
-def test_tf_saved_model_model_with_tf_keras_api(tmpdir):
-    tf.random.set_seed(1337)
-
-    mlflow_model_path = os.path.join(str(tmpdir), "mlflow_model")
-    tf_model_path = os.path.join(str(tmpdir), "tf_model")
-
-    # Build TensorFlow model.
-    inputs = tf.keras.layers.Input(shape=1, name="feature1", dtype=tf.float32)
-    outputs = tf.keras.layers.Dense(1)(inputs)
-    model = tf.keras.Model(inputs=inputs, outputs=[outputs])
-
-    # Save model in TensorFlow SavedModel format.
-    tf.saved_model.save(model, tf_model_path)
-
-    # Save TensorFlow SavedModel as MLflow model.
-    mlflow.tensorflow.save_model(
-        tf_saved_model_dir=tf_model_path,
-        tf_meta_graph_tags=["serve"],
-        tf_signature_def_key="serving_default",
-        path=mlflow_model_path,
-    )
-
-    def load_and_predict():
-        model_uri = mlflow_model_path
-        mlflow_model = mlflow.pyfunc.load_model(model_uri)
-        feed_dict = {"feature1": tf.constant([[2.0]])}
-        predictions = mlflow_model.predict(feed_dict)
-        assert np.allclose(predictions["dense"], np.asarray([-0.09599352]))
-
-    load_and_predict()

--- a/tests/xgboost/test_xgboost_model_export.py
+++ b/tests/xgboost/test_xgboost_model_export.py
@@ -2,12 +2,10 @@ from unittest import mock
 import os
 import pytest
 import yaml
-import json
 from collections import namedtuple
 
 import numpy as np
 import pandas as pd
-import pandas.testing
 import sklearn.datasets as datasets
 import xgboost as xgb
 


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

- Follow-up for https://github.com/mlflow/mlflow/pull/4627#discussion_r681947544
- Remove tests marked by `pytest.mark.release` because we no longer run them.

## How is this patch tested?

Existing tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
