### PR TITLE
Fix autologging event logger behavior when patch function failed before original function called

### DIFF
--- a/mlflow/utils/autologging_utils/safety.py
+++ b/mlflow/utils/autologging_utils/safety.py
@@ -559,7 +559,36 @@ def safe_patch(
                     return original_result
                 else:
                     try:
-                        call_original(*args, **kwargs)
+                        try_log_autologging_event(
+                            AutologgingEventLogger.get_logger().log_original_function_start,
+                            session,
+                            destination,
+                            function_name,
+                            args,
+                            kwargs,
+                        )
+                        original_result = original(*args, **kwargs)
+                        try_log_autologging_event(
+                            AutologgingEventLogger.get_logger().log_original_function_success,
+                            session,
+                            destination,
+                            function_name,
+                            args,
+                            kwargs,
+                        )
+                        return original_result
+                    except Exception as e:
+                        try_log_autologging_event(
+                            AutologgingEventLogger.get_logger().log_original_function_error,
+                            session,
+                            destination,
+                            function_name,
+                            args,
+                            kwargs,
+                            e,
+                        )
+                        failed_during_original = True
+                        raise
                     finally:
                         if not failed_during_original:
                             try_log_autologging_event(

--- a/mlflow/utils/autologging_utils/safety.py
+++ b/mlflow/utils/autologging_utils/safety.py
@@ -554,58 +554,58 @@ def safe_patch(
                         _validate_autologging_run(
                             autologging_integration, patch_function_run_for_testing.info.run_id
                         )
-
-                if original_has_been_called:
-                    return original_result
-                else:
-                    try:
-                        try_log_autologging_event(
-                            AutologgingEventLogger.get_logger().log_original_function_start,
-                            session,
-                            destination,
-                            function_name,
-                            args,
-                            kwargs,
-                        )
-                        original_result = original(*args, **kwargs)
-                        try_log_autologging_event(
-                            AutologgingEventLogger.get_logger().log_original_function_success,
-                            session,
-                            destination,
-                            function_name,
-                            args,
-                            kwargs,
-                        )
+                try:
+                    if original_has_been_called:
                         return original_result
-                    except Exception as e:
-                        try_log_autologging_event(
-                            AutologgingEventLogger.get_logger().log_original_function_error,
-                            session,
-                            destination,
-                            function_name,
-                            args,
-                            kwargs,
-                            e,
-                        )
-                        failed_during_original = True
-                        raise
-                    finally:
-                        if not failed_during_original:
+                    else:
+                        try:
                             try_log_autologging_event(
-                                AutologgingEventLogger.get_logger().log_patch_function_error,
+                                AutologgingEventLogger.get_logger().log_original_function_start,
                                 session,
                                 destination,
                                 function_name,
                                 args,
                                 kwargs,
-                                patch_function_exception,
                             )
+                            original_result = original(*args, **kwargs)
+                            try_log_autologging_event(
+                                AutologgingEventLogger.get_logger().log_original_function_success,
+                                session,
+                                destination,
+                                function_name,
+                                args,
+                                kwargs,
+                            )
+                            return original_result
+                        except Exception as e:
+                            try_log_autologging_event(
+                                AutologgingEventLogger.get_logger().log_original_function_error,
+                                session,
+                                destination,
+                                function_name,
+                                args,
+                                kwargs,
+                                e,
+                            )
+                            failed_during_original = True
+                            raise
+                finally:
+                    if patch_function_exception is not None and not failed_during_original:
+                        try_log_autologging_event(
+                            AutologgingEventLogger.get_logger().log_patch_function_error,
+                            session,
+                            destination,
+                            function_name,
+                            args,
+                            kwargs,
+                            patch_function_exception,
+                        )
 
-                            _logger.warning(
-                                "Encountered unexpected error during %s autologging: %s",
-                                autologging_integration,
-                                patch_function_exception,
-                            )
+                        _logger.warning(
+                            "Encountered unexpected error during %s autologging: %s",
+                            autologging_integration,
+                            patch_function_exception,
+                        )
 
     if is_property_method:
         # Create a patched function (also property decorated)

--- a/mlflow/utils/autologging_utils/safety.py
+++ b/mlflow/utils/autologging_utils/safety.py
@@ -443,7 +443,7 @@ def safe_patch(
                         "Failed to log autologging event via '%s'. Exception: %s", log_fn, e,
                     )
 
-            def call_original_fn_with_event_logging(original_fn, *og_args, **og_kwargs):
+            def call_original_fn_with_event_logging(original_fn, og_args, og_kwargs):
                 try:
                     try_log_autologging_event(
                         AutologgingEventLogger.get_logger().log_original_function_start,
@@ -510,9 +510,7 @@ def safe_patch(
                                 original_result = original(*_og_args, **_og_kwargs)
                                 return original_result
 
-                        return call_original_fn_with_event_logging(
-                            _original_fn, *og_args, **og_kwargs
-                        )
+                        return call_original_fn_with_event_logging(_original_fn, og_args, og_kwargs)
 
                     # Apply the name, docstring, and signature of `original` to `call_original`.
                     # This is important because several autologging patch implementations inspect
@@ -566,7 +564,7 @@ def safe_patch(
                     if original_has_been_called:
                         return original_result
                     else:
-                        return call_original_fn_with_event_logging(original, *args, **kwargs)
+                        return call_original_fn_with_event_logging(original, args, kwargs)
                 finally:
                     if patch_function_exception is not None and not failed_during_original:
                         try_log_autologging_event(

--- a/mlflow/utils/autologging_utils/safety.py
+++ b/mlflow/utils/autologging_utils/safety.py
@@ -3,6 +3,7 @@ import inspect
 import itertools
 import functools
 import os
+import traceback
 import uuid
 import warnings
 from abc import abstractmethod
@@ -549,6 +550,10 @@ def safe_patch(
                     # mode should be reraised to detect bugs in autologging implementations
                     if failed_during_original or is_testing():
                         raise
+
+                    # Attach the stack trace to the exception object
+                    # so that in event logging we can log exception with stack trace
+                    patch_function_exception._stack_trace = traceback.format_exc()
 
                 if is_testing() and not preexisting_run_for_testing:
                     # If an MLflow run was created during the execution of patch code, verify that

--- a/mlflow/utils/autologging_utils/safety.py
+++ b/mlflow/utils/autologging_utils/safety.py
@@ -3,7 +3,6 @@ import inspect
 import itertools
 import functools
 import os
-import traceback
 import uuid
 import warnings
 from abc import abstractmethod
@@ -550,10 +549,6 @@ def safe_patch(
                     # mode should be reraised to detect bugs in autologging implementations
                     if failed_during_original or is_testing():
                         raise
-
-                    # Attach the stack trace to the exception object
-                    # so that in event logging we can log exception with stack trace
-                    patch_function_exception._stack_trace = traceback.format_exc()
 
                 if is_testing() and not preexisting_run_for_testing:
                     # If an MLflow run was created during the execution of patch code, verify that

--- a/mlflow/utils/autologging_utils/safety.py
+++ b/mlflow/utils/autologging_utils/safety.py
@@ -566,6 +566,12 @@ def safe_patch(
                     else:
                         return call_original_fn_with_event_logging(original, args, kwargs)
                 finally:
+                    # If original function succeeds, but `patch_function_exception` exists,
+                    # it represent patching code unexpected failure, so we call
+                    # `log_patch_function_error` in this case.
+                    # If original function failed, we don't call `log_patch_function_error`
+                    # even if `patch_function_exception` exists, because original function failure
+                    # means there's some error in user code (e.g. user provide wrong arguments)
                     if patch_function_exception is not None and not failed_during_original:
                         try_log_autologging_event(
                             AutologgingEventLogger.get_logger().log_patch_function_error,

--- a/tests/autologging/fixtures.py
+++ b/tests/autologging/fixtures.py
@@ -29,7 +29,7 @@ def patch_destination():
             else:
                 return self.recursive_fn(level + 1, max_depth)
 
-        def bad_fn(self, error_to_raise):
+        def throw_error_fn(self, error_to_raise):
             raise error_to_raise
 
     return PatchObj()

--- a/tests/autologging/fixtures.py
+++ b/tests/autologging/fixtures.py
@@ -29,6 +29,9 @@ def patch_destination():
             else:
                 return self.recursive_fn(level + 1, max_depth)
 
+        def bad_fn(self, error_to_raise):
+            raise error_to_raise
+
     return PatchObj()
 
 

--- a/tests/autologging/test_autologging_safety_unit.py
+++ b/tests/autologging/test_autologging_safety_unit.py
@@ -650,6 +650,8 @@ def test_safe_patch_makes_expected_event_logging_calls_when_patch_implementation
     exc_to_raise = Exception("thrown from patch")
     original_err_to_raise = Exception("throw from original")
 
+    throw_location = "before"
+
     def patch_impl(original, *args, **kwargs):
         nonlocal patch_session
         nonlocal throw_location

--- a/tests/autologging/test_autologging_safety_unit.py
+++ b/tests/autologging/test_autologging_safety_unit.py
@@ -643,7 +643,7 @@ def test_safe_patch_makes_expected_event_logging_calls_for_successful_patch_invo
     assert patch_success.exception is original_success.exception is None
 
 
-def test_safe_patch_makes_expected_event_logging_calls_when_patch_implementation_throws_and_original_succeeds(
+def test_safe_patch_makes_expected_event_logging_calls_when_patch_implementation_throws_and_original_succeeds(  # pylint: disable=E501
     patch_destination, test_autologging_integration, mock_event_logger,
 ):
     patch_session = None
@@ -685,7 +685,7 @@ def test_safe_patch_makes_expected_event_logging_calls_when_patch_implementation
         assert patch_error.exception == exc_to_raise
 
 
-def test_safe_patch_makes_expected_event_logging_calls_when_patch_implementation_throws_and_original_throws(
+def test_safe_patch_makes_expected_event_logging_calls_when_patch_implementation_throws_and_original_throws(  # pylint: disable=E501
     patch_destination, test_autologging_integration, mock_event_logger,
 ):
     patch_session = None

--- a/tests/autologging/test_autologging_safety_unit.py
+++ b/tests/autologging/test_autologging_safety_unit.py
@@ -647,8 +647,8 @@ def test_safe_patch_makes_expected_event_logging_calls_when_patch_implementation
     patch_destination, test_autologging_integration, mock_event_logger,
 ):
     patch_session = None
-    exc_to_raise = Exception("thrown from patch")
-    original_err_to_raise = Exception("throw from original")
+    exc_to_raise_msg = "thrown from patch"
+    original_err_to_raise_msg = "throw from original"
 
     throw_location = "before"
 
@@ -658,12 +658,12 @@ def test_safe_patch_makes_expected_event_logging_calls_when_patch_implementation
         patch_session = _AutologgingSessionManager.active_session()
 
         if throw_location == "before":
-            raise exc_to_raise
+            raise Exception(exc_to_raise_msg)
 
         original(*args, **kwargs)
 
         if throw_location != "before":
-            raise exc_to_raise
+            raise Exception(exc_to_raise_msg)
 
     safe_patch(test_autologging_integration, patch_destination, "fn", patch_impl)
     safe_patch(test_autologging_integration, patch_destination, "throw_error_fn", patch_impl)
@@ -685,16 +685,23 @@ def test_safe_patch_makes_expected_event_logging_calls_when_patch_implementation
         assert patch_start.exception is None
         assert original_start.exception is None
         assert original_success.exception is None
-        assert patch_error.exception == exc_to_raise
+        assert patch_error.exception.args[0] == exc_to_raise_msg
+        stack_trace = patch_error.exception._stack_trace
+        assert (
+            "Traceback" in stack_trace
+            and "in safe_patch_function" in stack_trace
+            and "in patch_impl" in stack_trace
+            and "Exception: thrown from patch" in stack_trace
+        )
 
         mock_event_logger.reset()
-        with pytest.raises(Exception, match="throw from original"):
-            patch_destination.throw_error_fn(original_err_to_raise)
+        with pytest.raises(Exception, match=original_err_to_raise_msg):
+            patch_destination.throw_error_fn(Exception(original_err_to_raise_msg))
         assert [call.method for call in mock_event_logger.calls] == expected_order_bad_fn
         patch_start, original_start, original_error = mock_event_logger.calls
         assert patch_start.exception is None
         assert original_start.exception is None
-        assert original_error.exception == original_err_to_raise
+        assert original_error.exception.args[0] == original_err_to_raise_msg
 
 
 def test_safe_patch_makes_expected_event_logging_calls_when_original_function_throws(

--- a/tests/autologging/test_autologging_safety_unit.py
+++ b/tests/autologging/test_autologging_safety_unit.py
@@ -652,6 +652,7 @@ def test_safe_patch_makes_expected_event_logging_calls_when_patch_implementation
 
     def patch_impl(original, *args, **kwargs):
         nonlocal patch_session
+        nonlocal throw_location
         patch_session = _AutologgingSessionManager.active_session()
 
         if throw_location == "before":

--- a/tests/autologging/test_autologging_safety_unit.py
+++ b/tests/autologging/test_autologging_safety_unit.py
@@ -652,7 +652,6 @@ def test_safe_patch_makes_expected_event_logging_calls_when_patch_implementation
 
     def patch_impl(original, *args, **kwargs):
         nonlocal throw_location
-        patch_session = _AutologgingSessionManager.active_session()
 
         if throw_location == "before":
             raise exc_to_raise
@@ -692,7 +691,6 @@ def test_safe_patch_makes_expected_event_logging_calls_when_patch_implementation
 
     def patch_impl(original, *args, **kwargs):
         nonlocal throw_location
-        patch_session = _AutologgingSessionManager.active_session()
 
         if throw_location == "before":
             raise exc_to_raise

--- a/tests/autologging/test_autologging_safety_unit.py
+++ b/tests/autologging/test_autologging_safety_unit.py
@@ -663,7 +663,7 @@ def test_safe_patch_makes_expected_event_logging_calls_when_patch_implementation
             raise exc_to_raise
 
     safe_patch(test_autologging_integration, patch_destination, "fn", patch_impl)
-    safe_patch(test_autologging_integration, patch_destination, "bad_fn", patch_impl)
+    safe_patch(test_autologging_integration, patch_destination, "throw_error_fn", patch_impl)
 
     expected_order_good_fn = [
         "patch_start",
@@ -673,7 +673,6 @@ def test_safe_patch_makes_expected_event_logging_calls_when_patch_implementation
     ]
 
     expected_order_bad_fn = ["patch_start", "original_start", "original_error"]
-    throw_location = "before"
 
     for throw_location in ["before", "after"]:
         mock_event_logger.reset()
@@ -687,7 +686,7 @@ def test_safe_patch_makes_expected_event_logging_calls_when_patch_implementation
 
         mock_event_logger.reset()
         with pytest.raises(Exception, match="throw from original"):
-            patch_destination.bad_fn(original_err_to_raise)
+            patch_destination.throw_error_fn(original_err_to_raise)
         assert [call.method for call in mock_event_logger.calls] == expected_order_bad_fn
         patch_start, original_start, original_error = mock_event_logger.calls
         assert patch_start.exception is None

--- a/tests/autologging/test_autologging_safety_unit.py
+++ b/tests/autologging/test_autologging_safety_unit.py
@@ -648,7 +648,7 @@ def test_safe_patch_makes_expected_event_logging_calls_when_patch_implementation
 ):
     exc_to_raise = Exception("thrown from patch")
 
-    throw_location = "before"
+    throw_location = None
 
     def patch_impl(original, *args, **kwargs):
         nonlocal throw_location
@@ -687,7 +687,7 @@ def test_safe_patch_makes_expected_event_logging_calls_when_patch_implementation
     exc_to_raise = Exception("thrown from patch")
     original_err_to_raise = Exception("throw from original")
 
-    throw_location = "before"
+    throw_location = None
 
     def patch_impl(original, *args, **kwargs):
         nonlocal throw_location

--- a/tests/autologging/test_autologging_safety_unit.py
+++ b/tests/autologging/test_autologging_safety_unit.py
@@ -1639,7 +1639,6 @@ def test_log_behaivor_when_patch_fn_raise_error_before_original_called():
 
     def patched_fn(original, self, *args, **kwargs):
         raise RuntimeError("patch function error")
-        return original(self, *args, **kwargs)
 
     flavor_name = "test_log_behaivor_when_patch_fn_raise_error_before_original_called"
 

--- a/tests/autologging/test_autologging_safety_unit.py
+++ b/tests/autologging/test_autologging_safety_unit.py
@@ -672,11 +672,7 @@ def test_safe_patch_makes_expected_event_logging_calls_when_patch_implementation
         "patch_error",
     ]
 
-    expected_order_bad_fn = [
-        "patch_start",
-        "original_start",
-        "original_error"
-    ]
+    expected_order_bad_fn = ["patch_start", "original_start", "original_error"]
     throw_location = "before"
 
     for throw_location in ["before", "after"]:

--- a/tests/autologging/test_autologging_safety_unit.py
+++ b/tests/autologging/test_autologging_safety_unit.py
@@ -643,7 +643,7 @@ def test_safe_patch_makes_expected_event_logging_calls_for_successful_patch_invo
     assert patch_success.exception is original_success.exception is None
 
 
-def test_safe_patch_makes_expected_event_logging_calls_when_patch_implementation_throws_and_original_succeeds(  # pylint: disable=E501
+def test_safe_patch_makes_expected_event_logging_calls_when_patch_implementation_throws_and_original_succeeds(  # noqa
     patch_destination, test_autologging_integration, mock_event_logger,
 ):
     patch_session = None
@@ -685,7 +685,7 @@ def test_safe_patch_makes_expected_event_logging_calls_when_patch_implementation
         assert patch_error.exception == exc_to_raise
 
 
-def test_safe_patch_makes_expected_event_logging_calls_when_patch_implementation_throws_and_original_throws(  # pylint: disable=E501
+def test_safe_patch_makes_expected_event_logging_calls_when_patch_implementation_throws_and_original_throws(  # noqa
     patch_destination, test_autologging_integration, mock_event_logger,
 ):
     patch_session = None

--- a/tests/spark_autologging/ml/test_pyspark_ml_autologging.py
+++ b/tests/spark_autologging/ml/test_pyspark_ml_autologging.py
@@ -779,12 +779,14 @@ def test_log_post_training_metrics_configuration(dataset_iris_binomial):
 
 
 def test_autologging_handle_wrong_pipeline_stage(dataset_regression):
+    import os
+
+    os.environ["MLFLOW_AUTOLOGGING_TESTING"] = "false"
     mlflow.pyspark.ml.autolog()
 
     lr = LinearRegression(maxIter=1)
     pipeline = Pipeline(stages=lr)
-    with pytest.raises(TypeError, match="Pipeline stages should be iterable"):
-        pipeline.fit(dataset_regression)
+    pipeline.fit(dataset_regression)
 
 
 def test_autologging_handle_wrong_tuning_params(dataset_regression):

--- a/tests/spark_autologging/ml/test_pyspark_ml_autologging.py
+++ b/tests/spark_autologging/ml/test_pyspark_ml_autologging.py
@@ -779,14 +779,12 @@ def test_log_post_training_metrics_configuration(dataset_iris_binomial):
 
 
 def test_autologging_handle_wrong_pipeline_stage(dataset_regression):
-    import os
-
-    os.environ["MLFLOW_AUTOLOGGING_TESTING"] = "false"
     mlflow.pyspark.ml.autolog()
 
     lr = LinearRegression(maxIter=1)
     pipeline = Pipeline(stages=lr)
-    pipeline.fit(dataset_regression)
+    with pytest.raises(TypeError, match="Pipeline stages should be iterable"):
+        pipeline.fit(dataset_regression)
 
 
 def test_autologging_handle_wrong_tuning_params(dataset_regression):


### PR DESCRIPTION
## What changes are proposed in this pull request?

When patch function raise exception before original function called, the expected behavior should be:
(1) if following original function call succeeds, then this is unexpected mlflow error, we should call `log_patch_function_error` and `log_original_function_success`
(2) if following original function call raise error, then this is **NOT** unexpected mlflow error we should **NOT** call `log_patch_function_error`, but we should call `log_original_function_error`

In contrast, the current behavior is:
(1) if following original function call succeeds, it forget to call `log_original_function_success`
(2) if following original function call raise error, then it still call `log_patch_function_error`, and it forget call `log_original_function_error`

## How is this patch tested?

Unit test.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
