### PR TITLE
Fix keras early stopping logging logic

### DIFF
--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -752,8 +752,7 @@ def autolog(
         stopped_epoch, restore_best_weights, _ = callback_attrs
         metrics_logger.record_metrics({"stopped_epoch": stopped_epoch})
 
-        restored_best_weights = restore_best_weights and callback.best_weights is not None
-        if not restored_best_weights:
+        if not restore_best_weights or callback.best_weights is None:
             return
 
         monitored_metric = history.history.get(callback.monitor)

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -748,11 +748,11 @@ def autolog(
         if not restored_best_weights:
             return
 
-        restored_epoch = 0 if stopped_epoch == 0 else stopped_epoch - max(1, patience)
+        restored_epoch = history.history[callback.monitor].index(callback.best)
         metrics_logger.record_metrics({"restored_epoch": restored_epoch})
         restored_index = history.epoch.index(restored_epoch)
         restored_metrics = {
-            key: history.history[key][restored_index] for key in history.history.keys()
+            key: metrics[restored_index] for key, metrics in history.history.items()
         }
         # Checking that a metric history exists
         metric_key = next(iter(history.history), None)

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -784,7 +784,7 @@ def autolog(
         metric_key = next(iter(history.history), None)
         if metric_key is not None:
             last_epoch = len(history.history[metric_key])
-            metrics_logger.record_metrics(restored_metrics, last_epoch)
+            metrics_logger.record_metrics(restored_metrics, initial_epoch + last_epoch)
 
     def _run_and_log_function(self, original, args, kwargs, unlogged_params, callback_arg_index):
         log_fn_args_as_params(original, args, kwargs, unlogged_params)

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -761,9 +761,10 @@ def autolog(
             return
 
         initial_epoch = history.epoch[0]
-        # If `monitored_metric` contains multiple best values, the epoch corresponding to the first
-        # occurrence is the best epoch. In keras > 2.6.0, the best epoch can be obtained via
-        # `callback.best_epoch`: https://github.com/keras-team/keras/pull/15197
+        # If `monitored_metric` contains multiple best values (e.g. [0.1, 0.1, 0.2] where 0.1 is
+        # the minimum loss), the epoch corresponding to the first occurrence of the best value is
+        # the best epoch. In keras > 2.6.0, the best epoch can be obtained via the `best_epoch`
+        # attribute of an `EarlyStopping` instance: https://github.com/keras-team/keras/pull/15197
         restored_epoch = initial_epoch + monitored_metric.index(callback.best)
         metrics_logger.record_metrics({"restored_epoch": restored_epoch})
         restored_index = history.epoch.index(restored_epoch)

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -739,10 +739,10 @@ def autolog(
             if callback_attrs is None:
                 return
             stopped_epoch, restore_best_weights, patience = callback_attrs
-            metrics_logger.record_metrics({"stopped_epoch": stopped_epoch})
             # Weights are restored only if early stopping occurs
-            if stopped_epoch != 0 and restore_best_weights:
-                restored_epoch = stopped_epoch - max(1, patience)
+            if callback.model.stop_training:
+                metrics_logger.record_metrics({"stopped_epoch": stopped_epoch})
+                restored_epoch = 0 if stopped_epoch == 0 else stopped_epoch - max(1, patience)
                 metrics_logger.record_metrics({"restored_epoch": restored_epoch})
                 restored_index = history.epoch.index(restored_epoch)
                 restored_metrics = {

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -756,25 +756,15 @@ def autolog(
         if not restored_best_weights:
             return
 
-        monitored_metrics = history.history.get(callback.monitor)
-        if not monitored_metrics:
+        monitored_metric = history.history.get(callback.monitor)
+        if not monitored_metric:
             return
 
         initial_epoch = history.epoch[0]
-        # Example
-        # -------
-        # history.history = {
-        #   "loss": [
-        #     0.3,
-        #     0.2,  # The best epoch. `monitored_metrics.index(callback.best)` returns this
-        #     0.25,
-        #     0.2,  # Not the best epoch because the loss didn't improve from the best value (0.2)
-        #   ]
-        # }
-        #
-        # In keras > 2.6.0, the best epoch can be obtained via `callback.best_epoch`:
-        # https://github.com/keras-team/keras/pull/15197
-        restored_epoch = initial_epoch + monitored_metrics.index(callback.best)
+        # If `monitored_metric` contains multiple best values, the epoch corresponding to the first
+        # occurrence is the best epoch. In keras > 2.6.0, the best epoch can be obtained via
+        # `callback.best_epoch`: https://github.com/keras-team/keras/pull/15197
+        restored_epoch = initial_epoch + monitored_metric.index(callback.best)
         metrics_logger.record_metrics({"restored_epoch": restored_epoch})
         restored_index = history.epoch.index(restored_epoch)
         restored_metrics = {

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -756,7 +756,8 @@ def autolog(
         if not restored_best_weights:
             return
 
-        restored_epoch = history.history[callback.monitor].index(callback.best)
+        initial_epoch = history.epoch[0]
+        restored_epoch = initial_epoch + history.history[callback.monitor].index(callback.best)
         metrics_logger.record_metrics({"restored_epoch": restored_epoch})
         restored_index = history.epoch.index(restored_epoch)
         restored_metrics = {

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -773,8 +773,7 @@ def autolog(
         # Checking that a metric history exists
         metric_key = next(iter(history.history), None)
         if metric_key is not None:
-            last_epoch = len(history.history[metric_key])
-            metrics_logger.record_metrics(restored_metrics, initial_epoch + last_epoch)
+            metrics_logger.record_metrics(restored_metrics, stopped_epoch + 1)
 
     def _run_and_log_function(self, original, args, kwargs, unlogged_params, callback_arg_index):
         log_fn_args_as_params(original, args, kwargs, unlogged_params)

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -772,6 +772,8 @@ def autolog(
         #   ]
         # }
         #
+        # In keras > 2.6.0, the best epoch can be obtained via `callback.best_epoch`:
+        # https://github.com/keras-team/keras/pull/15197
         restored_epoch = initial_epoch + monitored_metrics.index(callback.best)
         metrics_logger.record_metrics({"restored_epoch": restored_epoch})
         restored_index = history.epoch.index(restored_epoch)

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -1070,9 +1070,10 @@ def autolog(
             return
 
         initial_epoch = history.epoch[0]
-        # If `monitored_metric` contains multiple best values, the epoch corresponding to the first
-        # occurrence is the best epoch. In keras > 2.6.0, the best epoch can be obtained via
-        # `callback.best_epoch`: https://github.com/keras-team/keras/pull/15197
+        # If `monitored_metric` contains multiple best values (e.g. [0.1, 0.1, 0.2] where 0.1 is
+        # the minimum loss), the epoch corresponding to the first occurrence of the best value is
+        # the best epoch. In keras > 2.6.0, the best epoch can be obtained via the `best_epoch`
+        # attribute of an `EarlyStopping` instance: https://github.com/keras-team/keras/pull/15197
         restored_epoch = initial_epoch + monitored_metrics.index(callback.best)
         metrics_logger.record_metrics({"restored_epoch": restored_epoch})
         restored_index = history.epoch.index(restored_epoch)

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -1101,7 +1101,7 @@ def autolog(
         if metric_key is not None:
             last_epoch = len(history.history[metric_key])
             print(restored_metrics, last_epoch)
-            metrics_logger.record_metrics(restored_metrics, last_epoch)
+            metrics_logger.record_metrics(restored_metrics, initial_epoch + last_epoch)
             metrics_logger.flush()
 
     class FitPatch(PatchFunction):

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -1084,9 +1084,7 @@ def autolog(
         # Checking that a metric history exists
         metric_key = next(iter(history.history), None)
         if metric_key is not None:
-            last_epoch = len(history.history[metric_key])
-            metrics_logger.record_metrics(restored_metrics, initial_epoch + last_epoch)
-            metrics_logger.flush()
+            metrics_logger.record_metrics(restored_metrics, stopped_epoch + 1)
 
     class FitPatch(PatchFunction):
         def __init__(self):

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -1050,39 +1050,50 @@ def autolog(
         except Exception:  # pylint: disable=W0703
             return None
 
-    def _log_early_stop_callback_metrics(callback, history, expected_last_epoch, metrics_logger):
-        if callback:
-            callback_attrs = _get_early_stop_callback_attrs(callback)
-            if callback_attrs is None:
-                return
-            stopped_epoch, restore_best_weights, patience = callback_attrs
-            metrics_logger.record_metrics({"stopped_epoch": stopped_epoch})
+    def _log_early_stop_callback_metrics(callback, history, metrics_logger):
+        if callback is None or not callback.model.stop_training:
+            return
 
-            # Only log restored model metrics if early stopping occurs, as determined by the
-            # the value of `stopped_epoch`. `stopped_epoch` is non-zero if early stopping has
-            # occurred, except in the case where training was early stopped after the first epoch
-            # due to a configured patience value of zero
-            if (
-                (stopped_epoch > 0) or (patience == 0 and expected_last_epoch > 0)
-            ) and restore_best_weights:
-                restored_epoch = stopped_epoch - patience
-                metrics_logger.record_metrics({"restored_epoch": restored_epoch})
-                restored_index = history.epoch.index(restored_epoch)
+        callback_attrs = _get_early_stop_callback_attrs(callback)
+        if callback_attrs is None:
+            return
 
-                restored_metrics = {
-                    key: history.history[key][restored_index] for key in history.history.keys()
-                }
-                # Metrics are logged as 'epoch_loss' and 'epoch_acc' in TF 1.X
-                if Version(tensorflow.__version__) < Version("2.0.0"):
-                    if "loss" in restored_metrics:
-                        restored_metrics["epoch_loss"] = restored_metrics.pop("loss")
-                    if "acc" in restored_metrics:
-                        restored_metrics["epoch_acc"] = restored_metrics.pop("acc")
-                # Checking that a metric history exists
-                metric_key = next(iter(history.history), None)
-                if metric_key is not None:
-                    last_epoch = len(history.history[metric_key])
-                    metrics_logger.record_metrics(restored_metrics, last_epoch)
+        stopped_epoch, restore_best_weights, _ = callback_attrs
+        metrics_logger.record_metrics({"stopped_epoch": stopped_epoch})
+
+        restored_best_weights = restore_best_weights and callback.best_weights is not None
+        if not restored_best_weights:
+            return
+
+        monitored_metrics = history.history.get(callback.monitor)
+        if not monitored_metrics:
+            return
+
+        initial_epoch = history.epoch[0]
+        # Example
+        # -------
+        # history.history = {
+        #   "loss": [
+        #     0.3,
+        #     0.2,  # The best epoch. `monitored_metrics.index(callback.best)` returns this
+        #     0.25,
+        #     0.2,  # Not the best epoch because the loss didn't improve from the best value (0.2)
+        #   ]
+        # }
+        #
+        # In keras > 2.6.0, the best epoch can be obtained via `callback.best_epoch`:
+        # https://github.com/keras-team/keras/pull/15197
+        restored_epoch = initial_epoch + monitored_metrics.index(callback.best)
+        metrics_logger.record_metrics({"restored_epoch": restored_epoch})
+        restored_index = history.epoch.index(restored_epoch)
+        restored_metrics = {
+            key: metrics[restored_index] for key, metrics in history.history.items()
+        }
+        # Checking that a metric history exists
+        metric_key = next(iter(history.history), None)
+        if metric_key is not None:
+            last_epoch = len(history.history[metric_key])
+            metrics_logger.record_metrics(restored_metrics, last_epoch)
 
     class FitPatch(PatchFunction):
         def __init__(self):

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -1070,19 +1070,9 @@ def autolog(
             return
 
         initial_epoch = history.epoch[0]
-        # Example
-        # -------
-        # history.history = {
-        #   "loss": [
-        #     0.3,
-        #     0.2,  # The best epoch. `monitored_metrics.index(callback.best)` returns this
-        #     0.25,
-        #     0.2,  # Not the best epoch because the loss didn't improve from the best value (0.2)
-        #   ]
-        # }
-        #
-        # In keras > 2.6.0, the best epoch can be obtained via `callback.best_epoch`:
-        # https://github.com/keras-team/keras/pull/15197
+        # If `monitored_metric` contains multiple best values, the epoch corresponding to the first
+        # occurrence is the best epoch. In keras > 2.6.0, the best epoch can be obtained via
+        # `callback.best_epoch`: https://github.com/keras-team/keras/pull/15197
         restored_epoch = initial_epoch + monitored_metrics.index(callback.best)
         metrics_logger.record_metrics({"restored_epoch": restored_epoch})
         restored_index = history.epoch.index(restored_epoch)

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -1138,11 +1138,9 @@ def autolog(
 
                 history = original(inst, *args, **kwargs)
 
-                epochs = args[3] if len(args) >= 4 else kwargs.get("epochs", 0)
                 _log_early_stop_callback_metrics(
                     callback=early_stop_callback,
                     history=history,
-                    expected_last_epoch=epochs,
                     metrics_logger=metrics_logger,
                 )
 

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -1139,9 +1139,7 @@ def autolog(
                 history = original(inst, *args, **kwargs)
 
                 _log_early_stop_callback_metrics(
-                    callback=early_stop_callback,
-                    history=history,
-                    metrics_logger=metrics_logger,
+                    callback=early_stop_callback, history=history, metrics_logger=metrics_logger,
                 )
 
             _flush_queue()

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -1061,6 +1061,11 @@ def autolog(
         stopped_epoch, restore_best_weights, _ = callback_attrs
         metrics_logger.record_metrics({"stopped_epoch": stopped_epoch})
 
+        print("=" * 80)
+        print(stopped_epoch)
+        print(history.epoch)
+        print(history.history)
+
         restored_best_weights = restore_best_weights and callback.best_weights is not None
         if not restored_best_weights:
             return

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -1077,11 +1077,15 @@ def autolog(
         restored_epoch = initial_epoch + monitored_metrics.index(callback.best)
         metrics_logger.record_metrics({"restored_epoch": restored_epoch})
         restored_index = history.epoch.index(restored_epoch)
-        # Metrics are logged as 'epoch_<metric_name>' in TF 1.X
-        prefix = "epoch_" if Version(tensorflow.__version__) < Version("2.0.0") else ""
         restored_metrics = {
-            prefix + key: metrics[restored_index] for key, metrics in history.history.items()
+            key: metrics[restored_index] for key, metrics in history.history.items()
         }
+        # Metrics are logged as 'epoch_loss' and 'epoch_acc' in TF 1.X
+        if Version(tensorflow.__version__) < Version("2.0.0"):
+            if "loss" in restored_metrics:
+                restored_metrics["epoch_loss"] = restored_metrics.pop("loss")
+            if "acc" in restored_metrics:
+                restored_metrics["epoch_acc"] = restored_metrics.pop("acc")
         # Checking that a metric history exists
         metric_key = next(iter(history.history), None)
         if metric_key is not None:

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -1061,12 +1061,11 @@ def autolog(
         stopped_epoch, restore_best_weights, _ = callback_attrs
         metrics_logger.record_metrics({"stopped_epoch": stopped_epoch})
 
-        restored_best_weights = restore_best_weights and callback.best_weights is not None
-        if not restored_best_weights:
+        if not restore_best_weights or callback.best_weights is None:
             return
 
-        monitored_metrics = history.history.get(callback.monitor)
-        if not monitored_metrics:
+        monitored_metric = history.history.get(callback.monitor)
+        if not monitored_metric:
             return
 
         initial_epoch = history.epoch[0]
@@ -1074,7 +1073,7 @@ def autolog(
         # the minimum loss), the epoch corresponding to the first occurrence of the best value is
         # the best epoch. In keras > 2.6.0, the best epoch can be obtained via the `best_epoch`
         # attribute of an `EarlyStopping` instance: https://github.com/keras-team/keras/pull/15197
-        restored_epoch = initial_epoch + monitored_metrics.index(callback.best)
+        restored_epoch = initial_epoch + monitored_metric.index(callback.best)
         metrics_logger.record_metrics({"restored_epoch": restored_epoch})
         restored_index = history.epoch.index(restored_epoch)
         restored_metrics = {

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -1102,6 +1102,7 @@ def autolog(
             last_epoch = len(history.history[metric_key])
             print(restored_metrics, last_epoch)
             metrics_logger.record_metrics(restored_metrics, last_epoch)
+            metrics_logger.flush()
 
     class FitPatch(PatchFunction):
         def __init__(self):

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -1097,8 +1097,10 @@ def autolog(
         }
         # Checking that a metric history exists
         metric_key = next(iter(history.history), None)
+        print(metric_key)
         if metric_key is not None:
             last_epoch = len(history.history[metric_key])
+            print(restored_metrics, last_epoch)
             metrics_logger.record_metrics(restored_metrics, last_epoch)
 
     class FitPatch(PatchFunction):

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -1061,12 +1061,6 @@ def autolog(
         stopped_epoch, restore_best_weights, _ = callback_attrs
         metrics_logger.record_metrics({"stopped_epoch": stopped_epoch})
 
-        print("=" * 80)
-        print(callback.best, callback.monitor)
-        print(stopped_epoch)
-        print(history.epoch)
-        print(history.history)
-
         restored_best_weights = restore_best_weights and callback.best_weights is not None
         if not restored_best_weights:
             return
@@ -1092,15 +1086,15 @@ def autolog(
         restored_epoch = initial_epoch + monitored_metrics.index(callback.best)
         metrics_logger.record_metrics({"restored_epoch": restored_epoch})
         restored_index = history.epoch.index(restored_epoch)
+        # Metrics are logged as 'epoch_<metric_name>' in TF 1.X
+        prefix = "epoch_" if Version(tensorflow.__version__) < Version("2.0.0") else ""
         restored_metrics = {
-            key: metrics[restored_index] for key, metrics in history.history.items()
+            prefix + key: metrics[restored_index] for key, metrics in history.history.items()
         }
         # Checking that a metric history exists
         metric_key = next(iter(history.history), None)
-        print(metric_key)
         if metric_key is not None:
             last_epoch = len(history.history[metric_key])
-            print(restored_metrics, last_epoch)
             metrics_logger.record_metrics(restored_metrics, initial_epoch + last_epoch)
             metrics_logger.flush()
 

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -1062,6 +1062,7 @@ def autolog(
         metrics_logger.record_metrics({"stopped_epoch": stopped_epoch})
 
         print("=" * 80)
+        print(callback.best, callback.monitor)
         print(stopped_epoch)
         print(history.epoch)
         print(history.history)

--- a/tests/keras_autolog/test_keras_autolog.py
+++ b/tests/keras_autolog/test_keras_autolog.py
@@ -249,7 +249,7 @@ def test_keras_autolog_early_stop_logs(keras_random_data_run_with_callback, init
     # Check that MLflow has logged the correct steps
     assert steps == [*history.epoch, callback.stopped_epoch + 1]
     # Check that MLflow has logged the correct metric values
-    assert values == [*loss, callback.best]
+    np.testing.assert_allclose(values, [*loss, callback.best])
 
 
 @pytest.mark.large

--- a/tests/keras_autolog/test_keras_autolog.py
+++ b/tests/keras_autolog/test_keras_autolog.py
@@ -236,6 +236,8 @@ def test_keras_autolog_early_stop_logs(keras_random_data_run_with_callback, init
     assert "stopped_epoch" in metrics
     assert "restored_epoch" in metrics
     restored_epoch = int(metrics["restored_epoch"])
+    # In this test, the best epoch is always the first epoch because the early stopping callback
+    # never observes a loss improvement due to an extremely large `min_delta` value
     assert restored_epoch == initial_epoch
     assert "loss" in history.history
     client = mlflow.tracking.MlflowClient()

--- a/tests/keras_autolog/test_keras_autolog.py
+++ b/tests/keras_autolog/test_keras_autolog.py
@@ -355,8 +355,7 @@ def test_keras_autolog_early_stop_no_stop_does_not_log(keras_random_data_run_wit
     assert params["monitor"] == "loss"
     assert "verbose" not in params
     assert "mode" not in params
-    assert "stopped_epoch" in metrics
-    assert metrics["stopped_epoch"] == 0
+    assert "stopped_epoch" not in metrics
     assert "restored_epoch" not in metrics
     assert "loss" in history.history
     num_of_epochs = len(history.history["loss"])
@@ -417,33 +416,3 @@ def test_keras_autolog_non_early_stop_callback_does_not_log(keras_random_data_ru
     # Check the test epoch numbers are correct
     assert num_of_epochs == 10
     assert len(metric_history) == num_of_epochs
-
-
-def test_stopped_epoch_is_not_logged_when_training_did_not_early_stop():
-    mlflow.keras.autolog()
-
-    model = create_model()
-    patience = 10
-    early_stopping_callback = keras.callbacks.EarlyStopping(
-        monitor="loss", patience=patience, restore_best_weights=True, verbose=1
-    )
-
-    size = 10
-    num_classes = 3
-    X = np.random.random((size, 4))
-    y = np.random.randint(0, num_classes, size)
-    y = np.eye(num_classes)[y]
-
-    with mlflow.start_run() as run:
-        model.fit(
-            X,
-            y,
-            callbacks=[early_stopping_callback],
-            # Set `epochs` to `patience + 1` to avoid early stopping
-            epochs=patience + 1,
-        )
-        assert not model.stop_training
-
-    run = mlflow.tracking.MlflowClient().get_run(run.info.run_id)
-    assert "stopped_epoch" not in run.data.metrics
-    assert "restored_epoch" not in run.data.metrics

--- a/tests/keras_autolog/test_keras_autolog.py
+++ b/tests/keras_autolog/test_keras_autolog.py
@@ -247,7 +247,7 @@ def test_keras_autolog_early_stop_logs(keras_random_data_run_with_callback, init
     assert len(metric_history) == len(loss) + 1
     steps, values = map(list, zip(*[(m.step, m.value) for m in metric_history]))
     # Check that MLflow has logged the correct steps
-    assert steps == [initial_epoch + i for i in range(len(loss) + 1)]
+    assert steps == [*history.epoch, callback.stopped_epoch + 1]
     # Check that MLflow has logged the correct metric values
     assert values == [*loss, callback.best]
 

--- a/tests/keras_autolog/test_keras_autolog.py
+++ b/tests/keras_autolog/test_keras_autolog.py
@@ -223,7 +223,7 @@ patience_values = [1, 5] if keras_version == "2.6.0" else [0, 1, 5]
 @pytest.mark.parametrize("callback", ["early"])
 @pytest.mark.parametrize("patience", patience_values)
 @pytest.mark.parametrize("initial_epoch", [0, 10])
-def test_keras_autolog_early_stop_logs(keras_random_data_run_with_callback):
+def test_keras_autolog_early_stop_logs(keras_random_data_run_with_callback, initial_epoch):
     run, history, callback = keras_random_data_run_with_callback
     metrics = run.data.metrics
     params = run.data.params
@@ -236,17 +236,16 @@ def test_keras_autolog_early_stop_logs(keras_random_data_run_with_callback):
     assert "stopped_epoch" in metrics
     assert "restored_epoch" in metrics
     restored_epoch = int(metrics["restored_epoch"])
-    assert int(metrics["stopped_epoch"]) - max(1, callback.patience) == restored_epoch
+    assert restored_epoch == initial_epoch
     assert "loss" in history.history
-    num_of_epochs = len(history.history["loss"])
     client = mlflow.tracking.MlflowClient()
     metric_history = client.get_metric_history(run.info.run_id, "loss")
-    # Check the test epoch numbers are correct
-    assert num_of_epochs == max(1, callback.patience) + 1
-    # Check that MLflow has logged the metrics of the "best" model
-    assert len(metric_history) == num_of_epochs + 1
+    # Check that MLflow has logged the metrics of the "best" model, in addition to per-epoch metrics
+    loss = history.history["loss"]
+    assert len(metric_history) == len(loss) + 1
+    assert [m.step for m in metric_history] == [initial_epoch + i for i in range(len(loss) + 1)]
     # Check that MLflow has logged the correct data
-    assert history.history["loss"][history.epoch.index(restored_epoch)] == metric_history[-1].value
+    assert metric_history[-1].value == loss[history.epoch.index(restored_epoch)]
 
 
 @pytest.mark.large

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -360,7 +360,7 @@ def test_tf_keras_autolog_batch_metrics_logger_logs_expected_metrics(
         assert metric_name in patched_metrics_data
 
     restored_epoch = int(patched_metrics_data["restored_epoch"])
-    assert int(patched_metrics_data["stopped_epoch"]) - callback.patience == restored_epoch
+    assert restored_epoch == initial_epoch
 
 
 @pytest.mark.large

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -307,6 +307,8 @@ def test_tf_keras_autolog_early_stop_logs(tf_keras_random_data_run_with_callback
     assert "stopped_epoch" in metrics
     assert "restored_epoch" in metrics
     restored_epoch = int(metrics["restored_epoch"])
+    # In this test, the best epoch is always the first epoch because the early stopping callback
+    # never observes a loss improvement due to an extremely large `min_delta` value
     assert restored_epoch == initial_epoch
     assert "loss" in history.history
     client = mlflow.tracking.MlflowClient()

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -320,7 +320,7 @@ def test_tf_keras_autolog_early_stop_logs(tf_keras_random_data_run_with_callback
     # Check that MLflow has logged the correct steps
     assert steps == [*history.epoch, callback.stopped_epoch + 1]
     # Check that MLflow has logged the correct metric values
-    assert values == [*loss, callback.best]
+    np.testing.assert_allclose(values, [*loss, callback.best])
 
 
 @pytest.mark.large

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -318,7 +318,7 @@ def test_tf_keras_autolog_early_stop_logs(tf_keras_random_data_run_with_callback
     assert len(metric_history) == len(loss) + 1
     steps, values = map(list, zip(*[(m.step, m.value) for m in metric_history]))
     # Check that MLflow has logged the correct steps
-    assert steps == [initial_epoch + i for i in range(len(loss) + 1)]
+    assert steps == [*history.epoch, callback.stopped_epoch + 1]
     # Check that MLflow has logged the correct metric values
     assert values == [*loss, callback.best]
 

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -374,8 +374,7 @@ def test_tf_keras_autolog_early_stop_no_stop_does_not_log(tf_keras_random_data_r
     assert params["monitor"] == "loss"
     assert "verbose" not in params
     assert "mode" not in params
-    assert "stopped_epoch" in metrics
-    assert metrics["stopped_epoch"] == 0
+    assert "stopped_epoch" not in metrics
     assert "restored_epoch" not in metrics
     assert "loss" in history.history
     num_of_epochs = len(history.history["loss"])

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -316,9 +316,11 @@ def test_tf_keras_autolog_early_stop_logs(tf_keras_random_data_run_with_callback
     # Check that MLflow has logged the metrics of the "best" model, in addition to per-epoch metrics
     loss = history.history["loss"]
     assert len(metric_history) == len(loss) + 1
-    assert [m.step for m in metric_history] == [initial_epoch + i for i in range(len(loss) + 1)]
-    # Check that MLflow has logged the correct data
-    assert metric_history[-1].value == loss[history.epoch.index(restored_epoch)]
+    steps, values = map(list, zip(*[(m.step, m.value) for m in metric_history]))
+    # Check that MLflow has logged the correct steps
+    assert steps == [initial_epoch + i for i in range(len(loss) + 1)]
+    # Check that MLflow has logged the correct metric values
+    assert values == [*loss, callback.best]
 
 
 @pytest.mark.large

--- a/tests/tensorflow_autolog/test_tensorflow_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow_autolog.py
@@ -236,6 +236,8 @@ def test_tf_keras_autolog_early_stop_logs(tf_keras_random_data_run_with_callback
     assert "restored_epoch" in metrics
     assert "epoch_loss" in metrics
     restored_epoch = int(metrics["restored_epoch"])
+    # In this test, the best epoch is always the first epoch because the early stopping callback
+    # never observes a loss improvement due to an extremely large `min_delta` value
     assert restored_epoch == initial_epoch
     assert "loss" in history.history
     client = mlflow.tracking.MlflowClient()

--- a/tests/tensorflow_autolog/test_tensorflow_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow_autolog.py
@@ -250,7 +250,7 @@ def test_tf_keras_autolog_early_stop_logs(tf_keras_random_data_run_with_callback
     # Check that MLflow has logged the correct steps
     assert steps == [*history.epoch, callback.stopped_epoch + 1]
     # Check that MLflow has logged the correct metric values
-    assert values == [*loss, callback.best]
+    np.testing.assert_allclose(values, [*loss, callback.best])
 
 
 @pytest.mark.large

--- a/tests/tensorflow_autolog/test_tensorflow_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow_autolog.py
@@ -222,7 +222,7 @@ def tf_keras_random_data_run_with_callback(
 @pytest.mark.parametrize("callback", ["early"])
 @pytest.mark.parametrize("patience", [0, 1, 5])
 @pytest.mark.parametrize("initial_epoch", [0, 10])
-def test_tf_keras_autolog_early_stop_logs(tf_keras_random_data_run_with_callback):
+def test_tf_keras_autolog_early_stop_logs(tf_keras_random_data_run_with_callback, initial_epoch):
     run, history, callback = tf_keras_random_data_run_with_callback
     metrics = run.data.metrics
     params = run.data.params
@@ -236,15 +236,17 @@ def test_tf_keras_autolog_early_stop_logs(tf_keras_random_data_run_with_callback
     assert "restored_epoch" in metrics
     assert "epoch_loss" in metrics
     restored_epoch = int(metrics["restored_epoch"])
-    assert int(metrics["stopped_epoch"]) - callback.patience == restored_epoch
+    assert restored_epoch == initial_epoch
     assert "loss" in history.history
     client = mlflow.tracking.MlflowClient()
     # TF 1.X TB callback logs loss as `epoch_loss`
     metric_history = client.get_metric_history(run.info.run_id, "epoch_loss")
     # Check that MLflow has logged the metrics of the "best" model, in addition to per-epoch metrics
-    assert len(metric_history) == len(history.history["loss"]) + 1
+    loss = history.history["epoch_loss"]
+    assert len(metric_history) == len(loss) + 1
+    assert [m.step for m in metric_history] == [initial_epoch + i for i in range(len(loss) + 1)]
     # Check that MLflow has logged the correct data
-    assert history.history["loss"][history.epoch.index(restored_epoch)] == metric_history[-1].value
+    assert metric_history[-1].value == loss[history.epoch.index(restored_epoch)]
 
 
 @pytest.mark.large

--- a/tests/tensorflow_autolog/test_tensorflow_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow_autolog.py
@@ -248,7 +248,7 @@ def test_tf_keras_autolog_early_stop_logs(tf_keras_random_data_run_with_callback
     assert len(metric_history) == len(loss) + 1
     steps, values = map(list, zip(*[(m.step, m.value) for m in metric_history]))
     # Check that MLflow has logged the correct steps
-    assert steps == [initial_epoch + i for i in range(len(loss) + 1)]
+    assert steps == [*history.epoch, callback.stopped_epoch + 1]
     # Check that MLflow has logged the correct metric values
     assert values == [*loss, callback.best]
 

--- a/tests/tensorflow_autolog/test_tensorflow_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow_autolog.py
@@ -244,7 +244,7 @@ def test_tf_keras_autolog_early_stop_logs(tf_keras_random_data_run_with_callback
     # TF 1.X TB callback logs loss as `epoch_loss`
     metric_history = client.get_metric_history(run.info.run_id, "epoch_loss")
     # Check that MLflow has logged the metrics of the "best" model, in addition to per-epoch metrics
-    loss = history.history["epoch_loss"]
+    loss = history.history["loss"]
     assert len(metric_history) == len(loss) + 1
     assert [m.step for m in metric_history] == [initial_epoch + i for i in range(len(loss) + 1)]
     # Check that MLflow has logged the correct data

--- a/tests/tensorflow_autolog/test_tensorflow_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow_autolog.py
@@ -262,10 +262,9 @@ def test_tf_keras_autolog_early_stop_no_stop_does_not_log(tf_keras_random_data_r
     assert params["monitor"] == "loss"
     assert "verbose" not in params
     assert "mode" not in params
-    assert "stopped_epoch" in metrics
-    assert "epoch_loss" in metrics
-    assert metrics["stopped_epoch"] == 0
+    assert "stopped_epoch" not in metrics
     assert "restored_epoch" not in metrics
+    assert "epoch_loss" in metrics
     assert "loss" in history.history
     num_of_epochs = len(history.history["loss"])
     client = mlflow.tracking.MlflowClient()
@@ -291,8 +290,8 @@ def test_tf_keras_autolog_early_stop_no_restore_doesnt_log(tf_keras_random_data_
     assert "verbose" not in params
     assert "mode" not in params
     assert "stopped_epoch" in metrics
-    assert "epoch_loss" in metrics
     assert "restored_epoch" not in metrics
+    assert "epoch_loss" in metrics
     assert "loss" in history.history
     num_of_epochs = len(history.history["loss"])
     client = mlflow.tracking.MlflowClient()

--- a/tests/tensorflow_autolog/test_tensorflow_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow_autolog.py
@@ -246,9 +246,11 @@ def test_tf_keras_autolog_early_stop_logs(tf_keras_random_data_run_with_callback
     # Check that MLflow has logged the metrics of the "best" model, in addition to per-epoch metrics
     loss = history.history["loss"]
     assert len(metric_history) == len(loss) + 1
-    assert [m.step for m in metric_history] == [initial_epoch + i for i in range(len(loss) + 1)]
-    # Check that MLflow has logged the correct data
-    assert metric_history[-1].value == loss[history.epoch.index(restored_epoch)]
+    steps, values = map(list, zip(*[(m.step, m.value) for m in metric_history]))
+    # Check that MLflow has logged the correct steps
+    assert steps == [initial_epoch + i for i in range(len(loss) + 1)]
+    # Check that MLflow has logged the correct metric values
+    assert values == [*loss, callback.best]
 
 
 @pytest.mark.large


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

This PR fixes keras early stopping logging logic.

## How is this patch tested?

Unit tests

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Tensorflow and keras autologging don't log `stopped_epoch` when training is not early stopped.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
