### PR TITLE
Remove `manual_run` fixture in keras, tensorflow and fastai tests to decrease the number of tests

### DIFF
--- a/tests/fastai/test_fastai_autolog.py
+++ b/tests/fastai/test_fastai_autolog.py
@@ -25,14 +25,6 @@ NUM_EPOCHS = 3
 MIN_DELTA = 99999999  # Forces earlystopping
 
 
-@pytest.fixture(params=[True, False])
-def manual_run(request):
-    if request.param:
-        mlflow.start_run()
-    yield
-    mlflow.end_run()
-
-
 def iris_dataframe():
     iris = datasets.load_iris()
     return pd.DataFrame(iris.data[:, :2], columns=iris.feature_names[:2])
@@ -111,7 +103,7 @@ def test_fastai_autolog_persists_manually_created_run(iris_data, fit_variant):
 
 
 @pytest.fixture
-def fastai_random_tabular_data_run(iris_data, fit_variant, manual_run):
+def fastai_random_tabular_data_run(iris_data, fit_variant):
     # pylint: disable=unused-argument
     mlflow.fastai.autolog()
 
@@ -187,7 +179,7 @@ def test_fastai_autolog_logs_expected_data(fastai_random_tabular_data_run, fit_v
 
 @pytest.mark.large
 @pytest.mark.parametrize("fit_variant", ["fit", "fit_one_cycle", "fine_tune"])
-def test_fastai_autolog_opt_func_expected_data(iris_data, fit_variant, manual_run):
+def test_fastai_autolog_opt_func_expected_data(iris_data, fit_variant):
     # pylint: disable=unused-argument
     mlflow.fastai.autolog()
     model = fastai_tabular_model(iris_data, opt_func=partial(OptimWrapper, opt=optim.Adam))
@@ -256,9 +248,7 @@ def test_fastai_autolog_model_can_load_from_artifact(fastai_random_tabular_data_
     model_wrapper.predict(iris_dataframe())
 
 
-def get_fastai_random_data_run_with_callback(
-    iris_data, fit_variant, manual_run, callback, patience, tmpdir
-):
+def get_fastai_random_data_run_with_callback(iris_data, fit_variant, callback, patience, tmpdir):
     # pylint: disable=unused-argument
     mlflow.fastai.autolog()
 
@@ -284,11 +274,9 @@ def get_fastai_random_data_run_with_callback(
 
 
 @pytest.fixture
-def fastai_random_data_run_with_callback(
-    iris_data, fit_variant, manual_run, callback, patience, tmpdir
-):
+def fastai_random_data_run_with_callback(iris_data, fit_variant, callback, patience, tmpdir):
     return get_fastai_random_data_run_with_callback(
-        iris_data, fit_variant, manual_run, callback, patience, tmpdir
+        iris_data, fit_variant, callback, patience, tmpdir
     )
 
 
@@ -412,7 +400,7 @@ def test_fastai_autolog_batch_metrics_logger_logs_expected_metrics(
 
         record_metrics_mock.side_effect = record_metrics_side_effect
         _, run = get_fastai_random_data_run_with_callback(
-            iris_data, fit_variant, manual_run, callback, patience, tmpdir
+            iris_data, fit_variant, callback, patience, tmpdir
         )
 
     patched_metrics_data = dict(patched_metrics_data)

--- a/tests/keras/test_keras_autolog.py
+++ b/tests/keras/test_keras_autolog.py
@@ -44,14 +44,6 @@ def random_one_hot_labels():
     return labels
 
 
-@pytest.fixture(params=[True, False])
-def manual_run(request):
-    if request.param:
-        mlflow.start_run()
-    yield
-    mlflow.end_run()
-
-
 def create_model():
     model = keras.Sequential()
 
@@ -94,7 +86,7 @@ def test_keras_autolog_persists_manually_created_run(random_train_data, random_o
 
 
 @pytest.fixture
-def keras_random_data_run(random_train_data, random_one_hot_labels, manual_run, initial_epoch):
+def keras_random_data_run(random_train_data, random_one_hot_labels, initial_epoch):
     # pylint: disable=unused-argument
     mlflow.keras.autolog()
 
@@ -153,13 +145,7 @@ def test_keras_autolog_model_can_load_from_artifact(keras_random_data_run, rando
 
 
 def get_keras_random_data_run_with_callback(
-    random_train_data,
-    random_one_hot_labels,
-    manual_run,
-    callback,
-    restore_weights,
-    patience,
-    initial_epoch,
+    random_train_data, random_one_hot_labels, callback, restore_weights, patience, initial_epoch,
 ):
     # pylint: disable=unused-argument
     mlflow.keras.autolog()
@@ -195,18 +181,11 @@ def get_keras_random_data_run_with_callback(
 
 @pytest.fixture
 def keras_random_data_run_with_callback(
-    random_train_data,
-    random_one_hot_labels,
-    manual_run,
-    callback,
-    restore_weights,
-    patience,
-    initial_epoch,
+    random_train_data, random_one_hot_labels, callback, restore_weights, patience, initial_epoch,
 ):
     return get_keras_random_data_run_with_callback(
         random_train_data,
         random_one_hot_labels,
-        manual_run,
         callback,
         restore_weights,
         patience,
@@ -298,7 +277,6 @@ def test_keras_autolog_batch_metrics_logger_logs_expected_metrics(
         run, _, callback = get_keras_random_data_run_with_callback(
             random_train_data,
             random_one_hot_labels,
-            manual_run,
             callback,
             restore_weights,
             patience,

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -46,14 +46,6 @@ def random_one_hot_labels():
     return labels
 
 
-@pytest.fixture(params=[True, False])
-def manual_run(request):
-    if request.param:
-        mlflow.start_run()
-    yield
-    mlflow.end_run()
-
-
 @pytest.fixture
 def clear_tf_keras_imports():
     """
@@ -139,7 +131,7 @@ def test_tf_keras_autolog_persists_manually_created_run(random_train_data, rando
 
 
 @pytest.fixture
-def tf_keras_random_data_run(random_train_data, random_one_hot_labels, manual_run, initial_epoch):
+def tf_keras_random_data_run(random_train_data, random_one_hot_labels, initial_epoch):
     # pylint: disable=unused-argument
     mlflow.tensorflow.autolog()
 
@@ -272,13 +264,7 @@ def test_tf_keras_autolog_model_can_load_from_artifact(tf_keras_random_data_run,
 
 
 def get_tf_keras_random_data_run_with_callback(
-    random_train_data,
-    random_one_hot_labels,
-    manual_run,
-    callback,
-    restore_weights,
-    patience,
-    initial_epoch,
+    random_train_data, random_one_hot_labels, callback, restore_weights, patience, initial_epoch,
 ):
     # pylint: disable=unused-argument
     mlflow.tensorflow.autolog(every_n_iter=1)
@@ -314,18 +300,11 @@ def get_tf_keras_random_data_run_with_callback(
 
 @pytest.fixture
 def tf_keras_random_data_run_with_callback(
-    random_train_data,
-    random_one_hot_labels,
-    manual_run,
-    callback,
-    restore_weights,
-    patience,
-    initial_epoch,
+    random_train_data, random_one_hot_labels, callback, restore_weights, patience, initial_epoch,
 ):
     return get_tf_keras_random_data_run_with_callback(
         random_train_data,
         random_one_hot_labels,
-        manual_run,
         callback,
         restore_weights,
         patience,
@@ -393,7 +372,6 @@ def test_tf_keras_autolog_batch_metrics_logger_logs_expected_metrics(
         run, _, callback = get_tf_keras_random_data_run_with_callback(
             random_train_data,
             random_one_hot_labels,
-            manual_run,
             callback,
             restore_weights,
             patience,
@@ -640,7 +618,7 @@ def test_tf_estimator_autolog_persists_manually_created_run(tmpdir, export):
 
 
 @pytest.fixture
-def tf_estimator_random_data_run(tmpdir, manual_run, export):
+def tf_estimator_random_data_run(tmpdir, export):
     # pylint: disable=unused-argument
     directory = tmpdir.mkdir("test")
     mlflow.tensorflow.autolog()


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

This PR removes `manual_run` fixture in keras and tensorflow tests to decrease the number of tests that we need to run.

## How is this patch tested?

Updated test scripts

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
