### PR TITLE
Limit length of tag set by Spark datasource autologging

### DIFF
--- a/mlflow/_spark_autologging.py
+++ b/mlflow/_spark_autologging.py
@@ -12,10 +12,12 @@ import mlflow
 from mlflow.exceptions import MlflowException
 from mlflow.tracking.client import MlflowClient
 from mlflow.tracking.context.abstract_context import RunContextProvider
+from mlflow.utils import _truncate_dict
 from mlflow.utils.autologging_utils import (
     autologging_is_disabled,
     ExceptionSafeClass,
 )
+from mlflow.utils.validation import MAX_TAG_VAL_LENGTH
 from mlflow.utils.databricks_utils import get_repl_id as get_databricks_repl_id
 from mlflow.spark import FLAVOR_NAME
 
@@ -243,11 +245,14 @@ class SparkAutologgingContext(RunContextProvider):
                     unique_infos.append(info)
                     seen.add(info)
             if len(unique_infos) > 0:
-                tags = {
-                    _SPARK_TABLE_INFO_TAG_NAME: "\n".join(
-                        [_get_table_info_string(*info) for info in unique_infos]
-                    )
-                }
+                tags = _truncate_dict(
+                    {
+                        _SPARK_TABLE_INFO_TAG_NAME: "\n".join(
+                            [_get_table_info_string(*info) for info in unique_infos]
+                        )
+                    },
+                    max_value_length=MAX_TAG_VAL_LENGTH,
+                )
             else:
                 tags = {}
             return tags

--- a/mlflow/_spark_autologging.py
+++ b/mlflow/_spark_autologging.py
@@ -12,7 +12,7 @@ import mlflow
 from mlflow.exceptions import MlflowException
 from mlflow.tracking.client import MlflowClient
 from mlflow.tracking.context.abstract_context import RunContextProvider
-from mlflow.utils import _truncate_dict
+from mlflow.utils import _truncate_and_ellipsize
 from mlflow.utils.autologging_utils import (
     autologging_is_disabled,
     ExceptionSafeClass,
@@ -81,6 +81,10 @@ def _get_jvm_event_publisher():
     return getattr(jvm, qualified_classname)
 
 
+def _generate_datasource_tag_value(table_info_string):
+    return _truncate_and_ellipsize(table_info_string, MAX_TAG_VAL_LENGTH)
+
+
 def _set_run_tag_async(run_id, path, version, data_format):
     _thread_pool.submit(
         _set_run_tag, run_id=run_id, path=path, version=version, data_format=data_format
@@ -93,7 +97,8 @@ def _set_run_tag(run_id, path, version, data_format):
     existing_run = client.get_run(run_id)
     existing_tag = existing_run.data.tags.get(_SPARK_TABLE_INFO_TAG_NAME)
     new_table_info = _merge_tag_lines(existing_tag, table_info_string)
-    client.set_tag(run_id, _SPARK_TABLE_INFO_TAG_NAME, new_table_info)
+    new_tag_value = _generate_datasource_tag_value(new_table_info)
+    client.set_tag(run_id, _SPARK_TABLE_INFO_TAG_NAME, new_tag_value)
 
 
 def _listen_for_spark_activity(spark_context):
@@ -245,14 +250,11 @@ class SparkAutologgingContext(RunContextProvider):
                     unique_infos.append(info)
                     seen.add(info)
             if len(unique_infos) > 0:
-                tags = _truncate_dict(
-                    {
-                        _SPARK_TABLE_INFO_TAG_NAME: "\n".join(
-                            [_get_table_info_string(*info) for info in unique_infos]
-                        )
-                    },
-                    max_value_length=MAX_TAG_VAL_LENGTH,
-                )
+                tags = {
+                    _SPARK_TABLE_INFO_TAG_NAME: _generate_datasource_tag_value(
+                        "\n".join([_get_table_info_string(*info) for info in unique_infos])
+                    )
+                }
             else:
                 tags = {}
             return tags

--- a/mlflow/utils/__init__.py
+++ b/mlflow/utils/__init__.py
@@ -78,15 +78,19 @@ def _chunk_dict(d, chunk_size):
         yield {k: d[k] for k in islice(it, chunk_size)}
 
 
+def _truncate_and_ellipsize(value, max_length):
+    """
+    Truncates the string representation of the specified value to the to the
+    specified maximum length, ellipsizing the end
+    """
+    return str(value)[: (max_length - 3)] + "..."
+
+
 def _truncate_dict(d, max_key_length=None, max_value_length=None):
     """
     Truncates keys and/or values in a dictionary to the specified maximum length.
     Truncated items will be converted to strings and ellipsized.
     """
-
-    def _truncate_and_ellipsize(value, max_length):
-        return str(value)[: (max_length - 3)] + "..."
-
     key_is_none = max_key_length is None
     val_is_none = max_value_length is None
 

--- a/mlflow/utils/__init__.py
+++ b/mlflow/utils/__init__.py
@@ -80,9 +80,8 @@ def _chunk_dict(d, chunk_size):
 
 def _truncate_and_ellipsize(value, max_length):
     """
-    Truncates the string representation of the specified value to the to the
-    specified maximum length, if necessary. The end of the string is ellipsized
-    if truncation occurs
+    Truncates the string representation of the specified value to the specified
+    maximum length, if necessary. The end of the string is ellipsized if truncation occurs
     """
     value = str(value)
     if len(value) > max_length:

--- a/mlflow/utils/__init__.py
+++ b/mlflow/utils/__init__.py
@@ -81,9 +81,14 @@ def _chunk_dict(d, chunk_size):
 def _truncate_and_ellipsize(value, max_length):
     """
     Truncates the string representation of the specified value to the to the
-    specified maximum length, ellipsizing the end
+    specified maximum length, if necessary. The end of the string is ellipsized
+    if truncation occurs
     """
-    return str(value)[: (max_length - 3)] + "..."
+    value = str(value)
+    if len(value) > max_length:
+        return value[: (max_length - 3)] + "..."
+    else:
+        return value
 
 
 def _truncate_dict(d, max_key_length=None, max_value_length=None):

--- a/tests/spark_autologging/datasource/test_spark_datasource_autologging.py
+++ b/tests/spark_autologging/datasource/test_spark_datasource_autologging.py
@@ -260,7 +260,7 @@ def test_autologging_truncates_datasource_tag_to_maximum_supported_value(tmpdir,
     # exceeding the maximum length of an MLflow tag (`MAX_TAG_VAL_LENGTH`)
     long_path_base = str(tmpdir.join("a" * 150))
     saved_df_paths = []
-    for path_suffix in range(int(len(long_path_base) / MAX_TAG_VAL_LENGTH) + 1):
+    for path_suffix in range(int(MAX_TAG_VAL_LENGTH / len(long_path_base)) + 1):
         long_path = long_path_base + str(path_suffix)
         df.write.option("header", "true").format("csv").save(long_path)
         saved_df_paths.append(long_path)
@@ -283,7 +283,7 @@ def test_autologging_truncates_datasource_tag_to_maximum_supported_value(tmpdir,
         # Sleep a bit prior to ending the run to guarantee that the Python process can pick up on
         # datasource read events (simulate the common case of doing work, e.g. model training,
         # on the DataFrame after reading from it)
-        time.sleep(1)
+        time.sleep(3)
 
     # Verify that the Spark Datasource tag set on the run has been truncated to the maximum
     # tag value length allowed by MLflow

--- a/tests/spark_autologging/datasource/test_spark_datasource_autologging.py
+++ b/tests/spark_autologging/datasource/test_spark_datasource_autologging.py
@@ -260,7 +260,7 @@ def test_autologging_truncates_datasource_tag_to_maximum_supported_value(tmpdir,
     # exceeding the maximum length of an MLflow tag (`MAX_TAG_VAL_LENGTH`)
     long_path_base = str(tmpdir.join("a" * 150))
     saved_df_paths = []
-    for path_suffix in range(int(MAX_TAG_VAL_LENGTH / 150) + 1):
+    for path_suffix in range(int(MAX_TAG_VAL_LENGTH / 150) + 10):
         long_path = long_path_base + str(path_suffix)
         df.write.option("header", "true").format("csv").save(long_path)
         saved_df_paths.append(long_path)

--- a/tests/spark_autologging/datasource/test_spark_datasource_autologging.py
+++ b/tests/spark_autologging/datasource/test_spark_datasource_autologging.py
@@ -260,7 +260,7 @@ def test_autologging_truncates_datasource_tag_to_maximum_supported_value(tmpdir,
     # exceeding the maximum length of an MLflow tag (`MAX_TAG_VAL_LENGTH`)
     long_path_base = str(tmpdir.join("a" * 150))
     saved_df_paths = []
-    for path_suffix in range(int(MAX_TAG_VAL_LENGTH / len(long_path_base)) + 1):
+    for path_suffix in range(int(MAX_TAG_VAL_LENGTH / 150) + 1):
         long_path = long_path_base + str(path_suffix)
         df.write.option("header", "true").format("csv").save(long_path)
         saved_df_paths.append(long_path)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Limit length of tag set by Spark datasource autologging

## How is this patch tested?

Unit test

## Release Notes

Limit the length of the `sparkDatasourceInfo` tag set by Spark Datasource autologging to 5000 characters.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
