### PR TITLE
refactor: Extract the docker image building _build_image_from_context function

### DIFF
--- a/mlflow/models/docker_utils.py
+++ b/mlflow/models/docker_utils.py
@@ -111,6 +111,7 @@ def _build_image(image_name, entrypoint, mlflow_home=None, custom_setup_steps_ho
 
 def _build_image_from_context(context_dir: str, image_name: str):
     import docker
+
     client = docker.from_env()
     # In Docker < 19, `docker build` doesn't support the `--platform` option
     is_platform_supported = int(client.version()["Version"].split(".")[0]) >= 19

--- a/mlflow/models/docker_utils.py
+++ b/mlflow/models/docker_utils.py
@@ -91,8 +91,6 @@ def _build_image(image_name, entrypoint, mlflow_home=None, custom_setup_steps_ho
            of a dockerfile context directory and returns a string containing Dockerfile commands to
            run during the image build step.
     """
-    import docker
-
     mlflow_home = os.path.abspath(mlflow_home) if mlflow_home else None
     with TempDir() as tmp:
         cwd = tmp.path()
@@ -108,25 +106,29 @@ def _build_image(image_name, entrypoint, mlflow_home=None, custom_setup_steps_ho
             )
         _logger.info("Building docker image with name %s", image_name)
         os.system("find {cwd}/".format(cwd=cwd))
+        _build_image_from_context(context_dir=cwd, image_name=image_name)
 
-        client = docker.from_env()
-        # In Docker < 19, `docker build` doesn't support the `--platform` option
-        is_platform_supported = int(client.version()["Version"].split(".")[0]) >= 19
-        # Enforcing the AMD64 architecture build for Apple M1 users
-        platform_option = ["--platform", "linux/amd64"] if is_platform_supported else []
-        commands = [
-            "docker",
-            "build",
-            "-t",
-            image_name,
-            "-f",
-            "Dockerfile",
-            *platform_option,
-            ".",
-        ]
-        proc = Popen(commands, cwd=cwd, stdout=PIPE, stderr=STDOUT, universal_newlines=True,)
-        for x in iter(proc.stdout.readline, ""):
-            eprint(x, end="")
 
-        if proc.wait():
-            raise RuntimeError("Docker build failed.")
+def _build_image_from_context(context_dir: str, image_name: str):
+    import docker
+    client = docker.from_env()
+    # In Docker < 19, `docker build` doesn't support the `--platform` option
+    is_platform_supported = int(client.version()["Version"].split(".")[0]) >= 19
+    # Enforcing the AMD64 architecture build for Apple M1 users
+    platform_option = ["--platform", "linux/amd64"] if is_platform_supported else []
+    commands = [
+        "docker",
+        "build",
+        "-t",
+        image_name,
+        "-f",
+        "Dockerfile",
+        *platform_option,
+        ".",
+    ]
+    proc = Popen(commands, cwd=context_dir, stdout=PIPE, stderr=STDOUT, universal_newlines=True,)
+    for x in iter(proc.stdout.readline, ""):
+        eprint(x, end="")
+
+    if proc.wait():
+        raise RuntimeError("Docker build failed.")


### PR DESCRIPTION
Signed-off-by: Alexey Volkov <alexey.volkov@ark-kun.com>

## What changes are proposed in this pull request?

The `mlflow.models.docker_utils._build_image` function currently does too many things. It prepared the `Dockerfile`, prepares MLflow source and the docker context directory, then builds container image using Docker.
This PR extract the actual image building part as the `_build_image_from_context` function.
This small refactoring will make it easier to test the image building routines or mock the image building implementation.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
