### PR TITLE
improve pyspark ml log pretraining metadata error message: 

### DIFF
--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -163,7 +163,7 @@ def _traverse_stage(stage):
         try:
             iter(original_sub_stages)
         except TypeError:
-            raise ValueError(
+            raise TypeError(
                 f"Pipeline stages should be iterable, but found object {original_sub_stages}"
             )
         for stage in original_sub_stages:

--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -158,7 +158,12 @@ def _traverse_stage(stage):
 
     yield stage
     if isinstance(stage, Pipeline):
-        for stage in stage.getStages():
+        original_sub_stages = stage.getStages()
+        if not isinstance(original_sub_stages, list):
+            raise ValueError(
+                f"Pipeline stages should be a list but get object {str(original_sub_stages)}"
+            )
+        for stage in original_sub_stages:
             yield from _traverse_stage(stage)
     elif isinstance(stage, OneVsRest):
         yield from _traverse_stage(stage.getClassifier())
@@ -190,10 +195,7 @@ def _gen_stage_hierarchy_recursively(
 
     if isinstance(stage, Pipeline):
         sub_stages = []
-        original_sub_stages = stage.getStages()
-        if not isinstance(original_sub_stages, list):
-            raise ValueError(f"Pipeline stages should be a list but get {str(original_sub_stages)}")
-        for sub_stage in original_sub_stages:
+        for sub_stage in stage.getStages():
             sub_hierarchy = _gen_stage_hierarchy_recursively(sub_stage, uid_to_indexed_name_map)
             sub_stages.append(sub_hierarchy)
         return {"name": stage_name, "stages": sub_stages}

--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -162,13 +162,9 @@ def _traverse_stage(stage):
 
         try:
             iter(original_sub_stages)
-            is_iterable = True
         except TypeError:
-            is_iterable = False
-
-        if not is_iterable:
             raise ValueError(
-                f"Pipeline stages should be iterable, but found object {str(original_sub_stages)}"
+                f"Pipeline stages should be iterable, but found object {original_sub_stages}"
             )
         for stage in original_sub_stages:
             yield from _traverse_stage(stage)
@@ -407,7 +403,7 @@ def _get_tuning_param_maps(param_search_estimator, uid_to_indexed_name_map):
         if param.parent not in uid_to_indexed_name_map:
             raise ValueError(
                 "Tuning params should not include params not owned by the tuned estimator, but "
-                f"found a param {str(param)}"
+                f"found a param {param}"
             )
         return f"{uid_to_indexed_name_map[param.parent]}.{param.name}"
 

--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -159,9 +159,16 @@ def _traverse_stage(stage):
     yield stage
     if isinstance(stage, Pipeline):
         original_sub_stages = stage.getStages()
-        if not isinstance(original_sub_stages, list):
+
+        try:
+            iter(original_sub_stages)
+            is_iterable = True
+        except TypeError:
+            is_iterable = False
+
+        if not is_iterable:
             raise ValueError(
-                f"Pipeline stages should be a list but get object {str(original_sub_stages)}"
+                f"Pipeline stages should be iterable, but found object {str(original_sub_stages)}"
             )
         for stage in original_sub_stages:
             yield from _traverse_stage(stage)
@@ -396,13 +403,13 @@ def _get_warning_msg_for_fit_call_with_a_list_of_params(estimator):
 def _get_tuning_param_maps(param_search_estimator, uid_to_indexed_name_map):
     tuning_param_maps = []
 
-    def gen_log_key(k):
-        if k.parent not in uid_to_indexed_name_map:
+    def gen_log_key(param):
+        if param.parent not in uid_to_indexed_name_map:
             raise ValueError(
-                "tuning params should not include params not owned by the tuned estimator, but "
-                f"get a param which parent is {k.parent}"
+                "Tuning params should not include params not owned by the tuned estimator, but "
+                f"found a param {str(param)}"
             )
-        return f"{uid_to_indexed_name_map[k.parent]}.{k.name}"
+        return f"{uid_to_indexed_name_map[param.parent]}.{param.name}"
 
     for eps in param_search_estimator.getEstimatorParamMaps():
         tuning_param_maps.append({gen_log_key(k): v for k, v in eps.items()})


### PR DESCRIPTION
## What changes are proposed in this pull request?

Improve the 2 cases error message:
(1)
```
from pyspark.ml.regression import RandomForestRegressor
from pyspark.ml import Pipeline
from pyspark.ml.evaluation import RegressionEvaluator
from pyspark.ml.tuning import CrossValidator, ParamGridBuilder
from pyspark.ml.linalg import Vectors

import mlflow
import os

os.environ['MLFLOW_AUTOLOGGING_TESTING'] = 'true'
mlflow.pyspark.ml.autolog()

df_train = spark.createDataFrame([
  (Vectors.dense(1.0, 2.0, 3.0), 0),
  (Vectors.sparse(3, {1: 1.0, 2: 5.5}), 1)
] * 100, ["features", "label"])

rfr = RandomForestRegressor(maxDepth=2)
rfr2 = RandomForestRegressor(maxDepth=3)
pl = Pipeline(stages=[rfr])

grid = ParamGridBuilder().addGrid(rfr2.maxDepth, [1, 2]).build()
evaluator = RegressionEvaluator()
cv = CrossValidator(estimator=pl, estimatorParamMaps=grid, evaluator=evaluator)

pl4 = Pipeline(stages=[cv])
pl4.fit(df_train)
```

(2)
```
from pyspark.ml.linalg import Vectors
from pyspark.ml import Pipeline
from pyspark.sql import SparkSession
from pyspark.ml.clustering import KMeans

import mlflow
import os

os.environ['MLFLOW_AUTOLOGGING_TESTING'] = 'true'
mlflow.pyspark.ml.autolog()

spark = SparkSession.builder.getOrCreate()

data = [
    (Vectors.dense([0.0, 0.0]), 2.0),
    (Vectors.dense([1.0, 1.0]), 2.0),
    (Vectors.dense([9.0, 8.0]), 2.0),
    (Vectors.dense([8.0, 9.0]), 2.0),
]
df = spark.createDataFrame(data, ["features", "weighCol"])
kmeans = KMeans(k=2)
pipeline = Pipeline(stages=kmeans)
# ^ This is incorrect, should be fixed to `Pipeline(stages=[kmeans])`
pipeline.fit(df)
```

## How is this patch tested?

N/A

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
