### PR TITLE
Run `tests/models` in a separate job and decrease CI execution time by 9 ~ 10 minutes

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -318,6 +318,30 @@ jobs:
           sudo apt-get install libopenblas-dev
           ./dev/run-python-flavor-tests.sh;
 
+  # It takes 9 ~ 10 minutes to run tests in `tests/models`. To finish CI checks faster,
+  # run them in a separate workflow.
+  models:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v2
+        with:
+          java-version: 8
+          distribution: 'adopt'
+      - name: Install dependencies
+        env:
+          INSTALL_SMALL_PYTHON_DEPS: true
+          INSTALL_LARGE_PYTHON_DEPS: false
+        run: |
+          source ./dev/install-common-deps.sh
+      - name: Run tests
+        env:
+          SPARK_LOCAL_IP: 127.0.0.1
+        run: |
+          export PATH="$CONDA_DIR/bin:$PATH"
+          source activate test-environment
+          pytest tests/models --large
+
   import:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -318,8 +318,8 @@ jobs:
           sudo apt-get install libopenblas-dev
           ./dev/run-python-flavor-tests.sh;
 
-  # It takes 9 ~ 10 minutes to run tests in `tests/models`. To finish CI checks faster,
-  # run them in a separate workflow.
+  # It takes 9 ~ 10 minutes to run tests in `tests/models`. To make CI finish faster,
+  # run these tests in a separate job.
   models:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -341,6 +341,7 @@ jobs:
         run: |
           export PATH="$CONDA_DIR/bin:$PATH"
           source activate test-environment
+          export MLFLOW_HOME=$(pwd)
           pytest tests/models --large
 
   import:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -334,6 +334,7 @@ jobs:
           INSTALL_LARGE_PYTHON_DEPS: false
         run: |
           source ./dev/install-common-deps.sh
+          pip install pyspark
       - name: Run tests
         env:
           SPARK_LOCAL_IP: 127.0.0.1

--- a/dev/run-python-flavor-tests.sh
+++ b/dev/run-python-flavor-tests.sh
@@ -10,7 +10,6 @@ export MLFLOW_HOME=$(pwd)
 # overhead
 pytest tests/pyfunc --large
 pytest tests/azureml --large
-pytest tests/models --large
 pytest tests/utils/test_model_utils.py --large
 pytest tests/tracking/fluent/test_fluent_autolog.py --large
 pytest tests/autologging --large


### PR DESCRIPTION
## What changes are proposed in this pull request?

Running tests in `tests/models` takes really long time (see the log below). This PR separates them from the `flavors` check and runs them in a separate job to decrease the CI execution time.

https://github.com/mlflow/mlflow/runs/3394648497#step:6:265

```
=========================== slowest 5 test durations ===========================
439.51s call     tests/models/test_cli.py::test_build_docker
123.64s call     tests/models/test_cli.py::test_build_docker_with_env_override
81.69s call     tests/models/test_cli.py::test_predict
22.68s call     tests/models/test_cli.py::test_serve_gunicorn_opts
17.68s call     tests/models/test_cli.py::test_mlflow_is_not_installed_unless_specified
```

## Results

Before: the flavors check takkes 35 ~ 37 min
After: the flavors check takes 25 ~ 27 min.

## How is this patch tested?

NA

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
