### PR TITLE
Avoid calling packages_distributions upon requirements_utils import

### DIFF
--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -236,7 +236,7 @@ def _capture_imported_modules(model_uri, flavor):
             return f.read().splitlines()
 
 
-MODULES_TO_PACKAGES = None
+_MODULES_TO_PACKAGES = None
 
 
 def _infer_requirements(model_uri, flavor):
@@ -248,11 +248,11 @@ def _infer_requirements(model_uri, flavor):
     :param: flavor: The flavor name of the model.
     :return: A list of inferred pip requirements.
     """
-    global MODULES_TO_PACKAGES
-    if MODULES_TO_PACKAGES is None:
-        MODULES_TO_PACKAGES = importlib_metadata.packages_distributions()
+    global _MODULES_TO_PACKAGES
+    if _MODULES_TO_PACKAGES is None:
+        _MODULES_TO_PACKAGES = importlib_metadata.packages_distributions()
     modules = _capture_imported_modules(model_uri, flavor)
-    packages = _flatten([MODULES_TO_PACKAGES.get(module, []) for module in modules])
+    packages = _flatten([_MODULES_TO_PACKAGES.get(module, []) for module in modules])
     packages = map(_canonicalize_package_name, packages)
     packages = _prune_packages(packages)
     excluded_packages = [
@@ -264,7 +264,7 @@ def _infer_requirements(model_uri, flavor):
         # Exclude a package that provides the mlflow module (e.g. mlflow, mlflow-skinny).
         # Certain flavors (e.g. pytorch) import mlflow while loading a model, but mlflow should
         # not be counted as a model requirement.
-        *MODULES_TO_PACKAGES.get("mlflow", []),
+        *_MODULES_TO_PACKAGES.get("mlflow", []),
     ]
     packages = packages - set(excluded_packages)
     return sorted(map(_get_pinned_requirement, packages))

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -126,16 +126,6 @@ def _canonicalize_package_name(pkg_name):
     return pkg_name.lower().replace("_", "-")
 
 
-_MODULE_TO_PACKAGES = importlib_metadata.packages_distributions()
-
-
-def _module_to_packages(module_name):
-    """
-    Returns a list of packages that provide the specified module.
-    """
-    return _MODULE_TO_PACKAGES.get(module_name, [])
-
-
 def _get_requires_recursive(pkg_name):
     """
     Recursively yields both direct and transitive dependencies of the specified package.
@@ -255,8 +245,9 @@ def _infer_requirements(model_uri, flavor):
     :param: flavor: The flavor name of the model.
     :return: A list of inferred pip requirements.
     """
+    modules_to_packages = importlib_metadata.packages_distributions()
     modules = _capture_imported_modules(model_uri, flavor)
-    packages = _flatten(map(_module_to_packages, modules))
+    packages = _flatten([modules_to_packages.get(module, []) for module in modules])
     packages = map(_canonicalize_package_name, packages)
     packages = _prune_packages(packages)
     excluded_packages = [
@@ -268,7 +259,7 @@ def _infer_requirements(model_uri, flavor):
         # Exclude a package that provides the mlflow module (e.g. mlflow, mlflow-skinny).
         # Certain flavors (e.g. pytorch) import mlflow while loading a model, but mlflow should
         # not be counted as a model requirement.
-        *_MODULE_TO_PACKAGES.get("mlflow", []),
+        *modules_to_packages.get("mlflow", []),
     ]
     packages = packages - set(excluded_packages)
     return sorted(map(_get_pinned_requirement, packages))

--- a/tests/utils/test_requirements_utils.py
+++ b/tests/utils/test_requirements_utils.py
@@ -18,7 +18,6 @@ from mlflow.utils.requirements_utils import (
     _strip_local_version_label,
     _get_installed_version,
     _get_pinned_requirement,
-    _module_to_packages,
     _infer_requirements,
 )
 
@@ -268,5 +267,5 @@ def test_infer_requirements_excludes_mlflow():
         return_value=["mlflow", "pytest"],
     ):
         mlflow_package = "mlflow-skinny" if "MLFLOW_SKINNY" in os.environ else "mlflow"
-        assert mlflow_package in _module_to_packages("mlflow")
+        assert mlflow_package in importlib_metadata.packages_distributions()["mlflow"]
         assert _infer_requirements("path/to/model", "sklearn") == [f"pytest=={pytest.__version__}"]


### PR DESCRIPTION
Signed-off-by: dbczumar <corey.zumar@databricks.com>

## What changes are proposed in this pull request?

Avoid calling packages_distributions upon requirements_utils import

## How is this patch tested?

Unit tests

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
