### PR TITLE
Pyspark CrossValidator autolog "std metrics"

### DIFF
--- a/tests/spark_autologging/ml/test_pyspark_ml_autologging.py
+++ b/tests/spark_autologging/ml/test_pyspark_ml_autologging.py
@@ -459,10 +459,20 @@ def test_param_search_estimator(  # pylint: disable=unused-argument
 
         metric_name = estimator.getEvaluator().getMetricName()
         if isinstance(estimator, CrossValidator):
-            metric_name = f"avg_{metric_name}"
-        assert math.isclose(
-            run_data.metrics[metric_name], float(row.get(metric_name)), rel_tol=1e-6
-        )
+            avg_metric_value = model.avgMetrics[row_index]
+            avg_metric_name = f"avg_{metric_name}"
+        else:
+            avg_metric_value = model.validationMetrics[row_index]
+            avg_metric_name = metric_name
+
+        assert math.isclose(avg_metric_value, run_data.metrics[avg_metric_name], rel_tol=1e-6)
+        assert math.isclose(avg_metric_value, float(row.get(avg_metric_name)), rel_tol=1e-6)
+
+        if isinstance(estimator, CrossValidator) and Version(pyspark.__version__) > Version("3.2"):
+            std_metric_name = f"std_{metric_name}"
+            std_metric_value = model.stdMetrics[row_index]
+            assert math.isclose(std_metric_value, run_data.metrics[std_metric_name], rel_tol=1e-6)
+            assert math.isclose(std_metric_value, float(row.get(std_metric_name)), rel_tol=1e-6)
 
 
 def test_get_params_to_log(spark_session):  # pylint: disable=unused-argument


### PR DESCRIPTION
## What changes are proposed in this pull request?

Pyspark CrossValidator autolog "std metrics"

## How is this patch tested?

Unit tests

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
