### PR TITLE
Added a duration column to the runs table in the experiment UI. closes #4826

### DIFF
--- a/mlflow/server/js/src/common/utils/Utils.js
+++ b/mlflow/server/js/src/common/utils/Utils.js
@@ -184,6 +184,16 @@ class Utils {
     }
   }
 
+  /**
+   * Get the duration of a run given start- and end time.
+   *
+   * @param startTime in milliseconds
+   * @param endTime in milliseconds
+   */
+  static getDuration(startTime, endTime) {
+    return startTime && endTime ? this.formatDuration(endTime - startTime) : null;
+  }
+
   static baseName(path) {
     const pieces = path.split('/');
     return pieces[pieces.length - 1];

--- a/mlflow/server/js/src/common/utils/Utils.test.js
+++ b/mlflow/server/js/src/common/utils/Utils.test.js
@@ -81,8 +81,8 @@ test('getDuration', () => {
   expect(Utils.getDuration(1, 501)).toEqual('0.5s');
   expect(Utils.getDuration(1, 901)).toEqual('0.9s');
   expect(Utils.getDuration(1, 60001)).toEqual('1.0min');
-  expect(Utils.getDuration(1, (60 * 60 * 1000 + 1))).toEqual('1.0h');
-  expect(Utils.getDuration(1, (24 * 60 * 60 * 1000 + 1))).toEqual('1.0d');
+  expect(Utils.getDuration(1, 60 * 60 * 1000 + 1)).toEqual('1.0h');
+  expect(Utils.getDuration(1, 24 * 60 * 60 * 1000 + 1)).toEqual('1.0d');
 });
 
 test('baseName', () => {

--- a/mlflow/server/js/src/common/utils/Utils.test.js
+++ b/mlflow/server/js/src/common/utils/Utils.test.js
@@ -80,6 +80,9 @@ test('getDuration', () => {
   expect(Utils.getDuration(1, 11)).toEqual('10ms');
   expect(Utils.getDuration(1, 501)).toEqual('0.5s');
   expect(Utils.getDuration(1, 901)).toEqual('0.9s');
+  expect(Utils.getDuration(1, 60001)).toEqual('1.0min');
+  expect(Utils.getDuration(1, (60 * 60 * 1000 + 1))).toEqual('1.0h');
+  expect(Utils.getDuration(1, (24 * 60 * 60 * 1000 + 1))).toEqual('1.0d');
 });
 
 test('baseName', () => {

--- a/mlflow/server/js/src/common/utils/Utils.test.js
+++ b/mlflow/server/js/src/common/utils/Utils.test.js
@@ -70,6 +70,18 @@ test('formatDuration', () => {
   expect(Utils.formatDuration(480 * 60 * 60 * 1000)).toEqual('20.0d');
 });
 
+test('getDuration', () => {
+  expect(Utils.getDuration(1, null)).toEqual(null);
+  expect(Utils.getDuration(1, undefined)).toEqual(null);
+  expect(Utils.getDuration(null, 1)).toEqual(null);
+  expect(Utils.getDuration(undefined, 1)).toEqual(null);
+  expect(Utils.getDuration(undefined, undefined)).toEqual(null);
+  expect(Utils.getDuration(null, null)).toEqual(null);
+  expect(Utils.getDuration(1, 11)).toEqual('10ms');
+  expect(Utils.getDuration(1, 501)).toEqual('0.5s');
+  expect(Utils.getDuration(1, 901)).toEqual('0.9s');
+});
+
 test('baseName', () => {
   expect(Utils.baseName('foo')).toEqual('foo');
   expect(Utils.baseName('foo/bar/baz')).toEqual('baz');

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.js
@@ -178,6 +178,13 @@ export class ExperimentRunsTableMultiColumnView2 extends React.Component {
           cellStyle,
         },
         {
+          headerName: ExperimentViewUtil.AttributeColumnLabels.DURATION,
+          field: 'duration',
+          pinned: 'left',
+          initialWidth: 80,
+          cellStyle,
+        },
+        {
           headerName: ExperimentViewUtil.AttributeColumnLabels.RUN_NAME,
           pinned: 'left',
           field: 'runName',
@@ -328,6 +335,7 @@ export class ExperimentRunsTableMultiColumnView2 extends React.Component {
       const user = Utils.getUser(runInfo, tags);
       const queryParams = window.location && window.location.search ? window.location.search : '';
       const startTime = runInfo.start_time;
+      const duration = Utils.getDuration(runInfo.start_time, runInfo.end_time);
       const runName = Utils.getRunName(tags) || '-';
       const visibleTags = Utils.getVisibleTagValues(tags).map(([key, value]) => ({
         key,
@@ -337,6 +345,7 @@ export class ExperimentRunsTableMultiColumnView2 extends React.Component {
       return {
         runInfo,
         startTime,
+        duration,
         user,
         runName,
         tags,

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentViewUtil.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentViewUtil.js
@@ -72,7 +72,8 @@ export default class ExperimentViewUtil {
     const user = Utils.getUser(runInfo, tags);
     const queryParams = window.location && window.location.search ? window.location.search : '';
     const sourceType = Utils.renderSource(tags, queryParams);
-    const { status, start_time: startTime } = runInfo;
+    const { status, start_time: startTime, end_time: endTime } = runInfo;
+    const duration = Utils.getDuration(startTime, endTime);
     const runName = Utils.getRunName(tags);
     const childLeftMargin = isParent ? {} : { paddingLeft: 16 };
     const columnProps = [
@@ -91,6 +92,16 @@ export default class ExperimentViewUtil {
             <Link to={Routes.getRunPageRoute(runInfo.experiment_id, runInfo.run_uuid)}>
               {Utils.formatTimestamp(startTime)}
             </Link>
+          </div>
+        ),
+      },
+      {
+        key: ExperimentViewUtil.AttributeColumnLabels.DURATION,
+        className: 'run-table-container',
+        title: duration,
+        children: (
+          <div className='truncate-text single-line' style={ExperimentViewUtil.styles.runInfoCell}>
+            {duration}
           </div>
         ),
       },
@@ -181,6 +192,7 @@ export default class ExperimentViewUtil {
 
   static AttributeColumnLabels = {
     DATE: 'Start Time',
+    DURATION: 'Duration',
     USER: 'User',
     RUN_NAME: 'Run Name',
     SOURCE: 'Source',
@@ -246,6 +258,11 @@ export default class ExperimentViewUtil {
         key: 'start_time',
         displayName: this.AttributeColumnLabels.DATE,
         canonicalSortKey: this.AttributeColumnSortKey.DATE,
+      },
+      {
+        key: 'duration',
+        displayName: this.AttributeColumnLabels.DURATION,
+        canonicalSortKey: null,
       },
       {
         key: 'user_id',

--- a/mlflow/server/js/src/experiment-tracking/components/RunView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/RunView.js
@@ -203,8 +203,7 @@ export class RunViewImpl extends Component {
     const { showNoteEditor, isTagsRequestPending } = this.state;
     const noteInfo = NoteInfo.fromTags(tags);
     const startTime = run.getStartTime() ? Utils.formatTimestamp(run.getStartTime()) : '(unknown)';
-    const duration =
-      run.getStartTime() && run.getEndTime() ? run.getEndTime() - run.getStartTime() : null;
+    const duration = Utils.getDuration(run.getStartTime(), run.getEndTime());
     const status = RunViewImpl.getRunStatusDisplayName(run.getStatus());
     const queryParams = window.location && window.location.search ? window.location.search : '';
     const tableStyles = {
@@ -315,7 +314,7 @@ export class RunViewImpl extends Component {
                 description: 'Label for displaying the duration of the experiment run',
               })}
             >
-              {Utils.formatDuration(duration)}
+              {duration}
             </Descriptions.Item>
           ) : null}
           <Descriptions.Item

--- a/mlflow/server/js/src/experiment-tracking/components/RunsTableColumnSelectionDropdown.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/RunsTableColumnSelectionDropdown.test.js
@@ -44,6 +44,7 @@ describe('RunsTableColumnSelectionDropdown', () => {
     wrapper.update();
     expect(wrapper.find(SearchTree).prop('data')).toEqual([
       { key: 'attributes-Start Time', title: 'Start Time' },
+      { key: 'attributes-Duration', title: 'Duration' },
       { key: 'attributes-User', title: 'User' },
       { key: 'attributes-Run Name', title: 'Run Name' },
       { key: 'attributes-Source', title: 'Source' },
@@ -83,6 +84,7 @@ describe('RunsTableColumnSelectionDropdown', () => {
     wrapper.update();
     expect(wrapper.find(SearchTree).prop('checkedKeys')).toEqual([
       'attributes-Start Time',
+      'attributes-Duration',
       'attributes-User',
       'attributes-Run Name',
       'attributes-Source',
@@ -113,6 +115,7 @@ describe('RunsTableColumnSelectionDropdown', () => {
     wrapper.update();
     expect(wrapper.find(SearchTree).prop('checkedKeys')).toEqual([
       'attributes-Start Time',
+      'attributes-Duration',
       'params-p2',
       'metrics-m2',
       'tags-t2',


### PR DESCRIPTION
Signed-off-by: Marijn Valk <marijncv@hotmail.com>

## What changes are proposed in this pull request?

This PR adds a duration column in the experiment UI. This PR closes #4826 

## How is this patch tested?

Started runs, start the dev tracking server and see the column with the values for the runs. Check while a run is still in progress to see no value in the duration column for that run

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Introduce a run duration column to the Runs table in the MLflow Experiment UI.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
