### PR TITLE
Add roadmap links & info to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,7 @@ Roadmap
 -------
 The current MLflow Roadmap is available at https://github.com/mlflow/mlflow/milestone/3. We are
 seeking contributions to all of our roadmap items with the `help wanted` tag. Please see the
-:ref:`Contributing` section for more information.
+`Contributing`_ section for more information.
 
 Community
 ---------

--- a/README.rst
+++ b/README.rst
@@ -136,8 +136,6 @@ MLflow artifacts and then load them again for serving. There is an example train
     $ curl -d '{"columns":[0],"index":[0,1],"data":[[1],[-1]]}' -H 'Content-Type: application/json'  localhost:5000/invocations
 
 
-.. _Contributing:
-
 Contributing
 ------------
 We happily welcome contributions to MLflow. We are also seeking contributions to items on the

--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,7 @@ Official documentation for MLflow can be found at https://mlflow.org/docs/latest
 Roadmap
 -------
 The current MLflow Roadmap is available at https://github.com/mlflow/mlflow/milestone/3. We are
-seeking contributions to all of our roadmap items with the ``help wanted`` tag. Please see the
+seeking contributions to all of our roadmap items with the ``help wanted`` label. Please see the
 `Contributing`_ section for more information.
 
 Community

--- a/README.rst
+++ b/README.rst
@@ -139,5 +139,5 @@ MLflow artifacts and then load them again for serving. There is an example train
 Contributing
 ------------
 We happily welcome contributions to MLflow. We are also seeking contributions to items on the
-[MLflow Roadmap](https://github.com/mlflow/mlflow/milestone/3). Please see our
+`MLflow Roadmap <https://github.com/mlflow/mlflow/milestone/3>`_. Please see our
 `contribution guide <CONTRIBUTING.rst>`_ to learn more about contributing to MLflow.

--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,7 @@ Official documentation for MLflow can be found at https://mlflow.org/docs/latest
 Roadmap
 -------
 The current MLflow Roadmap is available at https://github.com/mlflow/mlflow/milestone/3. We are
-seeking contributions to all of our roadmap items with the `help wanted` tag. Please see the
+seeking contributions to all of our roadmap items with the ``help wanted`` tag. Please see the
 `Contributing`_ section for more information.
 
 Community

--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,12 @@ Documentation
 -------------
 Official documentation for MLflow can be found at https://mlflow.org/docs/latest/index.html.
 
+Roadmap
+-------
+The current MLflow Roadmap is available at https://github.com/mlflow/mlflow/milestone/3. We are
+seeking contributions to all of our roadmap items with the `help wanted` tag. Please see the
+:ref:`Contributing` section for more information.
+
 Community
 ---------
 For help or questions about MLflow usage (e.g. "how do I do X?") see the `docs <https://mlflow.org/docs/latest/index.html>`_
@@ -130,7 +136,10 @@ MLflow artifacts and then load them again for serving. There is an example train
     $ curl -d '{"columns":[0],"index":[0,1],"data":[[1],[-1]]}' -H 'Content-Type: application/json'  localhost:5000/invocations
 
 
+.. _Contributing:
+
 Contributing
 ------------
-We happily welcome contributions to MLflow. Please see our `contribution guide <CONTRIBUTING.rst>`_
-for details.
+We happily welcome contributions to MLflow. We are also seeking contributions to items on the
+[MLflow Roadmap](https://github.com/mlflow/mlflow/milestone/3). Please see our
+`contribution guide <CONTRIBUTING.rst>`_ to learn more about contributing to MLflow.


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add roadmap links & info to README

## How is this patch tested?

Empirically

## Release Notes

The MLflow Roadmap has been released: https://github.com/mlflow/mlflow/milestone/3. We are actively seeking contributions to all issues with the ``help wanted`` label.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [X] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [X] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [X] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [X] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [X] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
