### PR TITLE
Avoid using `conda search` when setting python version

### DIFF
--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -11,22 +11,24 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: fetch-python-version
-      id: fetch-python-version
-      # What would happen if we skipped this step and directly pass `python-version` to the `setup-python` action?
-      # - Let's say the value of `python-version` is 3.6.
-      # - The `setup-python` action automatically selects 3.6.x (the latest available version of 3.6).
-      #   If 3.6.x is new, it may not be available on Anaconda yet.
-      # - mlflow logs a model and creates `conda.yaml` with 'python=3.6.x'.
-      # - `mlflow serve` tries to create an environment to serve the model via conda,
-      #   but fails to find 'python=3.6.x' on Anaconda.
+    - name: get-python-version
+      id: get-python-version
       shell: bash
+      # We used to use `conda search python=3.x` to dynamically fetch the latest available version
+      # in 3.x on Anaconda, but it turned out `conda search` is very slow (takes 40 ~ 50 seconds).
+      # This overhead sums up to a significant amount of delay in the cross version tests
+      # where we trigger more than 100 GitHub Actions runs.
       run: |
-        latest_micro_version=$(
-          $CONDA/bin/conda search -c conda-forge python=${{ inputs.python-version }} |
-          tail -1 | tr -s ' ' | cut -d' ' -f2
-        )
-        echo "::set-output name=version::$latest_micro_version"
+        python_version="${{ inputs.python-version }}"
+        if [[ "$python_version" == "3.6" ]]; then
+          python_version="3.6.13"
+        elif [[ "$python_version" == "3.7" ]]; then
+          python_version="3.7.12"
+        else
+          echo "Invalid python version: '$python_version'. Must be one of ['3.6', '3.7']"
+          exit 1
+        fi
+        echo "::set-output name=version::$python_version"
     - uses: actions/setup-python@v2
       with:
-        python-version: ${{ steps.fetch-python-version.outputs.version }}
+        python-version: ${{ steps.get-python-version.outputs.version }}


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

Avoid using `conda search` when setting python version since it's very slow (**takes 40 ~ 50 seconds**).

## How is this patch tested?

![image](https://user-images.githubusercontent.com/17039389/139038381-a1fd9de4-c501-486e-aea0-5a13c8c66bd7.png)

Now it takes about 7 seconds.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
