### PR TITLE
Use `from_password` and `from_token` when constructing `DatabricksConfig`

### DIFF
--- a/tests/projects/test_databricks.py
+++ b/tests/projects/test_databricks.py
@@ -426,7 +426,7 @@ class MockProfileConfigProvider:
         assert profile == "my-profile"
 
     def get_config(self):
-        return DatabricksConfig("host", "user", "pass", None, insecure=False)
+        return DatabricksConfig.from_password("host", "user", "pass", insecure=False)
 
 
 @mock.patch("requests.Session.request")
@@ -453,7 +453,7 @@ def test_databricks_http_request_integration(get_config, request):
         return http_response
 
     request.side_effect = confirm_request_params
-    get_config.return_value = DatabricksConfig("host", "user", "pass", None, insecure=False)
+    get_config.return_value = DatabricksConfig.from_password("host", "user", "pass", insecure=False)
 
     response = DatabricksJobRunner(databricks_profile_uri=None)._databricks_api_request(
         "/clusters/list", "PUT", json={"a": "b"}

--- a/tests/projects/test_docker_projects.py
+++ b/tests/projects/test_docker_projects.py
@@ -111,8 +111,8 @@ def test_docker_project_tracking_uri_propagation(
     ProfileConfigProvider, tmpdir, tracking_uri, expected_command_segment, docker_example_base_image
 ):  # pylint: disable=unused-argument
     mock_provider = mock.MagicMock()
-    mock_provider.get_config.return_value = DatabricksConfig(
-        "host", "user", "pass", None, insecure=True
+    mock_provider.get_config.return_value = DatabricksConfig.from_password(
+        "host", "user", "pass", insecure=True
     )
     ProfileConfigProvider.return_value = mock_provider
     # Create and mock local tracking directory
@@ -196,8 +196,8 @@ def test_docker_mount_local_artifact_uri(
 @mock.patch("databricks_cli.configure.provider.ProfileConfigProvider")
 def test_docker_databricks_tracking_cmd_and_envs(ProfileConfigProvider):
     mock_provider = mock.MagicMock()
-    mock_provider.get_config.return_value = DatabricksConfig(
-        "host", "user", "pass", None, insecure=True
+    mock_provider.get_config.return_value = DatabricksConfig.from_password(
+        "host", "user", "pass", insecure=True
     )
     ProfileConfigProvider.return_value = mock_provider
 

--- a/tests/projects/test_projects.py
+++ b/tests/projects/test_projects.py
@@ -450,7 +450,7 @@ def test_credential_propagation(get_config, synchronous):
         def communicate(self, _):
             return "", ""
 
-    get_config.return_value = DatabricksConfig("host", None, None, "mytoken", insecure=False)
+    get_config.return_value = DatabricksConfig.from_token("host", "mytoken", insecure=False)
     with mock.patch("subprocess.Popen") as popen_mock, mock.patch(
         "mlflow.utils.uri.is_databricks_uri"
     ) as is_databricks_tracking_uri_mock:

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -26,7 +26,7 @@ def test_no_throw():
 
 @mock.patch("databricks_cli.configure.provider.get_config")
 def test_databricks_params_token(get_config):
-    get_config.return_value = DatabricksConfig("host", None, None, "mytoken", insecure=False)
+    get_config.return_value = DatabricksConfig.from_token("host", "mytoken", insecure=False)
     params = databricks_utils.get_databricks_host_creds()
     assert params.host == "host"
     assert params.token == "mytoken"
@@ -35,7 +35,7 @@ def test_databricks_params_token(get_config):
 
 @mock.patch("databricks_cli.configure.provider.get_config")
 def test_databricks_params_user_password(get_config):
-    get_config.return_value = DatabricksConfig("host", "user", "pass", None, insecure=False)
+    get_config.return_value = DatabricksConfig.from_password("host", "user", "pass", insecure=False)
     params = databricks_utils.get_databricks_host_creds()
     assert params.host == "host"
     assert params.username == "user"
@@ -44,7 +44,7 @@ def test_databricks_params_user_password(get_config):
 
 @mock.patch("databricks_cli.configure.provider.get_config")
 def test_databricks_params_no_verify(get_config):
-    get_config.return_value = DatabricksConfig("host", "user", "pass", None, insecure=True)
+    get_config.return_value = DatabricksConfig.from_password("host", "user", "pass", insecure=True)
     params = databricks_utils.get_databricks_host_creds()
     assert params.ignore_tls_verification
 
@@ -52,8 +52,8 @@ def test_databricks_params_no_verify(get_config):
 @mock.patch("databricks_cli.configure.provider.ProfileConfigProvider")
 def test_databricks_params_custom_profile(ProfileConfigProvider):
     mock_provider = mock.MagicMock()
-    mock_provider.get_config.return_value = DatabricksConfig(
-        "host", "user", "pass", None, insecure=True
+    mock_provider.get_config.return_value = DatabricksConfig.from_password(
+        "host", "user", "pass", insecure=True
     )
     ProfileConfigProvider.return_value = mock_provider
     params = databricks_utils.get_databricks_host_creds(construct_db_uri_from_profile("profile"))
@@ -187,8 +187,8 @@ def test_is_databricks_default_tracking_uri(tracking_uri, result):
 def test_databricks_params_throws_errors(ProfileConfigProvider):
     # No hostname
     mock_provider = mock.MagicMock()
-    mock_provider.get_config.return_value = DatabricksConfig(
-        None, "user", "pass", None, insecure=True
+    mock_provider.get_config.return_value = DatabricksConfig.from_password(
+        None, "user", "pass", insecure=True
     )
     ProfileConfigProvider.return_value = mock_provider
     with pytest.raises(Exception):
@@ -196,8 +196,8 @@ def test_databricks_params_throws_errors(ProfileConfigProvider):
 
     # No authentication
     mock_provider = mock.MagicMock()
-    mock_provider.get_config.return_value = DatabricksConfig(
-        "host", None, None, None, insecure=True
+    mock_provider.get_config.return_value = DatabricksConfig.from_password(
+        "host", None, None, insecure=True
     )
     ProfileConfigProvider.return_value = mock_provider
     with pytest.raises(Exception):


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Use `from_password` and `from_token` when constructing `DatabricksConfig` to simplify the code. 

## How is this patch tested?

Existing tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
