### PR TITLE
Fix & simplify pytorch / statsmodels logging tests

### DIFF
--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -18,7 +18,6 @@ import mlflow.pyfunc as pyfunc
 import mlflow.pytorch
 import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 from mlflow.pytorch import get_default_conda_env
-from mlflow import tracking
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model, infer_signature
 from mlflow.models.utils import _read_example

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -215,16 +215,18 @@ def test_signature_and_examples_are_saved_correctly(sequential_model, data):
 @pytest.mark.large
 @pytest.mark.parametrize("scripted_model", [True, False])
 def test_log_model(sequential_model, data, sequential_predicted):
-    with mlflow.start_run():
+    try:
         artifact_path = "pytorch"
         mlflow.pytorch.log_model(sequential_model, artifact_path=artifact_path)
         model_uri = "runs:/{run_id}/{artifact_path}".format(
             run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path
         )
 
-    sequential_model_loaded = mlflow.pytorch.load_model(model_uri=model_uri)
-    test_predictions = _predict(sequential_model_loaded, data)
-    np.testing.assert_array_equal(test_predictions, sequential_predicted)
+        sequential_model_loaded = mlflow.pytorch.load_model(model_uri=model_uri)
+        test_predictions = _predict(sequential_model_loaded, data)
+        np.testing.assert_array_equal(test_predictions, sequential_predicted)
+    finally:
+        mlflow.end_run()
 
 
 def test_log_model_calls_register_model(module_scoped_subclassed_model):

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -215,29 +215,16 @@ def test_signature_and_examples_are_saved_correctly(sequential_model, data):
 @pytest.mark.large
 @pytest.mark.parametrize("scripted_model", [True, False])
 def test_log_model(sequential_model, data, sequential_predicted):
-    old_uri = tracking.get_tracking_uri()
-    # should_start_run tests whether or not calling log_model() automatically starts a run.
-    for should_start_run in [False, True]:
-        with TempDir(chdr=True, remove_on_exit=True) as tmp:
-            try:
-                tracking.set_tracking_uri(tmp.path("test"))
-                if should_start_run:
-                    mlflow.start_run()
+    with mlflow.start_run():
+        artifact_path = "pytorch"
+        mlflow.pytorch.log_model(sequential_model, artifact_path=artifact_path)
+        model_uri = "runs:/{run_id}/{artifact_path}".format(
+            run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path
+        )
 
-                artifact_path = "pytorch"
-                mlflow.pytorch.log_model(sequential_model, artifact_path=artifact_path)
-                model_uri = "runs:/{run_id}/{artifact_path}".format(
-                    run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path
-                )
-
-                # Load model
-                sequential_model_loaded = mlflow.pytorch.load_model(model_uri=model_uri)
-
-                test_predictions = _predict(sequential_model_loaded, data)
-                np.testing.assert_array_equal(test_predictions, sequential_predicted)
-            finally:
-                mlflow.end_run()
-                tracking.set_tracking_uri(old_uri)
+    sequential_model_loaded = mlflow.pytorch.load_model(model_uri=model_uri)
+    test_predictions = _predict(sequential_model_loaded, data)
+    np.testing.assert_array_equal(test_predictions, sequential_predicted)
 
 
 def test_log_model_calls_register_model(module_scoped_subclassed_model):


### PR DESCRIPTION
## What changes are proposed in this pull request?

When https://github.com/mlflow/mlflow/pull/4719 was merged, it broke a couple of test cases that needlessly modify the tracking URI used by MLflow and tear down a temporary tracking directory mid-way through the test. This PR refactors the test cases to reduce complexity while still testing the necessary functionality.

## How is this patch tested?

Integration tests

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [X] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
