### PR TITLE
Notify DCO check failure

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -29,7 +29,7 @@ env:
 
 jobs:
   notify-dco-failure:
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' && github.event.action == 'opened' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -34,9 +34,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Validate
-      uses: actions/github-script@v3
+      uses: actions/github-script@v4
       with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
           const script = require(
             `${process.env.GITHUB_WORKSPACE}/.github/workflows/notify-dco-failure.js`

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -28,19 +28,6 @@ env:
   CONDA_DIR: /usr/share/miniconda
 
 jobs:
-  notify-dco-failure:
-    if: ${{ github.event_name == 'pull_request' && github.event.action == 'opened' }}
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Validate
-      uses: actions/github-script@v4
-      with:
-        script: |
-          const script = require(
-            `${process.env.GITHUB_WORKSPACE}/.github/workflows/notify-dco-failure.js`
-          );
-          script({ context, github });
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -28,6 +28,20 @@ env:
   CONDA_DIR: /usr/share/miniconda
 
 jobs:
+  notify-dco-failure:
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Validate
+      uses: actions/github-script@v3
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const script = require(
+            `${process.env.GITHUB_WORKSPACE}/.github/workflows/notify-dco-failure.js`
+          );
+          script({ context, github });
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/notify-dco-failure.js
+++ b/.github/workflows/notify-dco-failure.js
@@ -2,8 +2,6 @@ module.exports = async ({ context, github }) => {
   const { after: ref } = context.payload;
   const { owner, repo } = context.repo;
   const { number: issue_number } = context.issue;
-  console.log(context);
-  console.log(ref, owner, repo);
 
   function sleep(ms) {
     return new Promise(resolve => setTimeout(resolve, ms));
@@ -29,7 +27,7 @@ module.exports = async ({ context, github }) => {
   const dcoCheck = await getDcoCheck();
   const { html_url, conclusion } = dcoCheck;
 
-  if (conclusion !== "success") {
+  if (conclusion === "success") {
     const body = `The DCO check failed. Please sign off your commits:\n${html_url}`;
     await github.issues.createComment({
       owner,

--- a/.github/workflows/notify-dco-failure.js
+++ b/.github/workflows/notify-dco-failure.js
@@ -1,15 +1,17 @@
 module.exports = async ({ context, github }) => {
-  const { after: ref } = context.payload;
   const { owner, repo } = context.repo;
   const { number: issue_number } = context.issue;
+  const { sha: ref } = context.payload.pull_request.head;
 
   function sleep(ms) {
     return new Promise(resolve => setTimeout(resolve, ms));
   }
 
   async function getDcoCheck() {
-    for (const sec of [0, 2, 4, 6, 8]) {
-      await sleep(sec * 1000);
+    const backoffs = [0, 2, 4, 6, 8];
+    const numAttempts = backoffs.length;
+    for (const [index, backoff] of backoff.entries()) {
+      await sleep(backoff * 1000);
       const resp = await github.checks.listForRef({
         owner,
         repo,
@@ -18,15 +20,18 @@ module.exports = async ({ context, github }) => {
       });
 
       const { check_runs } = resp.data;
-      if (check_runs.length > 0) {
+      if (check_runs.length > 0 && check_runs[0].status === "completed") {
         return check_runs[0];
       }
+      console.log(
+        `[Attempt ${index + 1}/${numAttempts}]`,
+        "The DCO check hasn't completed yet."
+      );
     }
   }
 
   const dcoCheck = await getDcoCheck();
   const { html_url, conclusion } = dcoCheck;
-
   if (conclusion === "success") {
     const body = `The DCO check failed. Please sign off your commits:\n${html_url}`;
     await github.issues.createComment({

--- a/.github/workflows/notify-dco-failure.js
+++ b/.github/workflows/notify-dco-failure.js
@@ -1,22 +1,32 @@
 module.exports = async ({ context, github }) => {
-  function sleep(ms) {
-    return new Promise(resolve => setTimeout(resolve, ms));
-  }
-
-  const { sha: ref } = context;
+  const { after: ref } = context.payload;
   const { owner, repo } = context.repo;
   const { number: issue_number } = context.issue;
   console.log(context);
   console.log(ref, owner, repo);
 
-  await sleep(10000);
-  const resp = await github.checks.listForRef({
-    owner,
-    repo,
-    ref,
-    app_id: 1861, // ID of the DCO check app
-  });
-  const dcoCheck = resp.data.check_runs[0];
+  function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+
+  function getDcoCheck() {
+    for (const sec of [0, 2, 4, 6, 8]) {
+      await sleep(sec * 1000);
+      const resp = await github.checks.listForRef({
+        owner,
+        repo,
+        ref,
+        app_id: 1861, // ID of the DCO check app
+      });
+
+      const { check_runs } = resp.data;
+      if (check_runs.length > 0) {
+        return check_runs[0];
+      }
+    }
+  }
+
+  const dcoCheck = getDcoCheck();
   const { html_url, conclusion } = dcoCheck;
 
   if (conclusion !== "success") {

--- a/.github/workflows/notify-dco-failure.js
+++ b/.github/workflows/notify-dco-failure.js
@@ -1,7 +1,7 @@
 module.exports = async ({ context, github }) => {
   const { owner, repo } = context.repo;
   const { number: issue_number } = context.issue;
-  const { sha: ref } = context.payload.pull_request.head;
+  const { sha: ref, user } = context.payload.pull_request.head;
 
   function sleep(ms) {
     return new Promise(resolve => setTimeout(resolve, ms));
@@ -33,7 +33,7 @@ module.exports = async ({ context, github }) => {
   const dcoCheck = await getDcoCheck();
   const { html_url, conclusion } = dcoCheck;
   if (conclusion !== "success") {
-    const body = `The DCO check failed. Please sign off your commits:\n${html_url}`;
+    const body = `@${user.login} The DCO check failed. Please sign off your commits:\n${html_url}`;
     await github.issues.createComment({
       owner,
       repo,

--- a/.github/workflows/notify-dco-failure.js
+++ b/.github/workflows/notify-dco-failure.js
@@ -1,17 +1,21 @@
 module.exports = async ({ context, github }) => {
+  function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+
   const { sha: ref } = context;
   const { owner, repo } = context.repo;
   const { number: issue_number } = context.issue;
   console.log(context);
   console.log(ref, owner, repo);
 
+  await sleep(10000);
   const resp = await github.checks.listForRef({
     owner,
     repo,
     ref,
     app_id: 1861, // ID of the DCO check app
   });
-  console.log(resp);
   const dcoCheck = resp.data.check_runs[0];
   const { html_url, conclusion } = dcoCheck;
 

--- a/.github/workflows/notify-dco-failure.js
+++ b/.github/workflows/notify-dco-failure.js
@@ -10,7 +10,7 @@ module.exports = async ({ context, github }) => {
   async function getDcoCheck() {
     const backoffs = [0, 2, 4, 6, 8];
     const numAttempts = backoffs.length;
-    for (const [index, backoff] of backoff.entries()) {
+    for (const [index, backoff] of backoffs.entries()) {
       await sleep(backoff * 1000);
       const resp = await github.checks.listForRef({
         owner,
@@ -31,9 +31,11 @@ module.exports = async ({ context, github }) => {
   }
 
   const dcoCheck = await getDcoCheck();
-  const { html_url, conclusion } = dcoCheck;
-  if (conclusion !== "success") {
-    const body = `@${user.login} The DCO check failed. Please sign off your commits:\n${html_url}`;
+  if (dcoCheck.conclusion !== "success") {
+    const body = [
+      `@${user.login} The DCO check failed. `,
+      `Please sign off your commits: ${dcoCheck.html_url}`,
+    ].join("");
     await github.issues.createComment({
       owner,
       repo,

--- a/.github/workflows/notify-dco-failure.js
+++ b/.github/workflows/notify-dco-failure.js
@@ -11,6 +11,7 @@ module.exports = async ({ context, github }) => {
     ref,
     app_id: 1861, // ID of the DCO check app
   });
+  console.log(resp);
   const dcoCheck = resp.data.check_runs[0];
   const { html_url, conclusion } = dcoCheck;
 

--- a/.github/workflows/notify-dco-failure.js
+++ b/.github/workflows/notify-dco-failure.js
@@ -9,7 +9,7 @@ module.exports = async ({ context, github }) => {
     return new Promise(resolve => setTimeout(resolve, ms));
   }
 
-  function getDcoCheck() {
+  async function getDcoCheck() {
     for (const sec of [0, 2, 4, 6, 8]) {
       await sleep(sec * 1000);
       const resp = await github.checks.listForRef({
@@ -26,7 +26,7 @@ module.exports = async ({ context, github }) => {
     }
   }
 
-  const dcoCheck = getDcoCheck();
+  const dcoCheck = await getDcoCheck();
   const { html_url, conclusion } = dcoCheck;
 
   if (conclusion !== "success") {

--- a/.github/workflows/notify-dco-failure.js
+++ b/.github/workflows/notify-dco-failure.js
@@ -32,7 +32,7 @@ module.exports = async ({ context, github }) => {
 
   const dcoCheck = await getDcoCheck();
   const { html_url, conclusion } = dcoCheck;
-  if (conclusion === "success") {
+  if (conclusion !== "success") {
     const body = `The DCO check failed. Please sign off your commits:\n${html_url}`;
     await github.issues.createComment({
       owner,

--- a/.github/workflows/notify-dco-failure.js
+++ b/.github/workflows/notify-dco-failure.js
@@ -1,0 +1,26 @@
+module.exports = async ({ context, github }) => {
+  const { sha: ref } = context;
+  const { owner, repo } = context.repo;
+  const { number: issue_number } = context.issue;
+  console.log(context);
+  console.log(ref, owner, repo);
+
+  const resp = await github.checks.listForRef({
+    owner,
+    repo,
+    ref,
+    app_id: 1861, // ID of the DCO check app
+  });
+  const dcoCheck = resp.data.check_runs[0];
+  const { html_url, conclusion } = dcoCheck;
+
+  if (conclusion !== "success") {
+    const body = `The DCO check failed. Please sign off your commits:\n${html_url}`;
+    await github.issues.createComment({
+      owner,
+      repo,
+      issue_number,
+      body,
+    });
+  }
+};

--- a/.github/workflows/notify-dco-failure.yml
+++ b/.github/workflows/notify-dco-failure.yml
@@ -1,0 +1,19 @@
+name: Notify DCO Failure
+
+on:
+  pull_request_target:
+    types:
+      - opened
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/github-script@v4
+        with:
+          script: |
+            const script = require(
+              `${process.env.GITHUB_WORKSPACE}/.github/workflows/notify-dco-failure.js`
+            );
+            script({ context, github });


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

It'a bit painful to tell first-time contributors "Please fix the DCO check failure" every time it fails. This PR introduces a bot to notify a DCO check failure.

## How is this patch tested?

Verify the new job works ok.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
