### PR TITLE
Fix `build_doc_r` job by replacing `install_github` with `install_git`

### DIFF
--- a/docs/build-rdoc.sh
+++ b/docs/build-rdoc.sh
@@ -16,7 +16,7 @@ Rscript -e 'devtools::install_dev_deps(dependencies = TRUE)'
 # Note that this commit is equivalent to commit 6b48255 of Rd2md master
 # (https://github.com/quantsch/Rd2md/tree/6b4825579a2df8a22898316d93729384f92a756b)
 # with a single extra commit to fix rendering of \link tags between methods in R documentation.
-Rscript -e 'devtools::install_github("https://github.com/smurching/Rd2md", ref = "ac7b22bb")'
+Rscript -e 'devtools::install_git("https://github.com/smurching/Rd2md", branch = "mlflow-patches")'
 Rscript -e 'install.packages("rmarkdown", repos = "https://cloud.r-project.org")'
 rm -rf man
 Rscript -e "roxygen2::roxygenise()"


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

Fix the `build_doc_r` job by replacing `install_github` with `install_git`:

https://app.circleci.com/pipelines/github/mlflow/mlflow/7098/workflows/d0bb8ae3-083c-4119-8453-a5f23eed4558/jobs/10499

```
+ Rscript -e 'devtools::install_github("https://github.com/smurching/Rd2md", ref = "ac7b22bb")'
Using bundled GitHub PAT. Please add your own PAT to the env var `GITHUB_PAT`
Error: Failed to install 'Rd2md' from GitHub:
  HTTP error 401.
  Bad credentials

  Rate limit remaining: 57/60
  Rate limit reset at: 2021-08-06 03:00:17 UTC
```

I guess the GitHub PAT (personal access token) bundled with `devtools` is no longer valid:

https://github.com/r-lib/devtools/blob/545131c0994830c590a1a3387c89ea07506c4dc4/R/github.R#L25

```
bundled_pat <- paste0(
  "b2b7441d",
  "aeeb010b",
  "1df26f1f6",
  "0a7f1ed",
  "c485e443"
)
```

## How is this patch tested?

Existing checks

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
