### PR TITLE
Added retry logic for recoverable errors in the HTTP request method

### DIFF
--- a/mlflow/azure/client.py
+++ b/mlflow/azure/client.py
@@ -36,7 +36,7 @@ def put_block(sas_url, block_id, data, headers):
             _logger.debug("Removed unsupported '%s' header for Put Block operation", name)
 
     with rest_utils.cloud_storage_http_request(
-        "put", request_url, data, headers=request_headers
+        "put", request_url, data=data, headers=request_headers
     ) as response:
         response.raise_for_status()
 
@@ -64,7 +64,7 @@ def put_block_list(sas_url, block_list, headers):
             _logger.debug("Removed unsupported '%s' header for Put Block List operation", name)
 
     with rest_utils.cloud_storage_http_request(
-        "put", request_url, data, headers=request_headers
+        "put", request_url, data=data, headers=request_headers
     ) as response:
         response.raise_for_status()
 

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -245,13 +245,13 @@ class DatabricksArtifactRepository(ArtifactRepository):
             # Putting an empty file in a request by reading file bytes gives 501 error.
             if os.stat(local_file).st_size == 0:
                 with rest_utils.cloud_storage_http_request(
-                    "put", signed_write_uri, "", headers=headers
+                    "put", signed_write_uri, data="", headers=headers
                 ) as response:
                     response.raise_for_status()
             else:
                 with open(local_file, "rb") as file:
                     with rest_utils.cloud_storage_http_request(
-                        "put", signed_write_uri, file, headers=headers
+                        "put", signed_write_uri, data=file, headers=headers
                     ) as response:
                         response.raise_for_status()
         except Exception as err:

--- a/mlflow/store/artifact/dbfs_artifact_repo.py
+++ b/mlflow/store/artifact/dbfs_artifact_repo.py
@@ -56,9 +56,9 @@ class DbfsRestArtifactRepository(ArtifactRepository):
         else:
             self.get_host_creds = _get_host_creds_from_default_store()
 
-    def _databricks_api_request(self, endpoint, **kwargs):
+    def _databricks_api_request(self, endpoint, method, **kwargs):
         host_creds = self.get_host_creds()
-        return http_request_safe(host_creds=host_creds, endpoint=endpoint, **kwargs)
+        return http_request_safe(host_creds=host_creds, endpoint=endpoint, method=method, **kwargs)
 
     def _dbfs_list_api(self, json):
         host_creds = self.get_host_creds()

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -1,6 +1,4 @@
 import base64
-import time
-import logging
 import json
 import requests
 from contextlib import contextmanager
@@ -14,27 +12,91 @@ from mlflow.utils.proto_json_utils import parse_dict
 from mlflow.utils.string_utils import strip_suffix
 from mlflow.exceptions import MlflowException, RestException
 
-_REST_API_PATH_PREFIX = "/api/2.0"
 RESOURCE_DOES_NOT_EXIST = "RESOURCE_DOES_NOT_EXIST"
-
-_logger = logging.getLogger(__name__)
-
+_REST_API_PATH_PREFIX = "/api/2.0"
 _DEFAULT_HEADERS = {"User-Agent": "mlflow-python-client/%s" % __version__}
+# Response codes that generally indicate transient network failures and merit client retries,
+# based on guidance from cloud service providers
+# (https://docs.microsoft.com/en-us/azure/architecture/best-practices/retry-service-specific#general-rest-and-retry-guidelines)
+_TRANSIENT_FAILURE_RESPONSE_CODES = frozenset(
+    [
+        408,  # Request Timeout
+        429,  # Too Many Requests
+        500,  # Internal Server Error
+        502,  # Bad Gateway
+        503,  # Service Unavailable
+        504,  # Gateway Timeout
+    ]
+)
+
+
+def _get_http_response_with_retries(
+    method, url, max_retries, backoff_factor, retry_codes, **kwargs
+):
+    """
+    Performs an HTTP request using Python's `requests` module with an automatic retry policy.
+
+    :param method: a string indicating the method to use, e.g. "GET", "POST", "PUT".
+    :param url: the target URL address for the HTTP request.
+    :param max_retries: Maximum total number of retries.
+    :param backoff_factor: a time factor for exponential backoff. e.g. value 5 means the HTTP
+      request will be retried with interval 5, 10, 20... seconds. A value of 0 turns off the
+      exponential backoff.
+    :param retry_codes: a list of HTTP response error codes that qualifies for retry.
+    :param kwargs: Additional keyword arguments to pass to `requests.Session.request()`
+
+    :return: requests.Response object.
+    """
+    assert 0 <= max_retries < 10
+    assert 0 <= backoff_factor < 120
+    retry = Retry(
+        total=max_retries,
+        connect=max_retries,
+        read=max_retries,
+        redirect=max_retries,
+        status=max_retries,
+        status_forcelist=retry_codes,
+        method_whitelist=None,  # Allow retry on any HTTP methods.
+        backoff_factor=backoff_factor,
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    with requests.Session() as http:
+        http.mount("https://", adapter)
+        http.mount("http://", adapter)
+        response = http.request(method, url, **kwargs)
+        return response
 
 
 def http_request(
-    host_creds, endpoint, retries=3, retry_interval=3, max_rate_limit_interval=60, **kwargs
+    host_creds,
+    endpoint,
+    method,
+    max_retries=5,
+    backoff_factor=2,
+    retry_codes=_TRANSIENT_FAILURE_RESPONSE_CODES,
+    timeout=10,
+    **kwargs
 ):
     """
-    Makes an HTTP request with the specified method to the specified hostname/endpoint. Ratelimit
-    error code (429) will be retried with an exponential back off (1, 2, 4, ... seconds) for at most
-    `max_rate_limit_interval` seconds.  Internal errors (500s) will be retried up to `retries` times
-    , waiting `retry_interval` seconds between successive retries. Parses the API response
-    (assumed to be JSON) into a Python object and returns it.
+    Makes an HTTP request with the specified method to the specified hostname/endpoint. Transient
+    errors such as Rate-limited (429), service unavailable (503) and internal error (500) are
+    retried with an exponential back off with backoff_factor * (1, 2, 4, ... seconds).
+    The function parses the API response (assumed to be JSON) into a Python object and returns it.
 
     :param host_creds: A :py:class:`mlflow.rest_utils.MlflowHostCreds` object containing
         hostname and optional authentication.
-    :return: Parsed API response
+    :param endpoint: a string for service endpoint, e.g. "/path/to/object".
+    :param method: a string indicating the method to use, e.g. "GET", "POST", "PUT".
+    :param max_retries: maximum number of retries before throwing an exception.
+    :param backoff_factor: a time factor for exponential backoff. e.g. value 5 means the HTTP
+      request will be retried with interval 5, 10, 20... seconds. A value of 0 turns off the
+      exponential backoff.
+    :param retry_codes: a list of HTTP response error codes that qualifies for retry.
+    :param timeout: wait for timeout seconds for response from remote server for connect and
+      read request.
+    :param kwargs: Additional keyword arguments to pass to `requests.Session.request()`
+
+    :return: requests.Response object.
     """
     hostname = host_creds.host
     auth_str = None
@@ -58,45 +120,22 @@ def http_request(
     if host_creds.client_cert_path is not None:
         kwargs["cert"] = host_creds.client_cert_path
 
-    def request_with_ratelimit_retries(max_rate_limit_interval, **kwargs):
-        response = requests.request(**kwargs)
-        time_left = max_rate_limit_interval
-        sleep = 1
-        while response.status_code == 429 and time_left > 0:
-            _logger.warning(
-                "API request to {path} returned status code 429 (Rate limit exceeded). "
-                "Retrying in %d seconds. "
-                "Will continue to retry 429s for up to %d seconds.",
-                sleep,
-                time_left,
-            )
-            time.sleep(sleep)
-            time_left -= sleep
-            response = requests.request(**kwargs)
-            sleep = min(time_left, sleep * 2)  # sleep for 1, 2, 4, ... seconds;
-        return response
-
     cleaned_hostname = strip_suffix(hostname, "/")
     url = "%s%s" % (cleaned_hostname, endpoint)
-    for i in range(retries):
-        response = request_with_ratelimit_retries(
-            max_rate_limit_interval, url=url, headers=headers, verify=verify, **kwargs
+    try:
+        return _get_http_response_with_retries(
+            method,
+            url,
+            max_retries,
+            backoff_factor,
+            retry_codes,
+            headers=headers,
+            verify=verify,
+            timeout=timeout,
+            **kwargs
         )
-        if response.status_code >= 200 and response.status_code < 500:
-            return response
-        else:
-            _logger.error(
-                "API request to %s failed with code %s != 200, retrying up to %s more times. "
-                "API response body: %s",
-                url,
-                response.status_code,
-                retries - i - 1,
-                response.text,
-            )
-            time.sleep(retry_interval)
-    raise MlflowException(
-        "API request to %s failed to return code 200 after %s tries" % (url, retries)
-    )
+    except Exception as e:
+        raise MlflowException("API request to %s failed with exception %s" % (url, e))
 
 
 def _can_parse_as_json(string):
@@ -107,11 +146,11 @@ def _can_parse_as_json(string):
         return False
 
 
-def http_request_safe(host_creds, endpoint, **kwargs):
+def http_request_safe(host_creds, endpoint, method, **kwargs):
     """
     Wrapper around ``http_request`` that also verifies that the request succeeds with code 200.
     """
-    response = http_request(host_creds=host_creds, endpoint=endpoint, **kwargs)
+    response = http_request(host_creds=host_creds, endpoint=endpoint, method=method, **kwargs)
     return verify_rest_response(response, endpoint)
 
 
@@ -173,63 +212,41 @@ def call_endpoint(host_creds, endpoint, method, json_body, response_proto):
     return response_proto
 
 
-# Response codes that generally indicate transient network failures and merit client retries,
-# based on guidance from cloud service providers
-# (https://docs.microsoft.com/en-us/azure/architecture/best-practices/retry-service-specific#general-rest-and-retry-guidelines)
-TRANSIENT_FAILURE_RESPONSE_CODES = [
-    408,  # Request Timeout
-    429,  # Too Many Requests
-    500,  # Internal Server Error
-    502,  # Bad Gateway
-    503,  # Service Unavailable
-    504,  # Gateway Timeout
-]
-
-
 @contextmanager
-def cloud_storage_http_request(method, *args, **kwargs):
+def cloud_storage_http_request(
+    method,
+    url,
+    max_retries=5,
+    backoff_factor=2,
+    retry_codes=_TRANSIENT_FAILURE_RESPONSE_CODES,
+    timeout=10,
+    **kwargs
+):
     """
-    Performs an HTTP PUT/GET request using Python's `requests` module with an automatic retry
-    policy of `retry_attempts` using exponential backoff for the following response codes:
+    Performs an HTTP PUT/GET request using Python's `requests` module with automatic retry.
 
-        - 408 (Request Timeout)
-        - 429 (Too Many Requests)
-        - 500 (Internal Server Error)
-        - 502 (Bad Gateway)
-        - 503 (Service Unavailable)
-        - 504 (Gateway Timeout)
+    :param method: string of 'PUT' or 'GET', specify to do http PUT or GET
+    :param url: the target URL address for the HTTP request.
+    :param max_retries: maximum number of retries before throwing an exception.
+    :param backoff_factor: a time factor for exponential backoff. e.g. value 5 means the HTTP
+      request will be retried with interval 5, 10, 20... seconds. A value of 0 turns off the
+      exponential backoff.
+    :param retry_codes: a list of HTTP response error codes that qualifies for retry.
+    :param timeout: wait for timeout seconds for response from remote server for connect and
+      read request.
+    :param kwargs: Additional keyword arguments to pass to `requests.Session.request()`
 
-    :method: string of 'PUT' or 'GET', specify to do http PUT or GET
-    :args: Positional arguments to pass to `requests.Session.put/get()`
-    :kwargs: Keyword arguments to pass to `requests.Session.put/get()`
+    :return requests.Response object.
     """
-    retry_attempts = kwargs.get("retry_attempts", 5)
-    retry_strategy = Retry(
-        total=None,
-        # Don't retry on connect-related errors raised before a request reaches a remote server
-        connect=0,
-        # Retry once for errors reading the response from a remote server
-        read=1,
-        # Limit the number of redirects to avoid infinite redirect loops
-        redirect=3,
-        # Retry a specified number of times for response codes indicating transient failures
-        status=retry_attempts,
-        status_forcelist=TRANSIENT_FAILURE_RESPONSE_CODES,
-        backoff_factor=1,
-    )
-    adapter = HTTPAdapter(max_retries=retry_strategy)
-    with requests.Session() as http:
-        http.mount("https://", adapter)
-        http.mount("http://", adapter)
-        if method.lower() == "put":
-            response = http.put(*args, **kwargs)
-        elif method.lower() == "get":
-            response = http.get(*args, **kwargs)
-        else:
-            raise ValueError("Illegal http method: " + method)
-
-        with response as r:
-            yield r
+    if method.lower() not in ("put", "get"):
+        raise ValueError("Illegal http method: " + method)
+    try:
+        with _get_http_response_with_retries(
+            method, url, max_retries, backoff_factor, retry_codes, timeout=timeout, **kwargs
+        ) as response:
+            yield response
+    except Exception as e:
+        raise MlflowException("API request failed with exception %s" % e)
 
 
 class MlflowHostCreds(object):

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -1,7 +1,9 @@
 import base64
 import json
 import requests
+import urllib3
 from contextlib import contextmanager
+from packaging.version import Version
 from requests.adapters import HTTPAdapter
 from urllib3.util import Retry
 
@@ -49,6 +51,21 @@ def _get_http_response_with_retries(
     """
     assert 0 <= max_retries < 10
     assert 0 <= backoff_factor < 120
+
+    retry_args = {
+        "total": max_retries,
+        "connect": max_retries,
+        "read": max_retries,
+        "redirect": max_retries,
+        "status": max_retries,
+        "status_forcelist": retry_codes,
+        "backoff_factor": backoff_factor,
+    }
+    if Version(urllib3.__version__) >= Version("1.26.0"):
+        retry_args["allowed_methods"] = None
+    else:
+        retry_args["method_whitelist"] = None
+
     retry = Retry(
         total=max_retries,
         connect=max_retries,

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -52,7 +52,7 @@ def _get_http_response_with_retries(
     assert 0 <= max_retries < 10
     assert 0 <= backoff_factor < 120
 
-    retry_args = {
+    retry_kwargs = {
         "total": max_retries,
         "connect": max_retries,
         "read": max_retries,
@@ -62,20 +62,11 @@ def _get_http_response_with_retries(
         "backoff_factor": backoff_factor,
     }
     if Version(urllib3.__version__) >= Version("1.26.0"):
-        retry_args["allowed_methods"] = None
+        retry_kwargs["allowed_methods"] = None
     else:
-        retry_args["method_whitelist"] = None
+        retry_kwargs["method_whitelist"] = None
 
-    retry = Retry(
-        total=max_retries,
-        connect=max_retries,
-        read=max_retries,
-        redirect=max_retries,
-        status=max_retries,
-        status_forcelist=retry_codes,
-        method_whitelist=None,  # Allow retry on any HTTP methods.
-        backoff_factor=backoff_factor,
-    )
+    retry = Retry(**retry_kwargs)
     adapter = HTTPAdapter(max_retries=retry)
     with requests.Session() as http:
         http.mount("https://", adapter)

--- a/tests/projects/test_databricks.py
+++ b/tests/projects/test_databricks.py
@@ -429,7 +429,7 @@ class MockProfileConfigProvider:
         return DatabricksConfig("host", "user", "pass", None, insecure=False)
 
 
-@mock.patch("requests.request")
+@mock.patch("requests.Session.request")
 @mock.patch("databricks_cli.configure.provider.get_config")
 @mock.patch.object(
     databricks_cli.configure.provider, "ProfileConfigProvider", MockProfileConfigProvider
@@ -437,15 +437,15 @@ class MockProfileConfigProvider:
 def test_databricks_http_request_integration(get_config, request):
     """Confirms that the databricks http request params can in fact be used as an HTTP request"""
 
-    def confirm_request_params(**kwargs):
+    def confirm_request_params(*args, **kwargs):
         headers = dict(_DEFAULT_HEADERS)
         headers["Authorization"] = "Basic dXNlcjpwYXNz"
+        assert args == ("PUT", "host/clusters/list")
         assert kwargs == {
-            "method": "PUT",
-            "url": "host/clusters/list",
             "headers": headers,
             "verify": True,
             "json": {"a": "b"},
+            "timeout": 10,
         }
         http_response = mock.MagicMock()
         http_response.status_code = 200

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -255,7 +255,7 @@ class TestDatabricksArtifactRepository(object):
             request_mock.assert_called_with(
                 "put",
                 MOCK_AZURE_SIGNED_URI + "?comp=blocklist",
-                ANY,
+                data=ANY,
                 headers=filtered_azure_headers,
             )
 
@@ -295,7 +295,7 @@ class TestDatabricksArtifactRepository(object):
             write_credential_infos_mock.assert_called_with(
                 run_id=MOCK_RUN_ID, paths=[expected_location]
             )
-            request_mock.assert_called_with("put", MOCK_AWS_SIGNED_URI, ANY, headers={})
+            request_mock.assert_called_with("put", MOCK_AWS_SIGNED_URI, data=ANY, headers={})
 
     @pytest.mark.parametrize("artifact_path,expected_location", [(None, "test.txt")])
     def test_log_artifact_aws_with_headers(
@@ -322,7 +322,7 @@ class TestDatabricksArtifactRepository(object):
                 run_id=MOCK_RUN_ID, paths=[expected_location]
             )
             request_mock.assert_called_with(
-                "put", MOCK_AWS_SIGNED_URI, ANY, headers=expected_headers
+                "put", MOCK_AWS_SIGNED_URI, data=ANY, headers=expected_headers
             )
 
     def test_log_artifact_aws_presigned_url_error(self, databricks_artifact_repo, test_file):
@@ -361,7 +361,7 @@ class TestDatabricksArtifactRepository(object):
             write_credential_infos_mock.assert_called_with(
                 run_id=MOCK_RUN_ID, paths=[expected_location]
             )
-            request_mock.assert_called_with("put", MOCK_GCP_SIGNED_URL, ANY, headers={})
+            request_mock.assert_called_with("put", MOCK_GCP_SIGNED_URL, data=ANY, headers={})
 
     @pytest.mark.parametrize("artifact_path,expected_location", [(None, "test.txt")])
     def test_log_artifact_gcp_with_headers(
@@ -388,7 +388,7 @@ class TestDatabricksArtifactRepository(object):
                 run_id=MOCK_RUN_ID, paths=[expected_location]
             )
             request_mock.assert_called_with(
-                "put", MOCK_GCP_SIGNED_URL, ANY, headers=expected_headers
+                "put", MOCK_GCP_SIGNED_URL, data=ANY, headers=expected_headers
             )
 
     def test_log_artifact_gcp_presigned_url_error(self, databricks_artifact_repo, test_file):

--- a/tests/store/tracking/test_rest_store.py
+++ b/tests/store/tracking/test_rest_store.py
@@ -67,17 +67,17 @@ def mock_http_request():
 
 
 class TestRestStore(object):
-    @mock.patch("requests.request")
+    @mock.patch("requests.Session.request")
     def test_successful_http_request(self, request):
-        def mock_request(**kwargs):
+        def mock_request(*args, **kwargs):
             # Filter out None arguments
+            assert args == ("GET", "https://hello/api/2.0/mlflow/experiments/list")
             kwargs = dict((k, v) for k, v in kwargs.items() if v is not None)
             assert kwargs == {
-                "method": "GET",
                 "params": {"view_type": "ACTIVE_ONLY"},
-                "url": "https://hello/api/2.0/mlflow/experiments/list",
                 "headers": _DEFAULT_HEADERS,
                 "verify": True,
+                "timeout": 10,
             }
             response = mock.MagicMock()
             response.status_code = 200
@@ -90,7 +90,7 @@ class TestRestStore(object):
         experiments = store.list_experiments()
         assert experiments[0].name == "Exp!"
 
-    @mock.patch("requests.request")
+    @mock.patch("requests.Session.request")
     def test_failed_http_request(self, request):
         response = mock.MagicMock()
         response.status_code = 404
@@ -102,7 +102,7 @@ class TestRestStore(object):
             store.list_experiments()
         assert "RESOURCE_DOES_NOT_EXIST: No experiment" in str(cm.value)
 
-    @mock.patch("requests.request")
+    @mock.patch("requests.Session.request")
     def test_failed_http_request_custom_handler(self, request):
         response = mock.MagicMock()
         response.status_code = 404
@@ -113,7 +113,7 @@ class TestRestStore(object):
         with pytest.raises(MyCoolException):
             store.list_experiments()
 
-    @mock.patch("requests.request")
+    @mock.patch("requests.Session.request")
     def test_response_with_unknown_fields(self, request):
         experiment_json = {
             "experiment_id": "1",

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -18,7 +18,7 @@ from tests import helper_functions
 
 
 def test_well_formed_json_error_response():
-    with mock.patch("requests.request") as request_mock:
+    with mock.patch("requests.Session.request") as request_mock:
         host_only = MlflowHostCreds("http://my-host")
         response_mock = mock.MagicMock()
         response_mock.status_code = 400
@@ -31,7 +31,7 @@ def test_well_formed_json_error_response():
 
 
 def test_non_json_ok_response():
-    with mock.patch("requests.request") as request_mock:
+    with mock.patch("requests.Session.request") as request_mock:
         host_only = MlflowHostCreds("http://my-host")
         response_mock = mock.MagicMock()
         response_mock.status_code = 200
@@ -56,7 +56,7 @@ def test_non_json_ok_response():
     ],
 )
 def test_malformed_json_error_response(response_mock):
-    with mock.patch("requests.request") as request_mock:
+    with mock.patch("requests.Session.request") as request_mock:
         host_only = MlflowHostCreds("http://my-host")
         request_mock.return_value = response_mock
 
@@ -65,97 +65,106 @@ def test_malformed_json_error_response(response_mock):
             call_endpoint(host_only, "/my/endpoint", "GET", "", response_proto)
 
 
-@mock.patch("requests.request")
+@mock.patch("requests.Session.request")
 def test_http_request_hostonly(request):
     host_only = MlflowHostCreds("http://my-host")
     response = mock.MagicMock()
     response.status_code = 200
     request.return_value = response
-    http_request(host_only, "/my/endpoint")
+    http_request(host_only, "/my/endpoint", "GET")
     request.assert_called_with(
-        url="http://my-host/my/endpoint", verify=True, headers=_DEFAULT_HEADERS,
+        "GET", "http://my-host/my/endpoint", verify=True, headers=_DEFAULT_HEADERS, timeout=10,
     )
 
 
-@mock.patch("requests.request")
+@mock.patch("requests.Session.request")
 def test_http_request_cleans_hostname(request):
     # Add a trailing slash, should be removed.
     host_only = MlflowHostCreds("http://my-host/")
     response = mock.MagicMock()
     response.status_code = 200
     request.return_value = response
-    http_request(host_only, "/my/endpoint")
+    http_request(host_only, "/my/endpoint", "GET")
     request.assert_called_with(
-        url="http://my-host/my/endpoint", verify=True, headers=_DEFAULT_HEADERS,
+        "GET", "http://my-host/my/endpoint", verify=True, headers=_DEFAULT_HEADERS, timeout=10,
     )
 
 
-@mock.patch("requests.request")
+@mock.patch("requests.Session.request")
 def test_http_request_with_basic_auth(request):
     host_only = MlflowHostCreds("http://my-host", username="user", password="pass")
     response = mock.MagicMock()
     response.status_code = 200
     request.return_value = response
-    http_request(host_only, "/my/endpoint")
+    http_request(host_only, "/my/endpoint", "GET")
     headers = dict(_DEFAULT_HEADERS)
     headers["Authorization"] = "Basic dXNlcjpwYXNz"
     request.assert_called_with(
-        url="http://my-host/my/endpoint", verify=True, headers=headers,
+        "GET", "http://my-host/my/endpoint", verify=True, headers=headers, timeout=10,
     )
 
 
-@mock.patch("requests.request")
+@mock.patch("requests.Session.request")
 def test_http_request_with_token(request):
     host_only = MlflowHostCreds("http://my-host", token="my-token")
     response = mock.MagicMock()
     response.status_code = 200
     request.return_value = response
-    http_request(host_only, "/my/endpoint")
+    http_request(host_only, "/my/endpoint", "GET")
     headers = dict(_DEFAULT_HEADERS)
     headers["Authorization"] = "Bearer my-token"
     request.assert_called_with(
-        url="http://my-host/my/endpoint", verify=True, headers=headers,
+        "GET", "http://my-host/my/endpoint", verify=True, headers=headers, timeout=10,
     )
 
 
-@mock.patch("requests.request")
+@mock.patch("requests.Session.request")
 def test_http_request_with_insecure(request):
     host_only = MlflowHostCreds("http://my-host", ignore_tls_verification=True)
     response = mock.MagicMock()
     response.status_code = 200
     request.return_value = response
-    http_request(host_only, "/my/endpoint")
+    http_request(host_only, "/my/endpoint", "GET")
     request.assert_called_with(
-        url="http://my-host/my/endpoint", verify=False, headers=_DEFAULT_HEADERS,
+        "GET", "http://my-host/my/endpoint", verify=False, headers=_DEFAULT_HEADERS, timeout=10,
     )
 
 
-@mock.patch("requests.request")
+@mock.patch("requests.Session.request")
 def test_http_request_client_cert_path(request):
     host_only = MlflowHostCreds("http://my-host", client_cert_path="/some/path")
     response = mock.MagicMock()
     response.status_code = 200
     request.return_value = response
-    http_request(host_only, "/my/endpoint")
+    http_request(host_only, "/my/endpoint", "GET")
     request.assert_called_with(
-        url="http://my-host/my/endpoint", verify=True, cert="/some/path", headers=_DEFAULT_HEADERS,
+        "GET",
+        "http://my-host/my/endpoint",
+        verify=True,
+        cert="/some/path",
+        headers=_DEFAULT_HEADERS,
+        timeout=10,
     )
 
 
-@mock.patch("requests.request")
+@mock.patch("requests.Session.request")
 def test_http_request_server_cert_path(request):
     host_only = MlflowHostCreds("http://my-host", server_cert_path="/some/path")
     response = mock.MagicMock()
     response.status_code = 200
     request.return_value = response
-    http_request(host_only, "/my/endpoint")
+    http_request(host_only, "/my/endpoint", "GET")
     request.assert_called_with(
-        url="http://my-host/my/endpoint", verify="/some/path", headers=_DEFAULT_HEADERS,
+        "GET",
+        "http://my-host/my/endpoint",
+        verify="/some/path",
+        headers=_DEFAULT_HEADERS,
+        timeout=10,
     )
 
 
 @pytest.mark.large
-@mock.patch("requests.request")
+@mock.patch("requests.Session.request")
 def test_http_request_request_headers(request):
     """This test requires the package in tests/resources/mlflow-test-plugin to be installed"""
 
@@ -170,11 +179,13 @@ def test_http_request_request_headers(request):
         response = mock.MagicMock()
         response.status_code = 200
         request.return_value = response
-        http_request(host_only, "/my/endpoint")
+        http_request(host_only, "/my/endpoint", "GET")
         request.assert_called_with(
-            url="http://my-host/my/endpoint",
+            "GET",
+            "http://my-host/my/endpoint",
             verify="/some/path",
             headers={**_DEFAULT_HEADERS, "test": "header"},
+            timeout=10,
         )
 
 
@@ -185,64 +196,34 @@ def test_ignore_tls_verification_not_server_cert_path():
         )
 
 
-@mock.patch("requests.request")
-def test_429_retries(request):
-    host_only = MlflowHostCreds("http://my-host", ignore_tls_verification=True)
-
-    class MockedResponse(object):
-        def __init__(self, status_code):
-            self.status_code = status_code
-            self.text = "mocked text"
-
-    request.side_effect = [MockedResponse(x) for x in (429, 200)]
-    assert http_request(host_only, "/my/endpoint", max_rate_limit_interval=0).status_code == 429
-    request.side_effect = [MockedResponse(x) for x in (429, 200)]
-    assert http_request(host_only, "/my/endpoint", max_rate_limit_interval=1).status_code == 200
-    request.side_effect = [MockedResponse(x) for x in (429, 429, 200)]
-    assert http_request(host_only, "/my/endpoint", max_rate_limit_interval=1).status_code == 429
-    request.side_effect = [MockedResponse(x) for x in (429, 429, 200)]
-    assert http_request(host_only, "/my/endpoint", max_rate_limit_interval=2).status_code == 200
-    request.side_effect = [MockedResponse(x) for x in (429, 429, 200)]
-    assert http_request(host_only, "/my/endpoint", max_rate_limit_interval=3).status_code == 200
-    # Test that any non 429 code is returned
-    request.side_effect = [MockedResponse(x) for x in (429, 404, 429, 200)]
-    assert http_request(host_only, "/my/endpoint").status_code == 404
-    # Test that retries work as expected
-    request.side_effect = [MockedResponse(x) for x in (429, 503, 429, 200)]
-    with pytest.raises(MlflowException, match="failed to return code 200"):
-        http_request(host_only, "/my/endpoint", retries=1)
-    request.side_effect = [MockedResponse(x) for x in (429, 503, 429, 200)]
-    assert http_request(host_only, "/my/endpoint", retries=2).status_code == 200
-
-
-@mock.patch("requests.request")
+@mock.patch("requests.Session.request")
 def test_http_request_wrapper(request):
     host_only = MlflowHostCreds("http://my-host", ignore_tls_verification=True)
     response = mock.MagicMock()
     response.status_code = 200
     response.text = "{}"
     request.return_value = response
-    http_request_safe(host_only, "/my/endpoint")
+    http_request_safe(host_only, "/my/endpoint", "GET")
     request.assert_called_with(
-        url="http://my-host/my/endpoint", verify=False, headers=_DEFAULT_HEADERS,
+        "GET", "http://my-host/my/endpoint", verify=False, headers=_DEFAULT_HEADERS, timeout=10,
     )
     response.text = "non json"
     request.return_value = response
-    http_request_safe(host_only, "/my/endpoint")
+    http_request_safe(host_only, "/my/endpoint", "GET")
     request.assert_called_with(
-        url="http://my-host/my/endpoint", verify=False, headers=_DEFAULT_HEADERS,
+        "GET", "http://my-host/my/endpoint", verify=False, headers=_DEFAULT_HEADERS, timeout=10,
     )
     response.status_code = 400
     response.text = ""
     request.return_value = response
     with pytest.raises(MlflowException, match="Response body"):
-        http_request_safe(host_only, "/my/endpoint")
+        http_request_safe(host_only, "/my/endpoint", "GET")
     response.text = (
         '{"error_code": "RESOURCE_DOES_NOT_EXIST", "message": "Node type not supported"}'
     )
     request.return_value = response
     with pytest.raises(RestException, match="RESOURCE_DOES_NOT_EXIST: Node type not supported"):
-        http_request_safe(host_only, "/my/endpoint")
+        http_request_safe(host_only, "/my/endpoint", "GET")
 
 
 def test_numpy_encoder():


### PR DESCRIPTION
## What changes are proposed in this pull request?
Introduced a general retry logic to the HTTP request method, which is used in most inter-service comms by MLflow.
Before the retry was manually implemented for 429 rate limited response. Temporary issues such as connection errors cause a raise instead of being retried. This change aims to extend the retry logic to most temporary recoverable errors. 

## How is this patch tested?
Modified unit tests to ensure the change work as intended.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
