### PR TITLE
Update spark support version to be 3.2

### DIFF
--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -170,7 +170,7 @@ def filter_versions(versions, min_ver, max_ver, excludes=None, allow_unreleased_
 
     # Prevent specifying non-existent versions
     assert min_ver in versions
-    assert max_ver in versions
+    assert max_ver in versions or allow_unreleased_max_version
     assert all(v in versions for v in excludes)
 
     versions = {Version(v): t for v, t in versions.items() if v not in excludes}

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -141,7 +141,7 @@ def select_latest_micro_versions(versions):
     return res
 
 
-def filter_versions(versions, min_ver, max_ver, excludes=None):
+def filter_versions(versions, min_ver, max_ver, excludes=None, allow_unreleased_max_version=False):
     """
     Filter versions that satisfy the following conditions:
 
@@ -439,7 +439,13 @@ def expand_config(config):
             # Released versions
             min_ver = cfg["minimum"]
             max_ver = cfg["maximum"]
-            versions = filter_versions(all_versions, min_ver, max_ver, cfg.get("unsupported"),)
+            versions = filter_versions(
+                all_versions,
+                min_ver,
+                max_ver,
+                cfg.get("unsupported"),
+                allow_unreleased_max_version=cfg.get("allow_unreleased_max_version", False)
+            )
             versions = select_latest_micro_versions(versions)
 
             # Explicitly include the minimum supported version

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -444,7 +444,7 @@ def expand_config(config):
                 min_ver,
                 max_ver,
                 cfg.get("unsupported"),
-                allow_unreleased_max_version=cfg.get("allow_unreleased_max_version", False)
+                allow_unreleased_max_version=cfg.get("allow_unreleased_max_version", False),
             )
             versions = select_latest_micro_versions(versions)
 

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -312,7 +312,7 @@ spark:
 
   models:
     minimum: "3.0.0"
-    maximum: "3.1.2"
+    maximum: "3.2.0"
     requirements: ["boto3", "scikit-learn", "pyarrow"]
     run: |
       SAGEMAKER_OUT=$(mktemp)
@@ -327,7 +327,7 @@ spark:
 
   autologging:
     minimum: "3.0.0"
-    maximum: "3.1.2"
+    maximum: "3.2.0"
     requirements: ["scikit-learn"]
     run: |
       find tests/spark_autologging/ml -name 'test*.py' | xargs -L 1 pytest --large

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -313,6 +313,10 @@ spark:
   models:
     minimum: "3.0.0"
     maximum: "3.2.0"
+    # NB: Allow unreleased maximum versions for the pyspark package to support models and
+    # autologging use cases in environments where newer versions of pyspark are available
+    # prior to their release on PyPI (e.g. Databricks)
+    allow_unreleased_max_version: True
     requirements: ["boto3", "scikit-learn", "pyarrow"]
     run: |
       SAGEMAKER_OUT=$(mktemp)
@@ -328,6 +332,10 @@ spark:
   autologging:
     minimum: "3.0.0"
     maximum: "3.2.0"
+    # NB: Allow unreleased maximum versions for the pyspark package to support models and
+    # autologging use cases in environments where newer versions of pyspark are available
+    # prior to their release on PyPI (e.g. Databricks)
+    allow_unreleased_max_version: True
     requirements: ["scikit-learn"]
     run: |
       find tests/spark_autologging/ml -name 'test*.py' | xargs -L 1 pytest --large


### PR DESCRIPTION
Signed-off-by: Weichen Xu <weichen.xu@databricks.com>

## What changes are proposed in this pull request?

Update spark support version to be 3.2

## How is this patch tested?

N/A

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
