### PR TITLE
Always use `importlib_metadata.version` when obtaining package version to prevent version mismatch between `importlib_metadata.version` and `<package>.__version__`

### DIFF
--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -180,16 +180,30 @@ def _run_command(cmd):
         raise MlflowException(msg)
 
 
-def _get_installed_version(package):
+def _get_installed_version(package, module=None):
     """
-    Obtains the version of the specified package from its metadata.
+    Obtains the package version using `importlib_metadata.version`. If it fails, use
+    `__import__(module or package).__version__`.
     """
     # In Databricks, strip a dev version suffix for pyspark (e.g. '3.1.2.dev0' -> '3.1.2')
     # and make it installable from PyPI.
     if package == "pyspark" and is_in_databricks_runtime():
         return _strip_dev_version_suffix(__import__("pyspark").__version__)
 
-    return importlib_metadata.version(package)
+    try:
+        return importlib_metadata.version(package)
+    except importlib_metadata.PackageNotFoundError:
+        # Note `importlib_metadata.version(package)` is not necessarily equal to
+        # `__import__(package).__version__`. See the example for pytorch below.
+        #
+        # Example
+        # -------
+        # $ pip install torch==1.9.0
+        # $ python -c "import torch; print(torch.__version__)"
+        # 1.9.0+cu102
+        # $ python -c "import importlib_metadata; print(importlib_metadata.version('torch'))"
+        # 1.9.0
+        return __import__(module or package).__version__
 
 
 def _infer_requirements(model_uri, flavor):

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -263,7 +263,7 @@ def _infer_requirements(model_uri, flavor):
 
 def _get_local_version_label(version):
     """
-    Extracts a local version label in `version`.
+    Extracts a local version label from `version`.
 
     :param version: A version string.
     """

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -290,6 +290,5 @@ def _get_pinned_requirement(package, version=None, module=None):
                    if `package` is 'scikit-learn', `module` should be 'sklearn'. If None, defaults
                    to `package`.
     """
-    module = module or package
-    version = version or _get_installed_version(module)
+    version = version or _get_installed_version(module or package)
     return f"{package}=={version}"

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -182,7 +182,7 @@ def _run_command(cmd):
 
 def _get_installed_version(package, module=None):
     """
-    Obtains the package version using `importlib_metadata.version`. If it fails, use
+    Obtains the installed package version using `importlib_metadata.version`. If it fails, use
     `__import__(module or package).__version__`.
     """
     try:

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -287,8 +287,8 @@ def _get_pinned_requirement(package, version=None, module=None):
     :param package: The name of the package.
     :param version: The version of the package. If None, defaults to the installed version.
     :param module: The name of the top-level module provided by the package . For example,
-                if `package` is 'scikit-learn', `module` should be 'sklearn'. If None, defaults
-                to `package`.
+                   if `package` is 'scikit-learn', `module` should be 'sklearn'. If None, defaults
+                   to `package`.
     """
     module = module or package
     version = version or _get_installed_version(module)

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -380,7 +380,7 @@ def _is_available_on_pypi(package, version=None, module=None):
     if not resp.ok:
         return False
 
-    version = version or _get_installed_version(package)
+    version = version or _get_installed_version(module or package)
     dist_files = resp.json()["releases"].get(version)
     return (
         dist_files is not None  # specified version exists

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -26,7 +26,7 @@ from mlflow.utils.environment import (
     _REQUIREMENTS_FILE_NAME,
     _CONSTRAINTS_FILE_NAME,
 )
-from mlflow.utils.requirements_utils import _strip_local_version_identifier, _get_installed_version
+from mlflow.utils.requirements_utils import _get_installed_version
 
 LOCALHOST = "127.0.0.1"
 
@@ -366,24 +366,18 @@ def _assert_pip_requirements(model_uri, requirements, constraints=None, strict=F
         assert compare_func(set(constraints), set(cons))
 
 
-def _is_available_on_pypi(package, version=None, module=None):
+def _is_available_on_pypi(package, version=None):
     """
     Returns True if the specified package version is available on PyPI.
 
     :param package: The name of the package.
     :param version: The version of the package. If None, defaults to the installed version.
-    :param module: The name of the top-level module provided by the package . For example,
-                   if `package` is 'scikit-learn', `module` should be 'sklearn'. If None, defaults
-                   to `package`.
     """
     resp = requests.get("https://pypi.python.org/pypi/{}/json".format(package))
     if not resp.ok:
         return False
 
-    module = module or package
-    version = version or _get_installed_version(module)
-    version = _strip_local_version_identifier(version)
-
+    version = version or _get_installed_version(package)
     dist_files = resp.json()["releases"].get(version)
     return (
         dist_files is not None  # specified version exists

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -366,12 +366,15 @@ def _assert_pip_requirements(model_uri, requirements, constraints=None, strict=F
         assert compare_func(set(constraints), set(cons))
 
 
-def _is_available_on_pypi(package, version=None):
+def _is_available_on_pypi(package, version=None, module=None):
     """
     Returns True if the specified package version is available on PyPI.
 
     :param package: The name of the package.
     :param version: The version of the package. If None, defaults to the installed version.
+    :param module: The name of the top-level module provided by the package . For example,
+                if `package` is 'scikit-learn', `module` should be 'sklearn'. If None, defaults
+                to `package`.
     """
     resp = requests.get("https://pypi.python.org/pypi/{}/json".format(package))
     if not resp.ok:

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -373,8 +373,8 @@ def _is_available_on_pypi(package, version=None, module=None):
     :param package: The name of the package.
     :param version: The version of the package. If None, defaults to the installed version.
     :param module: The name of the top-level module provided by the package . For example,
-                if `package` is 'scikit-learn', `module` should be 'sklearn'. If None, defaults
-                to `package`.
+                   if `package` is 'scikit-learn', `module` should be 'sklearn'. If None, defaults
+                   to `package`.
     """
     resp = requests.get("https://pypi.python.org/pypi/{}/json".format(package))
     if not resp.ok:

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -635,13 +635,11 @@ def test_sparkml_model_log_without_specified_conda_env_uses_default_env_with_exp
 
 @pytest.mark.large
 def test_default_conda_env_strips_dev_suffix_from_pyspark_version(spark_model_iris, model_path):
-    mock_version_standard = mock.PropertyMock(return_value="2.4.0")
-    with mock.patch("pyspark.__version__", new_callable=mock_version_standard):
+    with mock.patch("importlib_metadata.version", return_value="2.4.0"):
         default_conda_env_standard = sparkm.get_default_conda_env()
 
     for dev_version in ["2.4.0.dev0", "2.4.0.dev", "2.4.0.dev1", "2.4.0dev.a", "2.4.0.devb"]:
-        mock_version_dev = mock.PropertyMock(return_value=dev_version)
-        with mock.patch("pyspark.__version__", new_callable=mock_version_dev):
+        with mock.patch("importlib_metadata.version", return_value=dev_version):
             default_conda_env_dev = sparkm.get_default_conda_env()
             assert default_conda_env_dev == default_conda_env_standard
 
@@ -661,8 +659,7 @@ def test_default_conda_env_strips_dev_suffix_from_pyspark_version(spark_model_ir
             assert persisted_conda_env_dev == default_conda_env_standard
 
     for unaffected_version in ["2.0", "2.3.4", "2"]:
-        mock_version = mock.PropertyMock(return_value=unaffected_version)
-        with mock.patch("pyspark.__version__", new_callable=mock_version):
+        with mock.patch("importlib_metadata.version", return_value=unaffected_version):
             assert unaffected_version in yaml.safe_dump(sparkm.get_default_conda_env())
 
 

--- a/tests/utils/test_requirements_utils.py
+++ b/tests/utils/test_requirements_utils.py
@@ -227,7 +227,7 @@ def test_get_installed_version(tmpdir):
     sys.path.insert(0, tmpdir.strpath)
     with pytest.raises(importlib_metadata.PackageNotFoundError):
         importlib_metadata.version("not_found")
-    assert _get_pinned_requirement("not_found") == "1.2.3"
+    assert _get_installed_version("not_found") == "1.2.3"
 
 
 def test_get_pinned_requirement(tmpdir):


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

Always use `importlib_metadata.version` when obtaining a package version to prevent version mismatch between `importlib_metadata.version` (used in auto dependency inference) and `<package>.__version__` (used in `get_default_pip_requirements`).

## How is this patch tested?

Existing tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
