### PR TITLE
Sanitize MlflowHostCreds host field upon construction

### DIFF
--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -283,7 +283,7 @@ class MlflowHostCreds(object):
                 error_code=INVALID_PARAMETER_VALUE,
             )
         parsed_url = urlparse(host)
-        self.host = f"{parsed_url.scheme}://{parsed_url.hostname}"
+        self.host = f"{parsed_url.scheme}://{parsed_url.netloc}"
         self.username = username
         self.password = password
         self.token = token

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -283,7 +283,7 @@ class MlflowHostCreds(object):
                 error_code=INVALID_PARAMETER_VALUE,
             )
         parsed_url = urlparse(host)
-        self.host = f"{parsed_url.scheme}://{parsed_url.netloc}"
+        self.host = f"{parsed_url.scheme}://{parsed_url.hostname}"
         self.username = username
         self.password = password
         self.token = token

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -5,6 +5,7 @@ import json
 import requests
 from contextlib import contextmanager
 from requests.adapters import HTTPAdapter
+from six.moves.urllib.parse import urlparse
 from urllib3.util import Retry
 
 from mlflow import __version__
@@ -281,7 +282,8 @@ class MlflowHostCreds(object):
                 ),
                 error_code=INVALID_PARAMETER_VALUE,
             )
-        self.host = host
+        parsed_url = urlparse(host)
+        self.host = f"{parsed_url.scheme}://{parsed_url.hostname}"
         self.username = username
         self.password = password
         self.token = token

--- a/tests/catboost/test_catboost_model_export.py
+++ b/tests/catboost/test_catboost_model_export.py
@@ -356,7 +356,7 @@ def test_log_model_with_extra_pip_requirements(reg_model, tmpdir):
 def test_model_save_without_specified_conda_env_uses_default_env_with_expected_dependencies(
     reg_model, model_path
 ):
-    mlflow.catboost.save_model(reg_model.model, model_path, conda_env=None)
+    mlflow.catboost.save_model(reg_model.model, model_path)
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
     conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
     assert read_yaml(conda_env_path) == mlflow.catboost.get_default_conda_env()
@@ -368,7 +368,7 @@ def test_model_log_without_specified_conda_env_uses_default_env_with_expected_de
 ):
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.catboost.log_model(reg_model.model, artifact_path, conda_env=None)
+        mlflow.catboost.log_model(reg_model.model, artifact_path)
         model_uri = mlflow.get_artifact_uri(artifact_path)
 
     local_path = _download_artifact_from_uri(artifact_uri=model_uri)

--- a/tests/catboost/test_catboost_model_export.py
+++ b/tests/catboost/test_catboost_model_export.py
@@ -356,7 +356,7 @@ def test_log_model_with_extra_pip_requirements(reg_model, tmpdir):
 def test_model_save_without_specified_conda_env_uses_default_env_with_expected_dependencies(
     reg_model, model_path
 ):
-    mlflow.catboost.save_model(reg_model.model, model_path)
+    mlflow.catboost.save_model(reg_model.model, model_path, conda_env=None)
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
     conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
     assert read_yaml(conda_env_path) == mlflow.catboost.get_default_conda_env()
@@ -368,7 +368,7 @@ def test_model_log_without_specified_conda_env_uses_default_env_with_expected_de
 ):
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.catboost.log_model(reg_model.model, artifact_path)
+        mlflow.catboost.log_model(reg_model.model, artifact_path, conda_env=None)
         model_uri = mlflow.get_artifact_uri(artifact_path)
 
     local_path = _download_artifact_from_uri(artifact_uri=model_uri)

--- a/tests/fastai/test_fastai_model_export.py
+++ b/tests/fastai/test_fastai_model_export.py
@@ -375,7 +375,7 @@ def test_model_log_persists_requirements_in_mlflow_model_directory(fastai_model,
 def test_model_save_without_specified_conda_env_uses_default_env_with_expected_dependencies(
     fastai_model, model_path
 ):
-    mlflow.fastai.save_model(fastai_learner=fastai_model.model, path=model_path, conda_env=None)
+    mlflow.fastai.save_model(fastai_learner=fastai_model.model, path=model_path)
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
     conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
@@ -391,9 +391,7 @@ def test_model_log_without_specified_conda_env_uses_default_env_with_expected_de
 ):
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.fastai.log_model(
-            fastai_learner=fastai_model.model, artifact_path=artifact_path, conda_env=None
-        )
+        mlflow.fastai.log_model(fastai_learner=fastai_model.model, artifact_path=artifact_path)
         model_uri = "runs:/{run_id}/{artifact_path}".format(
             run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path
         )

--- a/tests/fastai/test_fastai_model_export.py
+++ b/tests/fastai/test_fastai_model_export.py
@@ -375,7 +375,7 @@ def test_model_log_persists_requirements_in_mlflow_model_directory(fastai_model,
 def test_model_save_without_specified_conda_env_uses_default_env_with_expected_dependencies(
     fastai_model, model_path
 ):
-    mlflow.fastai.save_model(fastai_learner=fastai_model.model, path=model_path)
+    mlflow.fastai.save_model(fastai_learner=fastai_model.model, path=model_path, conda_env=None)
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
     conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
@@ -391,7 +391,9 @@ def test_model_log_without_specified_conda_env_uses_default_env_with_expected_de
 ):
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.fastai.log_model(fastai_learner=fastai_model.model, artifact_path=artifact_path)
+        mlflow.fastai.log_model(
+            fastai_learner=fastai_model.model, artifact_path=artifact_path, conda_env=None
+        )
         model_uri = "runs:/{run_id}/{artifact_path}".format(
             run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path
         )

--- a/tests/h2o/test_h2o_model_export.py
+++ b/tests/h2o/test_h2o_model_export.py
@@ -300,7 +300,7 @@ def test_model_log_persists_requirements_in_mlflow_model_directory(h2o_iris_mode
 def test_model_save_without_specified_conda_env_uses_default_env_with_expected_dependencies(
     h2o_iris_model, model_path
 ):
-    mlflow.h2o.save_model(h2o_model=h2o_iris_model.model, path=model_path)
+    mlflow.h2o.save_model(h2o_model=h2o_iris_model.model, path=model_path, conda_env=None)
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
     conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])

--- a/tests/h2o/test_h2o_model_export.py
+++ b/tests/h2o/test_h2o_model_export.py
@@ -300,7 +300,7 @@ def test_model_log_persists_requirements_in_mlflow_model_directory(h2o_iris_mode
 def test_model_save_without_specified_conda_env_uses_default_env_with_expected_dependencies(
     h2o_iris_model, model_path
 ):
-    mlflow.h2o.save_model(h2o_model=h2o_iris_model.model, path=model_path, conda_env=None)
+    mlflow.h2o.save_model(h2o_model=h2o_iris_model.model, path=model_path)
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
     conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -554,7 +554,7 @@ def test_model_log_persists_specified_conda_env_in_mlflow_model_directory(model,
 def test_model_save_without_specified_conda_env_uses_default_env_with_expected_dependencies(
     model, model_path
 ):
-    mlflow.keras.save_model(keras_model=model, path=model_path, conda_env=None)
+    mlflow.keras.save_model(keras_model=model, path=model_path)
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
     conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
     with open(conda_env_path, "r") as f:
@@ -567,7 +567,7 @@ def test_model_save_without_specified_conda_env_uses_default_env_with_expected_d
 def test_model_log_without_specified_conda_env_uses_default_env_with_expected_dependencies(model):
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.keras.log_model(keras_model=model, artifact_path=artifact_path, conda_env=None)
+        mlflow.keras.log_model(keras_model=model, artifact_path=artifact_path)
         model_path = _download_artifact_from_uri(
             "runs:/{run_id}/{artifact_path}".format(
                 run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -554,7 +554,7 @@ def test_model_log_persists_specified_conda_env_in_mlflow_model_directory(model,
 def test_model_save_without_specified_conda_env_uses_default_env_with_expected_dependencies(
     model, model_path
 ):
-    mlflow.keras.save_model(keras_model=model, path=model_path)
+    mlflow.keras.save_model(keras_model=model, path=model_path, conda_env=None)
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
     conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
     with open(conda_env_path, "r") as f:
@@ -567,7 +567,7 @@ def test_model_save_without_specified_conda_env_uses_default_env_with_expected_d
 def test_model_log_without_specified_conda_env_uses_default_env_with_expected_dependencies(model):
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.keras.log_model(keras_model=model, artifact_path=artifact_path)
+        mlflow.keras.log_model(keras_model=model, artifact_path=artifact_path, conda_env=None)
         model_path = _download_artifact_from_uri(
             "runs:/{run_id}/{artifact_path}".format(
                 run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path

--- a/tests/lightgbm/test_lightgbm_model_export.py
+++ b/tests/lightgbm/test_lightgbm_model_export.py
@@ -335,7 +335,7 @@ def test_model_log_persists_requirements_in_mlflow_model_directory(lgb_model, lg
 def test_model_save_without_specified_conda_env_uses_default_env_with_expected_dependencies(
     lgb_model, model_path
 ):
-    mlflow.lightgbm.save_model(lgb_model=lgb_model.model, path=model_path, conda_env=None)
+    mlflow.lightgbm.save_model(lgb_model=lgb_model.model, path=model_path)
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
     conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
@@ -351,9 +351,7 @@ def test_model_log_without_specified_conda_env_uses_default_env_with_expected_de
 ):
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.lightgbm.log_model(
-            lgb_model=lgb_model.model, artifact_path=artifact_path, conda_env=None
-        )
+        mlflow.lightgbm.log_model(lgb_model=lgb_model.model, artifact_path=artifact_path)
         model_uri = "runs:/{run_id}/{artifact_path}".format(
             run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path
         )

--- a/tests/lightgbm/test_lightgbm_model_export.py
+++ b/tests/lightgbm/test_lightgbm_model_export.py
@@ -335,7 +335,7 @@ def test_model_log_persists_requirements_in_mlflow_model_directory(lgb_model, lg
 def test_model_save_without_specified_conda_env_uses_default_env_with_expected_dependencies(
     lgb_model, model_path
 ):
-    mlflow.lightgbm.save_model(lgb_model=lgb_model.model, path=model_path)
+    mlflow.lightgbm.save_model(lgb_model=lgb_model.model, path=model_path, conda_env=None)
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
     conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
@@ -351,7 +351,9 @@ def test_model_log_without_specified_conda_env_uses_default_env_with_expected_de
 ):
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.lightgbm.log_model(lgb_model=lgb_model.model, artifact_path=artifact_path)
+        mlflow.lightgbm.log_model(
+            lgb_model=lgb_model.model, artifact_path=artifact_path, conda_env=None
+        )
         model_uri = "runs:/{run_id}/{artifact_path}".format(
             run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path
         )

--- a/tests/onnx/test_onnx_model_export.py
+++ b/tests/onnx/test_onnx_model_export.py
@@ -607,7 +607,7 @@ def test_model_log_persists_requirements_in_mlflow_model_directory(onnx_model, o
 def test_model_save_without_specified_conda_env_uses_default_env_with_expected_dependencies(
     onnx_model, model_path
 ):
-    mlflow.onnx.save_model(onnx_model=onnx_model, path=model_path, conda_env=None)
+    mlflow.onnx.save_model(onnx_model=onnx_model, path=model_path)
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
     conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
     with open(conda_env_path, "r") as f:
@@ -622,7 +622,7 @@ def test_model_log_without_specified_conda_env_uses_default_env_with_expected_de
 ):
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.onnx.log_model(onnx_model=onnx_model, artifact_path=artifact_path, conda_env=None)
+        mlflow.onnx.log_model(onnx_model=onnx_model, artifact_path=artifact_path)
         model_path = _download_artifact_from_uri(
             "runs:/{run_id}/{artifact_path}".format(
                 run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path

--- a/tests/onnx/test_onnx_model_export.py
+++ b/tests/onnx/test_onnx_model_export.py
@@ -607,7 +607,7 @@ def test_model_log_persists_requirements_in_mlflow_model_directory(onnx_model, o
 def test_model_save_without_specified_conda_env_uses_default_env_with_expected_dependencies(
     onnx_model, model_path
 ):
-    mlflow.onnx.save_model(onnx_model=onnx_model, path=model_path)
+    mlflow.onnx.save_model(onnx_model=onnx_model, path=model_path, conda_env=None)
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
     conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
     with open(conda_env_path, "r") as f:
@@ -622,7 +622,7 @@ def test_model_log_without_specified_conda_env_uses_default_env_with_expected_de
 ):
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.onnx.log_model(onnx_model=onnx_model, artifact_path=artifact_path)
+        mlflow.onnx.log_model(onnx_model=onnx_model, artifact_path=artifact_path, conda_env=None)
         model_path = _download_artifact_from_uri(
             "runs:/{run_id}/{artifact_path}".format(
                 run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path

--- a/tests/paddle/test_paddle_model_export.py
+++ b/tests/paddle/test_paddle_model_export.py
@@ -189,10 +189,7 @@ def test_log_model_calls_register_model(pd_model):
     register_model_patch = mock.patch("mlflow.register_model")
     with mlflow.start_run(), register_model_patch:
         mlflow.paddle.log_model(
-            pd_model=pd_model.model,
-            artifact_path=artifact_path,
-            conda_env=None,
-            registered_model_name="AdsModel1",
+            pd_model=pd_model.model, artifact_path=artifact_path, registered_model_name="AdsModel1",
         )
         model_uri = "runs:/{run_id}/{artifact_path}".format(
             run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path
@@ -206,9 +203,7 @@ def test_log_model_no_registered_model_name(pd_model):
     artifact_path = "model"
     register_model_patch = mock.patch("mlflow.register_model")
     with mlflow.start_run(), register_model_patch:
-        mlflow.paddle.log_model(
-            pd_model=pd_model.model, artifact_path=artifact_path, conda_env=None,
-        )
+        mlflow.paddle.log_model(pd_model=pd_model.model, artifact_path=artifact_path)
         mlflow.register_model.assert_not_called()
 
 
@@ -273,7 +268,7 @@ def test_model_log_persists_specified_conda_env_in_mlflow_model_directory(pd_mod
 def test_model_save_without_specified_conda_env_uses_default_env_with_expected_dependencies(
     pd_model, model_path
 ):
-    mlflow.paddle.save_model(pd_model=pd_model.model, path=model_path, conda_env=None)
+    mlflow.paddle.save_model(pd_model=pd_model.model, path=model_path)
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
     conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
@@ -289,9 +284,7 @@ def test_model_log_without_specified_conda_env_uses_default_env_with_expected_de
 ):
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.paddle.log_model(
-            pd_model=pd_model.model, artifact_path=artifact_path, conda_env=None
-        )
+        mlflow.paddle.log_model(pd_model=pd_model.model, artifact_path=artifact_path)
         model_uri = "runs:/{run_id}/{artifact_path}".format(
             run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path
         )

--- a/tests/paddle/test_paddle_model_export.py
+++ b/tests/paddle/test_paddle_model_export.py
@@ -189,7 +189,10 @@ def test_log_model_calls_register_model(pd_model):
     register_model_patch = mock.patch("mlflow.register_model")
     with mlflow.start_run(), register_model_patch:
         mlflow.paddle.log_model(
-            pd_model=pd_model.model, artifact_path=artifact_path, registered_model_name="AdsModel1",
+            pd_model=pd_model.model,
+            artifact_path=artifact_path,
+            conda_env=None,
+            registered_model_name="AdsModel1",
         )
         model_uri = "runs:/{run_id}/{artifact_path}".format(
             run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path
@@ -203,7 +206,9 @@ def test_log_model_no_registered_model_name(pd_model):
     artifact_path = "model"
     register_model_patch = mock.patch("mlflow.register_model")
     with mlflow.start_run(), register_model_patch:
-        mlflow.paddle.log_model(pd_model=pd_model.model, artifact_path=artifact_path)
+        mlflow.paddle.log_model(
+            pd_model=pd_model.model, artifact_path=artifact_path, conda_env=None,
+        )
         mlflow.register_model.assert_not_called()
 
 
@@ -268,7 +273,7 @@ def test_model_log_persists_specified_conda_env_in_mlflow_model_directory(pd_mod
 def test_model_save_without_specified_conda_env_uses_default_env_with_expected_dependencies(
     pd_model, model_path
 ):
-    mlflow.paddle.save_model(pd_model=pd_model.model, path=model_path)
+    mlflow.paddle.save_model(pd_model=pd_model.model, path=model_path, conda_env=None)
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
     conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
@@ -284,7 +289,9 @@ def test_model_log_without_specified_conda_env_uses_default_env_with_expected_de
 ):
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.paddle.log_model(pd_model=pd_model.model, artifact_path=artifact_path)
+        mlflow.paddle.log_model(
+            pd_model=pd_model.model, artifact_path=artifact_path, conda_env=None
+        )
         model_uri = "runs:/{run_id}/{artifact_path}".format(
             run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path
         )

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -247,6 +247,7 @@ def test_log_model_calls_register_model(module_scoped_subclassed_model):
         mlflow.pytorch.log_model(
             artifact_path=artifact_path,
             pytorch_model=module_scoped_subclassed_model,
+            conda_env=None,
             pickle_module=custom_pickle_module,
             registered_model_name="AdsModel1",
         )
@@ -266,6 +267,7 @@ def test_log_model_no_registered_model_name(module_scoped_subclassed_model):
         mlflow.pytorch.log_model(
             artifact_path=artifact_path,
             pytorch_model=module_scoped_subclassed_model,
+            conda_env=None,
             pickle_module=custom_pickle_module,
         )
         mlflow.register_model.assert_not_called()
@@ -526,7 +528,7 @@ def test_model_log_persists_requirements_in_mlflow_model_directory(
 def test_model_save_without_specified_conda_env_uses_default_env_with_expected_dependencies(
     sequential_model, model_path
 ):
-    mlflow.pytorch.save_model(pytorch_model=sequential_model, path=model_path)
+    mlflow.pytorch.save_model(pytorch_model=sequential_model, path=model_path, conda_env=None)
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
     conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
@@ -543,7 +545,9 @@ def test_model_log_without_specified_conda_env_uses_default_env_with_expected_de
 ):
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.pytorch.log_model(pytorch_model=sequential_model, artifact_path=artifact_path)
+        mlflow.pytorch.log_model(
+            pytorch_model=sequential_model, artifact_path=artifact_path, conda_env=None
+        )
         model_path = _download_artifact_from_uri(
             "runs:/{run_id}/{artifact_path}".format(
                 run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path
@@ -620,7 +624,10 @@ def test_save_model_with_wrong_codepaths_fails_corrrectly(
     # pylint: disable=unused-argument
     with pytest.raises(TypeError) as exc_info:
         mlflow.pytorch.save_model(
-            path=model_path, pytorch_model=module_scoped_subclassed_model, code_paths="some string",
+            path=model_path,
+            pytorch_model=module_scoped_subclassed_model,
+            conda_env=None,
+            code_paths="some string",
         )
     assert "TypeError: Argument code_paths should be a list, not {}".format(type("")) in str(
         exc_info
@@ -635,6 +642,7 @@ def test_pyfunc_model_serving_with_main_scoped_subclassed_model_and_custom_pickl
     mlflow.pytorch.save_model(
         path=model_path,
         pytorch_model=main_scoped_subclassed_model,
+        conda_env=None,
         pickle_module=mlflow_pytorch_pickle_module,
     )
 
@@ -718,6 +726,7 @@ def test_load_pyfunc_loads_torch_model_using_pickle_module_specified_at_save_tim
     mlflow.pytorch.save_model(
         path=model_path,
         pytorch_model=module_scoped_subclassed_model,
+        conda_env=None,
         pickle_module=custom_pickle_module,
     )
 
@@ -749,6 +758,7 @@ def test_load_model_loads_torch_model_using_pickle_module_specified_at_save_time
         mlflow.pytorch.log_model(
             artifact_path=artifact_path,
             pytorch_model=module_scoped_subclassed_model,
+            conda_env=None,
             pickle_module=custom_pickle_module,
         )
         model_uri = "runs:/{run_id}/{artifact_path}".format(
@@ -782,7 +792,9 @@ def test_load_pyfunc_succeeds_when_data_is_model_file_instead_of_directory(
     serialized PyTorch model file, as opposed to the current format: a directory containing a
     serialized model file and pickle module information.
     """
-    mlflow.pytorch.save_model(path=model_path, pytorch_model=module_scoped_subclassed_model)
+    mlflow.pytorch.save_model(
+        path=model_path, pytorch_model=module_scoped_subclassed_model, conda_env=None
+    )
 
     model_conf_path = os.path.join(model_path, "MLmodel")
     model_conf = Model.load(model_conf_path)
@@ -818,7 +830,9 @@ def test_load_model_succeeds_when_data_is_model_file_instead_of_directory(
     artifact_path = "pytorch_model"
     with mlflow.start_run():
         mlflow.pytorch.log_model(
-            artifact_path=artifact_path, pytorch_model=module_scoped_subclassed_model,
+            artifact_path=artifact_path,
+            pytorch_model=module_scoped_subclassed_model,
+            conda_env=None,
         )
         model_path = _download_artifact_from_uri(
             "runs:/{run_id}/{artifact_path}".format(
@@ -852,7 +866,10 @@ def test_load_model_allows_user_to_override_pickle_module_via_keyword_argument(
     module_scoped_subclassed_model, model_path
 ):
     mlflow.pytorch.save_model(
-        path=model_path, pytorch_model=module_scoped_subclassed_model, pickle_module=pickle,
+        path=model_path,
+        pytorch_model=module_scoped_subclassed_model,
+        conda_env=None,
+        pickle_module=pickle,
     )
 
     with mock.patch("torch.load") as torch_load_mock, mock.patch(
@@ -867,7 +884,9 @@ def test_load_model_allows_user_to_override_pickle_module_via_keyword_argument(
 def test_load_model_raises_exception_when_pickle_module_cannot_be_imported(
     main_scoped_subclassed_model, model_path
 ):
-    mlflow.pytorch.save_model(path=model_path, pytorch_model=main_scoped_subclassed_model)
+    mlflow.pytorch.save_model(
+        path=model_path, pytorch_model=main_scoped_subclassed_model, conda_env=None
+    )
 
     bad_pickle_module_name = "not.a.real.module"
 
@@ -923,6 +942,7 @@ def test_requirements_file_log_model(create_requirements_file, sequential_model)
         mlflow.pytorch.log_model(
             pytorch_model=sequential_model,
             artifact_path="models",
+            conda_env=None,
             requirements_file=requirements_file,
         )
 
@@ -986,6 +1006,7 @@ def test_log_model_invalid_requirement_file_path(sequential_model):
         mlflow.pytorch.log_model(
             pytorch_model=sequential_model,
             artifact_path="models",
+            conda_env=None,
             requirements_file="inexistent_file.txt",
         )
 
@@ -998,6 +1019,7 @@ def test_log_model_invalid_requirement_file_type(sequential_model):
         mlflow.pytorch.log_model(
             pytorch_model=sequential_model,
             artifact_path="models",
+            conda_env=None,
             requirements_file=["inexistent_file.txt"],
         )
 
@@ -1026,7 +1048,10 @@ def test_extra_files_log_model(create_extra_files, sequential_model):
     extra_files, contents_expected = create_extra_files
     with mlflow.start_run():
         mlflow.pytorch.log_model(
-            pytorch_model=sequential_model, artifact_path="models", extra_files=extra_files,
+            pytorch_model=sequential_model,
+            artifact_path="models",
+            conda_env=None,
+            extra_files=extra_files,
         )
 
         model_uri = "runs:/{run_id}/{model_path}".format(
@@ -1077,6 +1102,7 @@ def test_log_model_invalid_extra_file_path(sequential_model):
         mlflow.pytorch.log_model(
             pytorch_model=sequential_model,
             artifact_path="models",
+            conda_env=None,
             extra_files=["inexistent_file.txt"],
         )
 
@@ -1089,6 +1115,7 @@ def test_log_model_invalid_extra_file_type(sequential_model):
         mlflow.pytorch.log_model(
             pytorch_model=sequential_model,
             artifact_path="models",
+            conda_env=None,
             extra_files="inexistent_file.txt",
         )
 

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -247,7 +247,6 @@ def test_log_model_calls_register_model(module_scoped_subclassed_model):
         mlflow.pytorch.log_model(
             artifact_path=artifact_path,
             pytorch_model=module_scoped_subclassed_model,
-            conda_env=None,
             pickle_module=custom_pickle_module,
             registered_model_name="AdsModel1",
         )
@@ -267,7 +266,6 @@ def test_log_model_no_registered_model_name(module_scoped_subclassed_model):
         mlflow.pytorch.log_model(
             artifact_path=artifact_path,
             pytorch_model=module_scoped_subclassed_model,
-            conda_env=None,
             pickle_module=custom_pickle_module,
         )
         mlflow.register_model.assert_not_called()
@@ -528,7 +526,7 @@ def test_model_log_persists_requirements_in_mlflow_model_directory(
 def test_model_save_without_specified_conda_env_uses_default_env_with_expected_dependencies(
     sequential_model, model_path
 ):
-    mlflow.pytorch.save_model(pytorch_model=sequential_model, path=model_path, conda_env=None)
+    mlflow.pytorch.save_model(pytorch_model=sequential_model, path=model_path)
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
     conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
@@ -545,9 +543,7 @@ def test_model_log_without_specified_conda_env_uses_default_env_with_expected_de
 ):
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.pytorch.log_model(
-            pytorch_model=sequential_model, artifact_path=artifact_path, conda_env=None
-        )
+        mlflow.pytorch.log_model(pytorch_model=sequential_model, artifact_path=artifact_path)
         model_path = _download_artifact_from_uri(
             "runs:/{run_id}/{artifact_path}".format(
                 run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path
@@ -624,10 +620,7 @@ def test_save_model_with_wrong_codepaths_fails_corrrectly(
     # pylint: disable=unused-argument
     with pytest.raises(TypeError) as exc_info:
         mlflow.pytorch.save_model(
-            path=model_path,
-            pytorch_model=module_scoped_subclassed_model,
-            conda_env=None,
-            code_paths="some string",
+            path=model_path, pytorch_model=module_scoped_subclassed_model, code_paths="some string",
         )
     assert "TypeError: Argument code_paths should be a list, not {}".format(type("")) in str(
         exc_info
@@ -642,7 +635,6 @@ def test_pyfunc_model_serving_with_main_scoped_subclassed_model_and_custom_pickl
     mlflow.pytorch.save_model(
         path=model_path,
         pytorch_model=main_scoped_subclassed_model,
-        conda_env=None,
         pickle_module=mlflow_pytorch_pickle_module,
     )
 
@@ -726,7 +718,6 @@ def test_load_pyfunc_loads_torch_model_using_pickle_module_specified_at_save_tim
     mlflow.pytorch.save_model(
         path=model_path,
         pytorch_model=module_scoped_subclassed_model,
-        conda_env=None,
         pickle_module=custom_pickle_module,
     )
 
@@ -758,7 +749,6 @@ def test_load_model_loads_torch_model_using_pickle_module_specified_at_save_time
         mlflow.pytorch.log_model(
             artifact_path=artifact_path,
             pytorch_model=module_scoped_subclassed_model,
-            conda_env=None,
             pickle_module=custom_pickle_module,
         )
         model_uri = "runs:/{run_id}/{artifact_path}".format(
@@ -792,9 +782,7 @@ def test_load_pyfunc_succeeds_when_data_is_model_file_instead_of_directory(
     serialized PyTorch model file, as opposed to the current format: a directory containing a
     serialized model file and pickle module information.
     """
-    mlflow.pytorch.save_model(
-        path=model_path, pytorch_model=module_scoped_subclassed_model, conda_env=None
-    )
+    mlflow.pytorch.save_model(path=model_path, pytorch_model=module_scoped_subclassed_model)
 
     model_conf_path = os.path.join(model_path, "MLmodel")
     model_conf = Model.load(model_conf_path)
@@ -830,9 +818,7 @@ def test_load_model_succeeds_when_data_is_model_file_instead_of_directory(
     artifact_path = "pytorch_model"
     with mlflow.start_run():
         mlflow.pytorch.log_model(
-            artifact_path=artifact_path,
-            pytorch_model=module_scoped_subclassed_model,
-            conda_env=None,
+            artifact_path=artifact_path, pytorch_model=module_scoped_subclassed_model,
         )
         model_path = _download_artifact_from_uri(
             "runs:/{run_id}/{artifact_path}".format(
@@ -866,10 +852,7 @@ def test_load_model_allows_user_to_override_pickle_module_via_keyword_argument(
     module_scoped_subclassed_model, model_path
 ):
     mlflow.pytorch.save_model(
-        path=model_path,
-        pytorch_model=module_scoped_subclassed_model,
-        conda_env=None,
-        pickle_module=pickle,
+        path=model_path, pytorch_model=module_scoped_subclassed_model, pickle_module=pickle,
     )
 
     with mock.patch("torch.load") as torch_load_mock, mock.patch(
@@ -884,9 +867,7 @@ def test_load_model_allows_user_to_override_pickle_module_via_keyword_argument(
 def test_load_model_raises_exception_when_pickle_module_cannot_be_imported(
     main_scoped_subclassed_model, model_path
 ):
-    mlflow.pytorch.save_model(
-        path=model_path, pytorch_model=main_scoped_subclassed_model, conda_env=None
-    )
+    mlflow.pytorch.save_model(path=model_path, pytorch_model=main_scoped_subclassed_model)
 
     bad_pickle_module_name = "not.a.real.module"
 
@@ -942,7 +923,6 @@ def test_requirements_file_log_model(create_requirements_file, sequential_model)
         mlflow.pytorch.log_model(
             pytorch_model=sequential_model,
             artifact_path="models",
-            conda_env=None,
             requirements_file=requirements_file,
         )
 
@@ -1006,7 +986,6 @@ def test_log_model_invalid_requirement_file_path(sequential_model):
         mlflow.pytorch.log_model(
             pytorch_model=sequential_model,
             artifact_path="models",
-            conda_env=None,
             requirements_file="inexistent_file.txt",
         )
 
@@ -1019,7 +998,6 @@ def test_log_model_invalid_requirement_file_type(sequential_model):
         mlflow.pytorch.log_model(
             pytorch_model=sequential_model,
             artifact_path="models",
-            conda_env=None,
             requirements_file=["inexistent_file.txt"],
         )
 
@@ -1048,10 +1026,7 @@ def test_extra_files_log_model(create_extra_files, sequential_model):
     extra_files, contents_expected = create_extra_files
     with mlflow.start_run():
         mlflow.pytorch.log_model(
-            pytorch_model=sequential_model,
-            artifact_path="models",
-            conda_env=None,
-            extra_files=extra_files,
+            pytorch_model=sequential_model, artifact_path="models", extra_files=extra_files,
         )
 
         model_uri = "runs:/{run_id}/{model_path}".format(
@@ -1102,7 +1077,6 @@ def test_log_model_invalid_extra_file_path(sequential_model):
         mlflow.pytorch.log_model(
             pytorch_model=sequential_model,
             artifact_path="models",
-            conda_env=None,
             extra_files=["inexistent_file.txt"],
         )
 
@@ -1115,7 +1089,6 @@ def test_log_model_invalid_extra_file_type(sequential_model):
         mlflow.pytorch.log_model(
             pytorch_model=sequential_model,
             artifact_path="models",
-            conda_env=None,
             extra_files="inexistent_file.txt",
         )
 

--- a/tests/sklearn/test_sklearn_model_export.py
+++ b/tests/sklearn/test_sklearn_model_export.py
@@ -445,7 +445,6 @@ def test_model_save_without_specified_conda_env_uses_default_env_with_expected_d
     mlflow.sklearn.save_model(
         sk_model=knn_model,
         path=model_path,
-        conda_env=None,
         serialization_format=mlflow.sklearn.SERIALIZATION_FORMAT_PICKLE,
     )
 
@@ -467,7 +466,6 @@ def test_model_log_without_specified_conda_env_uses_default_env_with_expected_de
         mlflow.sklearn.log_model(
             sk_model=knn_model,
             artifact_path=artifact_path,
-            conda_env=None,
             serialization_format=mlflow.sklearn.SERIALIZATION_FORMAT_PICKLE,
         )
         model_uri = "runs:/{run_id}/{artifact_path}".format(
@@ -485,7 +483,7 @@ def test_model_log_without_specified_conda_env_uses_default_env_with_expected_de
 
 @pytest.mark.large
 def test_model_save_uses_cloudpickle_serialization_format_by_default(sklearn_knn_model, model_path):
-    mlflow.sklearn.save_model(sk_model=sklearn_knn_model.model, path=model_path, conda_env=None)
+    mlflow.sklearn.save_model(sk_model=sklearn_knn_model.model, path=model_path)
 
     sklearn_conf = _get_flavor_configuration(
         model_path=model_path, flavor_name=mlflow.sklearn.FLAVOR_NAME
@@ -498,9 +496,7 @@ def test_model_save_uses_cloudpickle_serialization_format_by_default(sklearn_knn
 def test_model_log_uses_cloudpickle_serialization_format_by_default(sklearn_knn_model):
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.sklearn.log_model(
-            sk_model=sklearn_knn_model.model, artifact_path=artifact_path, conda_env=None
-        )
+        mlflow.sklearn.log_model(sk_model=sklearn_knn_model.model, artifact_path=artifact_path)
         model_uri = "runs:/{run_id}/{artifact_path}".format(
             run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path
         )
@@ -520,7 +516,6 @@ def test_model_save_with_cloudpickle_format_adds_cloudpickle_to_conda_environmen
     mlflow.sklearn.save_model(
         sk_model=sklearn_knn_model.model,
         path=model_path,
-        conda_env=None,
         serialization_format=mlflow.sklearn.SERIALIZATION_FORMAT_CLOUDPICKLE,
     )
 
@@ -556,7 +551,6 @@ def test_model_save_without_cloudpickle_format_does_not_add_cloudpickle_to_conda
         mlflow.sklearn.save_model(
             sk_model=sklearn_knn_model.model,
             path=model_path,
-            conda_env=None,
             serialization_format=serialization_format,
         )
 

--- a/tests/sklearn/test_sklearn_model_export.py
+++ b/tests/sklearn/test_sklearn_model_export.py
@@ -445,6 +445,7 @@ def test_model_save_without_specified_conda_env_uses_default_env_with_expected_d
     mlflow.sklearn.save_model(
         sk_model=knn_model,
         path=model_path,
+        conda_env=None,
         serialization_format=mlflow.sklearn.SERIALIZATION_FORMAT_PICKLE,
     )
 
@@ -466,6 +467,7 @@ def test_model_log_without_specified_conda_env_uses_default_env_with_expected_de
         mlflow.sklearn.log_model(
             sk_model=knn_model,
             artifact_path=artifact_path,
+            conda_env=None,
             serialization_format=mlflow.sklearn.SERIALIZATION_FORMAT_PICKLE,
         )
         model_uri = "runs:/{run_id}/{artifact_path}".format(
@@ -483,7 +485,7 @@ def test_model_log_without_specified_conda_env_uses_default_env_with_expected_de
 
 @pytest.mark.large
 def test_model_save_uses_cloudpickle_serialization_format_by_default(sklearn_knn_model, model_path):
-    mlflow.sklearn.save_model(sk_model=sklearn_knn_model.model, path=model_path)
+    mlflow.sklearn.save_model(sk_model=sklearn_knn_model.model, path=model_path, conda_env=None)
 
     sklearn_conf = _get_flavor_configuration(
         model_path=model_path, flavor_name=mlflow.sklearn.FLAVOR_NAME
@@ -496,7 +498,9 @@ def test_model_save_uses_cloudpickle_serialization_format_by_default(sklearn_knn
 def test_model_log_uses_cloudpickle_serialization_format_by_default(sklearn_knn_model):
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.sklearn.log_model(sk_model=sklearn_knn_model.model, artifact_path=artifact_path)
+        mlflow.sklearn.log_model(
+            sk_model=sklearn_knn_model.model, artifact_path=artifact_path, conda_env=None
+        )
         model_uri = "runs:/{run_id}/{artifact_path}".format(
             run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path
         )
@@ -516,6 +520,7 @@ def test_model_save_with_cloudpickle_format_adds_cloudpickle_to_conda_environmen
     mlflow.sklearn.save_model(
         sk_model=sklearn_knn_model.model,
         path=model_path,
+        conda_env=None,
         serialization_format=mlflow.sklearn.SERIALIZATION_FORMAT_CLOUDPICKLE,
     )
 
@@ -551,6 +556,7 @@ def test_model_save_without_cloudpickle_format_does_not_add_cloudpickle_to_conda
         mlflow.sklearn.save_model(
             sk_model=sklearn_knn_model.model,
             path=model_path,
+            conda_env=None,
             serialization_format=serialization_format,
         )
 

--- a/tests/spacy/test_spacy_model_export.py
+++ b/tests/spacy/test_spacy_model_export.py
@@ -337,7 +337,9 @@ def test_model_log_persists_requirements_in_mlflow_model_directory(
 def test_model_save_without_specified_conda_env_uses_default_env_with_expected_dependencies(
     spacy_model_with_data, model_path
 ):
-    mlflow.spacy.save_model(spacy_model=spacy_model_with_data.model, path=model_path)
+    mlflow.spacy.save_model(
+        spacy_model=spacy_model_with_data.model, path=model_path, conda_env=None
+    )
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
     conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])

--- a/tests/spacy/test_spacy_model_export.py
+++ b/tests/spacy/test_spacy_model_export.py
@@ -337,9 +337,7 @@ def test_model_log_persists_requirements_in_mlflow_model_directory(
 def test_model_save_without_specified_conda_env_uses_default_env_with_expected_dependencies(
     spacy_model_with_data, model_path
 ):
-    mlflow.spacy.save_model(
-        spacy_model=spacy_model_with_data.model, path=model_path, conda_env=None
-    )
+    mlflow.spacy.save_model(spacy_model=spacy_model_with_data.model, path=model_path)
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
     conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -287,7 +287,7 @@ def test_model_deployment(spark_model_iris, model_path, spark_custom_env):
     reason="The dev version of pyspark built from the source doesn't exist on PyPI or Anaconda",
 )
 def test_sagemaker_docker_model_scoring_with_default_conda_env(spark_model_iris, model_path):
-    sparkm.save_model(spark_model_iris.model, path=model_path)
+    sparkm.save_model(spark_model_iris.model, path=model_path, conda_env=None)
 
     scoring_response = score_model_in_sagemaker_docker_container(
         model_uri=model_path,
@@ -603,7 +603,7 @@ def test_sparkml_model_log_persists_requirements_in_mlflow_model_directory(
 def test_sparkml_model_save_without_specified_conda_env_uses_default_env_with_expected_dependencies(
     spark_model_iris, model_path
 ):
-    sparkm.save_model(spark_model=spark_model_iris.model, path=model_path)
+    sparkm.save_model(spark_model=spark_model_iris.model, path=model_path, conda_env=None)
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
     conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
@@ -619,7 +619,9 @@ def test_sparkml_model_log_without_specified_conda_env_uses_default_env_with_exp
 ):
     artifact_path = "model"
     with mlflow.start_run():
-        sparkm.log_model(spark_model=spark_model_iris.model, artifact_path=artifact_path)
+        sparkm.log_model(
+            spark_model=spark_model_iris.model, artifact_path=artifact_path, conda_env=None
+        )
         model_uri = "runs:/{run_id}/{artifact_path}".format(
             run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path
         )
@@ -646,7 +648,9 @@ def test_default_conda_env_strips_dev_suffix_from_pyspark_version(spark_model_ir
             assert default_conda_env_dev == default_conda_env_standard
 
             with mlflow.start_run():
-                sparkm.log_model(spark_model=spark_model_iris.model, artifact_path="model")
+                sparkm.log_model(
+                    spark_model=spark_model_iris.model, artifact_path="model", conda_env=None
+                )
                 model_uri = "runs:/{run_id}/{artifact_path}".format(
                     run_id=mlflow.active_run().info.run_id, artifact_path="model"
                 )

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -287,7 +287,7 @@ def test_model_deployment(spark_model_iris, model_path, spark_custom_env):
     reason="The dev version of pyspark built from the source doesn't exist on PyPI or Anaconda",
 )
 def test_sagemaker_docker_model_scoring_with_default_conda_env(spark_model_iris, model_path):
-    sparkm.save_model(spark_model_iris.model, path=model_path, conda_env=None)
+    sparkm.save_model(spark_model_iris.model, path=model_path)
 
     scoring_response = score_model_in_sagemaker_docker_container(
         model_uri=model_path,
@@ -603,7 +603,7 @@ def test_sparkml_model_log_persists_requirements_in_mlflow_model_directory(
 def test_sparkml_model_save_without_specified_conda_env_uses_default_env_with_expected_dependencies(
     spark_model_iris, model_path
 ):
-    sparkm.save_model(spark_model=spark_model_iris.model, path=model_path, conda_env=None)
+    sparkm.save_model(spark_model=spark_model_iris.model, path=model_path)
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
     conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
@@ -619,9 +619,7 @@ def test_sparkml_model_log_without_specified_conda_env_uses_default_env_with_exp
 ):
     artifact_path = "model"
     with mlflow.start_run():
-        sparkm.log_model(
-            spark_model=spark_model_iris.model, artifact_path=artifact_path, conda_env=None
-        )
+        sparkm.log_model(spark_model=spark_model_iris.model, artifact_path=artifact_path)
         model_uri = "runs:/{run_id}/{artifact_path}".format(
             run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path
         )
@@ -648,9 +646,7 @@ def test_default_conda_env_strips_dev_suffix_from_pyspark_version(spark_model_ir
             assert default_conda_env_dev == default_conda_env_standard
 
             with mlflow.start_run():
-                sparkm.log_model(
-                    spark_model=spark_model_iris.model, artifact_path="model", conda_env=None
-                )
+                sparkm.log_model(spark_model=spark_model_iris.model, artifact_path="model")
                 model_uri = "runs:/{run_id}/{artifact_path}".format(
                     run_id=mlflow.active_run().info.run_id, artifact_path="model"
                 )

--- a/tests/statsmodels/test_statsmodels_model_export.py
+++ b/tests/statsmodels/test_statsmodels_model_export.py
@@ -386,7 +386,9 @@ def test_model_save_without_specified_conda_env_uses_default_env_with_expected_d
     ols_model, model_path
 ):
 
-    mlflow.statsmodels.save_model(statsmodels_model=ols_model.model, path=model_path)
+    mlflow.statsmodels.save_model(
+        statsmodels_model=ols_model.model, path=model_path, conda_env=None
+    )
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
     conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
@@ -402,7 +404,9 @@ def test_model_log_without_specified_conda_env_uses_default_env_with_expected_de
 
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.statsmodels.log_model(statsmodels_model=ols_model.model, artifact_path=artifact_path)
+        mlflow.statsmodels.log_model(
+            statsmodels_model=ols_model.model, artifact_path=artifact_path, conda_env=None
+        )
         model_uri = "runs:/{run_id}/{artifact_path}".format(
             run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path
         )

--- a/tests/statsmodels/test_statsmodels_model_export.py
+++ b/tests/statsmodels/test_statsmodels_model_export.py
@@ -386,9 +386,7 @@ def test_model_save_without_specified_conda_env_uses_default_env_with_expected_d
     ols_model, model_path
 ):
 
-    mlflow.statsmodels.save_model(
-        statsmodels_model=ols_model.model, path=model_path, conda_env=None
-    )
+    mlflow.statsmodels.save_model(statsmodels_model=ols_model.model, path=model_path)
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
     conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
@@ -404,9 +402,7 @@ def test_model_log_without_specified_conda_env_uses_default_env_with_expected_de
 
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.statsmodels.log_model(
-            statsmodels_model=ols_model.model, artifact_path=artifact_path, conda_env=None
-        )
+        mlflow.statsmodels.log_model(statsmodels_model=ols_model.model, artifact_path=artifact_path)
         model_uri = "runs:/{run_id}/{artifact_path}".format(
             run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path
         )

--- a/tests/tensorflow/test_tensorflow2_model_export.py
+++ b/tests/tensorflow/test_tensorflow2_model_export.py
@@ -634,7 +634,6 @@ def test_save_model_without_specified_conda_env_uses_default_env_with_expected_d
         tf_meta_graph_tags=saved_tf_iris_model.meta_graph_tags,
         tf_signature_def_key=saved_tf_iris_model.signature_def_key,
         path=model_path,
-        conda_env=None,
     )
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
@@ -656,7 +655,6 @@ def test_log_model_without_specified_conda_env_uses_default_env_with_expected_de
             tf_meta_graph_tags=saved_tf_iris_model.meta_graph_tags,
             tf_signature_def_key=saved_tf_iris_model.signature_def_key,
             artifact_path=artifact_path,
-            conda_env=None,
         )
         model_uri = "runs:/{run_id}/{artifact_path}".format(
             run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path

--- a/tests/tensorflow/test_tensorflow2_model_export.py
+++ b/tests/tensorflow/test_tensorflow2_model_export.py
@@ -634,6 +634,7 @@ def test_save_model_without_specified_conda_env_uses_default_env_with_expected_d
         tf_meta_graph_tags=saved_tf_iris_model.meta_graph_tags,
         tf_signature_def_key=saved_tf_iris_model.signature_def_key,
         path=model_path,
+        conda_env=None,
     )
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
@@ -655,6 +656,7 @@ def test_log_model_without_specified_conda_env_uses_default_env_with_expected_de
             tf_meta_graph_tags=saved_tf_iris_model.meta_graph_tags,
             tf_signature_def_key=saved_tf_iris_model.signature_def_key,
             artifact_path=artifact_path,
+            conda_env=None,
         )
         model_uri = "runs:/{run_id}/{artifact_path}".format(
             run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path

--- a/tests/tensorflow/test_tensorflow_model_export.py
+++ b/tests/tensorflow/test_tensorflow_model_export.py
@@ -564,7 +564,6 @@ def test_save_model_without_specified_conda_env_uses_default_env_with_expected_d
         tf_meta_graph_tags=saved_tf_iris_model.meta_graph_tags,
         tf_signature_def_key=saved_tf_iris_model.signature_def_key,
         path=model_path,
-        conda_env=None,
     )
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
@@ -586,7 +585,6 @@ def test_log_model_without_specified_conda_env_uses_default_env_with_expected_de
             tf_meta_graph_tags=saved_tf_iris_model.meta_graph_tags,
             tf_signature_def_key=saved_tf_iris_model.signature_def_key,
             artifact_path=artifact_path,
-            conda_env=None,
         )
         model_uri = "runs:/{run_id}/{artifact_path}".format(
             run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path

--- a/tests/tensorflow/test_tensorflow_model_export.py
+++ b/tests/tensorflow/test_tensorflow_model_export.py
@@ -564,6 +564,7 @@ def test_save_model_without_specified_conda_env_uses_default_env_with_expected_d
         tf_meta_graph_tags=saved_tf_iris_model.meta_graph_tags,
         tf_signature_def_key=saved_tf_iris_model.signature_def_key,
         path=model_path,
+        conda_env=None,
     )
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
@@ -585,6 +586,7 @@ def test_log_model_without_specified_conda_env_uses_default_env_with_expected_de
             tf_meta_graph_tags=saved_tf_iris_model.meta_graph_tags,
             tf_signature_def_key=saved_tf_iris_model.signature_def_key,
             artifact_path=artifact_path,
+            conda_env=None,
         )
         model_uri = "runs:/{run_id}/{artifact_path}".format(
             run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path

--- a/tests/utils/test_environment.py
+++ b/tests/utils/test_environment.py
@@ -182,7 +182,9 @@ def test_parse_pip_requirements_with_invalid_argument_types(invalid_argument):
 
 
 def test_validate_env_arguments():
-    _validate_env_arguments(pip_requirements=None, extra_pip_requirements=None, conda_env=None)
+    _validate_env_arguments(
+        conda_env=None, pip_requirements=None, extra_pip_requirements=None,
+    )
 
     match = "Only one of `conda_env`, `pip_requirements`, and `extra_pip_requirements`"
     with pytest.raises(ValueError, match=match):
@@ -196,7 +198,9 @@ def test_validate_env_arguments():
         )
 
     with pytest.raises(ValueError, match=match):
-        _validate_env_arguments(conda_env=None, pip_requirements=[], extra_pip_requirements=[])
+        _validate_env_arguments(
+            conda_env=None, pip_requirements=[], extra_pip_requirements=[],
+        )
 
     with pytest.raises(ValueError, match=match):
         _validate_env_arguments(

--- a/tests/utils/test_environment.py
+++ b/tests/utils/test_environment.py
@@ -182,9 +182,7 @@ def test_parse_pip_requirements_with_invalid_argument_types(invalid_argument):
 
 
 def test_validate_env_arguments():
-    _validate_env_arguments(
-        conda_env=None, pip_requirements=None, extra_pip_requirements=None,
-    )
+    _validate_env_arguments(pip_requirements=None, extra_pip_requirements=None, conda_env=None)
 
     match = "Only one of `conda_env`, `pip_requirements`, and `extra_pip_requirements`"
     with pytest.raises(ValueError, match=match):
@@ -198,9 +196,7 @@ def test_validate_env_arguments():
         )
 
     with pytest.raises(ValueError, match=match):
-        _validate_env_arguments(
-            conda_env=None, pip_requirements=[], extra_pip_requirements=[],
-        )
+        _validate_env_arguments(conda_env=None, pip_requirements=[], extra_pip_requirements=[])
 
     with pytest.raises(ValueError, match=match):
         _validate_env_arguments(

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -77,10 +77,12 @@ def test_http_request_hostonly(request):
     )
 
 
+@pytest.mark.parametrize(
+    "host_url", ["http://my-host/", "http://my-host/?o=123", "http://my-host/?o=123/",],
+)
 @mock.patch("requests.request")
-def test_http_request_cleans_hostname(request):
-    # Add a trailing slash, should be removed.
-    host_only = MlflowHostCreds("http://my-host/")
+def test_http_request_cleans_hostname(request, host_url):
+    host_only = MlflowHostCreds(host_url)
     response = mock.MagicMock()
     response.status_code = 200
     request.return_value = response

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -78,7 +78,7 @@ def test_http_request_hostonly(request):
 
 
 @pytest.mark.parametrize(
-    "host_url", ["http://my-host/", "http://my-host/abc/?o=123", "http://my-host/?o=123/",],
+    "host_url", ["http://my-host/", "http://my-host/?o=123", "http://my-host/?o=123/",],
 )
 @mock.patch("requests.request")
 def test_http_request_cleans_hostname(request, host_url):
@@ -89,22 +89,6 @@ def test_http_request_cleans_hostname(request, host_url):
     http_request(host_only, "/my/endpoint")
     request.assert_called_with(
         url="http://my-host/my/endpoint", verify=True, headers=_DEFAULT_HEADERS,
-    )
-
-
-@pytest.mark.parametrize(
-    "host_url",
-    ["http://my-host:80/", "http://my-host:80/abc/?o=123", "http://my-host:80/?o=123/",],
-)
-@mock.patch("requests.request")
-def test_http_request_cleans_hostname_with_port(request, host_url):
-    host_only = MlflowHostCreds(host_url)
-    response = mock.MagicMock()
-    response.status_code = 200
-    request.return_value = response
-    http_request(host_only, "/my/endpoint")
-    request.assert_called_with(
-        url="http://my-host:80/my/endpoint", verify=True, headers=_DEFAULT_HEADERS,
     )
 
 

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -78,7 +78,7 @@ def test_http_request_hostonly(request):
 
 
 @pytest.mark.parametrize(
-    "host_url", ["http://my-host/", "http://my-host/?o=123", "http://my-host/?o=123/",],
+    "host_url", ["http://my-host/", "http://my-host/abc/?o=123", "http://my-host/?o=123/",],
 )
 @mock.patch("requests.request")
 def test_http_request_cleans_hostname(request, host_url):
@@ -89,6 +89,22 @@ def test_http_request_cleans_hostname(request, host_url):
     http_request(host_only, "/my/endpoint")
     request.assert_called_with(
         url="http://my-host/my/endpoint", verify=True, headers=_DEFAULT_HEADERS,
+    )
+
+
+@pytest.mark.parametrize(
+    "host_url",
+    ["http://my-host:80/", "http://my-host:80/abc/?o=123", "http://my-host:80/?o=123/",],
+)
+@mock.patch("requests.request")
+def test_http_request_cleans_hostname_with_port(request, host_url):
+    host_only = MlflowHostCreds(host_url)
+    response = mock.MagicMock()
+    response.status_code = 200
+    request.return_value = response
+    http_request(host_only, "/my/endpoint")
+    request.assert_called_with(
+        url="http://my-host:80/my/endpoint", verify=True, headers=_DEFAULT_HEADERS,
     )
 
 

--- a/tests/xgboost/test_xgboost_model_export.py
+++ b/tests/xgboost/test_xgboost_model_export.py
@@ -387,7 +387,7 @@ def test_model_log_persists_requirements_in_mlflow_model_directory(xgb_model, xg
 def test_model_save_without_specified_conda_env_uses_default_env_with_expected_dependencies(
     xgb_model, model_path
 ):
-    mlflow.xgboost.save_model(xgb_model=xgb_model.model, path=model_path)
+    mlflow.xgboost.save_model(xgb_model=xgb_model.model, path=model_path, conda_env=None)
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
     conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
@@ -403,7 +403,9 @@ def test_model_log_without_specified_conda_env_uses_default_env_with_expected_de
 ):
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.xgboost.log_model(xgb_model=xgb_model.model, artifact_path=artifact_path)
+        mlflow.xgboost.log_model(
+            xgb_model=xgb_model.model, artifact_path=artifact_path, conda_env=None
+        )
         model_uri = "runs:/{run_id}/{artifact_path}".format(
             run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path
         )

--- a/tests/xgboost/test_xgboost_model_export.py
+++ b/tests/xgboost/test_xgboost_model_export.py
@@ -387,7 +387,7 @@ def test_model_log_persists_requirements_in_mlflow_model_directory(xgb_model, xg
 def test_model_save_without_specified_conda_env_uses_default_env_with_expected_dependencies(
     xgb_model, model_path
 ):
-    mlflow.xgboost.save_model(xgb_model=xgb_model.model, path=model_path, conda_env=None)
+    mlflow.xgboost.save_model(xgb_model=xgb_model.model, path=model_path)
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
     conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
@@ -403,9 +403,7 @@ def test_model_log_without_specified_conda_env_uses_default_env_with_expected_de
 ):
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.xgboost.log_model(
-            xgb_model=xgb_model.model, artifact_path=artifact_path, conda_env=None
-        )
+        mlflow.xgboost.log_model(xgb_model=xgb_model.model, artifact_path=artifact_path)
         model_uri = "runs:/{run_id}/{artifact_path}".format(
             run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path
         )


### PR DESCRIPTION
## What changes are proposed in this pull request?
When constructing MlflowHostCreds, sanitize the host URL to only contain the host component.

## How is this patch tested?

Unit tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
