### PR TITLE
Avoid using conda when running tests

### DIFF
--- a/.github/actions/setup-python-conda/action.yml
+++ b/.github/actions/setup-python-conda/action.yml
@@ -21,7 +21,7 @@ runs:
       shell: bash
       run: |
         latest_micro_version=$(
-          $CONDA/bin/conda search -c conda-forge python=${{ inputs.python-version }} |
+          $CONDA/bin/conda search -c conda-forge python={{ inputs.python-version }} |
           tail -1 | tr -s ' ' | cut -d' ' -f2
         )
         echo "::set-output name=version::$latest_micro_version"

--- a/.github/actions/setup-python-conda/action.yml
+++ b/.github/actions/setup-python-conda/action.yml
@@ -18,13 +18,13 @@ runs:
     # - `mlflow serve` tries to create an environment to serve the model via conda,
     #   but fails to find 'python=3.6.13' on Anaconda.
     - name: fetch-python-version
+      id: fetch-python-version
       shell: bash
       run: |
         latest_micro_version=$(
           $CONDA/bin/conda search -c conda-forge python=${{ inputs.python-version }} |
           tail -1 | tr -s ' ' | cut -d' ' -f2
         )
-        echo $latest_micro_version
         echo "::set-output name=version::$latest_micro_version"
     - uses: actions/setup-python@v2
       with:

--- a/.github/actions/setup-python-conda/action.yml
+++ b/.github/actions/setup-python-conda/action.yml
@@ -18,6 +18,7 @@ runs:
     # - `mlflow serve` tries to create an environment to serve the model via conda,
     #   but fails to find 'python=3.6.13' on Anaconda.
     - name: fetch-python-version
+      shell: bash
       run: |
         latest_micro_version=$(
           $CONDA/bin/conda search -c conda-forge python=$python_version |

--- a/.github/actions/setup-python-conda/action.yml
+++ b/.github/actions/setup-python-conda/action.yml
@@ -21,9 +21,10 @@ runs:
       shell: bash
       run: |
         latest_micro_version=$(
-          $CONDA/bin/conda search -c conda-forge python={{ inputs.python-version }} |
+          $CONDA/bin/conda search -c conda-forge python=${{ inputs.python-version }} |
           tail -1 | tr -s ' ' | cut -d' ' -f2
         )
+        echo $latest_micro_version
         echo "::set-output name=version::$latest_micro_version"
     - uses: actions/setup-python@v2
       with:

--- a/.github/actions/setup-python-conda/action.yml
+++ b/.github/actions/setup-python-conda/action.yml
@@ -21,7 +21,7 @@ runs:
       shell: bash
       run: |
         latest_micro_version=$(
-          $CONDA/bin/conda search -c conda-forge python=$python_version |
+          $CONDA/bin/conda search -c conda-forge python=${{ inputs.python-version }} |
           tail -1 | tr -s ' ' | cut -d' ' -f2
         )
         echo "::set-output name=version::$latest_micro_version"

--- a/.github/actions/setup-python-conda/action.yml
+++ b/.github/actions/setup-python-conda/action.yml
@@ -11,12 +11,13 @@ outputs:
 runs:
   using: "composite"
   steps:
-    # What would happen if we skipped this step and set `python-version` of `actions/setup-python@v2 to '3.6'?
-    # - `actions/setup-python` automatically selects 3.6.13 (the latest micro version of 3.6),
-    #   but it's new and not available yet on Anaconda.
-    # - MLflow logs 'python=3.6.13' in `conda.yaml` when logging a model.
+    # What would happen if we skipped this step?
+    # - Let's say we set `python-version` of the `setup-python` action to '3.6'.
+    # - The `setup-python` action automatically selects 3.6.x (the latest micro version of 3.6).
+    #   If 3.6.x is new, it may not be available yet on Anaconda.
+    # - MLflow logs 'python=3.6.x' in `conda.yaml` when logging a model.
     # - `mlflow serve` tries to create an environment to serve the model via conda,
-    #   but fails to find 'python=3.6.13' on Anaconda.
+    #   but fails to find 'python=3.6.x' on Anaconda.
     - name: fetch-python-version
       id: fetch-python-version
       shell: bash

--- a/.github/actions/setup-python-conda/action.yml
+++ b/.github/actions/setup-python-conda/action.yml
@@ -1,0 +1,29 @@
+name: "setup-python-conda"
+description: "Ensures to install a python version that's available on Anaconda"
+inputs:
+  python-version:
+    description: "The python version to install (e.g. 3.6)"
+    required: true
+outputs:
+  installed-python-version:
+    description: "The installed python version"
+    value: ${{ steps.fetch-python-version.outputs.version }}
+runs:
+  using: "composite"
+  steps:
+    # What would happen if we skipped this step and set `python-version` of `actions/setup-python@v2 to '3.6'?
+    # - `actions/setup-python` automatically selects 3.6.13 (the latest micro version of 3.6),
+    #   but it's new and not available yet on Anaconda.
+    # - MLflow logs 'python=3.6.13' in `conda.yaml` when logging a model.
+    # - `mlflow serve` tries to create an environment to serve the model via conda,
+    #   but fails to find 'python=3.6.13' on Anaconda.
+    - name: fetch-python-version
+      run: |
+        latest_micro_version=$(
+          $CONDA/bin/conda search -c conda-forge python=$python_version |
+          tail -1 | tr -s ' ' | cut -d' ' -f2
+        )
+        echo "::set-output name=version::$latest_micro_version"
+    - uses: actions/setup-python@v2
+      with:
+        python-version: ${{ steps.fetch-python-version.outputs.version }}

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -1,4 +1,4 @@
-name: "setup-python-conda"
+name: "setup-python"
 description: "Ensures to install a python version that's available on Anaconda"
 inputs:
   python-version:

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -11,15 +11,15 @@ outputs:
 runs:
   using: "composite"
   steps:
-    # What would happen if we skipped this step?
-    # - Let's say we set `python-version` of the `setup-python` action to '3.6'.
-    # - The `setup-python` action automatically selects 3.6.x (the latest micro version of 3.6).
-    #   If 3.6.x is new, it may not be available yet on Anaconda.
-    # - MLflow logs 'python=3.6.x' in `conda.yaml` when logging a model.
-    # - `mlflow serve` tries to create an environment to serve the model via conda,
-    #   but fails to find 'python=3.6.x' on Anaconda.
     - name: fetch-python-version
       id: fetch-python-version
+      # What would happen if we skipped this step and directly pass `python-version` to the `setup-python` action?
+      # - Let's say the value of `python-version` is 3.6.
+      # - The `setup-python` action automatically selects 3.6.x (the latest available version of 3.6).
+      #   If 3.6.x is new, it may not be available on Anaconda yet.
+      # - mlflow logs a model and creates `conda.yaml` with 'python=3.6.x'.
+      # - `mlflow serve` tries to create an environment to serve the model via conda,
+      #   but fails to find 'python=3.6.x' on Anaconda.
       shell: bash
       run: |
         latest_micro_version=$(

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -121,7 +121,7 @@ jobs:
             python_version=3.6
           fi
           echo "::set-output name=version::$python_version"
-      - uses: ./.github/actions/setup-python-conda
+      - uses: ./.github/actions/setup-python
         with:
           python-version: ${{ steps.get-python-version.outputs.version }}
       - name: Get cache key

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -120,13 +120,10 @@ jobs:
           else
             python_version=3.6
           fi
-          # Use a python version that exists on Anaconda to ensure `mlflow serve` can successfully
-          # create a conda environment for serving an MLflow model.
-          latest_micro_version=$($CONDA/bin/conda search python | grep -F $python_version | tail -1 | tr -s ' ' | cut -d' ' -f2)
-          echo "::set-output name=python-version::$latest_micro_version"
-      - uses: actions/setup-python@v2
+          echo "::set-output name=version::$python_version"
+      - uses: ./.github/actions/setup-python-conda
         with:
-          python-version: ${{ steps.get-python-version.outputs.python-version }}
+          python-version: ${{ steps.get-python-version.outputs.version }}
       - name: Get cache key
         env:
           INSTALL_COMMAND: ${{ matrix.install }}

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -16,7 +16,7 @@ defaults:
     shell: bash
 
 env:
-  CONDA_DIR: /usr/share/miniconda
+  MLFLOW_CONDA_HOME: /usr/share/miniconda
 
 jobs:
   examples:
@@ -45,9 +45,9 @@ jobs:
         echo "EXAMPLES_CHANGED: $EXAMPLES_CHANGED"
         echo "::set-output name=examples_changed::$EXAMPLES_CHANGED"
 
-    - name: Enable conda
-      run: |
-        echo "/usr/share/miniconda/bin" >> $GITHUB_PATH
+    - uses: ./.github/actions/setup-python-conda
+      with:
+        python-version: 3.6
 
     - name: Install dependencies
       if: ${{ github.event_name == 'schedule' || steps.check-diff.outputs.examples_changed == 'true' }}
@@ -62,7 +62,6 @@ jobs:
       env:
         SPARK_LOCAL_IP: 127.0.0.1
       run: |
-        source activate test-environment
         pytest tests/examples --durations=30 --large
 
     - name: Remove conda environments

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -45,7 +45,7 @@ jobs:
         echo "EXAMPLES_CHANGED: $EXAMPLES_CHANGED"
         echo "::set-output name=examples_changed::$EXAMPLES_CHANGED"
 
-    - uses: ./.github/actions/setup-python-conda
+    - uses: ./.github/actions/setup-python
       with:
         python-version: 3.6
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -152,6 +152,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: ./.github/actions/setup-python-conda
+      with:
+        python-version: 3.6
     - name: Install dependencies
       env:
         INSTALL_SKINNY_PYTHON_DEPS: true
@@ -160,8 +163,6 @@ jobs:
         source ./dev/install-common-deps.sh
     - name: Run tests
       run: |
-        export PATH="$CONDA_DIR/bin:$PATH"
-        source activate test-environment
         ./dev/run-python-skinny-tests.sh
 
   python-small:
@@ -189,6 +190,9 @@ jobs:
         # Increase available disk space by removing unnecessary tool chains:
         # https://github.com/actions/virtual-environments/issues/709#issuecomment-612569242
         rm -rf "$AGENT_TOOLSDIRECTORY"
+    - uses: ./.github/actions/setup-python-conda
+      with:
+        python-version: 3.6
     - uses: actions/setup-java@v2
       with:
         # GitHub Actions' Ubuntu 20.04 image uses Java 11 (which is incompatible with Spark 2.4.x) by default:
@@ -206,8 +210,6 @@ jobs:
         # Fix for https://github.com/mlflow/mlflow/issues/4229
         SPARK_LOCAL_IP: 127.0.0.1
       run: |
-        export PATH="$CONDA_DIR/bin:$PATH"
-        source activate test-environment
         ./dev/run-large-python-tests.sh
     - name: Run database initialization tests
       run: |
@@ -235,6 +237,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: ./.github/actions/setup-python-conda
+      with:
+        python-version: 3.6
     - name: Set up Java
       uses: actions/setup-java@v2
       with:
@@ -247,8 +252,6 @@ jobs:
       env:
         SPARK_LOCAL_IP: 127.0.0.1
       run: |
-        export PATH="$CONDA_DIR/bin:$PATH"
-        source activate test-environment
         cd mlflow/java
         mvn clean package -q
 
@@ -301,6 +304,9 @@ jobs:
           # Increase available disk space by removing unnecessary tool chains:
           # https://github.com/actions/virtual-environments/issues/709#issuecomment-612569242
           rm -rf "$AGENT_TOOLSDIRECTORY"
+      - uses: ./.github/actions/setup-python-conda
+        with:
+          python-version: 3.6
       - uses: actions/setup-java@v2
         with:
           java-version: 8
@@ -315,8 +321,6 @@ jobs:
         env:
           SPARK_LOCAL_IP: 127.0.0.1
         run: |
-          export PATH="$CONDA_DIR/bin:$PATH"
-          source activate test-environment
           # Install libopenblas-dev for mxnet 1.8.0.post0
           sudo apt-get install libopenblas-dev
           ./dev/run-python-flavor-tests.sh;
@@ -327,6 +331,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: ./.github/actions/setup-python-conda
+        with:
+          python-version: 3.6
       - uses: actions/setup-java@v2
         with:
           java-version: 8
@@ -342,8 +349,6 @@ jobs:
         env:
           SPARK_LOCAL_IP: 127.0.0.1
         run: |
-          export PATH="$CONDA_DIR/bin:$PATH"
-          source activate test-environment
           export MLFLOW_HOME=$(pwd)
           pytest tests/models --large
 
@@ -371,6 +376,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: ./.github/actions/setup-python-conda
+        with:
+          python-version: 3.6
       - uses: actions/setup-java@v2
         with:
           java-version: 8
@@ -385,8 +393,6 @@ jobs:
         env:
           SPARK_LOCAL_IP: 127.0.0.1
         run: |
-          export PATH="$CONDA_DIR/bin:$PATH"
-          source activate test-environment
           ./dev/run-python-sagemaker-tests.sh;
 
   windows:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -25,6 +25,8 @@ defaults:
     shell: bash
 
 env:
+  # Note miniconda is pre-installed in for GitHub Actions' virtual-environments:
+  # https://github.com/actions/virtual-environments/blob/main/images/linux/scripts/installers/miniconda.sh
   MLFLOW_CONDA_HOME: /usr/share/miniconda
 
 jobs:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -25,7 +25,7 @@ defaults:
     shell: bash
 
 env:
-  CONDA_DIR: /usr/share/miniconda
+  MLFLOW_CONDA_HOME: /usr/share/miniconda
 
 jobs:
   lint:
@@ -178,8 +178,6 @@ jobs:
         source ./dev/install-common-deps.sh
     - name: Run tests
       run: |
-        export PATH="$CONDA_DIR/bin:$PATH"
-        source activate test-environment
         ./dev/run-small-python-tests.sh
 
   python-large:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -25,7 +25,7 @@ defaults:
     shell: bash
 
 env:
-  # Note miniconda is pre-installed in for GitHub Actions' virtual-environments:
+  # Note miniconda is pre-installed in the virtual environments for GitHub Actions:
   # https://github.com/actions/virtual-environments/blob/main/images/linux/scripts/installers/miniconda.sh
   MLFLOW_CONDA_HOME: /usr/share/miniconda
 
@@ -34,6 +34,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: ./.github/actions/setup-python-conda
+      with:
+        python-version: 3.6
     - name: Install dependencies
       env:
         INSTALL_LARGE_PYTHON_DEPS: true
@@ -43,8 +46,6 @@ jobs:
         pip install -r ./dev/lint-requirements.txt
     - name: Run tests
       run: |
-        export PATH="$CONDA_DIR/bin:$PATH"
-        source activate test-environment
         ./lint.sh
   r:
     runs-on: ubuntu-latest

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: ./.github/actions/setup-python-conda
+    - uses: ./.github/actions/setup-python
       with:
         python-version: 3.6
     - name: Install dependencies
@@ -155,7 +155,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: ./.github/actions/setup-python-conda
+    - uses: ./.github/actions/setup-python
       with:
         python-version: 3.6
     - name: Install dependencies
@@ -172,7 +172,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: ./.github/actions/setup-python-conda
+    - uses: ./.github/actions/setup-python
       with:
         python-version: 3.6
     - name: Install dependencies
@@ -193,7 +193,7 @@ jobs:
         # Increase available disk space by removing unnecessary tool chains:
         # https://github.com/actions/virtual-environments/issues/709#issuecomment-612569242
         rm -rf "$AGENT_TOOLSDIRECTORY"
-    - uses: ./.github/actions/setup-python-conda
+    - uses: ./.github/actions/setup-python
       with:
         python-version: 3.6
     - uses: actions/setup-java@v2
@@ -240,7 +240,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: ./.github/actions/setup-python-conda
+    - uses: ./.github/actions/setup-python
       with:
         python-version: 3.6
     - name: Set up Java
@@ -307,7 +307,7 @@ jobs:
           # Increase available disk space by removing unnecessary tool chains:
           # https://github.com/actions/virtual-environments/issues/709#issuecomment-612569242
           rm -rf "$AGENT_TOOLSDIRECTORY"
-      - uses: ./.github/actions/setup-python-conda
+      - uses: ./.github/actions/setup-python
         with:
           python-version: 3.6
       - uses: actions/setup-java@v2
@@ -334,7 +334,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: ./.github/actions/setup-python-conda
+      - uses: ./.github/actions/setup-python
         with:
           python-version: 3.6
       - uses: actions/setup-java@v2
@@ -379,7 +379,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: ./.github/actions/setup-python-conda
+      - uses: ./.github/actions/setup-python
         with:
           python-version: 3.6
       - uses: actions/setup-java@v2

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -168,6 +168,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: ./.github/actions/setup-python-conda
+      with:
+        python-version: 3.6
     - name: Install dependencies
       env:
         INSTALL_SMALL_PYTHON_DEPS: true

--- a/dev/install-common-deps.sh
+++ b/dev/install-common-deps.sh
@@ -43,7 +43,7 @@ if [[ "$INSTALL_LARGE_PYTHON_DEPS" == "true" ]]; then
   # Hack: make sure all spark-* scripts are executable.
   # Conda installs 2 version spark-* scripts and makes the ones spark
   # uses not executable. This is a temporary fix to unblock the tests.
-  SITE_PACKAGES_DIR=$(python -c "import site; print (site.getsitepackages())[0]")
+  SITE_PACKAGES_DIR=$(python -c "import site; print(site.getsitepackages()[0])")
   ls -lha $(find $SITE_PACKAGES_DIR -path "*bin/spark-*")
   chmod 777 $(find $SITE_PACKAGES_DIR -path "*bin/spark-*")
   ls -lha $(find $SITE_PACKAGES_DIR -path "*bin/spark-*")

--- a/dev/install-common-deps.sh
+++ b/dev/install-common-deps.sh
@@ -40,13 +40,6 @@ fi
 if [[ "$INSTALL_LARGE_PYTHON_DEPS" == "true" ]]; then
   retry-with-backoff pip install -r ./dev/large-requirements.txt
   retry-with-backoff pip install -r ./dev/extra-ml-requirements.txt
-  # Hack: make sure all spark-* scripts are executable.
-  # Conda installs 2 version spark-* scripts and makes the ones spark
-  # uses not executable. This is a temporary fix to unblock the tests.
-  SITE_PACKAGES_DIR=$(python -c "import site; print(site.getsitepackages()[0])")
-  ls -lha $(find $SITE_PACKAGES_DIR -path "*bin/spark-*")
-  chmod 777 $(find $SITE_PACKAGES_DIR -path "*bin/spark-*")
-  ls -lha $(find $SITE_PACKAGES_DIR -path "*bin/spark-*")
 fi
 
 # Install `mlflow-test-plugin` without dependencies

--- a/dev/install-common-deps.sh
+++ b/dev/install-common-deps.sh
@@ -16,28 +16,6 @@ function retry-with-backoff() {
 sudo apt clean
 df -h
 
-# Miniconda is pre-installed in the virtual-environments for GitHub Actions.
-# See this repository: https://github.com/actions/virtual-environments
-CONDA_DIR=/usr/share/miniconda
-export PATH="$CONDA_DIR/bin:$PATH"
-hash -r
-conda config --set always_yes yes --set changeps1 no
-conda config --add channels conda-forge
-conda config --remove channels defaults
-conda config --get channels
-# Useful for debugging any issues with conda
-conda info -a
-conda create -q -n test-environment python=3.6
-# Uninstall `certifi` via conda to avoid encoutering the following error when installing `mlflow` via pip
-# ```
-#   Attempting uninstall: certifi
-#     Found existing installation: certifi 2016.9.26
-# ERROR: Cannot uninstall 'certifi'. It is a distutils installed project and thus we cannot
-# accurately determine which files belong to it which would lead to only a partial uninstall.
-# ```
-conda remove --name test-environment --force certifi
-source activate test-environment
-
 python --version
 pip install --upgrade pip
 pip --version
@@ -65,9 +43,10 @@ if [[ "$INSTALL_LARGE_PYTHON_DEPS" == "true" ]]; then
   # Hack: make sure all spark-* scripts are executable.
   # Conda installs 2 version spark-* scripts and makes the ones spark
   # uses not executable. This is a temporary fix to unblock the tests.
-  ls -lha $(find $CONDA_DIR/envs/test-environment/ -path "*bin/spark-*")
-  chmod 777 $(find $CONDA_DIR/envs/test-environment/ -path "*bin/spark-*")
-  ls -lha $(find $CONDA_DIR/envs/test-environment/ -path "*bin/spark-*")
+  SITE_PACKAGES_DIR=$(python -m site --user-site)
+  ls -lha $(find $SITE_PACKAGES_DIR -path "*bin/spark-*")
+  chmod 777 $(find $SITE_PACKAGES_DIR -path "*bin/spark-*")
+  ls -lha $(find $SITE_PACKAGES_DIR -path "*bin/spark-*")
 fi
 
 # Install `mlflow-test-plugin` without dependencies

--- a/dev/install-common-deps.sh
+++ b/dev/install-common-deps.sh
@@ -43,7 +43,7 @@ if [[ "$INSTALL_LARGE_PYTHON_DEPS" == "true" ]]; then
   # Hack: make sure all spark-* scripts are executable.
   # Conda installs 2 version spark-* scripts and makes the ones spark
   # uses not executable. This is a temporary fix to unblock the tests.
-  SITE_PACKAGES_DIR=$(python -m site --user-site)
+  SITE_PACKAGES_DIR=$(python -c "import site; print (site.getsitepackages())[0]")
   ls -lha $(find $SITE_PACKAGES_DIR -path "*bin/spark-*")
   chmod 777 $(find $SITE_PACKAGES_DIR -path "*bin/spark-*")
   ls -lha $(find $SITE_PACKAGES_DIR -path "*bin/spark-*")

--- a/tests/projects/backend/test_local.py
+++ b/tests/projects/backend/test_local.py
@@ -51,7 +51,7 @@ def test_docker_gcs_artifact_cmd_and_envs_from_home():
         "GOOGLE_APPLICATION_CREDENTIALS": "mock_credentials_path",
     }
     gs_uri = "gs://mock_bucket"
-    with mock.patch.dict("os.environ", mock_env):
+    with mock.patch.dict("os.environ", mock_env, clear=True):
         cmds, envs = _get_docker_artifact_storage_cmd_and_envs(gs_uri)
         assert cmds == ["-v", "mock_credentials_path:/.gcs"]
         assert envs == {"GOOGLE_APPLICATION_CREDENTIALS": "/.gcs"}
@@ -64,7 +64,7 @@ def test_docker_hdfs_artifact_cmd_and_envs_from_home():
         "MLFLOW_PYARROW_EXTRA_CONF": "mock_pyarrow_extra_conf",
     }
     hdfs_uri = "hdfs://host:8020/path"
-    with mock.patch.dict("os.environ", mock_env):
+    with mock.patch.dict("os.environ", mock_env, clear=True):
         cmds, envs = _get_docker_artifact_storage_cmd_and_envs(hdfs_uri)
         assert cmds == ["-v", "/mock_ticket_cache:/mock_ticket_cache"]
         assert envs == mock_env

--- a/tests/projects/test_projects.py
+++ b/tests/projects/test_projects.py
@@ -301,7 +301,7 @@ def test_run_async():
 )
 def test_conda_path(mock_env, expected_conda, expected_activate):
     """Verify that we correctly determine the path to conda executables"""
-    with mock.patch.dict("os.environ", mock_env):
+    with mock.patch.dict("os.environ", mock_env, clear=True):
         assert mlflow.utils.conda.get_conda_bin_executable("conda") == expected_conda
         assert mlflow.utils.conda.get_conda_bin_executable("activate") == expected_activate
 
@@ -329,7 +329,7 @@ def test_find_conda_executables(mock_env, expected_conda_env_create_path):
     Verify that we correctly determine the path to executables to be used to
     create environments (for example, it could be mamba instead of conda)
     """
-    with mock.patch.dict("os.environ", mock_env):
+    with mock.patch.dict("os.environ", mock_env, clear=True):
         conda_env_create_path = mlflow.utils.conda._get_conda_executable_for_create_env()
         assert conda_env_create_path == expected_conda_env_create_path
 

--- a/tests/projects/test_projects.py
+++ b/tests/projects/test_projects.py
@@ -3,6 +3,7 @@ import os
 import git
 import shutil
 import yaml
+import subprocess
 
 import pytest
 from unittest import mock
@@ -89,19 +90,8 @@ def test_invalid_run_mode():
 def test_use_conda():
     """ Verify that we correctly handle the `use_conda` argument."""
     # Verify we throw an exception when conda is unavailable
-    old_path = os.environ["PATH"]
-    env.unset_variable("PATH")
-    conda_exe_path = ""
-    if "CONDA_EXE" in os.environ:
-        conda_exe_path = os.environ["CONDA_EXE"]
-        env.unset_variable("CONDA_EXE")
-    try:
-        with pytest.raises(ExecutionException):
-            mlflow.projects.run(TEST_PROJECT_DIR, use_conda=True)
-    finally:
-        os.environ["PATH"] = old_path
-        if conda_exe_path:
-            os.environ["CONDA_EXE"] = conda_exe_path
+    with mock.patch.dict("os.environ", {}, clear=True), pytest.raises(ExecutionException):
+        mlflow.projects.run(TEST_PROJECT_DIR, use_conda=True)
 
 
 @pytest.mark.large

--- a/tests/projects/test_projects.py
+++ b/tests/projects/test_projects.py
@@ -90,9 +90,6 @@ def test_use_conda():
     """ Verify that we correctly handle the `use_conda` argument."""
     # Verify we throw an exception when conda is unavailable
     with mock.patch.dict("os.environ", {}, clear=True):
-        with pytest.raises(subprocess.CalledProcessError, match="non-zero exit status 1"):
-            subprocess.run(["which", "conda"], check=True)
-
         with pytest.raises(ExecutionException):
             mlflow.projects.run(TEST_PROJECT_DIR, use_conda=True)
 

--- a/tests/projects/test_projects.py
+++ b/tests/projects/test_projects.py
@@ -3,7 +3,6 @@ import os
 import git
 import shutil
 import yaml
-import subprocess
 
 import pytest
 from unittest import mock

--- a/tests/projects/test_projects.py
+++ b/tests/projects/test_projects.py
@@ -17,7 +17,6 @@ from mlflow.exceptions import ExecutionException, MlflowException
 from mlflow.projects import _parse_kubernetes_config
 from mlflow.projects import _resolve_experiment_id
 from mlflow.store.tracking.file_store import FileStore
-from mlflow.utils import env
 from mlflow.utils.mlflow_tags import (
     MLFLOW_PARENT_RUN_ID,
     MLFLOW_USER,
@@ -90,8 +89,12 @@ def test_invalid_run_mode():
 def test_use_conda():
     """ Verify that we correctly handle the `use_conda` argument."""
     # Verify we throw an exception when conda is unavailable
-    with mock.patch.dict("os.environ", {}, clear=True), pytest.raises(ExecutionException):
-        mlflow.projects.run(TEST_PROJECT_DIR, use_conda=True)
+    with mock.patch.dict("os.environ", {}, clear=True):
+        with pytest.raises(subprocess.CalledProcessError, match="non-zero exit status 1"):
+            subprocess.run(["which", "conda"], check=True)
+
+        with pytest.raises(ExecutionException):
+            mlflow.projects.run(TEST_PROJECT_DIR, use_conda=True)
 
 
 @pytest.mark.large


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

Avoid using `conda` when running CI checks.

## How is this patch tested?

Existing checks

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
