### PR TITLE
[Example] Stream uploads/downloads

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -1,0 +1,20 @@
+import mlflow
+import os
+import sys
+
+path = sys.argv[1]
+
+mlflow.set_tracking_uri("http://localhost:5000")
+experiment_name = "stream-s3"
+if not mlflow.get_experiment_by_name(experiment_name):
+    mlflow.create_experiment(experiment_name)
+mlflow.set_experiment(experiment_name)
+
+with mlflow.start_run() as run:
+    mlflow.log_artifact(path, "test")
+
+client = mlflow.tracking.MlflowClient()
+dst_path = client.download_artifacts(run.info.run_id, "test")
+
+with open(os.path.join(dst_path, path)) as f:
+    print(f.read())

--- a/demo_multi.py
+++ b/demo_multi.py
@@ -1,0 +1,69 @@
+import mlflow
+import argparse
+from concurrent.futures import ThreadPoolExecutor
+import logging
+import traceback
+import tempfile
+import os
+
+logging.basicConfig(
+    format="%(asctime)s %(levelname)-8s %(message)s",
+    level=logging.INFO,
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger()
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--tracking-uri", required=True)
+parser.add_argument("--file-size-mib", required=True, default=1)
+parser.add_argument("--num-concurrent-requests", required=True, default=5)
+args = parser.parse_args()
+
+tracking_uri = args.tracking_uri
+file_size_mib = int(args.file_size_mib)
+num_concurrent_requests = int(args.num_concurrent_requests)
+
+
+def task(idx):
+    idx = str(idx)
+    logger.info(idx + " start")
+    mlflow.set_tracking_uri(tracking_uri)
+    client = mlflow.tracking.MlflowClient(tracking_uri)
+    experiment_name = "stream-s3"
+    experiment = client.get_experiment_by_name(experiment_name)
+    if not experiment:
+        experiment = client.create_experiment(experiment_name)
+    logger.info(idx + " created experiment")
+
+    experiment_id = experiment.experiment_id
+    run = client.create_run(experiment_id)
+    logger.info(idx + " created run")
+
+    logger.info(idx + " uploading artifact")
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = os.path.join(tmp_dir, "temp.txt")
+        with open(tmp_path, "w") as f:
+            # Create a large text file
+            f.write("a" * file_size_mib * 1024 ** 2)  # 100 MiB
+
+        client.log_artifact(run.info.run_id, tmp_path, "test")
+    logger.info(idx + " uploaded artifact")
+    client.set_terminated(run.info.run_id, status="FINISHED")
+    logger.info(idx + " downloading artifact")
+    client.download_artifacts(run.info.run_id, path="test")
+    logger.info(idx + " downloaded artifact")
+    logger.info(idx + " end")
+    return run.info.run_id
+
+
+with ThreadPoolExecutor() as pool:
+    futures = {idx: pool.submit(task, idx) for idx in range(num_concurrent_requests)}
+    failed = []
+    for idx, f in futures.items():
+        try:
+            f.result()
+        except:
+            failed.append(idx)
+            print(traceback.format_exc())
+    print(failed)

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -61,10 +61,10 @@ def _upload_to_s3(stream, bucket_name, key, chunk_size=5 * 1024 ** 2):
     # smart_open performs a multi part upload (MPU):
     # https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html
 
-    # Google Cloud Storage storage supports MLP:
+    # Google Cloud Storage storage supports MPU:
     # https://cloud.google.com/storage/docs/multipart-uploads
 
-    # Azure Blob Storage also supports MLP:
+    # Azure Blob Storage also supports MPU:
     # https://docs.microsoft.com/en-us/rest/api/storageservices/understanding-block-blobs--append-blobs--and-page-blobs
 
     url = f"s3://{bucket_name}/{key}"

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -62,7 +62,7 @@ def serve_artifacts():
     return get_artifact_handler()
 
 
-def _upload_to_s3(stream, bucket_name, key, chunk_size=10 * 1024 ** 2):
+def _upload_to_s3(stream, bucket_name, key, chunk_size=5 * 1024 ** 2):
     import time
 
     # smart_open:

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -99,7 +99,7 @@ def _read_from_s3(bucket_name, key, chunk_size=8192):
     url = f"s3://{bucket_name}/{key}"
     transport_params = {"client": boto3.client("s3")}
     # smart_open performs a multi part upload
-    with smart_open.open(url, "rb", transport_params=transport_params, compression="disable") as f:
+    with smart_open.open(url, "rb", transport_params=transport_params) as f:
         while True:
             chunk = f.read(chunk_size)
             if len(chunk) == 0:

--- a/mlflow/store/artifact/s3_artifact_repo.py
+++ b/mlflow/store/artifact/s3_artifact_repo.py
@@ -4,6 +4,9 @@ from mimetypes import guess_type
 import posixpath
 import urllib.parse
 import requests
+import logging
+
+_logger = logging.getLogger(__name__)
 
 from mlflow import data
 from mlflow.entities import FileInfo
@@ -111,6 +114,7 @@ class S3ArtifactRepository(ArtifactRepository):
         with open(local_file, "rb") as f:
             resp = requests.post(url, params=params, data=f)
             resp.raise_for_status()
+            _logger.info(resp.json())
 
     def log_artifacts(self, local_dir, artifact_path=None):
         (bucket, dest_path) = data.parse_s3_uri(self.artifact_uri)

--- a/mlflow/store/artifact/s3_artifact_repo.py
+++ b/mlflow/store/artifact/s3_artifact_repo.py
@@ -3,12 +3,22 @@ from mimetypes import guess_type
 
 import posixpath
 import urllib.parse
+import requests
 
 from mlflow import data
 from mlflow.entities import FileInfo
 from mlflow.exceptions import MlflowException
 from mlflow.store.artifact.artifact_repo import ArtifactRepository
 from mlflow.utils.file_utils import relative_path_to_artifact_path
+
+
+def _download_file_from_url(url, params, local_path, chunk_size=8192):
+    # https://stackoverflow.com/a/16696317
+    with requests.get(url, params=params, stream=True) as r:
+        r.raise_for_status()
+        with open(local_path, "wb") as f:
+            for chunk in r.iter_content(chunk_size):
+                f.write(chunk)
 
 
 class S3ArtifactRepository(ArtifactRepository):
@@ -79,7 +89,19 @@ class S3ArtifactRepository(ArtifactRepository):
             extra_args.update(environ_extra_args)
         s3_client.upload_file(Filename=local_file, Bucket=bucket, Key=key, ExtraArgs=extra_args)
 
+    # def log_artifact(self, local_file, artifact_path=None):
+    #     (bucket, dest_path) = data.parse_s3_uri(self.artifact_uri)
+    #     if artifact_path:
+    #         dest_path = posixpath.join(dest_path, artifact_path)
+    #     dest_path = posixpath.join(dest_path, os.path.basename(local_file))
+    #     self._upload_file(
+    #         s3_client=self._get_s3_client(), local_file=local_file, bucket=bucket, key=dest_path
+    #     )
+
     def log_artifact(self, local_file, artifact_path=None):
+        import requests
+        from mlflow import get_tracking_uri
+
         (bucket, dest_path) = data.parse_s3_uri(self.artifact_uri)
         if artifact_path:
             dest_path = posixpath.join(dest_path, artifact_path)
@@ -87,6 +109,11 @@ class S3ArtifactRepository(ArtifactRepository):
         self._upload_file(
             s3_client=self._get_s3_client(), local_file=local_file, bucket=bucket, key=dest_path
         )
+        url = get_tracking_uri() + "/artifacts/upload"
+        params = {"bucket_name": bucket, "key": dest_path}
+        with open(local_file, "rb") as f:
+            resp = requests.post(url, params=params, data=f)
+            resp.raise_for_status()
 
     def log_artifacts(self, local_dir, artifact_path=None):
         (bucket, dest_path) = data.parse_s3_uri(self.artifact_uri)
@@ -151,11 +178,20 @@ class S3ArtifactRepository(ArtifactRepository):
                 )
             )
 
+    # def _download_file(self, remote_file_path, local_path):
+    #     (bucket, s3_root_path) = data.parse_s3_uri(self.artifact_uri)
+    #     s3_full_path = posixpath.join(s3_root_path, remote_file_path)
+    #     s3_client = self._get_s3_client()
+    #     s3_client.download_file(bucket, s3_full_path, local_path)
+
     def _download_file(self, remote_file_path, local_path):
+        from mlflow import get_tracking_uri
+
         (bucket, s3_root_path) = data.parse_s3_uri(self.artifact_uri)
         s3_full_path = posixpath.join(s3_root_path, remote_file_path)
-        s3_client = self._get_s3_client()
-        s3_client.download_file(bucket, s3_full_path, local_path)
+        url = get_tracking_uri() + "/artifacts/get"
+        params = {"bucket_name": bucket, "key": s3_full_path}
+        _download_file_from_url(url, params, local_path)
 
     def delete_artifacts(self, artifact_path=None):
         (bucket, dest_path) = data.parse_s3_uri(self.artifact_uri)

--- a/mlflow/store/artifact/s3_artifact_repo.py
+++ b/mlflow/store/artifact/s3_artifact_repo.py
@@ -73,7 +73,8 @@ class S3ArtifactRepository(ArtifactRepository):
             from botocore import UNSIGNED
 
             signature_version = UNSIGNED
-        return boto3.client(
+        sess = boto3.Session()
+        return sess.client(
             "s3",
             config=Config(signature_version=signature_version),
             endpoint_url=s3_endpoint_url,

--- a/mlflow/store/artifact/s3_artifact_repo.py
+++ b/mlflow/store/artifact/s3_artifact_repo.py
@@ -106,9 +106,6 @@ class S3ArtifactRepository(ArtifactRepository):
         if artifact_path:
             dest_path = posixpath.join(dest_path, artifact_path)
         dest_path = posixpath.join(dest_path, os.path.basename(local_file))
-        self._upload_file(
-            s3_client=self._get_s3_client(), local_file=local_file, bucket=bucket, key=dest_path
-        )
         url = get_tracking_uri() + "/artifacts/upload"
         params = {"bucket_name": bucket, "key": dest_path}
         with open(local_file, "rb") as f:


### PR DESCRIPTION
# DEMO

https://user-images.githubusercontent.com/17039389/136049571-170b9ff1-9365-45a4-9d7d-7c72fbd185c9.mov


Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
