### PR TITLE
Replace keras models in tests with sklearn models to decrease maintenance burden

### DIFF
--- a/dev/run-python-tf-tests.sh
+++ b/dev/run-python-tf-tests.sh
@@ -6,10 +6,6 @@ err=0
 trap 'err=1' ERR
 export MLFLOW_HOME=$(pwd)
 
-
-# TODO: Fix `test_spark_datasource_autologging_crossframework.py` and remove this line
-pip install 'tensorflow==1.15.4' 'keras==2.2.5'
-
 # Run Spark autologging tests, which rely on tensorflow
 ./dev/test-spark-autologging.sh
 

--- a/tests/autologging/test_autologging_behaviors_integration.py
+++ b/tests/autologging/test_autologging_behaviors_integration.py
@@ -28,7 +28,7 @@ pytestmark = pytest.mark.large
 
 AUTOLOGGING_INTEGRATIONS_TO_TEST = {
     mlflow.sklearn: "sklearn",
-    mlflow.keras: "keras",
+    mlflow.sklearn: "keras",
     mlflow.xgboost: "xgboost",
     mlflow.lightgbm: "lightgbm",
     mlflow.pytorch: "torch",
@@ -56,18 +56,14 @@ def disable_autologging_at_test_end():
 
 
 @pytest.fixture()
-def setup_keras_model():
-    from keras.models import Sequential
-    from keras.layers import Dense
+def setup_sklearn_model():
+    from sklearn.datasets import load_iris
+    from sklearn.linear_model import LogisticRegression
 
-    x = [1, 2, 3]
-    y = [0, 1, 0]
-    model = Sequential()
-    model.add(Dense(12, input_dim=1, activation="relu"))
-    model.add(Dense(8, activation="relu"))
-    model.add(Dense(1, activation="sigmoid"))
-    model.compile(loss="binary_crossentropy", optimizer="adam", metrics=["accuracy"])
-    return x, y, model
+    X, y = load_iris(return_X_y=True)
+    model = LogisticRegression()
+
+    return X, y, model
 
 
 @pytest.mark.parametrize("integration", AUTOLOGGING_INTEGRATIONS_TO_TEST.keys())
@@ -104,12 +100,12 @@ def test_autologging_integrations_use_safe_patch_for_monkey_patching(integration
             assert safe_patch_mock.call_count == gorilla_mock.call_count
 
 
-def test_autolog_respects_exclusive_flag(setup_keras_model):
-    x, y, model = setup_keras_model
+def test_autolog_respects_exclusive_flag(setup_sklearn_model):
+    x, y, model = setup_sklearn_model
 
-    mlflow.keras.autolog(exclusive=True)
+    mlflow.sklearn.autolog(exclusive=True)
     run = mlflow.start_run()
-    model.fit(x, y, epochs=150, batch_size=10)
+    model.fit(x, y)
     mlflow.end_run()
     run_data = MlflowClient().get_run(run.info.run_id).data
     metrics, params, tags = run_data.metrics, run_data.params, run_data.tags
@@ -117,9 +113,9 @@ def test_autolog_respects_exclusive_flag(setup_keras_model):
     assert not params
     assert all("mlflow." in key for key in tags)
 
-    mlflow.keras.autolog(exclusive=False)
+    mlflow.sklearn.autolog(exclusive=False)
     run = mlflow.start_run()
-    model.fit(x, y, epochs=150, batch_size=10)
+    model.fit(x, y)
     mlflow.end_run()
     run_data = MlflowClient().get_run(run.info.run_id).data
     metrics, params = run_data.metrics, run_data.params
@@ -127,12 +123,12 @@ def test_autolog_respects_exclusive_flag(setup_keras_model):
     assert params
 
 
-def test_autolog_respects_disable_flag(setup_keras_model):
-    x, y, model = setup_keras_model
+def test_autolog_respects_disable_flag(setup_sklearn_model):
+    x, y, model = setup_sklearn_model
 
-    mlflow.keras.autolog(disable=True, exclusive=False)
+    mlflow.sklearn.autolog(disable=True, exclusive=False)
     run = mlflow.start_run()
-    model.fit(x, y, epochs=2, batch_size=10)
+    model.fit(x, y)
     mlflow.end_run()
     run_data = MlflowClient().get_run(run.info.run_id).data
     metrics, params, tags = run_data.metrics, run_data.params, run_data.tags
@@ -140,9 +136,9 @@ def test_autolog_respects_disable_flag(setup_keras_model):
     assert not params
     assert all("mlflow." in key for key in tags)
 
-    mlflow.keras.autolog(disable=False, exclusive=False)
+    mlflow.sklearn.autolog(disable=False, exclusive=False)
     run = mlflow.start_run()
-    model.fit(x, y, epochs=2, batch_size=10)
+    model.fit(x, y)
     mlflow.end_run()
     run_data = MlflowClient().get_run(run.info.run_id).data
     metrics, params = run_data.metrics, run_data.params

--- a/tests/autologging/test_autologging_behaviors_integration.py
+++ b/tests/autologging/test_autologging_behaviors_integration.py
@@ -28,7 +28,7 @@ pytestmark = pytest.mark.large
 
 AUTOLOGGING_INTEGRATIONS_TO_TEST = {
     mlflow.sklearn: "sklearn",
-    mlflow.sklearn: "keras",
+    mlflow.keras: "keras",
     mlflow.xgboost: "xgboost",
     mlflow.lightgbm: "lightgbm",
     mlflow.pytorch: "torch",

--- a/tests/azureml/test_deploy.py
+++ b/tests/azureml/test_deploy.py
@@ -8,14 +8,12 @@ from unittest.mock import Mock
 import pandas as pd
 import pandas.testing
 import sklearn.datasets as datasets
-import sklearn.linear_model as glm
-from keras.models import Sequential
-from keras.layers import Dense
+from sklearn.linear_model import LogisticRegression
+
 
 import mlflow
 import mlflow.azureml
 import mlflow.azureml.cli
-import mlflow.keras
 import mlflow.sklearn
 from mlflow import pyfunc
 from mlflow.exceptions import MlflowException
@@ -72,31 +70,23 @@ def sklearn_data():
 @pytest.fixture(scope="module")
 def sklearn_model(sklearn_data):
     x, y = sklearn_data
-    linear_lr = glm.LogisticRegression()
+    linear_lr = LogisticRegression()
     linear_lr.fit(x, y)
     return linear_lr
 
 
-@pytest.fixture(scope="module")
-def keras_data():
-    iris = datasets.load_iris()
-    data = pd.DataFrame(
-        data=np.c_[iris["data"], iris["target"]], columns=iris["feature_names"] + ["target"]
-    )
-    y = data["target"]
-    x = data.drop("target", axis=1)
-    return x, y
+class LogisticRegressionPandas(LogisticRegression):
+    def predict(self, *args, **kwargs):
+        # Wrap the output with `pandas.DataFrame`
+        return pd.DataFrame(super().predict(*args, **kwargs))
 
 
 @pytest.fixture(scope="module")
-def keras_model(keras_data):
-    x, y = keras_data
-    model = Sequential()
-    model.add(Dense(3, input_dim=4))
-    model.add(Dense(1))
-    model.compile(loss="mean_squared_error", optimizer="SGD")
-    model.fit(x, y)
-    return model
+def sklearn_pd_model(sklearn_data):
+    x, y = sklearn_data
+    linear_lr = LogisticRegressionPandas()
+    linear_lr.fit(x, y)
+    return linear_lr
 
 
 @pytest.fixture
@@ -413,11 +403,11 @@ def test_execution_script_run_method_scores_pandas_dfs_successfully_when_model_o
 
 @pytest.mark.large
 def test_execution_script_run_method_scores_pandas_dfs_successfully_when_model_outputs_pandas_dfs(
-    keras_model, keras_data, model_path
+    sklearn_pd_model, sklearn_data, model_path
 ):
-    mlflow.keras.save_model(keras_model=keras_model, path=model_path)
+    mlflow.sklearn.save_model(sk_model=sklearn_pd_model, path=model_path)
     pyfunc_model = mlflow.pyfunc.load_pyfunc(model_uri=model_path)
-    pyfunc_outputs = pyfunc_model.predict(keras_data[0])
+    pyfunc_outputs = pyfunc_model.predict(sklearn_data[0])
     assert isinstance(pyfunc_outputs, pd.DataFrame)
 
     model_mock = Mock()
@@ -452,7 +442,7 @@ def test_execution_script_run_method_scores_pandas_dfs_successfully_when_model_o
         # Invoke the `run` method of the execution script with sample input data and verify that
         # reasonable output data is produced
         # pylint: disable=undefined-variable
-        output_raw = run(pd.DataFrame(data=keras_data[0]).to_json(orient="split"))
+        output_raw = run(pd.DataFrame(data=sklearn_data[0]).to_json(orient="split"))
         output_df = pd.DataFrame(output_raw)
         pandas.testing.assert_frame_equal(
             output_df, pyfunc_outputs, check_dtype=False, check_less_precise=False

--- a/tests/azureml/test_deploy.py
+++ b/tests/azureml/test_deploy.py
@@ -76,7 +76,7 @@ def sklearn_model(sklearn_data):
 
 
 class LogisticRegressionPandas(LogisticRegression):
-    def predict(self, *args, **kwargs):
+    def predict(self, *args, **kwargs):  # pylint: disable=arguments-differ
         # Wrap the output with `pandas.DataFrame`
         return pd.DataFrame(super().predict(*args, **kwargs))
 

--- a/tests/azureml/test_image_creation.py
+++ b/tests/azureml/test_image_creation.py
@@ -80,7 +80,7 @@ def sklearn_model(sklearn_data):
 
 
 class LogisticRegressionPandas(LogisticRegression):
-    def predict(self, *args, **kwargs):
+    def predict(self, *args, **kwargs):  # pylint: disable=arguments-differ
         # Wrap the output with `pandas.DataFrame`
         return pd.DataFrame(super().predict(*args, **kwargs))
 

--- a/tests/azureml/test_image_creation.py
+++ b/tests/azureml/test_image_creation.py
@@ -10,15 +10,12 @@ from unittest.mock import Mock
 import pandas as pd
 import pandas.testing
 import sklearn.datasets as datasets
-import sklearn.linear_model as glm
-from keras.models import Sequential
-from keras.layers import Dense
+from sklearn.linear_model import LogisticRegression
 from click.testing import CliRunner
 
 import mlflow
 import mlflow.azureml
 import mlflow.azureml.cli
-import mlflow.keras
 import mlflow.sklearn
 from mlflow import pyfunc
 from mlflow.exceptions import MlflowException
@@ -77,31 +74,23 @@ def sklearn_data():
 @pytest.fixture(scope="module")
 def sklearn_model(sklearn_data):
     x, y = sklearn_data
-    linear_lr = glm.LogisticRegression()
+    linear_lr = LogisticRegression()
     linear_lr.fit(x, y)
     return linear_lr
 
 
-@pytest.fixture(scope="module")
-def keras_data():
-    iris = datasets.load_iris()
-    data = pd.DataFrame(
-        data=np.c_[iris["data"], iris["target"]], columns=iris["feature_names"] + ["target"]
-    )
-    y = data["target"]
-    x = data.drop("target", axis=1)
-    return x, y
+class LogisticRegressionPandas(LogisticRegression):
+    def predict(self, *args, **kwargs):
+        # Wrap the output with `pandas.DataFrame`
+        return pd.DataFrame(super().predict(*args, **kwargs))
 
 
 @pytest.fixture(scope="module")
-def keras_model(keras_data):
-    x, y = keras_data
-    model = Sequential()
-    model.add(Dense(3, input_dim=4))
-    model.add(Dense(1))
-    model.compile(loss="mean_squared_error", optimizer="SGD")
-    model.fit(x, y)
-    return model
+def sklearn_pd_model(sklearn_data):
+    x, y = sklearn_data
+    linear_lr = LogisticRegressionPandas()
+    linear_lr.fit(x, y)
+    return linear_lr
 
 
 @pytest.fixture
@@ -585,11 +574,11 @@ def test_execution_script_run_method_scores_pandas_dfs_successfully_when_model_o
 
 @pytest.mark.large
 def test_execution_script_run_method_scores_pandas_dfs_successfully_when_model_outputs_pandas_dfs(
-    keras_model, keras_data, model_path
+    sklearn_pd_model, sklearn_data, model_path
 ):
-    mlflow.keras.save_model(keras_model=keras_model, path=model_path)
+    mlflow.sklearn.save_model(sk_model=sklearn_pd_model, path=model_path)
     pyfunc_model = mlflow.pyfunc.load_pyfunc(model_uri=model_path)
-    pyfunc_outputs = pyfunc_model.predict(keras_data[0])
+    pyfunc_outputs = pyfunc_model.predict(sklearn_data[0])
     assert isinstance(pyfunc_outputs, pd.DataFrame)
 
     model_mock = Mock()
@@ -624,7 +613,7 @@ def test_execution_script_run_method_scores_pandas_dfs_successfully_when_model_o
         # Invoke the `run` method of the execution script with sample input data and verify that
         # reasonable output data is produced
         # pylint: disable=undefined-variable
-        output_raw = run(pd.DataFrame(data=keras_data[0]).to_json(orient="split"))
+        output_raw = run(pd.DataFrame(data=sklearn_data[0]).to_json(orient="split"))
         output_df = pd.DataFrame(output_raw)
         pandas.testing.assert_frame_equal(
             output_df, pyfunc_outputs, check_dtype=False, check_less_precise=False

--- a/tests/spark_autologging/datasource/test_spark_datasource_autologging_crossframework.py
+++ b/tests/spark_autologging/datasource/test_spark_datasource_autologging_crossframework.py
@@ -71,7 +71,7 @@ def test_spark_autologging_with_sklearn_autologging(spark_session, data_format, 
         .select("number1", "number2")
     )
     pandas_df = df.toPandas()
-    run = _fit_sklearn_model(pandas_df, epochs=1)
+    run = _fit_sklearn_model(pandas_df)
     _assert_spark_data_logged(run, file_path, data_format)
     assert mlflow.active_run() is None
 

--- a/tests/spark_autologging/datasource/test_spark_datasource_autologging_crossframework.py
+++ b/tests/spark_autologging/datasource/test_spark_datasource_autologging_crossframework.py
@@ -1,15 +1,11 @@
 import time
 
-from keras.layers import Dense
-from keras.models import Sequential
-
 import numpy as np
 import pytest
+from sklearn.linear_model import LinearRegression
 
 import mlflow
 import mlflow.spark
-import mlflow.keras
-import mlflow.tensorflow
 
 from tests.spark_autologging.utils import _assert_spark_data_logged
 from tests.spark_autologging.utils import spark_session  # pylint: disable=unused-import
@@ -24,13 +20,10 @@ def http_tracking_uri_mock():
     mlflow.set_tracking_uri(None)
 
 
-def _fit_keras(pandas_df, epochs):
+def _fit_sklearn(pandas_df):
     x = pandas_df.values
     y = np.array([4] * len(x))
-    keras_model = Sequential()
-    keras_model.add(Dense(1))
-    keras_model.compile(loss="mean_squared_error", optimizer="SGD")
-    keras_model.fit(x, y, epochs=epochs)
+    LinearRegression().fit(x, y)
     # Sleep to allow time for datasource read event to fire asynchronously from the JVM & for
     # the Python-side event handler to run & log a tag to the current active run.
     # This race condition (& the risk of dropping datasource read events for short-lived runs)
@@ -39,17 +32,17 @@ def _fit_keras(pandas_df, epochs):
     time.sleep(5)
 
 
-def _fit_keras_model_with_active_run(pandas_df, epochs):
+def _fit_sklearn_model_with_active_run(pandas_df):
     run_id = mlflow.active_run().info.run_id
-    _fit_keras(pandas_df, epochs)
+    _fit_sklearn(pandas_df)
     run_id = run_id
     return mlflow.get_run(run_id)
 
 
-def _fit_keras_model_no_active_run(pandas_df, epochs):
+def _fit_sklearn_model_no_active_run(pandas_df):
     orig_runs = mlflow.search_runs()
     orig_run_ids = set(orig_runs["run_id"])
-    _fit_keras(pandas_df, epochs)
+    _fit_sklearn(pandas_df)
     new_runs = mlflow.search_runs()
     new_run_ids = set(new_runs["run_id"])
     assert len(new_run_ids) == len(orig_run_ids) + 1
@@ -57,19 +50,19 @@ def _fit_keras_model_no_active_run(pandas_df, epochs):
     return mlflow.get_run(run_id)
 
 
-def _fit_keras_model(pandas_df, epochs):
+def _fit_sklearn_model(pandas_df):
     active_run = mlflow.active_run()
     if active_run:
-        return _fit_keras_model_with_active_run(pandas_df, epochs)
+        return _fit_sklearn_model_with_active_run(pandas_df)
     else:
-        return _fit_keras_model_no_active_run(pandas_df, epochs)
+        return _fit_sklearn_model_no_active_run(pandas_df)
 
 
 @pytest.mark.large
-def test_spark_autologging_with_keras_autologging(spark_session, data_format, file_path):
+def test_spark_autologging_with_sklearn_autologging(spark_session, data_format, file_path):
     assert mlflow.active_run() is None
     mlflow.spark.autolog()
-    mlflow.keras.autolog()
+    mlflow.sklearn.autolog()
     df = (
         spark_session.read.format(data_format)
         .option("header", "true")
@@ -78,15 +71,15 @@ def test_spark_autologging_with_keras_autologging(spark_session, data_format, fi
         .select("number1", "number2")
     )
     pandas_df = df.toPandas()
-    run = _fit_keras_model(pandas_df, epochs=1)
+    run = _fit_sklearn_model(pandas_df, epochs=1)
     _assert_spark_data_logged(run, file_path, data_format)
     assert mlflow.active_run() is None
 
 
 @pytest.mark.large
-def test_spark_keras_autologging_context_provider(spark_session, data_format, file_path):
+def test_spark_sklearn_autologging_context_provider(spark_session, data_format, file_path):
     mlflow.spark.autolog()
-    mlflow.keras.autolog()
+    mlflow.sklearn.autolog()
 
     df = (
         spark_session.read.format(data_format)
@@ -100,12 +93,12 @@ def test_spark_keras_autologging_context_provider(spark_session, data_format, fi
     # DF info should be logged to the first run (it should be added to our context provider after
     # the toPandas() call above & then logged here)
     with mlflow.start_run():
-        run = _fit_keras_model(pandas_df, epochs=1)
+        run = _fit_sklearn_model(pandas_df)
     _assert_spark_data_logged(run, file_path, data_format)
 
     with mlflow.start_run():
         pandas_df2 = df.filter("number1 > 0").toPandas()
-        run2 = _fit_keras_model(pandas_df2, epochs=1)
+        run2 = _fit_sklearn_model(pandas_df2)
     assert run2.info.run_id != run.info.run_id
     _assert_spark_data_logged(run2, file_path, data_format)
     time.sleep(1)
@@ -113,9 +106,9 @@ def test_spark_keras_autologging_context_provider(spark_session, data_format, fi
 
 
 @pytest.mark.large
-def test_spark_and_keras_autologging_all_runs_managed(spark_session, data_format, file_path):
+def test_spark_and_sklearn_autologging_all_runs_managed(spark_session, data_format, file_path):
     mlflow.spark.autolog()
-    mlflow.keras.autolog()
+    mlflow.sklearn.autolog()
     for _ in range(2):
         with mlflow.start_run():
             df = (
@@ -126,6 +119,6 @@ def test_spark_and_keras_autologging_all_runs_managed(spark_session, data_format
                 .select("number1", "number2")
             )
             pandas_df = df.toPandas()
-            run = _fit_keras_model(pandas_df, epochs=1)
+            run = _fit_sklearn_model(pandas_df)
         _assert_spark_data_logged(run, file_path, data_format)
     assert mlflow.active_run() is None


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

This PR attempts to minimize keras usage in our test suites and decrease the maintenance burden.

## How is this patch tested?

Updated tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
