### PR TITLE
Deprecate fast.ai V1 support

### DIFF
--- a/mlflow/fastai.py
+++ b/mlflow/fastai.py
@@ -39,7 +39,7 @@ from mlflow.utils.requirements_utils import _get_pinned_requirement
 from mlflow.utils.file_utils import write_to
 from mlflow.utils.docstring_utils import format_docstring, LOG_MODEL_PARAM_DOCS
 from mlflow.utils.model_utils import _get_flavor_configuration
-from mlflow.utils.annotations import experimental
+from mlflow.utils.annotations import experimental, deprecated
 from mlflow.utils.autologging_utils import (
     try_mlflow_log,
     log_fn_args_as_params,
@@ -98,6 +98,10 @@ def get_default_conda_env(include_cloudpickle=False):
     return _mlflow_conda_env(additional_pip_deps=get_default_pip_requirements(include_cloudpickle))
 
 
+@deprecated(
+    alternative="fast.ai V2 support, which will be available in MLflow shortly",
+    since="MLflow version 1.20.0",
+)
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
 def save_model(
     fastai_learner,
@@ -221,6 +225,10 @@ def save_model(
     write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME), "\n".join(pip_requirements))
 
 
+@deprecated(
+    alternative="fast.ai V2 support, which will be available in MLflow shortly",
+    since="MLflow version 1.20.0",
+)
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
 def log_model(
     fastai_learner,
@@ -394,6 +402,10 @@ def load_model(model_uri):
     return _load_model(path=model_file_path)
 
 
+@deprecated(
+    alternative="fast.ai V2 support, which will be available in MLflow shortly",
+    since="MLflow version 1.20.0",
+)
 @experimental
 @autologging_integration(FLAVOR_NAME)
 def autolog(

--- a/mlflow/fastai.py
+++ b/mlflow/fastai.py
@@ -57,7 +57,7 @@ FLAVOR_NAME = "fastai"
 @deprecated(
     alternative="fast.ai V2 support, which will be available in MLflow soon",
     since="MLflow version 1.20.0",
-    impact="This method will no longer support fast.ai V1 in a near future release."
+    impact="This method will no longer support fast.ai V1 in a near future release.",
 )
 def get_default_pip_requirements(include_cloudpickle=False):
     """
@@ -75,7 +75,7 @@ def get_default_pip_requirements(include_cloudpickle=False):
 @deprecated(
     alternative="fast.ai V2 support, which will be available in MLflow soon",
     since="MLflow version 1.20.0",
-    impact="This method will no longer support fast.ai V1 in a near future release."
+    impact="This method will no longer support fast.ai V1 in a near future release.",
 )
 def get_default_conda_env(include_cloudpickle=False):
     """
@@ -419,7 +419,7 @@ def load_model(model_uri):
 @deprecated(
     alternative="fast.ai V2 support, which will be available in MLflow soon",
     since="MLflow version 1.20.0",
-    impact="This method will no longer support fast.ai V1 in a near future release."
+    impact="This method will no longer support fast.ai V1 in a near future release.",
 )
 @experimental
 @autologging_integration(FLAVOR_NAME)

--- a/mlflow/fastai.py
+++ b/mlflow/fastai.py
@@ -57,6 +57,7 @@ FLAVOR_NAME = "fastai"
 @deprecated(
     alternative="fast.ai V2 support, which will be available in MLflow soon",
     since="MLflow version 1.20.0",
+    impact="This method will no longer support fast.ai V1 in a near future release."
 )
 def get_default_pip_requirements(include_cloudpickle=False):
     """
@@ -74,6 +75,7 @@ def get_default_pip_requirements(include_cloudpickle=False):
 @deprecated(
     alternative="fast.ai V2 support, which will be available in MLflow soon",
     since="MLflow version 1.20.0",
+    impact="This method will no longer support fast.ai V1 in a near future release."
 )
 def get_default_conda_env(include_cloudpickle=False):
     """
@@ -417,6 +419,7 @@ def load_model(model_uri):
 @deprecated(
     alternative="fast.ai V2 support, which will be available in MLflow soon",
     since="MLflow version 1.20.0",
+    impact="This method will no longer support fast.ai V1 in a near future release."
 )
 @experimental
 @autologging_integration(FLAVOR_NAME)

--- a/mlflow/fastai.py
+++ b/mlflow/fastai.py
@@ -55,7 +55,7 @@ FLAVOR_NAME = "fastai"
 
 
 @deprecated(
-    alternative="fast.ai V2 support, which will be available in MLflow shortly",
+    alternative="fast.ai V2 support, which will be available in MLflow soon",
     since="MLflow version 1.20.0",
 )
 def get_default_pip_requirements(include_cloudpickle=False):
@@ -72,7 +72,7 @@ def get_default_pip_requirements(include_cloudpickle=False):
 
 
 @deprecated(
-    alternative="fast.ai V2 support, which will be available in MLflow shortly",
+    alternative="fast.ai V2 support, which will be available in MLflow soon",
     since="MLflow version 1.20.0",
 )
 def get_default_conda_env(include_cloudpickle=False):
@@ -107,7 +107,7 @@ def get_default_conda_env(include_cloudpickle=False):
 
 
 @deprecated(
-    alternative="fast.ai V2 support, which will be available in MLflow shortly",
+    alternative="fast.ai V2 support, which will be available in MLflow soon",
     since="MLflow version 1.20.0",
 )
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
@@ -234,7 +234,7 @@ def save_model(
 
 
 @deprecated(
-    alternative="fast.ai V2 support, which will be available in MLflow shortly",
+    alternative="fast.ai V2 support, which will be available in MLflow soon",
     since="MLflow version 1.20.0",
 )
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
@@ -370,7 +370,7 @@ def _load_pyfunc(path):
 
 
 @deprecated(
-    alternative="fast.ai V2 support, which will be available in MLflow shortly",
+    alternative="fast.ai V2 support, which will be available in MLflow soon",
     since="MLflow version 1.20.0",
 )
 def load_model(model_uri):
@@ -415,7 +415,7 @@ def load_model(model_uri):
 
 
 @deprecated(
-    alternative="fast.ai V2 support, which will be available in MLflow shortly",
+    alternative="fast.ai V2 support, which will be available in MLflow soon",
     since="MLflow version 1.20.0",
 )
 @experimental

--- a/mlflow/fastai.py
+++ b/mlflow/fastai.py
@@ -54,6 +54,10 @@ from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 FLAVOR_NAME = "fastai"
 
 
+@deprecated(
+    alternative="fast.ai V2 support, which will be available in MLflow shortly",
+    since="MLflow version 1.20.0",
+)
 def get_default_pip_requirements(include_cloudpickle=False):
     """
     :return: A list of default pip requirements for MLflow Models produced by this flavor.
@@ -67,6 +71,10 @@ def get_default_pip_requirements(include_cloudpickle=False):
     return pip_deps
 
 
+@deprecated(
+    alternative="fast.ai V2 support, which will be available in MLflow shortly",
+    since="MLflow version 1.20.0",
+)
 def get_default_conda_env(include_cloudpickle=False):
     """
     :return: The default Conda environment as a dictionary for MLflow Models produced by calls to
@@ -361,6 +369,10 @@ def _load_pyfunc(path):
     return _FastaiModelWrapper(_load_model(path))
 
 
+@deprecated(
+    alternative="fast.ai V2 support, which will be available in MLflow shortly",
+    since="MLflow version 1.20.0",
+)
 def load_model(model_uri):
     """
     Load a fastai model from a local file or a run.

--- a/mlflow/utils/annotations.py
+++ b/mlflow/utils/annotations.py
@@ -17,7 +17,7 @@ def experimental(func):
     return func
 
 
-def deprecated(alternative=None, since=None):
+def deprecated(alternative=None, since=None, impact=None):
     """
     Decorator for marking APIs deprecated in the docstring.
 
@@ -27,10 +27,13 @@ def deprecated(alternative=None, since=None):
 
     def deprecated_decorator(func):
         since_str = " since %s" % since if since else ""
+        impact_str = impact if impact else "This method will be removed in a near future release."
+
         notice = (
-            "``{function_name}`` is deprecated{since_string}. This method will be"
-            " removed in a near future release.".format(
-                function_name=".".join([func.__module__, func.__name__]), since_string=since_str
+            "``{function_name}`` is deprecated{since_string}. {impact}".format(
+                function_name=".".join([func.__module__, func.__name__]),
+                since_string=since_str,
+                impact=impact_str,
             )
         )
         if alternative is not None and alternative.strip():

--- a/mlflow/utils/annotations.py
+++ b/mlflow/utils/annotations.py
@@ -42,7 +42,7 @@ def deprecated(alternative=None, since=None):
             return func(*args, **kwargs)
 
         if func.__doc__ is not None:
-            deprecated_func.__doc__ = ".. Warning::" + notice + "\n" + func.__doc__
+            deprecated_func.__doc__ = ".. Warning:: " + notice + "\n" + func.__doc__
 
         return deprecated_func
 

--- a/mlflow/utils/annotations.py
+++ b/mlflow/utils/annotations.py
@@ -29,12 +29,10 @@ def deprecated(alternative=None, since=None, impact=None):
         since_str = " since %s" % since if since else ""
         impact_str = impact if impact else "This method will be removed in a near future release."
 
-        notice = (
-            "``{function_name}`` is deprecated{since_string}. {impact}".format(
-                function_name=".".join([func.__module__, func.__name__]),
-                since_string=since_str,
-                impact=impact_str,
-            )
+        notice = "``{function_name}`` is deprecated{since_string}. {impact}".format(
+            function_name=".".join([func.__module__, func.__name__]),
+            since_string=since_str,
+            impact=impact_str,
         )
         if alternative is not None and alternative.strip():
             notice += " Use ``%s`` instead." % alternative

--- a/mlflow/utils/annotations.py
+++ b/mlflow/utils/annotations.py
@@ -28,7 +28,7 @@ def deprecated(alternative=None, since=None):
     def deprecated_decorator(func):
         since_str = " since %s" % since if since else ""
         notice = (
-            ".. Warning:: ``{function_name}`` is deprecated{since_string}. This method will be"
+            "``{function_name}`` is deprecated{since_string}. This method will be"
             " removed in a near future release.".format(
                 function_name=".".join([func.__module__, func.__name__]), since_string=since_str
             )
@@ -42,7 +42,7 @@ def deprecated(alternative=None, since=None):
             return func(*args, **kwargs)
 
         if func.__doc__ is not None:
-            deprecated_func.__doc__ = notice + "\n" + func.__doc__
+            deprecated_func.__doc__ = ".. Warning::" + notice + "\n" + func.__doc__
 
         return deprecated_func
 


### PR DESCRIPTION
Signed-off-by: dbczumar <corey.zumar@databricks.com>

## What changes are proposed in this pull request?

Deprecate fast.ai V1 support

## How is this patch tested?

Docs build tests

## Release Notes

MLflow Models support for fast.ai V1 has been deprecated and will be replaced with support for fast.ai V2 in a future release.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [X] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
