### PR TITLE
Push MLflow model to Sagemaker model registry

### DIFF
--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -1120,7 +1120,7 @@ def _upload_s3(local_model_path, bucket, prefix, region_name, s3_client):
                 Bucket=bucket, Key=key, Tagging={"TagSet": [{"Key": "SageMaker", "Value": "true"}]}
             )
             _logger.info("tag response: %s", response)
-            return "{}/{}/{}".format(s3_client.meta.endpoint_url, bucket, key)
+            return "s3://{}/{}".format(bucket, key)
 
 
 def _get_deployment_config(flavor_name):
@@ -1570,9 +1570,8 @@ def _delete_sagemaker_model(model_name, sage_client, s3_client):
     # procedure is safe due to the well-documented structure of the `ModelDataUrl`
     # (see https://docs.aws.amazon.com/sagemaker/latest/dg/API_ContainerDefinition.html)
     parsed_data_url = urllib.parse.urlparse(model_data_url)
-    bucket_data_path = parsed_data_url.path.split("/")
-    bucket_name = bucket_data_path[1]
-    bucket_key = "/".join(bucket_data_path[2:])
+    bucket_name = parsed_data_url.netloc
+    bucket_key = parsed_data_url.path.lstrip("/")
 
     s3_client.delete_object(Bucket=bucket_name, Key=bucket_key)
     sage_client.delete_model(ModelName=model_name)

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -1619,11 +1619,11 @@ def _find_endpoint(endpoint_name, sage_client):
 def _find_transform_job(job_name, sage_client):
     """
     Finds a SageMaker batch transform job with the specified name in the caller's AWS account,
-    returning a NoneType if the endpoint is not found.
+    returning a NoneType if the transform job is not found.
 
     :param sage_client: A boto3 client for SageMaker.
-    :return: If the endpoint exists, a dictionary of endpoint attributes. If the endpoint does not
-             exist, ``None``.
+    :return: If the transform job exists, a dictionary of transform job attributes. If the
+             transform job does not exist, ``None``.
     """
     transform_jobs_page = sage_client.list_transform_jobs(MaxResults=100, NameContains=job_name)
 

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -813,7 +813,7 @@ def terminate_transform_job(
 
 
 @experimental
-def push_sagemaker_model(
+def push_model_to_sagemaker(
     model_name,
     model_uri,
     execution_role_arn=None,
@@ -824,7 +824,7 @@ def push_sagemaker_model(
     flavor=None,
 ):
     """
-    Deploy an MLflow model to AWS SageMaker model registry.
+    Push an MLflow model to AWS SageMaker model registry.
     The currently active AWS account must have correct permissions set up.
 
     :param model_name: Name of the Sagemaker model.
@@ -879,7 +879,7 @@ def push_sagemaker_model(
                             'subnet-123456abc',
                         ]
                      }
-        mfs.push_sagemaker_model(..., vpc_config=vpc_config)
+        mfs.push_model_to_sagemaker(..., vpc_config=vpc_config)
 
     :param flavor: The name of the flavor of the model to use for deployment. Must be either
                    ``None`` or one of mlflow.sagemaker.SUPPORTED_DEPLOYMENT_FLAVORS. If ``None``,

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -1649,7 +1649,7 @@ def _does_model_exist(model_name, sage_client):
     """
     try:
         response = sage_client.describe_model(ModelName=model_name)
-    except Client.exceptions.ClientError as error:
+    except sage_client.exceptions.ClientError as error:
         if "Could not find model" in error.response["Error"]["Message"]:
             return False
     else:

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -812,6 +812,143 @@ def terminate_transform_job(
             stop_operation.clean_up()
 
 
+@experimental
+def push_sagemaker_model(
+    model_name,
+    model_uri,
+    execution_role_arn=None,
+    bucket=None,
+    image_url=None,
+    region_name="us-west-2",
+    vpc_config=None,
+    flavor=None,
+):
+    """
+    Deploy an MLflow model to AWS SageMaker model registry.
+    The currently active AWS account must have correct permissions set up.
+
+    :param model_name: Name of the Sagemaker model.
+    :param model_uri: The location, in URI format, of the MLflow model to deploy to SageMaker.
+                      For example:
+
+                      - ``/Users/me/path/to/local/model``
+                      - ``relative/path/to/local/model``
+                      - ``s3://my_bucket/path/to/model``
+                      - ``runs:/<mlflow_run_id>/run-relative/path/to/model``
+                      - ``models:/<model_name>/<model_version>``
+                      - ``models:/<model_name>/<stage>``
+
+                      For more information about supported URI schemes, see
+                      `Referencing Artifacts <https://www.mlflow.org/docs/latest/concepts.html#
+                      artifact-locations>`_.
+
+    :param execution_role_arn: The name of an IAM role granting the SageMaker service permissions to
+                               access the specified Docker image and S3 bucket containing MLflow
+                               model artifacts. If unspecified, the currently-assumed role will be
+                               used. This execution role is passed to the SageMaker service when
+                               creating a SageMaker model from the specified MLflow model. It is
+                               passed as the ``ExecutionRoleArn`` parameter of the `SageMaker
+                               CreateModel API call <https://docs.aws.amazon.com/sagemaker/latest/
+                               dg/API_CreateModel.html>`_. This role is *not* assumed for any other
+                               call. For more information about SageMaker execution roles for model
+                               creation, see
+                               https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-roles.html.
+    :param bucket: S3 bucket where model artifacts will be stored. Defaults to a
+                   SageMaker-compatible bucket name.
+    :param image_url: URL of the ECR-hosted Docker image the model should be deployed into, produced
+                      by ``mlflow sagemaker build-and-push-container``. This parameter can also
+                      be specified by the environment variable ``MLFLOW_SAGEMAKER_DEPLOY_IMG_URL``.
+    :param region_name: Name of the AWS region to which to deploy the application.
+    :param vpc_config: A dictionary specifying the VPC configuration to use when creating the
+                       new SageMaker model. The acceptable values for this parameter are identical
+                       to those of the ``VpcConfig`` parameter in the `SageMaker boto3 client's
+                       create_model method
+                       <https://boto3.readthedocs.io/en/latest/reference/services/sagemaker.html
+                       #SageMaker.Client.create_model>`_. For more information, see
+                       https://docs.aws.amazon.com/sagemaker/latest/dg/API_VpcConfig.html.
+
+    .. code-block:: python
+        :caption: Example
+
+        import mlflow.sagemaker as mfs
+        vpc_config = {
+                        'SecurityGroupIds': [
+                            'sg-123456abc',
+                        ],
+                        'Subnets': [
+                            'subnet-123456abc',
+                        ]
+                     }
+        mfs.push_sagemaker_model(..., vpc_config=vpc_config)
+
+    :param flavor: The name of the flavor of the model to use for deployment. Must be either
+                   ``None`` or one of mlflow.sagemaker.SUPPORTED_DEPLOYMENT_FLAVORS. If ``None``,
+                   a flavor is automatically selected from the model's available flavors. If the
+                   specified flavor is not present or not supported for deployment, an exception
+                   will be thrown.
+    """
+    import boto3
+
+    model_path = _download_artifact_from_uri(model_uri)
+    model_config_path = os.path.join(model_path, MLMODEL_FILE_NAME)
+    if not os.path.exists(model_config_path):
+        raise MlflowException(
+            message=(
+                "Failed to find {} configuration within the specified model's" " root directory."
+            ).format(MLMODEL_FILE_NAME),
+            error_code=INVALID_PARAMETER_VALUE,
+        )
+    model_config = Model.load(model_config_path)
+
+    if flavor is None:
+        flavor = _get_preferred_deployment_flavor(model_config)
+    else:
+        _validate_deployment_flavor(model_config, flavor)
+    _logger.info("Using the %s flavor for deployment!", flavor)
+
+    sage_client = boto3.client("sagemaker", region_name=region_name)
+    s3_client = boto3.client("s3", region_name=region_name)
+
+    model_exists = _find_model(model_name=model_name, sage_client=sage_client) is not None
+    if model_exists:
+        raise MlflowException(
+            message=(
+                "You are attempting to create a Sagemaker model with name: {model_name}."
+                "However, a model with the same name already exists.".format(model_name=model_name)
+            ),
+            error_code=INVALID_PARAMETER_VALUE,
+        )
+
+    if not image_url:
+        image_url = _get_default_image_url(region_name=region_name)
+    if not execution_role_arn:
+        execution_role_arn = _get_assumed_role_arn()
+    if not bucket:
+        _logger.info("No model data bucket specified, using the default bucket")
+        bucket = _get_default_s3_bucket(region_name)
+
+    model_s3_path = _upload_s3(
+        local_model_path=model_path,
+        bucket=bucket,
+        prefix=model_name,
+        region_name=region_name,
+        s3_client=s3_client,
+    )
+
+    model_response = _create_sagemaker_model(
+        model_name=model_name,
+        model_s3_path=model_s3_path,
+        model_uri=model_uri,
+        flavor=flavor,
+        vpc_config=vpc_config,
+        image_url=image_url,
+        execution_role=execution_role_arn,
+        sage_client=sage_client,
+    )
+
+    _logger.info("Created Sagemaker model with arn: %s", model_response["ModelArn"])
+
+
 def run_local(model_uri, port=5000, image=DEFAULT_IMAGE_NAME, flavor=None):
     """
     Serve model locally in a SageMaker compatible Docker container.
@@ -1498,6 +1635,30 @@ def _find_transform_job(job_name, sage_client):
         if "NextToken" in transform_jobs_page:
             transform_jobs_page = sage_client.list_transform_jobs(
                 MaxResults=100, NextToken=transform_jobs_page["NextToken"], NameContains=job_name,
+            )
+        else:
+            return None
+
+
+def _find_model(model_name, sage_client):
+    """
+    Finds a SageMaker model with the specified name in the caller's AWS account,
+    returning a NoneType if the model is not found.
+
+    :param sage_client: A boto3 client for SageMaker.
+    :return: If the model exists, a dictionary of model attributes. If the model does not
+             exist, ``None``.
+    """
+    models_page = sage_client.list_models(MaxResults=100, NameContains=model_name)
+
+    while True:
+        for model in models_page["Models"]:
+            if model["ModelName"] == model_name:
+                return model
+
+        if "NextToken" in models_page:
+            models_page = sage_client.list_models(
+                MaxResults=100, NextToken=models_page["NextToken"], NameContains=model_name,
             )
         else:
             return None

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -1648,18 +1648,10 @@ def _find_model(model_name, sage_client):
     :return: If the model exists, a dictionary of model attributes. If the model does not
              exist, ``None``.
     """
-    models_page = sage_client.list_models(MaxResults=100, NameContains=model_name)
-
-    while True:
-        for model in models_page["Models"]:
-            if model["ModelName"] == model_name:
-                return model
-
-        if "NextToken" in models_page:
-            models_page = sage_client.list_models(
-                MaxResults=100, NextToken=models_page["NextToken"], NameContains=model_name,
-            )
-        else:
+    try:
+        return sage_client.describe_model(ModelName=model_name)
+    except Client.exceptions.ClientError as error:
+        if "Could not find model" in error.response["Error"]["Message"]:
             return None
 
 

--- a/mlflow/sagemaker/cli.py
+++ b/mlflow/sagemaker/cli.py
@@ -478,7 +478,7 @@ def terminate_transform_job(job_name, region_name, archive, asynchronous, timeou
     )
 
 
-@commands.command("push-model-to-sagemaker")
+@commands.command("push-model")
 @click.option("--model-name", "-n", help="Sagemaker model name", required=True)
 @cli_args.MODEL_URI
 @click.option("--execution-role-arn", "-e", default=None, help="SageMaker execution role")

--- a/mlflow/sagemaker/cli.py
+++ b/mlflow/sagemaker/cli.py
@@ -511,14 +511,7 @@ def terminate_transform_job(job_name, region_name, archive, asynchronous, timeou
 )
 @experimental
 def push_model_to_sagemaker(
-    model_name,
-    model_uri,
-    execution_role_arn,
-    bucket,
-    image_url,
-    region_name,
-    vpc_config,
-    flavor,
+    model_name, model_uri, execution_role_arn, bucket, image_url, region_name, vpc_config, flavor,
 ):
     """
     Push an MLflow model to Sagemaker model registry. Current active AWS account needs to have
@@ -537,7 +530,7 @@ def push_model_to_sagemaker(
         region_name=region_name,
         vpc_config=vpc_config,
         flavor=flavor,
-    )    
+    )
 
 
 @commands.command("run-local")

--- a/mlflow/sagemaker/cli.py
+++ b/mlflow/sagemaker/cli.py
@@ -478,6 +478,68 @@ def terminate_transform_job(job_name, region_name, archive, asynchronous, timeou
     )
 
 
+@commands.command("push-model-to-sagemaker")
+@click.option("--model-name", "-n", help="Sagemaker model name", required=True)
+@cli_args.MODEL_URI
+@click.option("--execution-role-arn", "-e", default=None, help="SageMaker execution role")
+@click.option("--bucket", "-b", default=None, help="S3 bucket to store model artifacts")
+@click.option("--image-url", "-i", default=None, help="ECR URL for the Docker image")
+@click.option(
+    "--region-name",
+    default="us-west-2",
+    help="Name of the AWS region in which to push the Sagemaker model",
+)
+@click.option(
+    "--vpc-config",
+    "-v",
+    help="Path to a file containing a JSON-formatted VPC configuration. This"
+    " configuration will be used when creating the new SageMaker model."
+    " For more information, see"
+    " https://docs.aws.amazon.com/sagemaker/latest/dg/API_VpcConfig.html",
+)
+@click.option(
+    "--flavor",
+    "-f",
+    default=None,
+    help=(
+        "The name of the flavor to use for deployment. Must be one of the following:"
+        " {supported_flavors}. If unspecified, a flavor will be automatically selected"
+        " from the model's available flavors.".format(
+            supported_flavors=mlflow.sagemaker.SUPPORTED_DEPLOYMENT_FLAVORS
+        )
+    ),
+)
+@experimental
+def push_model_to_sagemaker(
+    model_name,
+    model_uri,
+    execution_role_arn,
+    bucket,
+    image_url,
+    region_name,
+    vpc_config,
+    flavor,
+):
+    """
+    Push an MLflow model to Sagemaker model registry. Current active AWS account needs to have
+    correct permissions setup.
+    """
+    if vpc_config is not None:
+        with open(vpc_config, "r") as f:
+            vpc_config = json.load(f)
+
+    mlflow.sagemaker.push_model_to_sagemaker(
+        model_name=model_name,
+        model_uri=model_uri,
+        execution_role_arn=execution_role_arn,
+        bucket=bucket,
+        image_url=image_url,
+        region_name=region_name,
+        vpc_config=vpc_config,
+        flavor=flavor,
+    )    
+
+
 @commands.command("run-local")
 @cli_args.MODEL_URI
 @click.option("--port", "-p", default=5000, help="Server port. [default: 5000]")


### PR DESCRIPTION
## What changes are proposed in this pull request?
This PR proposed the solutions to https://github.com/mlflow/mlflow/issues/4658 and https://github.com/mlflow/mlflow/issues/4667. 
- Implemented the push_model_to_sagemaker() API to push a model from MLflow to Sagemaker model registry.
- Built the CLI support for the API.
- Updated https:// protocol with s3:// protocol to upload Sagemaker model data to S3.

## How is this patch tested?
- Manually tested both push_model_to_sagemaker() API and the CLI.
- Executed all unit tests, including the tests for the existing private create_sagemaker_model method.
- Manually reviewed the python doc.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
- Create a new push_model_to_sagemaker() API and CLI to push MLflow model to Sagemaker model registry.
- Updated https:// protocol with s3:// protocol to upload Sagemaker model data to S3.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [x] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
