### PR TITLE
Fix flaky `build_doc_r` job 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
             # add the R 4.0 repo from CRAN -- adjust 'focal' to 'groovy' or 'bionic' as needed
             sudo add-apt-repository -y "deb https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -cs)-cran40/"
             # Install R and its dependencies.
-            sudo apt install --no-install-recommends -y r-base
+            sudo apt install --no-install-recommends -y r-base libcurl4-openssl-dev libssl-dev
 
       - run:
           name: Install pandoc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,15 +24,15 @@ jobs:
             # Reference: https://cran.r-project.org/bin/linux/ubuntu/
 
             # update indices
-            sudo apt update -qq
+            sudo apt update -qq -y
             # install two helper packages we need
-            sudo apt install --no-install-recommends software-properties-common dirmngr
+            sudo apt install --no-install-recommends -y software-properties-common dirmngr
             # add the signing key (by Michael Rutter) for these repos
             # To verify key, run gpg --show-keys /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc
             # Fingerprint: 298A3A825C0D65DFD57CBB651716619E084DAB9
             wget -qO- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | sudo tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc
             # add the R 4.0 repo from CRAN -- adjust 'focal' to 'groovy' or 'bionic' as needed
-            sudo add-apt-repository "deb https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -cs)-cran40/"
+            sudo add-apt-repository -y "deb https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -cs)-cran40/"
 
       - run:
           name: Install pandoc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,11 +21,18 @@ jobs:
       - run:
           name: Install R
           command: |
-            echo "deb https://cloud.r-project.org/bin/linux/ubuntu xenial-cran35/" | sudo tee -a /etc/apt/sources.list
-            sudo add-apt-repository ppa:cran/libgit2 --yes
-            sudo apt-get update --yes
-            sudo apt-get install --yes --allow-unauthenticated \
-              r-base r-base-dev libssl-dev libcurl4-openssl-dev texlive-latex-base libxml2-dev libssh2-1-dev libgit2-dev
+            # Reference: https://cran.r-project.org/bin/linux/ubuntu/
+
+            # update indices
+            sudo apt update -qq
+            # install two helper packages we need
+            sudo apt install --no-install-recommends software-properties-common dirmngr
+            # add the signing key (by Michael Rutter) for these repos
+            # To verify key, run gpg --show-keys /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc
+            # Fingerprint: 298A3A825C0D65DFD57CBB651716619E084DAB9
+            wget -qO- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | sudo tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc
+            # add the R 4.0 repo from CRAN -- adjust 'focal' to 'groovy' or 'bionic' as needed
+            sudo add-apt-repository "deb https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -cs)-cran40/"
 
       - run:
           name: Install pandoc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,8 @@ jobs:
             wget -qO- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | sudo tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc
             # add the R 4.0 repo from CRAN -- adjust 'focal' to 'groovy' or 'bionic' as needed
             sudo add-apt-repository -y "deb https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -cs)-cran40/"
+            # Install R and its dependencies.
+            sudo apt install --no-install-recommends -y r-base
 
       - run:
           name: Install pandoc

--- a/mlflow/R/mlflow/.dump-r-dependencies.R
+++ b/mlflow/R/mlflow/.dump-r-dependencies.R
@@ -1,5 +1,8 @@
 # Make sure the current working directory is 'mlflow/R/mlflow'
 print(R.version)
+repos = getOption("repos")
+repos["CRAN"] = "http://cran.us.r-project.org"
+options(repos = repos)
 install.packages('remotes')
 saveRDS(remotes::dev_package_deps(".", dependencies = TRUE), "depends.Rds", version = 2)
 writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), "R-version")


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

Fix flaky `build_doc_r` job .

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
