### PR TITLE
Rename `disable_prevent_infer_pip_requirements_fallback` with `allow_infer_pip_requirements_fallback`

### DIFF
--- a/tests/catboost/test_catboost_model_export.py
+++ b/tests/catboost/test_catboost_model_export.py
@@ -132,7 +132,7 @@ save_formats = SUPPORTS_DESERIALIZATION + ["python", "cpp", "pmml"]
 
 
 @pytest.mark.large
-@pytest.mark.disable_prevent_infer_pip_requirements_fallback
+@pytest.mark.allow_infer_pip_requirements_fallback
 @pytest.mark.parametrize("save_format", save_formats)
 def test_log_model_logs_save_format(reg_model, save_format):
     with mlflow.start_run():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,7 +80,7 @@ def _called_in_save_model():
 def prevent_infer_pip_requirements_fallback(request):
     """
     Prevents `mlflow.models.infer_pip_requirements` from falling back in `mlflow.*.save_model`
-    unless explicitly disabled via `pytest.mark.disable_prevent_infer_pip_requirements_fallback`.
+    unless explicitly disabled via `pytest.mark.allow_infer_pip_requirements_fallback`.
     """
     from mlflow.utils.environment import _INFER_PIP_REQUIREMENTS_FALLBACK_MESSAGE
 
@@ -91,7 +91,7 @@ def prevent_infer_pip_requirements_fallback(request):
                 "`mlflow.*.save_model` during test"
             )
 
-    if "disable_prevent_infer_pip_requirements_fallback" not in request.keywords:
+    if "allow_infer_pip_requirements_fallback" not in request.keywords:
         with mock.patch("mlflow.utils.environment._logger.exception", new=new_exception):
             yield
     else:

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -397,8 +397,8 @@ def _is_importable(module_name):
         return False
 
 
-def disable_prevent_infer_pip_requirements_fallback_if(condition):
+def allow_infer_pip_requirements_fallback_if(condition):
     def decorator(f):
-        return pytest.mark.disable_prevent_infer_pip_requirements_fallback(f) if condition else f
+        return pytest.mark.allow_infer_pip_requirements_fallback(f) if condition else f
 
     return decorator

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -170,7 +170,7 @@ def keras_custom_env(tmpdir):
     return conda_env
 
 
-@pytest.mark.disable_prevent_infer_pip_requirements_fallback
+@pytest.mark.allow_infer_pip_requirements_fallback
 def test_that_keras_module_arg_works(model_path):
     class MyModel(object):
         def __init__(self, x):
@@ -333,7 +333,7 @@ def test_custom_model_save_load(custom_model, custom_layer, data, custom_predict
     np.allclose(np.array(spark_udf_preds), custom_predicted.reshape(len(spark_udf_preds)))
 
 
-@pytest.mark.disable_prevent_infer_pip_requirements_fallback
+@pytest.mark.allow_infer_pip_requirements_fallback
 def test_custom_model_save_respects_user_custom_objects(custom_model, custom_layer, model_path):
     class DifferentCustomLayer:
         def __init__(self):
@@ -592,7 +592,7 @@ def test_model_load_succeeds_with_missing_data_key_when_data_exists_at_default_p
     assert all(model_loaded.predict(data[0].values) == tf_keras_model.predict(data[0].values))
 
 
-@pytest.mark.disable_prevent_infer_pip_requirements_fallback
+@pytest.mark.allow_infer_pip_requirements_fallback
 def test_save_model_with_tf_save_format(model_path):
     """Ensures that Keras models can be saved with SavedModel format.
 

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -116,7 +116,7 @@ def test_predict_with_old_mlflow_in_conda_and_with_orient_records(iris_data):
 
 
 @pytest.mark.large
-@pytest.mark.disable_prevent_infer_pip_requirements_fallback
+@pytest.mark.allow_infer_pip_requirements_fallback
 def test_mlflow_is_not_installed_unless_specified():
     if no_conda:
         pytest.skip("This test requires conda.")

--- a/tests/spacy/test_spacy_model_export.py
+++ b/tests/spacy/test_spacy_model_export.py
@@ -27,7 +27,7 @@ from tests.helper_functions import (
     _compare_conda_env_requirements,
     _assert_pip_requirements,
     _is_available_on_pypi,
-    disable_prevent_infer_pip_requirements_fallback_if,
+    allow_infer_pip_requirements_fallback_if,
 )
 
 EXTRA_PYFUNC_SERVING_TEST_ARGS = [] if _is_available_on_pypi("spacy") else ["--no-conda"]
@@ -371,9 +371,7 @@ def test_model_log_with_pyfunc_flavor(spacy_model_with_data):
 @pytest.mark.large
 # In this test, `infer_pip_requirements` fails to load a spacy model for spacy < 3.0.0 due to:
 # https://github.com/explosion/spaCy/issues/4658
-@disable_prevent_infer_pip_requirements_fallback_if(
-    not IS_SPACY_VERSION_NEWER_THAN_OR_EQUAL_TO_3_0_0
-)
+@allow_infer_pip_requirements_fallback_if(not IS_SPACY_VERSION_NEWER_THAN_OR_EQUAL_TO_3_0_0)
 def test_model_log_without_pyfunc_flavor():
     artifact_path = "model"
     nlp = spacy.blank("en")

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -364,7 +364,7 @@ def test_log_batch(mlflow_client, backend_store_uri):
     assert metric.step == 3
 
 
-@pytest.mark.disable_prevent_infer_pip_requirements_fallback
+@pytest.mark.allow_infer_pip_requirements_fallback
 def test_log_model(mlflow_client, backend_store_uri):
     experiment_id = mlflow_client.create_experiment("Log models")
     with TempDir(chdr=True):


### PR DESCRIPTION
## What changes are proposed in this pull request?

- A follow-up for #4518
- Rename `disable_prevent_infer_pip_requirements_fallback` to `allow_infer_pip_requirements_fallback` to avoid using double negative and make it easier to understand.

## How is this patch tested?

Existing checks

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
