### PR TITLE
GC CLI SFTP Support: implement delete_artifacts in sftp_artifact_repository

### DIFF
--- a/mlflow/store/artifact/sftp_artifact_repo.py
+++ b/mlflow/store/artifact/sftp_artifact_repo.py
@@ -6,7 +6,6 @@ import urllib.parse
 
 from mlflow.entities import FileInfo
 from mlflow.store.artifact.artifact_repo import ArtifactRepository
-from mlflow.exceptions import MlflowException
 
 
 # Based on: https://stackoverflow.com/a/58466685

--- a/mlflow/store/artifact/sftp_artifact_repo.py
+++ b/mlflow/store/artifact/sftp_artifact_repo.py
@@ -110,4 +110,10 @@ class SFTPArtifactRepository(ArtifactRepository):
         self.sftp.get(remote_full_path, local_path)
 
     def delete_artifacts(self, artifact_path=None):
-        raise MlflowException("Not implemented yet")
+        if self.sftp.isdir(artifact_path):
+            with self.sftp.cd(artifact_path):
+                for element in self.sftp.listdir():
+                    self.delete_artifacts(element)
+            self.sftp.rmdir(artifact_path)
+        elif self.sftp.isfile(artifact_path):
+            self.sftp.remove(artifact_path)

--- a/tests/store/artifact/test_sftp_artifact_repo.py
+++ b/tests/store/artifact/test_sftp_artifact_repo.py
@@ -103,9 +103,7 @@ def test_list_artifacts_with_subdir(sftp_mock):
     artifacts = repo.list_artifacts(path=dir_name)
 
     sftp_mock.listdir.assert_called_once_with(artifact_root_path + dir_name)
-    sftp_mock.stat.assert_called_once_with(
-        artifact_root_path + dir_name + "/" + file_path
-    )
+    sftp_mock.stat.assert_called_once_with(artifact_root_path + dir_name + "/" + file_path)
 
     assert len(artifacts) == 2
     assert artifacts[0].path == posixpath.join(dir_name, file_path)
@@ -119,9 +117,7 @@ def test_list_artifacts_with_subdir(sftp_mock):
 @pytest.mark.requires_ssh
 def test_log_artifact():
     for artifact_path in [None, "sub_dir", "very/nested/sub/dir"]:
-        file_content = "A simple test artifact\nThe artifact is located in: " + str(
-            artifact_path
-        )
+        file_content = "A simple test artifact\nThe artifact is located in: " + str(artifact_path)
         with NamedTemporaryFile(mode="w") as local, TempDir() as remote:
             local.write(file_content)
             local.flush()
@@ -144,9 +140,7 @@ def test_log_artifact():
 @pytest.mark.requires_ssh
 def test_log_artifacts():
     for artifact_path in [None, "sub_dir", "very/nested/sub/dir"]:
-        file_content_1 = "A simple test artifact\nThe artifact is located in: " + str(
-            artifact_path
-        )
+        file_content_1 = "A simple test artifact\nThe artifact is located in: " + str(artifact_path)
         file_content_2 = os.urandom(300)
 
         file1 = "meta.yaml"
@@ -174,18 +168,14 @@ def test_log_artifacts():
             with open(posixpath.join(remote_dir, file1), "r") as remote_content:
                 assert remote_content.read() == file_content_1
 
-            with open(
-                posixpath.join(remote_dir, directory, file2), "rb"
-            ) as remote_content:
+            with open(posixpath.join(remote_dir, directory, file2), "rb") as remote_content:
                 assert remote_content.read() == file_content_2
 
 
 @pytest.mark.requires_ssh
 @pytest.mark.parametrize("artifact_path", [None, "sub_dir", "very/nested/sub/dir"])
 def test_delete_artifact(artifact_path):
-    file_content = (
-        f"A simple test artifact\nThe artifact is located in: {artifact_path}"
-    )
+    file_content = f"A simple test artifact\nThe artifact is located in: {artifact_path}"
     with NamedTemporaryFile(mode="w") as local, TempDir() as remote:
         local.write(file_content)
         local.flush()
@@ -213,9 +203,7 @@ def test_delete_artifact(artifact_path):
 @pytest.mark.requires_ssh
 @pytest.mark.parametrize("artifact_path", [None, "sub_dir", "very/nested/sub/dir"])
 def test_delete_artifacts(artifact_path):
-    file_content_1 = (
-        f"A simple test artifact\nThe artifact is located in: {artifact_path}"
-    )
+    file_content_1 = f"A simple test artifact\nThe artifact is located in: {artifact_path}"
     file_content_2 = os.urandom(300)
 
     file1 = "meta.yaml"
@@ -232,17 +220,13 @@ def test_delete_artifacts(artifact_path):
         store = SFTPArtifactRepository(sftp_path)
         store.log_artifacts(local.path(), artifact_path)
 
-        remote_dir = posixpath.join(
-            remote.path(), "." if artifact_path is None else artifact_path
-        )
+        remote_dir = posixpath.join(remote.path(), "." if artifact_path is None else artifact_path)
         assert posixpath.isdir(remote_dir)
         assert posixpath.isdir(posixpath.join(remote_dir, directory))
         assert posixpath.isfile(posixpath.join(remote_dir, file1))
         assert posixpath.isfile(posixpath.join(remote_dir, directory, file2))
 
-        with open(
-            posixpath.join(remote_dir, file1), "r", encoding="utf8"
-        ) as remote_content:
+        with open(posixpath.join(remote_dir, file1), "r", encoding="utf8") as remote_content:
             assert remote_content.read() == file_content_1
 
         with open(posixpath.join(remote_dir, directory, file2), "rb") as remote_content:
@@ -260,9 +244,7 @@ def test_delete_artifacts(artifact_path):
 @pytest.mark.requires_ssh
 @pytest.mark.parametrize("artifact_path", [None, "sub_dir", "very/nested/sub/dir"])
 def test_delete_selective_artifacts(artifact_path):
-    file_content_1 = (
-        f"A simple test artifact\nThe artifact is located in: {artifact_path}"
-    )
+    file_content_1 = f"A simple test artifact\nThe artifact is located in: {artifact_path}"
     file_content_2 = os.urandom(300)
 
     file1 = "meta.yaml"
@@ -279,17 +261,13 @@ def test_delete_selective_artifacts(artifact_path):
         store = SFTPArtifactRepository(sftp_path)
         store.log_artifacts(local.path(), artifact_path)
 
-        remote_dir = posixpath.join(
-            remote.path(), "." if artifact_path is None else artifact_path
-        )
+        remote_dir = posixpath.join(remote.path(), "." if artifact_path is None else artifact_path)
         assert posixpath.isdir(remote_dir)
         assert posixpath.isdir(posixpath.join(remote_dir, directory))
         assert posixpath.isfile(posixpath.join(remote_dir, file1))
         assert posixpath.isfile(posixpath.join(remote_dir, directory, file2))
 
-        with open(
-            posixpath.join(remote_dir, file1), "r", encoding="utf8"
-        ) as remote_content:
+        with open(posixpath.join(remote_dir, file1), "r", encoding="utf8") as remote_content:
             assert remote_content.read() == file_content_1
 
         with open(posixpath.join(remote_dir, directory, file2), "rb") as remote_content:

--- a/tests/store/artifact/test_sftp_artifact_repo.py
+++ b/tests/store/artifact/test_sftp_artifact_repo.py
@@ -103,7 +103,9 @@ def test_list_artifacts_with_subdir(sftp_mock):
     artifacts = repo.list_artifacts(path=dir_name)
 
     sftp_mock.listdir.assert_called_once_with(artifact_root_path + dir_name)
-    sftp_mock.stat.assert_called_once_with(artifact_root_path + dir_name + "/" + file_path)
+    sftp_mock.stat.assert_called_once_with(
+        artifact_root_path + dir_name + "/" + file_path
+    )
 
     assert len(artifacts) == 2
     assert artifacts[0].path == posixpath.join(dir_name, file_path)
@@ -117,7 +119,9 @@ def test_list_artifacts_with_subdir(sftp_mock):
 @pytest.mark.requires_ssh
 def test_log_artifact():
     for artifact_path in [None, "sub_dir", "very/nested/sub/dir"]:
-        file_content = "A simple test artifact\nThe artifact is located in: " + str(artifact_path)
+        file_content = "A simple test artifact\nThe artifact is located in: " + str(
+            artifact_path
+        )
         with NamedTemporaryFile(mode="w") as local, TempDir() as remote:
             local.write(file_content)
             local.flush()
@@ -140,7 +144,9 @@ def test_log_artifact():
 @pytest.mark.requires_ssh
 def test_log_artifacts():
     for artifact_path in [None, "sub_dir", "very/nested/sub/dir"]:
-        file_content_1 = "A simple test artifact\nThe artifact is located in: " + str(artifact_path)
+        file_content_1 = "A simple test artifact\nThe artifact is located in: " + str(
+            artifact_path
+        )
         file_content_2 = os.urandom(300)
 
         file1 = "meta.yaml"
@@ -168,76 +174,130 @@ def test_log_artifacts():
             with open(posixpath.join(remote_dir, file1), "r") as remote_content:
                 assert remote_content.read() == file_content_1
 
-            with open(posixpath.join(remote_dir, directory, file2), "rb") as remote_content:
+            with open(
+                posixpath.join(remote_dir, directory, file2), "rb"
+            ) as remote_content:
                 assert remote_content.read() == file_content_2
 
 
 @pytest.mark.requires_ssh
-def test_delete_artifact():
-    for artifact_path in [None, "sub_dir", "very/nested/sub/dir"]:
-        file_content = "A simple test artifact\nThe artifact is located in: " + str(artifact_path)
-        with NamedTemporaryFile(mode="w") as local, TempDir() as remote:
-            local.write(file_content)
-            local.flush()
+@pytest.mark.parametrize("artifact_path", [None, "sub_dir", "very/nested/sub/dir"])
+def test_delete_artifact(artifact_path):
+    file_content = (
+        f"A simple test artifact\nThe artifact is located in: {artifact_path}"
+    )
+    with NamedTemporaryFile(mode="w") as local, TempDir() as remote:
+        local.write(file_content)
+        local.flush()
 
-            sftp_path = "sftp://" + remote.path()
-            store = SFTPArtifactRepository(sftp_path)
-            store.log_artifact(local.name, artifact_path)
+        sftp_path = f"sftp://{remote.path}"
+        store = SFTPArtifactRepository(sftp_path)
+        store.log_artifact(local.name, artifact_path)
 
-            remote_file = posixpath.join(
-                remote.path(),
-                "." if artifact_path is None else artifact_path,
-                os.path.basename(local.name),
-            )
-            assert posixpath.isfile(remote_file)
+        remote_file = posixpath.join(
+            remote.path(),
+            "." if artifact_path is None else artifact_path,
+            os.path.basename(local.name),
+        )
+        assert posixpath.isfile(remote_file)
 
-            with open(remote_file, "r") as remote_content:
-                assert remote_content.read() == file_content
+        with open(remote_file, "r", encoding="uft8") as remote_content:
+            assert remote_content.read() == file_content
 
-            store.delete_artifacts(remote.path())
+        store.delete_artifacts(remote.path())
 
-            assert not posixpath.exists(remote_file)
-            assert not posixpath.exists(remote.path())
+        assert not posixpath.exists(remote_file)
+        assert not posixpath.exists(remote.path())
 
 
 @pytest.mark.requires_ssh
-def test_delete_artifacts():
-    for artifact_path in [None, "sub_dir", "very/nested/sub/dir"]:
-        file_content_1 = "A simple test artifact\nThe artifact is located in: " + str(artifact_path)
-        file_content_2 = os.urandom(300)
+@pytest.mark.parametrize("artifact_path", [None, "sub_dir", "very/nested/sub/dir"])
+def test_delete_artifacts(artifact_path):
+    file_content_1 = (
+        f"A simple test artifact\nThe artifact is located in: {artifact_path}"
+    )
+    file_content_2 = os.urandom(300)
 
-        file1 = "meta.yaml"
-        directory = "saved_model"
-        file2 = "sk_model.pickle"
-        with TempDir() as local, TempDir() as remote:
-            with open(os.path.join(local.path(), file1), "w") as f:
-                f.write(file_content_1)
-            os.mkdir(os.path.join(local.path(), directory))
-            with open(os.path.join(local.path(), directory, file2), "wb") as f:
-                f.write(file_content_2)
+    file1 = "meta.yaml"
+    directory = "saved_model"
+    file2 = "sk_model.pickle"
+    with TempDir() as local, TempDir() as remote:
+        with open(os.path.join(local.path(), file1), "w", encoding="utf8") as f:
+            f.write(file_content_1)
+        os.mkdir(os.path.join(local.path(), directory))
+        with open(os.path.join(local.path(), directory, file2), "wb") as f:
+            f.write(file_content_2)
 
-            sftp_path = "sftp://" + remote.path()
-            store = SFTPArtifactRepository(sftp_path)
-            store.log_artifacts(local.path(), artifact_path)
+        sftp_path = f"sftp://{remote.path()}"
+        store = SFTPArtifactRepository(sftp_path)
+        store.log_artifacts(local.path(), artifact_path)
 
-            remote_dir = posixpath.join(
-                remote.path(), "." if artifact_path is None else artifact_path
-            )
-            assert posixpath.isdir(remote_dir)
-            assert posixpath.isdir(posixpath.join(remote_dir, directory))
-            assert posixpath.isfile(posixpath.join(remote_dir, file1))
-            assert posixpath.isfile(posixpath.join(remote_dir, directory, file2))
+        remote_dir = posixpath.join(
+            remote.path(), "." if artifact_path is None else artifact_path
+        )
+        assert posixpath.isdir(remote_dir)
+        assert posixpath.isdir(posixpath.join(remote_dir, directory))
+        assert posixpath.isfile(posixpath.join(remote_dir, file1))
+        assert posixpath.isfile(posixpath.join(remote_dir, directory, file2))
 
-            with open(posixpath.join(remote_dir, file1), "r") as remote_content:
-                assert remote_content.read() == file_content_1
+        with open(
+            posixpath.join(remote_dir, file1), "r", encoding="utf8"
+        ) as remote_content:
+            assert remote_content.read() == file_content_1
 
-            with open(posixpath.join(remote_dir, directory, file2), "rb") as remote_content:
-                assert remote_content.read() == file_content_2
+        with open(posixpath.join(remote_dir, directory, file2), "rb") as remote_content:
+            assert remote_content.read() == file_content_2
 
-            store.delete_artifacts(remote.path())
+        store.delete_artifacts(remote.path())
 
-            assert not posixpath.exists(posixpath.join(remote_dir, directory))
-            assert not posixpath.exists(posixpath.join(remote_dir, file1))
-            assert not posixpath.exists(posixpath.join(remote_dir, directory, file2))
-            assert not posixpath.exists(remote_dir)
-            assert not posixpath.exists(remote.path())
+        assert not posixpath.exists(posixpath.join(remote_dir, directory))
+        assert not posixpath.exists(posixpath.join(remote_dir, file1))
+        assert not posixpath.exists(posixpath.join(remote_dir, directory, file2))
+        assert not posixpath.exists(remote_dir)
+        assert not posixpath.exists(remote.path())
+
+
+@pytest.mark.requires_ssh
+@pytest.mark.parametrize("artifact_path", [None, "sub_dir", "very/nested/sub/dir"])
+def test_delete_selective_artifacts(artifact_path):
+    file_content_1 = (
+        f"A simple test artifact\nThe artifact is located in: {artifact_path}"
+    )
+    file_content_2 = os.urandom(300)
+
+    file1 = "meta.yaml"
+    directory = "saved_model"
+    file2 = "sk_model.pickle"
+    with TempDir() as local, TempDir() as remote:
+        with open(os.path.join(local.path(), file1), "w", encoding="utf8") as f:
+            f.write(file_content_1)
+        os.mkdir(os.path.join(local.path(), directory))
+        with open(os.path.join(local.path(), directory, file2), "wb") as f:
+            f.write(file_content_2)
+
+        sftp_path = f"sftp://{remote.path()}"
+        store = SFTPArtifactRepository(sftp_path)
+        store.log_artifacts(local.path(), artifact_path)
+
+        remote_dir = posixpath.join(
+            remote.path(), "." if artifact_path is None else artifact_path
+        )
+        assert posixpath.isdir(remote_dir)
+        assert posixpath.isdir(posixpath.join(remote_dir, directory))
+        assert posixpath.isfile(posixpath.join(remote_dir, file1))
+        assert posixpath.isfile(posixpath.join(remote_dir, directory, file2))
+
+        with open(
+            posixpath.join(remote_dir, file1), "r", encoding="utf8"
+        ) as remote_content:
+            assert remote_content.read() == file_content_1
+
+        with open(posixpath.join(remote_dir, directory, file2), "rb") as remote_content:
+            assert remote_content.read() == file_content_2
+
+        store.delete_artifacts(posixpath.join(remote_dir, file1))
+
+        assert posixpath.isdir(posixpath.join(remote_dir, directory))
+        assert not posixpath.exists(posixpath.join(remote_dir, file1))
+        assert posixpath.isfile(posixpath.join(remote_dir, directory, file2))
+        assert posixpath.isdir(remote_dir)

--- a/tests/store/artifact/test_sftp_artifact_repo.py
+++ b/tests/store/artifact/test_sftp_artifact_repo.py
@@ -170,3 +170,74 @@ def test_log_artifacts():
 
             with open(posixpath.join(remote_dir, directory, file2), "rb") as remote_content:
                 assert remote_content.read() == file_content_2
+
+
+@pytest.mark.requires_ssh
+def test_delete_artifact():
+    for artifact_path in [None, "sub_dir", "very/nested/sub/dir"]:
+        file_content = "A simple test artifact\nThe artifact is located in: " + str(artifact_path)
+        with NamedTemporaryFile(mode="w") as local, TempDir() as remote:
+            local.write(file_content)
+            local.flush()
+
+            sftp_path = "sftp://" + remote.path()
+            store = SFTPArtifactRepository(sftp_path)
+            store.log_artifact(local.name, artifact_path)
+
+            remote_file = posixpath.join(
+                remote.path(),
+                "." if artifact_path is None else artifact_path,
+                os.path.basename(local.name),
+            )
+            assert posixpath.isfile(remote_file)
+
+            with open(remote_file, "r") as remote_content:
+                assert remote_content.read() == file_content
+
+            store.delete_artifacts(remote.path())
+
+            assert not posixpath.exists(remote_file)
+            assert not posixpath.exists(remote.path())
+
+
+@pytest.mark.requires_ssh
+def test_delete_artifacts():
+    for artifact_path in [None, "sub_dir", "very/nested/sub/dir"]:
+        file_content_1 = "A simple test artifact\nThe artifact is located in: " + str(artifact_path)
+        file_content_2 = os.urandom(300)
+
+        file1 = "meta.yaml"
+        directory = "saved_model"
+        file2 = "sk_model.pickle"
+        with TempDir() as local, TempDir() as remote:
+            with open(os.path.join(local.path(), file1), "w") as f:
+                f.write(file_content_1)
+            os.mkdir(os.path.join(local.path(), directory))
+            with open(os.path.join(local.path(), directory, file2), "wb") as f:
+                f.write(file_content_2)
+
+            sftp_path = "sftp://" + remote.path()
+            store = SFTPArtifactRepository(sftp_path)
+            store.log_artifacts(local.path(), artifact_path)
+
+            remote_dir = posixpath.join(
+                remote.path(), "." if artifact_path is None else artifact_path
+            )
+            assert posixpath.isdir(remote_dir)
+            assert posixpath.isdir(posixpath.join(remote_dir, directory))
+            assert posixpath.isfile(posixpath.join(remote_dir, file1))
+            assert posixpath.isfile(posixpath.join(remote_dir, directory, file2))
+
+            with open(posixpath.join(remote_dir, file1), "r") as remote_content:
+                assert remote_content.read() == file_content_1
+
+            with open(posixpath.join(remote_dir, directory, file2), "rb") as remote_content:
+                assert remote_content.read() == file_content_2
+
+            store.delete_artifacts(remote.path())
+
+            assert not posixpath.exists(posixpath.join(remote_dir, directory))
+            assert not posixpath.exists(posixpath.join(remote_dir, file1))
+            assert not posixpath.exists(posixpath.join(remote_dir, directory, file2))
+            assert not posixpath.exists(remote_dir)
+            assert not posixpath.exists(remote.path())


### PR DESCRIPTION

Signed-off-by: Alexander Faul <kontakt-github-signature@afaul.de>

## What changes are proposed in this pull request?

Implementation of delete_artifacts in sftp_artifact_repository.py

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
