### PR TITLE
Cache python dependencies to make CI build faster

### DIFF
--- a/.github/actions/cache-pip/action.yml
+++ b/.github/actions/cache-pip/action.yml
@@ -5,6 +5,7 @@ runs:
   steps:
     - name: Get cache key prefix
       id: get-cache-key-prefix
+      shell: bash
       run: |
         echo "::set-output name=prefix::$ImageOS-$ImageVersion"
     - uses: actions/cache@v2

--- a/.github/actions/cache-pip/action.yml
+++ b/.github/actions/cache-pip/action.yml
@@ -1,0 +1,15 @@
+name: "cache-pip"
+description: "Cache pip dependencies"
+runs:
+  using: "composite"
+  steps:
+    - name: Get cache key prefix
+      id: get-cache-key-prefix
+      run: |
+        echo "::set-output name=prefix::$ImageOS-$ImageVersion"
+    - uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ steps.get-cache-key-prefix.outputs.prefix }}-pip-${{ hashFiles('**/*-requirements.txt') }}
+        restore-keys: |
+          ${{ steps.get-cache-key-prefix.outputs.prefix }}-pip-

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -304,17 +304,12 @@ jobs:
         with:
           java-version: 8
           distribution: 'adopt'
-      - name: Get cache key prefix
-        id: get-cache-key-prefix
-        run: |
-          date=$(date -u "+%Y%m%d")
-          echo "::set-output name=key::$ImageOS-$ImageVersion-$date"
       - uses: actions/cache@v2
         with:
           path: ~/.cache/pip
-          key: ${{ steps.get-cache-key-prefix.outputs.key }}-pip-${{ hashFiles('**/*-requirements.txt') }}
+          key: ${{ env.ImageOS }}-${{ env.ImageVersion }}-pip-${{ hashFiles('**/*-requirements.txt') }}
           restore-keys: |
-            ${{ steps.get-cache-key-prefix.outputs.key }}-pip-
+            ${{ env.ImageOS }}-${{ env.ImageVersion }}-pip-
       - name: Install dependencies
         env:
           INSTALL_LARGE_PYTHON_DEPS: true

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -304,6 +304,17 @@ jobs:
         with:
           java-version: 8
           distribution: 'adopt'
+      - name: Get cache key prefix
+        id: get-cache-key-prefix
+        run: |
+          date=$(date -u "+%Y%m%d")
+          echo "::set-output name=key::$ImageOS-$ImageVersion-$date"
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ steps.get-cache-key-prefix.outputs.key }}-pip-${{ hashFiles('**/*-requirements.txt') }}
+          restore-keys: |
+            ${{ steps.get-cache-key-prefix.outputs.key }}-pip-
       - name: Install dependencies
         env:
           INSTALL_LARGE_PYTHON_DEPS: true

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -330,7 +330,6 @@ jobs:
           INSTALL_SMALL_PYTHON_DEPS: true
         run: |
           source ./dev/install-common-deps.sh
-          pip install --upgrade --no-deps --force-reinstall prophet
       - name: Run tests
         env:
           SPARK_LOCAL_IP: 127.0.0.1

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -37,6 +37,7 @@ jobs:
     - uses: ./.github/actions/setup-python
       with:
         python-version: 3.6
+    - uses: ./.github/actions/cache-pip
     - name: Install dependencies
       env:
         INSTALL_LARGE_PYTHON_DEPS: true
@@ -202,6 +203,7 @@ jobs:
         # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md#java
         java-version: 8
         distribution: 'adopt'
+    - uses: ./.github/actions/cache-pip
     - name: Install dependencies
       env:
         INSTALL_LARGE_PYTHON_DEPS: true
@@ -314,16 +316,7 @@ jobs:
         with:
           java-version: 8
           distribution: 'adopt'
-      - name: Get cache key prefix
-        id: get-cache-key-prefix
-        run: |
-          echo "::set-output name=prefix::$ImageOS-$ImageVersion"
-      - uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ steps.get-cache-key-prefix.outputs.prefix }}-pip-${{ hashFiles('**/*-requirements.txt') }}
-          restore-keys: |
-            ${{ steps.get-cache-key-prefix.outputs.prefix }}-pip-
+      - uses: ./.github/actions/cache-pip
       - name: Install dependencies
         env:
           INSTALL_LARGE_PYTHON_DEPS: true

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -330,6 +330,7 @@ jobs:
           INSTALL_SMALL_PYTHON_DEPS: true
         run: |
           source ./dev/install-common-deps.sh
+          pip install --upgrade --no-deps --force-reinstall prophet
       - name: Run tests
         env:
           SPARK_LOCAL_IP: 127.0.0.1

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -307,9 +307,9 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ~/.cache/pip
-          key: ${{ env.ImageOS }}-${{ env.ImageVersion }}-pip-${{ hashFiles('**/*-requirements.txt') }}
+          key: ${{ env.IMAGE_OS }}-${{ env.IMAGE_VERSION }}-pip-${{ hashFiles('**/*-requirements.txt') }}
           restore-keys: |
-            ${{ env.ImageOS }}-${{ env.ImageVersion }}-pip-
+            ${{ env.IMAGE_OS }}-${{ env.IMAGE_VERSION }}-pip-
       - name: Install dependencies
         env:
           INSTALL_LARGE_PYTHON_DEPS: true

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -304,12 +304,16 @@ jobs:
         with:
           java-version: 8
           distribution: 'adopt'
+      - name: Get cache key prefix
+        id: get-cache-key-prefix
+        run: |
+          echo "::set-output name=prefix::$ImageOS-$ImageVersion"
       - uses: actions/cache@v2
         with:
           path: ~/.cache/pip
-          key: ${{ env.IMAGE_OS }}-${{ env.IMAGE_VERSION }}-pip-${{ hashFiles('**/*-requirements.txt') }}
+          key: ${{ steps.get-cache-key-prefix.outputs.prefix }}-pip-${{ hashFiles('**/*-requirements.txt') }}
           restore-keys: |
-            ${{ env.IMAGE_OS }}-${{ env.IMAGE_VERSION }}-pip-
+            ${{ steps.get-cache-key-prefix.outputs.prefix }}-pip-
       - name: Install dependencies
         env:
           INSTALL_LARGE_PYTHON_DEPS: true

--- a/dev/install-common-deps.sh
+++ b/dev/install-common-deps.sh
@@ -39,6 +39,14 @@ if [[ "$INSTALL_SKINNY_PYTHON_DEPS" == "true" ]]; then
 fi
 if [[ "$INSTALL_LARGE_PYTHON_DEPS" == "true" ]]; then
   retry-with-backoff pip install -r ./dev/large-requirements.txt
+
+  # Install prophet's dependencies beforehand, otherwise pip would fail to build a wheel for prophet
+  tmp_dir=$(mktemp -d)
+  pip download --no-deps --dest $tmp_dir prophet
+  tar -zxvf $tmp_dir/*.tar.gz -C $tmp_dir
+  pip install -r $(find $tmp_dir -name requirements.txt)
+  rm -rf $tmp_dir
+
   retry-with-backoff pip install -r ./dev/extra-ml-requirements.txt
 fi
 

--- a/dev/install-common-deps.sh
+++ b/dev/install-common-deps.sh
@@ -41,6 +41,7 @@ if [[ "$INSTALL_LARGE_PYTHON_DEPS" == "true" ]]; then
   retry-with-backoff pip install -r ./dev/large-requirements.txt
 
   # Install prophet's dependencies beforehand, otherwise pip would fail to build a wheel for prophet
+  pip cache list prophet --format abspath
   tmp_dir=$(mktemp -d)
   pip download --no-deps --dest $tmp_dir --no-cache-dir prophet
   tar -zxvf $tmp_dir/*.tar.gz -C $tmp_dir

--- a/dev/install-common-deps.sh
+++ b/dev/install-common-deps.sh
@@ -17,7 +17,7 @@ sudo apt clean
 df -h
 
 python --version
-pip install --upgrade pip
+pip install --upgrade pip wheel
 pip --version
 
 if [[ "$MLFLOW_SKINNY" == "true" ]]; then

--- a/dev/install-common-deps.sh
+++ b/dev/install-common-deps.sh
@@ -41,11 +41,11 @@ if [[ "$INSTALL_LARGE_PYTHON_DEPS" == "true" ]]; then
   retry-with-backoff pip install -r ./dev/large-requirements.txt
 
   # Install prophet's dependencies beforehand, otherwise pip would fail to build a wheel for prophet
-  # tmp_dir=$(mktemp -d)
-  # pip download --no-deps --dest $tmp_dir prophet
-  # tar -zxvf $tmp_dir/*.tar.gz -C $tmp_dir
-  # pip install -r $(find $tmp_dir -name requirements.txt)
-  # rm -rf $tmp_dir
+  tmp_dir=$(mktemp -d)
+  pip download --no-deps --dest $tmp_dir --no-cache-dir prophet
+  tar -zxvf $tmp_dir/*.tar.gz -C $tmp_dir
+  pip install -r $(find $tmp_dir -name requirements.txt)
+  rm -rf $tmp_dir
 
   retry-with-backoff pip install -r ./dev/extra-ml-requirements.txt
 fi

--- a/dev/install-common-deps.sh
+++ b/dev/install-common-deps.sh
@@ -41,11 +41,11 @@ if [[ "$INSTALL_LARGE_PYTHON_DEPS" == "true" ]]; then
   retry-with-backoff pip install -r ./dev/large-requirements.txt
 
   # Install prophet's dependencies beforehand, otherwise pip would fail to build a wheel for prophet
-  tmp_dir=$(mktemp -d)
-  pip download --no-deps --dest $tmp_dir prophet
-  tar -zxvf $tmp_dir/*.tar.gz -C $tmp_dir
-  pip install -r $(find $tmp_dir -name requirements.txt)
-  rm -rf $tmp_dir
+  # tmp_dir=$(mktemp -d)
+  # pip download --no-deps --dest $tmp_dir prophet
+  # tar -zxvf $tmp_dir/*.tar.gz -C $tmp_dir
+  # pip install -r $(find $tmp_dir -name requirements.txt)
+  # rm -rf $tmp_dir
 
   retry-with-backoff pip install -r ./dev/extra-ml-requirements.txt
 fi

--- a/dev/install-common-deps.sh
+++ b/dev/install-common-deps.sh
@@ -41,12 +41,13 @@ if [[ "$INSTALL_LARGE_PYTHON_DEPS" == "true" ]]; then
   retry-with-backoff pip install -r ./dev/large-requirements.txt
 
   # Install prophet's dependencies beforehand, otherwise pip would fail to build a wheel for prophet
-  pip cache list prophet --format abspath
-  tmp_dir=$(mktemp -d)
-  pip download --no-deps --dest $tmp_dir --no-cache-dir prophet
-  tar -zxvf $tmp_dir/*.tar.gz -C $tmp_dir
-  pip install -r $(find $tmp_dir -name requirements.txt)
-  rm -rf $tmp_dir
+  if [[ -z "$(pip cache list prophet --format abspath)" ]]; then
+    tmp_dir=$(mktemp -d)
+    pip download --no-deps --dest $tmp_dir --no-cache-dir prophet
+    tar -zxvf $tmp_dir/*.tar.gz -C $tmp_dir
+    pip install -r $(find $tmp_dir -name requirements.txt)
+    rm -rf $tmp_dir
+  fi
 
   retry-with-backoff pip install -r ./dev/extra-ml-requirements.txt
 fi


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

Cache python dependencies to make CI build faster.

## How is this patch tested?

NA

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
