### PR TITLE
Unpin `pytest`

### DIFF
--- a/dev/skinny-requirements.txt
+++ b/dev/skinny-requirements.txt
@@ -1,3 +1,3 @@
 ## Test-only dependencies
-pytest==3.2.1
-pytest-cov==2.6.0
+pytest
+pytest-cov

--- a/dev/small-requirements.txt
+++ b/dev/small-requirements.txt
@@ -6,8 +6,8 @@ scipy
 # execute schema consistency checks, the semantics of which were changed in sqlalchemy 1.3.21
 sqlalchemy>=1.3.21
 ## Test-only dependencies
-pytest==3.2.1
-pytest-cov==2.6.0
+pytest
+pytest-cov
 pytest-localserver==0.5.0
 moto!=2.0.7
 azure-storage-blob>=12.0.0

--- a/tests/autologging/fixtures.py
+++ b/tests/autologging/fixtures.py
@@ -49,8 +49,7 @@ def test_mode_off():
             del os.environ[_AUTOLOGGING_TEST_MODE_ENV_VAR]
 
 
-@pytest.fixture
-def test_mode_on():
+def _test_mode_on():
     try:
         prev_env_var_value = os.environ.pop(_AUTOLOGGING_TEST_MODE_ENV_VAR, None)
         os.environ[_AUTOLOGGING_TEST_MODE_ENV_VAR] = "true"
@@ -61,6 +60,9 @@ def test_mode_on():
             os.environ[_AUTOLOGGING_TEST_MODE_ENV_VAR] = prev_env_var_value
         else:
             del os.environ[_AUTOLOGGING_TEST_MODE_ENV_VAR]
+
+
+test_mode_on = pytest.fixture(_test_mode_on)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/autologging/fixtures.py
+++ b/tests/autologging/fixtures.py
@@ -49,7 +49,7 @@ def test_mode_off():
             del os.environ[_AUTOLOGGING_TEST_MODE_ENV_VAR]
 
 
-def _test_mode_on():
+def enable_test_mode():
     try:
         prev_env_var_value = os.environ.pop(_AUTOLOGGING_TEST_MODE_ENV_VAR, None)
         os.environ[_AUTOLOGGING_TEST_MODE_ENV_VAR] = "true"
@@ -64,7 +64,7 @@ def _test_mode_on():
 
 @pytest.fixture
 def test_mode_on():
-    yield from _test_mode_on()
+    yield from enable_test_mode()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/autologging/fixtures.py
+++ b/tests/autologging/fixtures.py
@@ -62,7 +62,9 @@ def _test_mode_on():
             del os.environ[_AUTOLOGGING_TEST_MODE_ENV_VAR]
 
 
-test_mode_on = pytest.fixture(_test_mode_on)
+@pytest.fixture
+def test_mode_on():
+    yield from _test_mode_on()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/autologging/test_autologging_client.py
+++ b/tests/autologging/test_autologging_client.py
@@ -281,5 +281,5 @@ def test_logging_failures_are_handled_as_expected():
 
         assert "Failed to perform one or more operations on the run with ID {run_id}".format(
             run_id=run.info.run_id
-        ) in str(exc)
+        ) in str(exc.value)
         assert "Batch logging failed!" in str(exc.value)

--- a/tests/autologging/test_autologging_client.py
+++ b/tests/autologging/test_autologging_client.py
@@ -282,4 +282,4 @@ def test_logging_failures_are_handled_as_expected():
         assert "Failed to perform one or more operations on the run with ID {run_id}".format(
             run_id=run.info.run_id
         ) in str(exc)
-        assert "Batch logging failed!" in str(exc)
+        assert "Batch logging failed!" in str(exc.value)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import pytest
 import mlflow
 from mlflow.utils.file_utils import path_to_local_sqlite_uri
 
-from tests.autologging.fixtures import _test_mode_on
+from tests.autologging.fixtures import enable_test_mode
 
 
 @pytest.fixture
@@ -46,7 +46,7 @@ def enable_test_mode_by_default_for_autologging_integrations():
     are raised and detected. For more information about autologging test mode, see the docstring
     for :py:func:`mlflow.utils.autologging_utils._is_testing()`.
     """
-    yield from _test_mode_on()
+    yield from enable_test_mode()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import pytest
 import mlflow
 from mlflow.utils.file_utils import path_to_local_sqlite_uri
 
-from tests.autologging.fixtures import test_mode_on
+from tests.autologging.fixtures import _test_mode_on
 
 
 @pytest.fixture
@@ -46,7 +46,7 @@ def enable_test_mode_by_default_for_autologging_integrations():
     are raised and detected. For more information about autologging test mode, see the docstring
     for :py:func:`mlflow.utils.autologging_utils._is_testing()`.
     """
-    yield from test_mode_on()
+    yield from _test_mode_on()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/fastai/test_fastai_autolog.py
+++ b/tests/fastai/test_fastai_autolog.py
@@ -256,7 +256,7 @@ def test_fastai_autolog_model_can_load_from_artifact(fastai_random_tabular_data_
     model_wrapper.predict(iris_dataframe())
 
 
-def _fastai_random_data_run_with_callback(
+def get_fastai_random_data_run_with_callback(
     iris_data, fit_variant, manual_run, callback, patience, tmpdir
 ):
     # pylint: disable=unused-argument
@@ -287,7 +287,7 @@ def _fastai_random_data_run_with_callback(
 def fastai_random_data_run_with_callback(
     iris_data, fit_variant, manual_run, callback, patience, tmpdir
 ):
-    return _fastai_random_data_run_with_callback(
+    return get_fastai_random_data_run_with_callback(
         iris_data, fit_variant, manual_run, callback, patience, tmpdir
     )
 
@@ -411,7 +411,7 @@ def test_fastai_autolog_batch_metrics_logger_logs_expected_metrics(
             original(self, metrics, step)
 
         record_metrics_mock.side_effect = record_metrics_side_effect
-        _, run = _fastai_random_data_run_with_callback(
+        _, run = get_fastai_random_data_run_with_callback(
             iris_data, fit_variant, manual_run, callback, patience, tmpdir
         )
 

--- a/tests/fastai/test_fastai_autolog.py
+++ b/tests/fastai/test_fastai_autolog.py
@@ -256,8 +256,7 @@ def test_fastai_autolog_model_can_load_from_artifact(fastai_random_tabular_data_
     model_wrapper.predict(iris_dataframe())
 
 
-@pytest.fixture
-def fastai_random_data_run_with_callback(
+def _fastai_random_data_run_with_callback(
     iris_data, fit_variant, manual_run, callback, patience, tmpdir
 ):
     # pylint: disable=unused-argument
@@ -282,6 +281,16 @@ def fastai_random_data_run_with_callback(
 
     client = mlflow.tracking.MlflowClient()
     return model, client.get_run(client.list_run_infos(experiment_id="0")[0].run_id)
+
+
+@pytest.fixture
+def fastai_random_data_run_with_callback(
+    iris_data, fit_variant, manual_run, callback, patience, tmpdir
+):
+    # pylint: disable=unused-argument
+    return _fastai_random_data_run_with_callback(
+        iris_data, fit_variant, manual_run, callback, patience, tmpdir
+    )
 
 
 @pytest.mark.large
@@ -403,7 +412,7 @@ def test_fastai_autolog_batch_metrics_logger_logs_expected_metrics(
             original(self, metrics, step)
 
         record_metrics_mock.side_effect = record_metrics_side_effect
-        _, run = fastai_random_data_run_with_callback(
+        _, run = _fastai_random_data_run_with_callback(
             iris_data, fit_variant, manual_run, callback, patience, tmpdir
         )
 

--- a/tests/fastai/test_fastai_autolog.py
+++ b/tests/fastai/test_fastai_autolog.py
@@ -213,9 +213,9 @@ def test_fastai_autolog_opt_func_expected_data(iris_data, fit_variant, manual_ru
 
 @pytest.mark.large
 @pytest.mark.parametrize("log_models", [True, False])
-def test_fastai_autolog_log_models_configuration(log_models):
+def test_fastai_autolog_log_models_configuration(log_models, iris_data):
     mlflow.fastai.autolog(log_models=log_models)
-    model = fastai_tabular_model(iris_data())
+    model = fastai_tabular_model(iris_data)
     model.fit(NUM_EPOCHS)
 
     client = mlflow.tracking.MlflowClient()
@@ -386,7 +386,7 @@ def test_fastai_autolog_non_early_stop_callback_does_not_log(fastai_random_data_
 @pytest.mark.parametrize("callback", ["not-early"])
 @pytest.mark.parametrize("patience", [5])
 def test_fastai_autolog_batch_metrics_logger_logs_expected_metrics(
-    fit_variant, callback, patience, tmpdir
+    fit_variant, callback, patience, tmpdir, iris_data
 ):
     patched_metrics_data = []
 
@@ -404,7 +404,7 @@ def test_fastai_autolog_batch_metrics_logger_logs_expected_metrics(
 
         record_metrics_mock.side_effect = record_metrics_side_effect
         _, run = fastai_random_data_run_with_callback(
-            iris_data(), fit_variant, manual_run, callback, patience, tmpdir
+            iris_data, fit_variant, manual_run, callback, patience, tmpdir
         )
 
     patched_metrics_data = dict(patched_metrics_data)

--- a/tests/fastai/test_fastai_autolog.py
+++ b/tests/fastai/test_fastai_autolog.py
@@ -287,7 +287,6 @@ def _fastai_random_data_run_with_callback(
 def fastai_random_data_run_with_callback(
     iris_data, fit_variant, manual_run, callback, patience, tmpdir
 ):
-    # pylint: disable=unused-argument
     return _fastai_random_data_run_with_callback(
         iris_data, fit_variant, manual_run, callback, patience, tmpdir
     )

--- a/tests/gluon_autolog/test_gluon_autolog.py
+++ b/tests/gluon_autolog/test_gluon_autolog.py
@@ -57,7 +57,7 @@ def get_train_prefix():
     return "train" if is_mxnet_older_than_1_6_0() else "training"
 
 
-def _gluon_random_data_run(log_models=True):
+def get_gluon_random_data_run(log_models=True):
     mlflow.gluon.autolog(log_models)
 
     with mlflow.start_run() as run:
@@ -88,7 +88,7 @@ def _gluon_random_data_run(log_models=True):
 
 @pytest.fixture
 def gluon_random_data_run(log_models=True):
-    return _gluon_random_data_run(log_models)
+    return get_gluon_random_data_run(log_models)
 
 
 @pytest.mark.large
@@ -128,7 +128,7 @@ def test_gluon_autolog_batch_metrics_logger_logs_expected_metrics():
             original(self, metrics, step)
 
         record_metrics_mock.side_effect = record_metrics_side_effect
-        run = _gluon_random_data_run()
+        run = get_gluon_random_data_run()
 
     patched_metrics_data = dict(patched_metrics_data)
     original_metrics = run.data.metrics
@@ -155,7 +155,7 @@ def test_gluon_autolog_model_can_load_from_artifact(gluon_random_data_run):
 @pytest.mark.large
 @pytest.mark.parametrize("log_models", [True, False])
 def test_gluon_autolog_log_models_configuration(log_models):
-    random_data_run = _gluon_random_data_run(log_models)
+    random_data_run = get_gluon_random_data_run(log_models)
     client = mlflow.tracking.MlflowClient()
     artifacts = client.list_artifacts(random_data_run.info.run_id)
     artifacts = list(map(lambda x: x.path, artifacts))

--- a/tests/gluon_autolog/test_gluon_autolog.py
+++ b/tests/gluon_autolog/test_gluon_autolog.py
@@ -57,8 +57,7 @@ def get_train_prefix():
     return "train" if is_mxnet_older_than_1_6_0() else "training"
 
 
-@pytest.fixture
-def gluon_random_data_run(log_models=True):
+def _gluon_random_data_run(log_models=True):
     mlflow.gluon.autolog(log_models)
 
     with mlflow.start_run() as run:
@@ -85,6 +84,11 @@ def gluon_random_data_run(log_models=True):
             est.fit(data, epochs=3, val_data=validation)
     client = mlflow.tracking.MlflowClient()
     return client.get_run(run.info.run_id)
+
+
+@pytest.fixture
+def gluon_random_data_run(log_models=True):
+    return _gluon_random_data_run(log_models)
 
 
 @pytest.mark.large
@@ -124,7 +128,7 @@ def test_gluon_autolog_batch_metrics_logger_logs_expected_metrics():
             original(self, metrics, step)
 
         record_metrics_mock.side_effect = record_metrics_side_effect
-        run = gluon_random_data_run()
+        run = _gluon_random_data_run()
 
     patched_metrics_data = dict(patched_metrics_data)
     original_metrics = run.data.metrics
@@ -151,7 +155,7 @@ def test_gluon_autolog_model_can_load_from_artifact(gluon_random_data_run):
 @pytest.mark.large
 @pytest.mark.parametrize("log_models", [True, False])
 def test_gluon_autolog_log_models_configuration(log_models):
-    random_data_run = gluon_random_data_run(log_models)
+    random_data_run = _gluon_random_data_run(log_models)
     client = mlflow.tracking.MlflowClient()
     artifacts = client.list_artifacts(random_data_run.info.run_id)
     artifacts = list(map(lambda x: x.path, artifacts))

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -87,7 +87,7 @@ def data():
     return x, y
 
 
-def _model(data):
+def get_model(data):
     x, y = data
     model = Sequential()
     model.add(Dense(3, input_dim=4))
@@ -109,10 +109,10 @@ def _model(data):
 
 @pytest.fixture(scope="module")
 def model(data):
-    return _model(data)
+    return get_model(data)
 
 
-def _tf_keras_model(data):
+def get_tf_keras_model(data):
     x, y = data
     model = TfSequential()
     model.add(TfDense(3, input_dim=4))
@@ -124,7 +124,7 @@ def _tf_keras_model(data):
 
 @pytest.fixture(scope="module")
 def tf_keras_model(data):
-    return _tf_keras_model(data)
+    return get_tf_keras_model(data)
 
 
 @pytest.fixture(scope="module")
@@ -255,13 +255,18 @@ def test_that_keras_module_arg_works(model_path):
 
 @pytest.mark.parametrize(
     "build_model,save_format",
-    [(_model, None), (_tf_keras_model, None), (_tf_keras_model, "h5"), (_tf_keras_model, "tf")],
+    [
+        (get_model, None),
+        (get_tf_keras_model, None),
+        (get_tf_keras_model, "h5"),
+        (get_tf_keras_model, "tf"),
+    ],
 )
 @pytest.mark.large
 def test_model_save_load(build_model, save_format, model_path, data):
     x, _ = data
     keras_model = build_model(data)
-    if build_model == _tf_keras_model:
+    if build_model == get_tf_keras_model:
         model_path = os.path.join(model_path, "tf")
     else:
         model_path = os.path.join(model_path, "plain")

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -87,8 +87,7 @@ def data():
     return x, y
 
 
-@pytest.fixture(scope="module")
-def model(data):
+def _model(data):
     x, y = data
     model = Sequential()
     model.add(Dense(3, input_dim=4))
@@ -109,7 +108,11 @@ def model(data):
 
 
 @pytest.fixture(scope="module")
-def tf_keras_model(data):
+def model(data):
+    return _model(data)
+
+
+def _tf_keras_model(data):
     x, y = data
     model = TfSequential()
     model.add(TfDense(3, input_dim=4))
@@ -117,6 +120,11 @@ def tf_keras_model(data):
     model.compile(loss="mean_squared_error", optimizer=TfSGD(learning_rate=0.001))
     model.fit(x.values, y.values)
     return model
+
+
+@pytest.fixture(scope="module")
+def tf_keras_model(data):
+    return _tf_keras_model(data)
 
 
 @pytest.fixture(scope="module")
@@ -247,13 +255,13 @@ def test_that_keras_module_arg_works(model_path):
 
 @pytest.mark.parametrize(
     "build_model,save_format",
-    [(model, None), (tf_keras_model, None), (tf_keras_model, "h5"), (tf_keras_model, "tf")],
+    [(_model, None), (_tf_keras_model, None), (_tf_keras_model, "h5"), (_tf_keras_model, "tf")],
 )
 @pytest.mark.large
 def test_model_save_load(build_model, save_format, model_path, data):
     x, _ = data
     keras_model = build_model(data)
-    if build_model == tf_keras_model:
+    if build_model == _tf_keras_model:
         model_path = os.path.join(model_path, "tf")
     else:
         model_path = os.path.join(model_path, "plain")

--- a/tests/keras_autolog/test_keras_autolog.py
+++ b/tests/keras_autolog/test_keras_autolog.py
@@ -152,8 +152,7 @@ def test_keras_autolog_model_can_load_from_artifact(keras_random_data_run, rando
     model.predict(random_train_data)
 
 
-@pytest.fixture
-def keras_random_data_run_with_callback(
+def _keras_random_data_run_with_callback(
     random_train_data,
     random_one_hot_labels,
     manual_run,
@@ -192,6 +191,27 @@ def keras_random_data_run_with_callback(
 
     client = mlflow.tracking.MlflowClient()
     return client.get_run(client.list_run_infos(experiment_id="0")[0].run_id), history, callback
+
+
+@pytest.fixture
+def keras_random_data_run_with_callback(
+    random_train_data,
+    random_one_hot_labels,
+    manual_run,
+    callback,
+    restore_weights,
+    patience,
+    initial_epoch,
+):
+    return _keras_random_data_run_with_callback(
+        random_train_data,
+        random_one_hot_labels,
+        manual_run,
+        callback,
+        restore_weights,
+        patience,
+        initial_epoch,
+    )
 
 
 @pytest.mark.large
@@ -258,7 +278,7 @@ def test_keras_autolog_early_stop_logs(keras_random_data_run_with_callback, init
 @pytest.mark.parametrize("patience", patience_values)
 @pytest.mark.parametrize("initial_epoch", [0, 10])
 def test_keras_autolog_batch_metrics_logger_logs_expected_metrics(
-    callback, restore_weights, patience, initial_epoch
+    callback, restore_weights, patience, initial_epoch, random_train_data, random_one_hot_labels
 ):
     patched_metrics_data = []
 
@@ -275,9 +295,9 @@ def test_keras_autolog_batch_metrics_logger_logs_expected_metrics(
             original(self, metrics, step)
 
         record_metrics_mock.side_effect = record_metrics_side_effect
-        run, _, callback = keras_random_data_run_with_callback(
-            random_train_data(),
-            random_one_hot_labels(),
+        run, _, callback = _keras_random_data_run_with_callback(
+            random_train_data,
+            random_one_hot_labels,
             manual_run,
             callback,
             restore_weights,

--- a/tests/keras_autolog/test_keras_autolog.py
+++ b/tests/keras_autolog/test_keras_autolog.py
@@ -152,7 +152,7 @@ def test_keras_autolog_model_can_load_from_artifact(keras_random_data_run, rando
     model.predict(random_train_data)
 
 
-def _keras_random_data_run_with_callback(
+def get_keras_random_data_run_with_callback(
     random_train_data,
     random_one_hot_labels,
     manual_run,
@@ -203,7 +203,7 @@ def keras_random_data_run_with_callback(
     patience,
     initial_epoch,
 ):
-    return _keras_random_data_run_with_callback(
+    return get_keras_random_data_run_with_callback(
         random_train_data,
         random_one_hot_labels,
         manual_run,
@@ -295,7 +295,7 @@ def test_keras_autolog_batch_metrics_logger_logs_expected_metrics(
             original(self, metrics, step)
 
         record_metrics_mock.side_effect = record_metrics_side_effect
-        run, _, callback = _keras_random_data_run_with_callback(
+        run, _, callback = get_keras_random_data_run_with_callback(
             random_train_data,
             random_one_hot_labels,
             manual_run,

--- a/tests/paddle/test_paddle_model_export.py
+++ b/tests/paddle/test_paddle_model_export.py
@@ -288,8 +288,8 @@ class UCIHousing(paddle.nn.Layer):
 
 
 @pytest.fixture
-def pd_model_built_in_high_level_api():
-    train_dataset, test_dataset = get_dataset_built_in_high_level_api()
+def pd_model_built_in_high_level_api(get_dataset_built_in_high_level_api):
+    train_dataset, test_dataset = get_dataset_built_in_high_level_api
 
     model = paddle.Model(UCIHousing())
     optim = paddle.optimizer.Adam(learning_rate=0.01, parameters=model.parameters())
@@ -388,12 +388,15 @@ def model_retrain_path(tmpdir):
 @pytest.mark.large
 @pytest.mark.allow_infer_pip_requirements_fallback
 def test_model_retrain_built_in_high_level_api(
-    pd_model_built_in_high_level_api, model_path, model_retrain_path
+    pd_model_built_in_high_level_api,
+    model_path,
+    model_retrain_path,
+    get_dataset_built_in_high_level_api,
 ):
     model = pd_model_built_in_high_level_api.model
     mlflow.paddle.save_model(pd_model=model, path=model_path, training=True)
 
-    training_dataset, test_dataset = get_dataset_built_in_high_level_api()
+    training_dataset, test_dataset = get_dataset_built_in_high_level_api
 
     model_retrain = paddle.Model(UCIHousing())
     model_retrain = mlflow.paddle.load_model(model_uri=model_path, model=model_retrain)
@@ -435,9 +438,11 @@ def test_model_retrain_built_in_high_level_api(
 
 
 @pytest.mark.large
-def test_log_model_built_in_high_level_api(pd_model_built_in_high_level_api, model_path, tmpdir):
+def test_log_model_built_in_high_level_api(
+    pd_model_built_in_high_level_api, model_path, tmpdir, get_dataset_built_in_high_level_api
+):
     model = pd_model_built_in_high_level_api.model
-    _, test_dataset = get_dataset_built_in_high_level_api()
+    test_dataset = get_dataset_built_in_high_level_api[1]
 
     try:
         artifact_path = "model"

--- a/tests/paddle/test_paddle_model_export.py
+++ b/tests/paddle/test_paddle_model_export.py
@@ -31,7 +31,6 @@ from tests.helper_functions import pyfunc_serve_and_score_model, _assert_pip_req
 ModelWithData = namedtuple("ModelWithData", ["model", "inference_dataframe"])
 
 
-@pytest.fixture(scope="session")
 def get_dataset():
     X, y = load_boston(return_X_y=True)
 

--- a/tests/prophet/test_prophet_model_export.py
+++ b/tests/prophet/test_prophet_model_export.py
@@ -133,7 +133,6 @@ def future_horizon_df(model, horizon):
     return model.make_future_dataframe(periods=horizon)
 
 
-@pytest.fixture
 def generate_forecast(model, horizon):
     return model.predict(model.make_future_dataframe(periods=horizon))[TARGET_FIELD_NAME]
 

--- a/tests/prophet/test_prophet_model_export.py
+++ b/tests/prophet/test_prophet_model_export.py
@@ -129,7 +129,6 @@ def prophet_custom_env(tmpdir):
     return conda_env
 
 
-@pytest.fixture
 def future_horizon_df(model, horizon):
     return model.make_future_dataframe(periods=horizon)
 

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -598,9 +598,7 @@ def test_save_model_with_wrong_codepaths_fails_correctly(
         mlflow.pytorch.save_model(
             path=model_path, pytorch_model=module_scoped_subclassed_model, code_paths="some string"
         )
-    assert "TypeError: Argument code_paths should be a list, not {}".format(type("")) in str(
-        exc_info.value
-    )
+    assert "Argument code_paths should be a list, not {}".format(type("")) in str(exc_info.value)
     assert not os.path.exists(model_path)
 
 

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -590,7 +590,7 @@ def test_pyfunc_model_serving_with_module_scoped_subclassed_model_and_default_co
     )
 
 
-def test_save_model_with_wrong_codepaths_fails_corrrectly(
+def test_save_model_with_wrong_codepaths_fails_correctly(
     module_scoped_subclassed_model, model_path, data
 ):
     # pylint: disable=unused-argument
@@ -599,7 +599,7 @@ def test_save_model_with_wrong_codepaths_fails_corrrectly(
             path=model_path, pytorch_model=module_scoped_subclassed_model, code_paths="some string"
         )
     assert "TypeError: Argument code_paths should be a list, not {}".format(type("")) in str(
-        exc_info
+        exc_info.value
     )
     assert not os.path.exists(model_path)
 

--- a/tests/shap/test_log.py
+++ b/tests/shap/test_log.py
@@ -121,22 +121,25 @@ def test_sklearn_log_explainer_pyfunc():
 
 
 def test_log_explanation_doesnt_create_autologged_run():
-    mlflow.sklearn.autolog(disable=False, exclusive=False)
-    dataset = sklearn.datasets.load_boston()
-    X = pd.DataFrame(dataset.data[:50, :8], columns=dataset.feature_names[:8])
-    y = dataset.target[:50]
-    model = sklearn.linear_model.LinearRegression()
-    model.fit(X, y)
+    try:
+        mlflow.sklearn.autolog(disable=False, exclusive=False)
+        dataset = sklearn.datasets.load_boston()
+        X = pd.DataFrame(dataset.data[:50, :8], columns=dataset.feature_names[:8])
+        y = dataset.target[:50]
+        model = sklearn.linear_model.LinearRegression()
+        model.fit(X, y)
 
-    with mlflow.start_run() as run:
-        mlflow.shap.log_explanation(model.predict, X)
+        with mlflow.start_run() as run:
+            mlflow.shap.log_explanation(model.predict, X)
 
-    run_data = MlflowClient().get_run(run.info.run_id).data
-    metrics, params, tags = run_data.metrics, run_data.params, run_data.tags
-    assert not metrics
-    assert not params
-    assert all("mlflow." in key for key in tags)
-    assert "mlflow.autologging" not in tags
+        run_data = MlflowClient().get_run(run.info.run_id).data
+        metrics, params, tags = run_data.metrics, run_data.params, run_data.tags
+        assert not metrics
+        assert not params
+        assert all("mlflow." in key for key in tags)
+        assert "mlflow.autologging" not in tags
+    finally:
+        mlflow.sklearn.autolog(disable=True)
 
 
 def test_load_pyfunc(tmpdir):

--- a/tests/statsmodels/model_fixtures.py
+++ b/tests/statsmodels/model_fixtures.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pandas as pd
-from functools import lru_cache
 import statsmodels.api as sm
 from collections import namedtuple
 from statsmodels.tsa.arima_process import arma_generate_sample

--- a/tests/statsmodels/model_fixtures.py
+++ b/tests/statsmodels/model_fixtures.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pandas as pd
-import pytest
+from functools import lru_cache
 import statsmodels.api as sm
 from collections import namedtuple
 from statsmodels.tsa.arima_process import arma_generate_sample
@@ -17,7 +17,6 @@ ModelWithResults = namedtuple("ModelWithResults", ["model", "alg", "inference_da
 """
 
 
-@pytest.fixture(scope="session")
 def ols_model(**kwargs):
     # Ordinary Least Squares (OLS)
     np.random.seed(9876789)
@@ -35,7 +34,6 @@ def ols_model(**kwargs):
     return ModelWithResults(model=model, alg=ols, inference_dataframe=X)
 
 
-@pytest.fixture(scope="session")
 def failing_logit_model():
     X = pd.DataFrame(
         {
@@ -60,7 +58,6 @@ def get_dataset(name):
     return data
 
 
-@pytest.fixture(scope="session")
 def gls_model():
     # Generalized Least Squares (GLS)
     data = get_dataset("longley")
@@ -76,7 +73,6 @@ def gls_model():
     return ModelWithResults(model=model, alg=gls, inference_dataframe=data.exog)
 
 
-@pytest.fixture(scope="session")
 def glsar_model():
     # Generalized Least Squares with AR covariance structure
     X = range(1, 8)
@@ -88,7 +84,6 @@ def glsar_model():
     return ModelWithResults(model=model, alg=glsar, inference_dataframe=X)
 
 
-@pytest.fixture(scope="session")
 def wls_model():
     # Weighted Least Squares
     Y = [1, 3, 4, 5, 2, 3, 4]
@@ -100,7 +95,6 @@ def wls_model():
     return ModelWithResults(model=model, alg=wls, inference_dataframe=X)
 
 
-@pytest.fixture(scope="session")
 def recursivels_model():
     # Recursive Least Squares
     dta = sm.datasets.copper.load_pandas().data
@@ -118,7 +112,6 @@ def recursivels_model():
     return ModelWithResults(model=model, alg=rls, inference_dataframe=inference_dataframe)
 
 
-@pytest.fixture(scope="session")
 def rolling_ols_model():
     # Rolling Ordinary Least Squares (Rolling OLS)
     from statsmodels.regression.rolling import RollingOLS
@@ -131,7 +124,6 @@ def rolling_ols_model():
     return ModelWithResults(model=model, alg=rolling_ols, inference_dataframe=exog)
 
 
-@pytest.fixture(scope="session")
 def rolling_wls_model():
     # Rolling Weighted Least Squares (Rolling WLS)
     from statsmodels.regression.rolling import RollingWLS
@@ -144,7 +136,6 @@ def rolling_wls_model():
     return ModelWithResults(model=model, alg=rolling_wls, inference_dataframe=exog)
 
 
-@pytest.fixture(scope="session")
 def gee_model():
     # Example taken from
     # https://www.statsmodels.org/devel/examples/notebooks/generated/gee_nested_simulation.html
@@ -193,7 +184,6 @@ def gee_model():
     return ModelWithResults(model=model, alg=gee, inference_dataframe=df)
 
 
-@pytest.fixture(scope="session")
 def glm_model():
     # Generalized Linear Model (GLM)
     data = get_dataset("scotland")
@@ -204,7 +194,6 @@ def glm_model():
     return ModelWithResults(model=model, alg=glm, inference_dataframe=data.exog)
 
 
-@pytest.fixture(scope="session")
 def glmgam_model():
     # Generalized Additive Model (GAM)
     from statsmodels.gam.tests.test_penalized import df_autos
@@ -220,7 +209,6 @@ def glmgam_model():
     return ModelWithResults(model=model, alg=gam_bs, inference_dataframe=df_autos)
 
 
-@pytest.fixture(scope="session")
 def arma_model():
     # Autoregressive Moving Average (ARMA)
     np.random.seed(12345)

--- a/tests/statsmodels/test_statsmodels_model_export.py
+++ b/tests/statsmodels/test_statsmodels_model_export.py
@@ -81,7 +81,7 @@ def _test_models_list(tmpdir, func_to_apply):
 
     for algorithm in fixtures:
         name = algorithm.__name__
-        path = model_path(tmpdir, name)
+        path = os.path.join(tmpdir, name)
         model = algorithm()
         if isinstance(model.alg, TimeSeriesModel):
             start_date, end_date = _get_dates_from_df(model.inference_dataframe)
@@ -147,9 +147,8 @@ def test_models_log(tmpdir):
     _test_models_list(tmpdir, _test_model_log)
 
 
-def test_signature_and_examples_are_saved_correctly(ols_model):
-    model = ols_model.model
-    X = ols_model.inference_dataframe
+def test_signature_and_examples_are_saved_correctly():
+    model, _, X = ols_model()
     signature_ = infer_signature(X)
     example_ = X[0:3, :]
 
@@ -168,8 +167,9 @@ def test_signature_and_examples_are_saved_correctly(ols_model):
                     assert np.array_equal(_read_example(mlflow_model, path), example)
 
 
-def test_model_load_from_remote_uri_succeeds(arma_model, model_path, mock_s3_bucket):
-    mlflow.statsmodels.save_model(statsmodels_model=arma_model.model, path=model_path)
+def test_model_load_from_remote_uri_succeeds(model_path, mock_s3_bucket):
+    model, _, inference_dataframe = arma_model()
+    mlflow.statsmodels.save_model(statsmodels_model=model, path=model_path)
 
     artifact_root = "s3://{bucket_name}".format(bucket_name=mock_s3_bucket)
     artifact_path = "model"
@@ -178,22 +178,23 @@ def test_model_load_from_remote_uri_succeeds(arma_model, model_path, mock_s3_buc
 
     model_uri = artifact_root + "/" + artifact_path
     reloaded_model = mlflow.statsmodels.load_model(model_uri=model_uri)
-    start_date, end_date = _get_dates_from_df(arma_model.inference_dataframe)
+    start_date, end_date = _get_dates_from_df(inference_dataframe)
     np.testing.assert_array_almost_equal(
-        arma_model.model.predict(start=start_date, end=end_date),
+        model.predict(start=start_date, end=end_date),
         reloaded_model.predict(start=start_date, end=end_date),
     )
 
 
-def test_log_model_calls_register_model(ols_model):
+def test_log_model_calls_register_model():
     # Adapted from lightgbm tests
+    model = ols_model().model
     artifact_path = "model"
     register_model_patch = mock.patch("mlflow.register_model")
     with mlflow.start_run(), register_model_patch, TempDir(chdr=True, remove_on_exit=True) as tmp:
         conda_env = os.path.join(tmp.path(), "conda_env.yaml")
         _mlflow_conda_env(conda_env, additional_pip_deps=["statsmodels"])
         mlflow.statsmodels.log_model(
-            statsmodels_model=ols_model.model,
+            statsmodels_model=model,
             artifact_path=artifact_path,
             conda_env=conda_env,
             registered_model_name="OLSModel1",
@@ -206,24 +207,25 @@ def test_log_model_calls_register_model(ols_model):
         )
 
 
-def test_log_model_no_registered_model_name(ols_model):
+def test_log_model_no_registered_model_name():
+    model = ols_model().model
     artifact_path = "model"
     register_model_patch = mock.patch("mlflow.register_model")
     with mlflow.start_run(), register_model_patch, TempDir(chdr=True, remove_on_exit=True) as tmp:
         conda_env = os.path.join(tmp.path(), "conda_env.yaml")
         _mlflow_conda_env(conda_env, additional_pip_deps=["statsmodels"])
         mlflow.statsmodels.log_model(
-            statsmodels_model=ols_model.model, artifact_path=artifact_path, conda_env=conda_env
+            statsmodels_model=model, artifact_path=artifact_path, conda_env=conda_env
         )
         mlflow.register_model.assert_not_called()
 
 
 def test_model_save_persists_specified_conda_env_in_mlflow_model_directory(
-    ols_model, model_path, statsmodels_custom_env
+    model_path, statsmodels_custom_env
 ):
-
+    model = ols_model().model
     mlflow.statsmodels.save_model(
-        statsmodels_model=ols_model.model, path=model_path, conda_env=statsmodels_custom_env
+        statsmodels_model=model, path=model_path, conda_env=statsmodels_custom_env
     )
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
@@ -239,11 +241,11 @@ def test_model_save_persists_specified_conda_env_in_mlflow_model_directory(
 
 
 def test_model_save_persists_requirements_in_mlflow_model_directory(
-    ols_model, model_path, statsmodels_custom_env
+    model_path, statsmodels_custom_env
 ):
-
+    model = ols_model().model
     mlflow.statsmodels.save_model(
-        statsmodels_model=ols_model.model, path=model_path, conda_env=statsmodels_custom_env
+        statsmodels_model=model, path=model_path, conda_env=statsmodels_custom_env
     )
 
     saved_pip_req_path = os.path.join(model_path, "requirements.txt")
@@ -251,18 +253,19 @@ def test_model_save_persists_requirements_in_mlflow_model_directory(
 
 
 @pytest.mark.large
-def test_log_model_with_pip_requirements(ols_model, tmpdir):
+def test_log_model_with_pip_requirements(tmpdir):
+    model = ols_model().model
     # Path to a requirements file
     req_file = tmpdir.join("requirements.txt")
     req_file.write("a")
     with mlflow.start_run():
-        mlflow.statsmodels.log_model(ols_model.model, "model", pip_requirements=req_file.strpath)
+        mlflow.statsmodels.log_model(model, "model", pip_requirements=req_file.strpath)
         _assert_pip_requirements(mlflow.get_artifact_uri("model"), ["mlflow", "a"], strict=True)
 
     # List of requirements
     with mlflow.start_run():
         mlflow.statsmodels.log_model(
-            ols_model.model, "model", pip_requirements=[f"-r {req_file.strpath}", "b"]
+            model, "model", pip_requirements=[f"-r {req_file.strpath}", "b"]
         )
         _assert_pip_requirements(
             mlflow.get_artifact_uri("model"), ["mlflow", "a", "b"], strict=True
@@ -271,7 +274,7 @@ def test_log_model_with_pip_requirements(ols_model, tmpdir):
     # Constraints file
     with mlflow.start_run():
         mlflow.statsmodels.log_model(
-            ols_model.model, "model", pip_requirements=[f"-c {req_file.strpath}", "b"]
+            model, "model", pip_requirements=[f"-c {req_file.strpath}", "b"]
         )
         _assert_pip_requirements(
             mlflow.get_artifact_uri("model"),
@@ -282,22 +285,21 @@ def test_log_model_with_pip_requirements(ols_model, tmpdir):
 
 
 @pytest.mark.large
-def test_log_model_with_extra_pip_requirements(ols_model, tmpdir):
+def test_log_model_with_extra_pip_requirements(tmpdir):
+    model = ols_model().model
     default_reqs = mlflow.statsmodels.get_default_pip_requirements()
 
     # Path to a requirements file
     req_file = tmpdir.join("requirements.txt")
     req_file.write("a")
     with mlflow.start_run():
-        mlflow.statsmodels.log_model(
-            ols_model.model, "model", extra_pip_requirements=req_file.strpath
-        )
+        mlflow.statsmodels.log_model(model, "model", extra_pip_requirements=req_file.strpath)
         _assert_pip_requirements(mlflow.get_artifact_uri("model"), ["mlflow", *default_reqs, "a"])
 
     # List of requirements
     with mlflow.start_run():
         mlflow.statsmodels.log_model(
-            ols_model.model, "model", extra_pip_requirements=[f"-r {req_file.strpath}", "b"]
+            model, "model", extra_pip_requirements=[f"-r {req_file.strpath}", "b"]
         )
         _assert_pip_requirements(
             mlflow.get_artifact_uri("model"), ["mlflow", *default_reqs, "a", "b"]
@@ -306,7 +308,7 @@ def test_log_model_with_extra_pip_requirements(ols_model, tmpdir):
     # Constraints file
     with mlflow.start_run():
         mlflow.statsmodels.log_model(
-            ols_model.model, "model", extra_pip_requirements=[f"-c {req_file.strpath}", "b"]
+            model, "model", extra_pip_requirements=[f"-c {req_file.strpath}", "b"]
         )
         _assert_pip_requirements(
             mlflow.get_artifact_uri("model"),
@@ -315,12 +317,11 @@ def test_log_model_with_extra_pip_requirements(ols_model, tmpdir):
         )
 
 
-def test_model_save_accepts_conda_env_as_dict(ols_model, model_path):
+def test_model_save_accepts_conda_env_as_dict(model_path):
+    model = ols_model().model
     conda_env = dict(mlflow.statsmodels.get_default_conda_env())
     conda_env["dependencies"].append("pytest")
-    mlflow.statsmodels.save_model(
-        statsmodels_model=ols_model.model, path=model_path, conda_env=conda_env
-    )
+    mlflow.statsmodels.save_model(statsmodels_model=model, path=model_path, conda_env=conda_env)
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
     saved_conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
@@ -331,16 +332,12 @@ def test_model_save_accepts_conda_env_as_dict(ols_model, model_path):
     assert saved_conda_env_parsed == conda_env
 
 
-def test_model_log_persists_specified_conda_env_in_mlflow_model_directory(
-    ols_model, statsmodels_custom_env
-):
-
+def test_model_log_persists_specified_conda_env_in_mlflow_model_directory(statsmodels_custom_env):
+    model = ols_model().model
     artifact_path = "model"
     with mlflow.start_run():
         mlflow.statsmodels.log_model(
-            statsmodels_model=ols_model.model,
-            artifact_path=artifact_path,
-            conda_env=statsmodels_custom_env,
+            statsmodels_model=model, artifact_path=artifact_path, conda_env=statsmodels_custom_env,
         )
         model_uri = "runs:/{run_id}/{artifact_path}".format(
             run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path
@@ -359,16 +356,12 @@ def test_model_log_persists_specified_conda_env_in_mlflow_model_directory(
     assert saved_conda_env_parsed == statsmodels_custom_env_parsed
 
 
-def test_model_log_persists_requirements_in_mlflow_model_directory(
-    ols_model, statsmodels_custom_env
-):
-
+def test_model_log_persists_requirements_in_mlflow_model_directory(statsmodels_custom_env):
+    model = ols_model().model
     artifact_path = "model"
     with mlflow.start_run():
         mlflow.statsmodels.log_model(
-            statsmodels_model=ols_model.model,
-            artifact_path=artifact_path,
-            conda_env=statsmodels_custom_env,
+            statsmodels_model=model, artifact_path=artifact_path, conda_env=statsmodels_custom_env,
         )
         model_uri = "runs:/{run_id}/{artifact_path}".format(
             run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path
@@ -380,26 +373,24 @@ def test_model_log_persists_requirements_in_mlflow_model_directory(
 
 
 def test_model_save_without_specified_conda_env_uses_default_env_with_expected_dependencies(
-    ols_model, model_path
+    model_path,
 ):
-
-    mlflow.statsmodels.save_model(statsmodels_model=ols_model.model, path=model_path)
+    model = ols_model().model
+    mlflow.statsmodels.save_model(statsmodels_model=model, path=model_path)
     _assert_pip_requirements(model_path, mlflow.statsmodels.get_default_pip_requirements())
 
 
-def test_model_log_without_specified_conda_env_uses_default_env_with_expected_dependencies(
-    ols_model,
-):
-
+def test_model_log_without_specified_conda_env_uses_default_env_with_expected_dependencies():
+    model = ols_model().model
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.statsmodels.log_model(statsmodels_model=ols_model.model, artifact_path=artifact_path)
+        mlflow.statsmodels.log_model(statsmodels_model=model, artifact_path=artifact_path)
         model_uri = mlflow.get_artifact_uri(artifact_path)
     _assert_pip_requirements(model_uri, mlflow.statsmodels.get_default_pip_requirements())
 
 
-def test_pyfunc_serve_and_score(ols_model):
-    model, _, inference_dataframe = ols_model
+def test_pyfunc_serve_and_score():
+    model, _, inference_dataframe = ols_model()
     artifact_path = "model"
     with mlflow.start_run():
         mlflow.statsmodels.log_model(model, artifact_path)

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -1005,11 +1005,12 @@ class TestDatabricksArtifactRepository(object):
             with pytest.raises(MlflowException) as exc:
                 databricks_artifact_repo.download_artifacts("test_path")
 
-            assert MOCK_RUN_ROOT_URI in str(exc)
-            assert "file_1.txt" in str(exc)
-            assert "MOCK ERROR 1" in str(exc)
-            assert "file_2.txt" in str(exc)
-            assert "MOCK ERROR 2" in str(exc)
+            err_msg = str(exc.value)
+            assert MOCK_RUN_ROOT_URI in err_msg
+            assert "file_1.txt" in err_msg
+            assert "MOCK ERROR 1" in err_msg
+            assert "file_2.txt" in err_msg
+            assert "MOCK ERROR 2" in err_msg
 
     def test_log_artifacts_provides_failure_info(self, databricks_artifact_repo, tmpdir):
         src_file1_path = os.path.join(str(tmpdir), "file_1.txt")
@@ -1040,8 +1041,9 @@ class TestDatabricksArtifactRepository(object):
             with pytest.raises(MlflowException) as exc:
                 databricks_artifact_repo.log_artifacts(str(tmpdir), "test_artifacts")
 
-            assert MOCK_RUN_ROOT_URI in str(exc)
-            assert "file_1.txt" in str(exc)
-            assert "MOCK ERROR 1" in str(exc)
-            assert "file_2.txt" in str(exc)
-            assert "MOCK ERROR 2" in str(exc)
+            err_msg = str(exc.value)
+            assert MOCK_RUN_ROOT_URI in err_msg
+            assert "file_1.txt" in err_msg
+            assert "MOCK ERROR 1" in err_msg
+            assert "file_2.txt" in err_msg
+            assert "MOCK ERROR 2" in err_msg

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -271,8 +271,7 @@ def test_tf_keras_autolog_model_can_load_from_artifact(tf_keras_random_data_run,
     model.predict(random_train_data)
 
 
-@pytest.fixture
-def tf_keras_random_data_run_with_callback(
+def _tf_keras_random_data_run_with_callback(
     random_train_data,
     random_one_hot_labels,
     manual_run,
@@ -311,6 +310,27 @@ def tf_keras_random_data_run_with_callback(
 
     client = mlflow.tracking.MlflowClient()
     return client.get_run(client.list_run_infos(experiment_id="0")[0].run_id), history, callback
+
+
+@pytest.fixture
+def tf_keras_random_data_run_with_callback(
+    random_train_data,
+    random_one_hot_labels,
+    manual_run,
+    callback,
+    restore_weights,
+    patience,
+    initial_epoch,
+):
+    return _tf_keras_random_data_run_with_callback(
+        random_train_data,
+        random_one_hot_labels,
+        manual_run,
+        callback,
+        restore_weights,
+        patience,
+        initial_epoch,
+    )
 
 
 @pytest.mark.large
@@ -353,7 +373,7 @@ def test_tf_keras_autolog_early_stop_logs(tf_keras_random_data_run_with_callback
 @pytest.mark.parametrize("patience", [0, 1, 5])
 @pytest.mark.parametrize("initial_epoch", [0, 10])
 def test_tf_keras_autolog_batch_metrics_logger_logs_expected_metrics(
-    callback, restore_weights, patience, initial_epoch
+    callback, restore_weights, patience, initial_epoch, random_train_data, random_one_hot_labels,
 ):
     patched_metrics_data = []
 
@@ -370,9 +390,9 @@ def test_tf_keras_autolog_batch_metrics_logger_logs_expected_metrics(
             original(self, metrics, step)
 
         record_metrics_mock.side_effect = record_metrics_side_effect
-        run, _, callback = tf_keras_random_data_run_with_callback(
-            random_train_data(),
-            random_one_hot_labels(),
+        run, _, callback = _tf_keras_random_data_run_with_callback(
+            random_train_data,
+            random_one_hot_labels,
             manual_run,
             callback,
             restore_weights,

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -271,7 +271,7 @@ def test_tf_keras_autolog_model_can_load_from_artifact(tf_keras_random_data_run,
     model.predict(random_train_data)
 
 
-def _tf_keras_random_data_run_with_callback(
+def get_tf_keras_random_data_run_with_callback(
     random_train_data,
     random_one_hot_labels,
     manual_run,
@@ -322,7 +322,7 @@ def tf_keras_random_data_run_with_callback(
     patience,
     initial_epoch,
 ):
-    return _tf_keras_random_data_run_with_callback(
+    return get_tf_keras_random_data_run_with_callback(
         random_train_data,
         random_one_hot_labels,
         manual_run,
@@ -390,7 +390,7 @@ def test_tf_keras_autolog_batch_metrics_logger_logs_expected_metrics(
             original(self, metrics, step)
 
         record_metrics_mock.side_effect = record_metrics_side_effect
-        run, _, callback = _tf_keras_random_data_run_with_callback(
+        run, _, callback = get_tf_keras_random_data_run_with_callback(
             random_train_data,
             random_one_hot_labels,
             manual_run,

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -846,7 +846,7 @@ def test_start_deleted_run():
     with mlflow.start_run() as active_run:
         run_id = active_run.info.run_id
     tracking.MlflowClient().delete_run(run_id)
-    with pytest.raises(MlflowException, matches="because it is in the deleted state."):
+    with pytest.raises(MlflowException, match="because it is in the deleted state."):
         with mlflow.start_run(run_id=run_id):
             pass
     assert mlflow.active_run() is None


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Unpin pytest

## Motivation

We're currently using `pytest 3.2.1` which is very old (released on [Aug 10, 2017](https://pypi.org/project/pytest/3.2.1/)). Many new features have been introduced and many bugs have been fixed since then.

### Useful features

#### Showing the progress in the verbose mode:

![image](https://user-images.githubusercontent.com/17039389/138803804-da8fbad7-b2d4-4a52-be87-b24b22fa978b.png)

#### `DepreacationWarning` is shown by default:

This helps us to spot deprecated APIs:

![image](https://user-images.githubusercontent.com/17039389/138803984-f0123a4b-bcdf-49c1-bde5-c881b761b2bc.png)

#### Warnings are de-duplicated

In pytest 3.2.1:

![image](https://user-images.githubusercontent.com/17039389/138804171-d98f6d58-9048-44ea-b537-6f6a21c0d08c.png)

In pytest 6.2.5:

![image](https://user-images.githubusercontent.com/17039389/138804210-5a015aa8-8c5e-499d-9284-6a81312d3658.png)


## How is this patch tested?

Existing tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
