### PR TITLE
Share button for experiment view state 

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentPage.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentPage.js
@@ -30,6 +30,7 @@ import {
   DEFAULT_ORDER_BY_KEY,
   DEFAULT_ORDER_BY_ASC,
   DEFAULT_START_TIME,
+  DEFAULT_CATEGORIZED_UNCHECKED_KEYS,
   ATTRIBUTE_COLUMN_SORT_KEY,
 } from '../constants';
 
@@ -87,6 +88,10 @@ export class ExperimentPage extends Component {
         orderByAsc:
           urlState.orderByAsc === undefined ? DEFAULT_ORDER_BY_ASC : urlState.orderByAsc === 'true',
         startTime: urlState.startTime === undefined ? DEFAULT_START_TIME : urlState.startTime,
+        categorizedUncheckedKeys:
+          urlState.categorizedUncheckedKeys === undefined
+            ? DEFAULT_CATEGORIZED_UNCHECKED_KEYS
+            : urlState.categorizedUncheckedKeys,
       },
     };
   }
@@ -244,6 +249,20 @@ export class ExperimentPage extends Component {
     return (!orderByKey && !searchInput) || orderByKey === ATTRIBUTE_COLUMN_SORT_KEY.DATE;
   }
 
+  handleColumnSelectionCheck = (categorizedUncheckedKeys) => {
+    this.setState(
+      {
+        persistedState: new ExperimentPagePersistedState({
+          ...this.state.persistedState,
+          categorizedUncheckedKeys,
+        }).toJSON(),
+      },
+      () => {
+        this.updateUrlWithSearchFilter({ categorizedUncheckedKeys });
+      },
+    );
+  };
+
   onSearch = (
     paramKeyFilterString,
     metricKeyFilterString,
@@ -253,6 +272,7 @@ export class ExperimentPage extends Component {
     orderByAsc,
     modelVersionFilterInput,
     startTime,
+    categorizedUncheckedKeys,
   ) => {
     this.updateUrlWithSearchFilter({
       paramKeyFilterString,
@@ -261,6 +281,7 @@ export class ExperimentPage extends Component {
       orderByKey,
       orderByAsc,
       startTime,
+      categorizedUncheckedKeys,
     });
 
     this.setState(
@@ -274,6 +295,7 @@ export class ExperimentPage extends Component {
           orderByKey,
           orderByAsc,
           startTime,
+          categorizedUncheckedKeys,
         }).toJSON(),
         lifecycleFilter: lifecycleFilterInput,
         modelVersionFilter: modelVersionFilterInput,
@@ -340,26 +362,31 @@ export class ExperimentPage extends Component {
     orderByKey,
     orderByAsc,
     startTime,
+    categorizedUncheckedKeys,
   }) {
     const state = {};
-    if (paramKeyFilterString) {
-      state['params'] = paramKeyFilterString;
+    if (paramKeyFilterString || this.state.persistedState.paramKeyFilterString) {
+      state['params'] = paramKeyFilterString || this.state.persistedState.paramKeyFilterString;
     }
-    if (metricKeyFilterString) {
-      state['metrics'] = metricKeyFilterString;
+    if (metricKeyFilterString || this.state.persistedState.metricKeyFilterString) {
+      state['metrics'] = metricKeyFilterString || this.state.persistedState.metricKeyFilterString;
     }
-    if (searchInput) {
-      state['search'] = searchInput;
+    if (searchInput || this.state.persistedState.searchInput) {
+      state['search'] = searchInput || this.state.persistedState.searchInput;
     }
-    if (startTime) {
-      state['startTime'] = startTime;
+    if (startTime || this.state.persistedState.startTime) {
+      state['startTime'] = startTime || this.state.persistedState.startTime;
     }
-    if (orderByKey) {
-      state['orderByKey'] = orderByKey;
+    if (orderByKey || this.state.persistedState.orderByKey) {
+      state['orderByKey'] = orderByKey || this.state.persistedState.orderByKey;
     }
     // orderByAsc defaults to true, so only encode it if it is false.
-    if (orderByAsc === false) {
-      state['orderByAsc'] = orderByAsc;
+    if (orderByAsc === false || this.state.persistedState.orderByAsc === false) {
+      state['orderByAsc'] = orderByAsc || this.state.persistedState.orderByAsc;
+    }
+    if (categorizedUncheckedKeys || this.state.persistedState.categorizedUncheckedKeys) {
+      state['categorizedUncheckedKeys'] =
+        categorizedUncheckedKeys || this.state.persistedState.categorizedUncheckedKeys;
     }
     const newUrl = `/experiments/${this.props.experimentId}/s?${Utils.getSearchUrlFromState(
       state,
@@ -397,6 +424,7 @@ export class ExperimentPage extends Component {
       orderByKey,
       orderByAsc,
       startTime,
+      categorizedUncheckedKeys,
     } = this.state.persistedState;
 
     const experimentViewProps = {
@@ -414,9 +442,11 @@ export class ExperimentPage extends Component {
       orderByKey: orderByKey,
       orderByAsc: orderByAsc,
       startTime: startTime,
+      categorizedUncheckedKeys: categorizedUncheckedKeys,
       nextPageToken: this.state.nextPageToken,
       numRunsFromLatestSearch: this.state.numRunsFromLatestSearch,
       handleLoadMoreRuns: this.handleLoadMoreRuns,
+      handleColumnSelectionCheck: this.handleColumnSelectionCheck.bind(this),
       loadingMore: this.state.loadingMore,
       nestChildren: this.shouldNestChildrenAndFetchParents(orderByKey, searchInput),
       numberOfNewRuns: this.state.numberOfNewRuns,

--- a/mlflow/server/js/src/experiment-tracking/constants.js
+++ b/mlflow/server/js/src/experiment-tracking/constants.js
@@ -47,6 +47,12 @@ export const DEFAULT_ORDER_BY_KEY = ATTRIBUTE_COLUMN_SORT_KEY.DATE;
 export const DEFAULT_ORDER_BY_ASC = false;
 export const DEFAULT_START_TIME = 'ALL';
 export const DEFAULT_EXPANDED_VALUE = false;
+export const DEFAULT_CATEGORIZED_UNCHECKED_KEYS = {
+  [COLUMN_TYPES.ATTRIBUTES]: [],
+  [COLUMN_TYPES.PARAMS]: [],
+  [COLUMN_TYPES.METRICS]: [],
+  [COLUMN_TYPES.TAGS]: [],
+};
 
 export const PAGINATION_DEFAULT_STATE = {
   nextPageToken: null,

--- a/mlflow/server/js/src/experiment-tracking/sdk/MlflowLocalStorageMessages.js
+++ b/mlflow/server/js/src/experiment-tracking/sdk/MlflowLocalStorageMessages.js
@@ -15,7 +15,7 @@
  *    local storage.
  */
 import Immutable from 'immutable';
-import { COLUMN_TYPES } from '../constants';
+import { DEFAULT_CATEGORIZED_UNCHECKED_KEYS } from '../constants';
 
 /**
  * This class wraps attributes of the ExperimentPage component's state that should be
@@ -36,6 +36,8 @@ export const ExperimentPagePersistedState = Immutable.Record(
     orderByAsc: false,
     // Filter key to show results based on start time
     startTime: null,
+    // Unchecked keys in the columns dropdown
+    categorizedUncheckedKeys: DEFAULT_CATEGORIZED_UNCHECKED_KEYS,
   },
   'ExperimentPagePersistedState',
 );
@@ -58,13 +60,6 @@ export const ExperimentViewPersistedState = Immutable.Record(
     // columns that have already been split out)
     unbaggedMetrics: [],
     unbaggedParams: [],
-    // Unchecked keys in the columns dropdown
-    categorizedUncheckedKeys: {
-      [COLUMN_TYPES.ATTRIBUTES]: [],
-      [COLUMN_TYPES.PARAMS]: [],
-      [COLUMN_TYPES.METRICS]: [],
-      [COLUMN_TYPES.TAGS]: [],
-    },
   },
   'ExperimentViewPersistedState',
 );


### PR DESCRIPTION
Signed-off-by: Marijn Valk <marijncv@hotmail.com>

## What changes are proposed in this pull request?

Added a button that will copy the current experiment view state to your clipboard so it can be shared. closes #4820 

## How is this patch tested?

Open an experiment, change some state (order by, column selected etc.) use the share button and open in another browser.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Introduced a "share" button that can be used to share a view / configuration of the MLflow experiment UI with other users

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
