### PR TITLE
Fix issue where pd.read_json converts strings to dates

### DIFF
--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -130,13 +130,7 @@ def _dataframe_from_json(
                     df[name] = df[name].map(lambda x: base64.decodebytes(bytes(x, "utf8")))
         return df
     else:
-        return pd.read_json(
-            path_or_str,
-            orient=pandas_orient,
-            dtype=False,
-            precise_float=precise_float,
-            convert_dates=False,
-        )
+        return pd.read_json(path_or_str, orient=pandas_orient, dtype=False, precise_float=precise_float)
 
 
 def _get_jsonable_obj(data, pandas_orient="records"):

--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -117,7 +117,11 @@ def _dataframe_from_json(
             dtypes = dict(zip(schema.input_names(), schema.pandas_types()))
 
         df = pd.read_json(
-            path_or_str, orient=pandas_orient, dtype=dtypes, precise_float=precise_float, convert_dates=False
+            path_or_str,
+            orient=pandas_orient,
+            dtype=dtypes,
+            precise_float=precise_float,
+            convert_dates=False,
         )
         if not schema.is_tensor_spec():
             actual_cols = set(df.columns)
@@ -127,7 +131,11 @@ def _dataframe_from_json(
         return df
     else:
         return pd.read_json(
-            path_or_str, orient=pandas_orient, dtype=False, precise_float=precise_float, convert_dates=False
+            path_or_str,
+            orient=pandas_orient,
+            dtype=False,
+            precise_float=precise_float,
+            convert_dates=False,
         )
 
 

--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -130,7 +130,9 @@ def _dataframe_from_json(
                     df[name] = df[name].map(lambda x: base64.decodebytes(bytes(x, "utf8")))
         return df
     else:
-        return pd.read_json(path_or_str, orient=pandas_orient, dtype=False, precise_float=precise_float)
+        return pd.read_json(
+            path_or_str, orient=pandas_orient, dtype=False, precise_float=precise_float
+        )
 
 
 def _get_jsonable_obj(data, pandas_orient="records"):

--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -117,7 +117,7 @@ def _dataframe_from_json(
             dtypes = dict(zip(schema.input_names(), schema.pandas_types()))
 
         df = pd.read_json(
-            path_or_str, orient=pandas_orient, dtype=dtypes, precise_float=precise_float
+            path_or_str, orient=pandas_orient, dtype=dtypes, precise_float=precise_float, convert_dates=False
         )
         if not schema.is_tensor_spec():
             actual_cols = set(df.columns)
@@ -127,7 +127,7 @@ def _dataframe_from_json(
         return df
     else:
         return pd.read_json(
-            path_or_str, orient=pandas_orient, dtype=False, precise_float=precise_float
+            path_or_str, orient=pandas_orient, dtype=False, precise_float=precise_float, convert_dates=False
         )
 
 

--- a/tests/utils/test_proto_json_utils.py
+++ b/tests/utils/test_proto_json_utils.py
@@ -249,7 +249,16 @@ def test_dataframe_from_json():
             "binary": [bytes([1, 2, 3]), bytes([4, 5]), bytes([6])],
             "date_string": ["2018-02-03", "1996-03-02", "2021-03-05"],
         },
-        columns=["boolean", "string", "float", "double", "integer", "long", "binary", "date_string"],
+        columns=[
+            "boolean",
+            "string",
+            "float",
+            "double",
+            "integer",
+            "long",
+            "binary",
+            "date_string",
+        ],
     )
 
     jsonable_df = pd.DataFrame(source, copy=True)

--- a/tests/utils/test_proto_json_utils.py
+++ b/tests/utils/test_proto_json_utils.py
@@ -272,7 +272,7 @@ def test_dataframe_from_json():
             ColSpec("integer", "integer"),
             ColSpec("long", "long"),
             ColSpec("binary", "binary"),
-            ColSpec("date_string", "string"),
+            ColSpec("string", "date_string"),
         ]
     )
     parsed = _dataframe_from_json(

--- a/tests/utils/test_proto_json_utils.py
+++ b/tests/utils/test_proto_json_utils.py
@@ -247,8 +247,9 @@ def test_dataframe_from_json():
             "integer": np.array([3, 4, 5], dtype=np.int32),
             "long": np.array([3, 4, 5], dtype=np.int64),
             "binary": [bytes([1, 2, 3]), bytes([4, 5]), bytes([6])],
+            "date_string": ["2018-02-03", "1996-03-02", "2021-03-05"],
         },
-        columns=["boolean", "string", "float", "double", "integer", "long", "binary"],
+        columns=["boolean", "string", "float", "double", "integer", "long", "binary", "date_string"],
     )
 
     jsonable_df = pd.DataFrame(source, copy=True)
@@ -262,6 +263,7 @@ def test_dataframe_from_json():
             ColSpec("integer", "integer"),
             ColSpec("long", "long"),
             ColSpec("binary", "binary"),
+            ColSpec("date_string", "string"),
         ]
     )
     parsed = _dataframe_from_json(


### PR DESCRIPTION
Signed-off-by: Wendy Hu <wendy.hu@databricks.com>

## What changes are proposed in this pull request?

This fixes a bug during schema enforcement where date-like strings are cast to datetime objects when converting json to dataframes

## How is this patch tested?

unit tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
