### PR TITLE
Throw Exception When Invalid URI with Databricks Scheme Provided

### DIFF
--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -69,7 +69,7 @@ def get_db_info_from_uri(uri):
     parsed_uri = urllib.parse.urlparse(uri)
     if parsed_uri.scheme == "databricks":
         # netloc should not be an empty string unless URI is formatted incorrectly.
-        if parsed_uri.netloc == '':
+        if parsed_uri.netloc == "":
             raise MlflowException(
                 "URI is formatted incorrectly: no netloc in URI '%s'." % parsed_uri.netloc
             )

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -71,7 +71,7 @@ def get_db_info_from_uri(uri):
         # netloc should not be an empty string unless URI is formatted incorrectly.
         if parsed_uri.netloc == "":
             raise MlflowException(
-                "URI is formatted incorrectly: no netloc in URI '%s'." % parsed_uri.netloc
+                "URI is formatted incorrectly: no netloc in URI '%s'." % uri
             )
         profile_tokens = parsed_uri.netloc.split(":")
         parsed_scope = profile_tokens[0]

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -70,7 +70,10 @@ def get_db_info_from_uri(uri):
     if parsed_uri.scheme == "databricks":
         # netloc should not be an empty string unless URI is formatted incorrectly.
         if parsed_uri.netloc == "":
-            raise MlflowException("URI is formatted incorrectly: no netloc in URI '%s'." % uri)
+            raise MlflowException(
+                "URI is formatted incorrectly: no netloc in URI '%s'." % uri
+                + " This may be the case if there is only one slash in the URI."
+            )
         profile_tokens = parsed_uri.netloc.split(":")
         parsed_scope = profile_tokens[0]
         if len(profile_tokens) == 1:

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -68,6 +68,11 @@ def get_db_info_from_uri(uri):
     """
     parsed_uri = urllib.parse.urlparse(uri)
     if parsed_uri.scheme == "databricks":
+        # netloc should not be an empty string unless URI is formatted incorrectly.
+        if parsed_uri.netloc == '':
+            raise MlflowException(
+                "URI is formatted incorrectly: no netloc in URI '%s'." % parsed_uri.netloc
+            )
         profile_tokens = parsed_uri.netloc.split(":")
         parsed_scope = profile_tokens[0]
         if len(profile_tokens) == 1:

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -70,9 +70,7 @@ def get_db_info_from_uri(uri):
     if parsed_uri.scheme == "databricks":
         # netloc should not be an empty string unless URI is formatted incorrectly.
         if parsed_uri.netloc == "":
-            raise MlflowException(
-                "URI is formatted incorrectly: no netloc in URI '%s'." % uri
-            )
+            raise MlflowException("URI is formatted incorrectly: no netloc in URI '%s'." % uri)
         profile_tokens = parsed_uri.netloc.split(":")
         parsed_scope = profile_tokens[0]
         if len(profile_tokens) == 1:

--- a/tests/utils/test_uri.py
+++ b/tests/utils/test_uri.py
@@ -66,6 +66,7 @@ def test_get_db_info_from_uri(server_uri, result):
         "databricks://profile:",
         "databricks://profile: ",
         "databricks:/profile:prefix",
+        "databricks:/",
         "databricks://",
     ],
 )

--- a/tests/utils/test_uri.py
+++ b/tests/utils/test_uri.py
@@ -65,6 +65,7 @@ def test_get_db_info_from_uri(server_uri, result):
         "databricks://profile ",
         "databricks://profile:",
         "databricks://profile: ",
+        "databricks:/profile:prefix",
     ],
 )
 def test_get_db_info_from_uri_errors(server_uri):

--- a/tests/utils/test_uri.py
+++ b/tests/utils/test_uri.py
@@ -48,7 +48,6 @@ def test_extract_db_type_from_uri():
         ("nondatabricks://profile:prefix", (None, None)),
         ("databricks://profile", ("profile", None)),
         ("databricks://profile/", ("profile", None)),
-        ("databricks://", ("", None)),
     ],
 )
 def test_get_db_info_from_uri(server_uri, result):

--- a/tests/utils/test_uri.py
+++ b/tests/utils/test_uri.py
@@ -66,6 +66,7 @@ def test_get_db_info_from_uri(server_uri, result):
         "databricks://profile:",
         "databricks://profile: ",
         "databricks:/profile:prefix",
+        "databricks://",
     ],
 )
 def test_get_db_info_from_uri_errors(server_uri):

--- a/tests/utils/test_uri.py
+++ b/tests/utils/test_uri.py
@@ -458,7 +458,6 @@ def test_remove_databricks_profile_info_from_artifact_uri(uri, result):
         # test various profile URIs
         ("dbfs:/path/a/b", "databricks", "dbfs://databricks/path/a/b"),
         ("dbfs:/path/a/b/", "databricks", "dbfs://databricks/path/a/b/"),
-        ("dbfs:/path/a/b/", "databricks://", "dbfs://@databricks/path/a/b/"),
         ("dbfs:/path/a/b/", "databricks://Profile", "dbfs://Profile@databricks/path/a/b/"),
         ("dbfs:/path/a/b/", "databricks://profile/", "dbfs://profile@databricks/path/a/b/"),
         ("dbfs:/path/a/b/", "databricks://scope:key", "dbfs://scope:key@databricks/path/a/b/"),


### PR DESCRIPTION
Signed-off-by: Yun Park <yun@databricks.com>

## What changes are proposed in this pull request?

When a user uses a single slash in the URI when referencing the registry URI in Databricks, e.g. databricks:/profile:prefix, it incorrectly references the local registry. The user most likely intended to not use the local registry but the registry provided with a correctly formatted URI.

<img width="1379" alt="Screen Shot 2021-10-07 at 1 57 44 PM" src="https://user-images.githubusercontent.com/1789613/136461202-5a98b7cd-000e-4f1b-af53-e523e4f29b6f.png">

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Tracking and registry URIs provided to the client that reference a Databricks endpoint (useing the `databricks` URI scheme) must be correctly formatted using 2 slashes after the colon instead of 1. Previously, if URIs such as `databricks://`, `databricks:/`, `databricks:/default` or `databricks:/scope:prefix` were provided, they defaulted to the local profile (in Databricks, this would be the default tracking server or registry in the workspace). This will no longer be the case, and you will instead get an error about an incorrectly formatted URI.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [x] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
