### PR TITLE
Normalize package names using rule defined in PEP 503

### DIFF
--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -152,8 +152,8 @@ def _get_requires_recursive(pkg_name):
         return
 
     for req in reqs:
-        yield req.name
-        yield from _get_requires_recursive(req.name)
+        yield req.project_name
+        yield from _get_requires_recursive(req.project_name)
 
 
 def _prune_packages(packages):

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -143,6 +143,7 @@ def _get_requires_recursive(pkg_name):
     """
     Recursively yields both direct and transitive dependencies of the specified package.
     """
+    pkg_name = _normalize_package_name(pkg_name)
     if pkg_name not in pkg_resources.working_set.by_key:
         return
 
@@ -152,8 +153,8 @@ def _get_requires_recursive(pkg_name):
         return
 
     for req in reqs:
-        yield req.project_name
-        yield from _get_requires_recursive(req.project_name)
+        yield _normalize_package_name(req.name)
+        yield from _get_requires_recursive(req.name)
 
 
 def _prune_packages(packages):

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -13,6 +13,7 @@ import importlib_metadata
 from itertools import filterfalse, chain
 from collections import namedtuple
 import logging
+import re
 
 from mlflow.exceptions import MlflowException
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
@@ -127,8 +128,15 @@ def _flatten(iterable):
     return chain.from_iterable(iterable)
 
 
-def _canonicalize_package_name(pkg_name):
-    return pkg_name.lower().replace("_", "-")
+_NORMALIZE_REGEX = re.compile(r"[-_.]+")
+
+
+def _normalize_package_name(pkg_name):
+    """
+    Normalizes a package name using the rule defined in PEP 503:
+    https://www.python.org/dev/peps/pep-0503/#normalized-names
+    """
+    return _NORMALIZE_REGEX.sub("-", pkg_name).lower()
 
 
 def _get_requires_recursive(pkg_name):
@@ -267,7 +275,7 @@ def _infer_requirements(model_uri, flavor):
 
     modules = _capture_imported_modules(model_uri, flavor)
     packages = _flatten([_MODULES_TO_PACKAGES.get(module, []) for module in modules])
-    packages = map(_canonicalize_package_name, packages)
+    packages = map(_normalize_package_name, packages)
     packages = _prune_packages(packages)
     excluded_packages = [
         # Certain packages (e.g. scikit-learn 0.24.2) imports `setuptools` or `pkg_resources`

--- a/tests/utils/test_requirements_utils.py
+++ b/tests/utils/test_requirements_utils.py
@@ -19,6 +19,7 @@ from mlflow.utils.requirements_utils import (
     _get_installed_version,
     _get_pinned_requirement,
     _infer_requirements,
+    _normalize_package_name,
 )
 
 
@@ -183,6 +184,16 @@ line-cont-eof\
         assert [r.requirement for r in pip_reqs if r.constraint] == expected_cons
     finally:
         os.chdir(request.config.invocation_dir)
+
+
+def test_normalize_package_name():
+    assert _normalize_package_name("abc") == "abc"
+    assert _normalize_package_name("ABC") == "abc"
+    assert _normalize_package_name("a-b-c") == "a-b-c"
+    assert _normalize_package_name("a.b.c") == "a-b-c"
+    assert _normalize_package_name("a_b_c") == "a-b-c"
+    assert _normalize_package_name("a--b--c") == "a-b-c"
+    assert _normalize_package_name("a-._b-._c") == "a-b-c"
 
 
 def test_prune_packages():


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

Normalize package names using the official implementation in PEP 503.

## How is this patch tested?

Unit test

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
