### PR TITLE
Fixed Metric plot view erroneously displays NaN value on click

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/MetricsPlotPanel.js
+++ b/mlflow/server/js/src/experiment-tracking/components/MetricsPlotPanel.js
@@ -446,7 +446,7 @@ export class MetricsPlotPanel extends React.Component {
             runId: point.data.runId,
             name: point.data.name,
             color: point.fullData.marker.color,
-            y: point.text,
+            y: point.y,
           }));
 
         this.setState({

--- a/mlflow/server/js/src/experiment-tracking/components/MetricsPlotPanel.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/MetricsPlotPanel.test.js
@@ -3,6 +3,7 @@ import { shallow } from 'enzyme';
 import { MetricsPlotPanel, CHART_TYPE_BAR, CHART_TYPE_LINE } from './MetricsPlotPanel';
 import { X_AXIS_RELATIVE, X_AXIS_STEP, X_AXIS_WALL } from './MetricsPlotControls';
 import Utils from '../../common/utils/Utils';
+import { RunLinksPopover } from './RunLinksPopover';
 
 describe('unit tests', () => {
   let wrapper;
@@ -310,6 +311,66 @@ describe('unit tests', () => {
     instance.handleLegendClick({ curveNumber: 1, data: data });
     window.setTimeout(() => {
       expect(instance.getUrlState().deselectedCurves).toEqual(['runUuid1']);
+      done();
+    }, 1000);
+  });
+
+  test('click into RunLinksPopover', (done) => {
+    const data = {
+      event: {
+        clientX: 1,
+        clientY: 1,
+      },
+      points: [
+        {
+          data: { runId: 'runUuid1', name: 'run1' },
+          fullData: {
+            marker: { color: 'rgb(1, 1, 1)' },
+          },
+          y: 0.2,
+        },
+        {
+          data: { runId: 'runUuid2', name: 'run2' },
+          fullData: {
+            marker: { color: 'rgb(2, 2, 2)' },
+          },
+          y: 0.1,
+        },
+      ],
+    };
+    const props = {
+      experimentId: '1',
+      visible: true,
+      x: 1,
+      y: 1,
+      runItems: [
+        {
+          runId: 'runUuid1',
+          name: 'run1',
+          color: 'rgb(1, 1, 1)',
+          y: 0.2,
+        },
+        {
+          runId: 'runUuid2',
+          name: 'run2',
+          color: 'rgb(2, 2, 2)',
+          y: 0.1,
+        },
+      ],
+      handleClose: jest.fn(),
+      handleKeyDown: jest.fn(),
+      handleVisibleChange: jest.fn(),
+    };
+    wrapper = shallow(<MetricsPlotPanel {...minimalPropsForLineChart} />);
+    instance = wrapper.instance();
+    instance.updatePopover(data);
+    window.setTimeout(() => {
+      const popover = wrapper.find(RunLinksPopover);
+      expect(popover.props().x).toEqual(props.x);
+      expect(popover.props().y).toEqual(props.y);
+      expect(popover.props().visible).toEqual(props.visible);
+      expect(popover.props().experimentId).toEqual(props.experimentId);
+      expect(popover.props().runItems).toEqual(props.runItems);
       done();
     }, 1000);
   });


### PR DESCRIPTION
## What changes are proposed in this pull request?
Updates parameter value passed in to the run links popover on the metric plot view page.

## How is this patch tested?
Manually and UI tested.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Users will no longer see NaN for their correct metric plot points in the run links popover.

Pre Bug-Fix
<img width="1743" alt="pre-bug-fix" src="https://user-images.githubusercontent.com/87999496/135359899-fbc2d055-8993-46b2-8a4f-888e2acc0149.png">

Post Bug-Fix
<img width="1767" alt="post-bug-fix" src="https://user-images.githubusercontent.com/87999496/135359919-84289e18-5c74-435c-9824-fdeffe681787.png">

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<a name="bug-fix"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
