### PR TITLE
Improve statsmodels autologging metrics

### DIFF
--- a/mlflow/statsmodels.py
+++ b/mlflow/statsmodels.py
@@ -498,5 +498,5 @@ def autolog(
 
 
 autolog.__doc__ = autolog.__doc__.format(
-    autolog_metric_whitelist=','.join(_autolog_metric_whitelist)
+    autolog_metric_whitelist=",".join(_autolog_metric_whitelist)
 )

--- a/mlflow/statsmodels.py
+++ b/mlflow/statsmodels.py
@@ -362,6 +362,7 @@ _autolog_metric_allowlist = [
 def _get_autolog_metrics(fitted_model):
     result_metrics = {}
 
+    failed_evaluating_metric = []
     for metric in _autolog_metric_allowlist:
         try:
             if hasattr(fitted_model, metric):
@@ -369,7 +370,8 @@ def _get_autolog_metrics(fitted_model):
                 if _is_numeric(metric_value):
                     result_metrics[metric] = metric_value
         except Exception:
-            pass
+            failed_evaluating_metric.append(metric)
+    _logger.warning(f"Failed to autolog metrics: {','.join(failed_evaluating_metric)}")
     return result_metrics
 
 

--- a/mlflow/statsmodels.py
+++ b/mlflow/statsmodels.py
@@ -75,7 +75,7 @@ def get_default_conda_env():
     return _mlflow_conda_env(additional_pip_deps=get_default_pip_requirements())
 
 
-_model_size_threshold_for_emitting_warning = 100 * 1024 * 1024
+_model_size_threshold_for_emitting_warning = 100 * 1024 * 1024  # 100 MB
 
 
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
@@ -362,7 +362,7 @@ _autolog_metric_allowlist = [
 def _get_autolog_metrics(fitted_model):
     result_metrics = {}
 
-    failed_evaluating_metric = []
+    failed_evaluating_metrics = set()
     for metric in _autolog_metric_allowlist:
         try:
             if hasattr(fitted_model, metric):
@@ -370,8 +370,12 @@ def _get_autolog_metrics(fitted_model):
                 if _is_numeric(metric_value):
                     result_metrics[metric] = metric_value
         except Exception:
-            failed_evaluating_metric.append(metric)
-    _logger.warning(f"Failed to autolog metrics: {','.join(failed_evaluating_metric)}")
+            failed_evaluating_metrics.add(metric)
+
+    if len(failed_evaluating_metrics) > 0:
+        _logger.warning(
+            f"Failed to autolog metrics: {', '.join(sorted(failed_evaluating_metrics))}"
+        )
     return result_metrics
 
 
@@ -514,5 +518,5 @@ def autolog(
 
 
 autolog.__doc__ = autolog.__doc__.format(
-    autolog_metric_allowlist=",".join(_autolog_metric_allowlist)
+    autolog_metric_allowlist=", ".join(_autolog_metric_allowlist)
 )

--- a/mlflow/statsmodels.py
+++ b/mlflow/statsmodels.py
@@ -377,7 +377,7 @@ def _get_autolog_metrics(fitted_model):
 
     if len(failed_evaluating_metrics) > 0:
         _logger.warning(
-            f"Failed to autolog metrics: {', '.join(sorted(failed_evaluating_metrics))}"
+            f"Failed to autolog metrics: {', '.join(sorted(failed_evaluating_metrics))}."
         )
     return result_metrics
 

--- a/mlflow/statsmodels.py
+++ b/mlflow/statsmodels.py
@@ -459,7 +459,6 @@ def autolog(
         for clazz, method_name, patch_impl in patches_list:
             safe_patch(FLAVOR_NAME, clazz, method_name, patch_impl, manage_run=True)
 
-
     def wrapper_fit(original, self, *args, **kwargs):
 
         should_autolog = False

--- a/mlflow/statsmodels.py
+++ b/mlflow/statsmodels.py
@@ -15,7 +15,6 @@ statsmodels (native) format
 import os
 import yaml
 import logging
-import numpy as np
 
 import mlflow
 from mlflow import pyfunc

--- a/mlflow/statsmodels.py
+++ b/mlflow/statsmodels.py
@@ -325,16 +325,32 @@ class AutologHelpers:
 
 # Currently we only autolog basic metrics
 _autolog_metric_whitelist = [
-    'aic', 'bic', 'centered_tss', 'condition_number',  'df_model', 'df_resid', 'ess', 'f_pvalue',
-    'fvalue', 'llf', 'mse_model', 'mse_resid',  'mse_total', 'rsquared', 'rsquared_adj', 'scale',
-    'ssr', 'uncentered_tss'
+    "aic",
+    "bic",
+    "centered_tss",
+    "condition_number",
+    "df_model",
+    "df_resid",
+    "ess",
+    "f_pvalue",
+    "fvalue",
+    "llf",
+    "mse_model",
+    "mse_resid",
+    "mse_total",
+    "rsquared",
+    "rsquared_adj",
+    "scale",
+    "ssr",
+    "uncentered_tss",
 ]
 
 
 def _get_autolog_metrics(fitted_model):
     result_metrics = {}
-    whitelist_metrics = [metric for metric in dir(fitted_model)
-                         if metric in _autolog_metric_whitelist]
+    whitelist_metrics = [
+        metric for metric in dir(fitted_model) if metric in _autolog_metric_whitelist
+    ]
 
     for metric in whitelist_metrics:
         try:
@@ -490,7 +506,7 @@ def autolog(
                     try_mlflow_log(mlflow.log_metrics, metrics_dict)
 
                     model_summary = model.summary().as_html()
-                    try_mlflow_log(mlflow.log_text, model_summary, 'model_summary.txt')
+                    try_mlflow_log(mlflow.log_text, model_summary, "model_summary.txt")
 
             return model
 

--- a/mlflow/statsmodels.py
+++ b/mlflow/statsmodels.py
@@ -356,12 +356,12 @@ def autolog(
     disable_for_unsupported_versions=False,
     silent=False,
 ):  # pylint: disable=unused-argument
-    f"""
+    """
     Enables (or disables) and configures automatic logging from statsmodels to MLflow.
     Logs the following:
 
     - basic results metrics returned by method `fit` of any subclass of
-      statsmodels.base.model.Model, basic metrics including: {','.join(_autolog_metric_whitelist)}
+      statsmodels.base.model.Model, basic metrics including: {autolog_metric_whitelist}
     - trained model.
 
 
@@ -500,3 +500,6 @@ def autolog(
                 AutologHelpers.should_autolog = True
 
     patch_class_tree(statsmodels.base.model.Model)
+
+
+autolog.__doc__ = autolog.__doc__.format(autolog_metric_whitelist=_autolog_metric_whitelist)

--- a/tests/statsmodels/test_statsmodels_autolog.py
+++ b/tests/statsmodels/test_statsmodels_autolog.py
@@ -81,8 +81,8 @@ def test_statsmodels_autolog_logs_summary_artifact():
     mlflow.statsmodels.autolog()
     with mlflow.start_run():
         model = ols_model().model
-        summary_path = mlflow.get_artifact_uri('model_summary.txt').replace("file://", "")
-        with open(summary_path, 'r') as f:
+        summary_path = mlflow.get_artifact_uri("model_summary.txt").replace("file://", "")
+        with open(summary_path, "r") as f:
             saved_summary = f.read()
 
     assert model.summary().as_html() == saved_summary

--- a/tests/statsmodels/test_statsmodels_autolog.py
+++ b/tests/statsmodels/test_statsmodels_autolog.py
@@ -85,7 +85,7 @@ def test_statsmodels_autolog_logs_summary_artifact():
         with open(summary_path, 'r') as f:
             saved_summary = f.read()
 
-    assert model.summary().as_text() == saved_summary
+    assert model.summary().as_html() == saved_summary
 
 
 def test_statsmodels_autolog_logs_basic_metrics():
@@ -94,7 +94,6 @@ def test_statsmodels_autolog_logs_basic_metrics():
     run = get_latest_run()
     metrics = run.data.metrics
     assert set(metrics.keys()) == set(mlflow.statsmodels._autolog_metric_whitelist)
-    mlflow.end_run()
 
 
 def test_statsmodels_autolog_works_after_exception():

--- a/tests/statsmodels/test_statsmodels_autolog.py
+++ b/tests/statsmodels/test_statsmodels_autolog.py
@@ -136,8 +136,7 @@ def test_statsmodels_autolog_failed_metrics_warning():
     ), mock.patch(
         "statsmodels.regression.linear_model.OLSResults.fvalue", metric_raise_error
     ), mock.patch(
-        # because we patch metric property to make it raise error, OLSResults.summary internally
-        # call metric property will also raise error, so also patch OLSResults.summary
+        # Prevent `OLSResults.summary` from calling `fvalue` and `f_pvalue` that raise an exception
         "statsmodels.regression.linear_model.OLSResults.summary",
         return_value=MockSummary(),
     ), mock.patch(

--- a/tests/statsmodels/test_statsmodels_autolog.py
+++ b/tests/statsmodels/test_statsmodels_autolog.py
@@ -87,7 +87,7 @@ def test_statsmodels_autolog_logs_summary_artifact():
             saved_summary = f.read()
 
     # don't compare the whole summary text because it includes a "Time" field which may change.
-    assert model.summary().as_text().split('\n')[:4] == saved_summary.split('\n')[:4]
+    assert model.summary().as_text().split("\n")[:4] == saved_summary.split("\n")[:4]
 
 
 def test_statsmodels_autolog_emit_warning_when_model_is_large():
@@ -136,7 +136,10 @@ def test_statsmodels_autolog_failed_metrics_warning():
     ), mock.patch(
         "statsmodels.regression.linear_model.OLSResults.fvalue", metric_raise_error
     ), mock.patch(
-        "statsmodels.regression.linear_model.OLSResults.summary", return_value=MockSummary()
+        # because we patch metric property to make it raise error, OLSResults.summary internally
+        # call metric property will also raise error, so also patch OLSResults.summary
+        "statsmodels.regression.linear_model.OLSResults.summary",
+        return_value=MockSummary(),
     ), mock.patch(
         "mlflow.statsmodels._logger.warning"
     ) as mock_warning:

--- a/tests/statsmodels/test_statsmodels_autolog.py
+++ b/tests/statsmodels/test_statsmodels_autolog.py
@@ -1,4 +1,3 @@
-import os
 import pytest
 from unittest import mock
 import numpy as np
@@ -82,7 +81,7 @@ def test_statsmodels_autolog_logs_specified_params():
 def test_statsmodels_autolog_logs_summary_artifact():
     mlflow.statsmodels.autolog()
     with mlflow.start_run():
-        model = ols_model()
+        model = ols_model().model
         summary_path = mlflow.get_artifact_uri("model_summary.txt").replace("file://", "")
         with open(summary_path, "r") as f:
             saved_summary = f.read()
@@ -120,7 +119,7 @@ def test_statsmodels_autolog_logs_basic_metrics():
     assert set(metrics.keys()) == set(mlflow.statsmodels._autolog_metric_allowlist)
 
     @property
-    def metric_raise_error(self):
+    def metric_raise_error(_):
         raise RuntimeError()
 
     class MockSummary:

--- a/tests/statsmodels/test_statsmodels_autolog.py
+++ b/tests/statsmodels/test_statsmodels_autolog.py
@@ -81,7 +81,7 @@ def test_statsmodels_autolog_logs_summary_artifact():
     mlflow.statsmodels.autolog()
     with mlflow.start_run():
         model = ols_model().model
-        summary_path = mlflow.get_artifact_uri("model_summary.txt").replace("file://", "")
+        summary_path = mlflow.get_artifact_uri("model_summary.html").replace("file://", "")
         with open(summary_path, "r") as f:
             saved_summary = f.read()
 

--- a/tests/statsmodels/test_statsmodels_autolog.py
+++ b/tests/statsmodels/test_statsmodels_autolog.py
@@ -83,7 +83,7 @@ def test_statsmodels_autolog_logs_specified_params():
 def test_statsmodels_autolog_logs_summary_artifact():
     mlflow.statsmodels.autolog()
     with mlflow.start_run():
-        model = ols_model().model
+        model = ols_model()
         summary_path = mlflow.get_artifact_uri("model_summary.txt").replace("file://", "")
         with open(summary_path, "r") as f:
             saved_summary = f.read()
@@ -95,9 +95,9 @@ def test_statsmodels_autolog_emit_warning_when_model_is_large():
     mlflow.statsmodels.autolog()
 
     with mock.patch(
-        "mlflow.statsmodels._model_size_threshold_for_emitting_warning", 100000000
+        "mlflow.statsmodels._model_size_threshold_for_emitting_warning", float("inf")
     ), mock.patch("mlflow.statsmodels._logger.warning") as mock_warning:
-        ols_model().model
+        ols_model()
         assert all(
             not call_args[0][0].startswith("The fitted model is larger than")
             for call_args in mock_warning.call_args_list
@@ -106,7 +106,7 @@ def test_statsmodels_autolog_emit_warning_when_model_is_large():
     with mock.patch("mlflow.statsmodels._model_size_threshold_for_emitting_warning", 1), mock.patch(
         "mlflow.statsmodels._logger.warning"
     ) as mock_warning:
-        ols_model().model
+        ols_model()
         assert any(
             call_args[0][0].startswith("The fitted model is larger than")
             for call_args in mock_warning.call_args_list

--- a/tests/statsmodels/test_statsmodels_autolog.py
+++ b/tests/statsmodels/test_statsmodels_autolog.py
@@ -77,6 +77,26 @@ def test_statsmodels_autolog_logs_specified_params():
     mlflow.end_run()
 
 
+def test_statsmodels_autolog_logs_summary_artifact():
+    mlflow.statsmodels.autolog()
+    with mlflow.start_run():
+        model = ols_model().model
+        summary_path = mlflow.get_artifact_uri('model_summary.txt').replace("file://", "")
+        with open(summary_path, 'r') as f:
+            saved_summary = f.read()
+
+    assert model.summary().as_text() == saved_summary
+
+
+def test_statsmodels_autolog_logs_basic_metrics():
+    mlflow.statsmodels.autolog()
+    ols_model()
+    run = get_latest_run()
+    metrics = run.data.metrics
+    assert set(metrics.keys()) == set(mlflow.statsmodels._autolog_metric_whitelist)
+    mlflow.end_run()
+
+
 def test_statsmodels_autolog_works_after_exception():
     mlflow.statsmodels.autolog()
     # We first fit a model known to raise an exception


### PR DESCRIPTION
Signed-off-by: Weichen Xu <weichen.xu@databricks.com>

Improve statsmodels autologging metrics
(1) We only log basic metrics of:
[
    'aic', 'bic', 'centered_tss', 'condition_number',  'df_model', 'df_resid', 'ess', 'f_pvalue',
    'fvalue', 'llf', 'mse_model', 'mse_resid',  'mse_total', 'rsquared', 'rsquared_adj', 'scale',
    'ssr', 'uncentered_tss'
]

(2) log the model.summary() as a text artifact.
Example of artifact display:
![image](https://user-images.githubusercontent.com/19235986/139215875-492572ed-ffa9-4425-96f9-0d28b8a370d1.png)

## How is this patch tested?

Unit tests.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
