### PR TITLE
Shallow git fetch before mlflow run

### DIFF
--- a/mlflow/projects/utils.py
+++ b/mlflow/projects/utils.py
@@ -41,6 +41,7 @@ PROJECT_USE_CONDA = "USE_CONDA"
 PROJECT_SYNCHRONOUS = "SYNCHRONOUS"
 PROJECT_DOCKER_ARGS = "DOCKER_ARGS"
 PROJECT_STORAGE_DIR = "STORAGE_DIR"
+GIT_FETCH_DEPTH = 1
 
 
 _logger = logging.getLogger(__name__)
@@ -182,9 +183,9 @@ def _fetch_git_repo(uri, version, dst_dir):
 
     repo = git.Repo.init(dst_dir)
     origin = repo.create_remote("origin", uri)
+    origin.fetch(depth=GIT_FETCH_DEPTH)
     if version is not None:
         try:
-            origin.fetch(version, depth=1)
             repo.git.checkout(version)
         except git.exc.GitCommandError as e:
             raise ExecutionException(
@@ -193,7 +194,6 @@ def _fetch_git_repo(uri, version, dst_dir):
                 "Error: %s" % (version, uri, e)
             )
     else:
-        origin.fetch("master", depth=1)
         repo.create_head("master", origin.refs.master)
         repo.heads.master.checkout()
     repo.submodule_update(init=True, recursive=True)

--- a/mlflow/projects/utils.py
+++ b/mlflow/projects/utils.py
@@ -183,13 +183,9 @@ def _fetch_git_repo(uri, version, dst_dir):
 
     repo = git.Repo.init(dst_dir)
     origin = repo.create_remote("origin", uri)
-<<<<<<< HEAD
     origin.fetch(depth=GIT_FETCH_DEPTH)
-=======
->>>>>>> shallow fetch
     if version is not None:
         try:
-            origin.fetch(version, depth=1)
             repo.git.checkout(version)
         except git.exc.GitCommandError as e:
             raise ExecutionException(
@@ -198,7 +194,6 @@ def _fetch_git_repo(uri, version, dst_dir):
                 "Error: %s" % (version, uri, e)
             )
     else:
-        origin.fetch("master", depth=1)
         repo.create_head("master", origin.refs.master)
         repo.heads.master.checkout()
     repo.submodule_update(init=True, recursive=True)

--- a/mlflow/projects/utils.py
+++ b/mlflow/projects/utils.py
@@ -182,9 +182,9 @@ def _fetch_git_repo(uri, version, dst_dir):
 
     repo = git.Repo.init(dst_dir)
     origin = repo.create_remote("origin", uri)
-    origin.fetch()
     if version is not None:
         try:
+            origin.fetch(version, depth=1)
             repo.git.checkout(version)
         except git.exc.GitCommandError as e:
             raise ExecutionException(
@@ -193,6 +193,7 @@ def _fetch_git_repo(uri, version, dst_dir):
                 "Error: %s" % (version, uri, e)
             )
     else:
+        origin.fetch("master", depth=1)
         repo.create_head("master", origin.refs.master)
         repo.heads.master.checkout()
     repo.submodule_update(init=True, recursive=True)

--- a/mlflow/projects/utils.py
+++ b/mlflow/projects/utils.py
@@ -183,9 +183,13 @@ def _fetch_git_repo(uri, version, dst_dir):
 
     repo = git.Repo.init(dst_dir)
     origin = repo.create_remote("origin", uri)
+<<<<<<< HEAD
     origin.fetch(depth=GIT_FETCH_DEPTH)
+=======
+>>>>>>> shallow fetch
     if version is not None:
         try:
+            origin.fetch(version, depth=1)
             repo.git.checkout(version)
         except git.exc.GitCommandError as e:
             raise ExecutionException(
@@ -194,6 +198,7 @@ def _fetch_git_repo(uri, version, dst_dir):
                 "Error: %s" % (version, uri, e)
             )
     else:
+        origin.fetch("master", depth=1)
         repo.create_head("master", origin.refs.master)
         repo.heads.master.checkout()
     repo.submodule_update(init=True, recursive=True)

--- a/mlflow/statsmodels.py
+++ b/mlflow/statsmodels.py
@@ -477,7 +477,7 @@ def autolog(
                     elif _is_numeric(field):
                         results_dict[f] = field
 
-            except AttributeError:
+            except Exception:
                 pass
 
         return results_dict

--- a/mlflow/utils/__init__.py
+++ b/mlflow/utils/__init__.py
@@ -78,15 +78,23 @@ def _chunk_dict(d, chunk_size):
         yield {k: d[k] for k in islice(it, chunk_size)}
 
 
+def _truncate_and_ellipsize(value, max_length):
+    """
+    Truncates the string representation of the specified value to the specified
+    maximum length, if necessary. The end of the string is ellipsized if truncation occurs
+    """
+    value = str(value)
+    if len(value) > max_length:
+        return value[: (max_length - 3)] + "..."
+    else:
+        return value
+
+
 def _truncate_dict(d, max_key_length=None, max_value_length=None):
     """
     Truncates keys and/or values in a dictionary to the specified maximum length.
     Truncated items will be converted to strings and ellipsized.
     """
-
-    def _truncate_and_ellipsize(value, max_length):
-        return str(value)[: (max_length - 3)] + "..."
-
     key_is_none = max_key_length is None
     val_is_none = max_value_length is None
 

--- a/tests/projects/conftest.py
+++ b/tests/projects/conftest.py
@@ -4,7 +4,7 @@ import os
 import git
 import pytest
 
-from tests.projects.utils import TEST_PROJECT_DIR
+from tests.projects.utils import TEST_PROJECT_DIR, GIT_PROJECT_BRANCH
 
 
 @pytest.fixture
@@ -15,6 +15,7 @@ def local_git_repo(tmpdir):
     dir_util.copy_tree(src=os.path.dirname(TEST_PROJECT_DIR), dst=local_git)
     repo.git.add(A=True)
     repo.index.commit("test")
+    repo.create_head(GIT_PROJECT_BRANCH)
     yield os.path.abspath(local_git)
 
 

--- a/tests/projects/utils.py
+++ b/tests/projects/utils.py
@@ -16,6 +16,7 @@ TEST_DOCKER_PROJECT_DIR = os.path.join(TEST_DIR, "resources", "example_docker_pr
 TEST_PROJECT_NAME = "example_project"
 TEST_NO_SPEC_PROJECT_DIR = os.path.join(TEST_DIR, "resources", "example_project_no_spec")
 GIT_PROJECT_URI = "https://github.com/mlflow/mlflow-example"
+GIT_PROJECT_BRANCH = "test-branch"
 SSH_PROJECT_URI = "git@github.com:mlflow/mlflow-example.git"
 
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR updates the project run utils such that it fetches the user code repository with depth=1. This is a small optimization to reduce the size of the .git folder in the repository that is cloned (and subsequently sent to dbfs when running on Databricks backend). The revisions are not needed when running a project. 

## How is this patch tested?

Used the `mlflow run` command with a git repository uri. Tested with and without version specified. 

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
