### PR TITLE
Set `nextPageToken` to `null` when switching experiments

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentPage.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentPage.js
@@ -113,6 +113,7 @@ export class ExperimentPage extends Component {
             : new ExperimentPagePersistedState().toJSON(),
         lastExperimentId: props.experimentId,
         lifecycleFilter: LIFECYCLE_FILTER.ACTIVE,
+        nextPageToken: null,
       };
     }
     return null;


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Fixes https://github.com/mlflow/mlflow/issues/4727

## How is this patch tested?

Create some runs using the code below and verify that runs in `experiment2` show up when switching to `experiment2` from `experiment1`.

```python
# Code to populate runs

import mlflow

mlflow.set_experiment('experiment1')
for i in range(150):
    with mlflow.start_run():
        mlflow.log_param('x', i)

mlflow.set_experiment('experiment2')
for i in range(5):
    with mlflow.start_run():
        mlflow.log_param('y', i)
```

### Before:

https://user-images.githubusercontent.com/17039389/130564465-212fd077-77f9-46d1-b535-1ab60235d69a.mov

### After:

https://user-images.githubusercontent.com/17039389/130563965-d6bdb006-4b5e-480e-a6c0-74bcea355f30.mov

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix a bug where the pagination token for run search is not refreshed when switching experiments

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
