### PR TITLE
Shallow git fetch before mlflow run

### DIFF
--- a/mlflow/projects/utils.py
+++ b/mlflow/projects/utils.py
@@ -41,6 +41,7 @@ PROJECT_USE_CONDA = "USE_CONDA"
 PROJECT_SYNCHRONOUS = "SYNCHRONOUS"
 PROJECT_DOCKER_ARGS = "DOCKER_ARGS"
 PROJECT_STORAGE_DIR = "STORAGE_DIR"
+GIT_FETCH_DEPTH = 1
 
 
 _logger = logging.getLogger(__name__)
@@ -182,7 +183,7 @@ def _fetch_git_repo(uri, version, dst_dir):
 
     repo = git.Repo.init(dst_dir)
     origin = repo.create_remote("origin", uri)
-    origin.fetch()
+    origin.fetch(depth=GIT_FETCH_DEPTH)
     if version is not None:
         try:
             repo.git.checkout(version)

--- a/tests/projects/conftest.py
+++ b/tests/projects/conftest.py
@@ -4,7 +4,7 @@ import os
 import git
 import pytest
 
-from tests.projects.utils import TEST_PROJECT_DIR
+from tests.projects.utils import TEST_PROJECT_DIR, GIT_PROJECT_BRANCH
 
 
 @pytest.fixture
@@ -15,6 +15,7 @@ def local_git_repo(tmpdir):
     dir_util.copy_tree(src=os.path.dirname(TEST_PROJECT_DIR), dst=local_git)
     repo.git.add(A=True)
     repo.index.commit("test")
+    repo.create_head(GIT_PROJECT_BRANCH)
     yield os.path.abspath(local_git)
 
 

--- a/tests/projects/test_utils.py
+++ b/tests/projects/test_utils.py
@@ -4,7 +4,6 @@ import tempfile
 
 import pytest
 from unittest import mock
-from contextlib import ExitStack as does_not_raise
 
 import mlflow
 from mlflow.exceptions import ExecutionException

--- a/tests/projects/test_utils.py
+++ b/tests/projects/test_utils.py
@@ -97,19 +97,18 @@ def test__fetch_project(local_git_repo, local_git_repo_uri, zipped_repo, httpser
 
 
 @pytest.mark.parametrize(
-    "version,expected_version,raises",
-    [
-        (None, "master", does_not_raise()),
-        (GIT_PROJECT_BRANCH, GIT_PROJECT_BRANCH, does_not_raise()),
-        ("non-version", "", pytest.raises(ExecutionException)),
-    ],
+    "version,expected_version", [(None, "master"), (GIT_PROJECT_BRANCH, GIT_PROJECT_BRANCH)]
 )
-def test__fetch_git_repo(local_git_repo, local_git_repo_uri, version, expected_version, raises):
+def test__fetch_git_repo(local_git_repo, local_git_repo_uri, version, expected_version):
     # Verify that the correct branch is checked out
-    with raises:
-        _fetch_git_repo(local_git_repo_uri, version, local_git_repo)
-        repo = git.Repo(local_git_repo)
-        assert repo.active_branch.name == expected_version
+    _fetch_git_repo(local_git_repo_uri, version, local_git_repo)
+    repo = git.Repo(local_git_repo)
+    assert repo.active_branch.name == expected_version
+
+
+def test_fetching_non_existing_version_fails(local_git_repo, local_git_repo_uri):
+    with pytest.raises(ExecutionException, match="Unable to checkout"):
+        _fetch_git_repo(local_git_repo_uri, "non-version", local_git_repo)
 
 
 def test_fetch_project_validations(local_git_repo_uri):

--- a/tests/projects/utils.py
+++ b/tests/projects/utils.py
@@ -16,6 +16,7 @@ TEST_DOCKER_PROJECT_DIR = os.path.join(TEST_DIR, "resources", "example_docker_pr
 TEST_PROJECT_NAME = "example_project"
 TEST_NO_SPEC_PROJECT_DIR = os.path.join(TEST_DIR, "resources", "example_project_no_spec")
 GIT_PROJECT_URI = "https://github.com/mlflow/mlflow-example"
+GIT_PROJECT_BRANCH = "test-branch"
 SSH_PROJECT_URI = "git@github.com:mlflow/mlflow-example.git"
 
 


### PR DESCRIPTION
Signed-off-by: Marijn Valk <marijncv@hotmail.com>

## What changes are proposed in this pull request?

This PR updates the project run utils such that it fetches the user code repository with depth=1. This is a small optimization to reduce the size of the .git folder in the repository that is cloned (and subsequently sent to dbfs when running on Databricks backend). The revisions are not needed when running a project.

## How is this patch tested?

Used the `mlflow run` command with a git repository uri. Tested with and without version specified.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
