### PR TITLE
Run keras tests against `keras-nightly`

### DIFF
--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -162,5 +162,6 @@ jobs:
         env:
           MLFLOW_CONDA_HOME: /usr/share/miniconda
           SPARK_LOCAL_IP: 127.0.0.1
+          PACKAGE_VERSION: ${{ matrix.version }}
         run: |
           ${{ matrix.run }}

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -72,6 +72,12 @@ tensorflow:
         pytest tests/tensorflow/test_tensorflow2_model_export.py --large
       fi
 
+      # Run keras tests against keras-nightly that's installed with tf-nightly:
+      # https://github.com/tensorflow/tensorflow/blob/v2.6.0/tensorflow/tools/pip_package/setup.py#L110-L122
+      if [ "$PACKAGE_VERSION" == "dev" ]; then
+        pytest tests/keras/test_keras_model_export.py --large
+      fi
+
   autologging:
     minimum: "1.15.4"
     maximum: "2.6.0"
@@ -90,6 +96,10 @@ tensorflow:
         pytest tests/tensorflow_autolog/test_tensorflow_autolog.py --large
       else
         pytest tests/tensorflow_autolog/test_tensorflow2_autolog.py --large
+      fi
+
+      if [ "$PACKAGE_VERSION" == "dev" ]; then
+        pytest tests/keras_autolog/test_keras_autolog.py --large
       fi
 
 keras:

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -57,6 +57,7 @@ tensorflow:
     maximum: "2.6.0"
     requirements:
       "< 2.2": ["h5py<3.0", "scikit-learn"]
+      "== dev": ["scikit-learn"]
     run: |
       python_code="
       import tensorflow as tf
@@ -83,6 +84,7 @@ tensorflow:
     maximum: "2.6.0"
     requirements:
       "< 2.2": ["h5py<3.0"]
+      "== dev": ["scikit-learn"]
     run: |
       python_code="
       import tensorflow as tf

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -57,7 +57,8 @@ tensorflow:
     maximum: "2.6.0"
     requirements:
       "< 2.2": ["h5py<3.0", "scikit-learn"]
-      "== dev": ["scikit-learn"]
+      # Requirements to run tests for keras
+      "== dev": ["scikit-learn", "pyspark", "pyarrow"]
     run: |
       python_code="
       import tensorflow as tf
@@ -73,7 +74,7 @@ tensorflow:
         pytest tests/tensorflow/test_tensorflow2_model_export.py --large
       fi
 
-      # Run keras tests against keras-nightly that's installed with tf-nightly:
+      # Run tests for keras against keras-nightly that's installed with tf-nightly:
       # https://github.com/tensorflow/tensorflow/blob/v2.6.0/tensorflow/tools/pip_package/setup.py#L110-L122
       if [ "$PACKAGE_VERSION" == "dev" ]; then
         pytest tests/keras/test_keras_model_export.py --large
@@ -84,7 +85,7 @@ tensorflow:
     maximum: "2.6.0"
     requirements:
       "< 2.2": ["h5py<3.0"]
-      "== dev": ["scikit-learn"]
+      "== dev": ["scikit-learn", "pyspark", "pyarrow"]
     run: |
       python_code="
       import tensorflow as tf

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -85,7 +85,7 @@ tensorflow:
     maximum: "2.6.0"
     requirements:
       "< 2.2": ["h5py<3.0"]
-      "== dev": ["scikit-learn", "pyspark", "pyarrow"]
+      "== dev": ["scikit-learn"]
     run: |
       python_code="
       import tensorflow as tf


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

Run keras tests against `keras-nightly` as part of the tesnroflow workflow.

## How is this patch tested?

Existing tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
