### PR TITLE
Set globally_configured flag correctly for spark and pyspark.ml autologging integration

### DIFF
--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1532,6 +1532,7 @@ def autolog(
     try:
         import pyspark as pyspark_module
         import pyspark.ml as pyspark_ml_module
+
         setup_autologging(pyspark_module)
         setup_autologging(pyspark_ml_module)
     except ImportError as ie:

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1530,8 +1530,10 @@ def autolog(
     # this is because on Databricks a SparkSession already exists and the user can directly
     #   interact with it, and this activity should be logged.
     try:
-        spark.autolog(**get_autologging_params(spark.autolog))
-        pyspark.ml.autolog(**get_autologging_params(pyspark.ml.autolog))
+        import pyspark as pyspark_module
+        import pyspark.ml as pyspark_ml_module
+        setup_autologging(pyspark_module)
+        setup_autologging(pyspark_ml_module)
     except ImportError as ie:
         # if pyspark isn't installed, a user could potentially install it in the middle
         #   of their session so we want to enable autologging once they do

--- a/tests/autologging/test_autologging_behaviors_integration.py
+++ b/tests/autologging/test_autologging_behaviors_integration.py
@@ -281,3 +281,24 @@ def test_autolog_respects_silent_mode(tmpdir):
     # `clean_up_leaked_runs` fixture in `tests/conftest.py` to fail.
     while mlflow.active_run():
         mlflow.end_run()
+
+
+def test_autolog_globally_configured_flag_set_correctly():
+    import sklearn  # pylint: disable=unused-import
+    import pyspark  # pylint: disable=unused-import
+    import pyspark.ml  # pylint: disable=unused-import
+    from mlflow.utils.autologging_utils import AUTOLOGGING_INTEGRATIONS
+
+    integration_to_test = ["sklearn", "spark", "pyspark.ml"]
+    mlflow.autolog()
+    for integration_name in integration_to_test:
+        assert AUTOLOGGING_INTEGRATIONS[integration_name]["globally_configured"]
+
+    mlflow.sklearn.autolog()
+    mlflow.tensorflow.autolog()
+    mlflow.keras.autolog()
+    mlflow.spark.autolog()
+    mlflow.pyspark.ml.autolog()
+
+    for integration_name in integration_to_test:
+        assert "globally_configured" not in AUTOLOGGING_INTEGRATIONS[integration_name]

--- a/tests/autologging/test_autologging_behaviors_integration.py
+++ b/tests/autologging/test_autologging_behaviors_integration.py
@@ -289,16 +289,14 @@ def test_autolog_globally_configured_flag_set_correctly():
     import pyspark.ml  # pylint: disable=unused-import
     from mlflow.utils.autologging_utils import AUTOLOGGING_INTEGRATIONS
 
-    integration_to_test = ["sklearn", "spark", "pyspark.ml"]
+    integrations_to_test = ["sklearn", "spark", "pyspark.ml"]
     mlflow.autolog()
-    for integration_name in integration_to_test:
+    for integration_name in integrations_to_test:
         assert AUTOLOGGING_INTEGRATIONS[integration_name]["globally_configured"]
 
     mlflow.sklearn.autolog()
-    mlflow.tensorflow.autolog()
-    mlflow.keras.autolog()
     mlflow.spark.autolog()
     mlflow.pyspark.ml.autolog()
 
-    for integration_name in integration_to_test:
+    for integration_name in integrations_to_test:
         assert "globally_configured" not in AUTOLOGGING_INTEGRATIONS[integration_name]

--- a/tests/autologging/test_autologging_behaviors_integration.py
+++ b/tests/autologging/test_autologging_behaviors_integration.py
@@ -284,10 +284,12 @@ def test_autolog_respects_silent_mode(tmpdir):
 
 
 def test_autolog_globally_configured_flag_set_correctly():
-    import sklearn  # pylint: disable=unused-import
-    import pyspark  # pylint: disable=unused-import
-    import pyspark.ml  # pylint: disable=unused-import
     from mlflow.utils.autologging_utils import AUTOLOGGING_INTEGRATIONS
+
+    AUTOLOGGING_INTEGRATIONS.clear()
+    import sklearn  # pylint: disable=unused-import,unused-variable
+    import pyspark  # pylint: disable=unused-import,unused-variable
+    import pyspark.ml  # pylint: disable=unused-import,unused-variable
 
     integrations_to_test = ["sklearn", "spark", "pyspark.ml"]
     mlflow.autolog()


### PR DESCRIPTION
Signed-off-by: Weichen Xu <weichen.xu@databricks.com>

## What changes are proposed in this pull request?

Set globally_configured flag correctly for spark and pyspark.ml autologging integration

## How is this patch tested?

Unit test.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
