### PR TITLE
Fix Kubernetes example

### DIFF
--- a/docs/source/projects.rst
+++ b/docs/source/projects.rst
@@ -506,11 +506,11 @@ execution. Replaced fields are indicated using bracketed text.
           image: "{replaced with URI of Docker image created during Project execution}"
           command: ["{replaced with MLflow Project entry point command}"]
           env: ["{appended with MLFLOW_TRACKING_URI, MLFLOW_RUN_ID and MLFLOW_EXPERIMENT_ID}"]
-        resources:
-          limits:
-            memory: 512Mi
-          requests:
-            memory: 256Mi
+          resources:
+            limits:
+              memory: 512Mi
+            requests:
+              memory: 256Mi
         restartPolicy: Never
 
 The ``container.name``, ``container.image``, and ``container.command`` fields are only replaced for

--- a/examples/docker/kubernetes_job_template.yaml
+++ b/examples/docker/kubernetes_job_template.yaml
@@ -12,9 +12,9 @@ spec:
       - name: "{replaced with MLflow Project name}"
         image: "{replaced with URI of Docker image created during Project execution}"
         command: ["{replaced with MLflow Project entry point command}"]
-      resources:
-        limits:
-          memory: 512Mi
-        requests:
-          memory: 256Mi
+        resources:
+          limits:
+            memory: 512Mi
+          requests:
+            memory: 256Mi
       restartPolicy: Never


### PR DESCRIPTION
## What changes are proposed in this pull request?

The `resources` object should have been nested under the `Container` object instead of the `PodSpec` object.

## How is this patch tested?

I validated the example [against the schema](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources).

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [x] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
