### PR TITLE
Increase HTTP timeout to 120s. Disabled cloud storage HTTP timeout.

### DIFF
--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -82,7 +82,7 @@ def http_request(
     max_retries=5,
     backoff_factor=2,
     retry_codes=_TRANSIENT_FAILURE_RESPONSE_CODES,
-    timeout=90,
+    timeout=120,
     **kwargs
 ):
     """

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -82,7 +82,7 @@ def http_request(
     max_retries=5,
     backoff_factor=2,
     retry_codes=_TRANSIENT_FAILURE_RESPONSE_CODES,
-    timeout=10,
+    timeout=90,
     **kwargs
 ):
     """
@@ -227,7 +227,7 @@ def cloud_storage_http_request(
     max_retries=5,
     backoff_factor=2,
     retry_codes=_TRANSIENT_FAILURE_RESPONSE_CODES,
-    timeout=10,
+    timeout=None,
     **kwargs
 ):
     """
@@ -241,7 +241,7 @@ def cloud_storage_http_request(
       exponential backoff.
     :param retry_codes: a list of HTTP response error codes that qualifies for retry.
     :param timeout: wait for timeout seconds for response from remote server for connect and
-      read request.
+      read request. Default to None owing to long duration operation in read / write.
     :param kwargs: Additional keyword arguments to pass to `requests.Session.request()`
 
     :return requests.Response object.

--- a/tests/projects/test_databricks.py
+++ b/tests/projects/test_databricks.py
@@ -445,7 +445,7 @@ def test_databricks_http_request_integration(get_config, request):
             "headers": headers,
             "verify": True,
             "json": {"a": "b"},
-            "timeout": 10,
+            "timeout": 120,
         }
         http_response = mock.MagicMock()
         http_response.status_code = 200

--- a/tests/store/tracking/test_rest_store.py
+++ b/tests/store/tracking/test_rest_store.py
@@ -77,7 +77,7 @@ class TestRestStore(object):
                 "params": {"view_type": "ACTIVE_ONLY"},
                 "headers": _DEFAULT_HEADERS,
                 "verify": True,
-                "timeout": 10,
+                "timeout": 120,
             }
             response = mock.MagicMock()
             response.status_code = 200

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -73,7 +73,7 @@ def test_http_request_hostonly(request):
     request.return_value = response
     http_request(host_only, "/my/endpoint", "GET")
     request.assert_called_with(
-        "GET", "http://my-host/my/endpoint", verify=True, headers=_DEFAULT_HEADERS, timeout=10,
+        "GET", "http://my-host/my/endpoint", verify=True, headers=_DEFAULT_HEADERS, timeout=120,
     )
 
 
@@ -86,7 +86,7 @@ def test_http_request_cleans_hostname(request):
     request.return_value = response
     http_request(host_only, "/my/endpoint", "GET")
     request.assert_called_with(
-        "GET", "http://my-host/my/endpoint", verify=True, headers=_DEFAULT_HEADERS, timeout=10,
+        "GET", "http://my-host/my/endpoint", verify=True, headers=_DEFAULT_HEADERS, timeout=120,
     )
 
 
@@ -100,7 +100,7 @@ def test_http_request_with_basic_auth(request):
     headers = dict(_DEFAULT_HEADERS)
     headers["Authorization"] = "Basic dXNlcjpwYXNz"
     request.assert_called_with(
-        "GET", "http://my-host/my/endpoint", verify=True, headers=headers, timeout=10,
+        "GET", "http://my-host/my/endpoint", verify=True, headers=headers, timeout=120,
     )
 
 
@@ -114,7 +114,7 @@ def test_http_request_with_token(request):
     headers = dict(_DEFAULT_HEADERS)
     headers["Authorization"] = "Bearer my-token"
     request.assert_called_with(
-        "GET", "http://my-host/my/endpoint", verify=True, headers=headers, timeout=10,
+        "GET", "http://my-host/my/endpoint", verify=True, headers=headers, timeout=120,
     )
 
 
@@ -126,7 +126,7 @@ def test_http_request_with_insecure(request):
     request.return_value = response
     http_request(host_only, "/my/endpoint", "GET")
     request.assert_called_with(
-        "GET", "http://my-host/my/endpoint", verify=False, headers=_DEFAULT_HEADERS, timeout=10,
+        "GET", "http://my-host/my/endpoint", verify=False, headers=_DEFAULT_HEADERS, timeout=120,
     )
 
 
@@ -143,7 +143,7 @@ def test_http_request_client_cert_path(request):
         verify=True,
         cert="/some/path",
         headers=_DEFAULT_HEADERS,
-        timeout=10,
+        timeout=120,
     )
 
 
@@ -159,7 +159,7 @@ def test_http_request_server_cert_path(request):
         "http://my-host/my/endpoint",
         verify="/some/path",
         headers=_DEFAULT_HEADERS,
-        timeout=10,
+        timeout=120,
     )
 
 
@@ -185,7 +185,7 @@ def test_http_request_request_headers(request):
             "http://my-host/my/endpoint",
             verify="/some/path",
             headers={**_DEFAULT_HEADERS, "test": "header"},
-            timeout=10,
+            timeout=120,
         )
 
 
@@ -205,13 +205,13 @@ def test_http_request_wrapper(request):
     request.return_value = response
     http_request_safe(host_only, "/my/endpoint", "GET")
     request.assert_called_with(
-        "GET", "http://my-host/my/endpoint", verify=False, headers=_DEFAULT_HEADERS, timeout=10,
+        "GET", "http://my-host/my/endpoint", verify=False, headers=_DEFAULT_HEADERS, timeout=120,
     )
     response.text = "non json"
     request.return_value = response
     http_request_safe(host_only, "/my/endpoint", "GET")
     request.assert_called_with(
-        "GET", "http://my-host/my/endpoint", verify=False, headers=_DEFAULT_HEADERS, timeout=10,
+        "GET", "http://my-host/my/endpoint", verify=False, headers=_DEFAULT_HEADERS, timeout=120,
     )
     response.status_code = 400
     response.text = ""


### PR DESCRIPTION
## What changes are proposed in this pull request?
Non-idempotent operations such as log_metrics() could potentially log the same metric multiple times if a timeout occurs after the server has recorded the operation. Increasing the timeout limit would mitigate such situation from happening too often.

## How is this patch tested?
Unit tests.

## Release Notes
Increased MLflow client HTTP request timeout from 10s to 90s.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.


### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
