### PR TITLE
Fix default value for `verbose_eval` in lightgbm autologging

### DIFF
--- a/tests/lightgbm/test_lightgbm_autolog.py
+++ b/tests/lightgbm/test_lightgbm_autolog.py
@@ -74,11 +74,11 @@ def test_lgb_autolog_logs_default_params(bst_params, train_set):
         "feature_name": "auto",
         "categorical_feature": "auto",
         "verbose_eval": (
-            # The default value for `verbose_eval` has been changed to 'warn' in this PR:
-            # https://github.com/microsoft/LightGBM/pull/4577
+            # The default value of `verbose_eval` in `lightgbm.train` has been changed to 'warn'
+            # in this PR: https://github.com/microsoft/LightGBM/pull/4577
             "warn"
             if Version(lgb.__version__) > Version("3.2.1")
-            else True
+            else ""
         ),
         "keep_training_booster": False,
     }

--- a/tests/lightgbm/test_lightgbm_autolog.py
+++ b/tests/lightgbm/test_lightgbm_autolog.py
@@ -7,6 +7,7 @@ import pandas as pd
 from sklearn import datasets
 import lightgbm as lgb
 import matplotlib as mpl
+from packaging.version import Version
 
 import mlflow
 import mlflow.lightgbm
@@ -72,7 +73,13 @@ def test_lgb_autolog_logs_default_params(bst_params, train_set):
         "num_boost_round": 100,
         "feature_name": "auto",
         "categorical_feature": "auto",
-        "verbose_eval": True,
+        "verbose_eval": (
+            # The default value for `verbose_eval` has been changed to 'warn' in this PR:
+            # https://github.com/microsoft/LightGBM/pull/4577
+            "warn"
+            if Version(lgb.__version__) > Version("3.2.1")
+            else True
+        ),
         "keep_training_booster": False,
     }
     expected_params.update(bst_params)

--- a/tests/lightgbm/test_lightgbm_autolog.py
+++ b/tests/lightgbm/test_lightgbm_autolog.py
@@ -78,7 +78,7 @@ def test_lgb_autolog_logs_default_params(bst_params, train_set):
             # in this PR: https://github.com/microsoft/LightGBM/pull/4577
             "warn"
             if Version(lgb.__version__) > Version("3.2.1")
-            else ""
+            else True
         ),
         "keep_training_booster": False,
     }


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

The default value for `verbose_eval` in `lightgbm.train` was changed to `"warn"` yesterday by this PR:
https://github.com/microsoft/LightGBM/pull/4574

This change broke one of lightgbm autologging tests. This PR fixes it.

## How is this patch tested?

Fixed test

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
