### PR TITLE
Avoid creating a temporary file in `infer_pip_requirments`

### DIFF
--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -1,5 +1,4 @@
 import yaml
-import tempfile
 import os
 import logging
 

--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -156,6 +156,9 @@ def _parse_pip_requirements(pip_requirements):
             return False
 
     if _is_string(pip_requirements):
+        with open(pip_requirements) as f:
+            return _parse_pip_requirements(f.read().splitlines())
+    elif _is_iterable(pip_requirements) and all(map(_is_string, pip_requirements)):
         requirements = []
         constraints = []
         for req_or_con in _parse_requirements(pip_requirements, is_constraint=False):
@@ -165,24 +168,6 @@ def _parse_pip_requirements(pip_requirements):
                 requirements.append(req_or_con.req_str)
 
         return requirements, constraints
-    elif _is_iterable(pip_requirements) and all(map(_is_string, pip_requirements)):
-        try:
-            # Create a temporary requirements file in the current working directory
-            tmp_req_file = tempfile.NamedTemporaryFile(
-                mode="w",
-                prefix="mlflow.",
-                suffix=".tmp.requirements.txt",
-                dir=os.getcwd(),
-                # Setting `delete` to True causes a permission-denied error on Windows
-                # while trying to read the generated temporary file.
-                delete=False,
-            )
-            tmp_req_file.write("\n".join(pip_requirements))
-            tmp_req_file.close()
-            return _parse_pip_requirements(tmp_req_file.name)
-        finally:
-            # Clean up the temporary requirements file
-            os.remove(tmp_req_file.name)
     else:
         raise TypeError(
             "`pip_requirements` must be either a string path to a pip requirements file on the "


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

Avoid creating a temporary file in `infer_pip_requirments`.

## How is this patch tested?

Make sure the existing relevant tests pass to ensure that the proposed change doesn't alter the `infer_pip_requirments` behavior.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
