### PR TITLE
Avoid using `inspect.getfullargspec` that doesn't work properly for a wrapped function

### DIFF
--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -22,7 +22,6 @@ import yaml
 import json
 import tempfile
 import shutil
-import inspect
 import logging
 from copy import deepcopy
 

--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -48,6 +48,7 @@ from mlflow.utils.docstring_utils import format_docstring, LOG_MODEL_PARAM_DOCS
 from mlflow.utils.model_utils import _get_flavor_configuration
 from mlflow.exceptions import MlflowException
 from mlflow.utils.annotations import experimental
+from mlflow.utils.arguments_utils import _get_arg_names
 from mlflow.utils.autologging_utils import (
     autologging_integration,
     safe_patch,
@@ -452,7 +453,7 @@ def autolog(
 
         param_logging_operations = autologging_client.flush(synchronous=False)
 
-        all_arg_names = inspect.getfullargspec(original)[0]
+        all_arg_names = _get_arg_names(original)
         num_pos_args = len(args)
 
         # adding a callback that records evaluation results.

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -1158,7 +1158,6 @@ def autolog(
         _get_args_for_metrics,
         _log_estimator_content,
         _all_estimators,
-        _get_arg_names,
         _get_estimator_info_tags,
         _get_meta_estimators_for_autologging,
         _is_parameter_search_estimator,

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -10,6 +10,7 @@ import warnings
 from mlflow.tracking.client import MlflowClient
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils.mlflow_tags import MLFLOW_PARENT_RUN_ID
+from mlflow.utils.arguments_utils import _get_arg_names
 
 _logger = logging.getLogger(__name__)
 
@@ -42,12 +43,6 @@ def _get_estimator_info_tags(estimator):
         "estimator_name": estimator.__class__.__name__,
         "estimator_class": (estimator.__class__.__module__ + "." + estimator.__class__.__name__),
     }
-
-
-def _get_arg_names(f):
-    # `inspect.getargspec` doesn't return a wrapped function's argspec
-    # See: https://hynek.me/articles/decorators#mangled-signatures
-    return list(inspect.signature(f).parameters.keys())
 
 
 def _get_args_for_metrics(fit_func, fit_args, fit_kwargs):

--- a/mlflow/utils/arguments_utils.py
+++ b/mlflow/utils/arguments_utils.py
@@ -8,6 +8,6 @@ def _get_arg_names(f):
     :param f: A function.
     :return: A list of argument names.
     """
-    # `inspect.getargspec` or `inspect.getfullargspec` doesn't return a wrapped function's argspec
-    # See: https://hynek.me/articles/decorators#mangled-signatures
+    # `inspect.getargspec` or `inspect.getfullargspec` doesn't work properly for a wrapped function.
+    # See https://hynek.me/articles/decorators#mangled-signatures for details.
     return list(inspect.signature(f).parameters.keys())

--- a/mlflow/utils/arguments_utils.py
+++ b/mlflow/utils/arguments_utils.py
@@ -1,0 +1,13 @@
+import inspect
+
+
+def _get_arg_names(f):
+    """
+    Get the argument names of a function.
+
+    :param f: A function.
+    :return: A list of argument names.
+    """
+    # `inspect.getargspec` or `inspect.getfullargspec` doesn't return a wrapped function's argspec
+    # See: https://hynek.me/articles/decorators#mangled-signatures
+    return list(inspect.signature(f).parameters.keys())

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -22,7 +22,6 @@ import shutil
 import json
 import yaml
 import tempfile
-import inspect
 import logging
 from copy import deepcopy
 

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -48,6 +48,7 @@ from mlflow.utils.model_utils import _get_flavor_configuration
 from mlflow.exceptions import MlflowException
 from mlflow.utils.annotations import experimental
 from mlflow.utils.docstring_utils import format_docstring, LOG_MODEL_PARAM_DOCS
+from mlflow.utils.arguments_utils import _get_arg_names
 from mlflow.utils.autologging_utils import (
     autologging_integration,
     safe_patch,
@@ -562,7 +563,7 @@ def autolog(
 
         param_logging_operations = autologging_client.flush(synchronous=False)
 
-        all_arg_names = inspect.getfullargspec(original)[0]  # pylint: disable=W1505
+        all_arg_names = _get_arg_names(original)
         num_pos_args = len(args)
 
         # adding a callback that records evaluation results.

--- a/tests/utils/test_arguments_utils.py
+++ b/tests/utils/test_arguments_utils.py
@@ -5,29 +5,56 @@ import pytest
 from mlflow.utils.arguments_utils import _get_arg_names
 
 
-def only_positional(a, b):
-    return a + b
+def no_args():
+    pass
 
 
-def only_keyword(a=0, b=0):
-    return a + b
+def positional(a, b):
+    return a, b
+
+
+def keyword(a=0, b=0):
+    return a, b
 
 
 def positional_and_keyword(a, b=0):
-    return a + b
+    return a, b
 
 
 def keyword_only(*, a, b=0):
-    return a + b
+    return a, b
 
 
-@functools.wraps(only_positional)
+def var_positional(*args):
+    return args
+
+
+def var_keyword(**kwargs):
+    return kwargs
+
+
+def var_positional_and_keyword(*args, **kwargs):
+    return args, kwargs
+
+
+@functools.wraps(positional)
 def wrapper(*args, **kwargs):
-    return only_positional(*args, **kwargs)
+    return positional(*args, **kwargs)
 
 
 @pytest.mark.parametrize(
-    "func", [only_positional, only_keyword, positional_and_keyword, keyword_only, wrapper]
+    "func, expected_args",
+    [
+        (no_args, []),
+        (positional, ["a", "b"]),
+        (keyword, ["a", "b"]),
+        (positional_and_keyword, ["a", "b"]),
+        (keyword_only, ["a", "b"]),
+        (var_positional, ["args"]),
+        (var_keyword, ["kwargs"]),
+        (var_positional_and_keyword, ["args", "kwargs"]),
+        (wrapper, ["a", "b"]),
+    ],
 )
-def test_get_arg_names(func):
-    assert _get_arg_names(func) == ["a", "b"]
+def test_get_arg_names(func, expected_args):
+    assert _get_arg_names(func) == expected_args

--- a/tests/utils/test_arguments_utils.py
+++ b/tests/utils/test_arguments_utils.py
@@ -1,0 +1,33 @@
+import functools
+
+import pytest
+
+from mlflow.utils.arguments_utils import _get_arg_names
+
+
+def only_positional(a, b):
+    return a + b
+
+
+def only_keyword(a=0, b=0):
+    return a + b
+
+
+def positional_and_keyword(a, b=0):
+    return a + b
+
+
+def keyword_only(*, a, b=0):
+    return a + b
+
+
+@functools.wraps(only_positional)
+def wrapper(*args, **kwargs):
+    return only_positional(*args, **kwargs)
+
+
+@pytest.mark.parametrize(
+    "func", [only_positional, only_keyword, positional_and_keyword, keyword_only, wrapper]
+)
+def test_get_arg_names(func):
+    assert _get_arg_names(func) == ["a", "b"]


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

In https://github.com/dmlc/xgboost/pull/6751, `xgboost.train` is wrapped by `_deprecate_positional_args` to deprecate the positional arguments. This change broke xgboost autologging because `inspect.getfullargspec` doesn't work properly for a wrapped function:

https://github.com/mlflow/mlflow/runs/4033126360?check_suite_focus=true#step:11:8877

```python
        all_arg_names = inspect.getfullargspec(original)[0]  # `original` is `xgboost.train`
                              # ^^^^^^^^^^^^^^
                              # doesn't work for a wrapped function
        num_pos_args = len(args)
    
        # adding a callback that records evaluation results.
        eval_results = []
>       callbacks_index = all_arg_names.index("callbacks")
E       ValueError: 'callbacks' is not in list
```

This PR fixes the issue by using `inspect.signature`.

## How is this patch tested?

Existing tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
