### PR TITLE
Remove mlflow.keras raise deprecation warning to avoid keras==2.4.3 tensorflow==2.5.1 issue

### DIFF
--- a/mlflow/R/mlflow/DESCRIPTION
+++ b/mlflow/R/mlflow/DESCRIPTION
@@ -61,7 +61,7 @@ Suggests:
     testthat (>= 2.0.0),
     xgboost
 Encoding: UTF-8
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Collate:
     'cli.R'
     'databricks-utils.R'

--- a/mlflow/R/mlflow/DESCRIPTION
+++ b/mlflow/R/mlflow/DESCRIPTION
@@ -61,7 +61,7 @@ Suggests:
     testthat (>= 2.0.0),
     xgboost
 Encoding: UTF-8
-RoxygenNote: 7.1.2
+RoxygenNote: 7.1.1
 Collate:
     'cli.R'
     'databricks-utils.R'

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -64,7 +64,7 @@ _PIP_ENV_SUBPATH = "requirements.txt"
 def _raise_deprecation_warning(keras_module=None):
     # Avoid `ModuleNotFoundError` thrown when this function is called from `mlflow.tensorflow` to
     # save a model created using `tensorflow.keras` but `keras` is not installed.
-    if "tensorflow" in keras_module:
+    if isinstance(keras_module, str) and "tensorflow" in keras_module:
         return
     try:
         import keras

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -68,6 +68,8 @@ def _raise_deprecation_warning():
         import keras
     except ImportError:
         return
+    except AttributeError:
+        return
 
     if Version(keras.__version__) < Version("2.3.0"):
         warnings.warn(

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -61,27 +61,6 @@ _MODEL_SAVE_PATH = "model"
 _PIP_ENV_SUBPATH = "requirements.txt"
 
 
-def _raise_deprecation_warning(keras_module=None):
-    # Avoid `ModuleNotFoundError` thrown when this function is called from `mlflow.tensorflow` to
-    # save a model created using `tensorflow.keras` but `keras` is not installed.
-    if isinstance(keras_module, str) and "tensorflow" in keras_module:
-        return
-    try:
-        import keras
-    except ImportError:
-        return
-
-    if Version(keras.__version__) < Version("2.3.0"):
-        warnings.warn(
-            (
-                "Support for keras < 2.3.0 has been deprecated and will be removed in a future "
-                "MLflow release"
-            ),
-            FutureWarning,
-            stacklevel=2,
-        )
-
-
 def get_default_pip_requirements(include_cloudpickle=False, keras_module=None):
     """
     :return: A list of default pip requirements for MLflow Models produced by this flavor.
@@ -192,7 +171,6 @@ def save_model(
         # Save the model as an MLflow Model
         mlflow.keras.save_model(keras_model, keras_model_path)
     """
-    _raise_deprecation_warning(keras_module)
     _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
 
     if keras_module is None:
@@ -586,9 +564,6 @@ def load_model(model_uri, **kwargs):
     local_model_path = _download_artifact_from_uri(artifact_uri=model_uri)
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     keras_module = importlib.import_module(flavor_conf.get("keras_module", "keras"))
-
-    _raise_deprecation_warning(keras_module)
-
     keras_model_artifacts_path = os.path.join(
         local_model_path, flavor_conf.get("data", _MODEL_SAVE_PATH)
     )
@@ -674,8 +649,6 @@ def autolog(
                    autologging.
     """
     import keras
-
-    _raise_deprecation_warning()
 
     if Version(keras.__version__) >= Version("2.6.0"):
         warnings.warn(

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -64,7 +64,7 @@ _PIP_ENV_SUBPATH = "requirements.txt"
 def _raise_deprecation_warning(keras_module=None):
     # Avoid `ModuleNotFoundError` thrown when this function is called from `mlflow.tensorflow` to
     # save a model created using `tensorflow.keras` but `keras` is not installed.
-    if keras_module is not None or keras_module == "keras":
+    if "tensorflow" in keras_module:
         return
     try:
         import keras

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -583,10 +583,12 @@ def load_model(model_uri, **kwargs):
         keras_model = mlflow.keras.load_model("runs:/96771d893a5e46159d9f3b49bf9013e2" + "/models")
         predictions = keras_model.predict(x_test)
     """
-    keras_module = importlib.import_module(flavor_conf.get("keras_module", "keras"))
-    _raise_deprecation_warning(keras_module)
     local_model_path = _download_artifact_from_uri(artifact_uri=model_uri)
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
+    keras_module = importlib.import_module(flavor_conf.get("keras_module", "keras"))
+
+    _raise_deprecation_warning(keras_module)
+
     keras_model_artifacts_path = os.path.join(
         local_model_path, flavor_conf.get("data", _MODEL_SAVE_PATH)
     )

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -700,7 +700,7 @@ def test_raise_deprecation_warning():
     assert len(record) == 0
 
 
-def test_raise_deprecation_warning_ignore_if_module_set():
+def test_raise_deprecation_warning_ignore_if_module_tf():
     with mock.patch("keras.__version__", new="2.2.0"), pytest.warns(None) as record:
-        mlflow.keras._raise_deprecation_warning(keras_module=True)
+        mlflow.keras._raise_deprecation_warning(keras_module="tensorflow.keras")
     assert len(record) == 0

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -687,20 +687,3 @@ def test_pyfunc_serve_and_score_transformers():
     data = json.dumps({"inputs": dummy_inputs.tolist()})
     resp = pyfunc_serve_and_score_model(model_uri, data, pyfunc_scoring_server.CONTENT_TYPE_JSON)
     np.testing.assert_array_equal(json.loads(resp.content), model.predict(dummy_inputs))
-
-
-def test_raise_deprecation_warning():
-    with mock.patch("keras.__version__", new="2.2.0"), pytest.warns(
-        FutureWarning, match="Support for keras"
-    ):
-        mlflow.keras._raise_deprecation_warning()
-
-    with mock.patch("keras.__version__", new="2.3.0"), pytest.warns(None) as record:
-        mlflow.keras._raise_deprecation_warning()
-    assert len(record) == 0
-
-
-def test_raise_deprecation_warning_ignore_if_module_tf():
-    with mock.patch("keras.__version__", new="2.2.0"), pytest.warns(None) as record:
-        mlflow.keras._raise_deprecation_warning(keras_module="tensorflow.keras")
-    assert len(record) == 0

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -699,6 +699,7 @@ def test_raise_deprecation_warning():
         mlflow.keras._raise_deprecation_warning()
     assert len(record) == 0
 
+
 def test_raise_deprecation_warning_ignore_if_module_set():
     with mock.patch("keras.__version__", new="2.2.0"), pytest.warns(None) as record:
         mlflow.keras._raise_deprecation_warning(keras_module=True)

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -698,3 +698,8 @@ def test_raise_deprecation_warning():
     with mock.patch("keras.__version__", new="2.3.0"), pytest.warns(None) as record:
         mlflow.keras._raise_deprecation_warning()
     assert len(record) == 0
+
+def test_raise_deprecation_warning_ignore_if_module_set():
+    with mock.patch("keras.__version__", new="2.2.0"), pytest.warns(None) as record:
+        mlflow.keras._raise_deprecation_warning(keras_module=True)
+    assert len(record) == 0


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adding a protection against attribute errors that arise when tensorflow.keras and keras are both installed.
https://stackoverflow.com/questions/61137954/attributeerror-module-tensorflow-python-keras-utils-generic-utils-has-no-attr

keras==2.4.3
tensorflow==2.5.1

## How is this patch tested?

The above error is now silent in the original code path. The keras_module is set to tensorflow.keras and successfully logs the model

## Release Notes

Patch bug due to incompatible keras and tensorflow.keras versions. 

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.


### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
