### PR TITLE
Remove mleap / spark from sagemaker tests

### DIFF
--- a/dev/run-python-sagemaker-tests.sh
+++ b/dev/run-python-sagemaker-tests.sh
@@ -18,12 +18,4 @@ fi
 pytest tests/sagemaker --large
 pytest tests/sagemaker/mock --large
 
-# Added here due to dependency on sagemaker
-# TODO: split out sagemaker tests and move other spark tests to run-python-flavor-tests.sh
-pytest tests/spark --large  --ignore tests/spark/test_mleap_model_export.py
-
-# MLeap doesn't support spark 3.x (https://github.com/combust/mleap#mleapspark-version)
-pip install pyspark==2.4.5
-pytest tests/spark/test_mleap_model_export.py --large
-
 test $err = 0

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -328,3 +328,14 @@ spark:
         ./dev/setup-spark-datasource-autologging.sh
         find tests/spark_autologging/datasource -name 'test*.py' | xargs -L 1 pytest --large
       fi
+
+mleap:
+  package_info:
+    pip_release: "mleap"
+
+  models:
+    minimum: "0.15.0"
+    maximum: "0.17.0"
+    requirements: ["pyspark==2.4.5"]
+    run: |
+      pytest tests/spark/test_mleap_model_export.py --large


### PR DESCRIPTION
## What changes are proposed in this pull request?

Remove mleap / spark from sagemaker tests

## How is this patch tested?

Cross version tests

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [X] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
