### PR TITLE
Run `test_databricks_utils.py` against the latest master version of `databricks-cli`

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -342,7 +342,7 @@ mleap:
       fi
       pytest tests/mleap/test_mleap_model_export.py --large
 
-mleap:
+databricks-cli:
   package_info:
     pip_release: "databricks-cli"
     install_dev: |

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -348,6 +348,6 @@ mleap:
     install_dev: |
       pip install git+https://github.com/databricks/databricks-cli.git
 
-  models:
+  tests:
     run: |
       pytest tests/utils/test_databricks_utils.py

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -349,5 +349,7 @@ databricks-cli:
       pip install git+https://github.com/databricks/databricks-cli.git
 
   tests:
+    minimum: "0.14.3"
+    maximum: "0.16.2"
     run: |
       pytest tests/utils/test_databricks_utils.py

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -341,3 +341,13 @@ mleap:
         exit 1
       fi
       pytest tests/mleap/test_mleap_model_export.py --large
+
+mleap:
+  package_info:
+    pip_release: "databricks-cli"
+    install_dev: |
+      pip install git+https://github.com/databricks/databricks-cli.git
+
+  models:
+    run: |
+      pytest tests/utils/test_databricks_utils.py


### PR DESCRIPTION
## What changes are proposed in this pull request?

Run `test_databricks_utils.py` against the latest master version of `databricks-cli`.

## How is this patch tested?

New tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
