### PR TITLE
Introduce `log_post_training_metrics` to enable/disable evaluation metrics autologging

### DIFF
--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -777,6 +777,7 @@ def autolog(
                    autologging. If ``False``, show all events and warnings during pyspark ML
                    autologging.
     :param log_eval_metrics: If ``True``, evaluation metrics are logged. Defaults to ``True``.
+                             See the post training metrics section for details.
 
     **The default log model allowlist in mlflow**
         .. literalinclude:: ../../../mlflow/pyspark/ml/log_model_allowlist.txt

--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -666,6 +666,7 @@ def autolog(
     exclusive=False,
     disable_for_unsupported_versions=False,
     silent=False,
+    log_eval_metrics=True,
 ):  # pylint: disable=unused-argument
     """
     Enables (or disables) and configures autologging for pyspark ml estimators.
@@ -775,6 +776,7 @@ def autolog(
     :param silent: If ``True``, suppress all event logs and warnings from MLflow during pyspark ML
                    autologging. If ``False``, show all events and warnings during pyspark ML
                    autologging.
+    :param log_eval_metrics: If ``True``, evaluation metrics are logged. Defaults to ``True``.
 
     **The default log model allowlist in mlflow**
         .. literalinclude:: ../../../mlflow/pyspark/ml/log_model_allowlist.txt
@@ -974,9 +976,11 @@ def autolog(
     safe_patch(
         AUTOLOGGING_INTEGRATION_NAME, Estimator, "fit", patched_fit, manage_run=True,
     )
-    safe_patch(
-        AUTOLOGGING_INTEGRATION_NAME, Model, "transform", patched_transform, manage_run=False,
-    )
-    safe_patch(
-        AUTOLOGGING_INTEGRATION_NAME, Evaluator, "evaluate", patched_evaluate, manage_run=False,
-    )
+
+    if log_eval_metrics:
+        safe_patch(
+            AUTOLOGGING_INTEGRATION_NAME, Model, "transform", patched_transform, manage_run=False,
+        )
+        safe_patch(
+            AUTOLOGGING_INTEGRATION_NAME, Evaluator, "evaluate", patched_evaluate, manage_run=False,
+        )

--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -688,6 +688,8 @@ def autolog(
         - A fully qualified estimator class name
           (e.g. "pyspark.ml.regression.LinearRegression").
 
+      .. _post training metrics:
+
       **Post training metrics**
         When users call evaluator APIs after model training, MLflow tries to capture the
         `Evaluator.evaluate` results and log them as MLflow metrics to the Run associated with
@@ -777,7 +779,8 @@ def autolog(
                    autologging. If ``False``, show all events and warnings during pyspark ML
                    autologging.
     :param log_post_training_metrics: If ``True``, post training metrics are logged. Defaults to
-                                      ``True``.
+                                      ``True``. See the `post training metrics`_ section for more
+                                      details.
 
     **The default log model allowlist in mlflow**
         .. literalinclude:: ../../../mlflow/pyspark/ml/log_model_allowlist.txt

--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -146,8 +146,8 @@ def _should_log_hierarchy(estimator):
     return isinstance(estimator, (Pipeline, OneVsRest)) or _is_parameter_search_estimator(estimator)
 
 
-AutologgingEstimatorMetadata = namedtuple(
-    "AutologgingEstimatorMetadata",
+_AutologgingEstimatorMetadata = namedtuple(
+    "_AutologgingEstimatorMetadata",
     ["hierarchy", "uid_to_indexed_name_map", "param_search_estimators"],
 )
 
@@ -215,8 +215,8 @@ def _gen_stage_hierarchy_recursively(
 
 def _gen_estimator_metadata(estimator):
     """
-    Returns an AutologgingEstimatorMetadata object.
-    The AutologgingEstimatorMetadata object includes:
+    Returns an `_AutologgingEstimatorMetadata` object.
+    The `_AutologgingEstimatorMetadata` object includes:
      - hierarchy: the hierarchy of the estimator, it will expand
          pipeline/meta estimator/param tuning estimator
      - uid_to_indexed_name_map: a map of `uid` -> `name`, each nested instance uid will be
@@ -232,7 +232,7 @@ def _gen_estimator_metadata(estimator):
     ]
     hierarchy = _gen_stage_hierarchy_recursively(estimator, uid_to_indexed_name_map)
 
-    metadata = AutologgingEstimatorMetadata(
+    metadata = _AutologgingEstimatorMetadata(
         hierarchy=hierarchy,
         uid_to_indexed_name_map=uid_to_indexed_name_map,
         param_search_estimators=param_search_estimators,

--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -666,7 +666,7 @@ def autolog(
     exclusive=False,
     disable_for_unsupported_versions=False,
     silent=False,
-    log_eval_metrics=True,
+    log_post_training_metrics=True,
 ):  # pylint: disable=unused-argument
     """
     Enables (or disables) and configures autologging for pyspark ml estimators.
@@ -776,8 +776,8 @@ def autolog(
     :param silent: If ``True``, suppress all event logs and warnings from MLflow during pyspark ML
                    autologging. If ``False``, show all events and warnings during pyspark ML
                    autologging.
-    :param log_eval_metrics: If ``True``, evaluation metrics are logged. Defaults to ``True``.
-                             See the post training metrics section for details.
+    :param log_post_training_metrics: If ``True``, post training metrics are logged. Defaults to
+                                      ``True``.
 
     **The default log model allowlist in mlflow**
         .. literalinclude:: ../../../mlflow/pyspark/ml/log_model_allowlist.txt
@@ -913,7 +913,8 @@ def autolog(
 
     def patched_fit(original, self, *args, **kwargs):
         should_log_post_training_metrics = (
-            log_eval_metrics and _AUTOLOGGING_METRICS_MANAGER.should_log_post_training_metrics()
+            log_post_training_metrics
+            and _AUTOLOGGING_METRICS_MANAGER.should_log_post_training_metrics()
         )
         with _SparkTrainingSession(clazz=self.__class__, allow_children=False) as t:
             if t.should_log():
@@ -978,7 +979,7 @@ def autolog(
         AUTOLOGGING_INTEGRATION_NAME, Estimator, "fit", patched_fit, manage_run=True,
     )
 
-    if log_eval_metrics:
+    if log_post_training_metrics:
         safe_patch(
             AUTOLOGGING_INTEGRATION_NAME, Model, "transform", patched_transform, manage_run=False,
         )

--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -913,7 +913,7 @@ def autolog(
 
     def patched_fit(original, self, *args, **kwargs):
         should_log_post_training_metrics = (
-            _AUTOLOGGING_METRICS_MANAGER.should_log_post_training_metrics()
+            log_eval_metrics and _AUTOLOGGING_METRICS_MANAGER.should_log_post_training_metrics()
         )
         with _SparkTrainingSession(clazz=self.__class__, allow_children=False) as t:
             if t.should_log():

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -1324,8 +1324,9 @@ def autolog(
                           `sklearn.linear_model.LogisticRegression.fit()` is being patched)
         """
         should_log_post_training_metrics = (
-            _AUTOLOGGING_METRICS_MANAGER.should_log_post_training_metrics()
+            log_eval_metrics and _AUTOLOGGING_METRICS_MANAGER.should_log_post_training_metrics()
         )
+
         with _SklearnTrainingSession(clazz=self.__class__, allow_children=False) as t:
             if t.should_log():
                 # In `fit_mlflow` call, it will also call metric API for computing training metrics

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -930,6 +930,8 @@ def autolog(
           .. _r2 score:
               https://scikit-learn.org/stable/modules/generated/sklearn.metrics.r2_score.html
 
+      .. _post training metrics:
+
       **Post training metrics**
         When users call metric APIs after model training, MLflow tries to capture the metric API
         results and log them as MLflow metrics to the Run associated with the model. The following
@@ -1104,7 +1106,8 @@ def autolog(
                             results. To change metric used for selecting best k results, change
                             ordering of dict passed as `scoring` parameter for estimator.
     :param log_post_training_metrics: If ``True``, post training metrics are logged. Defaults to
-                                      ``True``.
+                                      ``True``. See the `post training metrics`_ section for more
+                                      details.
     """
     import pandas as pd
     import sklearn

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -856,6 +856,7 @@ def autolog(
     disable_for_unsupported_versions=False,
     silent=False,
     max_tuning_runs=5,
+    log_eval_metrics=True,
 ):  # pylint: disable=unused-argument
     """
     Enables (or disables) and configures autologging for scikit-learn estimators.
@@ -1102,6 +1103,7 @@ def autolog(
                             `rank_test_score_<scorer_name>` will be used to select the best k
                             results. To change metric used for selecting best k results, change
                             ordering of dict passed as `scoring` parameter for estimator.
+    :param log_eval_metrics: If ``True``, evaluation metrics are logged.
     """
     import pandas as pd
     import sklearn
@@ -1536,11 +1538,14 @@ def autolog(
             FLAVOR_NAME, class_def, "score", patched_model_score, manage_run=False,
         )
 
-    for metric_name in _get_metric_name_list():
-        safe_patch(FLAVOR_NAME, sklearn.metrics, metric_name, patched_metric_api, manage_run=False)
+    if log_eval_metrics:
+        for metric_name in _get_metric_name_list():
+            safe_patch(
+                FLAVOR_NAME, sklearn.metrics, metric_name, patched_metric_api, manage_run=False
+            )
 
-    for scorer in sklearn.metrics.SCORERS.values():
-        safe_patch(FLAVOR_NAME, scorer, "_score_func", patched_metric_api, manage_run=False)
+        for scorer in sklearn.metrics.SCORERS.values():
+            safe_patch(FLAVOR_NAME, scorer, "_score_func", patched_metric_api, manage_run=False)
 
     def patched_fn_with_autolog_disabled(original, *args, **kwargs):
         with disable_autologging():

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -856,7 +856,7 @@ def autolog(
     disable_for_unsupported_versions=False,
     silent=False,
     max_tuning_runs=5,
-    log_eval_metrics=True,
+    log_post_training_metrics=True,
 ):  # pylint: disable=unused-argument
     """
     Enables (or disables) and configures autologging for scikit-learn estimators.
@@ -1103,8 +1103,8 @@ def autolog(
                             `rank_test_score_<scorer_name>` will be used to select the best k
                             results. To change metric used for selecting best k results, change
                             ordering of dict passed as `scoring` parameter for estimator.
-     :param log_eval_metrics: If ``True``, evaluation metrics are logged. Defaults to ``True``.
-                             See the post training metrics section for details.
+    :param log_post_training_metrics: If ``True``, post training metrics are logged. Defaults to
+                                      ``True``.
     """
     import pandas as pd
     import sklearn
@@ -1325,7 +1325,8 @@ def autolog(
                           `sklearn.linear_model.LogisticRegression.fit()` is being patched)
         """
         should_log_post_training_metrics = (
-            log_eval_metrics and _AUTOLOGGING_METRICS_MANAGER.should_log_post_training_metrics()
+            log_post_training_metrics
+            and _AUTOLOGGING_METRICS_MANAGER.should_log_post_training_metrics()
         )
 
         with _SklearnTrainingSession(clazz=self.__class__, allow_children=False) as t:
@@ -1540,7 +1541,7 @@ def autolog(
             FLAVOR_NAME, class_def, "score", patched_model_score, manage_run=False,
         )
 
-    if log_eval_metrics:
+    if log_post_training_metrics:
         for metric_name in _get_metric_name_list():
             safe_patch(
                 FLAVOR_NAME, sklearn.metrics, metric_name, patched_metric_api, manage_run=False

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -1103,8 +1103,8 @@ def autolog(
                             `rank_test_score_<scorer_name>` will be used to select the best k
                             results. To change metric used for selecting best k results, change
                             ordering of dict passed as `scoring` parameter for estimator.
-    :param log_eval_metrics: If ``True``, evaluation metrics are logged.
-    """
+     :param log_eval_metrics: If ``True``, evaluation metrics are logged. Defaults to ``True``.
+                             See the post training metrics section for details.    """
     import pandas as pd
     import sklearn
     import sklearn.metrics

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -1104,7 +1104,8 @@ def autolog(
                             results. To change metric used for selecting best k results, change
                             ordering of dict passed as `scoring` parameter for estimator.
      :param log_eval_metrics: If ``True``, evaluation metrics are logged. Defaults to ``True``.
-                             See the post training metrics section for details.    """
+                             See the post training metrics section for details.
+    """
     import pandas as pd
     import sklearn
     import sklearn.metrics

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -1861,9 +1861,9 @@ def test_is_metrics_value_loggable():
     assert not is_metric_value_loggable(np.array([1, 2]))
 
 
-@pytest.mark.parametrize("log_eval_metrics", [True, False])
-def test_log_eval_metrics_configuration(log_eval_metrics):
-    mlflow.sklearn.autolog(log_eval_metrics=log_eval_metrics)
+@pytest.mark.parametrize("log_post_training_metrics", [True, False])
+def test_log_post_training_metrics_configuration(log_post_training_metrics):
+    mlflow.sklearn.autolog(log_post_training_metrics=log_post_training_metrics)
 
     model = sklearn.linear_model.LogisticRegression()
     X, y = get_iris()
@@ -1875,7 +1875,7 @@ def test_log_eval_metrics_configuration(log_eval_metrics):
 
     metrics = get_run_data(run.info.run_id)[1]
     metric_name = sklearn.metrics.r2_score.__name__
-    if log_eval_metrics:
+    if log_post_training_metrics:
         assert any(k.startswith(metric_name) for k in metrics.keys())
     else:
         assert all(not k.startswith(metric_name) for k in metrics.keys())

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -1862,27 +1862,20 @@ def test_is_metrics_value_loggable():
 
 
 def test_log_post_training_metrics_configuration():
-    mlflow.sklearn.autolog(log_post_training_metrics=True)
+    from sklearn.linear_model import LogisticRegression
 
-    model = sklearn.linear_model.LogisticRegression()
     X, y = get_iris()
-
-    with mlflow.start_run() as run:
-        model.fit(X, y)
-        y_pred = model.predict(X)
-        sklearn.metrics.r2_score(y, y_pred)
-
-    metrics = get_run_data(run.info.run_id)[1]
+    model = LogisticRegression()
     metric_name = sklearn.metrics.r2_score.__name__
-    assert any(k.startswith(metric_name) for k in metrics.keys())
 
-    # Ensure post-traning metrics autologging can be toggled off
-    mlflow.sklearn.autolog(log_post_training_metrics=False)
+    # Ensure post-traning metrics autologging can be toggled on / off
+    for log_post_training_metrics in [True, False, True]:
+        mlflow.sklearn.autolog(log_post_training_metrics=log_post_training_metrics)
 
-    with mlflow.start_run() as run:
-        model.fit(X, y)
-        y_pred = model.predict(X)
-        sklearn.metrics.r2_score(y, y_pred)
+        with mlflow.start_run() as run:
+            model.fit(X, y)
+            y_pred = model.predict(X)
+            sklearn.metrics.r2_score(y, y_pred)
 
-    metrics = get_run_data(run.info.run_id)[1]
-    assert all(not k.startswith(metric_name) for k in metrics.keys())
+        metrics = get_run_data(run.info.run_id)[1]
+        assert any(k.startswith(metric_name) for k in metrics.keys()) is log_post_training_metrics

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -1861,11 +1861,12 @@ def test_is_metrics_value_loggable():
     assert not is_metric_value_loggable(np.array([1, 2]))
 
 
-def test_eval_metrics_are_not_logged_when_log_eval_metrics_is_false():
+@pytest.mark.parametrize("log_eval_metrics", [True, False])
+def test_log_eval_metrics_configuration(log_eval_metrics):
     from sklearn.metrics import r2_score
     from sklearn.linear_model import LogisticRegression
 
-    mlflow.sklearn.autolog(log_eval_metrics=False)
+    mlflow.sklearn.autolog(log_eval_metrics=log_eval_metrics)
 
     model = LogisticRegression()
     X, y = get_iris()
@@ -1876,4 +1877,4 @@ def test_eval_metrics_are_not_logged_when_log_eval_metrics_is_false():
         r2_score(y, y_pred)
 
     metrics = get_run_data(run.info.run_id)[1]
-    assert all(not k.startswith("r2_score") for k in metrics.keys())
+    assert all(not k.startswith("r2_score") for k in metrics.keys()) is log_eval_metrics

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -1859,3 +1859,21 @@ def test_is_metrics_value_loggable():
     assert not is_metric_value_loggable(np.bool(True))
     assert not is_metric_value_loggable([1, 2])
     assert not is_metric_value_loggable(np.array([1, 2]))
+
+
+def test_eval_metrics_are_not_logged_when_log_eval_metrics_is_false():
+    from sklearn.metrics import r2_score
+    from sklearn.linear_model import LogisticRegression
+
+    mlflow.sklearn.autolog(log_eval_metrics=False)
+
+    model = LogisticRegression()
+    X, y = get_iris()
+
+    with mlflow.start_run() as run:
+        model.fit(X, y)
+        y_pred = model.predict(X)
+        r2_score(y, y_pred)
+
+    metrics = get_run_data(run.info.run_id)[1]
+    assert all(not k.startswith("r2_score") for k in metrics.keys())

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -1863,18 +1863,19 @@ def test_is_metrics_value_loggable():
 
 @pytest.mark.parametrize("log_eval_metrics", [True, False])
 def test_log_eval_metrics_configuration(log_eval_metrics):
-    from sklearn.metrics import r2_score
-    from sklearn.linear_model import LogisticRegression
-
     mlflow.sklearn.autolog(log_eval_metrics=log_eval_metrics)
 
-    model = LogisticRegression()
+    model = sklearn.linear_model.LogisticRegression()
     X, y = get_iris()
 
     with mlflow.start_run() as run:
         model.fit(X, y)
         y_pred = model.predict(X)
-        r2_score(y, y_pred)
+        sklearn.metrics.r2_score(y, y_pred)
 
     metrics = get_run_data(run.info.run_id)[1]
-    assert all(not k.startswith("r2_score") for k in metrics.keys()) is log_eval_metrics
+    metric_name = sklearn.metrics.r2_score.__name__
+    if log_eval_metrics:
+        assert any(k.startswith(metric_name) for k in metrics.keys())
+    else:
+        assert all(not k.startswith(metric_name) for k in metrics.keys())

--- a/tests/spark_autologging/ml/test_pyspark_ml_autologging.py
+++ b/tests/spark_autologging/ml/test_pyspark_ml_autologging.py
@@ -760,9 +760,9 @@ def test_is_metrics_value_loggable():
     assert not is_metric_value_loggable(np.array([1, 2]))
 
 
-@pytest.mark.parametrize("log_eval_metrics", [True, False])
-def test_log_eval_metrics_configuration(log_eval_metrics, dataset_iris_binomial):
-    mlflow.pyspark.ml.autolog(log_eval_metrics=log_eval_metrics)
+@pytest.mark.parametrize("log_post_training_metrics", [True, False])
+def test_log_post_training_metrics_configuration(log_post_training_metrics, dataset_iris_binomial):
+    mlflow.pyspark.ml.autolog(log_post_training_metrics=log_post_training_metrics)
 
     estimator = LogisticRegression(maxIter=1)
     mce = MulticlassClassificationEvaluator()
@@ -774,7 +774,7 @@ def test_log_eval_metrics_configuration(log_eval_metrics, dataset_iris_binomial)
 
     metrics = get_run_data(run.info.run_id)[1]
     metric_name = mce.getMetricName()
-    if log_eval_metrics:
+    if log_post_training_metrics:
         assert any(k.startswith(metric_name) for k in metrics.keys())
     else:
         assert all(not k.startswith(metric_name) for k in metrics.keys())

--- a/tests/spark_autologging/ml/test_pyspark_ml_autologging.py
+++ b/tests/spark_autologging/ml/test_pyspark_ml_autologging.py
@@ -776,4 +776,3 @@ def test_log_post_training_metrics_configuration(dataset_iris_binomial):
 
         metrics = get_run_data(run.info.run_id)[1]
         assert any(k.startswith(metric_name) for k in metrics.keys()) is log_post_training_metrics
-

--- a/tests/spark_autologging/ml/test_pyspark_ml_autologging.py
+++ b/tests/spark_autologging/ml/test_pyspark_ml_autologging.py
@@ -761,27 +761,19 @@ def test_is_metrics_value_loggable():
 
 
 def test_log_post_training_metrics_configuration(dataset_iris_binomial):
-    mlflow.pyspark.ml.autolog(log_post_training_metrics=True)
-
     estimator = LogisticRegression(maxIter=1)
     mce = MulticlassClassificationEvaluator()
-
-    with mlflow.start_run() as run:
-        model = estimator.fit(dataset_iris_binomial)
-        pred_result = model.transform(dataset_iris_binomial)
-        mce.evaluate(pred_result)
-
-    metrics = get_run_data(run.info.run_id)[1]
     metric_name = mce.getMetricName()
-    assert any(k.startswith(metric_name) for k in metrics.keys())
 
-    # Ensure post-traning metrics autologging can be toggled off
-    mlflow.pyspark.ml.autolog(log_post_training_metrics=False)
+    # Ensure post-traning metrics autologging can be toggled on / off
+    for log_post_training_metrics in [True, False, True]:
+        mlflow.pyspark.ml.autolog(log_post_training_metrics=log_post_training_metrics)
 
-    with mlflow.start_run() as run:
-        model = estimator.fit(dataset_iris_binomial)
-        pred_result = model.transform(dataset_iris_binomial)
-        mce.evaluate(pred_result)
+        with mlflow.start_run() as run:
+            model = estimator.fit(dataset_iris_binomial)
+            pred_result = model.transform(dataset_iris_binomial)
+            mce.evaluate(pred_result)
 
-    metrics = get_run_data(run.info.run_id)[1]
-    assert all(not k.startswith(metric_name) for k in metrics.keys())
+        metrics = get_run_data(run.info.run_id)[1]
+        assert any(k.startswith(metric_name) for k in metrics.keys()) is log_post_training_metrics
+


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

Introduce `log_eval_metrics` to enable/disable evaluation metrics autologging.

## How is this patch tested?

Unit tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
