### PR TITLE
Run bash with `-x` in GitHub Actions to make it easier to debug

### DIFF
--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -24,7 +24,7 @@ concurrency:
 
 defaults:
   run:
-    shell: bash
+    shell: bash --noprofile --norc -eox pipefail {0}
 
 jobs:
   set-matrix:

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -125,7 +125,6 @@ jobs:
             ${{ steps.get-cache-key.outputs.key }}
       - name: Install mlflow & test dependencies
         run: |
-          set -x
           python --version
           pip install --upgrade pip wheel
           pip install -e .
@@ -134,7 +133,6 @@ jobs:
         env:
           CACHE_DIR: /home/runner/.cache/wheels
         run: |
-          set -x
           ${{ matrix.install }}
       - name: Check package versions
         run: |

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -9,7 +9,7 @@ on:
 
 defaults:
   run:
-    shell: bash
+    shell: bash --noprofile --norc -eox pipefail {0}
 
 env:
   CONDA_DIR: /usr/share/miniconda

--- a/.github/workflows/labeling.yml
+++ b/.github/workflows/labeling.yml
@@ -12,7 +12,7 @@ on:
 
 defaults:
   run:
-    shell: bash
+    shell: bash --noprofile --norc -eox pipefail {0}
 
 jobs:
   labeling:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -206,7 +206,6 @@ jobs:
         ./dev/run-large-python-tests.sh
     - name: Run database initialization tests
       run: |
-        set -x
         # Build wheel and copy it under tests/db
         python setup.py bdist_wheel
         cp -r dist tests/db

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -14,15 +14,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-# Use `bash` by default for all `run` steps in this workflow:
-# https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#defaultsrun
 defaults:
   run:
-    # GitHub Actions runner executes commands specified in a run step via:
-    # $ bash --noprofile --norc -eo pipefail < commands >
-    #
+    # The default bash entry point doesn't set '-x' which is useful for debugging:
     # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#using-a-specific-shell
-    shell: bash
+    shell: bash --noprofile --norc -eox pipefail {0}
 
 env:
   CONDA_DIR: /usr/share/miniconda

--- a/.github/workflows/release-note-category.yml
+++ b/.github/workflows/release-note-category.yml
@@ -13,7 +13,7 @@ on:
 
 defaults:
   run:
-    shell: bash
+    shell: bash --noprofile --norc -eox pipefail {0}
 
 jobs:
   validate:

--- a/.github/workflows/test-package-build.yml
+++ b/.github/workflows/test-package-build.yml
@@ -8,7 +8,7 @@ on:
 
 defaults:
   run:
-    shell: bash
+    shell: bash --noprofile --norc -eox pipefail {0}
 
 jobs:
   build:


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

Run bash with `-x` in GitHub Actions to make it easier to debug.

## How is this patch tested?

Existing tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
