### PR TITLE
Projects cli logging statements add for large project status reporting [ML-11215]

### DIFF
--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -153,13 +153,11 @@ class DatabricksJobRunner(object):
             return None if os.path.basename(x.name) == "mlruns" else x
 
         try:
-            directory_size = sum(
-                [os.path.getsize(f) for f in os.listdir(project_dir) if os.path.isfile(f)]
-            )
+            directory_size = file_utils._get_local_project_dir_size(project_dir)
             _logger.info(
                 f"=== Creating tarball from {project_dir} in temp directory {temp_tar_filename} ==="
             )
-            _logger.info(f"=== Total file size to compress: {directory_size} ===")
+            _logger.info(f"=== Total file size to compress: {directory_size} KB ===")
             file_utils.make_tarfile(
                 temp_tar_filename, project_dir, DB_TARFILE_ARCHIVE_NAME, custom_filter=custom_filter
             )
@@ -172,11 +170,11 @@ class DatabricksJobRunner(object):
                 "projects-code",
                 "%s.tar.gz" % tarfile_hash,
             )
-            tar_size = os.path.getsize(temp_tar_filename)
+            tar_size = os.path.getsize(temp_tar_filename) / 1024.0
             dbfs_fuse_uri = posixpath.join("/dbfs", dbfs_path)
             if not self._dbfs_path_exists(dbfs_path):
                 _logger.info(
-                    f"=== Uploading the project tarball (size: {tar_size}) to {dbfs_fuse_uri} ==="
+                    f"=== Uploading project tarball (size: {tar_size} KB) to {dbfs_fuse_uri} ==="
                 )
                 self._upload_to_dbfs(temp_tar_filename, dbfs_fuse_uri)
                 _logger.info("=== Finished uploading project to %s ===", dbfs_fuse_uri)

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -155,7 +155,7 @@ class DatabricksJobRunner(object):
         try:
             directory_size = file_utils._get_local_project_dir_size(project_dir)
             _logger.info(
-                f"=== Creating tarball from {project_dir} in temp directory {temp_tar_filename} ==="
+                f"=== Creating tarball from {project_dir} in temp directory {temp_tarfile_dir} ==="
             )
             _logger.info(f"=== Total file size to compress: {directory_size} KB ===")
             file_utils.make_tarfile(
@@ -170,7 +170,7 @@ class DatabricksJobRunner(object):
                 "projects-code",
                 "%s.tar.gz" % tarfile_hash,
             )
-            tar_size = os.path.getsize(temp_tar_filename) / 1024.0
+            tar_size = file_utils._get_local_file_size(temp_tar_filename)
             dbfs_fuse_uri = posixpath.join("/dbfs", dbfs_path)
             if not self._dbfs_path_exists(dbfs_path):
                 _logger.info(
@@ -231,7 +231,7 @@ class DatabricksJobRunner(object):
             "shell_command_task": {"command": command, "env_vars": env_vars},
             "libraries": libraries,
         }
-        _logger.info("=== Creating a job to execute the MLflow project... ===")
+        _logger.info("=== Submitting a run to execute the MLflow project... ===")
         run_submit_res = self._jobs_runs_submit(req_body_json)
         databricks_run_id = run_submit_res["run_id"]
         return databricks_run_id

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -365,11 +365,18 @@ def _get_local_project_dir_size(project_path):
     """
 
     total_size = 0
-    for root, _, files in os.walk(project_path):  # pylint: disable=unused-variable
+    for root, _, files in os.walk(project_path):
         for f in files:
             path = os.path.join(root, f)
             total_size += os.path.getsize(path)
     return round(total_size / 1024.0, 1)
+
+
+def _get_local_file_size(file):
+    """
+    Get the size of a local file in KB
+    """
+    return round(os.path.getsize(file) / 1024.0, 1)
 
 
 def get_parent_dir(path):

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -356,7 +356,7 @@ def _copy_file_or_tree(src, dst, dst_dir=None):
     return dst_subpath
 
 
-def _get_local_project_dir_size(project_path):
+def _get_local_project_dir_size(project_path):  # pylint: disable=unused-variable
     """
     Internal function for reporting the size of a local project directory before copying to
     destination for cli logging reporting to stdout.

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -356,6 +356,22 @@ def _copy_file_or_tree(src, dst, dst_dir=None):
     return dst_subpath
 
 
+def _get_local_project_dir_size(project_path):
+    """
+    Internal function for reporting the size of a local project directory before copying to
+    destination for cli logging reporting to stdout.
+    :param project_path: local path of the project directory
+    :return: directory file sizes in KB, rounded to single decimal point for legibility
+    """
+
+    total_size = 0
+    for root, dirs, files in os.walk(project_path):
+        for f in files:
+            path = os.path.join(root, f)
+            total_size += os.path.getsize(path)
+    return round(total_size / 1024.0, 1)
+
+
 def get_parent_dir(path):
     return os.path.abspath(os.path.join(path, os.pardir))
 

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -356,7 +356,7 @@ def _copy_file_or_tree(src, dst, dst_dir=None):
     return dst_subpath
 
 
-def _get_local_project_dir_size(project_path):  # pylint: disable=unused-variable
+def _get_local_project_dir_size(project_path):
     """
     Internal function for reporting the size of a local project directory before copying to
     destination for cli logging reporting to stdout.
@@ -365,7 +365,7 @@ def _get_local_project_dir_size(project_path):  # pylint: disable=unused-variabl
     """
 
     total_size = 0
-    for root, dirs, files in os.walk(project_path):
+    for root, _, files in os.walk(project_path):  # pylint: disable=unused-variable
         for f in files:
             path = os.path.join(root, f)
             total_size += os.path.getsize(path)


### PR DESCRIPTION
Signed-off-by: Ben Wilson <benjamin.wilson@databricks.com>

## What changes are proposed in this pull request?

- calculated project directory size estimation (no tree walking)
- calculate tarball size
- add log events for cli usage that show steps around:
  - compression of project dir
  - uploading from project local dir to dbfs
  - status of job creation initialization

## How is this patch tested?

Existing cli tests (no new functionality other than logging state added)

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [x] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
