### PR TITLE
Visibility of default column sorting order. closes #4825

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentPage.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentPage.js
@@ -250,9 +250,7 @@ export class ExperimentPage extends Component {
   */
   shouldNestChildrenAndFetchParents() {
     const { orderByKey, searchInput } = this.state.persistedState;
-    return (
-      (!orderByKey && !searchInput) || orderByKey === DEFAULT_ORDER_BY_KEY
-    );
+    return (!orderByKey && !searchInput) || orderByKey === DEFAULT_ORDER_BY_KEY;
   }
 
   onSearch = (

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentPage.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentPage.js
@@ -21,26 +21,17 @@ import { MAX_RUNS_IN_SEARCH_MODEL_VERSIONS_FILTER } from '../../model-registry/c
 import { getExperiment } from '../reducers/Reducers';
 import { Experiment } from '../sdk/MlflowMessages';
 import { injectIntl } from 'react-intl';
-
-export const LIFECYCLE_FILTER = { ACTIVE: 'Active', DELETED: 'Deleted' };
-export const MODEL_VERSION_FILTER = {
-  WITH_MODEL_VERSIONS: 'With Model Versions',
-  WTIHOUT_MODEL_VERSIONS: 'Without Model Versions',
-  ALL_RUNS: 'All Runs',
-};
-
-export const DEFAULT_ORDER_BY_KEY = 'attributes.start_time';
-export const DEFAULT_ORDER_BY_ASC = false;
-export const DEFAULT_START_TIME = 'ALL';
-
-export const PAGINATION_DEFAULT_STATE = {
-  nextPageToken: null,
-  numRunsFromLatestSearch: null, // number of runs returned from the most recent search request
-  loadingMore: false,
-};
-
-export const MAX_DETECT_NEW_RUNS_RESULTS = 26; // so the refresh button badge can be 25+
-export const DETECT_NEW_RUNS_INTERVAL = 15000;
+import {
+  LIFECYCLE_FILTER,
+  MODEL_VERSION_FILTER,
+  PAGINATION_DEFAULT_STATE,
+  MAX_DETECT_NEW_RUNS_RESULTS,
+  DETECT_NEW_RUNS_INTERVAL,
+  DEFAULT_ORDER_BY_KEY,
+  DEFAULT_ORDER_BY_ASC,
+  DEFAULT_START_TIME,
+  ATTRIBUTE_COLUMN_SORT_KEY,
+} from '../constants';
 
 export const isNewRun = (lastRunsRefreshTime, run) => {
   if (run && run.info) {
@@ -250,7 +241,7 @@ export class ExperimentPage extends Component {
   */
   shouldNestChildrenAndFetchParents() {
     const { orderByKey, searchInput } = this.state.persistedState;
-    return (!orderByKey && !searchInput) || orderByKey === DEFAULT_ORDER_BY_KEY;
+    return (!orderByKey && !searchInput) || orderByKey === ATTRIBUTE_COLUMN_SORT_KEY.DATE;
   }
 
   onSearch = (

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentPage.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentPage.js
@@ -29,6 +29,10 @@ export const MODEL_VERSION_FILTER = {
   ALL_RUNS: 'All Runs',
 };
 
+export const DEFAULT_ORDER_BY_KEY = 'attributes.start_time';
+export const DEFAULT_ORDER_BY_ASC = false;
+export const DEFAULT_START_TIME = 'ALL';
+
 export const PAGINATION_DEFAULT_STATE = {
   nextPageToken: null,
   numRunsFromLatestSearch: null, // number of runs returned from the most recent search request
@@ -88,9 +92,10 @@ export class ExperimentPage extends Component {
         paramKeyFilterString: urlState.params === undefined ? '' : urlState.params,
         metricKeyFilterString: urlState.metrics === undefined ? '' : urlState.metrics,
         searchInput: urlState.search === undefined ? '' : urlState.search,
-        orderByKey: urlState.orderByKey === undefined ? null : urlState.orderByKey,
-        orderByAsc: urlState.orderByAsc === undefined ? false : urlState.orderByAsc === 'true',
-        startTime: urlState.startTime === undefined ? 'ALL' : urlState.startTime,
+        orderByKey: urlState.orderByKey === undefined ? DEFAULT_ORDER_BY_KEY : urlState.orderByKey,
+        orderByAsc:
+          urlState.orderByAsc === undefined ? DEFAULT_ORDER_BY_ASC : urlState.orderByAsc === 'true',
+        startTime: urlState.startTime === undefined ? DEFAULT_START_TIME : urlState.startTime,
       },
     };
   }
@@ -240,11 +245,14 @@ export class ExperimentPage extends Component {
   /*
     If this function returns true, the ExperimentView should nest children underneath their parents
     and fetch all root level parents of visible runs. If this function returns false, the views will
-    not nest children or fetch any additional parents.
+    not nest children or fetch any additional parents. Will always return true if the orderByKey is
+    'attributes.start_time'
   */
   shouldNestChildrenAndFetchParents() {
     const { orderByKey, searchInput } = this.state.persistedState;
-    return !orderByKey && !searchInput;
+    return (
+      (!orderByKey && !searchInput) || orderByKey === DEFAULT_ORDER_BY_KEY
+    );
   }
 
   onSearch = (

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentPage.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentPage.test.js
@@ -4,21 +4,20 @@ import { shallow } from 'enzyme';
 import { MemoryRouter as Router } from 'react-router-dom';
 
 import { ErrorCodes } from '../../common/constants';
-import {
-  DETECT_NEW_RUNS_INTERVAL,
-  ExperimentPage,
-  MAX_DETECT_NEW_RUNS_RESULTS,
-  PAGINATION_DEFAULT_STATE,
-  isNewRun,
-  lifecycleFilterToRunViewType,
-  DEFAULT_ORDER_BY_KEY,
-  DEFAULT_ORDER_BY_ASC,
-} from './ExperimentPage';
+import { ExperimentPage, isNewRun, lifecycleFilterToRunViewType } from './ExperimentPage';
 import ExperimentView from './ExperimentView';
 import { PermissionDeniedView } from './PermissionDeniedView';
 import { ViewType } from '../sdk/MlflowEnums';
 import { ErrorWrapper } from '../../common/utils/ActionUtils';
 import { MAX_RUNS_IN_SEARCH_MODEL_VERSIONS_FILTER } from '../../model-registry/constants';
+import {
+  ATTRIBUTE_COLUMN_SORT_KEY,
+  DETECT_NEW_RUNS_INTERVAL,
+  MAX_DETECT_NEW_RUNS_RESULTS,
+  PAGINATION_DEFAULT_STATE,
+  DEFAULT_ORDER_BY_KEY,
+  DEFAULT_ORDER_BY_ASC,
+} from '../constants';
 
 const BASE_PATH = '/experiments/17/s';
 const EXPERIMENT_ID = '17';
@@ -292,6 +291,24 @@ test('should nest children when filtering or sorting', () => {
       },
     },
     () => expect(instance.shouldNestChildrenAndFetchParents()).toBe(false),
+  );
+  instance.setState(
+    {
+      persistedState: {
+        orderByKey: ATTRIBUTE_COLUMN_SORT_KEY.DATE,
+        searchInput: 'metrics.a > 1',
+      },
+    },
+    () => expect(instance.shouldNestChildrenAndFetchParents()).toBe(true),
+  );
+  instance.setState(
+    {
+      persistedState: {
+        orderByKey: ATTRIBUTE_COLUMN_SORT_KEY.DATE,
+        searchInput: null,
+      },
+    },
+    () => expect(instance.shouldNestChildrenAndFetchParents()).toBe(true),
   );
 });
 

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentPage.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentPage.test.js
@@ -11,6 +11,8 @@ import {
   PAGINATION_DEFAULT_STATE,
   isNewRun,
   lifecycleFilterToRunViewType,
+  DEFAULT_ORDER_BY_KEY,
+  DEFAULT_ORDER_BY_ASC,
 } from './ExperimentPage';
 import ExperimentView from './ExperimentView';
 import { PermissionDeniedView } from './PermissionDeniedView';
@@ -129,8 +131,8 @@ test('Loading state without any URL params', () => {
   expect(state.persistedState.paramKeyFilterString).toEqual('');
   expect(state.persistedState.metricKeyFilterString).toEqual('');
   expect(state.persistedState.searchInput).toEqual('');
-  expect(state.persistedState.orderByKey).toBe(null);
-  expect(state.persistedState.orderByAsc).toEqual(false);
+  expect(state.persistedState.orderByKey).toBe(DEFAULT_ORDER_BY_KEY);
+  expect(state.persistedState.orderByAsc).toEqual(DEFAULT_ORDER_BY_ASC);
 });
 
 test('Loading state with all URL params', () => {

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableCompactView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableCompactView.js
@@ -12,7 +12,7 @@ import _ from 'lodash';
 import { LoadMoreBar } from './LoadMoreBar';
 
 import 'react-virtualized/styles.css';
-import { ColumnTypes } from '../constants';
+import { COLUMN_TYPES } from '../constants';
 
 export const NUM_RUN_METADATA_COLS = 10;
 const TABLE_HEADER_HEIGHT = 40;
@@ -155,14 +155,14 @@ export class ExperimentRunsTableCompactView extends React.Component {
         'div',
       ),
     ];
-    const excludedTagsSet = new Set(categorizedUncheckedKeys[ColumnTypes.TAGS]);
+    const excludedTagsSet = new Set(categorizedUncheckedKeys[COLUMN_TYPES.TAGS]);
     ExperimentViewUtil.getRunInfoCellsForRow(
       runInfo,
       _.pickBy(tagsList[idx], (t) => !excludedTagsSet.has(t.key)),
       isParent,
       'div',
       this.handleCellToggle,
-      categorizedUncheckedKeys[ColumnTypes.ATTRIBUTES],
+      categorizedUncheckedKeys[COLUMN_TYPES.ATTRIBUTES],
     ).forEach((col) => rowContents.push(col));
     rowContents.push(
       ExperimentViewUtil.getLinkedModelCell(modelVersionInfo, this.handleCellToggle),
@@ -403,7 +403,7 @@ export class ExperimentRunsTableCompactView extends React.Component {
       orderByKey,
       orderByAsc,
       'div',
-      categorizedUncheckedKeys[ColumnTypes.ATTRIBUTES],
+      categorizedUncheckedKeys[COLUMN_TYPES.ATTRIBUTES],
     ).forEach((headerCell) => headerCells.push(headerCell));
 
     this.getMetricParamHeaderCells().forEach((cell) => headerCells.push(cell));
@@ -466,7 +466,7 @@ export class ExperimentRunsTableCompactView extends React.Component {
               cellMeasurerProps.rowHeight = 32;
             }
             const numVisibleMetaColumns =
-              NUM_RUN_METADATA_COLS - categorizedUncheckedKeys[ColumnTypes.ATTRIBUTES].length;
+              NUM_RUN_METADATA_COLS - categorizedUncheckedKeys[COLUMN_TYPES.ATTRIBUTES].length;
             return [
               <Table
                 key='table'

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.js
@@ -23,10 +23,10 @@ import { Spinner } from '../../common/components/Spinner';
 import { ExperimentRunsTableEmptyOverlay } from '../../common/components/ExperimentRunsTableEmptyOverlay';
 import LocalStorageUtils from '../../common/utils/LocalStorageUtils';
 import { AgGridPersistedState } from '../sdk/MlflowLocalStorageMessages';
-import { ColumnTypes } from '../constants';
 import { TrimmedText } from '../../common/components/TrimmedText';
 import { getModelVersionPageRoute } from '../../model-registry/routes';
 import { css } from 'emotion';
+import { COLUMN_TYPES, ATTRIBUTE_COLUMN_LABELS, ATTRIBUTE_COLUMN_SORT_KEY } from '../constants';
 
 const PARAM_PREFIX = '$$$param$$$';
 const METRIC_PREFIX = '$$$metric$$$';
@@ -164,7 +164,7 @@ export class ExperimentRunsTableMultiColumnView2 extends React.Component {
           initialWidth: 50,
         },
         {
-          headerName: ExperimentViewUtil.AttributeColumnLabels.DATE,
+          headerName: ATTRIBUTE_COLUMN_LABELS.DATE,
           field: 'startTime',
           pinned: 'left',
           initialWidth: 150,
@@ -172,69 +172,69 @@ export class ExperimentRunsTableMultiColumnView2 extends React.Component {
           sortable: true,
           headerComponentParams: {
             ...commonSortOrderProps,
-            canonicalSortKey: ExperimentViewUtil.AttributeColumnSortKey.DATE,
+            canonicalSortKey: ATTRIBUTE_COLUMN_SORT_KEY.DATE,
             computedStylesOnSortKey: headerStyle,
           },
           cellStyle,
         },
         {
-          headerName: ExperimentViewUtil.AttributeColumnLabels.RUN_NAME,
+          headerName: ATTRIBUTE_COLUMN_LABELS.RUN_NAME,
           pinned: 'left',
           field: 'runName',
           sortable: true,
           headerComponentParams: {
             ...commonSortOrderProps,
-            canonicalSortKey: ExperimentViewUtil.AttributeColumnSortKey.RUN_NAME,
+            canonicalSortKey: ATTRIBUTE_COLUMN_SORT_KEY.RUN_NAME,
             computedStylesOnSortKey: headerStyle,
           },
           cellStyle,
         },
         {
-          headerName: ExperimentViewUtil.AttributeColumnLabels.USER,
+          headerName: ATTRIBUTE_COLUMN_LABELS.USER,
           field: 'user',
           sortable: true,
           headerComponentParams: {
             ...commonSortOrderProps,
-            canonicalSortKey: ExperimentViewUtil.AttributeColumnSortKey.USER,
+            canonicalSortKey: ATTRIBUTE_COLUMN_SORT_KEY.USER,
             computedStylesOnSortKey: headerStyle,
           },
           cellStyle,
         },
         {
-          headerName: ExperimentViewUtil.AttributeColumnLabels.SOURCE,
+          headerName: ATTRIBUTE_COLUMN_LABELS.SOURCE,
           field: 'source',
           cellRenderer: 'sourceCellRenderer',
           sortable: true,
           headerComponentParams: {
             ...commonSortOrderProps,
-            canonicalSortKey: ExperimentViewUtil.AttributeColumnSortKey.SOURCE,
+            canonicalSortKey: ATTRIBUTE_COLUMN_SORT_KEY.SOURCE,
             computedStylesOnSortKey: headerStyle,
           },
           cellStyle,
         },
         {
-          headerName: ExperimentViewUtil.AttributeColumnLabels.VERSION,
+          headerName: ATTRIBUTE_COLUMN_LABELS.VERSION,
           field: 'version',
           cellRenderer: 'versionCellRenderer',
           sortable: true,
           headerComponentParams: {
             ...commonSortOrderProps,
-            canonicalSortKey: ExperimentViewUtil.AttributeColumnSortKey.VERSION,
+            canonicalSortKey: ATTRIBUTE_COLUMN_SORT_KEY.VERSION,
             computedStylesOnSortKey: headerStyle,
           },
           cellStyle,
         },
         {
-          headerName: ExperimentViewUtil.AttributeColumnLabels.MODELS,
+          headerName: ATTRIBUTE_COLUMN_LABELS.MODELS,
           field: 'models',
           cellRenderer: 'modelsCellRenderer',
           initialWidth: 200,
         },
-      ].filter((c) => !categorizedUncheckedKeys[ColumnTypes.ATTRIBUTES].includes(c.headerName)),
+      ].filter((c) => !categorizedUncheckedKeys[COLUMN_TYPES.ATTRIBUTES].includes(c.headerName)),
       {
         headerName: 'Metrics',
         children: metricKeyList.map((metricKey, i) => {
-          const columnKey = ExperimentViewUtil.makeCanonicalKey(ColumnTypes.METRICS, metricKey);
+          const columnKey = ExperimentViewUtil.makeCanonicalKey(COLUMN_TYPES.METRICS, metricKey);
           return {
             headerName: metricKey,
             headerTooltip: metricKey,
@@ -257,7 +257,7 @@ export class ExperimentRunsTableMultiColumnView2 extends React.Component {
       {
         headerName: 'Parameters',
         children: paramKeyList.map((paramKey, i) => {
-          const columnKey = ExperimentViewUtil.makeCanonicalKey(ColumnTypes.PARAMS, paramKey);
+          const columnKey = ExperimentViewUtil.makeCanonicalKey(COLUMN_TYPES.PARAMS, paramKey);
           return {
             headerName: paramKey,
             headerTooltip: paramKey,

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.test.js
@@ -4,7 +4,7 @@ import {
   ExperimentRunsTableMultiColumnView2,
   ModelsCellRenderer,
 } from './ExperimentRunsTableMultiColumnView2';
-import { ColumnTypes } from '../constants';
+import { COLUMN_TYPES } from '../constants';
 import { RunTag } from '../sdk/MlflowMessages';
 import { MemoryRouter as Router } from 'react-router-dom';
 
@@ -44,10 +44,10 @@ describe('ExperimentRunsTableMultiColumnView2', () => {
       loadingMore: false,
       isLoading: false,
       categorizedUncheckedKeys: {
-        [ColumnTypes.ATTRIBUTES]: [],
-        [ColumnTypes.PARAMS]: [],
-        [ColumnTypes.METRICS]: [],
-        [ColumnTypes.TAGS]: [],
+        [COLUMN_TYPES.ATTRIBUTES]: [],
+        [COLUMN_TYPES.PARAMS]: [],
+        [COLUMN_TYPES.METRICS]: [],
+        [COLUMN_TYPES.TAGS]: [],
       },
     };
   });

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentView.js
@@ -89,6 +89,8 @@ export class ExperimentView extends Component {
       showFilters: false,
       showOnboardingHelper: onboardingInformationStore.getItem('showTrackingHelper') === null,
       searchInput: props.searchInput,
+      orderByKey: props.orderByKey || ExperimentViewUtil.DefaultColumnSortKey,
+      orderByAsc: props.orderByAsc || ExperimentViewUtil.DefaultColumnSortAsc,
     };
   }
   static propTypes = {
@@ -443,8 +445,6 @@ export class ExperimentView extends Component {
       tagsList,
       paramKeyList,
       metricKeyList,
-      orderByKey,
-      orderByAsc,
       startTime,
       nestChildren,
       numberOfNewRuns,
@@ -634,18 +634,9 @@ export class ExperimentView extends Component {
                   >
                     <Select
                       className='sort-select'
-                      value={
-                        orderByKey
-                          ? `${orderByKey}${SortDelimiterSymbol}${
-                              orderByAsc ? ColumnSortByAscending : ColumnSortByDescending
-                            }`
-                          : this.props.intl.formatMessage({
-                              defaultMessage: 'Sort by',
-                              description:
-                                // eslint-disable-next-line max-len
-                                'Sort by default option for sort by select dropdown for experiment runs',
-                            })
-                      }
+                      value={`${this.state.orderByKey}${SortDelimiterSymbol}${
+                        this.state.orderByAsc ? ColumnSortByAscending : ColumnSortByDescending
+                      }`}
                       size='large'
                       onChange={this.onHandleSortByDropdown}
                       data-test-id='sort-select-dropdown'
@@ -935,8 +926,8 @@ export class ExperimentView extends Component {
                 categorizedUncheckedKeys={categorizedUncheckedKeys}
                 isAllChecked={this.isAllChecked()}
                 onSortBy={this.onSortBy}
-                orderByKey={orderByKey}
-                orderByAsc={this.props.orderByAsc}
+                orderByKey={this.state.orderByKey}
+                orderByAsc={this.state.orderByAsc}
                 runsSelected={this.state.runsSelected}
                 runsExpanded={this.state.persistedState.runsExpanded}
                 onExpand={this.onExpand}
@@ -964,8 +955,8 @@ export class ExperimentView extends Component {
                 onCheckAll={this.onCheckAll}
                 isAllChecked={this.isAllChecked()}
                 onSortBy={this.onSortBy}
-                orderByKey={orderByKey}
-                orderByAsc={this.props.orderByAsc}
+                orderByKey={this.state.orderByKey}
+                orderByAsc={this.state.orderByAsc}
                 runsSelected={this.state.runsSelected}
                 runsExpanded={this.state.persistedState.runsExpanded}
                 onExpand={this.onExpand}
@@ -996,6 +987,7 @@ export class ExperimentView extends Component {
   }
 
   onSortBy(orderByKey, orderByAsc) {
+    this.setState({ orderByKey, orderByAsc });
     this.initiateSearch({ orderByKey, orderByAsc });
   }
 
@@ -1016,8 +1008,8 @@ export class ExperimentView extends Component {
     const mySearchInput = searchInput !== undefined ? searchInput : this.props.searchInput;
     const myLifecycleFilterInput =
       lifecycleFilterInput !== undefined ? lifecycleFilterInput : this.props.lifecycleFilter;
-    const myOrderByKey = orderByKey !== undefined ? orderByKey : this.props.orderByKey;
-    const myOrderByAsc = orderByAsc !== undefined ? orderByAsc : this.props.orderByAsc;
+    const myOrderByKey = orderByKey !== undefined ? orderByKey : this.state.orderByKey;
+    const myOrderByAsc = orderByAsc !== undefined ? orderByAsc : this.state.orderByAsc;
     const myModelVersionFilterInput = modelVersionFilterInput || this.props.modelVersionFilter;
     const myStartTime = startTime || this.props.startTime;
     try {
@@ -1156,19 +1148,25 @@ export class ExperimentView extends Component {
     const newPersistedState = new ExperimentViewPersistedState({
       showMultiColumns: this.state.persistedState.showMultiColumns,
     });
-    this.setState({ persistedState: newPersistedState.toJSON(), searchInput: '' }, () => {
-      this.snapshotComponentState();
-      this.initiateSearch({
-        paramKeyFilterInput: '',
-        metricKeyFilterInput: '',
+    this.setState(
+      {
+        persistedState: newPersistedState.toJSON(),
         searchInput: '',
-        lifecycleFilterInput: LIFECYCLE_FILTER.ACTIVE,
-        modelVersionFilterInput: MODEL_VERSION_FILTER.ALL_RUNS,
-        orderByKey: null,
-        orderByAsc: false,
-        startTime: 'ALL',
-      });
-    });
+        orderByKey: ExperimentViewUtil.DefaultColumnSortKey,
+        orderByAsc: ExperimentViewUtil.DefaultColumnSortAsc,
+      },
+      () => {
+        this.snapshotComponentState();
+        this.initiateSearch({
+          paramKeyFilterInput: '',
+          metricKeyFilterInput: '',
+          searchInput: '',
+          lifecycleFilterInput: LIFECYCLE_FILTER.ACTIVE,
+          modelVersionFilterInput: MODEL_VERSION_FILTER.ALL_RUNS,
+          startTime: 'ALL',
+        });
+      },
+    );
   }
 
   onCompare() {

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentView.js
@@ -21,6 +21,9 @@ import {
   LIFECYCLE_FILTER,
   MAX_DETECT_NEW_RUNS_RESULTS,
   MODEL_VERSION_FILTER,
+  DEFAULT_ORDER_BY_KEY,
+  DEFAULT_ORDER_BY_ASC,
+  DEFAULT_START_TIME,
 } from './ExperimentPage';
 import ExperimentViewUtil from './ExperimentViewUtil';
 import DeleteRunModal from './modals/DeleteRunModal';
@@ -89,8 +92,8 @@ export class ExperimentView extends Component {
       showFilters: false,
       showOnboardingHelper: onboardingInformationStore.getItem('showTrackingHelper') === null,
       searchInput: props.searchInput,
-      orderByKey: props.orderByKey || ExperimentViewUtil.DefaultColumnSortKey,
-      orderByAsc: props.orderByAsc || ExperimentViewUtil.DefaultColumnSortAsc,
+      orderByKey: props.orderByKey,
+      orderByAsc: props.orderByAsc,
     };
   }
   static propTypes = {
@@ -445,6 +448,8 @@ export class ExperimentView extends Component {
       tagsList,
       paramKeyList,
       metricKeyList,
+      orderByKey,
+      orderByAsc,
       startTime,
       nestChildren,
       numberOfNewRuns,
@@ -634,8 +639,8 @@ export class ExperimentView extends Component {
                   >
                     <Select
                       className='sort-select'
-                      value={`${this.state.orderByKey}${SortDelimiterSymbol}${
-                        this.state.orderByAsc ? ColumnSortByAscending : ColumnSortByDescending
+                      value={`${orderByKey}${SortDelimiterSymbol}${
+                        orderByAsc ? ColumnSortByAscending : ColumnSortByDescending
                       }`}
                       size='large'
                       onChange={this.onHandleSortByDropdown}
@@ -926,8 +931,8 @@ export class ExperimentView extends Component {
                 categorizedUncheckedKeys={categorizedUncheckedKeys}
                 isAllChecked={this.isAllChecked()}
                 onSortBy={this.onSortBy}
-                orderByKey={this.state.orderByKey}
-                orderByAsc={this.state.orderByAsc}
+                orderByKey={orderByKey}
+                orderByAsc={orderByAsc}
                 runsSelected={this.state.runsSelected}
                 runsExpanded={this.state.persistedState.runsExpanded}
                 onExpand={this.onExpand}
@@ -955,8 +960,8 @@ export class ExperimentView extends Component {
                 onCheckAll={this.onCheckAll}
                 isAllChecked={this.isAllChecked()}
                 onSortBy={this.onSortBy}
-                orderByKey={this.state.orderByKey}
-                orderByAsc={this.state.orderByAsc}
+                orderByKey={orderByKey}
+                orderByAsc={orderByAsc}
                 runsSelected={this.state.runsSelected}
                 runsExpanded={this.state.persistedState.runsExpanded}
                 onExpand={this.onExpand}
@@ -987,7 +992,6 @@ export class ExperimentView extends Component {
   }
 
   onSortBy(orderByKey, orderByAsc) {
-    this.setState({ orderByKey, orderByAsc });
     this.initiateSearch({ orderByKey, orderByAsc });
   }
 
@@ -1008,8 +1012,8 @@ export class ExperimentView extends Component {
     const mySearchInput = searchInput !== undefined ? searchInput : this.props.searchInput;
     const myLifecycleFilterInput =
       lifecycleFilterInput !== undefined ? lifecycleFilterInput : this.props.lifecycleFilter;
-    const myOrderByKey = orderByKey !== undefined ? orderByKey : this.state.orderByKey;
-    const myOrderByAsc = orderByAsc !== undefined ? orderByAsc : this.state.orderByAsc;
+    const myOrderByKey = orderByKey !== undefined ? orderByKey : this.props.orderByKey;
+    const myOrderByAsc = orderByAsc !== undefined ? orderByAsc : this.props.orderByAsc;
     const myModelVersionFilterInput = modelVersionFilterInput || this.props.modelVersionFilter;
     const myStartTime = startTime || this.props.startTime;
     try {
@@ -1152,8 +1156,6 @@ export class ExperimentView extends Component {
       {
         persistedState: newPersistedState.toJSON(),
         searchInput: '',
-        orderByKey: ExperimentViewUtil.DefaultColumnSortKey,
-        orderByAsc: ExperimentViewUtil.DefaultColumnSortAsc,
       },
       () => {
         this.snapshotComponentState();
@@ -1163,7 +1165,9 @@ export class ExperimentView extends Component {
           searchInput: '',
           lifecycleFilterInput: LIFECYCLE_FILTER.ACTIVE,
           modelVersionFilterInput: MODEL_VERSION_FILTER.ALL_RUNS,
-          startTime: 'ALL',
+          orderByKey: DEFAULT_ORDER_BY_KEY,
+          orderByAsc: DEFAULT_ORDER_BY_ASC,
+          startTime: DEFAULT_START_TIME,
         });
       },
     );

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentView.js
@@ -17,14 +17,6 @@ import { getLatestMetrics } from '../reducers/MetricReducer';
 import KeyFilter from '../utils/KeyFilter';
 import { ExperimentRunsTableMultiColumnView2 } from './ExperimentRunsTableMultiColumnView2';
 import ExperimentRunsTableCompactView from './ExperimentRunsTableCompactView';
-import {
-  LIFECYCLE_FILTER,
-  MAX_DETECT_NEW_RUNS_RESULTS,
-  MODEL_VERSION_FILTER,
-  DEFAULT_ORDER_BY_KEY,
-  DEFAULT_ORDER_BY_ASC,
-  DEFAULT_START_TIME,
-} from './ExperimentPage';
 import ExperimentViewUtil from './ExperimentViewUtil';
 import DeleteRunModal from './modals/DeleteRunModal';
 import RestoreRunModal from './modals/RestoreRunModal';
@@ -35,7 +27,6 @@ import Utils from '../../common/utils/Utils';
 import { CSSTransition } from 'react-transition-group';
 import { Spinner } from '../../common/components/Spinner';
 import { RunsTableColumnSelectionDropdown } from './RunsTableColumnSelectionDropdown';
-import { ColumnTypes } from '../constants';
 import { getUUID } from '../../common/utils/ActionUtils';
 import { ExperimentTrackingDocUrl, onboarding } from '../../common/constants';
 import filterIcon from '../../common/static/filter-icon.svg';
@@ -48,8 +39,21 @@ import { Spacer } from '../../shared/building_blocks/Spacer';
 import { SearchBox } from '../../shared/building_blocks/SearchBox';
 import { Radio } from '../../shared/building_blocks/Radio';
 import syncSvg from '../../common/static/sync.svg';
+import {
+  COLUMN_TYPES,
+  LIFECYCLE_FILTER,
+  MAX_DETECT_NEW_RUNS_RESULTS,
+  MODEL_VERSION_FILTER,
+  DEFAULT_ORDER_BY_KEY,
+  DEFAULT_ORDER_BY_ASC,
+  DEFAULT_START_TIME,
+  ATTRIBUTE_COLUMN_SORT_LABEL,
+  ATTRIBUTE_COLUMN_SORT_KEY,
+  COLUMN_SORT_BY_ASC,
+  COLUMN_SORT_BY_DESC,
+  SORT_DELIMITER_SYMBOL,
+} from '../constants';
 
-export const DEFAULT_EXPANDED_VALUE = false;
 const { Option } = Select;
 export class ExperimentView extends Component {
   constructor(props) {
@@ -92,8 +96,6 @@ export class ExperimentView extends Component {
       showFilters: false,
       showOnboardingHelper: onboardingInformationStore.getItem('showTrackingHelper') === null,
       searchInput: props.searchInput,
-      orderByKey: props.orderByKey,
-      orderByAsc: props.orderByAsc,
     };
   }
   static propTypes = {
@@ -457,12 +459,12 @@ export class ExperimentView extends Component {
     const { experiment_id, name } = experiment;
     const { persistedState } = this.state;
     const { unbaggedParams, unbaggedMetrics, categorizedUncheckedKeys } = persistedState;
-    const filteredParamKeys = this.getFilteredKeys(paramKeyList, ColumnTypes.PARAMS);
-    const filteredMetricKeys = this.getFilteredKeys(metricKeyList, ColumnTypes.METRICS);
+    const filteredParamKeys = this.getFilteredKeys(paramKeyList, COLUMN_TYPES.PARAMS);
+    const filteredMetricKeys = this.getFilteredKeys(metricKeyList, COLUMN_TYPES.METRICS);
     const visibleTagKeyList = Utils.getVisibleTagKeyList(tagsList);
-    const filteredVisibleTagKeyList = this.getFilteredKeys(visibleTagKeyList, ColumnTypes.TAGS);
-    const filteredUnbaggedParamKeys = this.getFilteredKeys(unbaggedParams, ColumnTypes.PARAMS);
-    const filteredUnbaggedMetricKeys = this.getFilteredKeys(unbaggedMetrics, ColumnTypes.METRICS);
+    const filteredVisibleTagKeyList = this.getFilteredKeys(visibleTagKeyList, COLUMN_TYPES.TAGS);
+    const filteredUnbaggedParamKeys = this.getFilteredKeys(unbaggedParams, COLUMN_TYPES.PARAMS);
+    const filteredUnbaggedMetricKeys = this.getFilteredKeys(unbaggedMetrics, COLUMN_TYPES.METRICS);
     const compareDisabled = Object.keys(this.state.runsSelected).length < 2;
     const deleteDisabled = Object.keys(this.state.runsSelected).length < 1;
     const restoreDisabled = Object.keys(this.state.runsSelected).length < 1;
@@ -515,12 +517,7 @@ export class ExperimentView extends Component {
       intl: this.props.intl,
     };
 
-    const {
-      ColumnSortByAscending,
-      ColumnSortByDescending,
-      SortDelimiterSymbol,
-    } = ExperimentViewUtil;
-    const ColumnSortByOrder = [ColumnSortByAscending, ColumnSortByDescending];
+    const ColumnSortByOrder = [COLUMN_SORT_BY_ASC, COLUMN_SORT_BY_DESC];
 
     return (
       <div className='ExperimentView runs-table-flex-container'>
@@ -639,19 +636,18 @@ export class ExperimentView extends Component {
                   >
                     <Select
                       className='sort-select'
-                      value={`${orderByKey}${SortDelimiterSymbol}${
-                        orderByAsc ? ColumnSortByAscending : ColumnSortByDescending
+                      value={`${orderByKey}${SORT_DELIMITER_SYMBOL}${
+                        orderByAsc ? COLUMN_SORT_BY_ASC : COLUMN_SORT_BY_DESC
                       }`}
                       size='large'
                       onChange={this.onHandleSortByDropdown}
                       data-test-id='sort-select-dropdown'
                     >
-                      {Object.keys(ExperimentViewUtil.AttributeColumnSortLabel).reduce(
+                      {Object.keys(ATTRIBUTE_COLUMN_SORT_LABEL).reduce(
                         (sortOptions, sortLabelKey) => {
-                          const sortLabel =
-                            ExperimentViewUtil.AttributeColumnSortLabel[sortLabelKey];
+                          const sortLabel = ATTRIBUTE_COLUMN_SORT_LABEL[sortLabelKey];
                           if (
-                            !categorizedUncheckedKeys[ColumnTypes.ATTRIBUTES].includes(sortLabel)
+                            !categorizedUncheckedKeys[COLUMN_TYPES.ATTRIBUTES].includes(sortLabel)
                           ) {
                             ColumnSortByOrder.forEach((order) => {
                               sortOptions.push(
@@ -660,12 +656,12 @@ export class ExperimentView extends Component {
                                   title={sortLabel}
                                   data-test-id={`sort-select-${sortLabel}-${order}`}
                                   value={
-                                    ExperimentViewUtil.AttributeColumnSortKey[sortLabelKey] +
-                                    SortDelimiterSymbol +
+                                    ATTRIBUTE_COLUMN_SORT_KEY[sortLabelKey] +
+                                    SORT_DELIMITER_SYMBOL +
                                     order
                                   }
                                 >
-                                  {order === ColumnSortByAscending ? (
+                                  {order === COLUMN_SORT_BY_ASC ? (
                                     <Icon type='arrow-up' />
                                   ) : (
                                     <Icon type='arrow-down' />
@@ -688,11 +684,11 @@ export class ExperimentView extends Component {
                               title={metricKey}
                               data-test-id={`sort-select-${metricKey}-${order}`}
                               value={`${ExperimentViewUtil.makeCanonicalKey(
-                                ColumnTypes.METRICS,
+                                COLUMN_TYPES.METRICS,
                                 metricKey,
-                              )}${SortDelimiterSymbol}${order}`}
+                              )}${SORT_DELIMITER_SYMBOL}${order}`}
                             >
-                              {order === ColumnSortByAscending ? (
+                              {order === COLUMN_SORT_BY_ASC ? (
                                 <Icon type='arrow-up' />
                               ) : (
                                 <Icon type='arrow-down' />
@@ -712,11 +708,11 @@ export class ExperimentView extends Component {
                               title={paramKey}
                               data-test-id={`sort-select-${paramKey}-${order}`}
                               value={`${ExperimentViewUtil.makeCanonicalKey(
-                                ColumnTypes.PARAMS,
+                                COLUMN_TYPES.PARAMS,
                                 paramKey,
-                              )}${SortDelimiterSymbol}${order}`}
+                              )}${SORT_DELIMITER_SYMBOL}${order}`}
                             >
-                              {order === ColumnSortByAscending ? (
+                              {order === COLUMN_SORT_BY_ASC ? (
                                 <Icon type='arrow-up' />
                               ) : (
                                 <Icon type='arrow-down' />
@@ -982,9 +978,9 @@ export class ExperimentView extends Component {
   }
 
   onHandleSortByDropdown(value) {
-    const [orderByKey, orderBy] = value.split(ExperimentViewUtil.SortDelimiterSymbol);
+    const [orderByKey, orderBy] = value.split(SORT_DELIMITER_SYMBOL);
 
-    this.onSortBy(orderByKey, orderBy === ExperimentViewUtil.ColumnSortByAscending);
+    this.onSortBy(orderByKey, orderBy === COLUMN_SORT_BY_ASC);
   }
 
   onHandleStartTimeDropdown(startTime) {
@@ -1182,10 +1178,10 @@ export class ExperimentView extends Component {
 
   onDownloadCsv() {
     const { paramKeyList, metricKeyList, runInfos, paramsList, metricsList, tagsList } = this.props;
-    const filteredParamKeys = this.getFilteredKeys(paramKeyList, ColumnTypes.PARAMS);
-    const filteredMetricKeys = this.getFilteredKeys(metricKeyList, ColumnTypes.METRICS);
+    const filteredParamKeys = this.getFilteredKeys(paramKeyList, COLUMN_TYPES.PARAMS);
+    const filteredMetricKeys = this.getFilteredKeys(metricKeyList, COLUMN_TYPES.METRICS);
     const visibleTagKeys = Utils.getVisibleTagKeyList(tagsList);
-    const filteredTagKeys = this.getFilteredKeys(visibleTagKeys, ColumnTypes.TAGS);
+    const filteredTagKeys = this.getFilteredKeys(visibleTagKeys, COLUMN_TYPES.TAGS);
     const csv = ExperimentView.runInfosToCsv(
       runInfos,
       filteredParamKeys,

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentView.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentView.test.js
@@ -5,16 +5,7 @@ import FileSaver from 'file-saver';
 import { BrowserRouter } from 'react-router-dom';
 
 import { ExperimentViewWithIntl, mapStateToProps } from './ExperimentView';
-import ExperimentViewUtil from './ExperimentViewUtil';
 import Fixtures from '../utils/test-utils/Fixtures';
-import {
-  LIFECYCLE_FILTER,
-  MODEL_VERSION_FILTER,
-  DEFAULT_ORDER_BY_KEY,
-  DEFAULT_ORDER_BY_ASC,
-  DEFAULT_START_TIME,
-} from './ExperimentPage';
-import { ColumnTypes } from '../constants';
 import KeyFilter from '../utils/KeyFilter';
 import {
   addApiToState,
@@ -29,6 +20,16 @@ import { ExperimentViewPersistedState } from '../sdk/MlflowLocalStorageMessages'
 import { getUUID } from '../../common/utils/ActionUtils';
 import { Metric, Param, RunTag, RunInfo } from '../sdk/MlflowMessages';
 import { mountWithIntl, shallowWithInjectIntl } from '../../common/utils/TestUtils';
+import {
+  COLUMN_TYPES,
+  LIFECYCLE_FILTER,
+  MODEL_VERSION_FILTER,
+  DEFAULT_ORDER_BY_KEY,
+  DEFAULT_ORDER_BY_ASC,
+  DEFAULT_START_TIME,
+  COLUMN_SORT_BY_ASC,
+  COLUMN_SORT_BY_DESC,
+} from '../constants';
 
 let onSearchSpy;
 
@@ -234,7 +235,7 @@ run-id,name,LOCAL,src.py,user,FINISHED,512,0.1,0
     // Uncheck the tag 'b'
     wrapper.setState({
       persistedState: {
-        categorizedUncheckedKeys: { [ColumnTypes.TAGS]: ['b'], [ColumnTypes.ATTRIBUTES]: [] },
+        categorizedUncheckedKeys: { [COLUMN_TYPES.TAGS]: ['b'], [COLUMN_TYPES.ATTRIBUTES]: [] },
       },
     });
     // Then, download CSV
@@ -378,36 +379,18 @@ describe('Sort by dropdown', () => {
     const sortSelect = wrapper.find("Select [data-test-id='sort-select-dropdown']").first();
     sortSelect.simulate('click');
 
+    expect(wrapper.exists(`[data-test-id="sort-select-User-${COLUMN_SORT_BY_ASC}"] li`)).toBe(true);
+    expect(wrapper.exists(`[data-test-id="sort-select-batch_size-${COLUMN_SORT_BY_ASC}"] li`)).toBe(
+      true,
+    );
+    expect(wrapper.exists(`[data-test-id="sort-select-acc-${COLUMN_SORT_BY_ASC}"] li`)).toBe(true);
+    expect(wrapper.exists(`[data-test-id="sort-select-User-${COLUMN_SORT_BY_DESC}"] li`)).toBe(
+      true,
+    );
     expect(
-      wrapper.exists(
-        `[data-test-id="sort-select-User-${ExperimentViewUtil.ColumnSortByAscending}"] li`,
-      ),
+      wrapper.exists(`[data-test-id="sort-select-batch_size-${COLUMN_SORT_BY_DESC}"] li`),
     ).toBe(true);
-    expect(
-      wrapper.exists(
-        `[data-test-id="sort-select-batch_size-${ExperimentViewUtil.ColumnSortByAscending}"] li`,
-      ),
-    ).toBe(true);
-    expect(
-      wrapper.exists(
-        `[data-test-id="sort-select-acc-${ExperimentViewUtil.ColumnSortByAscending}"] li`,
-      ),
-    ).toBe(true);
-    expect(
-      wrapper.exists(
-        `[data-test-id="sort-select-User-${ExperimentViewUtil.ColumnSortByDescending}"] li`,
-      ),
-    ).toBe(true);
-    expect(
-      wrapper.exists(
-        `[data-test-id="sort-select-batch_size-${ExperimentViewUtil.ColumnSortByDescending}"] li`,
-      ),
-    ).toBe(true);
-    expect(
-      wrapper.exists(
-        `[data-test-id="sort-select-acc-${ExperimentViewUtil.ColumnSortByDescending}"] li`,
-      ),
-    ).toBe(true);
+    expect(wrapper.exists(`[data-test-id="sort-select-acc-${COLUMN_SORT_BY_DESC}"] li`)).toBe(true);
 
     sortSelect.prop('onChange')('attributes.start_time');
     expect(onSearchSpy).toBeCalledWith(

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentView.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentView.test.js
@@ -7,7 +7,13 @@ import { BrowserRouter } from 'react-router-dom';
 import { ExperimentViewWithIntl, mapStateToProps } from './ExperimentView';
 import ExperimentViewUtil from './ExperimentViewUtil';
 import Fixtures from '../utils/test-utils/Fixtures';
-import { LIFECYCLE_FILTER, MODEL_VERSION_FILTER } from './ExperimentPage';
+import { 
+  LIFECYCLE_FILTER, 
+  MODEL_VERSION_FILTER,
+  DEFAULT_ORDER_BY_KEY,
+  DEFAULT_ORDER_BY_ASC,
+  DEFAULT_START_TIME,
+ } from './ExperimentPage';
 import { ColumnTypes } from '../constants';
 import KeyFilter from '../utils/KeyFilter';
 import {
@@ -61,8 +67,8 @@ const getDefaultExperimentViewProps = () => {
     isLoading: true,
     loadingMore: false,
     handleLoadMoreRuns: jest.fn(),
-    orderByKey: null,
-    orderByAsc: ExperimentViewUtil.DefaultColumnSortAsc,
+    orderByKey: DEFAULT_ORDER_BY_KEY,
+    orderByAsc: DEFAULT_ORDER_BY_ASC,
     setExperimentTagApi: jest.fn(),
     location: { pathname: '/' },
     modelVersionsByRunUuid: {},
@@ -97,20 +103,6 @@ test('Should render compact view without exploding', () => {
   expect(wrapper.length).toBe(1);
 });
 
-test('Should take orderByKey & orderByAsc from props', () => {
-  const wrapper = getExperimentViewMock({ orderByKey: 'SomeKey', orderByAsc: true });
-  const instance = wrapper.instance();
-  expect(instance.state.orderByKey).toBe('SomeKey');
-  expect(instance.state.orderByAsc).toBe(true);
-});
-
-test('Should take default orderByKey & orderByAsc in prop absence', () => {
-  const wrapper = getExperimentViewMock({ orderByKey: null, orderByAsc: null });
-  const instance = wrapper.instance();
-  expect(instance.state.orderByKey).toBe(ExperimentViewUtil.DefaultColumnSortKey);
-  expect(instance.state.orderByAsc).toBe(ExperimentViewUtil.DefaultColumnSortAsc);
-});
-
 test(`Clearing filter state calls search handler with correct arguments`, () => {
   const wrapper = getExperimentViewMock();
   wrapper.instance().onClear();
@@ -119,9 +111,9 @@ test(`Clearing filter state calls search handler with correct arguments`, () => 
   expect(onSearchSpy.mock.calls[0][1]).toBe('');
   expect(onSearchSpy.mock.calls[0][2]).toBe('');
   expect(onSearchSpy.mock.calls[0][3]).toBe(LIFECYCLE_FILTER.ACTIVE);
-  expect(onSearchSpy.mock.calls[0][4]).toBe(ExperimentViewUtil.DefaultColumnSortKey);
-  expect(onSearchSpy.mock.calls[0][5]).toBe(ExperimentViewUtil.DefaultColumnSortAsc);
-  expect(onSearchSpy.mock.calls[0][7]).toBe('ALL');
+  expect(onSearchSpy.mock.calls[0][4]).toBe(DEFAULT_ORDER_BY_KEY);
+  expect(onSearchSpy.mock.calls[0][5]).toBe(DEFAULT_ORDER_BY_ASC);
+  expect(onSearchSpy.mock.calls[0][7]).toBe(DEFAULT_START_TIME);
 });
 
 test('Onboarding alert shows', () => {
@@ -279,8 +271,8 @@ describe('ExperimentView event handlers', () => {
     searchInput = '',
     lifecycleFilterInput = LIFECYCLE_FILTER.ACTIVE,
     modelVersionFilterInput = MODEL_VERSION_FILTER.ALL_RUNS,
-    orderByKey = ExperimentViewUtil.DefaultColumnSortKey,
-    orderByAsc = ExperimentViewUtil.DefaultColumnSortAsc,
+    orderByKey = DEFAULT_ORDER_BY_KEY,
+    orderByAsc = DEFAULT_ORDER_BY_ASC,
     startTime = undefined,
   } = {}) => [
     paramKeyFilterInput,
@@ -338,9 +330,9 @@ describe('ExperimentView event handlers', () => {
     expect(onSearchSpy).toHaveBeenCalledTimes(1);
     expect(onSearchSpy).toBeCalledWith(
       ...getSearchParams({
-        orderByKey: ExperimentViewUtil.DefaultColumnSortKey,
-        orderByAsc: ExperimentViewUtil.DefaultColumnSortAsc,
-        startTime: 'ALL',
+        orderByKey: DEFAULT_ORDER_BY_KEY,
+        orderByAsc: DEFAULT_ORDER_BY_ASC,
+        startTime: DEFAULT_START_TIME,
       }),
     );
   });
@@ -424,9 +416,9 @@ describe('Sort by dropdown', () => {
       '',
       LIFECYCLE_FILTER.ACTIVE,
       'attributes.start_time',
-      false,
+      DEFAULT_ORDER_BY_ASC,
       MODEL_VERSION_FILTER.ALL_RUNS,
-      'ALL',
+      DEFAULT_START_TIME,
     );
   });
 });
@@ -457,8 +449,8 @@ describe('Start time dropdown', () => {
       '',
       '',
       LIFECYCLE_FILTER.ACTIVE,
-      ExperimentViewUtil.DefaultColumnSortKey,
-      ExperimentViewUtil.DefaultColumnSortAsc,
+      DEFAULT_ORDER_BY_KEY,
+      DEFAULT_ORDER_BY_ASC,
       MODEL_VERSION_FILTER.ALL_RUNS,
       'LAST_7_DAYS',
     );

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentView.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentView.test.js
@@ -62,7 +62,7 @@ const getDefaultExperimentViewProps = () => {
     loadingMore: false,
     handleLoadMoreRuns: jest.fn(),
     orderByKey: null,
-    orderByAsc: false,
+    orderByAsc: ExperimentViewUtil.DefaultColumnSortAsc,
     setExperimentTagApi: jest.fn(),
     location: { pathname: '/' },
     modelVersionsByRunUuid: {},
@@ -97,6 +97,20 @@ test('Should render compact view without exploding', () => {
   expect(wrapper.length).toBe(1);
 });
 
+test('Should take orderByKey & orderByAsc from props', () => {
+  const wrapper = getExperimentViewMock({ orderByKey: 'SomeKey', orderByAsc: true });
+  const instance = wrapper.instance();
+  expect(instance.state.orderByKey).toBe('SomeKey');
+  expect(instance.state.orderByAsc).toBe(true);
+});
+
+test('Should take default orderByKey & orderByAsc in prop absence', () => {
+  const wrapper = getExperimentViewMock({ orderByKey: null, orderByAsc: null });
+  const instance = wrapper.instance();
+  expect(instance.state.orderByKey).toBe(ExperimentViewUtil.DefaultColumnSortKey);
+  expect(instance.state.orderByAsc).toBe(ExperimentViewUtil.DefaultColumnSortAsc);
+});
+
 test(`Clearing filter state calls search handler with correct arguments`, () => {
   const wrapper = getExperimentViewMock();
   wrapper.instance().onClear();
@@ -105,8 +119,8 @@ test(`Clearing filter state calls search handler with correct arguments`, () => 
   expect(onSearchSpy.mock.calls[0][1]).toBe('');
   expect(onSearchSpy.mock.calls[0][2]).toBe('');
   expect(onSearchSpy.mock.calls[0][3]).toBe(LIFECYCLE_FILTER.ACTIVE);
-  expect(onSearchSpy.mock.calls[0][4]).toBe(null);
-  expect(onSearchSpy.mock.calls[0][5]).toBe(false);
+  expect(onSearchSpy.mock.calls[0][4]).toBe(ExperimentViewUtil.DefaultColumnSortKey);
+  expect(onSearchSpy.mock.calls[0][5]).toBe(ExperimentViewUtil.DefaultColumnSortAsc);
   expect(onSearchSpy.mock.calls[0][7]).toBe('ALL');
 });
 
@@ -265,8 +279,8 @@ describe('ExperimentView event handlers', () => {
     searchInput = '',
     lifecycleFilterInput = LIFECYCLE_FILTER.ACTIVE,
     modelVersionFilterInput = MODEL_VERSION_FILTER.ALL_RUNS,
-    orderByKey = null,
-    orderByAsc = false,
+    orderByKey = ExperimentViewUtil.DefaultColumnSortKey,
+    orderByAsc = ExperimentViewUtil.DefaultColumnSortAsc,
     startTime = undefined,
   } = {}) => [
     paramKeyFilterInput,
@@ -324,8 +338,8 @@ describe('ExperimentView event handlers', () => {
     expect(onSearchSpy).toHaveBeenCalledTimes(1);
     expect(onSearchSpy).toBeCalledWith(
       ...getSearchParams({
-        orderByKey: null,
-        orderByAsc: false,
+        orderByKey: ExperimentViewUtil.DefaultColumnSortKey,
+        orderByAsc: ExperimentViewUtil.DefaultColumnSortAsc,
         startTime: 'ALL',
       }),
     );
@@ -443,8 +457,8 @@ describe('Start time dropdown', () => {
       '',
       '',
       LIFECYCLE_FILTER.ACTIVE,
-      null,
-      false,
+      ExperimentViewUtil.DefaultColumnSortKey,
+      ExperimentViewUtil.DefaultColumnSortAsc,
       MODEL_VERSION_FILTER.ALL_RUNS,
       'LAST_7_DAYS',
     );

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentView.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentView.test.js
@@ -7,13 +7,13 @@ import { BrowserRouter } from 'react-router-dom';
 import { ExperimentViewWithIntl, mapStateToProps } from './ExperimentView';
 import ExperimentViewUtil from './ExperimentViewUtil';
 import Fixtures from '../utils/test-utils/Fixtures';
-import { 
-  LIFECYCLE_FILTER, 
+import {
+  LIFECYCLE_FILTER,
   MODEL_VERSION_FILTER,
   DEFAULT_ORDER_BY_KEY,
   DEFAULT_ORDER_BY_ASC,
   DEFAULT_START_TIME,
- } from './ExperimentPage';
+} from './ExperimentPage';
 import { ColumnTypes } from '../constants';
 import KeyFilter from '../utils/KeyFilter';
 import {

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentViewUtil.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentViewUtil.js
@@ -4,13 +4,17 @@ import Utils from '../../common/utils/Utils';
 import { Link } from 'react-router-dom';
 import Routes from '../routes';
 import { getModelVersionPageRoute } from '../../model-registry/routes';
-import { DEFAULT_EXPANDED_VALUE } from './ExperimentView';
 import { CollapsibleTagsCell } from '../../common/components/CollapsibleTagsCell';
 import _ from 'lodash';
 import ExpandableList from '../../common/components/ExpandableList';
 import registryIcon from '../../common/static/registryIcon.svg';
 import { TrimmedText } from '../../common/components/TrimmedText';
 import { SEARCH_MAX_RESULTS } from '../actions';
+import {
+  ATTRIBUTE_COLUMN_LABELS,
+  ATTRIBUTE_COLUMN_SORT_KEY,
+  DEFAULT_EXPANDED_VALUE,
+} from '../constants';
 
 export default class ExperimentViewUtil {
   /** Returns checkbox cell for a row. */
@@ -83,7 +87,7 @@ export default class ExperimentViewUtil {
         children: ExperimentViewUtil.getRunStatusIcon(status),
       },
       {
-        key: ExperimentViewUtil.AttributeColumnLabels.DATE,
+        key: ATTRIBUTE_COLUMN_LABELS.DATE,
         className: 'run-table-container',
         style: { whiteSpace: 'inherit' },
         children: (
@@ -95,7 +99,7 @@ export default class ExperimentViewUtil {
         ),
       },
       {
-        key: ExperimentViewUtil.AttributeColumnLabels.USER,
+        key: ATTRIBUTE_COLUMN_LABELS.USER,
         className: 'run-table-container',
         title: user,
         children: (
@@ -105,7 +109,7 @@ export default class ExperimentViewUtil {
         ),
       },
       {
-        key: ExperimentViewUtil.AttributeColumnLabels.RUN_NAME,
+        key: ATTRIBUTE_COLUMN_LABELS.RUN_NAME,
         className: 'run-table-container',
         title: runName,
         children: (
@@ -115,7 +119,7 @@ export default class ExperimentViewUtil {
         ),
       },
       {
-        key: ExperimentViewUtil.AttributeColumnLabels.SOURCE,
+        key: ATTRIBUTE_COLUMN_LABELS.SOURCE,
         className: 'run-table-container',
         title: sourceType,
         children: (
@@ -126,7 +130,7 @@ export default class ExperimentViewUtil {
         ),
       },
       {
-        key: ExperimentViewUtil.AttributeColumnLabels.VERSION,
+        key: ATTRIBUTE_COLUMN_LABELS.VERSION,
         className: 'run-table-container',
         children: (
           <div className='truncate-text single-line' style={ExperimentViewUtil.styles.runInfoCell}>
@@ -179,35 +183,6 @@ export default class ExperimentViewUtil {
     );
   }
 
-  static AttributeColumnLabels = {
-    DATE: 'Start Time',
-    USER: 'User',
-    RUN_NAME: 'Run Name',
-    SOURCE: 'Source',
-    VERSION: 'Version',
-    MODELS: 'Models',
-  };
-
-  static AttributeColumnSortLabel = {
-    DATE: 'Start Time',
-    USER: 'User',
-    RUN_NAME: 'Run Name',
-    SOURCE: 'Source',
-    VERSION: 'Version',
-  };
-
-  static AttributeColumnSortKey = {
-    DATE: 'attributes.start_time',
-    USER: 'tags.`mlflow.user`',
-    RUN_NAME: 'tags.`mlflow.runName`',
-    SOURCE: 'tags.`mlflow.source.name`',
-    VERSION: 'tags.`mlflow.source.git.commit`',
-  };
-
-  static ColumnSortByAscending = 'ASCENDING';
-  static ColumnSortByDescending = 'DESCENDING';
-  static SortDelimiterSymbol = '***';
-
   /**
    * Returns header-row table cells for columns containing run metadata.
    */
@@ -244,28 +219,28 @@ export default class ExperimentViewUtil {
       },
       {
         key: 'start_time',
-        displayName: this.AttributeColumnLabels.DATE,
-        canonicalSortKey: this.AttributeColumnSortKey.DATE,
+        displayName: ATTRIBUTE_COLUMN_LABELS.DATE,
+        canonicalSortKey: ATTRIBUTE_COLUMN_SORT_KEY.DATE,
       },
       {
         key: 'user_id',
-        displayName: this.AttributeColumnLabels.USER,
-        canonicalSortKey: this.AttributeColumnSortKey.USER,
+        displayName: ATTRIBUTE_COLUMN_LABELS.USER,
+        canonicalSortKey: ATTRIBUTE_COLUMN_SORT_KEY.USER,
       },
       {
         key: 'run_name',
-        displayName: this.AttributeColumnLabels.RUN_NAME,
-        canonicalSortKey: this.AttributeColumnSortKey.RUN_NAME,
+        displayName: ATTRIBUTE_COLUMN_LABELS.RUN_NAME,
+        canonicalSortKey: ATTRIBUTE_COLUMN_SORT_KEY.RUN_NAME,
       },
       {
         key: 'source',
-        displayName: this.AttributeColumnLabels.SOURCE,
-        canonicalSortKey: this.AttributeColumnSortKey.SOURCE,
+        displayName: ATTRIBUTE_COLUMN_LABELS.SOURCE,
+        canonicalSortKey: ATTRIBUTE_COLUMN_SORT_KEY.SOURCE,
       },
       {
         key: 'source_version',
-        displayName: this.AttributeColumnLabels.VERSION,
-        canonicalSortKey: this.AttributeColumnSortKey.VERSION,
+        displayName: ATTRIBUTE_COLUMN_LABELS.VERSION,
+        canonicalSortKey: ATTRIBUTE_COLUMN_SORT_KEY.VERSION,
       },
       {
         key: 'tags',

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentViewUtil.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentViewUtil.js
@@ -207,6 +207,8 @@ export default class ExperimentViewUtil {
   static ColumnSortByAscending = 'ASCENDING';
   static ColumnSortByDescending = 'DESCENDING';
   static SortDelimiterSymbol = '***';
+  static DefaultColumnSortKey = this.AttributeColumnSortKey.DATE;
+  static DefaultColumnSortAsc = false;
 
   /**
    * Returns header-row table cells for columns containing run metadata.

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentViewUtil.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentViewUtil.js
@@ -207,8 +207,6 @@ export default class ExperimentViewUtil {
   static ColumnSortByAscending = 'ASCENDING';
   static ColumnSortByDescending = 'DESCENDING';
   static SortDelimiterSymbol = '***';
-  static DefaultColumnSortKey = this.AttributeColumnSortKey.DATE;
-  static DefaultColumnSortAsc = false;
 
   /**
    * Returns header-row table cells for columns containing run metadata.

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentViewUtil.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentViewUtil.test.js
@@ -4,6 +4,7 @@ import ExperimentViewUtil, { TreeNode } from './ExperimentViewUtil';
 import { getModelVersionPageRoute } from '../../model-registry/routes';
 import { BrowserRouter } from 'react-router-dom';
 import { SEARCH_MAX_RESULTS } from '../actions';
+import { ATTRIBUTE_COLUMN_LABELS } from '../constants';
 
 describe('ExperimentViewUtil', () => {
   test('getCheckboxForRow should render', () => {
@@ -78,17 +79,15 @@ describe('ExperimentViewUtil', () => {
       'user_id',
       true,
       'div',
-      [ExperimentViewUtil.AttributeColumnLabels.DATE],
+      [ATTRIBUTE_COLUMN_LABELS.DATE],
     );
     const headers = headerComponents.map((c) => shallow(c));
     headers.forEach((h) => {
-      expect(h.text()).not.toContain(ExperimentViewUtil.AttributeColumnLabels.DATE);
+      expect(h.text()).not.toContain(ATTRIBUTE_COLUMN_LABELS.DATE);
     });
 
     // As a sanity check, let's make sure the headers contain some other column
-    const userHeaders = headers.filter(
-      (h) => h.text() === ExperimentViewUtil.AttributeColumnLabels.USER,
-    );
+    const userHeaders = headers.filter((h) => h.text() === ATTRIBUTE_COLUMN_LABELS.USER);
     expect(userHeaders.length).toBe(1);
   });
 

--- a/mlflow/server/js/src/experiment-tracking/components/RunsTableColumnSelectionDropdown.js
+++ b/mlflow/server/js/src/experiment-tracking/components/RunsTableColumnSelectionDropdown.js
@@ -4,8 +4,7 @@ import { Button } from '../../shared/building_blocks/Button';
 import { SearchTree } from '../../common/components/SearchTree';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
-import ExperimentViewUtil from './ExperimentViewUtil';
-import { ColumnTypes } from '../constants';
+import { COLUMN_TYPES, ATTRIBUTE_COLUMN_LABELS } from '../constants';
 
 import { FormattedMessage } from 'react-intl';
 
@@ -40,8 +39,8 @@ export class RunsTableColumnSelectionDropdown extends React.Component {
 
     // Attributes
     const data = [
-      ...Object.values(ExperimentViewUtil.AttributeColumnLabels).map((text) => ({
-        key: `${ColumnTypes.ATTRIBUTES}-${text}`,
+      ...Object.values(ATTRIBUTE_COLUMN_LABELS).map((text) => ({
+        key: `${COLUMN_TYPES.ATTRIBUTES}-${text}`,
         title: text,
       })),
     ];
@@ -50,8 +49,8 @@ export class RunsTableColumnSelectionDropdown extends React.Component {
     if (paramKeyList.length > 0) {
       data.push({
         title: 'Parameters',
-        key: ColumnTypes.PARAMS,
-        children: paramKeyList.map((key) => ({ key: `${ColumnTypes.PARAMS}-${key}`, title: key })),
+        key: COLUMN_TYPES.PARAMS,
+        children: paramKeyList.map((key) => ({ key: `${COLUMN_TYPES.PARAMS}-${key}`, title: key })),
       });
     }
 
@@ -59,9 +58,9 @@ export class RunsTableColumnSelectionDropdown extends React.Component {
     if (metricKeyList.length > 0) {
       data.push({
         title: 'Metrics',
-        key: ColumnTypes.METRICS,
+        key: COLUMN_TYPES.METRICS,
         children: metricKeyList.map((key) => ({
-          key: `${ColumnTypes.METRICS}-${key}`,
+          key: `${COLUMN_TYPES.METRICS}-${key}`,
           title: key,
         })),
       });
@@ -71,9 +70,9 @@ export class RunsTableColumnSelectionDropdown extends React.Component {
     if (visibleTagKeyList.length > 0) {
       data.push({
         title: 'Tags',
-        key: ColumnTypes.TAGS,
+        key: COLUMN_TYPES.TAGS,
         children: visibleTagKeyList.map((key) => ({
-          key: `${ColumnTypes.TAGS}-${key}`,
+          key: `${COLUMN_TYPES.TAGS}-${key}`,
           title: key,
         })),
       });
@@ -86,17 +85,17 @@ export class RunsTableColumnSelectionDropdown extends React.Component {
     const { paramKeyList, metricKeyList, visibleTagKeyList, categorizedUncheckedKeys } = this.props;
     return [
       ..._.difference(
-        Object.values(ExperimentViewUtil.AttributeColumnLabels),
-        categorizedUncheckedKeys[ColumnTypes.ATTRIBUTES],
-      ).map((key) => `${ColumnTypes.ATTRIBUTES}-${key}`),
-      ..._.difference(paramKeyList, categorizedUncheckedKeys[ColumnTypes.PARAMS]).map(
-        (key) => `${ColumnTypes.PARAMS}-${key}`,
+        Object.values(ATTRIBUTE_COLUMN_LABELS),
+        categorizedUncheckedKeys[COLUMN_TYPES.ATTRIBUTES],
+      ).map((key) => `${COLUMN_TYPES.ATTRIBUTES}-${key}`),
+      ..._.difference(paramKeyList, categorizedUncheckedKeys[COLUMN_TYPES.PARAMS]).map(
+        (key) => `${COLUMN_TYPES.PARAMS}-${key}`,
       ),
-      ..._.difference(metricKeyList, categorizedUncheckedKeys[ColumnTypes.METRICS]).map(
-        (key) => `${ColumnTypes.METRICS}-${key}`,
+      ..._.difference(metricKeyList, categorizedUncheckedKeys[COLUMN_TYPES.METRICS]).map(
+        (key) => `${COLUMN_TYPES.METRICS}-${key}`,
       ),
-      ..._.difference(visibleTagKeyList, categorizedUncheckedKeys[ColumnTypes.TAGS]).map(
-        (key) => `${ColumnTypes.TAGS}-${key}`,
+      ..._.difference(visibleTagKeyList, categorizedUncheckedKeys[COLUMN_TYPES.TAGS]).map(
+        (key) => `${COLUMN_TYPES.TAGS}-${key}`,
       ),
     ];
   }
@@ -147,18 +146,18 @@ export class RunsTableColumnSelectionDropdown extends React.Component {
 function getCategorizedUncheckedKeys(checkedKeys, allKeys) {
   const uncheckedKeys = _.difference(allKeys, checkedKeys);
   const result = {
-    [ColumnTypes.ATTRIBUTES]: [],
-    [ColumnTypes.PARAMS]: [],
-    [ColumnTypes.METRICS]: [],
-    [ColumnTypes.TAGS]: [],
+    [COLUMN_TYPES.ATTRIBUTES]: [],
+    [COLUMN_TYPES.PARAMS]: [],
+    [COLUMN_TYPES.METRICS]: [],
+    [COLUMN_TYPES.TAGS]: [],
   };
   uncheckedKeys.forEach((key) => {
     // split on first instance of '-' in case there are keys with '-'
     const [columnType, rawKey] = key.split(/-(.+)/);
     if (rawKey) {
       result[columnType].push(rawKey);
-    } else if (columnType !== ColumnTypes.PARAMS && columnType !== ColumnTypes.METRICS) {
-      result[ColumnTypes.ATTRIBUTES].push(columnType);
+    } else if (columnType !== COLUMN_TYPES.PARAMS && columnType !== COLUMN_TYPES.METRICS) {
+      result[COLUMN_TYPES.ATTRIBUTES].push(columnType);
     }
   });
   return result;

--- a/mlflow/server/js/src/experiment-tracking/components/RunsTableColumnSelectionDropdown.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/RunsTableColumnSelectionDropdown.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { RunsTableColumnSelectionDropdown } from './RunsTableColumnSelectionDropdown';
 import { SearchTree } from '../../common/components/SearchTree';
-import { ColumnTypes } from '../constants';
+import { COLUMN_TYPES } from '../constants';
 import { mountWithIntl, shallowWithIntl } from '../../common/utils/TestUtils';
 
 describe('RunsTableColumnSelectionDropdown', () => {
@@ -17,10 +17,10 @@ describe('RunsTableColumnSelectionDropdown', () => {
       visibleTagKeyList: [],
       onCheck: jest.fn(),
       categorizedUncheckedKeys: {
-        [ColumnTypes.ATTRIBUTES]: [],
-        [ColumnTypes.PARAMS]: [],
-        [ColumnTypes.METRICS]: [],
-        [ColumnTypes.TAGS]: [],
+        [COLUMN_TYPES.ATTRIBUTES]: [],
+        [COLUMN_TYPES.PARAMS]: [],
+        [COLUMN_TYPES.METRICS]: [],
+        [COLUMN_TYPES.TAGS]: [],
       },
     };
 
@@ -101,10 +101,10 @@ describe('RunsTableColumnSelectionDropdown', () => {
     const props = {
       ...commonProps,
       categorizedUncheckedKeys: {
-        [ColumnTypes.ATTRIBUTES]: ['User', 'Run Name', 'Source', 'Models', 'Version'],
-        [ColumnTypes.PARAMS]: ['p1'],
-        [ColumnTypes.METRICS]: ['m1'],
-        [ColumnTypes.TAGS]: ['t1'],
+        [COLUMN_TYPES.ATTRIBUTES]: ['User', 'Run Name', 'Source', 'Models', 'Version'],
+        [COLUMN_TYPES.PARAMS]: ['p1'],
+        [COLUMN_TYPES.METRICS]: ['m1'],
+        [COLUMN_TYPES.TAGS]: ['t1'],
       },
     };
     wrapper = mountWithIntl(<RunsTableColumnSelectionDropdown {...props} />);

--- a/mlflow/server/js/src/experiment-tracking/constants.js
+++ b/mlflow/server/js/src/experiment-tracking/constants.js
@@ -1,7 +1,57 @@
-export const ColumnTypes = {
+export const COLUMN_TYPES = {
   ATTRIBUTES: 'attributes',
   PARAMS: 'params',
   METRICS: 'metrics',
   TAGS: 'tags',
 };
 export const MLMODEL_FILE_NAME = 'MLmodel';
+
+export const ATTRIBUTE_COLUMN_LABELS = {
+  DATE: 'Start Time',
+  USER: 'User',
+  RUN_NAME: 'Run Name',
+  SOURCE: 'Source',
+  VERSION: 'Version',
+  MODELS: 'Models',
+};
+
+export const ATTRIBUTE_COLUMN_SORT_LABEL = {
+  DATE: 'Start Time',
+  USER: 'User',
+  RUN_NAME: 'Run Name',
+  SOURCE: 'Source',
+  VERSION: 'Version',
+};
+
+export const ATTRIBUTE_COLUMN_SORT_KEY = {
+  DATE: 'attributes.start_time',
+  USER: 'tags.`mlflow.user`',
+  RUN_NAME: 'tags.`mlflow.runName`',
+  SOURCE: 'tags.`mlflow.source.name`',
+  VERSION: 'tags.`mlflow.source.git.commit`',
+};
+
+export const COLUMN_SORT_BY_ASC = 'ASCENDING';
+export const COLUMN_SORT_BY_DESC = 'DESCENDING';
+export const SORT_DELIMITER_SYMBOL = '***';
+
+export const LIFECYCLE_FILTER = { ACTIVE: 'Active', DELETED: 'Deleted' };
+export const MODEL_VERSION_FILTER = {
+  WITH_MODEL_VERSIONS: 'With Model Versions',
+  WTIHOUT_MODEL_VERSIONS: 'Without Model Versions',
+  ALL_RUNS: 'All Runs',
+};
+
+export const DEFAULT_ORDER_BY_KEY = ATTRIBUTE_COLUMN_SORT_KEY.DATE;
+export const DEFAULT_ORDER_BY_ASC = false;
+export const DEFAULT_START_TIME = 'ALL';
+export const DEFAULT_EXPANDED_VALUE = false;
+
+export const PAGINATION_DEFAULT_STATE = {
+  nextPageToken: null,
+  numRunsFromLatestSearch: null, // number of runs returned from the most recent search request
+  loadingMore: false,
+};
+
+export const MAX_DETECT_NEW_RUNS_RESULTS = 26; // so the refresh button badge can be 25+
+export const DETECT_NEW_RUNS_INTERVAL = 15000;

--- a/mlflow/server/js/src/experiment-tracking/sdk/MlflowLocalStorageMessages.js
+++ b/mlflow/server/js/src/experiment-tracking/sdk/MlflowLocalStorageMessages.js
@@ -15,7 +15,7 @@
  *    local storage.
  */
 import Immutable from 'immutable';
-import { ColumnTypes } from '../constants';
+import { COLUMN_TYPES } from '../constants';
 
 /**
  * This class wraps attributes of the ExperimentPage component's state that should be
@@ -60,10 +60,10 @@ export const ExperimentViewPersistedState = Immutable.Record(
     unbaggedParams: [],
     // Unchecked keys in the columns dropdown
     categorizedUncheckedKeys: {
-      [ColumnTypes.ATTRIBUTES]: [],
-      [ColumnTypes.PARAMS]: [],
-      [ColumnTypes.METRICS]: [],
-      [ColumnTypes.TAGS]: [],
+      [COLUMN_TYPES.ATTRIBUTES]: [],
+      [COLUMN_TYPES.PARAMS]: [],
+      [COLUMN_TYPES.METRICS]: [],
+      [COLUMN_TYPES.TAGS]: [],
     },
   },
   'ExperimentViewPersistedState',


### PR DESCRIPTION
Signed-off-by: Marijn Valk <marijncv@hotmail.com>

## What changes are proposed in this pull request?

This PR makes the default sorting order (on start_time) better visible in the experiment UI. closes #4825

## How is this patch tested?

Open up the tracking server, navigate to an experiment. See the visibility of the sorting order. Make changes to the sorting order. Copy the url into another browser tab and see the edited sorting order reflected in the new browser tab

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The default column sorting order is now visible in the runs table column headers and in the column sorting dropdown.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
