### PR TITLE
Revert `h2o`, `shap`, and `paddle` in `dev/run-python-flavor-tests.sh`

### DIFF
--- a/dev/run-python-flavor-tests.sh
+++ b/dev/run-python-flavor-tests.sh
@@ -12,6 +12,12 @@ pytest tests/pyfunc --large
 pytest tests/azureml --large
 pytest tests/models --large
 pytest tests/utils/test_model_utils.py --large
+
+# TODO: Run tests for h2o, shap, and paddle in the cross-version-tests workflow
+pytest tests/h2o --large
+pytest tests/shap --large
+pytest tests/paddle --large
+
 pytest tests/tracking/fluent/test_fluent_autolog.py --large
 pytest tests/autologging --large
 find tests/spark_autologging/ml -name 'test*.py' | xargs -L 1 pytest --large

--- a/tests/h2o/test_h2o_model_export.py
+++ b/tests/h2o/test_h2o_model_export.py
@@ -99,31 +99,22 @@ def test_signature_and_examples_are_saved_correctly(h2o_iris_model):
 
 
 @pytest.mark.large
-@pytest.mark.parametrize("should_start_run", [False, True])
-def test_model_log(h2o_iris_model, should_start_run):
+def test_model_log(h2o_iris_model):
     h2o_model = h2o_iris_model.model
-    old_uri = mlflow.get_tracking_uri()
-    # should_start_run tests whether or not calling log_model() automatically starts a run.
-    with TempDir(chdr=True, remove_on_exit=True):
-        try:
-            artifact_path = "gbm_model"
-            mlflow.set_tracking_uri("test")
-            if should_start_run:
-                mlflow.start_run()
-            mlflow.h2o.log_model(h2o_model=h2o_model, artifact_path=artifact_path)
-            model_uri = "runs:/{run_id}/{artifact_path}".format(
-                run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path
-            )
-
-            # Load model
-            h2o_model_loaded = mlflow.h2o.load_model(model_uri=model_uri)
-            assert all(
-                h2o_model_loaded.predict(h2o_iris_model.inference_data).as_data_frame()
-                == h2o_model.predict(h2o_iris_model.inference_data).as_data_frame()
-            )
-        finally:
-            mlflow.end_run()
-            mlflow.set_tracking_uri(old_uri)
+    try:
+        artifact_path = "gbm_model"
+        mlflow.h2o.log_model(h2o_model=h2o_model, artifact_path=artifact_path)
+        model_uri = "runs:/{run_id}/{artifact_path}".format(
+            run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path
+        )
+        # Load model
+        h2o_model_loaded = mlflow.h2o.load_model(model_uri=model_uri)
+        assert all(
+            h2o_model_loaded.predict(h2o_iris_model.inference_data).as_data_frame()
+            == h2o_model.predict(h2o_iris_model.inference_data).as_data_frame()
+        )
+    finally:
+        mlflow.end_run()
 
 
 @pytest.mark.large

--- a/tests/h2o/test_h2o_model_export.py
+++ b/tests/h2o/test_h2o_model_export.py
@@ -99,31 +99,31 @@ def test_signature_and_examples_are_saved_correctly(h2o_iris_model):
 
 
 @pytest.mark.large
-def test_model_log(h2o_iris_model):
+@pytest.mark.parametrize("should_start_run", [False, True])
+def test_model_log(h2o_iris_model, should_start_run):
     h2o_model = h2o_iris_model.model
     old_uri = mlflow.get_tracking_uri()
     # should_start_run tests whether or not calling log_model() automatically starts a run.
-    for should_start_run in [False, True]:
-        with TempDir(chdr=True, remove_on_exit=True):
-            try:
-                artifact_path = "gbm_model"
-                mlflow.set_tracking_uri("test")
-                if should_start_run:
-                    mlflow.start_run()
-                mlflow.h2o.log_model(h2o_model=h2o_model, artifact_path=artifact_path)
-                model_uri = "runs:/{run_id}/{artifact_path}".format(
-                    run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path
-                )
+    with TempDir(chdr=True, remove_on_exit=True):
+        try:
+            artifact_path = "gbm_model"
+            mlflow.set_tracking_uri("test")
+            if should_start_run:
+                mlflow.start_run()
+            mlflow.h2o.log_model(h2o_model=h2o_model, artifact_path=artifact_path)
+            model_uri = "runs:/{run_id}/{artifact_path}".format(
+                run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path
+            )
 
-                # Load model
-                h2o_model_loaded = mlflow.h2o.load_model(model_uri=model_uri)
-                assert all(
-                    h2o_model_loaded.predict(h2o_iris_model.inference_data).as_data_frame()
-                    == h2o_model.predict(h2o_iris_model.inference_data).as_data_frame()
-                )
-            finally:
-                mlflow.end_run()
-                mlflow.set_tracking_uri(old_uri)
+            # Load model
+            h2o_model_loaded = mlflow.h2o.load_model(model_uri=model_uri)
+            assert all(
+                h2o_model_loaded.predict(h2o_iris_model.inference_data).as_data_frame()
+                == h2o_model.predict(h2o_iris_model.inference_data).as_data_frame()
+            )
+        finally:
+            mlflow.end_run()
+            mlflow.set_tracking_uri(old_uri)
 
 
 @pytest.mark.large

--- a/tests/paddle/test_paddle_model_export.py
+++ b/tests/paddle/test_paddle_model_export.py
@@ -269,7 +269,7 @@ def test_model_save_without_specified_conda_env_uses_default_env_with_expected_d
     pd_model, model_path
 ):
     mlflow.paddle.save_model(pd_model=pd_model.model, path=model_path)
-    _assert_pip_requirements(model_path, mlflow.onnx.get_default_pip_requirements())
+    _assert_pip_requirements(model_path, mlflow.paddle.get_default_pip_requirements())
 
 
 @pytest.mark.large
@@ -280,7 +280,7 @@ def test_model_log_without_specified_conda_env_uses_default_env_with_expected_de
     with mlflow.start_run():
         mlflow.paddle.log_model(pd_model=pd_model.model, artifact_path=artifact_path)
         model_uri = mlflow.get_artifact_uri(artifact_path)
-    _assert_pip_requirements(model_uri, mlflow.onnx.get_default_pip_requirements())
+    _assert_pip_requirements(model_uri, mlflow.paddle.get_default_pip_requirements())
 
 
 @pytest.fixture(scope="session")
@@ -412,6 +412,7 @@ def model_retrain_path(tmpdir):
 
 
 @pytest.mark.large
+@pytest.mark.allow_infer_pip_requirements_fallback
 def test_model_retrain_built_in_high_level_api(
     pd_model_built_in_high_level_api, model_path, model_retrain_path
 ):
@@ -460,53 +461,55 @@ def test_model_retrain_built_in_high_level_api(
 
 
 @pytest.mark.large
-def test_log_model_built_in_high_level_api(pd_model_built_in_high_level_api, model_path):
+@pytest.mark.parametrize("should_start_run", [False, True])
+def test_log_model_built_in_high_level_api(
+    pd_model_built_in_high_level_api, model_path, should_start_run
+):
     old_uri = mlflow.get_tracking_uri()
     model = pd_model_built_in_high_level_api.model
 
     _, test_dataset = get_dataset_built_in_high_level_api()
 
     with TempDir(chdr=True, remove_on_exit=True) as tmp:
-        for should_start_run in [False, True]:
-            try:
-                mlflow.set_tracking_uri("test")
-                if should_start_run:
-                    mlflow.start_run()
+        try:
+            mlflow.set_tracking_uri(tmp.path)
+            if should_start_run:
+                mlflow.start_run()
 
-                artifact_path = "model"
-                conda_env = os.path.join(tmp.path(), "conda_env.yaml")
-                _mlflow_conda_env(conda_env, additional_pip_deps=["paddle"])
+            artifact_path = "model"
+            conda_env = os.path.join(tmp.path(), "conda_env.yaml")
+            _mlflow_conda_env(conda_env, additional_pip_deps=["paddle"])
 
-                mlflow.paddle.log_model(
-                    pd_model=model, artifact_path=artifact_path, conda_env=conda_env, training=True
-                )
-                model_uri = "runs:/{run_id}/{artifact_path}".format(
-                    run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path
-                )
+            mlflow.paddle.log_model(
+                pd_model=model, artifact_path=artifact_path, conda_env=conda_env, training=True
+            )
+            model_uri = "runs:/{run_id}/{artifact_path}".format(
+                run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path
+            )
 
-                model_uri = mlflow.get_artifact_uri("model")
+            model_uri = mlflow.get_artifact_uri("model")
 
-                model_retrain = paddle.Model(UCIHousing())
-                optim = paddle.optimizer.Adam(learning_rate=0.015, parameters=model.parameters())
-                model_retrain.prepare(optim, paddle.nn.MSELoss())
-                model_retrain = mlflow.paddle.load_model(model_uri=model_uri, model=model_retrain)
+            model_retrain = paddle.Model(UCIHousing())
+            optim = paddle.optimizer.Adam(learning_rate=0.015, parameters=model.parameters())
+            model_retrain.prepare(optim, paddle.nn.MSELoss())
+            model_retrain = mlflow.paddle.load_model(model_uri=model_uri, model=model_retrain)
 
-                np.testing.assert_array_almost_equal(
-                    np.array(model.predict(test_dataset)).squeeze(),
-                    np.array(model_retrain.predict(test_dataset)).squeeze(),
-                    decimal=5,
-                )
+            np.testing.assert_array_almost_equal(
+                np.array(model.predict(test_dataset)).squeeze(),
+                np.array(model_retrain.predict(test_dataset)).squeeze(),
+                decimal=5,
+            )
 
-                model_path = _download_artifact_from_uri(artifact_uri=model_uri)
-                model_config = Model.load(os.path.join(model_path, "MLmodel"))
-                assert pyfunc.FLAVOR_NAME in model_config.flavors
-                assert pyfunc.ENV in model_config.flavors[pyfunc.FLAVOR_NAME]
-                env_path = model_config.flavors[pyfunc.FLAVOR_NAME][pyfunc.ENV]
-                assert os.path.exists(os.path.join(model_path, env_path))
+            model_path = _download_artifact_from_uri(artifact_uri=model_uri)
+            model_config = Model.load(os.path.join(model_path, "MLmodel"))
+            assert pyfunc.FLAVOR_NAME in model_config.flavors
+            assert pyfunc.ENV in model_config.flavors[pyfunc.FLAVOR_NAME]
+            env_path = model_config.flavors[pyfunc.FLAVOR_NAME][pyfunc.ENV]
+            assert os.path.exists(os.path.join(model_path, env_path))
 
-            finally:
-                mlflow.end_run()
-                mlflow.set_tracking_uri(old_uri)
+        finally:
+            mlflow.end_run()
+            mlflow.set_tracking_uri(old_uri)
 
 
 @pytest.mark.large

--- a/tests/paddle/test_paddle_model_export.py
+++ b/tests/paddle/test_paddle_model_export.py
@@ -472,7 +472,7 @@ def test_log_model_built_in_high_level_api(
 
     with TempDir(chdr=True, remove_on_exit=True) as tmp:
         try:
-            mlflow.set_tracking_uri(tmp.path)
+            mlflow.set_tracking_uri(tmp.path())
             if should_start_run:
                 mlflow.start_run()
 

--- a/tests/paddle/test_paddle_model_export.py
+++ b/tests/paddle/test_paddle_model_export.py
@@ -20,7 +20,6 @@ from mlflow.models import Model
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.environment import _mlflow_conda_env
-from mlflow.utils.file_utils import TempDir
 from mlflow.utils.model_utils import _get_flavor_configuration
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

In https://github.com/mlflow/mlflow/pull/4662, I mistakenly removed `h2o`, `shap` and `paddle` in `dev/run-python-flavor-tests.sh`. This PR reverts them.

https://github.com/mlflow/mlflow/pull/4662/files#diff-1f78b4f0d0c7832b7641c7402bde51627afcc5763ebce2c832d91a632581300f

## How is this patch tested?

Existing tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
