### PR TITLE
BUG-FIX: Multicolview uncheck behavior

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.js
@@ -94,6 +94,9 @@ export class ExperimentRunsTableMultiColumnView2 extends React.Component {
   constructor(props) {
     super(props);
     this.getColumnDefs = this.getColumnDefs.bind(this);
+    this.state = {
+      columnDefs: [],
+    };
   }
 
   componentDidMount() {
@@ -102,7 +105,7 @@ export class ExperimentRunsTableMultiColumnView2 extends React.Component {
     // column defs here to handle that case, as well as the one already
     // handled in componentDidUpdate for when the request resolves after the
     // fact.
-    this.columnDefs = this.getColumnDefs();
+    this.setColumnDefs();
   }
 
   /**
@@ -475,16 +478,15 @@ export class ExperimentRunsTableMultiColumnView2 extends React.Component {
       prevProps.orderByAsc !== this.props.orderByAsc ||
       prevProps.onSortBy !== this.props.onSortBy
     ) {
-      this.updateColumnDefs(this.getColumnDefs());
+      this.setColumnDefs();
     }
   }
 
-  updateColumnDefs(columnDefs) {
-    if (!this.gridApi) return;
-    // setColumnDefs is called twice to make sure the order of columnDefs is consistent
-    this.gridApi.setColumnDefs([]);
-    this.gridApi.setColumnDefs(columnDefs);
-  }
+  setColumnDefs = () => {
+    this.setState(() => ({
+      columnDefs: this.getColumnDefs(),
+    }));
+  };
 
   render() {
     const { handleLoadMoreRuns, loadingMore, numRunsFromLatestSearch, nestChildren } = this.props;
@@ -497,7 +499,7 @@ export class ExperimentRunsTableMultiColumnView2 extends React.Component {
       <div className='ag-theme-balham multi-column-view' data-test-id='detailed-runs-table-view'>
         <AgGridReact
           defaultColDef={defaultColDef}
-          columnDefs={this.columnDefs}
+          columnDefs={this.state.columnDefs}
           rowData={this.getRowData()}
           modules={[Grid, ClientSideRowModelModule]}
           rowSelection='multiple'

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.js
@@ -75,6 +75,7 @@ export class ExperimentRunsTableMultiColumnView2 extends React.Component {
     filter: true,
     suppressMenu: true,
     suppressMovable: true,
+    maintainColumnOrder: true,
   };
 
   // A map of framework(React) specific custom components.
@@ -468,14 +469,19 @@ export class ExperimentRunsTableMultiColumnView2 extends React.Component {
     if (
       prevProps.metricKeyList.length !== this.props.metricKeyList.length ||
       prevProps.paramKeyList.length !== this.props.paramKeyList.length ||
-      prevProps.categorizedUncheckedKeys.length !== this.props.categorizedUncheckedKeys.length ||
       prevProps.visibleTagKeyList.length !== this.props.visibleTagKeyList.length ||
+      prevProps.categorizedUncheckedKeys[COLUMN_TYPES.ATTRIBUTES].length !==
+        this.props.categorizedUncheckedKeys[COLUMN_TYPES.ATTRIBUTES].length ||
       prevProps.orderByKey !== this.props.orderByKey ||
       prevProps.orderByAsc !== this.props.orderByAsc ||
       prevProps.onSortBy !== this.props.onSortBy
     ) {
-      this.columnDefs = this.getColumnDefs();
+      this.updateColumnDefs(this.getColumnDefs());
     }
+  }
+
+  updateColumnDefs(columnDefs) {
+    this.gridApi.setColumnDefs(columnDefs);
   }
 
   render() {

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.js
@@ -75,7 +75,6 @@ export class ExperimentRunsTableMultiColumnView2 extends React.Component {
     filter: true,
     suppressMenu: true,
     suppressMovable: true,
-    maintainColumnOrder: true,
   };
 
   // A map of framework(React) specific custom components.
@@ -481,6 +480,9 @@ export class ExperimentRunsTableMultiColumnView2 extends React.Component {
   }
 
   updateColumnDefs(columnDefs) {
+    if (!this.gridApi) return;
+    // setColumnDefs is called twice to make sure the order of columnDefs is consistent
+    this.gridApi.setColumnDefs([]);
     this.gridApi.setColumnDefs(columnDefs);
   }
 

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.test.js
@@ -4,13 +4,23 @@ import {
   ExperimentRunsTableMultiColumnView2,
   ModelsCellRenderer,
 } from './ExperimentRunsTableMultiColumnView2';
-import { COLUMN_TYPES } from '../constants';
+import { COLUMN_TYPES, ATTRIBUTE_COLUMN_LABELS } from '../constants';
 import { RunTag } from '../sdk/MlflowMessages';
 import { MemoryRouter as Router } from 'react-router-dom';
+
+function getChildColumnNames(columnDefs, parentName) {
+  return columnDefs
+    .find((header) => header.headerName === parentName)
+    .children.map((childHeader) => {
+      return childHeader.headerName;
+    });
+}
 
 describe('ExperimentRunsTableMultiColumnView2', () => {
   let wrapper;
   let minimalProps;
+  let commonProps;
+  let updateColumnDefsSpy;
   const runTags = {
     'mlflow.log-model.history': RunTag.fromJs({
       key: 'mlflow.log-model.history',
@@ -50,6 +60,16 @@ describe('ExperimentRunsTableMultiColumnView2', () => {
         [COLUMN_TYPES.TAGS]: [],
       },
     };
+    commonProps = {
+      ...minimalProps,
+      metricKeyList: ['metric1', 'metric2'],
+      paramKeyList: ['param1', 'param2'],
+      visibleTagKeyList: ['tag1', 'tag2'],
+      categorizedUncheckedKeys: {
+        [COLUMN_TYPES.ATTRIBUTES]: [ATTRIBUTE_COLUMN_LABELS.DATE, ATTRIBUTE_COLUMN_LABELS.DURATION],
+      },
+    };
+    updateColumnDefsSpy = jest.fn();
   });
 
   test('should render with minimal props without exploding', () => {
@@ -228,5 +248,126 @@ describe('ExperimentRunsTableMultiColumnView2', () => {
     const output = ModelsCellRenderer(props);
     wrapper = shallow(<Router>{output}</Router>);
     expect(wrapper.html()).toContain('1 more');
+  });
+
+  test('getColumnDefs should return only attribute columns that are not unchecked', () => {
+    const expectedColumnNames = [
+      undefined,
+      ATTRIBUTE_COLUMN_LABELS.RUN_NAME,
+      ATTRIBUTE_COLUMN_LABELS.USER,
+      ATTRIBUTE_COLUMN_LABELS.SOURCE,
+      ATTRIBUTE_COLUMN_LABELS.VERSION,
+      ATTRIBUTE_COLUMN_LABELS.MODELS,
+      'Metrics',
+      'Parameters',
+      'Tags',
+    ];
+    const expectedMetricColumnNames = ['metric1', 'metric2'];
+    const expectedParameterColumnNames = ['param1', 'param2'];
+    const expectedTagColumnNames = ['tag1', 'tag2'];
+
+    wrapper = shallow(<ExperimentRunsTableMultiColumnView2 {...commonProps} />);
+    const instance = wrapper.instance();
+    const columnNames = instance.columnDefs.map((column) => {
+      return column.headerName;
+    });
+    const metricColumnNames = getChildColumnNames(instance.columnDefs, 'Metrics');
+    const paramColumnNames = getChildColumnNames(instance.columnDefs, 'Parameters');
+    const tagColumnNames = getChildColumnNames(instance.columnDefs, 'Tags');
+
+    expect(columnNames).toEqual(expectedColumnNames);
+    expect(metricColumnNames).toEqual(expectedMetricColumnNames);
+    expect(paramColumnNames).toEqual(expectedParameterColumnNames);
+    expect(tagColumnNames).toEqual(expectedTagColumnNames);
+  });
+
+  test('getColumnDefs should not no longer return columnDef after column uncheck', () => {
+    const expectedColumnNames = [
+      undefined,
+      ATTRIBUTE_COLUMN_LABELS.USER,
+      ATTRIBUTE_COLUMN_LABELS.SOURCE,
+      ATTRIBUTE_COLUMN_LABELS.VERSION,
+      ATTRIBUTE_COLUMN_LABELS.MODELS,
+      'Metrics',
+      'Parameters',
+      'Tags',
+    ];
+    const expectedMetricColumnNames = ['metric1'];
+    const expectedParameterColumnNames = ['param1'];
+    const expectedTagColumnNames = ['tag1'];
+
+    wrapper = shallow(<ExperimentRunsTableMultiColumnView2 {...commonProps} />);
+    const instance = wrapper.instance();
+    instance.updateColumnDefs = updateColumnDefsSpy;
+
+    wrapper.setProps({
+      metricKeyList: expectedMetricColumnNames,
+      paramKeyList: expectedParameterColumnNames,
+      visibleTagKeyList: expectedTagColumnNames,
+      categorizedUncheckedKeys: {
+        [COLUMN_TYPES.ATTRIBUTES]: [
+          ATTRIBUTE_COLUMN_LABELS.RUN_NAME,
+          ATTRIBUTE_COLUMN_LABELS.DATE,
+          ATTRIBUTE_COLUMN_LABELS.DURATION,
+        ],
+      },
+    });
+
+    const columnNames = instance.getColumnDefs().map((column) => {
+      return column.headerName;
+    });
+    const metricColumnNames = getChildColumnNames(instance.getColumnDefs(), 'Metrics');
+    const paramColumnNames = getChildColumnNames(instance.getColumnDefs(), 'Parameters');
+    const tagColumnNames = getChildColumnNames(instance.getColumnDefs(), 'Tags');
+
+    expect(columnNames).toEqual(expectedColumnNames);
+    expect(metricColumnNames).toEqual(expectedMetricColumnNames);
+    expect(paramColumnNames).toEqual(expectedParameterColumnNames);
+    expect(tagColumnNames).toEqual(expectedTagColumnNames);
+    expect(updateColumnDefsSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test('getColumnDefs should return columnDef after column check', () => {
+    const expectedColumnNames = [
+      undefined,
+      ATTRIBUTE_COLUMN_LABELS.DATE,
+      ATTRIBUTE_COLUMN_LABELS.RUN_NAME,
+      ATTRIBUTE_COLUMN_LABELS.USER,
+      ATTRIBUTE_COLUMN_LABELS.SOURCE,
+      ATTRIBUTE_COLUMN_LABELS.VERSION,
+      ATTRIBUTE_COLUMN_LABELS.MODELS,
+      'Metrics',
+      'Parameters',
+      'Tags',
+    ];
+    const expectedMetricColumnNames = ['metric1', 'metric2', 'metric3'];
+    const expectedParameterColumnNames = ['param1', 'param2', 'param3'];
+    const expectedTagColumnNames = ['tag1', 'tag2', 'tag3'];
+
+    wrapper = shallow(<ExperimentRunsTableMultiColumnView2 {...commonProps} />);
+    const instance = wrapper.instance();
+    instance.updateColumnDefs = updateColumnDefsSpy;
+
+    wrapper.setProps({
+      metricKeyList: expectedMetricColumnNames,
+      paramKeyList: expectedParameterColumnNames,
+      visibleTagKeyList: expectedTagColumnNames,
+      categorizedUncheckedKeys: {
+        [COLUMN_TYPES.ATTRIBUTES]: [ATTRIBUTE_COLUMN_LABELS.DURATION],
+      },
+    });
+
+    const columnNames = instance.getColumnDefs().map((column) => {
+      return column.headerName;
+    });
+    const metricColumnNames = getChildColumnNames(instance.getColumnDefs(), 'Metrics');
+    const paramColumnNames = getChildColumnNames(instance.getColumnDefs(), 'Parameters');
+    const tagColumnNames = getChildColumnNames(instance.getColumnDefs(), 'Tags');
+
+    expect(columnNames).toEqual(expectedColumnNames);
+    expect(metricColumnNames).toEqual(expectedMetricColumnNames);
+    expect(paramColumnNames).toEqual(expectedParameterColumnNames);
+    expect(tagColumnNames).toEqual(expectedTagColumnNames);
+    expect(updateColumnDefsSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.test.js
@@ -20,7 +20,7 @@ describe('ExperimentRunsTableMultiColumnView2', () => {
   let wrapper;
   let minimalProps;
   let commonProps;
-  let updateColumnDefsSpy;
+  let setColumnDefsSpy;
   const runTags = {
     'mlflow.log-model.history': RunTag.fromJs({
       key: 'mlflow.log-model.history',
@@ -69,7 +69,7 @@ describe('ExperimentRunsTableMultiColumnView2', () => {
         [COLUMN_TYPES.ATTRIBUTES]: [ATTRIBUTE_COLUMN_LABELS.DATE, ATTRIBUTE_COLUMN_LABELS.DURATION],
       },
     };
-    updateColumnDefsSpy = jest.fn();
+    setColumnDefsSpy = jest.fn();
   });
 
   test('should render with minimal props without exploding', () => {
@@ -268,12 +268,12 @@ describe('ExperimentRunsTableMultiColumnView2', () => {
 
     wrapper = shallow(<ExperimentRunsTableMultiColumnView2 {...commonProps} />);
     const instance = wrapper.instance();
-    const columnNames = instance.columnDefs.map((column) => {
+    const columnNames = instance.state.columnDefs.map((column) => {
       return column.headerName;
     });
-    const metricColumnNames = getChildColumnNames(instance.columnDefs, 'Metrics');
-    const paramColumnNames = getChildColumnNames(instance.columnDefs, 'Parameters');
-    const tagColumnNames = getChildColumnNames(instance.columnDefs, 'Tags');
+    const metricColumnNames = getChildColumnNames(instance.state.columnDefs, 'Metrics');
+    const paramColumnNames = getChildColumnNames(instance.state.columnDefs, 'Parameters');
+    const tagColumnNames = getChildColumnNames(instance.state.columnDefs, 'Tags');
 
     expect(columnNames).toEqual(expectedColumnNames);
     expect(metricColumnNames).toEqual(expectedMetricColumnNames);
@@ -298,7 +298,7 @@ describe('ExperimentRunsTableMultiColumnView2', () => {
 
     wrapper = shallow(<ExperimentRunsTableMultiColumnView2 {...commonProps} />);
     const instance = wrapper.instance();
-    instance.updateColumnDefs = updateColumnDefsSpy;
+    instance.setColumnDefs = setColumnDefsSpy;
 
     wrapper.setProps({
       metricKeyList: expectedMetricColumnNames,
@@ -324,7 +324,7 @@ describe('ExperimentRunsTableMultiColumnView2', () => {
     expect(metricColumnNames).toEqual(expectedMetricColumnNames);
     expect(paramColumnNames).toEqual(expectedParameterColumnNames);
     expect(tagColumnNames).toEqual(expectedTagColumnNames);
-    expect(updateColumnDefsSpy).toHaveBeenCalledTimes(1);
+    expect(setColumnDefsSpy).toHaveBeenCalledTimes(1);
   });
 
   test('getColumnDefs should return columnDef after column check', () => {
@@ -346,7 +346,7 @@ describe('ExperimentRunsTableMultiColumnView2', () => {
 
     wrapper = shallow(<ExperimentRunsTableMultiColumnView2 {...commonProps} />);
     const instance = wrapper.instance();
-    instance.updateColumnDefs = updateColumnDefsSpy;
+    instance.setColumnDefs = setColumnDefsSpy;
 
     wrapper.setProps({
       metricKeyList: expectedMetricColumnNames,
@@ -368,6 +368,6 @@ describe('ExperimentRunsTableMultiColumnView2', () => {
     expect(metricColumnNames).toEqual(expectedMetricColumnNames);
     expect(paramColumnNames).toEqual(expectedParameterColumnNames);
     expect(tagColumnNames).toEqual(expectedTagColumnNames);
-    expect(updateColumnDefsSpy).toHaveBeenCalledTimes(1);
+    expect(setColumnDefsSpy).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Signed-off-by: Marijn Valk <marijncv@hotmail.com>

## What changes are proposed in this pull request?

This bugfix makes the MultiColumnView react to the checked/unchecked columns by updating the visible columns. Partially resolves #4819

## How is this patch tested?

Go to the experiment UI, switch to the multi column view and select/unselect some columns and see them become visible/invisible

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
