### PR TITLE
Add deprecation warnings for tensorflow < 2 and keras < 2.3

### DIFF
--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -62,7 +62,12 @@ _PIP_ENV_SUBPATH = "requirements.txt"
 
 
 def _raise_deprecation_warning():
-    import keras
+    # Avoid `ModuleNotFoundError` thrown when this function is called from `mlflow.tensorflow` to
+    # save a model created using `tensorflow.keras` but `keras` is not installed.
+    try:
+        import keras
+    except ImportError:
+        return
 
     if Version(keras.__version__) < Version("2.3.0"):
         warnings.warn(

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -666,6 +666,8 @@ def autolog(
     """
     import keras
 
+    _raise_deprecation_warning()
+
     def getKerasCallback(metrics_logger):
         class __MLflowKerasCallback(keras.callbacks.Callback, metaclass=ExceptionSafeClass):
             """

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -13,6 +13,7 @@ import re
 import yaml
 import tempfile
 import shutil
+import warnings
 
 import pandas as pd
 
@@ -58,6 +59,20 @@ _KERAS_SAVE_FORMAT_PATH = "save_format.txt"
 # File name to which keras model is saved
 _MODEL_SAVE_PATH = "model"
 _PIP_ENV_SUBPATH = "requirements.txt"
+
+
+def _raise_deprecation_warning():
+    import keras
+
+    if Version(keras.__version__) < Version("2.3.0"):
+        warnings.warn(
+            (
+                "Support for keras < 2.3.0 has been deprecated and will be removed in a future "
+                "MLflow release"
+            ),
+            FutureWarning,
+            stacklevel=2,
+        )
 
 
 def get_default_pip_requirements(include_cloudpickle=False, keras_module=None):
@@ -170,6 +185,7 @@ def save_model(
         # Save the model as an MLflow Model
         mlflow.keras.save_model(keras_model, keras_model_path)
     """
+    _raise_deprecation_warning()
     _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
 
     if keras_module is None:
@@ -560,6 +576,7 @@ def load_model(model_uri, **kwargs):
         keras_model = mlflow.keras.load_model("runs:/96771d893a5e46159d9f3b49bf9013e2" + "/models")
         predictions = keras_model.predict(x_test)
     """
+    _raise_deprecation_warning()
     local_model_path = _download_artifact_from_uri(artifact_uri=model_uri)
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     keras_module = importlib.import_module(flavor_conf.get("keras_module", "keras"))

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -84,8 +84,8 @@ def _raise_deprecation_warning():
     if Version(tf.__version__) < Version("2.0.0"):
         warnings.warn(
             (
-                "Support for tensorflow < 2.0.0 has been deprecated and will be removed in a future "
-                "MLflow release"
+                "Support for tensorflow < 2.0.0 has been deprecated and will be removed in "
+                "a future MLflow release"
             ),
             FutureWarning,
             stacklevel=2,

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -20,7 +20,6 @@ from collections import namedtuple
 import pandas
 from packaging.version import Version
 from threading import RLock
-import warnings
 
 import mlflow
 import mlflow.keras

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -20,6 +20,7 @@ from collections import namedtuple
 import pandas
 from packaging.version import Version
 from threading import RLock
+import warnings
 
 import mlflow
 import mlflow.keras
@@ -75,6 +76,20 @@ _thread_pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
 
 # For tracking if the run was started by autologging.
 _AUTOLOG_RUN_ID = None
+
+
+def _raise_deprecation_warning():
+    import tensorflow as tf
+
+    if Version(tf.__version__) < Version("2.0.0"):
+        warnings.warn(
+            (
+                "Support for tensorflow < 2.0.0 has been deprecated and will be removed in a future "
+                "MLflow release"
+            ),
+            FutureWarning,
+            stacklevel=2,
+        )
 
 
 def get_default_pip_requirements():
@@ -252,6 +267,7 @@ def save_model(
     :param pip_requirements: {{ pip_requirements }}
     :param extra_pip_requirements: {{ extra_pip_requirements }}
     """
+    _raise_deprecation_warning()
     _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
 
     _logger.info(
@@ -388,6 +404,8 @@ def load_model(model_uri, tf_sess=None):
                                 for _, output_signature in signature_definition.outputs.items()]
     """
     import tensorflow
+
+    _raise_deprecation_warning()
 
     if Version(tensorflow.__version__) < Version("2.0.0"):
         if not tf_sess:

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -949,6 +949,8 @@ def autolog(
     """
     import tensorflow
 
+    _raise_deprecation_warning()
+
     global _LOG_EVERY_N_STEPS
     _LOG_EVERY_N_STEPS = every_n_iter
 

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -691,12 +691,10 @@ def test_pyfunc_serve_and_score_transformers():
 
 def test_raise_deprecation_warning():
     with mock.patch("keras.__version__", new="2.2.0"), pytest.warns(
-        FutureWarning, msg="Support for keras"
+        FutureWarning, match="Support for keras"
     ):
         mlflow.keras._raise_deprecation_warning()
 
-    with mock.patch("keras.__version__", new="2.3.0"), pytest.warns(
-        None, msg="Support for keras"
-    ) as record:
+    with mock.patch("keras.__version__", new="2.3.0"), pytest.warns(None) as record:
         mlflow.keras._raise_deprecation_warning()
     assert len(record) == 0

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -687,3 +687,16 @@ def test_pyfunc_serve_and_score_transformers():
     data = json.dumps({"inputs": dummy_inputs.tolist()})
     resp = pyfunc_serve_and_score_model(model_uri, data, pyfunc_scoring_server.CONTENT_TYPE_JSON)
     np.testing.assert_array_equal(json.loads(resp.content), model.predict(dummy_inputs))
+
+
+def test_raise_deprecation_warning():
+    with mock.patch("keras.__version__", new="2.2.0"), pytest.warns(
+        FutureWarning, msg="Support for keras"
+    ):
+        mlflow.keras._raise_deprecation_warning()
+
+    with mock.patch("keras.__version__", new="2.3.0"), pytest.warns(
+        None, msg="Support for keras"
+    ) as record:
+        mlflow.keras._raise_deprecation_warning()
+    assert len(record) == 0

--- a/tests/tensorflow/test_tensorflow2_model_export.py
+++ b/tests/tensorflow/test_tensorflow2_model_export.py
@@ -793,3 +793,16 @@ def test_tf_saved_model_model_with_tf_keras_api(tmpdir):
         assert np.allclose(predictions["dense"], np.asarray([-0.09599352]))
 
     load_and_predict()
+
+
+def test_raise_deprecation_warning():
+    with mock.patch("tensorflow.__version__", new="1.15.0"), pytest.warns(
+        FutureWarning, msg="Support for tensorflow"
+    ):
+        mlflow.tensorflow._raise_deprecation_warning()
+
+    with mock.patch("tensorflow.__version__", new="2.0.0"), pytest.warns(
+        None, msg="Support for tensorflow"
+    ) as record:
+        mlflow.tensorflow._raise_deprecation_warning()
+    assert len(record) == 0

--- a/tests/tensorflow/test_tensorflow2_model_export.py
+++ b/tests/tensorflow/test_tensorflow2_model_export.py
@@ -797,12 +797,10 @@ def test_tf_saved_model_model_with_tf_keras_api(tmpdir):
 
 def test_raise_deprecation_warning():
     with mock.patch("tensorflow.__version__", new="1.15.0"), pytest.warns(
-        FutureWarning, msg="Support for tensorflow"
+        FutureWarning, match="Support for tensorflow"
     ):
         mlflow.tensorflow._raise_deprecation_warning()
 
-    with mock.patch("tensorflow.__version__", new="2.0.0"), pytest.warns(
-        None, msg="Support for tensorflow"
-    ) as record:
+    with mock.patch("tensorflow.__version__", new="2.0.0"), pytest.warns(None) as record:
         mlflow.tensorflow._raise_deprecation_warning()
     assert len(record) == 0


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

Add deprecation warnings for tensorflow < 2 and keras < 2.3. Their support will be dropped in MLflow 1.21.0.

## How is this patch tested?

Unit tests.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Support for tensorflow < 2.0.0 and keras < 2.3.0 has been deprecated and will be removed in a future MLflow release.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [x] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
