### PR TITLE
Add support to serve MLflow models through MLServer

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -1051,20 +1051,19 @@ For more information about serializing tensor inputs using the TF serving format
 Serving with MLServer (experimental)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In some cases, the scoring server built into MLflow may not offer a robust
-production-grade experience.
-To account for this, MLflow allows you to also serve models using `Seldon's
-MLServer <https://mlserver.readthedocs.io/en/latest/>`_, a fully-featured
-inference server, aimed towards production use cases and currently used as the
-core Python inference server used to serve machine learning models in
-Kubernetes-native frameworks, including `Seldon Core
+Python models can be deployed using `Seldon's MLServer
+<https://mlserver.readthedocs.io/en/latest/>`_ as alternative inference server. 
+MLServer is integrated with two leading open source model deployment tools,
+`Seldon Core
 <https://docs.seldon.io/projects/seldon-core/en/latest/graph/protocols.html#v2-kfserving-protocol>`
 and `KServe (formerly known as KFServing)
-<https://kserve.github.io/website/modelserving/v1beta1/sklearn/v2/>`_.
+<https://kserve.github.io/website/modelserving/v1beta1/sklearn/v2/>`_, and can
+be used to test and deploy models using these frameworks. 
+This is especially powerful when building docker images since the docker image
+built with MLServer can be deployed directly with both of these frameworks. 
 
-MLServer should provide a **drop-in replacement for the existing scoring
-server**, exposing a similar scoring API through the ``/invocations`` endpoint.
-This endpoint is supported on top of the standard `V2 Inference Protocol
+MLServer exposes the same scoring API through the ``/invocations`` endpoint.
+In addition, it supports the standard `V2 Inference Protocol
 <https://github.com/kubeflow/kfserving/tree/master/docs/predict-api/v2>`_.
 
 To serve a MLflow model using MLServer, you can use the ``--enable-mlserver`` flag,
@@ -1073,6 +1072,13 @@ such as:
 .. code-block:: bash
 
     mlflow models serve -m my_model --enable-mlserver
+
+Similarly, to build a Docker image built with MLServer you can use the
+``--enable-mlserver`` flag, such as:
+
+.. code-block:: bash
+
+    mlflow models build -m my_model --enable-mlserver -n my-model
 
 To read more about the integration between MLflow and MLServer, please check
 the `end-to-end example in the MLServer documentation

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -1057,25 +1057,26 @@ To account for this, MLflow allows you to also serve models using `Seldon's
 MLServer <https://mlserver.readthedocs.io/en/latest/>`_, a fully-featured
 inference server, aimed towards production use cases, including:
 
-* Support for the standard `V2 Inference Protocol
-  <https://github.com/kubeflow/kfserving/tree/master/docs/predict-api/v2>`_  on
-  both the gRPC and REST flavours.
 * Multi-model serving, letting users run multiple models within the same
   process.
-* Ability to run `inference in parallel
+* Ability to run `inference in parallel for vertical scaling
   <https://mlserver.readthedocs.io/en/latest/user-guide/parallel-inference.html>`_
   across multiple models through a pool of inference workers.
 * Support for `adaptive batching
   <https://mlserver.readthedocs.io/en/latest/user-guide/adaptive-batching.html>`_,
   to group inference requests together on the fly.
-* Integration with `Seldon Core
-  <https://docs.seldon.io/projects/seldon-core/en/latest/graph/protocols.html#v2-kfserving-protocol>`_,
+* Scalability with deployment in Kubernetes native frameworks, including `Seldon Core
+  <https://docs.seldon.io/projects/seldon-core/en/latest/graph/protocols.html#v2-kfserving-protocol>`_, 
   `KFServing
   <https://github.com/kubeflow/kfserving/tree/master/docs/samples/v1beta1/sklearn/v2>`_
   and `KServe
   <https://kserve.github.io/website/modelserving/v1beta1/sklearn/v2/>`_, where
-  MLServer is one of the core inference servers used to serve machine learning
+  MLServer is the core Python inference server used to serve machine learning
   models.
+* Support for the standard `V2 Inference Protocol
+  <https://github.com/kubeflow/kfserving/tree/master/docs/predict-api/v2>`_  on
+  both the gRPC and REST flavours, which has been standardised and adopted by
+  various model serving frameworks.
 
 MLServer should provide a drop-in replacement for the local development server,
 exposing a similar API through the ``/invocations`` endpoint.

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -1051,48 +1051,33 @@ For more information about serializing tensor inputs using the TF serving format
 Serving with MLServer (experimental)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In some cases, the local development server provided by MLflow may not offer a
-robust production-grade experience.
+In some cases, the scoring server built into MLflow may not offer a robust
+production-grade experience.
 To account for this, MLflow allows you to also serve models using `Seldon's
 MLServer <https://mlserver.readthedocs.io/en/latest/>`_, a fully-featured
-inference server, aimed towards production use cases, including:
+inference server, aimed towards production use cases and currently used as the
+core Python inference server used to serve machine learning models in
+Kubernetes-native frameworks, including `Seldon Core
+<https://docs.seldon.io/projects/seldon-core/en/latest/graph/protocols.html#v2-kfserving-protocol>`
+and `KServe (formerly known as KFServing)
+<https://kserve.github.io/website/modelserving/v1beta1/sklearn/v2/>`_.
 
-* Multi-model serving, letting users run multiple models within the same
-  process.
-* Ability to run `inference in parallel for vertical scaling
-  <https://mlserver.readthedocs.io/en/latest/user-guide/parallel-inference.html>`_
-  across multiple models through a pool of inference workers.
-* Support for `adaptive batching
-  <https://mlserver.readthedocs.io/en/latest/user-guide/adaptive-batching.html>`_,
-  to group inference requests together on the fly.
-* Scalability with deployment in Kubernetes native frameworks, including `Seldon Core
-  <https://docs.seldon.io/projects/seldon-core/en/latest/graph/protocols.html#v2-kfserving-protocol>`_, 
-  `KFServing
-  <https://github.com/kubeflow/kfserving/tree/master/docs/samples/v1beta1/sklearn/v2>`_
-  and `KServe
-  <https://kserve.github.io/website/modelserving/v1beta1/sklearn/v2/>`_, where
-  MLServer is the core Python inference server used to serve machine learning
-  models.
-* Support for the standard `V2 Inference Protocol
-  <https://github.com/kubeflow/kfserving/tree/master/docs/predict-api/v2>`_  on
-  both the gRPC and REST flavours, which has been standardised and adopted by
-  various model serving frameworks.
-
-MLServer should provide a drop-in replacement for the local development server,
-exposing a similar API through the ``/invocations`` endpoint.
+MLServer should provide a **drop-in replacement for the existing scoring
+server**, exposing a similar scoring API through the ``/invocations`` endpoint.
 This endpoint is supported on top of the standard `V2 Inference Protocol
 <https://github.com/kubeflow/kfserving/tree/master/docs/predict-api/v2>`_.
 
-To serve a MLflow model using MLServer, you can use the ``--mlserver`` flag,
+To serve a MLflow model using MLServer, you can use the ``--enable-mlserver`` flag,
 such as:
 
 .. code-block:: bash
 
-    mlflow models serve -m my_model --mlserver
+    mlflow models serve -m my_model --enable-mlserver
 
 To read more about the integration between MLflow and MLServer, please check
 the `end-to-end example in the MLServer documentation
-<https://mlserver.readthedocs.io/en/latest/examples/mlflow/README.html>`_.
+<https://mlserver.readthedocs.io/en/latest/examples/mlflow/README.html>`_ or
+visit the `MLServer docs <https://mlserver.readthedocs.io/en/latest/>`_.
 
 .. note::
     - This feature is experimental and is subject to change.

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -1046,6 +1046,56 @@ For more information about serializing pandas DataFrames, see
 For more information about serializing tensor inputs using the TF serving format, see
 `TF serving's request format docs <https://www.tensorflow.org/tfx/serving/api_rest#request_format_2>`_.
 
+.. _serving_with_mlserver:
+
+Serving with MLServer (experimental)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In some cases, the local development server provided by MLflow may not offer a
+robust production-grade experience.
+To account for this, MLflow allows you to also serve models using `Seldon's
+MLServer <https://mlserver.readthedocs.io/en/latest/>`, a fully-featured
+inference server, aimed towards production use cases, including:
+
+* Support for the standard `V2 Inference Protocol
+  <https://github.com/kubeflow/kfserving/tree/master/docs/predict-api/v2>`  on
+  both the gRPC and REST flavours.
+* Multi-Model Serving, which lets users run multiple models within the same process.
+* Ability to run `inference in parallel
+  <https://mlserver.readthedocs.io/en/latest/user-guide/parallel-inference.html>`
+  across multiple models through a pool of inference workers.
+* Support for `adaptive batching
+  <https://mlserver.readthedocs.io/en/latest/user-guide/adaptive-batching.html>`,
+  to group inference requests together on the fly.
+* Integration with `Seldon Core
+  <https://docs.seldon.io/projects/seldon-core/en/latest/graph/protocols.html#v2-kfserving-protocol>`,
+  `KFServing
+  <https://github.com/kubeflow/kfserving/tree/master/docs/samples/v1beta1/sklearn/v2>`
+  and `KServe
+  <https://kserve.github.io/website/modelserving/v1beta1/sklearn/v2/>`, where
+  MLServer is one of the core inference servers used to serve machine learning
+  models.
+
+MLServer should provide a drop-in replacement for the local development server,
+exposing a similar API through the ``/invocations`` endpoint.
+This endpoint is supported on top of the standard `V2 Inference Protocol
+<https://github.com/kubeflow/kfserving/tree/master/docs/predict-api/v2>`.
+
+To serve a MLflow model using MLServer, you can use the ``--mlserver`` flag
+such as:
+
+.. code-block:: bash
+
+    mlflow models serve -m my_model --mlserver
+
+To read more about the integration between MLflow and MLServer, please check
+the `end-to-end example in the MLServer documentation
+<https://mlserver.readthedocs.io/en/latest/examples/mlflow/README.html>`.
+
+.. note::
+    - This feature is experimental and is subject to change.
+    - MLServer requires Python 3.7 or above.
+
 .. _encoding-complex-data:
 
 Encoding complex data

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -1049,39 +1049,40 @@ For more information about serializing tensor inputs using the TF serving format
 .. _serving_with_mlserver:
 
 Serving with MLServer (experimental)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In some cases, the local development server provided by MLflow may not offer a
 robust production-grade experience.
 To account for this, MLflow allows you to also serve models using `Seldon's
-MLServer <https://mlserver.readthedocs.io/en/latest/>`, a fully-featured
+MLServer <https://mlserver.readthedocs.io/en/latest/>`_, a fully-featured
 inference server, aimed towards production use cases, including:
 
 * Support for the standard `V2 Inference Protocol
-  <https://github.com/kubeflow/kfserving/tree/master/docs/predict-api/v2>`  on
+  <https://github.com/kubeflow/kfserving/tree/master/docs/predict-api/v2>`_  on
   both the gRPC and REST flavours.
-* Multi-Model Serving, which lets users run multiple models within the same process.
+* Multi-model serving, letting users run multiple models within the same
+  process.
 * Ability to run `inference in parallel
-  <https://mlserver.readthedocs.io/en/latest/user-guide/parallel-inference.html>`
+  <https://mlserver.readthedocs.io/en/latest/user-guide/parallel-inference.html>`_
   across multiple models through a pool of inference workers.
 * Support for `adaptive batching
-  <https://mlserver.readthedocs.io/en/latest/user-guide/adaptive-batching.html>`,
+  <https://mlserver.readthedocs.io/en/latest/user-guide/adaptive-batching.html>`_,
   to group inference requests together on the fly.
 * Integration with `Seldon Core
-  <https://docs.seldon.io/projects/seldon-core/en/latest/graph/protocols.html#v2-kfserving-protocol>`,
+  <https://docs.seldon.io/projects/seldon-core/en/latest/graph/protocols.html#v2-kfserving-protocol>`_,
   `KFServing
-  <https://github.com/kubeflow/kfserving/tree/master/docs/samples/v1beta1/sklearn/v2>`
+  <https://github.com/kubeflow/kfserving/tree/master/docs/samples/v1beta1/sklearn/v2>`_
   and `KServe
-  <https://kserve.github.io/website/modelserving/v1beta1/sklearn/v2/>`, where
+  <https://kserve.github.io/website/modelserving/v1beta1/sklearn/v2/>`_, where
   MLServer is one of the core inference servers used to serve machine learning
   models.
 
 MLServer should provide a drop-in replacement for the local development server,
 exposing a similar API through the ``/invocations`` endpoint.
 This endpoint is supported on top of the standard `V2 Inference Protocol
-<https://github.com/kubeflow/kfserving/tree/master/docs/predict-api/v2>`.
+<https://github.com/kubeflow/kfserving/tree/master/docs/predict-api/v2>`_.
 
-To serve a MLflow model using MLServer, you can use the ``--mlserver`` flag
+To serve a MLflow model using MLServer, you can use the ``--mlserver`` flag,
 such as:
 
 .. code-block:: bash
@@ -1090,7 +1091,7 @@ such as:
 
 To read more about the integration between MLflow and MLServer, please check
 the `end-to-end example in the MLServer documentation
-<https://mlserver.readthedocs.io/en/latest/examples/mlflow/README.html>`.
+<https://mlserver.readthedocs.io/en/latest/examples/mlflow/README.html>`_.
 
 .. note::
     - This feature is experimental and is subject to change.

--- a/docs/source/tutorials-and-examples/tutorial.rst
+++ b/docs/source/tutorials-and-examples/tutorial.rst
@@ -413,7 +413,6 @@ For example, to build a image named ``my-docker-image``, we could do:
 
   mlflow models build-docker \
     -m /Users/mlflow/mlflow-prototype/mlruns/0/7c1a0d5c42844dcdb8f5191146925174/artifacts/model \
-    -p 1234 \
     -n my-docker-image \
     --enable-mlserver
 

--- a/docs/source/tutorials-and-examples/tutorial.rst
+++ b/docs/source/tutorials-and-examples/tutorial.rst
@@ -458,7 +458,7 @@ the ``kubectl`` CLI:
                         securityContext:
                           runAsUser: 0
                         ports:
-                          - containerPort: 8000
+                          - containerPort: 8080
                             name: http
                             protocol: TCP
                           - containerPort: 8081
@@ -484,7 +484,7 @@ the ``kubectl`` CLI:
               - name: mlflow-model
                 image: my-docker-image
                 ports:
-                  - containerPort: 8000
+                  - containerPort: 8080
                     protocol: TCP
                 env:
                   - name: PROTOCOL

--- a/docs/source/tutorials-and-examples/tutorial.rst
+++ b/docs/source/tutorials-and-examples/tutorial.rst
@@ -295,7 +295,7 @@ in MLflow saved the model as an artifact within the run.
 
               mlflow models serve \
                 -m /Users/mlflow/mlflow-prototype/mlruns/0/7c1a0d5c42844dcdb8f5191146925174/artifacts/model \
-                -p 1234 --mlserver
+                -p 1234 --enable-mlserver
 
       .. note::
 

--- a/docs/source/tutorials-and-examples/tutorial.rst
+++ b/docs/source/tutorials-and-examples/tutorial.rst
@@ -286,6 +286,18 @@ in MLflow saved the model as an artifact within the run.
           mlflow models serve -m /Users/mlflow/mlflow-prototype/mlruns/0/7c1a0d5c42844dcdb8f5191146925174/artifacts/model -p 1234
 
       .. note::
+     
+          For production use cases, it's also possible to :ref:`serve your model using MLServer<serving_with_mlserver>`.
+          Note that this feature is still **experimental**.
+          In this example, this could be done as:
+
+          .. code-block:: bash
+
+              mlflow models serve \
+                -m /Users/mlflow/mlflow-prototype/mlruns/0/7c1a0d5c42844dcdb8f5191146925174/artifacts/model \
+                -p 1234 --mlserver
+
+      .. note::
 
           The version of Python used to create the model must be the same as the one running ``mlflow models serve``.
           If this is not the case, you may see the error

--- a/examples/sklearn_elasticnet_wine/conda.yaml
+++ b/examples/sklearn_elasticnet_wine/conda.yaml
@@ -2,9 +2,9 @@ name: tutorial
 channels:
   - conda-forge
 dependencies:
-  - python=3.6
+  - python=3.7
   - pip
   - pip:
-    - scikit-learn==0.23.2
-    - mlflow>=1.0
-    - pandas
+      - scikit-learn==0.23.2
+      - mlflow>=1.0
+      - pandas

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -32,9 +32,7 @@ def commands():
 @cli_args.NO_CONDA
 @cli_args.INSTALL_MLFLOW
 @cli_args.MLSERVER
-def serve(
-        model_uri, port, host, workers,
-        no_conda=False, install_mlflow=False, mlserver=False):
+def serve(model_uri, port, host, workers, no_conda=False, install_mlflow=False, mlserver=False):
     """
     Serve a model saved with MLflow by launching a webserver on the specified host and port.
     The command supports models with the ``python_function`` or ``crate`` (R Function) flavor.

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -126,7 +126,8 @@ def prepare_env(model_uri, no_conda, install_mlflow):
 @cli_args.MODEL_URI
 @click.option("--name", "-n", default="mlflow-pyfunc-servable", help="Name to use for built image")
 @cli_args.INSTALL_MLFLOW
-def build_docker(model_uri, name, install_mlflow):
+@cli_args.MLSERVER
+def build_docker(model_uri, name, install_mlflow, mlserver):
     """
     Builds a Docker image whose default entrypoint serves the specified MLflow
     model at port 8080 within the container, using the 'python_function' flavor.
@@ -158,7 +159,7 @@ def build_docker(model_uri, name, install_mlflow):
     """
     mlflow_home = os.environ.get("MLFLOW_HOME", None)
     _get_flavor_backend(model_uri, docker_build=True).build_image(
-        model_uri, name, mlflow_home=mlflow_home, install_mlflow=install_mlflow
+        model_uri, name, mlflow_home=mlflow_home, install_mlflow=install_mlflow, mlserver=mlserver
     )
 
 

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -31,7 +31,10 @@ def commands():
 @cli_args.WORKERS
 @cli_args.NO_CONDA
 @cli_args.INSTALL_MLFLOW
-def serve(model_uri, port, host, workers, no_conda=False, install_mlflow=False):
+@cli_args.MLSERVER
+def serve(
+        model_uri, port, host, workers,
+        no_conda=False, install_mlflow=False, mlserver=False):
     """
     Serve a model saved with MLflow by launching a webserver on the specified host and port.
     The command supports models with the ``python_function`` or ``crate`` (R Function) flavor.
@@ -53,7 +56,7 @@ def serve(model_uri, port, host, workers, no_conda=False, install_mlflow=False):
     """
     return _get_flavor_backend(
         model_uri, no_conda=no_conda, workers=workers, install_mlflow=install_mlflow
-    ).serve(model_uri=model_uri, port=port, host=host)
+    ).serve(model_uri=model_uri, port=port, host=host, mlserver=mlserver)
 
 
 @commands.command("predict")

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -31,8 +31,10 @@ def commands():
 @cli_args.WORKERS
 @cli_args.NO_CONDA
 @cli_args.INSTALL_MLFLOW
-@cli_args.MLSERVER
-def serve(model_uri, port, host, workers, no_conda=False, install_mlflow=False, mlserver=False):
+@cli_args.ENABLE_MLSERVER
+def serve(
+    model_uri, port, host, workers, no_conda=False, install_mlflow=False, enable_mlserver=False
+):
     """
     Serve a model saved with MLflow by launching a webserver on the specified host and port.
     The command supports models with the ``python_function`` or ``crate`` (R Function) flavor.
@@ -54,7 +56,7 @@ def serve(model_uri, port, host, workers, no_conda=False, install_mlflow=False, 
     """
     return _get_flavor_backend(
         model_uri, no_conda=no_conda, workers=workers, install_mlflow=install_mlflow
-    ).serve(model_uri=model_uri, port=port, host=host, mlserver=mlserver)
+    ).serve(model_uri=model_uri, port=port, host=host, enable_mlserver=enable_mlserver)
 
 
 @commands.command("predict")
@@ -126,8 +128,8 @@ def prepare_env(model_uri, no_conda, install_mlflow):
 @cli_args.MODEL_URI
 @click.option("--name", "-n", default="mlflow-pyfunc-servable", help="Name to use for built image")
 @cli_args.INSTALL_MLFLOW
-@cli_args.MLSERVER
-def build_docker(model_uri, name, install_mlflow, mlserver):
+@cli_args.ENABLE_MLSERVER
+def build_docker(model_uri, name, install_mlflow, enable_mlserver):
     """
     Builds a Docker image whose default entrypoint serves the specified MLflow
     model at port 8080 within the container, using the 'python_function' flavor.
@@ -159,7 +161,11 @@ def build_docker(model_uri, name, install_mlflow, mlserver):
     """
     mlflow_home = os.environ.get("MLFLOW_HOME", None)
     _get_flavor_backend(model_uri, docker_build=True).build_image(
-        model_uri, name, mlflow_home=mlflow_home, install_mlflow=install_mlflow, mlserver=mlserver
+        model_uri,
+        name,
+        mlflow_home=mlflow_home,
+        install_mlflow=install_mlflow,
+        enable_mlserver=enable_mlserver,
     )
 
 

--- a/mlflow/models/container/__init__.py
+++ b/mlflow/models/container/__init__.py
@@ -165,8 +165,8 @@ def _serve_pyfunc(model):
     )
 
     bash_cmds.append(cmd)
-    inference_server = Popen(["/bin/bash", "-c", " && ".join(bash_cmds)], env=cmd_env)
-    procs.append(inference_server)
+    inference_server_process = Popen(["/bin/bash", "-c", " && ".join(bash_cmds)], env=cmd_env)
+    procs.append(inference_server_process)
 
     signal.signal(signal.SIGTERM, lambda a, b: _sigterm_handler(pids=[p.pid for p in procs]))
     # If either subprocess exits, so do we.

--- a/mlflow/models/container/__init__.py
+++ b/mlflow/models/container/__init__.py
@@ -121,16 +121,17 @@ def _install_pyfunc_deps(model_path=None, install_mlflow=False):
 
 
 def _serve_pyfunc(model):
-    conf = model.flavors[pyfunc.FLAVOR_NAME]
-    bash_cmds = []
-    if pyfunc.ENV in conf:
-        if not os.environ.get(DISABLE_ENV_CREATION) == "true":
-            _install_pyfunc_deps(MODEL_PATH, install_mlflow=True)
-        bash_cmds += ["source /miniconda/bin/activate custom_env"]
-
     # option to disable manually nginx. The default behavior is to enable nginx.
     disable_nginx = os.getenv(DISABLE_NGINX, "false").lower() == "true"
     enable_mlserver = os.getenv(ENABLE_MLSERVER, "false").lower() == "true"
+    disable_env_creation = os.environ.get(DISABLE_ENV_CREATION) == "true"
+
+    conf = model.flavors[pyfunc.FLAVOR_NAME]
+    bash_cmds = []
+    if pyfunc.ENV in conf:
+        if not disable_env_creation:
+            _install_pyfunc_deps(MODEL_PATH, install_mlflow=True)
+        bash_cmds += ["source /miniconda/bin/activate custom_env"]
 
     procs = []
 

--- a/mlflow/models/container/__init__.py
+++ b/mlflow/models/container/__init__.py
@@ -147,7 +147,8 @@ def _serve_pyfunc(model):
         nginx = Popen(["nginx", "-c", nginx_conf]) if start_nginx else None
 
         # link the log streams to stdout/err so they will be logged to the container logs.
-        # Default behavior is to do the redirection unless explicitly specified by environment variable.
+        # Default behavior is to do the redirection unless explicitly specified
+        # by environment variable.
         check_call(["ln", "-sf", "/dev/stdout", "/var/log/nginx/access.log"])
         check_call(["ln", "-sf", "/dev/stderr", "/var/log/nginx/error.log"])
 

--- a/mlflow/models/container/__init__.py
+++ b/mlflow/models/container/__init__.py
@@ -31,6 +31,7 @@ DEPLOYMENT_CONFIG_KEY_FLAVOR_NAME = "MLFLOW_DEPLOYMENT_FLAVOR_NAME"
 DEFAULT_SAGEMAKER_SERVER_PORT = 8080
 DEFAULT_INFERENCE_SERVER_PORT = 8000
 DEFAULT_NGINX_SERVER_PORT = 8080
+DEFAULT_MLSERVER_PORT = 8080
 
 SUPPORTED_FLAVORS = [pyfunc.FLAVOR_NAME, mleap.FLAVOR_NAME]
 
@@ -160,9 +161,10 @@ def _serve_pyfunc(model):
     os.system('python -c"from mlflow.version import VERSION as V; print(V)"')
 
     inference_server = mlserver if enable_mlserver else scoring_server
-    cmd, cmd_env = inference_server.get_cmd(
-        model_uri=MODEL_PATH, nworkers=cpu_count, port=DEFAULT_INFERENCE_SERVER_PORT
-    )
+    # Since MLServer will run without NGINX, expose the server in the `8080`
+    # port, which is the assumed "public" port.
+    port = DEFAULT_MLSERVER_PORT if enable_mlserver else DEFAULT_INFERENCE_SERVER_PORT
+    cmd, cmd_env = inference_server.get_cmd(model_uri=MODEL_PATH, nworkers=cpu_count, port=port)
 
     bash_cmds.append(cmd)
     inference_server_process = Popen(["/bin/bash", "-c", " && ".join(bash_cmds)], env=cmd_env)

--- a/mlflow/models/container/scoring_server/nginx.conf
+++ b/mlflow/models/container/scoring_server/nginx.conf
@@ -14,7 +14,7 @@ http {
   default_type application/octet-stream;
   access_log /var/log/nginx/access.log combined;
   
-  upstream inference_server {
+  upstream gunicorn {
     server 127.0.0.1:8000;
   }
 
@@ -24,11 +24,11 @@ http {
 
     keepalive_timeout 5;
 
-    location ~ ^/(v2|ping|invocations) {
+    location ~ ^/(ping|invocations) {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Host $http_host;
       proxy_redirect off;
-      proxy_pass http://inference_server;
+      proxy_pass http://gunicorn;
     }
 
     location / {

--- a/mlflow/models/container/scoring_server/nginx.conf
+++ b/mlflow/models/container/scoring_server/nginx.conf
@@ -14,7 +14,7 @@ http {
   default_type application/octet-stream;
   access_log /var/log/nginx/access.log combined;
   
-  upstream gunicorn {
+  upstream inference_server {
     server 127.0.0.1:8000;
   }
 
@@ -24,11 +24,11 @@ http {
 
     keepalive_timeout 5;
 
-    location ~ ^/(ping|invocations) {
+    location ~ ^/(v2|ping|invocations) {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Host $http_host;
       proxy_redirect off;
-      proxy_pass http://gunicorn;
+      proxy_pass http://inference_server;
     }
 
     location / {

--- a/mlflow/models/flavor_backend.py
+++ b/mlflow/models/flavor_backend.py
@@ -35,13 +35,14 @@ class FlavorBackend(object):
         pass
 
     @abstractmethod
-    def serve(self, model_uri, port, host):
+    def serve(self, model_uri, port, host, enable_mlserver):
         """
         Serve the specified MLflow model locally.
 
         :param model_uri: URI pointing to the MLflow model to be used for scoring.
         :param port: Port to use for the model deployment.
         :param host: Host to use for the model deployment. Defaults to ``localhost``.
+        :param enable_mlserver: Whether to use MLServer or the local scoring server.
         """
         pass
 

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -36,12 +36,7 @@ class PyFuncBackend(FlavorBackend):
         return _execute_in_conda_env(conda_env_path, command, self._install_mlflow)
 
     def predict(
-        self,
-        model_uri,
-        input_path,
-        output_path,
-        content_type,
-        json_format,
+        self, model_uri, input_path, output_path, content_type, json_format,
     ):
         """
         Generate predictions using generic python model saved with MLflow.
@@ -71,7 +66,7 @@ class PyFuncBackend(FlavorBackend):
         else:
             scoring_server._predict(local_uri, input_path, output_path, content_type, json_format)
 
-    def serve(self, model_uri, port, host, enable_mlserver):
+    def serve(self, model_uri, port, host, enable_mlserver):  # pylint: disable=W0221
         """
         Serve pyfunc model locally.
         """

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -5,7 +5,7 @@ import subprocess
 import posixpath
 from mlflow.models import FlavorBackend
 from mlflow.models.docker_utils import _build_image, DISABLE_ENV_CREATION
-from mlflow.pyfunc import ENV, scoring_server
+from mlflow.pyfunc import ENV, scoring_server, mlserver as _mlserver
 
 from mlflow.utils.conda import get_or_create_conda_env, get_conda_bin_executable, get_conda_command
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
@@ -65,27 +65,16 @@ class PyFuncBackend(FlavorBackend):
         else:
             scoring_server._predict(local_uri, input_path, output_path, content_type, json_format)
 
-    def serve(self, model_uri, port, host):
+    def serve(self, model_uri, port, host, mlserver):
         """
         Serve pyfunc model locally.
         """
         local_path = _download_artifact_from_uri(model_uri)
-        # NB: Absolute windows paths do not work with mlflow apis, use file uri to ensure
-        # platform compatibility.
-        local_uri = path_to_local_file_uri(local_path)
-        if os.name != "nt":
-            command = (
-                "gunicorn --timeout=60 -b {host}:{port} -w {nworkers} ${{GUNICORN_CMD_ARGS}}"
-                " -- mlflow.pyfunc.scoring_server.wsgi:app"
-            ).format(host=host, port=port, nworkers=self._nworkers)
-        else:
-            command = (
-                "waitress-serve --host={host} --port={port} "
-                "--ident=mlflow mlflow.pyfunc.scoring_server.wsgi:app"
-            ).format(host=host, port=port)
 
-        command_env = os.environ.copy()
-        command_env[scoring_server._SERVER_MODEL_PATH] = local_uri
+        server_implementation = _mlserver if mlserver else scoring_server
+        command, command_env = server_implementation.get_cmd(
+            local_path, port, host, self._nworkers)
+
         if not self._no_conda and ENV in self._config:
             conda_env_path = os.path.join(local_path, self._config[ENV])
             return _execute_in_conda_env(

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -17,7 +17,7 @@ _logger = logging.getLogger(__name__)
 
 class PyFuncBackend(FlavorBackend):
     """
-        Flavor backend implementation for the generic python models.
+    Flavor backend implementation for the generic python models.
     """
 
     def __init__(self, config, workers=1, no_conda=False, install_mlflow=False, **kwargs):
@@ -35,7 +35,12 @@ class PyFuncBackend(FlavorBackend):
         return _execute_in_conda_env(conda_env_path, command, self._install_mlflow)
 
     def predict(
-        self, model_uri, input_path, output_path, content_type, json_format,
+        self,
+        model_uri,
+        input_path,
+        output_path,
+        content_type,
+        json_format,
     ):
         """
         Generate predictions using generic python model saved with MLflow.
@@ -72,8 +77,7 @@ class PyFuncBackend(FlavorBackend):
         local_path = _download_artifact_from_uri(model_uri)
 
         server_implementation = _mlserver if mlserver else scoring_server
-        command, command_env = server_implementation.get_cmd(
-            local_path, port, host, self._nworkers)
+        command, command_env = server_implementation.get_cmd(local_path, port, host, self._nworkers)
 
         if not self._no_conda and ENV in self._config:
             conda_env_path = os.path.join(local_path, self._config[ENV])

--- a/mlflow/pyfunc/mlserver.py
+++ b/mlflow/pyfunc/mlserver.py
@@ -1,0 +1,37 @@
+import asyncio
+import os
+
+from typing import Tuple, Dict
+
+from mlserver.server import MLServer
+from mlserver.cli.serve import load_settings
+
+MLServerMLflowRuntime = "mlserver_mlflow.MLflowRuntime"
+
+def _predict(model_uri: str, input_path: str, output_path: str, content_type: str, json_format: str):
+    pass
+
+def _serve(model_uri: str, port: int, host: str):
+    settings, models = asyncio.run(load_settings(model_uri))
+
+    settings.host = host
+    settings.http_port = port
+
+    server = MLServer(settings)
+    asyncio.run(server.start(models))
+
+def get_cmd(model_uri: str, port: int, host: str, nworkers: int) -> Tuple[str, Dict[str, str]]:
+    cmd = f"mlserver start {model_uri}"
+
+    cmd_env = os.environ.copy()
+    cmd_env["MLSERVER_HTTP_PORT"] = str(port)
+    cmd_env["MLSERVER_HOST"] = host
+
+    # TODO: What name should it have?
+    #  cmd_env["MLSERVER_MODEL_NAME"] = model_details.name,
+    cmd_env["MLSERVER_MODEL_PARALLEL_WORKERS"] = str(nworkers)
+    cmd_env["MLSERVER_MODEL_IMPLEMENTATION"] = MLServerMLflowRuntime
+    cmd_env["MLSERVER_MODEL_URI"] = model_uri
+
+    return cmd, cmd_env
+

--- a/mlflow/pyfunc/mlserver.py
+++ b/mlflow/pyfunc/mlserver.py
@@ -9,32 +9,25 @@ from mlserver.cli.serve import load_settings
 MLServerMLflowRuntime = "mlserver_mlflow.MLflowRuntime"
 
 
-def _predict(
-    model_uri: str, input_path: str, output_path: str, content_type: str, json_format: str
-):
-    pass
-
-
-def _serve(model_uri: str, port: int, host: str):
-    settings, models = asyncio.run(load_settings(model_uri))
-
-    settings.host = host
-    settings.http_port = port
-
-    server = MLServer(settings)
-    asyncio.run(server.start(models))
-
-
-def get_cmd(model_uri: str, port: int, host: str, nworkers: int) -> Tuple[str, Dict[str, str]]:
+def get_cmd(
+    model_uri: str, port: int = None, host: str = None, nworkers: int = None
+) -> Tuple[str, Dict[str, str]]:
     cmd = f"mlserver start {model_uri}"
 
     cmd_env = os.environ.copy()
-    cmd_env["MLSERVER_HTTP_PORT"] = str(port)
-    cmd_env["MLSERVER_HOST"] = host
+
+    if port:
+        cmd_env["MLSERVER_HTTP_PORT"] = str(port)
+
+    if host:
+        cmd_env["MLSERVER_HOST"] = host
 
     # TODO: What name should it have?
     #  cmd_env["MLSERVER_MODEL_NAME"] = model_details.name,
-    cmd_env["MLSERVER_MODEL_PARALLEL_WORKERS"] = str(nworkers)
+
+    if nworkers:
+        cmd_env["MLSERVER_MODEL_PARALLEL_WORKERS"] = str(nworkers)
+
     cmd_env["MLSERVER_MODEL_IMPLEMENTATION"] = MLServerMLflowRuntime
     cmd_env["MLSERVER_MODEL_URI"] = model_uri
 

--- a/mlflow/pyfunc/mlserver.py
+++ b/mlflow/pyfunc/mlserver.py
@@ -1,10 +1,6 @@
-import asyncio
 import os
 
 from typing import Tuple, Dict
-
-from mlserver.server import MLServer
-from mlserver.cli.serve import load_settings
 
 MLServerMLflowRuntime = "mlserver_mlflow.MLflowRuntime"
 MLServerDefaultModelName = "mlflow-model"

--- a/mlflow/pyfunc/mlserver.py
+++ b/mlflow/pyfunc/mlserver.py
@@ -8,8 +8,12 @@ from mlserver.cli.serve import load_settings
 
 MLServerMLflowRuntime = "mlserver_mlflow.MLflowRuntime"
 
-def _predict(model_uri: str, input_path: str, output_path: str, content_type: str, json_format: str):
+
+def _predict(
+    model_uri: str, input_path: str, output_path: str, content_type: str, json_format: str
+):
     pass
+
 
 def _serve(model_uri: str, port: int, host: str):
     settings, models = asyncio.run(load_settings(model_uri))
@@ -19,6 +23,7 @@ def _serve(model_uri: str, port: int, host: str):
 
     server = MLServer(settings)
     asyncio.run(server.start(models))
+
 
 def get_cmd(model_uri: str, port: int, host: str, nworkers: int) -> Tuple[str, Dict[str, str]]:
     cmd = f"mlserver start {model_uri}"
@@ -34,4 +39,3 @@ def get_cmd(model_uri: str, port: int, host: str, nworkers: int) -> Tuple[str, D
     cmd_env["MLSERVER_MODEL_URI"] = model_uri
 
     return cmd, cmd_env
-

--- a/mlflow/pyfunc/mlserver.py
+++ b/mlflow/pyfunc/mlserver.py
@@ -7,6 +7,7 @@ from mlserver.server import MLServer
 from mlserver.cli.serve import load_settings
 
 MLServerMLflowRuntime = "mlserver_mlflow.MLflowRuntime"
+MLServerDefaultModelName = "mlflow-model"
 
 
 def get_cmd(
@@ -22,8 +23,7 @@ def get_cmd(
     if host:
         cmd_env["MLSERVER_HOST"] = host
 
-    # TODO: What name should it have?
-    #  cmd_env["MLSERVER_MODEL_NAME"] = model_details.name,
+    cmd_env["MLSERVER_MODEL_NAME"] = MLServerDefaultModelName
 
     if nworkers:
         cmd_env["MLSERVER_MODEL_PARALLEL_WORKERS"] = str(nworkers)

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -28,7 +28,6 @@ import traceback
 # ALl of the mlfow dependencies below need to be backwards compatible.
 from mlflow.exceptions import MlflowException
 from mlflow.types import Schema
-from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils import reraise
 from mlflow.utils.file_utils import path_to_local_file_uri
 from mlflow.utils.proto_json_utils import (
@@ -99,8 +98,7 @@ def infer_and_parse_json_input(json_input, schema: Schema = None):
                 return parse_tf_serving_input(decoded_input, schema=schema)
             except MlflowException as ex:
                 _handle_serving_error(
-                    error_message=(ex.message),
-                    error_code=MALFORMED_REQUEST,
+                    error_message=(ex.message), error_code=MALFORMED_REQUEST,
                 )
         else:
             return parse_json_input(json_input=json_input, orient="split", schema=schema)

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -350,7 +350,7 @@ def _serve(model_uri, port, host):
 
 
 def get_cmd(
-    model_uri: str, port: str = None, host: int = None, nworkers: int = None
+    model_uri: str, port: int = None, host: int = None, nworkers: int = None
 ) -> Tuple[str, Dict[str, str]]:
     local_uri = path_to_local_file_uri(model_uri)
     # NB: Absolute windows paths do not work with mlflow apis, use file uri to ensure

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -99,7 +99,8 @@ def infer_and_parse_json_input(json_input, schema: Schema = None):
                 return parse_tf_serving_input(decoded_input, schema=schema)
             except MlflowException as ex:
                 _handle_serving_error(
-                    error_message=(ex.message), error_code=MALFORMED_REQUEST,
+                    error_message=(ex.message),
+                    error_code=MALFORMED_REQUEST,
                 )
         else:
             return parse_json_input(json_input=json_input, orient="split", schema=schema)
@@ -347,6 +348,7 @@ def _serve(model_uri, port, host):
     pyfunc_model = load_model(model_uri)
     init(pyfunc_model).run(port=port, host=host)
 
+
 def get_cmd(model_uri: str, port: str, host: int, nworkers: int) -> Tuple[str, Dict[str, str]]:
     local_uri = path_to_local_file_uri(model_uri)
     # NB: Absolute windows paths do not work with mlflow apis, use file uri to ensure
@@ -366,4 +368,3 @@ def get_cmd(model_uri: str, port: str, host: int, nworkers: int) -> Tuple[str, D
     command_env[_SERVER_MODEL_PATH] = local_uri
 
     return command, command_env
-

--- a/mlflow/rfunc/backend.py
+++ b/mlflow/rfunc/backend.py
@@ -37,9 +37,13 @@ class RFuncBackend(FlavorBackend):
         )
         _execute(command)
 
-    def serve(self, model_uri, port, host):
+    def serve(self, model_uri, port, host, enable_mlserver):
         """
         Generate R model locally.
+
+        NOTE: The `enable_mlserver` parameter is there to comply with the
+        FlavorBackend interface but won't be used for R models yet.
+        https://github.com/SeldonIO/MLServer/issues/183
         """
         model_path = _download_artifact_from_uri(model_uri)
         command = "mlflow::mlflow_rfunc_serve('{0}', port = {1}, host = '{2}')".format(

--- a/mlflow/rfunc/backend.py
+++ b/mlflow/rfunc/backend.py
@@ -42,9 +42,12 @@ class RFuncBackend(FlavorBackend):
         Generate R model locally.
 
         NOTE: The `enable_mlserver` parameter is there to comply with the
-        FlavorBackend interface but won't be used for R models yet.
+        FlavorBackend interface but is not supported by MLServer yet.
         https://github.com/SeldonIO/MLServer/issues/183
         """
+        if enable_mlserver:
+            raise Exception("The MLServer inference server is not yet supported in the R backend.")
+
         model_path = _download_artifact_from_uri(model_uri)
         command = "mlflow::mlflow_rfunc_serve('{0}', port = {1}, host = '{2}')".format(
             quote(model_path), port, host

--- a/mlflow/utils/cli_args.py
+++ b/mlflow/utils/cli_args.py
@@ -81,8 +81,8 @@ WORKERS = click.option(
     help="Number of gunicorn worker processes to handle requests (default: 4).",
 )
 
-MLSERVER = click.option(
-    "--mlserver",
+ENABLE_MLSERVER = click.option(
+    "--enable-mlserver",
     is_flag=True,
     default=False,
     help="Enable serving with MLServer through the v2 inference protocol.",

--- a/mlflow/utils/cli_args.py
+++ b/mlflow/utils/cli_args.py
@@ -80,3 +80,10 @@ WORKERS = click.option(
     default=None,
     help="Number of gunicorn worker processes to handle requests (default: 4).",
 )
+
+MLSERVER = click.option(
+    "--mlserver",
+    is_flag=True,
+    default=False,
+    help="Enable serving with MLServer through the v2 inference protocol.",
+)

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -139,7 +139,7 @@ def _normalize_package_name(pkg_name):
     return _NORMALIZE_REGEX.sub("-", pkg_name).lower()
 
 
-def _get_requires_recursive(pkg_name, packages=set()) -> set:
+def _get_requires_recursive(pkg_name, packages=None) -> set:
     """
     Recursively yields both direct and transitive dependencies of the specified
     package.
@@ -148,6 +148,9 @@ def _get_requires_recursive(pkg_name, packages=set()) -> set:
     This ensures that we don't fall into recursive loops for packages with are
     dependant on each other.
     """
+    if packages is None:
+        packages = set()
+
     pkg_name = _normalize_package_name(pkg_name)
     if pkg_name not in pkg_resources.working_set.by_key:
         return packages

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -169,7 +169,7 @@ def _get_requires_recursive(pkg_name, visited_packages=None) -> set:
 
     for req in reqs:
         yield _normalize_package_name(req.name)
-        yield from _get_requires_recursive(req.name)
+        yield from _get_requires_recursive(req.name, visited_packages)
 
 
 def _prune_packages(packages):

--- a/setup.py
+++ b/setup.py
@@ -79,8 +79,8 @@ CORE_REQUIREMENTS = SKINNY_REQUIREMENTS + [
     # Required to run the MLflow server against SQL-backed storage
     "sqlalchemy",
     "waitress; platform_system == 'Windows'",
-    "mlserver>=0.5.1",
-    "mlserver-mlflow>=0.5.1",
+    "mlserver>=0.5.2",
+    "mlserver-mlflow>=0.5.2",
 ]
 
 _is_mlflow_skinny = bool(os.environ.get(_MLFLOW_SKINNY_ENV_VAR))

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,8 @@ CORE_REQUIREMENTS = SKINNY_REQUIREMENTS + [
     # Required to run the MLflow server against SQL-backed storage
     "sqlalchemy",
     "waitress; platform_system == 'Windows'",
+    "mlserver",
+    "mlserver-mlflow",
 ]
 
 _is_mlflow_skinny = bool(os.environ.get(_MLFLOW_SKINNY_ENV_VAR))

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,6 @@ CORE_REQUIREMENTS = SKINNY_REQUIREMENTS + [
     # Required to run the MLflow server against SQL-backed storage
     "sqlalchemy",
     "waitress; platform_system == 'Windows'",
-    "mlserver",
     "mlserver-mlflow",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -79,8 +79,8 @@ CORE_REQUIREMENTS = SKINNY_REQUIREMENTS + [
     # Required to run the MLflow server against SQL-backed storage
     "sqlalchemy",
     "waitress; platform_system == 'Windows'",
-    "mlserver",
-    "mlserver-mlflow",
+    "mlserver>=0.5.1",
+    "mlserver-mlflow>=0.5.1",
 ]
 
 _is_mlflow_skinny = bool(os.environ.get(_MLFLOW_SKINNY_ENV_VAR))

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ CORE_REQUIREMENTS = SKINNY_REQUIREMENTS + [
     # Required to run the MLflow server against SQL-backed storage
     "sqlalchemy",
     "waitress; platform_system == 'Windows'",
+    "mlserver",
     "mlserver-mlflow",
 ]
 

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -430,7 +430,7 @@ def test_build_docker(iris_data, sk_model, enable_mlserver):
     if enable_mlserver:
         extra_args.append("--enable-mlserver")
 
-    image_name = pyfunc_build_image(model_uri, extra_args=["--install-mlflow"] + enable_mlserver)
+    image_name = pyfunc_build_image(model_uri, extra_args=extra_args)
     host_port = get_safe_port()
     scoring_proc = pyfunc_serve_from_docker_image(image_name, host_port)
     _validate_with_rest_endpoint(scoring_proc, host_port, df, x, sk_model)

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -415,7 +415,13 @@ def test_prepare_env_fails(sk_model):
 @pytest.mark.parametrize("enable_mlserver", [True, False])
 def test_build_docker(iris_data, sk_model, enable_mlserver):
     with mlflow.start_run() as active_run:
-        mlflow.sklearn.log_model(sk_model, "model")
+        conda_env = None
+        if enable_mlserver:
+            # MLServer requires Python 3.7, so we'll add it to the model's
+            # Conda environment
+            conda_env = {"dependencies": ["python=3.7"]}
+
+        mlflow.sklearn.log_model(sk_model, "model", conda_env=conda_env)
         model_uri = "runs:/{run_id}/model".format(run_id=active_run.info.run_id)
     x, _ = iris_data
     df = pd.DataFrame(x)
@@ -434,7 +440,13 @@ def test_build_docker(iris_data, sk_model, enable_mlserver):
 @pytest.mark.parametrize("enable_mlserver", [True, False])
 def test_build_docker_with_env_override(iris_data, sk_model, enable_mlserver):
     with mlflow.start_run() as active_run:
-        mlflow.sklearn.log_model(sk_model, "model")
+        conda_env = None
+        if enable_mlserver:
+            # MLServer requires Python 3.7, so we'll add it to the model's
+            # Conda environment
+            conda_env = {"dependencies": ["python=3.7"]}
+
+        mlflow.sklearn.log_model(sk_model, "model", conda_env=conda_env)
         model_uri = "runs:/{run_id}/model".format(run_id=active_run.info.run_id)
     x, _ = iris_data
     df = pd.DataFrame(x)

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -11,6 +11,8 @@ import sklearn
 import sklearn.datasets
 import sklearn.neighbors
 
+from unittest import mock
+
 try:
     from StringIO import StringIO
 except ImportError:
@@ -19,6 +21,7 @@ except ImportError:
 import mlflow
 from mlflow import pyfunc
 import mlflow.sklearn
+
 from mlflow.utils.file_utils import TempDir, path_to_local_file_uri
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils import PYTHON_VERSION
@@ -415,14 +418,14 @@ def test_prepare_env_fails(sk_model):
 @pytest.mark.parametrize("enable_mlserver", [True, False])
 def test_build_docker(iris_data, sk_model, enable_mlserver):
     with mlflow.start_run() as active_run:
-        conda_env = None
         if enable_mlserver:
-            # MLServer requires Python 3.7, so we'll add it to the model's
-            # Conda environment
-            conda_env = {"dependencies": ["python=3.7"]}
-
-        mlflow.sklearn.log_model(sk_model, "model", conda_env=conda_env)
+            # MLServer requires Python 3.7, so we'll force that Python version
+            with mock.patch("mlflow.utils.environment.PYTHON_VERSION", "3.7"):
+                mlflow.sklearn.log_model(sk_model, "model")
+        else:
+            mlflow.sklearn.log_model(sk_model, "model")
         model_uri = "runs:/{run_id}/model".format(run_id=active_run.info.run_id)
+
     x, _ = iris_data
     df = pd.DataFrame(x)
 
@@ -440,13 +443,12 @@ def test_build_docker(iris_data, sk_model, enable_mlserver):
 @pytest.mark.parametrize("enable_mlserver", [True, False])
 def test_build_docker_with_env_override(iris_data, sk_model, enable_mlserver):
     with mlflow.start_run() as active_run:
-        conda_env = None
         if enable_mlserver:
-            # MLServer requires Python 3.7, so we'll add it to the model's
-            # Conda environment
-            conda_env = {"dependencies": ["python=3.7"]}
-
-        mlflow.sklearn.log_model(sk_model, "model", conda_env=conda_env)
+            # MLServer requires Python 3.7, so we'll force that Python version
+            with mock.patch("mlflow.utils.environment.PYTHON_VERSION", "3.7"):
+                mlflow.sklearn.log_model(sk_model, "model")
+        else:
+            mlflow.sklearn.log_model(sk_model, "model")
         model_uri = "runs:/{run_id}/model".format(run_id=active_run.info.run_id)
     x, _ = iris_data
     df = pd.DataFrame(x)

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -412,26 +412,28 @@ def test_prepare_env_fails(sk_model):
 
 
 @pytest.mark.large
-def test_build_docker(iris_data, sk_model):
+@pytest.mark.parametrize("extra_args", [[], ["--mlserver"]])
+def test_build_docker(iris_data, sk_model, extra_args):
     with mlflow.start_run() as active_run:
         mlflow.sklearn.log_model(sk_model, "model")
         model_uri = "runs:/{run_id}/model".format(run_id=active_run.info.run_id)
     x, _ = iris_data
     df = pd.DataFrame(x)
-    image_name = pyfunc_build_image(model_uri, extra_args=["--install-mlflow"])
+    image_name = pyfunc_build_image(model_uri, extra_args=["--install-mlflow"] + extra_args)
     host_port = get_safe_port()
     scoring_proc = pyfunc_serve_from_docker_image(image_name, host_port)
     _validate_with_rest_endpoint(scoring_proc, host_port, df, x, sk_model)
 
 
 @pytest.mark.large
-def test_build_docker_with_env_override(iris_data, sk_model):
+@pytest.mark.parametrize("extra_args", [[], ["--mlserver"]])
+def test_build_docker_with_env_override(iris_data, sk_model, extra_args):
     with mlflow.start_run() as active_run:
         mlflow.sklearn.log_model(sk_model, "model")
         model_uri = "runs:/{run_id}/model".format(run_id=active_run.info.run_id)
     x, _ = iris_data
     df = pd.DataFrame(x)
-    image_name = pyfunc_build_image(model_uri, extra_args=["--install-mlflow"])
+    image_name = pyfunc_build_image(model_uri, extra_args=["--install-mlflow"] + extra_args)
     host_port = get_safe_port()
     scoring_proc = pyfunc_serve_from_docker_image_with_env_override(
         image_name, host_port, gunicorn_options

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -412,28 +412,28 @@ def test_prepare_env_fails(sk_model):
 
 
 @pytest.mark.large
-@pytest.mark.parametrize("extra_args", [[], ["--mlserver"]])
+@pytest.mark.parametrize("enable_mlserver", [[], ["--enable-mlserver"]])
 def test_build_docker(iris_data, sk_model, extra_args):
     with mlflow.start_run() as active_run:
         mlflow.sklearn.log_model(sk_model, "model")
         model_uri = "runs:/{run_id}/model".format(run_id=active_run.info.run_id)
     x, _ = iris_data
     df = pd.DataFrame(x)
-    image_name = pyfunc_build_image(model_uri, extra_args=["--install-mlflow"] + extra_args)
+    image_name = pyfunc_build_image(model_uri, extra_args=["--install-mlflow"] + enable_mlserver)
     host_port = get_safe_port()
     scoring_proc = pyfunc_serve_from_docker_image(image_name, host_port)
     _validate_with_rest_endpoint(scoring_proc, host_port, df, x, sk_model)
 
 
 @pytest.mark.large
-@pytest.mark.parametrize("extra_args", [[], ["--mlserver"]])
+@pytest.mark.parametrize("enable_mlserver", [[], ["--enable-mlserver"]])
 def test_build_docker_with_env_override(iris_data, sk_model, extra_args):
     with mlflow.start_run() as active_run:
         mlflow.sklearn.log_model(sk_model, "model")
         model_uri = "runs:/{run_id}/model".format(run_id=active_run.info.run_id)
     x, _ = iris_data
     df = pd.DataFrame(x)
-    image_name = pyfunc_build_image(model_uri, extra_args=["--install-mlflow"] + extra_args)
+    image_name = pyfunc_build_image(model_uri, extra_args=["--install-mlflow"] + enable_mlserver)
     host_port = get_safe_port()
     scoring_proc = pyfunc_serve_from_docker_image_with_env_override(
         image_name, host_port, gunicorn_options

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -436,7 +436,7 @@ def test_build_docker(iris_data, sk_model, enable_mlserver):
     image_name = pyfunc_build_image(model_uri, extra_args=extra_args)
     host_port = get_safe_port()
     scoring_proc = pyfunc_serve_from_docker_image(image_name, host_port)
-    _validate_with_rest_endpoint(scoring_proc, host_port, df, x, sk_model)
+    _validate_with_rest_endpoint(scoring_proc, host_port, df, x, sk_model, enable_mlserver)
 
 
 @pytest.mark.large
@@ -462,10 +462,10 @@ def test_build_docker_with_env_override(iris_data, sk_model, enable_mlserver):
     scoring_proc = pyfunc_serve_from_docker_image_with_env_override(
         image_name, host_port, gunicorn_options
     )
-    _validate_with_rest_endpoint(scoring_proc, host_port, df, x, sk_model)
+    _validate_with_rest_endpoint(scoring_proc, host_port, df, x, sk_model, enable_mlserver)
 
 
-def _validate_with_rest_endpoint(scoring_proc, host_port, df, x, sk_model):
+def _validate_with_rest_endpoint(scoring_proc, host_port, df, x, sk_model, enable_mlserver=False):
     with RestEndpoint(proc=scoring_proc, port=host_port) as endpoint:
         for content_type in [CONTENT_TYPE_JSON_SPLIT_ORIENTED, CONTENT_TYPE_CSV, CONTENT_TYPE_JSON]:
             scoring_response = endpoint.invoke(df, content_type)
@@ -482,6 +482,13 @@ def _validate_with_rest_endpoint(scoring_proc, host_port, df, x, sk_model):
                 "Expected server failure with error code 500, got response with status code %s "
                 "and body %s" % (scoring_response.status_code, scoring_response.text)
             )
+
+            if enable_mlserver:
+                # MLServer returns a different set of errors.
+                # Skip these assertions until this issue gets tackled:
+                # https://github.com/SeldonIO/MLServer/issues/360)
+                continue
+
             scoring_response_dict = json.loads(scoring_response.content)
             assert "error_code" in scoring_response_dict
             assert scoring_response_dict["error_code"] == ErrorCode.Name(MALFORMED_REQUEST)

--- a/tests/pyfunc/test_mlserver.py
+++ b/tests/pyfunc/test_mlserver.py
@@ -17,28 +17,14 @@ from mlflow.pyfunc.mlserver import get_cmd, MLServerMLflowRuntime, MLServerDefau
         ),
         (
             {"host": "0.0.0.0", "nworkers": 4},
-            {
-                "MLSERVER_HOST": "0.0.0.0",
-                "MLSERVER_MODEL_PARALLEL_WORKERS": "4",
-            },
+            {"MLSERVER_HOST": "0.0.0.0", "MLSERVER_MODEL_PARALLEL_WORKERS": "4"},
         ),
         (
             {"port": 5000, "nworkers": 4},
-            {
-                "MLSERVER_HTTP_PORT": "5000",
-                "MLSERVER_MODEL_PARALLEL_WORKERS": "4",
-            },
+            {"MLSERVER_HTTP_PORT": "5000", "MLSERVER_MODEL_PARALLEL_WORKERS": "4"},
         ),
-        (
-            {"port": 5000},
-            {
-                "MLSERVER_HTTP_PORT": "5000",
-            },
-        ),
-        (
-            {},
-            {},
-        ),
+        ({"port": 5000}, {"MLSERVER_HTTP_PORT": "5000"}),
+        ({}, {}),
     ],
 )
 def test_get_cmd(params: dict, expected: dict):

--- a/tests/pyfunc/test_mlserver.py
+++ b/tests/pyfunc/test_mlserver.py
@@ -1,7 +1,7 @@
 import pytest
 import os
 
-from mlflow.pyfunc.mlserver import get_cmd, MLServerMLflowRuntime
+from mlflow.pyfunc.mlserver import get_cmd, MLServerMLflowRuntime, MLServerDefaultModelName
 
 
 @pytest.mark.parametrize(
@@ -13,7 +13,6 @@ from mlflow.pyfunc.mlserver import get_cmd, MLServerMLflowRuntime
                 "MLSERVER_HTTP_PORT": "5000",
                 "MLSERVER_HOST": "0.0.0.0",
                 "MLSERVER_MODEL_PARALLEL_WORKERS": "4",
-                "MLSERVER_MODEL_IMPLEMENTATION": MLServerMLflowRuntime,
             },
         ),
         (
@@ -21,7 +20,6 @@ from mlflow.pyfunc.mlserver import get_cmd, MLServerMLflowRuntime
             {
                 "MLSERVER_HOST": "0.0.0.0",
                 "MLSERVER_MODEL_PARALLEL_WORKERS": "4",
-                "MLSERVER_MODEL_IMPLEMENTATION": MLServerMLflowRuntime,
             },
         ),
         (
@@ -29,21 +27,17 @@ from mlflow.pyfunc.mlserver import get_cmd, MLServerMLflowRuntime
             {
                 "MLSERVER_HTTP_PORT": "5000",
                 "MLSERVER_MODEL_PARALLEL_WORKERS": "4",
-                "MLSERVER_MODEL_IMPLEMENTATION": MLServerMLflowRuntime,
             },
         ),
         (
             {"port": 5000},
             {
                 "MLSERVER_HTTP_PORT": "5000",
-                "MLSERVER_MODEL_IMPLEMENTATION": MLServerMLflowRuntime,
             },
         ),
         (
             {},
-            {
-                "MLSERVER_MODEL_IMPLEMENTATION": MLServerMLflowRuntime,
-            },
+            {},
         ),
     ],
 )
@@ -53,4 +47,10 @@ def test_get_cmd(params: dict, expected: dict):
 
     assert cmd == f"mlserver start {model_uri}"
 
-    assert cmd_env == {"MLSERVER_MODEL_URI": model_uri, **expected, **os.environ.copy()}
+    assert cmd_env == {
+        "MLSERVER_MODEL_URI": model_uri,
+        "MLSERVER_MODEL_IMPLEMENTATION": MLServerMLflowRuntime,
+        "MLSERVER_MODEL_NAME": MLServerDefaultModelName,
+        **expected,
+        **os.environ.copy(),
+    }

--- a/tests/pyfunc/test_mlserver.py
+++ b/tests/pyfunc/test_mlserver.py
@@ -1,0 +1,56 @@
+import pytest
+import os
+
+from mlflow.pyfunc.mlserver import get_cmd, MLServerMLflowRuntime
+
+
+@pytest.mark.parametrize(
+    "params, expected",
+    [
+        (
+            {"port": 5000, "host": "0.0.0.0", "nworkers": 4},
+            {
+                "MLSERVER_HTTP_PORT": "5000",
+                "MLSERVER_HOST": "0.0.0.0",
+                "MLSERVER_MODEL_PARALLEL_WORKERS": "4",
+                "MLSERVER_MODEL_IMPLEMENTATION": MLServerMLflowRuntime,
+            },
+        ),
+        (
+            {"host": "0.0.0.0", "nworkers": 4},
+            {
+                "MLSERVER_HOST": "0.0.0.0",
+                "MLSERVER_MODEL_PARALLEL_WORKERS": "4",
+                "MLSERVER_MODEL_IMPLEMENTATION": MLServerMLflowRuntime,
+            },
+        ),
+        (
+            {"port": 5000, "nworkers": 4},
+            {
+                "MLSERVER_HTTP_PORT": "5000",
+                "MLSERVER_MODEL_PARALLEL_WORKERS": "4",
+                "MLSERVER_MODEL_IMPLEMENTATION": MLServerMLflowRuntime,
+            },
+        ),
+        (
+            {"port": 5000},
+            {
+                "MLSERVER_HTTP_PORT": "5000",
+                "MLSERVER_MODEL_IMPLEMENTATION": MLServerMLflowRuntime,
+            },
+        ),
+        (
+            {},
+            {
+                "MLSERVER_MODEL_IMPLEMENTATION": MLServerMLflowRuntime,
+            },
+        ),
+    ],
+)
+def test_get_cmd(params: dict, expected: dict):
+    model_uri = "/foo/bar"
+    cmd, cmd_env = get_cmd(model_uri=model_uri, **params)
+
+    assert cmd == f"mlserver start {model_uri}"
+
+    assert cmd_env == {"MLSERVER_MODEL_URI": model_uri, **expected, **os.environ.copy()}

--- a/tests/pyfunc/test_scoring_server.py
+++ b/tests/pyfunc/test_scoring_server.py
@@ -17,6 +17,7 @@ import mlflow.sklearn
 from mlflow.models import ModelSignature, infer_signature
 from mlflow.protos.databricks_pb2 import ErrorCode, MALFORMED_REQUEST, BAD_REQUEST
 from mlflow.pyfunc import PythonModel
+from mlflow.pyfunc.scoring_server import get_cmd
 from mlflow.types import Schema, ColSpec, DataType
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils.proto_json_utils import NumpyEncoder
@@ -597,3 +598,24 @@ def test_parse_json_input_including_path():
         content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
     )
     assert response_records_content_type.status_code == 200
+
+
+@pytest.mark.parametrize(
+    "args, expected",
+    [
+        (
+            {"port": 5000, "host": "0.0.0.0", "nworkers": 4},
+            "--timeout=60 -b 0.0.0.0:5000 -w 4",
+        ),
+        ({"host": "0.0.0.0", "nworkers": 4}, "--timeout=60 -b 0.0.0.0 -w 4"),
+        ({"port": 5000, "nworkers": 4}, "--timeout=60 -w 4"),
+        ({"nworkers": 4}, "--timeout=60 -w 4"),
+        ({}, "--timeout=60"),
+    ],
+)
+def test_get_cmd(args: dict, expected: str):
+    cmd, _ = get_cmd(model_uri="foo", **args)
+
+    assert cmd == (
+        f"gunicorn {expected} ${{GUNICORN_CMD_ARGS}} -- mlflow.pyfunc.scoring_server.wsgi:app"
+    )

--- a/tests/pyfunc/test_scoring_server.py
+++ b/tests/pyfunc/test_scoring_server.py
@@ -603,10 +603,7 @@ def test_parse_json_input_including_path():
 @pytest.mark.parametrize(
     "args, expected",
     [
-        (
-            {"port": 5000, "host": "0.0.0.0", "nworkers": 4},
-            "--timeout=60 -b 0.0.0.0:5000 -w 4",
-        ),
+        ({"port": 5000, "host": "0.0.0.0", "nworkers": 4}, "--timeout=60 -b 0.0.0.0:5000 -w 4",),
         ({"host": "0.0.0.0", "nworkers": 4}, "--timeout=60 -b 0.0.0.0 -w 4"),
         ({"port": 5000, "nworkers": 4}, "--timeout=60 -w 4"),
         ({"nworkers": 4}, "--timeout=60 -w 4"),

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -150,7 +150,7 @@ def test_spark_udf_autofills_no_arguments(spark):
                 columns=["x", "b", "c", "d"], data={"x": [1], "b": [2], "c": [3], "d": [4]}
             )
         )
-        with pytest.raises(AnalysisException, match=r"cannot resolve '`a`' given input columns"):
+        with pytest.raises(AnalysisException, match=r"cannot resolve 'a' given input columns"):
             bad_data.withColumn("res", udf())
 
     nameless_signature = ModelSignature(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -166,7 +166,8 @@ def test_mlflow_gc_not_deleted_run(file_store):
     assert len(runs) == 1
 
 
-def test_mlflow_models_serve():
+@pytest.mark.parametrize("extra_args", [[], ["--mlserver"]])
+def test_mlflow_models_serve(extra_args):
     class MyModel(pyfunc.PythonModel):
         def predict(self, context, model_input):  # pylint: disable=unused-variable
             return np.array([1, 2, 3])
@@ -183,7 +184,7 @@ def test_mlflow_models_serve():
         model_uri=model_uri,
         data=data,
         content_type=pyfunc.scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
-        extra_args=["--no-conda"],
+        extra_args=["--no-conda"] + extra_args,
     )
     assert scoring_response.status_code == 200
     served_model_preds = np.array(json.loads(scoring_response.content))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -175,12 +175,12 @@ def test_mlflow_models_serve(enable_mlserver):
     model = MyModel()
 
     with mlflow.start_run():
-        conda_env = None
         if enable_mlserver:
-            # MLServer requires Python 3.7, so we'll add it to the model's
-            # Conda environment
-            conda_env = {"dependencies": ["python=3.7"]}
-        mlflow.pyfunc.log_model(artifact_path="model", python_model=model, conda_env=conda_env)
+            # MLServer requires Python 3.7, so we'll force that Python version
+            with mock.patch("mlflow.utils.environment.PYTHON_VERSION", "3.7"):
+                mlflow.pyfunc.log_model(artifact_path="model", python_model=model)
+        else:
+            mlflow.pyfunc.log_model(artifact_path="model", python_model=model)
         model_uri = mlflow.get_artifact_uri("model")
 
     data = pd.DataFrame({"a": [0]})

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ import shutil
 import tempfile
 import time
 import subprocess
+import sys
 
 from urllib.request import url2pathname
 from urllib.parse import urlparse, unquote
@@ -185,11 +186,16 @@ def test_mlflow_models_serve(enable_mlserver):
 
     data = pd.DataFrame({"a": [0]})
 
-    extra_args = ["--no-conda"]
+    extra_args = []
+    python_37_or_above = sys.version_info >= (3, 7)
     if enable_mlserver:
-        # When MLServer is enabled, we want to use Conda to ensure Python 3.7
-        # is used
-        extra_args = ["--enable-mlserver"]
+        extra_args.append("--enable-mlserver")
+
+    if not enable_mlserver or python_37_or_above:
+        # When MLServer is enabled, we want to ensure that (at least) Python
+        # 3.7 is used. Therefore, we  need to either check if Python 3.7 is
+        # already in use, or enable Conda.
+        extra_args.append("--no-conda")
 
     scoring_response = pyfunc_serve_and_score_model(
         model_uri=model_uri,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -166,8 +166,8 @@ def test_mlflow_gc_not_deleted_run(file_store):
     assert len(runs) == 1
 
 
-@pytest.mark.parametrize("extra_args", [[], ["--mlserver"]])
-def test_mlflow_models_serve(extra_args):
+@pytest.mark.parametrize("enable_mlserver", [[], ["--enable-mlserver"]])
+def test_mlflow_models_serve(inference_server):
     class MyModel(pyfunc.PythonModel):
         def predict(self, context, model_input):  # pylint: disable=unused-variable
             return np.array([1, 2, 3])
@@ -184,7 +184,7 @@ def test_mlflow_models_serve(extra_args):
         model_uri=model_uri,
         data=data,
         content_type=pyfunc.scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
-        extra_args=["--no-conda"] + extra_args,
+        extra_args=["--no-conda"] + enable_mlserver,
     )
     assert scoring_response.status_code == 200
     served_model_preds = np.array(json.loads(scoring_response.content))


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes #4844

This PR introduces support to serve MLflow models through [MLServer](https://mlserver.readthedocs.io/en/latest/), directly from the `mlflow` CLI. [MLServer](https://mlserver.readthedocs.io/en/latest/) is a fully-featured inference server built on top of FastAPI / AsyncIO, aimed towards production use cases.

Following some initial work to integrate MLflow within MLServer (discussed in more detail in issue #4844), and after discussions between both teams, it was agreed by the MLFlow team that the next step would be to contribute this work upstream to MLflow. The full initial design for this can be seen in [this design
document](https://docs.google.com/document/d/1ITRBAleZUzS8DxZC0WZjmh0q6dlxNE2q8Yk0X20A2zs/edit?usp=sharing).

This PR enables users to serve models through MLServer doing something like:

```bash
$ mlflow models serve -m my_model --mlserver
```

Additionally, it also adds support to build a Docker image, including MLServer doing something like:

```bash
$ mlflow models build-docker -m my_model -n my-model-image:0.1.0 --mlserver
```

## How is this patch tested?

The unit tests for the `mlflow models serve` and `mlflow models build-docker` subcommands are now parametrized through `pytest` to run on both the existing scoring server and MLServer.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add support to serve MLflow models through MLServer (a fully-featured Python inference server built on top of FastAPI), directly from the `mlflow` CLI. Users should now be able to leverage the `--mlserver` flag on both the `mlflow models serve` and `mlflow models build-docker` subcommands.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
