### PR TITLE
Persist `preSwitchCategorizedUncheckedKeys` and `postSwitchCategorizedUncheckedKeys` to preserve the diff swtich state when switching experiments

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentView.js
@@ -170,10 +170,6 @@ export class ExperimentView extends Component {
       showDeleteRunModal: false,
       // True if a model for restoring one or more runs should be displayed
       showRestoreRunModal: false,
-      // Columns unselected before turning on the diff-view switch
-      preSwitchCategorizedUncheckedKeys: DEFAULT_CATEGORIZED_UNCHECKED_KEYS,
-      // Columns unselected as the result of turning on the diff-view switch
-      postSwitchCategorizedUncheckedKeys: DEFAULT_CATEGORIZED_UNCHECKED_KEYS,
     };
   }
 
@@ -1168,34 +1164,46 @@ export class ExperimentView extends Component {
   }
 
   handleDiffSwitchChange() {
-    this.setState(
-      {
-        persistedState: new ExperimentViewPersistedState({
-          ...this.state.persistedState,
-          diffSwitchSelected: !this.state.persistedState.diffSwitchSelected,
-        }).toJSON(),
-      },
-      () => {
-        let categorizedUncheckedKeys;
-        if (this.state.persistedState.diffSwitchSelected) {
-          categorizedUncheckedKeys = ExperimentViewUtil.getCategorizedUncheckedKeysDiffView({
-            ...this.props,
-            categorizedUncheckedKeys: this.state.persistedState.categorizedUncheckedKeys,
-          });
-          this.setState({
+    if (!this.state.persistedState.diffSwitchSelected) {
+      // When turning on the diff switch
+      const categorizedUncheckedKeys = ExperimentViewUtil.getCategorizedUncheckedKeysDiffView({
+        ...this.props,
+        categorizedUncheckedKeys: this.state.persistedState.categorizedUncheckedKeys,
+      });
+      this.setState(
+        {
+          persistedState: new ExperimentViewPersistedState({
+            ...this.state.persistedState,
+            diffSwitchSelected: !this.state.persistedState.diffSwitchSelected,
             preSwitchCategorizedUncheckedKeys: this.state.persistedState.categorizedUncheckedKeys,
             postSwitchCategorizedUncheckedKeys: categorizedUncheckedKeys,
-          });
-        } else {
-          categorizedUncheckedKeys = ExperimentViewUtil.getRestoredCategorizedUncheckedKeys({
-            preSwitchCategorizedUncheckedKeys: this.state.preSwitchCategorizedUncheckedKeys,
-            postSwitchCategorizedUncheckedKeys: this.state.postSwitchCategorizedUncheckedKeys,
-            currCategorizedUncheckedKeys: this.state.persistedState.categorizedUncheckedKeys,
-          });
-        }
-        this.handleColumnSelectionCheck(categorizedUncheckedKeys);
-      },
-    );
+          }).toJSON(),
+        },
+        () => {
+          this.handleColumnSelectionCheck(categorizedUncheckedKeys);
+        },
+      );
+    } else {
+      // When turning off the diff switch
+      const categorizedUncheckedKeys = ExperimentViewUtil.getRestoredCategorizedUncheckedKeys({
+        preSwitchCategorizedUncheckedKeys: this.state.persistedState
+          .preSwitchCategorizedUncheckedKeys,
+        postSwitchCategorizedUncheckedKeys: this.state.persistedState
+          .postSwitchCategorizedUncheckedKeys,
+        currCategorizedUncheckedKeys: this.state.persistedState.categorizedUncheckedKeys,
+      });
+      this.setState(
+        {
+          persistedState: new ExperimentViewPersistedState({
+            ...this.state.persistedState,
+            diffSwitchSelected: !this.state.persistedState.diffSwitchSelected,
+          }).toJSON(),
+        },
+        () => {
+          this.handleColumnSelectionCheck(categorizedUncheckedKeys);
+        },
+      );
+    }
   }
 
   onSearch = (e, searchInput) => {

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentView.js
@@ -57,7 +57,6 @@ import {
   DEFAULT_ORDER_BY_KEY,
   DEFAULT_ORDER_BY_ASC,
   DEFAULT_START_TIME,
-  DEFAULT_CATEGORIZED_UNCHECKED_KEYS,
   ATTRIBUTE_COLUMN_SORT_LABEL,
   ATTRIBUTE_COLUMN_SORT_KEY,
   COLUMN_SORT_BY_ASC,
@@ -1164,46 +1163,46 @@ export class ExperimentView extends Component {
   }
 
   handleDiffSwitchChange() {
+    let newCategorizedUncheckedKeys;
+    let switchPersistedState;
     if (!this.state.persistedState.diffSwitchSelected) {
       // When turning on the diff switch
-      const categorizedUncheckedKeys = ExperimentViewUtil.getCategorizedUncheckedKeysDiffView({
+      const { categorizedUncheckedKeys } = this.state.persistedState;
+      newCategorizedUncheckedKeys = ExperimentViewUtil.getCategorizedUncheckedKeysDiffView({
         ...this.props,
-        categorizedUncheckedKeys: this.state.persistedState.categorizedUncheckedKeys,
+        categorizedUncheckedKeys,
       });
-      this.setState(
-        {
-          persistedState: new ExperimentViewPersistedState({
-            ...this.state.persistedState,
-            diffSwitchSelected: !this.state.persistedState.diffSwitchSelected,
-            preSwitchCategorizedUncheckedKeys: this.state.persistedState.categorizedUncheckedKeys,
-            postSwitchCategorizedUncheckedKeys: categorizedUncheckedKeys,
-          }).toJSON(),
-        },
-        () => {
-          this.handleColumnSelectionCheck(categorizedUncheckedKeys);
-        },
-      );
+      switchPersistedState = {
+        preSwitchCategorizedUncheckedKeys: categorizedUncheckedKeys,
+        postSwitchCategorizedUncheckedKeys: newCategorizedUncheckedKeys,
+      };
     } else {
       // When turning off the diff switch
-      const categorizedUncheckedKeys = ExperimentViewUtil.getRestoredCategorizedUncheckedKeys({
-        preSwitchCategorizedUncheckedKeys: this.state.persistedState
-          .preSwitchCategorizedUncheckedKeys,
-        postSwitchCategorizedUncheckedKeys: this.state.persistedState
-          .postSwitchCategorizedUncheckedKeys,
-        currCategorizedUncheckedKeys: this.state.persistedState.categorizedUncheckedKeys,
+      const {
+        preSwitchCategorizedUncheckedKeys,
+        postSwitchCategorizedUncheckedKeys,
+        categorizedUncheckedKeys: currCategorizedUncheckedKeys,
+      } = this.state.persistedState;
+      newCategorizedUncheckedKeys = ExperimentViewUtil.getRestoredCategorizedUncheckedKeys({
+        preSwitchCategorizedUncheckedKeys,
+        postSwitchCategorizedUncheckedKeys,
+        currCategorizedUncheckedKeys,
       });
-      this.setState(
-        {
-          persistedState: new ExperimentViewPersistedState({
-            ...this.state.persistedState,
-            diffSwitchSelected: !this.state.persistedState.diffSwitchSelected,
-          }).toJSON(),
-        },
-        () => {
-          this.handleColumnSelectionCheck(categorizedUncheckedKeys);
-        },
-      );
+      switchPersistedState = {};
     }
+
+    this.setState(
+      {
+        persistedState: new ExperimentViewPersistedState({
+          ...this.state.persistedState,
+          diffSwitchSelected: !this.state.persistedState.diffSwitchSelected,
+          ...switchPersistedState,
+        }).toJSON(),
+      },
+      () => {
+        this.handleColumnSelectionCheck(newCategorizedUncheckedKeys);
+      },
+    );
   }
 
   onSearch = (e, searchInput) => {

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentView.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentView.test.js
@@ -498,13 +498,13 @@ describe('Diff Switch', () => {
 
     // Switch turned on
     instance.handleDiffSwitchChange();
-    expect(wrapper.state().preSwitchCategorizedUncheckedKeys).toEqual({
+    expect(wrapper.state().persistedState.preSwitchCategorizedUncheckedKeys).toEqual({
       [COLUMN_TYPES.ATTRIBUTES]: ['a2'],
       [COLUMN_TYPES.PARAMS]: ['p2'],
       [COLUMN_TYPES.METRICS]: ['m2'],
       [COLUMN_TYPES.TAGS]: ['t2'],
     });
-    expect(wrapper.state().postSwitchCategorizedUncheckedKeys).toEqual({
+    expect(wrapper.state().persistedState.postSwitchCategorizedUncheckedKeys).toEqual({
       [COLUMN_TYPES.ATTRIBUTES]: ['a1'],
       [COLUMN_TYPES.PARAMS]: ['p1'],
       [COLUMN_TYPES.METRICS]: ['m1'],

--- a/mlflow/server/js/src/experiment-tracking/sdk/MlflowLocalStorageMessages.js
+++ b/mlflow/server/js/src/experiment-tracking/sdk/MlflowLocalStorageMessages.js
@@ -15,7 +15,7 @@
  *    local storage.
  */
 import Immutable from 'immutable';
-import { COLUMN_TYPES, DEFAULT_CATEGORIZED_UNCHECKED_KEYS } from '../constants';
+import { DEFAULT_CATEGORIZED_UNCHECKED_KEYS } from '../constants';
 
 /**
  * This class wraps attributes of the ExperimentPage component's state that should be

--- a/mlflow/server/js/src/experiment-tracking/sdk/MlflowLocalStorageMessages.js
+++ b/mlflow/server/js/src/experiment-tracking/sdk/MlflowLocalStorageMessages.js
@@ -15,7 +15,7 @@
  *    local storage.
  */
 import Immutable from 'immutable';
-import { COLUMN_TYPES } from '../constants';
+import { COLUMN_TYPES, DEFAULT_CATEGORIZED_UNCHECKED_KEYS } from '../constants';
 
 /**
  * This class wraps attributes of the ExperimentPage component's state that should be
@@ -55,14 +55,11 @@ export const ExperimentViewPersistedState = Immutable.Record(
     unbaggedMetrics: [],
     unbaggedParams: [],
     // Unchecked keys in the columns dropdown
-    categorizedUncheckedKeys: {
-      [COLUMN_TYPES.ATTRIBUTES]: [],
-      [COLUMN_TYPES.PARAMS]: [],
-      [COLUMN_TYPES.METRICS]: [],
-      [COLUMN_TYPES.TAGS]: [],
-    },
+    categorizedUncheckedKeys: DEFAULT_CATEGORIZED_UNCHECKED_KEYS,
     // Switch to select only columns with differences
     diffSwitchSelected: false,
+    preSwitchCategorizedUncheckedKeys: DEFAULT_CATEGORIZED_UNCHECKED_KEYS,
+    postSwitchCategorizedUncheckedKeys: DEFAULT_CATEGORIZED_UNCHECKED_KEYS,
   },
   'ExperimentViewPersistedState',
 );

--- a/mlflow/server/js/src/experiment-tracking/sdk/MlflowLocalStorageMessages.js
+++ b/mlflow/server/js/src/experiment-tracking/sdk/MlflowLocalStorageMessages.js
@@ -58,7 +58,9 @@ export const ExperimentViewPersistedState = Immutable.Record(
     categorizedUncheckedKeys: DEFAULT_CATEGORIZED_UNCHECKED_KEYS,
     // Switch to select only columns with differences
     diffSwitchSelected: false,
+    // Columns unselected before turning on the diff-view switch
     preSwitchCategorizedUncheckedKeys: DEFAULT_CATEGORIZED_UNCHECKED_KEYS,
+    // Columns unselected as the result of turning on the diff-view switch
     postSwitchCategorizedUncheckedKeys: DEFAULT_CATEGORIZED_UNCHECKED_KEYS,
   },
   'ExperimentViewPersistedState',


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Persist `preSwitchCategorizedUncheckedKeys` and `postSwitchCategorizedUncheckedKeys` to preserve the diff swtich state when switching experiments.

## How is this patch tested?

Manual testing.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
