### PR TITLE
tbx autolog copy

### DIFF
--- a/examples/pytorch/mnist_tensorboard_artifact.py
+++ b/examples/pytorch/mnist_tensorboard_artifact.py
@@ -21,6 +21,13 @@ import torch.optim as optim
 from torchvision import datasets, transforms
 from tensorboardX import SummaryWriter
 
+# from azureml.core import Workspace
+# ws = Workspace.from_config()
+# mlflow.set_tracking_uri(ws.get_mlflow_tracking_uri())
+
+# mlflow.set_experiment("autolog_experiment")
+
+mlflow.autolog()
 # Command-line arguments
 parser = argparse.ArgumentParser(description="PyTorch MNIST Example")
 parser.add_argument(
@@ -38,7 +45,7 @@ parser.add_argument(
     help="input batch size for testing (default: 1000)",
 )
 parser.add_argument(
-    "--epochs", type=int, default=10, metavar="N", help="number of epochs to train (default: 10)"
+    "--epochs", type=int, default=2, metavar="N", help="number of epochs to train (default: 10)"
 )
 parser.add_argument(
     "--lr", type=float, default=0.01, metavar="LR", help="learning rate (default: 0.01)"
@@ -159,7 +166,7 @@ def train(epoch):
             )
             step = epoch * len(train_loader) + batch_idx
             log_scalar("train_loss", loss.data.item(), step)
-            model.log_weights(step)
+            # model.log_weights(step)
 
 
 def test(epoch):
@@ -192,13 +199,13 @@ def test(epoch):
 def log_scalar(name, value, step):
     """Log a scalar value to both MLflow and TensorBoard"""
     writer.add_scalar(name, value, step)
-    mlflow.log_metric(name, value)
+    # mlflow.log_metric(name, value)
 
 
 with mlflow.start_run():
     # Log our parameters into mlflow
-    for key, value in vars(args).items():
-        mlflow.log_param(key, value)
+    # for key, value in vars(args).items():
+    #     mlflow.log_param(key, value)
 
     # Create a SummaryWriter to write TensorBoard events locally
     output_dir = dirpath = tempfile.mkdtemp()
@@ -211,29 +218,29 @@ with mlflow.start_run():
         test(epoch)
 
     # Upload the TensorBoard event logs as a run artifact
-    print("Uploading TensorBoard events as a run artifact...")
-    mlflow.log_artifacts(output_dir, artifact_path="events")
-    print(
-        "\nLaunch TensorBoard with:\n\ntensorboard --logdir=%s"
-        % os.path.join(mlflow.get_artifact_uri(), "events")
-    )
+    # print("Uploading TensorBoard events as a run artifact...")
+    # mlflow.log_artifacts(output_dir, artifact_path="events")
+    # print(
+    #     "\nLaunch TensorBoard with:\n\ntensorboard --logdir=%s"
+    #     % os.path.join(mlflow.get_artifact_uri(), "events")
+    # )
 
     # Log the model as an artifact of the MLflow run.
-    print("\nLogging the trained model as a run artifact...")
-    mlflow.pytorch.log_model(model, artifact_path="pytorch-model", pickle_module=pickle)
-    print(
-        "\nThe model is logged at:\n%s" % os.path.join(mlflow.get_artifact_uri(), "pytorch-model")
-    )
+    # print("\nLogging the trained model as a run artifact...")
+    # mlflow.pytorch.log_model(model, artifact_path="pytorch-model", pickle_module=pickle)
+    # print(
+    #     "\nThe model is logged at:\n%s" % os.path.join(mlflow.get_artifact_uri(), "pytorch-model")
+    # )
 
     # Since the model was logged as an artifact, it can be loaded to make predictions
-    loaded_model = mlflow.pytorch.load_model(mlflow.get_artifact_uri("pytorch-model"))
+    # loaded_model = mlflow.pytorch.load_model(mlflow.get_artifact_uri("pytorch-model"))
 
-    # Extract a few examples from the test dataset to evaulate on
-    eval_data, eval_labels = next(iter(test_loader))
+    # # Extract a few examples from the test dataset to evaulate on
+    # eval_data, eval_labels = next(iter(test_loader))
 
-    # Make a few predictions
-    predictions = loaded_model(eval_data).data.max(1)[1]
-    template = 'Sample {} : Ground truth is "{}", model prediction is "{}"'
-    print("\nSample predictions")
-    for index in range(5):
-        print(template.format(index, eval_labels[index], predictions[index]))
+    # # Make a few predictions
+    # predictions = loaded_model(eval_data).data.max(1)[1]
+    # template = 'Sample {} : Ground truth is "{}", model prediction is "{}"'
+    # print("\nSample predictions")
+    # for index in range(5):
+    #     print(template.format(index, eval_labels[index], predictions[index]))

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -61,6 +61,7 @@ try:
     import mlflow.spacy as spacy  # noqa: E402
     import mlflow.spark as spark  # noqa: E402
     import mlflow.statsmodels as statsmodels  # noqa: E402
+    import mlflow.tensorboardx_autologging as tbx_autolog # noqa: E402
     import mlflow.tensorflow as tensorflow  # noqa: E402
     import mlflow.xgboost as xgboost  # noqa: E402
     import mlflow.shap as shap  # noqa: E402
@@ -86,6 +87,7 @@ try:
         "xgboost",
         "shap",
         "paddle",
+        "tbx_autolog"
     ]
 except ImportError as e:
     # We are conditional loading these commands since the skinny client does

--- a/mlflow/tensorboardx_autologging.py
+++ b/mlflow/tensorboardx_autologging.py
@@ -1,0 +1,109 @@
+import time
+import atexit
+import mlflow
+from mlflow.entities import Metric
+import concurrent.futures
+from threading import RLock
+from mlflow.utils.autologging_utils import (
+    autologging_integration,
+    safe_patch,
+    exception_safe_function,
+    ExceptionSafeClass,
+    PatchFunction,
+    try_mlflow_log,
+    log_fn_args_as_params,
+    batch_metrics_logger,
+)
+from mlflow.utils.annotations import experimental
+from tensorboardX import SummaryWriter
+
+FLAVOR_NAME = "tbx_autolog"
+
+_metric_queue = []
+_MAX_METRIC_QUEUE_SIZE = 500
+_thread_pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+_metric_queue_lock = RLock()
+
+
+def _add_to_queue(key, value, step, time, run_id):
+    """
+    Add a metric to the metric queue. Flush the queue if it exceeds
+    max size.
+    """
+    met = Metric(key=key, value=value, timestamp=time, step=step)
+    _metric_queue.append((run_id, met))
+    if len(_metric_queue) > _MAX_METRIC_QUEUE_SIZE:
+        _thread_pool.submit(_flush_queue)
+
+
+def _log_scalar(arg1, arg2, arg3):
+    _add_to_queue(
+        key=arg1,
+        value=arg2,
+        step=arg3,
+        time=int(time.time() * 1000),
+        run_id=mlflow.active_run().info.run_id
+    )
+
+def _assoc_list_to_map(lst):
+    """
+    Convert an association list to a dictionary.
+    """
+    d = {}
+    for run_id, metric in lst:
+        d[run_id] = d[run_id] + [metric] if run_id in d else [metric]
+    return d
+
+def _flush_queue():
+    """
+    Flush the metric queue and log contents in batches to MLflow.
+    Queue is divided into batches according to run id.
+    """
+    try:
+        # Multiple queue flushes may be scheduled simultaneously on different threads
+        # (e.g., if the queue is at its flush threshold and several more items
+        # are added before a flush occurs). For correctness and efficiency, only one such
+        # flush operation should proceed; all others are redundant and should be dropped
+        acquired_lock = _metric_queue_lock.acquire(blocking=False)
+        if acquired_lock:
+            client = mlflow.tracking.MlflowClient()
+            # For thread safety and to avoid modifying a list while iterating over it, we record a
+            # separate list of the items being flushed and remove each one from the metric queue,
+            # rather than clearing the metric queue or reassigning it (clearing / reassigning is
+            # dangerous because we don't block threads from adding to the queue while a flush is
+            # in progress)
+            snapshot = _metric_queue[:]
+            for item in snapshot:
+                _metric_queue.remove(item)
+
+            metrics_by_run = _assoc_list_to_map(snapshot)
+            for run_id, metrics in metrics_by_run.items():
+                try_mlflow_log(client.log_batch, run_id, metrics=metrics, params=[], tags=[])
+    finally:
+        if acquired_lock:
+            _metric_queue_lock.release()
+
+@experimental
+@autologging_integration(FLAVOR_NAME)
+def autolog(
+    disable=False,
+    silent=False
+):
+    """
+    Enables automatic logging from TensorboardX to MLflow.
+    """
+
+    atexit.register(_flush_queue)
+
+    def add_scalar(original, self, arg1, arg2, arg3):
+        arg1 = "autologged-" + arg1
+        _log_scalar(arg1, arg2, arg3)
+        return original(self, arg1, arg2, arg3)
+
+    non_managed = [
+        (SummaryWriter, "add_scalar", add_scalar),
+    ]
+
+    for p in non_managed:
+        print("&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& Safe patching &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&")
+        safe_patch(FLAVOR_NAME, *p)

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1393,6 +1393,7 @@ def autolog(
         sklearn,
         fastai,
         pytorch,
+        tbx_autolog
     )
 
     locals_copy = locals().items()
@@ -1413,6 +1414,7 @@ def autolog(
         # TODO: Broaden this beyond pytorch_lightning as we add autologging support for more
         # Pytorch frameworks under mlflow.pytorch.autolog
         "pytorch_lightning": pytorch.autolog,
+        "tensorboardX": tbx_autolog.autolog
     }
 
     CONF_KEY_IS_GLOBALLY_CONFIGURED = "globally_configured"


### PR DESCRIPTION
## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
