### PR TITLE
feat: add header 'Orientation' that defines the pandas return orientation

### DIFF
--- a/tests/pyfunc/test_scoring_server.py
+++ b/tests/pyfunc/test_scoring_server.py
@@ -275,6 +275,51 @@ def test_scoring_server_successfully_evaluates_correct_split_to_numpy(sklearn_mo
 
 
 @pytest.mark.large
+def test_scoring_server_can_return_json_in_split_orientation(sklearn_model, model_path):
+    mlflow.sklearn.save_model(sk_model=sklearn_model.model, path=model_path)
+
+    pandas_split_content = pd.DataFrame(sklearn_model.inference_data).to_json(orient="split")
+    response_records = pyfunc_serve_and_score_model(
+        model_uri=os.path.abspath(model_path),
+        data=pandas_split_content,
+        content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_NUMPY,
+        headers={pyfunc_scoring_server.HEADER_ORIENTATION:pyfunc_scoring_server.ORIENTATION_SPLIT}
+    )
+    assert response_records.status_code == 200
+    assert pd.DataFrame.from_dict(response_records, orient='split') is not None
+
+
+@pytest.mark.large
+def test_scoring_server_can_return_json_in_records_orientation(sklearn_model, model_path):
+    mlflow.sklearn.save_model(sk_model=sklearn_model.model, path=model_path)
+
+    pandas_split_content = pd.DataFrame(sklearn_model.inference_data).to_json(orient="split")
+    response_records = pyfunc_serve_and_score_model(
+        model_uri=os.path.abspath(model_path),
+        data=pandas_split_content,
+        content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_NUMPY,
+        headers={pyfunc_scoring_server.HEADER_ORIENTATION:pyfunc_scoring_server.ORIENTATION_RECORDS}
+    )
+    assert response_records.status_code == 200
+    assert pd.DataFrame.from_dict(response_records, orient='records') is not None
+
+
+@pytest.mark.large
+def test_scoring_server_can_return_json_in_columns_orientation(sklearn_model, model_path):
+    mlflow.sklearn.save_model(sk_model=sklearn_model.model, path=model_path)
+
+    pandas_split_content = pd.DataFrame(sklearn_model.inference_data).to_json(orient="split")
+    response_records = pyfunc_serve_and_score_model(
+        model_uri=os.path.abspath(model_path),
+        data=pandas_split_content,
+        content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_NUMPY,
+        headers={pyfunc_scoring_server.HEADER_ORIENTATION:pyfunc_scoring_server.ORIENTATION_COLUMNS}
+    )
+    assert response_records.status_code == 200
+    assert pd.DataFrame.from_dict(response_records, orient='columns') is not None
+
+
+@pytest.mark.large
 def test_scoring_server_responds_to_invalid_content_type_request_with_unsupported_content_type_code(
     sklearn_model, model_path
 ):


### PR DESCRIPTION
the current default is records, which is highly inefficient for reasonable sized datasets.

Signed-off-by: Gerben Oostra <gerben.oostra@gmail.com>

## What changes are proposed in this pull request?

Gives callers to the pyfunc rest api (/invocations) the possibility to pass a header 'Orientation', that can be valued 'columns', 'records' or 'split'. This will change the json serialization of the returned pandas dataframe.

Currently only 'records' is used, which adds a lot of content to the json. This can cause errors for reasonably sized datasets (already with 5000 rows).

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.
Allow header 'Orientation' on pyfunc server, changing the orientation of returned pandas DataFrame's.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [X] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

Associated Issue: FR-4889 :  https://github.com/mlflow/mlflow/issues/4889 