### PR TITLE
Fix contour plot on run comparison page

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunContour.js
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunContour.js
@@ -168,11 +168,11 @@ export class CompareRunContour extends Component {
         invalidAxes.push('Y');
       }
       if (invalidAxes.length > 0) {
-        const message =
+        const messageHead =
           invalidAxes.length > 1
             ? `The ${invalidAxes.join(' and ')} axes don't`
             : `The ${invalidAxes[0]} axis doesn't`;
-        return <>{`${message} have enough unique data points to render the contour plot.`}</>;
+        return <>{`${messageHead} have enough unique data points to render the contour plot.`}</>;
       }
 
       return (

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunContour.js
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunContour.js
@@ -160,10 +160,19 @@ export class CompareRunContour extends Component {
     });
 
     const maybeRenderPlot = () => {
-      if (xsSorted.length < 2 || ysSorted.length < 2) {
-        return (
-          <div>X or Y axis doesn't have enough unique data points to draw the contour plot</div>
-        );
+      const invalidAxes = [];
+      if (xsSorted.length < 2) {
+        invalidAxes.push('X');
+      }
+      if (ysSorted.length < 2) {
+        invalidAxes.push('Y');
+      }
+      if (invalidAxes.length > 0) {
+        const message =
+          invalidAxes.length > 1
+            ? `The ${invalidAxes.join(' and ')} axes don't`
+            : `The ${invalidAxes[0]} axis doesn't`;
+        return <>{`${message} have enough unique data points to render the contour plot.`}</>;
       }
 
       return (

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunContour.js
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunContour.js
@@ -159,6 +159,76 @@ export class CompareRunContour extends Component {
       z[yi][xi] = zs[index];
     });
 
+    const maybeRenderPlot = () => {
+      if (xsSorted.length < 2 || ysSorted.length < 2) {
+        return (
+          <div>X or Y axis doesn't have enough unique data points to draw the contour plot</div>
+        );
+      }
+
+      return (
+        <LazyPlot
+          data={[
+            // contour plot
+            {
+              z,
+              x: xsSorted,
+              y: ysSorted,
+              type: 'contour',
+              hoverinfo: 'none',
+              colorscale: this.getColorscale(),
+              connectgaps: true,
+              contours: {
+                coloring: 'heatmap',
+              },
+            },
+            // scatter plot
+            {
+              x: xsSorted,
+              y: ysSorted,
+              text: tooltips,
+              hoverinfo: 'text',
+              type: 'scattergl',
+              mode: 'markers',
+              marker: {
+                size: 10,
+                color: 'rgba(200, 50, 100, .75)',
+              },
+            },
+          ]}
+          layout={{
+            margin: {
+              t: 30,
+            },
+            hovermode: 'closest',
+            xaxis: {
+              title: this.encodeHtml(Utils.truncateString(this.state['xaxis'].key, keyLength)),
+              range: [Math.min(...xs), Math.max(...xs)],
+            },
+            yaxis: {
+              title: this.encodeHtml(Utils.truncateString(this.state['yaxis'].key, keyLength)),
+              range: [Math.min(...ys), Math.max(...ys)],
+            },
+          }}
+          className={'scatter-plotly'}
+          config={{
+            responsive: true,
+            displaylogo: false,
+            scrollZoom: true,
+            modeBarButtonsToRemove: [
+              'sendDataToCloud',
+              'select2d',
+              'lasso2d',
+              'resetScale2d',
+              'hoverClosestCartesian',
+              'hoverCompareCartesian',
+            ],
+          }}
+          useResizeHandler
+        />
+      );
+    };
+
     return (
       <div className='responsive-table-container'>
         <div className='container-fluid'>
@@ -219,71 +289,7 @@ export class CompareRunContour extends Component {
                 />
               </div>
             </form>
-            <div className='col-xs-9'>
-              <LazyPlot
-                data={[
-                  // contour plot
-                  {
-                    z,
-                    x: xsSorted,
-                    y: ysSorted,
-                    type: 'contour',
-                    hoverinfo: 'none',
-                    colorscale: this.getColorscale(),
-                    connectgaps: true,
-                    contours: {
-                      coloring: 'heatmap',
-                    },
-                  },
-                  // scatter plot
-                  {
-                    x: xs,
-                    y: ys,
-                    text: tooltips,
-                    hoverinfo: 'text',
-                    type: 'scattergl',
-                    mode: 'markers',
-                    marker: {
-                      size: 10,
-                      color: 'rgba(200, 50, 100, .75)',
-                    },
-                  },
-                ]}
-                layout={{
-                  margin: {
-                    t: 30,
-                  },
-                  hovermode: 'closest',
-                  xaxis: {
-                    title: this.encodeHtml(
-                      Utils.truncateString(this.state['xaxis'].key, keyLength),
-                    ),
-                    range: [Math.min(...xs), Math.max(...xs)],
-                  },
-                  yaxis: {
-                    title: this.encodeHtml(
-                      Utils.truncateString(this.state['yaxis'].key, keyLength),
-                    ),
-                    range: [Math.min(...ys), Math.max(...ys)],
-                  },
-                }}
-                className={'scatter-plotly'}
-                config={{
-                  responsive: true,
-                  displaylogo: false,
-                  scrollZoom: true,
-                  modeBarButtonsToRemove: [
-                    'sendDataToCloud',
-                    'select2d',
-                    'lasso2d',
-                    'resetScale2d',
-                    'hoverClosestCartesian',
-                    'hoverCompareCartesian',
-                  ],
-                }}
-                useResizeHandler
-              />
-            </div>
+            <div className='col-xs-9'>{maybeRenderPlot()}</div>
           </div>
         </div>
       </div>

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunContour.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunContour.test.js
@@ -227,4 +227,53 @@ describe('unit tests', () => {
       zaxis: { key: 'm1', isMetric: true },
     });
   });
+
+  test('should render a warning message when X or Y axis does not have enough data points', () => {
+    const props = {
+      ...commonProps,
+      paramLists: [
+        [
+          { key: 'p1', value: 0 },
+          { key: 'p2', value: 1 },
+        ],
+        [
+          { key: 'p1', value: 0 },
+          { key: 'p2', value: 2 },
+        ],
+        [
+          { key: 'p1', value: 0 },
+          { key: 'p2', value: 3 },
+        ],
+      ],
+      metricLists: [
+        [{ key: 'm1', value: 4 }],
+        [{ key: 'm1', value: 5 }],
+        [{ key: 'm1', value: 6 }],
+      ],
+    };
+    wrapper = shallow(<CompareRunContour {...props} />);
+
+    // X axis: p1 | Y axis: p2
+    expect(wrapper.text().includes("The X axis doesn't have enough unique data points")).toBe(true);
+
+    // X axis: p2 | Y axis: p1
+    wrapper.setState({
+      xaxis: { key: 'p2', isMetric: false },
+      yaxis: { key: 'p1', isMetric: false },
+    });
+    expect(wrapper.text().includes("The Y axis doesn't have enough unique data points")).toBe(true);
+
+    // X axis: p1 | Y axis: p1
+    wrapper.setState({ xaxis: { key: 'p1', isMetric: false } });
+    expect(wrapper.text().includes("The X and Y axes don't have enough unique data points")).toBe(
+      true,
+    );
+
+    // X axis: p2 | Y axis: p2
+    wrapper.setState({
+      xaxis: { key: 'p2', isMetric: false },
+      yaxis: { key: 'p2', isMetric: false },
+    });
+    expect(wrapper.text().includes('have enough unique data points')).toBe(false);
+  });
 });


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

- Fixes https://github.com/mlflow/mlflow/issues/3503
- It's still WIP.

## How is this patch tested?

- Manually verify the plot works correctly
- Unit tests

### Before (master branch)

https://user-images.githubusercontent.com/17039389/138641649-c47b2570-de96-4a90-8111-18ff2c9203bf.mov

- plotly tries to draw the contour plot with `p1`, `p2`, and `m1`, but fails because `p1` has a single unique value: 0 (see the error message on the console). The contour plot seems to require at least two data points on each axis.
- plotly keeps failing to draw the plot even if we pass valid data.
- Note this issue occurs when we use `scattergl` (on [this line](https://github.com/mlflow/mlflow/blob/6b9ca5709f3aa41e3407c5f24cc091096484e7f6/mlflow/server/js/src/experiment-tracking/components/CompareRunScatter.js#L137)). The plot gets drawn successfully with `scatter`. I haven't taken a look at the internal implementation of plotly, but it looks like using `scattergl` changes how plotly updates the plot state.

### After

https://user-images.githubusercontent.com/17039389/138642237-1d4bfe3c-3ee5-472f-ac7a-935281df7b3b.mov

- The fix is to avoid drawing the plot if we know the data to plot doesn't enough data points.
- Showing a warning message is more helpful than showing an empty plot?

### Code to generate test data

```python
import mlflow

with mlflow.start_run():
    mlflow.log_param("p1", 0)
    mlflow.log_param("p2", 0.14427203773889796)
    mlflow.log_param("m1", 0)
    mlflow.log_metric("m2", 0.815)

with mlflow.start_run():
    mlflow.log_param("p1", 0)
    mlflow.log_param("p2", 0.17649088560647586)
    mlflow.log_param("m1", 0)
    mlflow.log_metric("m2", 0.269)

with mlflow.start_run():
    mlflow.log_param("p1", 0)
    mlflow.log_param("p2", 0.5324973999849046)
    mlflow.log_param("m1", 0)
    mlflow.log_metric("m2", 0.414)

```

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
