### PR TITLE
Added lifecycle stage to run page

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/RunView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/RunView.js
@@ -330,16 +330,16 @@ export class RunViewImpl extends Component {
             {status}
           </Descriptions.Item>
           {lifecycleStage ? (
-          <Descriptions.Item
-            label={this.props.intl.formatMessage({
-              defaultMessage: 'Lifecycle Stage',
-              description:
-                // eslint-disable-next-line max-len
-                'Label for displaying lifecycle stage of the experiment run to see if its active or deleted',
-            })}
-          >
-            {lifecycleStage}
-          </Descriptions.Item>
+            <Descriptions.Item
+              label={this.props.intl.formatMessage({
+                defaultMessage: 'Lifecycle Stage',
+                description:
+                  // eslint-disable-next-line max-len
+                  'Label for displaying lifecycle stage of the experiment run to see if its active or deleted',
+              })}
+            >
+              {lifecycleStage}
+            </Descriptions.Item>
           ) : null}
           {tags['mlflow.parentRunId'] !== undefined ? (
             <Descriptions.Item

--- a/mlflow/server/js/src/experiment-tracking/components/RunView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/RunView.js
@@ -206,6 +206,7 @@ export class RunViewImpl extends Component {
     const duration =
       run.getStartTime() && run.getEndTime() ? run.getEndTime() - run.getStartTime() : null;
     const status = RunViewImpl.getRunStatusDisplayName(run.getStatus());
+    const lifecycleStage = run.getLifecycleStage();
     const queryParams = window.location && window.location.search ? window.location.search : '';
     const tableStyles = {
       table: {
@@ -328,6 +329,18 @@ export class RunViewImpl extends Component {
           >
             {status}
           </Descriptions.Item>
+          {lifecycleStage ? (
+          <Descriptions.Item
+            label={this.props.intl.formatMessage({
+              defaultMessage: 'Lifecycle Stage',
+              description:
+                // eslint-disable-next-line max-len
+                'Label for displaying lifecycle stage of the experiment run to see if its active or deleted',
+            })}
+          >
+            {lifecycleStage}
+          </Descriptions.Item>
+          ) : null}
           {tags['mlflow.parentRunId'] !== undefined ? (
             <Descriptions.Item
               label={this.props.intl.formatMessage({


### PR DESCRIPTION
Signed-off-by: Marijn Valk <marijncv@hotmail.com>

## What changes are proposed in this pull request?

Added the lifecycle stage of a run to the run page in the UI. This pr closes #4779 

## How is this patch tested?

Visit the run page in the UI and see the lifecycle stage on the page

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Lifecycle stage added to the overview of a run on the run page in the UI.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
