### PR TITLE
Remove `fit_generator` tests in keras and tensorflow flavors

### DIFF
--- a/tests/keras_autolog/test_keras_autolog.py
+++ b/tests/keras_autolog/test_keras_autolog.py
@@ -57,8 +57,7 @@ def create_model():
 
 
 @pytest.mark.large
-@pytest.mark.parametrize("fit_variant", ["fit"])
-def test_keras_autolog_ends_auto_created_run(random_train_data, random_one_hot_labels, fit_variant):
+def test_keras_autolog_ends_auto_created_run(random_train_data, random_one_hot_labels):
     mlflow.keras.autolog()
 
     data = random_train_data
@@ -241,7 +240,7 @@ def test_keras_autolog_early_stop_logs(keras_random_data_run_with_callback):
 @pytest.mark.parametrize("patience", [0, 1, 5])
 @pytest.mark.parametrize("initial_epoch", [0, 10])
 def test_keras_autolog_batch_metrics_logger_logs_expected_metrics(
-    fit_variant, callback, restore_weights, patience, initial_epoch
+    callback, restore_weights, patience, initial_epoch
 ):
     patched_metrics_data = []
 
@@ -260,7 +259,6 @@ def test_keras_autolog_batch_metrics_logger_logs_expected_metrics(
         record_metrics_mock.side_effect = record_metrics_side_effect
         run, _, callback = keras_random_data_run_with_callback(
             random_train_data(),
-            fit_variant,
             random_one_hot_labels(),
             manual_run,
             callback,

--- a/tests/keras_autolog/test_keras_autolog.py
+++ b/tests/keras_autolog/test_keras_autolog.py
@@ -373,10 +373,13 @@ def test_keras_autolog_non_early_stop_callback_does_not_log(keras_random_data_ru
 def test_fit_generator(random_train_data, random_one_hot_labels):
     mlflow.keras.autolog()
     model = create_model()
-    generator = ((random_train_data, random_one_hot_labels) for _ in range(10))
+
+    def generator():
+        while True:
+            yield random_train_data, random_one_hot_labels
 
     with mlflow.start_run() as run:
-        model.fit_generator(generator, epochs=10, steps_per_epoch=1)
+        model.fit_generator(generator(), epochs=10, steps_per_epoch=1)
 
     run = mlflow.tracking.MlflowClient().get_run(run.info.run_id)
     params = run.data.params

--- a/tests/keras_autolog/test_keras_autolog.py
+++ b/tests/keras_autolog/test_keras_autolog.py
@@ -353,3 +353,14 @@ def test_keras_autolog_non_early_stop_callback_does_not_log(keras_random_data_ru
     # Check the test epoch numbers are correct
     assert num_of_epochs == 10
     assert len(metric_history) == num_of_epochs
+
+
+def test_fit_generator(random_train_data, random_one_hot_labels):
+    mlflow.keras.autolog()
+    model = create_model()
+
+    generator = ((random_train_data, random_one_hot_labels) for _ in range(10))
+    with mlflow.start_run() as run:
+        model.fit_generator(generator, epochs=10, steps_per_epoch=1)
+
+    run = mlflow.tracking.MlflowClient().get_run(run.info.run_id)

--- a/tests/keras_autolog/test_keras_autolog.py
+++ b/tests/keras_autolog/test_keras_autolog.py
@@ -373,8 +373,8 @@ def test_keras_autolog_non_early_stop_callback_does_not_log(keras_random_data_ru
 def test_fit_generator(random_train_data, random_one_hot_labels):
     mlflow.keras.autolog()
     model = create_model()
-
     generator = ((random_train_data, random_one_hot_labels) for _ in range(10))
+
     with mlflow.start_run() as run:
         model.fit_generator(generator, epochs=10, steps_per_epoch=1)
 
@@ -382,8 +382,8 @@ def test_fit_generator(random_train_data, random_one_hot_labels):
     params = run.data.params
     metrics = run.data.metrics
     assert "epochs" in params
-    assert params["epochs"] == 10
+    assert params["epochs"] == "10"
     assert "steps_per_epoch" in params
-    assert params["steps_per_epoch"] == 1
+    assert params["steps_per_epoch"] == "1"
     assert "acc" in metrics
     assert "loss" in metrics

--- a/tests/keras_autolog/test_keras_autolog.py
+++ b/tests/keras_autolog/test_keras_autolog.py
@@ -364,3 +364,11 @@ def test_fit_generator(random_train_data, random_one_hot_labels):
         model.fit_generator(generator, epochs=10, steps_per_epoch=1)
 
     run = mlflow.tracking.MlflowClient().get_run(run.info.run_id)
+    params = run.data.params
+    metrics = run.data.metrics
+    assert "epochs" in params
+    assert params["epochs"] == 10
+    assert "steps_per_epoch" in params
+    assert params["steps_per_epoch"] == 1
+    assert "acc" in metrics
+    assert "loss" in metrics

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -798,5 +798,5 @@ def test_fit_generator(random_train_data, random_one_hot_labels):
     assert params["epochs"] == "10"
     assert "steps_per_epoch" in params
     assert params["steps_per_epoch"] == "1"
-    assert "acc" in metrics
+    assert "accuracy" in metrics
     assert "loss" in metrics

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -792,7 +792,7 @@ def test_fit_generator(random_train_data, random_one_hot_labels):
             yield random_train_data, random_one_hot_labels
 
     with mlflow.start_run() as run:
-        model.fit_generator(generator, epochs=10, steps_per_epoch=1)
+        model.fit_generator(generator(), epochs=10, steps_per_epoch=1)
 
     run = mlflow.tracking.MlflowClient().get_run(run.info.run_id)
     params = run.data.params

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -780,3 +780,14 @@ def test_autolog_text_vec_model(tmpdir):
 
     loaded_model = mlflow.keras.load_model("runs:/" + run.info.run_id + "/model")
     np.testing.assert_array_equal(loaded_model.predict(train_samples), model.predict(train_samples))
+
+
+def test_fit_generator(random_train_data, random_one_hot_labels):
+    mlflow.keras.autolog()
+    model = create_tf_keras_model()
+
+    generator = ((random_train_data, random_one_hot_labels) for _ in range(10))
+    with mlflow.start_run() as run:
+        model.fit_generator(generator, epochs=10, steps_per_epoch=1)
+
+    run = mlflow.tracking.MlflowClient().get_run(run.info.run_id)

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -786,8 +786,8 @@ def test_autolog_text_vec_model(tmpdir):
 def test_fit_generator(random_train_data, random_one_hot_labels):
     mlflow.tensorflow.autolog()
     model = create_tf_keras_model()
-
     generator = ((random_train_data, random_one_hot_labels) for _ in range(10))
+
     with mlflow.start_run() as run:
         model.fit_generator(generator, epochs=10, steps_per_epoch=1)
 
@@ -795,8 +795,8 @@ def test_fit_generator(random_train_data, random_one_hot_labels):
     params = run.data.params
     metrics = run.data.metrics
     assert "epochs" in params
-    assert params["epochs"] == 10
+    assert params["epochs"] == "10"
     assert "steps_per_epoch" in params
-    assert params["steps_per_epoch"] == 1
+    assert params["steps_per_epoch"] == "1"
     assert "acc" in metrics
     assert "loss" in metrics

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -115,7 +115,7 @@ def test_tf_keras_autolog_persists_manually_created_run(random_train_data, rando
 
 
 @pytest.fixture
-def tf_keras_random_data_run(random_train_data, random_one_hot_labels, manual_runs, initial_epoch):
+def tf_keras_random_data_run(random_train_data, random_one_hot_labels, manual_run, initial_epoch):
     # pylint: disable=unused-argument
     mlflow.tensorflow.autolog()
 

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -466,7 +466,7 @@ def test_tf_keras_autolog_does_not_mutate_original_callbacks_list(
 
 @pytest.mark.large
 def test_tf_keras_autolog_does_not_delete_logging_directory_for_tensorboard_callback(
-    tmpdir, random_train_data, random_one_hot_labels, fit_variant
+    tmpdir, random_train_data, random_one_hot_labels
 ):
     tensorboard_callback_logging_dir_path = str(tmpdir.mkdir("tb_logs"))
     tensorboard_callback = tf.keras.callbacks.TensorBoard(
@@ -486,7 +486,7 @@ def test_tf_keras_autolog_does_not_delete_logging_directory_for_tensorboard_call
 
 @pytest.mark.large
 def test_tf_keras_autolog_logs_to_and_deletes_temporary_directory_when_tensorboard_callback_absent(
-    tmpdir, random_train_data, random_one_hot_labels, fit_variant
+    tmpdir, random_train_data, random_one_hot_labels
 ):
     from unittest import mock
     from mlflow.tensorflow import _TensorBoardLogDir

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -783,7 +783,7 @@ def test_autolog_text_vec_model(tmpdir):
 
 
 def test_fit_generator(random_train_data, random_one_hot_labels):
-    mlflow.keras.autolog()
+    mlflow.tensorflow.autolog()
     model = create_tf_keras_model()
 
     generator = ((random_train_data, random_one_hot_labels) for _ in range(10))
@@ -791,3 +791,11 @@ def test_fit_generator(random_train_data, random_one_hot_labels):
         model.fit_generator(generator, epochs=10, steps_per_epoch=1)
 
     run = mlflow.tracking.MlflowClient().get_run(run.info.run_id)
+    params = run.data.params
+    metrics = run.data.metrics
+    assert "epochs" in params
+    assert params["epochs"] == 10
+    assert "steps_per_epoch" in params
+    assert params["steps_per_epoch"] == 1
+    assert "acc" in metrics
+    assert "loss" in metrics

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -66,26 +66,14 @@ def create_tf_keras_model():
 
 
 @pytest.mark.large
-@pytest.mark.parametrize("fit_variant", ["fit", "fit_generator"])
-def test_tf_keras_autolog_ends_auto_created_run(
-    random_train_data, random_one_hot_labels, fit_variant
-):
+def test_tf_keras_autolog_ends_auto_created_run(random_train_data, random_one_hot_labels):
     mlflow.tensorflow.autolog()
 
     data = random_train_data
     labels = random_one_hot_labels
 
     model = create_tf_keras_model()
-
-    if fit_variant == "fit_generator":
-
-        def generator():
-            while True:
-                yield data, labels
-
-        model.fit_generator(generator(), epochs=10, steps_per_epoch=1)
-    else:
-        model.fit(data, labels, epochs=10)
+    model.fit(data, labels, epochs=10)
 
     assert mlflow.active_run() is None
 
@@ -113,35 +101,21 @@ def test_tf_keras_autolog_log_models_configuration(
 
 
 @pytest.mark.large
-@pytest.mark.parametrize("fit_variant", ["fit", "fit_generator"])
-def test_tf_keras_autolog_persists_manually_created_run(
-    random_train_data, random_one_hot_labels, fit_variant
-):
+def test_tf_keras_autolog_persists_manually_created_run(random_train_data, random_one_hot_labels):
     mlflow.tensorflow.autolog()
     with mlflow.start_run() as run:
         data = random_train_data
         labels = random_one_hot_labels
 
         model = create_tf_keras_model()
-
-        if fit_variant == "fit_generator":
-
-            def generator():
-                while True:
-                    yield data, labels
-
-            model.fit_generator(generator(), epochs=10, steps_per_epoch=1)
-        else:
-            model.fit(data, labels, epochs=10)
+        model.fit(data, labels, epochs=10)
 
         assert mlflow.active_run()
         assert mlflow.active_run().info.run_id == run.info.run_id
 
 
 @pytest.fixture
-def tf_keras_random_data_run(
-    random_train_data, random_one_hot_labels, manual_run, fit_variant, initial_epoch
-):
+def tf_keras_random_data_run(random_train_data, random_one_hot_labels, manual_runs, initial_epoch):
     # pylint: disable=unused-argument
     mlflow.tensorflow.autolog()
 
@@ -149,27 +123,15 @@ def tf_keras_random_data_run(
     labels = random_one_hot_labels
 
     model = create_tf_keras_model()
-
-    if fit_variant == "fit_generator":
-
-        def generator():
-            while True:
-                yield data, labels
-
-        history = model.fit_generator(
-            generator(), epochs=initial_epoch + 10, steps_per_epoch=1, initial_epoch=initial_epoch
-        )
-    else:
-        history = model.fit(
-            data, labels, epochs=initial_epoch + 10, steps_per_epoch=1, initial_epoch=initial_epoch
-        )
+    history = model.fit(
+        data, labels, epochs=initial_epoch + 10, steps_per_epoch=1, initial_epoch=initial_epoch
+    )
 
     client = mlflow.tracking.MlflowClient()
     return client.get_run(client.list_run_infos(experiment_id="0")[0].run_id), history
 
 
 @pytest.mark.large
-@pytest.mark.parametrize("fit_variant", ["fit", "fit_generator"])
 @pytest.mark.parametrize("initial_epoch", [0, 10])
 def test_tf_keras_autolog_logs_expected_data(tf_keras_random_data_run):
     run, history = tf_keras_random_data_run
@@ -272,7 +234,6 @@ def test_tf_keras_autolog_names_positional_parameters_correctly(
 
 
 @pytest.mark.large
-@pytest.mark.parametrize("fit_variant", ["fit", "fit_generator"])
 @pytest.mark.parametrize("initial_epoch", [0, 10])
 def test_tf_keras_autolog_model_can_load_from_artifact(tf_keras_random_data_run, random_train_data):
     run, _ = tf_keras_random_data_run
@@ -475,10 +436,9 @@ def test_tf_keras_autolog_non_early_stop_callback_no_log(tf_keras_random_data_ru
     assert len(metric_history) == num_of_epochs
 
 
-@pytest.mark.parametrize("fit_variant", ["fit", "fit_generator"])
 @pytest.mark.parametrize("positional", [True, False])
 def test_tf_keras_autolog_does_not_mutate_original_callbacks_list(
-    tmpdir, random_train_data, random_one_hot_labels, fit_variant, positional
+    tmpdir, random_train_data, random_one_hot_labels, positional
 ):
     """
     TensorFlow autologging passes new callbacks to the `fit()` / `fit_generator()` function. If
@@ -495,29 +455,16 @@ def test_tf_keras_autolog_does_not_mutate_original_callbacks_list(
     data = random_train_data
     labels = random_one_hot_labels
 
-    if fit_variant == "fit_generator":
-
-        def generator():
-            while True:
-                yield data, labels
-
-        if positional:
-            model.fit_generator(generator(), 1, 10, 1, callbacks)
-        else:
-            model.fit_generator(generator(), epochs=10, steps_per_epoch=1, callbacks=callbacks)
-
+    if positional:
+        model.fit(data, labels, None, 10, 1, callbacks)
     else:
-        if positional:
-            model.fit(data, labels, None, 10, 1, callbacks)
-        else:
-            model.fit(data, labels, epochs=10, callbacks=callbacks)
+        model.fit(data, labels, epochs=10, callbacks=callbacks)
 
     assert len(callbacks) == 1
     assert callbacks == [tensorboard_callback]
 
 
 @pytest.mark.large
-@pytest.mark.parametrize("fit_variant", ["fit", "fit_generator"])
 def test_tf_keras_autolog_does_not_delete_logging_directory_for_tensorboard_callback(
     tmpdir, random_train_data, random_one_hot_labels, fit_variant
 ):
@@ -532,24 +479,12 @@ def test_tf_keras_autolog_does_not_delete_logging_directory_for_tensorboard_call
     labels = random_one_hot_labels
 
     model = create_tf_keras_model()
-
-    if fit_variant == "fit_generator":
-
-        def generator():
-            while True:
-                yield data, labels
-
-        model.fit_generator(
-            generator(), epochs=10, steps_per_epoch=1, callbacks=[tensorboard_callback]
-        )
-    else:
-        model.fit(data, labels, epochs=10, callbacks=[tensorboard_callback])
+    model.fit(data, labels, epochs=10, callbacks=[tensorboard_callback])
 
     assert os.path.exists(tensorboard_callback_logging_dir_path)
 
 
 @pytest.mark.large
-@pytest.mark.parametrize("fit_variant", ["fit", "fit_generator"])
 def test_tf_keras_autolog_logs_to_and_deletes_temporary_directory_when_tensorboard_callback_absent(
     tmpdir, random_train_data, random_one_hot_labels, fit_variant
 ):
@@ -566,16 +501,7 @@ def test_tf_keras_autolog_logs_to_and_deletes_temporary_directory_when_tensorboa
         labels = random_one_hot_labels
 
         model = create_tf_keras_model()
-
-        if fit_variant == "fit_generator":
-
-            def generator():
-                while True:
-                    yield data, labels
-
-            model.fit_generator(generator(), epochs=10, steps_per_epoch=1)
-        else:
-            model.fit(data, labels, epochs=10)
+        model.fit(data, labels, epochs=10)
 
         assert not os.path.exists(mock_log_dir_inst.location)
 

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -786,7 +786,10 @@ def test_autolog_text_vec_model(tmpdir):
 def test_fit_generator(random_train_data, random_one_hot_labels):
     mlflow.tensorflow.autolog()
     model = create_tf_keras_model()
-    generator = ((random_train_data, random_one_hot_labels) for _ in range(10))
+
+    def generator():
+        while True:
+            yield random_train_data, random_one_hot_labels
 
     with mlflow.start_run() as run:
         model.fit_generator(generator, epochs=10, steps_per_epoch=1)

--- a/tests/tensorflow_autolog/test_tensorflow_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow_autolog.py
@@ -524,7 +524,10 @@ def test_duplicate_autolog_second_overrides(tf_estimator_random_data_run):
 def test_fit_generator(random_train_data, random_one_hot_labels):
     mlflow.tensorflow.autolog()
     model = create_tf_keras_model()
-    generator = ((random_train_data, random_one_hot_labels) for _ in range(10))
+
+    def generator():
+        while True:
+            yield random_train_data, random_one_hot_labels
 
     with mlflow.start_run() as run:
         model.fit_generator(generator, epochs=10, steps_per_epoch=1)

--- a/tests/tensorflow_autolog/test_tensorflow_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow_autolog.py
@@ -530,7 +530,7 @@ def test_fit_generator(random_train_data, random_one_hot_labels):
             yield random_train_data, random_one_hot_labels
 
     with mlflow.start_run() as run:
-        model.fit_generator(generator, epochs=10, steps_per_epoch=1)
+        model.fit_generator(generator(), epochs=10, steps_per_epoch=1)
 
     run = mlflow.tracking.MlflowClient().get_run(run.info.run_id)
     params = run.data.params

--- a/tests/tensorflow_autolog/test_tensorflow_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow_autolog.py
@@ -65,9 +65,7 @@ def create_tf_keras_model():
 
 
 @pytest.mark.large
-def test_tf_keras_autolog_ends_auto_created_run(
-    random_train_data, random_one_hot_labels, fit_variant
-):
+def test_tf_keras_autolog_ends_auto_created_run(random_train_data, random_one_hot_labels):
     # pylint: disable=unused-argument
     mlflow.tensorflow.autolog()
 
@@ -104,9 +102,7 @@ def test_tf_keras_autolog_log_models_configuration(
 
 
 @pytest.mark.large
-def test_tf_keras_autolog_persists_manually_created_run(
-    random_train_data, random_one_hot_labels, fit_variant
-):
+def test_tf_keras_autolog_persists_manually_created_run(random_train_data, random_one_hot_labels):
     # pylint: disable=unused-argument
     mlflow.tensorflow.autolog()
     with mlflow.start_run() as run:
@@ -353,7 +349,7 @@ def test_tf_keras_autolog_does_not_delete_logging_directory_for_tensorboard_call
 
 @pytest.mark.large
 def test_tf_keras_autolog_logs_to_and_deletes_temporary_directory_when_tensorboard_callback_absent(
-    tmpdir, random_train_data, random_one_hot_labels, fit_variant
+    tmpdir, random_train_data, random_one_hot_labels
 ):
     from unittest import mock
     from mlflow.tensorflow import _TensorBoardLogDir

--- a/tests/tensorflow_autolog/test_tensorflow_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow_autolog.py
@@ -524,8 +524,8 @@ def test_duplicate_autolog_second_overrides(tf_estimator_random_data_run):
 def test_fit_generator(random_train_data, random_one_hot_labels):
     mlflow.tensorflow.autolog()
     model = create_tf_keras_model()
-
     generator = ((random_train_data, random_one_hot_labels) for _ in range(10))
+
     with mlflow.start_run() as run:
         model.fit_generator(generator, epochs=10, steps_per_epoch=1)
 
@@ -533,8 +533,8 @@ def test_fit_generator(random_train_data, random_one_hot_labels):
     params = run.data.params
     metrics = run.data.metrics
     assert "epochs" in params
-    assert params["epochs"] == 10
+    assert params["epochs"] == "10"
     assert "steps_per_epoch" in params
-    assert params["steps_per_epoch"] == 1
+    assert params["steps_per_epoch"] == "1"
     assert "acc" in metrics
     assert "loss" in metrics

--- a/tests/tensorflow_autolog/test_tensorflow_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow_autolog.py
@@ -536,5 +536,5 @@ def test_fit_generator(random_train_data, random_one_hot_labels):
     assert params["epochs"] == "10"
     assert "steps_per_epoch" in params
     assert params["steps_per_epoch"] == "1"
-    assert "acc" in metrics
-    assert "loss" in metrics
+    assert "epoch_acc" in metrics
+    assert "epoch_loss" in metrics

--- a/tests/tensorflow_autolog/test_tensorflow_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow_autolog.py
@@ -519,3 +519,14 @@ def test_duplicate_autolog_second_overrides(tf_estimator_random_data_run):
     client = mlflow.tracking.MlflowClient()
     metrics = client.get_metric_history(tf_estimator_random_data_run.info.run_id, "loss")
     assert all((x.step - 1) % 4 == 0 for x in metrics)
+
+
+def test_fit_generator(random_train_data, random_one_hot_labels):
+    mlflow.keras.autolog()
+    model = create_tf_keras_model()
+
+    generator = ((random_train_data, random_one_hot_labels) for _ in range(10))
+    with mlflow.start_run() as run:
+        model.fit_generator(generator, epochs=10, steps_per_epoch=1)
+
+    run = mlflow.tracking.MlflowClient().get_run(run.info.run_id)

--- a/tests/tensorflow_autolog/test_tensorflow_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow_autolog.py
@@ -522,7 +522,7 @@ def test_duplicate_autolog_second_overrides(tf_estimator_random_data_run):
 
 
 def test_fit_generator(random_train_data, random_one_hot_labels):
-    mlflow.keras.autolog()
+    mlflow.tensorflow.autolog()
     model = create_tf_keras_model()
 
     generator = ((random_train_data, random_one_hot_labels) for _ in range(10))
@@ -530,3 +530,11 @@ def test_fit_generator(random_train_data, random_one_hot_labels):
         model.fit_generator(generator, epochs=10, steps_per_epoch=1)
 
     run = mlflow.tracking.MlflowClient().get_run(run.info.run_id)
+    params = run.data.params
+    metrics = run.data.metrics
+    assert "epochs" in params
+    assert params["epochs"] == 10
+    assert "steps_per_epoch" in params
+    assert params["steps_per_epoch"] == 1
+    assert "acc" in metrics
+    assert "loss" in metrics


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

It's been a while since `fit_generator` was deprecated in tensorflow 2.1.0-rc2:

https://github.com/tensorflow/tensorflow/releases/tag/v2.1.0-rc2

```
tests/tensorflow_autolog/test_tensorflow2_autolog.py::test_tf_keras_autolog_logs_expected_data[False-0-fit_generator]
  /opt/hostedtoolcache/Python/3.6.13/x64/lib/python3.6/site-packages/keras/engine/training.py:1972: UserWarning: `Model.fit_generator` is deprecated and will be removed in a future version. Please use `Model.fit`, which supports generators.
```

https://github.com/mlflow/mlflow/runs/3358400991?check_suite_focus=true#step:11:138

I think we can remove `fit_generator` tests. This change allows us to run CI faster.

## How is this patch tested?

Updated tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
