### PR TITLE
Support distributed pytorch lightning autologging execution

### DIFF
--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -1008,7 +1008,6 @@ def autolog(
         PyTorch autologged MLflow entities
     """
     import pytorch_lightning as pl
-    from mlflow.pytorch._pytorch_autolog import _create_patch_fit
+    from mlflow.pytorch._pytorch_autolog import patched_fit
 
-    fit = _create_patch_fit(log_every_n_epoch=log_every_n_epoch, log_models=log_models)
-    safe_patch(FLAVOR_NAME, pl.Trainer, "fit", fit, manage_run=True)
+    safe_patch(FLAVOR_NAME, pl.Trainer, "fit", patched_fit, manage_run=True)

--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -10,18 +10,15 @@ from pytorch_lightning.utilities import rank_zero_only
 
 from mlflow.utils.autologging_utils import (
     ExceptionSafeAbstractClass,
-    try_mlflow_log,
     BatchMetricsLogger,
+    MlflowAutologgingQueueingClient,
+    get_autologging_config,
 )
 
 logging.basicConfig(level=logging.ERROR)
 
-every_n_epoch = 1
 
-
-# autolog module uses `try_mlflow_log` - mlflow utility to log param/metrics/artifacts into mlflow
-# MlflowLogger(Pytorch Lightning's inbuild class),
-# following are the downsides in using MlflowLogger.
+# The following are the downsides of using PyTorch Lightning's built-in MlflowLogger.
 # 1. MlflowLogger doesn't provide a mechanism to store an entire model into mlflow.
 #    Only model checkpoint is saved.
 # 2. For storing the model into mlflow `mlflow.pytorch` library is used
@@ -55,11 +52,205 @@ def _get_optimizer_name(optimizer):
         )
 
 
-@rank_zero_only
-def _create_patch_fit(log_every_n_epoch=1, log_models=True):
+class __MLflowPLCallback(pl.Callback, metaclass=ExceptionSafeAbstractClass):
     """
-    Creates a patch implementation of `pytorch_lightning.Trainer.fit` which enables logging the
-    following parameters, metrics and artifacts.
+    Callback for auto-logging metrics and parameters.
+    """
+
+    def __init__(self, client, metrics_logger, run_id, log_models, log_every_n_epoch):
+        self.early_stopping = False
+        self.client = client
+        self.metrics_logger = metrics_logger
+        self.run_id = run_id
+        self.log_models = log_models
+        self.log_every_n_epoch = log_every_n_epoch
+
+    def _log_metrics(self, trainer, pl_module):
+        # pytorch-lightning runs a few steps of validation in the beginning of training
+        # as a sanity check to catch bugs without having to wait for the training routine
+        # to complete. During this check, we should skip logging metrics.
+        # https://pytorch-lightning.readthedocs.io/en/stable/common/trainer.html#num-sanity-val-steps # noqa
+        if trainer.running_sanity_check:
+            return
+
+        if (pl_module.current_epoch + 1) % self.log_every_n_epoch == 0:
+            # `trainer.callback_metrics` contains both training and validation metrics
+            cur_metrics = trainer.callback_metrics
+            # Cast metric value as  float before passing into logger.
+            metrics = dict(map(lambda x: (x[0], float(x[1])), cur_metrics.items()))
+
+            self.metrics_logger.record_metrics(metrics, pl_module.current_epoch)
+
+    _pl_version = Version(pl.__version__)
+
+    # In pytorch-lightning >= 1.4.0, validation is run inside the training epoch and
+    # `trainer.callback_metrics` contains both training and validation metrics of the
+    # current training epoch when `on_train_epoch_end` is called:
+    # https://github.com/PyTorchLightning/pytorch-lightning/pull/7357
+    if _pl_version >= Version("1.4.0dev"):
+
+        @rank_zero_only
+        def on_train_epoch_end(
+            self, trainer, pl_module, *args
+        ):  # pylint: disable=signature-differs,arguments-differ,unused-argument
+            self._log_metrics(trainer, pl_module)
+
+    # In pytorch-lightning >= 1.2.0, logging metrics in `on_epoch_end` results in duplicate
+    # metrics records because `on_epoch_end` is called after both train and validation
+    # epochs (related PR: https://github.com/PyTorchLightning/pytorch-lightning/pull/5986)
+    # As a workaround, use `on_train_epoch_end` and `on_validation_epoch_end` instead
+    # in pytorch-lightning >= 1.2.0.
+    elif _pl_version >= Version("1.2.0"):
+
+        # NB: Override `on_train_epoch_end` with an additional `*args` parameter for
+        # compatibility with versions of pytorch-lightning <= 1.2.0, which required an
+        # `outputs` argument that was not used and is no longer defined in
+        # pytorch-lightning >= 1.3.0
+
+        @rank_zero_only
+        def on_train_epoch_end(
+            self, trainer, pl_module, *args
+        ):  # pylint: disable=signature-differs,arguments-differ,unused-argument
+            """
+            Log loss and other metrics values after each train epoch
+
+            :param trainer: pytorch lightning trainer instance
+            :param pl_module: pytorch lightning base module
+            """
+            # If validation loop is enabled (meaning `validation_step` is overridden),
+            # log metrics in `on_validaion_epoch_end` to avoid logging the same metrics
+            # records twice
+            if trainer.disable_validation:
+                self._log_metrics(trainer, pl_module)
+
+        @rank_zero_only
+        def on_validation_epoch_end(self, trainer, pl_module):
+            """
+            Log loss and other metrics values after each validation epoch
+
+            :param trainer: pytorch lightning trainer instance
+            :param pl_module: pytorch lightning base module
+            """
+            self._log_metrics(trainer, pl_module)
+
+    else:
+
+        @rank_zero_only
+        def on_epoch_end(self, trainer, pl_module):
+            """
+            Log loss and other metrics values after each epoch
+
+            :param trainer: pytorch lightning trainer instance
+            :param pl_module: pytorch lightning base module
+            """
+            self._log_metrics(trainer, pl_module)
+
+    @rank_zero_only
+    def on_train_start(self, trainer, pl_module):
+        """
+        Logs Optimizer related metrics when the train begins
+
+        :param trainer: pytorch lightning trainer instance
+        :param pl_module: pytorch lightning base module
+        """
+        self.client.set_tags(self.run_id, {"Mode": "training"})
+
+        params = {"epochs": trainer.max_epochs}
+
+        # TODO For logging optimizer params - Following scenarios are to revisited.
+        # 1. In the current scenario, only the first optimizer details are logged.
+        #    Code to be enhanced to log params when multiple optimizers are used.
+        # 2. mlflow.log_params is used to store optimizer default values into mlflow.
+        #    The keys in default dictionary are too short, Ex: (lr - learning_rate).
+        #    Efficient mapping technique needs to be introduced
+        #    to rename the optimizer parameters based on keys in default dictionary.
+
+        if hasattr(trainer, "optimizers"):
+            optimizer = trainer.optimizers[0]
+            params["optimizer_name"] = _get_optimizer_name(optimizer)
+
+            if hasattr(optimizer, "defaults"):
+                params.update(optimizer.defaults)
+
+        self.client.log_params(self.run_id, params)
+        self.client.flush(synchronous=True)
+
+    @rank_zero_only
+    def on_train_end(self, trainer, pl_module):
+        """
+        Logs the model checkpoint into mlflow - models folder on the training end
+
+        :param trainer: pytorch lightning trainer instance
+        :param pl_module: pytorch lightning base module
+        """
+        # manually flush any remaining metadata from training
+        self.metrics_logger.flush()
+        self.client.flush(synchronous=True)
+
+    @rank_zero_only
+    def on_test_end(self, trainer, pl_module):
+        """
+        Logs accuracy and other relevant metrics on the testing end
+
+        :param trainer: pytorch lightning trainer instance
+        :param pl_module: pytorch lightning base module
+        """
+        self.client.set_tags(self.run_id, {"Mode": "testing"})
+        self.client.flush(synchronous=True)
+
+        self.metrics_logger.record_metrics(
+            {key: float(value) for key, value in trainer.callback_metrics.items()}
+        )
+        self.metrics_logger.flush()
+
+
+def _log_early_stop_params(early_stop_callback, client, run_id):
+    """
+    Logs early stopping configuration parameters to MLflow.
+
+    :param early_stop_callback: The early stopping callback instance used during training.
+    :param client: An `MlflowAutologgingQueueingClient` instance used for MLflow logging.
+    :param run_id: The ID of the MLflow Run to which to log configuration parameters.
+    """
+    client.log_params(
+        run_id,
+        {
+            p: getattr(early_stop_callback, p)
+            for p in ["monitor", "mode", "patience", "min_delta", "stopped_epoch"]
+            if hasattr(early_stop_callback, p)
+        },
+    )
+
+
+def _log_early_stop_metrics(early_stop_callback, client, run_id):
+    """
+    Logs early stopping behavior results (e.g. stopped epoch) as metrics to MLflow.
+
+    :param early_stop_callback: The early stopping callback instance used during training.
+    :param client: An `MlflowAutologgingQueueingClient` instance used for MLflow logging.
+    :param run_id: The ID of the MLflow Run to which to log configuration parameters.
+    """
+    if early_stop_callback.stopped_epoch == 0:
+        return
+
+    metrics = {
+        "stopped_epoch": early_stop_callback.stopped_epoch,
+        "restored_epoch": early_stop_callback.stopped_epoch - max(1, early_stop_callback.patience),
+    }
+
+    if hasattr(early_stop_callback, "best_score"):
+        metrics["best_score"] = float(early_stop_callback.best_score)
+
+    if hasattr(early_stop_callback, "wait_count"):
+        metrics["wait_count"] = early_stop_callback.wait_count
+
+    client.log_metrics(run_id, metrics)
+
+
+def patched_fit(original, self, *args, **kwargs):
+    """
+    A patched implementation of `pytorch_lightning.Trainer.fit` which enables logging the
+    following parameters, metrics and artifacts:
 
     - Training epochs
     - Optimizer parameters
@@ -70,249 +261,53 @@ def _create_patch_fit(log_every_n_epoch=1, log_models=True):
 
     .. _EarlyStoppingCallback:
         https://pytorch-lightning.readthedocs.io/en/latest/early_stopping.html
-
-    :param log_every_n_epoch: parameter to log metrics once in `n` epoch. By default, metrics
-                       are logged after every epoch.
-    :param log_models: If ``True``, trained models are logged as MLflow model artifacts.
-                       If ``False``, trained models are not logged.
     """
-    global every_n_epoch
-    every_n_epoch = log_every_n_epoch
+    run_id = mlflow.active_run().info.run_id
+    tracking_uri = mlflow.get_tracking_uri()
+    client = MlflowAutologgingQueueingClient(tracking_uri)
+    metrics_logger = BatchMetricsLogger(run_id, tracking_uri)
 
-    def getPLCallback(log_models, metrics_logger):
-        class __MLflowPLCallback(pl.Callback, metaclass=ExceptionSafeAbstractClass):
-            """
-            Callback for auto-logging metrics and parameters.
-            """
+    log_models = get_autologging_config(mlflow.pytorch.FLAVOR_NAME, "log_models", True)
+    log_every_n_epoch = get_autologging_config(mlflow.pytorch.FLAVOR_NAME, "log_every_n_epoch", 1)
 
-            def __init__(self):
-                self.early_stopping = False
+    early_stop_callback = None
+    for callback in self.callbacks:
+        if isinstance(callback, pl.callbacks.early_stopping.EarlyStopping):
+            early_stop_callback = callback
+            _log_early_stop_params(early_stop_callback, client, run_id)
 
-            def _log_metrics(self, trainer, pl_module):
-                # pytorch-lightning runs a few steps of validation in the beginning of training
-                # as a sanity check to catch bugs without having to wait for the training routine
-                # to complete. During this check, we should skip logging metrics.
-                # https://pytorch-lightning.readthedocs.io/en/stable/common/trainer.html#num-sanity-val-steps # noqa
-                if trainer.running_sanity_check:
-                    return
+    if not any(isinstance(callbacks, __MLflowPLCallback) for callbacks in self.callbacks):
+        self.callbacks += [
+            __MLflowPLCallback(client, metrics_logger, run_id, log_models, log_every_n_epoch)
+        ]
 
-                if (pl_module.current_epoch + 1) % every_n_epoch == 0:
-                    # `trainer.callback_metrics` contains both training and validation metrics
-                    cur_metrics = trainer.callback_metrics
-                    # Cast metric value as  float before passing into logger.
-                    metrics = dict(map(lambda x: (x[0], float(x[1])), cur_metrics.items()))
+    client.flush(synchronous=False)
 
-                    metrics_logger.record_metrics(metrics, pl_module.current_epoch)
+    result = original(self, *args, **kwargs)
 
-                for callback in trainer.callbacks:
-                    if isinstance(callback, pl.callbacks.early_stopping.EarlyStopping):
-                        self._early_stop_check(callback)
+    if early_stop_callback is not None:
+        _log_early_stop_metrics(early_stop_callback, client, run_id)
 
-            _pl_version = Version(pl.__version__)
+    summary = str(ModelSummary(self.model, mode="full"))
+    tempdir = tempfile.mkdtemp()
+    try:
+        summary_file = os.path.join(tempdir, "model_summary.txt")
+        with open(summary_file, "w") as f:
+            f.write(summary)
 
-            # In pytorch-lightning >= 1.4.0, validation is run inside the training epoch and
-            # `trainer.callback_metrics` contains both training and validation metrics of the
-            # current training epoch when `on_train_epoch_end` is called:
-            # https://github.com/PyTorchLightning/pytorch-lightning/pull/7357
-            if _pl_version >= Version("1.4.0dev"):
+        mlflow.log_artifact(local_path=summary_file)
+    finally:
+        shutil.rmtree(tempdir)
 
-                def on_train_epoch_end(
-                    self, trainer, pl_module, *args
-                ):  # pylint: disable=signature-differs,arguments-differ,unused-argument
-                    self._log_metrics(trainer, pl_module)
+    if log_models:
+        mlflow.pytorch.log_model(pytorch_model=self.model, artifact_path="model")
 
-            # In pytorch-lightning >= 1.2.0, logging metrics in `on_epoch_end` results in duplicate
-            # metrics records because `on_epoch_end` is called after both train and validation
-            # epochs (related PR: https://github.com/PyTorchLightning/pytorch-lightning/pull/5986)
-            # As a workaround, use `on_train_epoch_end` and `on_validation_epoch_end` instead
-            # in pytorch-lightning >= 1.2.0.
-            elif _pl_version >= Version("1.2.0"):
+        if early_stop_callback is not None and self.checkpoint_callback.best_model_path:
+            mlflow.log_artifact(
+                local_path=self.checkpoint_callback.best_model_path,
+                artifact_path="restored_model_checkpoint",
+            )
 
-                # NB: Override `on_train_epoch_end` with an additional `*args` parameter for
-                # compatibility with versions of pytorch-lightning <= 1.2.0, which required an
-                # `outputs` argument that was not used and is no longer defined in
-                # pytorch-lightning >= 1.3.0
+    client.flush(synchronous=True)
 
-                def on_train_epoch_end(
-                    self, trainer, pl_module, *args
-                ):  # pylint: disable=signature-differs,arguments-differ,unused-argument
-                    """
-                    Log loss and other metrics values after each train epoch
-
-                    :param trainer: pytorch lightning trainer instance
-                    :param pl_module: pytorch lightning base module
-                    """
-                    # If validation loop is enabled (meaning `validation_step` is overridden),
-                    # log metrics in `on_validaion_epoch_end` to avoid logging the same metrics
-                    # records twice
-                    if trainer.disable_validation:
-                        self._log_metrics(trainer, pl_module)
-
-                def on_validation_epoch_end(self, trainer, pl_module):
-                    """
-                    Log loss and other metrics values after each validation epoch
-
-                    :param trainer: pytorch lightning trainer instance
-                    :param pl_module: pytorch lightning base module
-                    """
-                    self._log_metrics(trainer, pl_module)
-
-            else:
-
-                def on_epoch_end(self, trainer, pl_module):
-                    """
-                    Log loss and other metrics values after each epoch
-
-                    :param trainer: pytorch lightning trainer instance
-                    :param pl_module: pytorch lightning base module
-                    """
-                    self._log_metrics(trainer, pl_module)
-
-            def on_train_start(self, trainer, pl_module):
-                """
-                Logs Optimizer related metrics when the train begins
-
-                :param trainer: pytorch lightning trainer instance
-                :param pl_module: pytorch lightning base module
-                """
-                try_mlflow_log(mlflow.set_tag, "Mode", "training")
-                try_mlflow_log(mlflow.log_param, "epochs", trainer.max_epochs)
-
-                for callback in trainer.callbacks:
-                    if isinstance(callback, pl.callbacks.early_stopping.EarlyStopping):
-                        self.early_stopping = True
-                        self._log_early_stop_params(callback)
-
-                # TODO For logging optimizer params - Following scenarios are to revisited.
-                # 1. In the current scenario, only the first optimizer details are logged.
-                #    Code to be enhanced to log params when multiple optimizers are used.
-                # 2. mlflow.log_params is used to store optimizer default values into mlflow.
-                #    The keys in default dictionary are too short, Ex: (lr - learning_rate).
-                #    Efficient mapping technique needs to be introduced
-                #    to rename the optimizer parameters based on keys in default dictionary.
-
-                if hasattr(trainer, "optimizers"):
-                    optimizer = trainer.optimizers[0]
-                    try_mlflow_log(
-                        mlflow.log_param, "optimizer_name", _get_optimizer_name(optimizer)
-                    )
-
-                    if hasattr(optimizer, "defaults"):
-                        try_mlflow_log(mlflow.log_params, optimizer.defaults)
-
-                summary = str(ModelSummary(pl_module, mode="full"))
-                tempdir = tempfile.mkdtemp()
-                try:
-                    summary_file = os.path.join(tempdir, "model_summary.txt")
-                    with open(summary_file, "w") as f:
-                        f.write(summary)
-
-                    try_mlflow_log(mlflow.log_artifact, local_path=summary_file)
-                finally:
-                    shutil.rmtree(tempdir)
-
-            def on_train_end(self, trainer, pl_module):
-                """
-                Logs the model checkpoint into mlflow - models folder on the training end
-
-                :param trainer: pytorch lightning trainer instance
-                :param pl_module: pytorch lightning base module
-                """
-                # manually flushing any remaining metrics from training.
-                metrics_logger.flush()
-
-                if log_models:
-                    mlflow.pytorch.log_model(pytorch_model=trainer.model, artifact_path="model")
-
-                    if self.early_stopping and trainer.checkpoint_callback.best_model_path:
-                        try_mlflow_log(
-                            mlflow.log_artifact,
-                            local_path=trainer.checkpoint_callback.best_model_path,
-                            artifact_path="restored_model_checkpoint",
-                        )
-
-            def on_test_end(self, trainer, pl_module):
-                """
-                Logs accuracy and other relevant metrics on the testing end
-
-                :param trainer: pytorch lightning trainer instance
-                :param pl_module: pytorch lightning base module
-                """
-                try_mlflow_log(mlflow.set_tag, "Mode", "testing")
-                for key, value in trainer.callback_metrics.items():
-                    try_mlflow_log(mlflow.log_metric, key, float(value))
-
-            @staticmethod
-            def _log_early_stop_params(early_stop_obj):
-                """
-                Logs Early Stop parameters into mlflow
-
-                :param early_stop_obj: Early stopping callback dict
-                """
-                if hasattr(early_stop_obj, "monitor"):
-                    try_mlflow_log(mlflow.log_param, "monitor", early_stop_obj.monitor)
-
-                if hasattr(early_stop_obj, "mode"):
-                    try_mlflow_log(mlflow.log_param, "mode", early_stop_obj.mode)
-
-                if hasattr(early_stop_obj, "patience"):
-                    try_mlflow_log(mlflow.log_param, "patience", early_stop_obj.patience)
-
-                if hasattr(early_stop_obj, "min_delta"):
-                    try_mlflow_log(mlflow.log_param, "min_delta", early_stop_obj.min_delta)
-
-                if hasattr(early_stop_obj, "stopped_epoch"):
-                    try_mlflow_log(mlflow.log_param, "stopped_epoch", early_stop_obj.stopped_epoch)
-
-            @staticmethod
-            def _early_stop_check(early_stop_callback):
-                """
-                Logs all early stopping metrics
-
-                :param early_stop_callback: Early stopping callback object
-                """
-                if early_stop_callback.stopped_epoch != 0:
-                    if hasattr(early_stop_callback, "stopped_epoch"):
-                        metrics_logger.record_metrics(
-                            {"stopped_epoch": early_stop_callback.stopped_epoch}
-                        )
-                        restored_epoch = early_stop_callback.stopped_epoch - max(
-                            1, early_stop_callback.patience
-                        )
-                        metrics_logger.record_metrics({"restored_epoch": restored_epoch})
-
-                    if hasattr(early_stop_callback, "best_score"):
-                        metrics_logger.record_metrics(
-                            {"best_score": float(early_stop_callback.best_score)}
-                        )
-
-                    if hasattr(early_stop_callback, "wait_count"):
-                        metrics_logger.record_metrics(
-                            {"wait_count": early_stop_callback.wait_count}
-                        )
-
-        return __MLflowPLCallback
-
-    def _run_and_log_function(self, original, args, kwargs):
-        """
-        This method would be called from patched fit method and
-        It adds the custom callback class into callback list.
-        """
-
-        # The run_id is not set here. Rather it will be retrieved from
-        # the current mlfow run's training session inside of BatchMetricsLogger.
-        metrics_logger = BatchMetricsLogger()
-        __MLflowPLCallback = getPLCallback(log_models, metrics_logger)
-        if not any(isinstance(callbacks, __MLflowPLCallback) for callbacks in self.callbacks):
-            self.callbacks += [__MLflowPLCallback()]
-        result = original(self, *args, **kwargs)
-
-        return result
-
-    def fit(original, self, *args, **kwargs):
-        """
-        Patching trainer.fit method to add autolog class into callback
-        """
-        return _run_and_log_function(self, original, args, kwargs)
-
-    return fit
+    return result

--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -194,8 +194,9 @@ class BatchMetricsLogger:
     `record_metrics()` or `flush()`.
     """
 
-    def __init__(self, run_id=None):
+    def __init__(self, run_id=None, tracking_uri=None):
         self.run_id = run_id
+        self.client = MlflowClient(tracking_uri)
 
         # data is an array of Metric objects
         self.data = []
@@ -223,7 +224,7 @@ class BatchMetricsLogger:
             for i in range(0, len(self.data), MAX_METRICS_PER_BATCH)
         ]
         for metrics_slice in metrics_slices:
-            try_mlflow_log(MlflowClient().log_batch, run_id=current_run_id, metrics=metrics_slice)
+            try_mlflow_log(self.client.log_batch, run_id=current_run_id, metrics=metrics_slice)
         end = time.time()
         self.total_log_batch_time += end - start
 

--- a/mlflow/utils/autologging_utils/client.py
+++ b/mlflow/utils/autologging_utils/client.py
@@ -72,6 +72,17 @@ class RunOperations:
             )
 
 
+# Define a threadpool for use across `MlflowAutologgingQueueingClient` instances to ensure that
+# `MlflowAutologgingQueueingClient` instances can be pickled (ThreadPoolExecutor objects are not
+# pickleable and therefore cannot be assigned as instance attributes).
+#
+# We limit the number of threads used for run operations, using at most 8 threads or 2 * the number
+# of CPU cores available on the system (whichever is smaller)
+num_cpus = os.cpu_count() or 4
+num_logging_workers = min(num_cpus * 2, 8)
+_AUTOLOGGING_QUEUEING_CLIENT_THREAD_POOL = ThreadPoolExecutor(max_workers=num_logging_workers)
+
+
 class MlflowAutologgingQueueingClient:
     """
     Efficiently implements a subset of MLflow Tracking's  `MlflowClient` and fluent APIs to provide
@@ -85,15 +96,9 @@ class MlflowAutologgingQueueingClient:
     concurrently.
     """
 
-    def __init__(self):
-        self._client = MlflowClient()
+    def __init__(self, tracking_uri=None):
+        self._client = MlflowClient(tracking_uri)
         self._pending_ops_by_run_id = {}
-
-        # Limit the number of threads used for run operations, using at most 8 threads or
-        # 2 * the number of CPU cores available on the system (whichever is smaller)
-        num_cpus = os.cpu_count() or 4
-        num_logging_workers = min(num_cpus * 2, 8)
-        self._thread_pool = ThreadPoolExecutor(max_workers=num_logging_workers)
 
     def __enter__(self):
         """
@@ -222,7 +227,7 @@ class MlflowAutologgingQueueingClient:
         """
         logging_futures = []
         for pending_operations in self._pending_ops_by_run_id.values():
-            future = self._thread_pool.submit(
+            future = _AUTOLOGGING_QUEUEING_CLIENT_THREAD_POOL.submit(
                 self._flush_pending_operations, pending_operations=pending_operations,
             )
             logging_futures.append(future)

--- a/tests/pytorch/test_pytorch_autolog.py
+++ b/tests/pytorch/test_pytorch_autolog.py
@@ -9,11 +9,11 @@ from pytorch_lightning.callbacks.early_stopping import EarlyStopping
 from pytorch_lightning.callbacks import ModelCheckpoint
 from mlflow.utils.file_utils import TempDir
 from iris_data_module import IrisDataModule, IrisDataModuleWithoutValidation
-from mlflow.utils.autologging_utils import BatchMetricsLogger
 from mlflow.pytorch._pytorch_autolog import _get_optimizer_name
-from unittest.mock import patch
 
 NUM_EPOCHS = 20
+
+pytestmark = pytest.mark.large
 
 
 @pytest.fixture
@@ -42,7 +42,6 @@ def pytorch_model_without_validation():
     return trainer, run
 
 
-@pytest.mark.large
 @pytest.mark.parametrize("log_models", [True, False])
 def test_pytorch_autolog_log_models_configuration(log_models):
     mlflow.pytorch.autolog(log_models=log_models)
@@ -173,7 +172,6 @@ def test_pytorch_autolog_model_can_load_from_artifact(pytorch_model_with_callbac
     assert result is not None
 
 
-@pytest.mark.large
 @pytest.mark.parametrize("log_models", [True, False])
 @pytest.mark.parametrize("patience", [3])
 def test_pytorch_with_early_stopping_autolog_log_models_configuration_with(log_models, patience):
@@ -212,36 +210,6 @@ def test_pytorch_early_stop_params_logged(pytorch_model_with_callback, patience)
     assert float(data.params["patience"]) == patience
     assert "min_delta" in data.params
     assert "stopped_epoch" in data.params
-
-
-@pytest.mark.parametrize("patience", [3])
-def test_pytorch_autolog_batch_metrics_logger_logs_expected_metrics(patience):
-    patched_metrics_data = []
-
-    # Mock patching BatchMetricsLogger.record_metrics()
-    # to ensure that expected metrics are being logged.
-    original = BatchMetricsLogger.record_metrics
-
-    with patch(
-        "mlflow.utils.autologging_utils.BatchMetricsLogger.record_metrics", autospec=True
-    ) as record_metrics_mock:
-
-        def record_metrics_side_effect(self, metrics, step=None):
-            patched_metrics_data.extend(metrics.items())
-            original(self, metrics, step)
-
-        record_metrics_mock.side_effect = record_metrics_side_effect
-        _, run = pytorch_model_with_callback(patience)
-
-    patched_metrics_data = dict(patched_metrics_data)
-    original_metrics = run.data.metrics
-
-    for metric_name in original_metrics:
-        assert metric_name in patched_metrics_data
-        assert original_metrics[metric_name] == patched_metrics_data[metric_name]
-
-    assert "loss" in original_metrics
-    assert "loss" in patched_metrics_data
 
 
 def test_pytorch_autolog_non_early_stop_callback_does_not_log(pytorch_model):
@@ -290,3 +258,23 @@ def test_get_optimizer_name_with_lightning_optimizer():
 
     adam = torch.optim.Adam(torch.nn.Linear(1, 1).parameters())
     assert _get_optimizer_name(LightningOptimizer(adam)) == "Adam"
+
+
+def test_pytorch_autologging_supports_data_parallel_execution():
+    mlflow.pytorch.autolog(log_models=False)
+    model = IrisClassification()
+    dm = IrisDataModule()
+    dm.setup(stage="fit")
+
+    trainer = pl.Trainer(max_epochs=NUM_EPOCHS, accelerator="ddp_cpu", num_processes=4)
+
+    with mlflow.start_run() as run:
+        trainer.fit(model, dm)
+        trainer.test()
+
+    client = mlflow.tracking.MlflowClient()
+    run = client.get_run(run.info.run_id)
+
+    data = run.data
+    assert "test_loss" in data.metrics
+    assert "test_acc" in data.metrics


### PR DESCRIPTION
## What changes are proposed in this pull request?

Supported PyTorch Lightning autologging execution in distributed contexts (e.g. execution with `ddp_cpu`).

## How is this patch tested?

Unit tests

## Release Notes

PyTorch Autologging now supports distributed, data parallel execution.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
