### PR TITLE
Add debugging statement to parameter collision exception

### DIFF
--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -819,8 +819,8 @@ class FileStore(AbstractStore):
         if current_value != new_value:
             explain_message = """
 
-            The cause of this error is typically due to repeated calls 
-            to an individual run_id event logging. 
+            The cause of this error is typically due to repeated calls
+            to an individual run_id event logging.
 
             Incorrect Example:
 
@@ -830,8 +830,8 @@ class FileStore(AbstractStore):
                 model = Model().fit(df, depth=5)
                 mlflow.log_param("depth", getattr(model, "depth"))
 
-            Which will throw an MlflowException for overwriting a 
-            logged parameter. 
+            Which will throw an MlflowException for overwriting a
+            logged parameter.
 
             Correct Example:
 
@@ -844,7 +844,7 @@ class FileStore(AbstractStore):
                   mlflow.log_param("depth", getattr(model, "depth"))
 
             Which will create a new nested run for each individual
-            model and prevent parameter key collisions within the 
+            model and prevent parameter key collisions within the
             tracking store.
             """
             raise MlflowException(

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -821,7 +821,7 @@ class FileStore(AbstractStore):
             raise MlflowException(
                 "Changing param values is not allowed. Param with key='{}' was already"
                 " logged with value='{}' for run ID='{}'. Attempted logging new value"
-                " '{}'.".format(param_key, current_value, run_id, new_value,),
+                " '{}'.".format(param_key, current_value, run_id, new_value),
                 databricks_pb2.INVALID_PARAMETER_VALUE,
             )
 

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -38,6 +38,7 @@ from mlflow.utils.validation import (
     _validate_batch_log_limits,
     _validate_batch_log_data,
     _validate_list_experiments_max_results,
+    _validate_param_keys_unique,
 )
 from mlflow.utils.env import get_env
 from mlflow.utils.file_utils import (
@@ -817,40 +818,10 @@ class FileStore(AbstractStore):
         with open(param_path, "r") as param_file:
             current_value = param_file.read()
         if current_value != new_value:
-            explain_message = """
-
-            The cause of this error is typically due to repeated calls
-            to an individual run_id event logging.
-
-            Incorrect Example:
-
-            with mlflow.start_run():
-                model = Model().fit(df, depth=3)
-                mlflow.log_param("depth", getattr(model, "depth"))
-                model = Model().fit(df, depth=5)
-                mlflow.log_param("depth", getattr(model, "depth"))
-
-            Which will throw an MlflowException for overwriting a
-            logged parameter.
-
-            Correct Example:
-
-            with mlflow.start_run():
-                with mlflow.start_run(nested=True):
-                  model = Model().fit(df, depth=3)
-                  mlflow.log_param("depth", getattr(model, "depth"))
-                with mlflow.start_run(nested=True):
-                  model = Model().fit(df, depth=5)
-                  mlflow.log_param("depth", getattr(model, "depth"))
-
-            Which will create a new nested run for each individual
-            model and prevent parameter key collisions within the
-            tracking store.
-            """
             raise MlflowException(
                 "Changing param values is not allowed. Param with key='{}' was already"
                 " logged with value='{}' for run ID='{}'. Attempted logging new value"
-                " '{}'.{}".format(param_key, current_value, run_id, new_value, explain_message),
+                " '{}'.".format(param_key, current_value, run_id, new_value,),
                 databricks_pb2.INVALID_PARAMETER_VALUE,
             )
 
@@ -912,6 +883,7 @@ class FileStore(AbstractStore):
         _validate_run_id(run_id)
         _validate_batch_log_data(metrics, params, tags)
         _validate_batch_log_limits(metrics, params, tags)
+        _validate_param_keys_unique(params)
         run_info = self._get_run_info(run_id)
         check_run_is_active(run_info)
         try:

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -150,7 +150,8 @@ class RestStore(AbstractStore):
 
         :param experiment_id: ID of the experiment for this run
         :param user_id: ID of the user launching this run
-        :param source_type: Enum (integer) describing the source of the run
+        :param start_time: timestamp of the initialization of the run
+        :param tags: tags to apply to this run at initialization
 
         :return: The created Run object
         """

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -680,8 +680,8 @@ class SqlAlchemyStore(AbstractStore):
                 if len(existing_params) > 0:
                     explain_message = """
 
-                                The cause of this error is typically due to repeated calls 
-                                to an individual run_id event logging. 
+                                The cause of this error is typically due to repeated calls
+                                to an individual run_id event logging.
 
                                 Incorrect Example:
 
@@ -691,8 +691,8 @@ class SqlAlchemyStore(AbstractStore):
                                     model = Model().fit(df, depth=5)
                                     mlflow.log_param("depth", getattr(model, "depth"))
 
-                                Which will throw an MlflowException for overwriting a 
-                                logged parameter. 
+                                Which will throw an MlflowException for overwriting a
+                                logged parameter.
 
                                 Correct Example:
 
@@ -705,7 +705,7 @@ class SqlAlchemyStore(AbstractStore):
                                       mlflow.log_param("depth", getattr(model, "depth"))
 
                                 Which will create a new nested run for each individual
-                                model and prevent parameter key collisions within the 
+                                model and prevent parameter key collisions within the
                                 tracking store.
                                 """
                     old_value = existing_params[0]

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -678,43 +678,11 @@ class SqlAlchemyStore(AbstractStore):
                 session.rollback()
                 existing_params = [p.value for p in run.params if p.key == param.key]
                 if len(existing_params) > 0:
-                    explain_message = """
-
-                                The cause of this error is typically due to repeated calls
-                                to an individual run_id event logging.
-
-                                Incorrect Example:
-
-                                with mlflow.start_run():
-                                    model = Model().fit(df, depth=3)
-                                    mlflow.log_param("depth", getattr(model, "depth"))
-                                    model = Model().fit(df, depth=5)
-                                    mlflow.log_param("depth", getattr(model, "depth"))
-
-                                Which will throw an MlflowException for overwriting a
-                                logged parameter.
-
-                                Correct Example:
-
-                                with mlflow.start_run():
-                                    with mlflow.start_run(nested=True):
-                                      model = Model().fit(df, depth=3)
-                                      mlflow.log_param("depth", getattr(model, "depth"))
-                                    with mlflow.start_run(nested=True):
-                                      model = Model().fit(df, depth=5)
-                                      mlflow.log_param("depth", getattr(model, "depth"))
-
-                                Which will create a new nested run for each individual
-                                model and prevent parameter key collisions within the
-                                tracking store.
-                                """
                     old_value = existing_params[0]
                     raise MlflowException(
                         "Changing param values is not allowed. Param with key='{}' was already"
                         " logged with value='{}' for run ID='{}'. Attempted logging new value"
-                        " '{}'.{}".format(
-                            param.key, old_value, run_id, param.value, explain_message
-                        ),
+                        " '{}'.".format(param.key, old_value, run_id, param.value),
                         INVALID_PARAMETER_VALUE,
                     )
                 else:

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -16,8 +16,12 @@ from mlflow.utils.validation import (
     _validate_experiment_artifact_location,
     _validate_experiment_name,
     _validate_metric,
+    _validate_param_keys_unique,
+    PARAM_VALIDATION_MSG,
 )
 from mlflow.entities import Param, Metric, RunStatus, RunTag, ViewType, ExperimentTag
+from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
 from mlflow.utils.mlflow_tags import MLFLOW_USER
 from mlflow.utils.string_utils import is_string_type
@@ -229,7 +233,11 @@ class TrackingServiceClient(object):
         """
         _validate_param_name(key)
         param = Param(key, str(value))
-        self.store.log_param(run_id, param)
+        try:
+            self.store.log_param(run_id, param)
+        except MlflowException as e:
+            msg = f"{e.message}\nInvalid key: ''{key}' already exists.\n{PARAM_VALIDATION_MSG}'"
+            raise MlflowException(msg, INVALID_PARAMETER_VALUE)
 
     def set_experiment_tag(self, experiment_id, key, value):
         """
@@ -278,6 +286,8 @@ class TrackingServiceClient(object):
         """
         if len(metrics) == 0 and len(params) == 0 and len(tags) == 0:
             return
+        if len(params) > 0:
+            _validate_param_keys_unique(params)
         for metric in metrics:
             _validate_metric(metric.key, metric.value, metric.timestamp, metric.step)
         for param in params:

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -237,7 +237,7 @@ class TrackingServiceClient(object):
             self.store.log_param(run_id, param)
         except MlflowException as e:
             if e.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE):
-                msg = f"{e.message}\nInvalid key: '{key}' already exists.\n{PARAM_VALIDATION_MSG}'"
+                msg = f"{e.message}{PARAM_VALIDATION_MSG}'"
                 raise MlflowException(msg, INVALID_PARAMETER_VALUE)
             else:
                 raise e
@@ -289,7 +289,7 @@ class TrackingServiceClient(object):
         """
         if len(metrics) == 0 and len(params) == 0 and len(tags) == 0:
             return
-        if len(params) > 0:
+        if len(params) > 1:
             _validate_param_keys_unique(params)
         for metric in metrics:
             _validate_metric(metric.key, metric.value, metric.timestamp, metric.step)

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -236,7 +236,7 @@ class TrackingServiceClient(object):
         try:
             self.store.log_param(run_id, param)
         except MlflowException as e:
-            msg = f"{e.message}\nInvalid key: ''{key}' already exists.\n{PARAM_VALIDATION_MSG}'"
+            msg = f"{e.message}\nInvalid key: '{key}' already exists.\n{PARAM_VALIDATION_MSG}'"
             raise MlflowException(msg, INVALID_PARAMETER_VALUE)
 
     def set_experiment_tag(self, experiment_id, key, value):

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -37,6 +37,32 @@ MAX_EXPERIMENTS_LISTED_PER_PAGE = 50000
 
 _UNSUPPORTED_DB_TYPE_MSG = "Supported database engines are {%s}" % ", ".join(DATABASE_ENGINES)
 
+PARAM_VALIDATION_MSG = """
+
+The cause of this error is typically due to repeated calls
+to an individual run_id event logging.
+
+Incorrect Example:
+
+with mlflow.start_run():
+    mlflow.log_param("depth", 3)
+    mlflow.log_param("depth", 5)
+
+Which will throw an MlflowException for overwriting a
+logged parameter.
+
+Correct Example:
+
+with mlflow.start_run():
+    with mlflow.start_run(nested=True):
+      mlflow.log_param("depth", 3)
+    with mlflow.start_run(nested=True):
+      mlflow.log_param("depth", 5)
+
+Which will create a new nested run for each individual
+model and prevent parameter key collisions within the
+tracking store."""
+
 
 def bad_path_message(name):
     return (
@@ -169,6 +195,24 @@ def _validate_list_experiments_max_results(max_results):
             "It must be at most {}, but got value {}".format(
                 MAX_EXPERIMENTS_LISTED_PER_PAGE, max_results
             ),
+            INVALID_PARAMETER_VALUE,
+        )
+
+
+def _validate_param_keys_unique(params):
+    """Ensures that duplicate param keys are not present in the `log_batch()` params argument"""
+    unique_keys = []
+    dupe_keys = []
+    for param in params:
+        if param.key not in unique_keys:
+            unique_keys.append(param.key)
+        else:
+            dupe_keys.append(param.key)
+
+    if dupe_keys:
+        raise MlflowException(
+            f"Duplicate parameter keys have been submitted: {dupe_keys}. Please ensure "
+            "the request contains only one param value per param key.",
             INVALID_PARAMETER_VALUE,
         )
 

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -43,21 +43,23 @@ The cause of this error is typically due to repeated calls
 to an individual run_id event logging.
 
 Incorrect Example:
-
+---------------------------------------
 with mlflow.start_run():
     mlflow.log_param("depth", 3)
     mlflow.log_param("depth", 5)
+---------------------------------------
 
 Which will throw an MlflowException for overwriting a
 logged parameter.
 
 Correct Example:
-
+---------------------------------------
 with mlflow.start_run():
     with mlflow.start_run(nested=True):
         mlflow.log_param("depth", 3)
     with mlflow.start_run(nested=True):
         mlflow.log_param("depth", 5)
+---------------------------------------
 
 Which will create a new nested run for each individual
 model and prevent parameter key collisions within the

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -55,9 +55,9 @@ Correct Example:
 
 with mlflow.start_run():
     with mlflow.start_run(nested=True):
-      mlflow.log_param("depth", 3)
+        mlflow.log_param("depth", 3)
     with mlflow.start_run(nested=True):
-      mlflow.log_param("depth", 5)
+        mlflow.log_param("depth", 5)
 
 Which will create a new nested run for each individual
 model and prevent parameter key collisions within the

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -1096,6 +1096,4 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
             )
         assert e.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
         self._verify_logged(fs, run.info.run_id, metrics=[], params=[], tags=[])
-        fs.log_batch(
-            run.info.run_id, metrics=[], params=[Param("a", "1"), Param("a", "2")], tags=[]
-        )
+

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -728,9 +728,10 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         fs.log_param(run_id, Param(param_name, "value1"))
         # Duplicate calls to `log_param` with the same key and value should succeed
         fs.log_param(run_id, Param(param_name, "value1"))
-        with pytest.raises(MlflowException) as exc:
+        with self.assertRaises(MlflowException) as e:
             fs.log_param(run_id, Param(param_name, "value2"))
-        assert exc.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+        assert e.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+        self.assertIn("Changing param values is not allowed. Param with key=", e.exception.message)
         run = fs.get_run(run_id)
         assert run.data.params[param_name] == "value1"
 

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -1089,11 +1089,10 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         fs = FileStore(self.test_root)
         run = self._create_run(fs)
         with self.assertRaisesRegex(
-            MlflowException, "Duplicate parameter keys have been submitted."
+            MlflowException, "Duplicate parameter keys have been submitted"
         ) as e:
             fs.log_batch(
                 run.info.run_id, metrics=[], params=[Param("a", "1"), Param("a", "2")], tags=[]
             )
         assert e.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
         self._verify_logged(fs, run.info.run_id, metrics=[], params=[], tags=[])
-

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -728,10 +728,11 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         fs.log_param(run_id, Param(param_name, "value1"))
         # Duplicate calls to `log_param` with the same key and value should succeed
         fs.log_param(run_id, Param(param_name, "value1"))
-        with self.assertRaises(MlflowException) as e:
+        with self.assertRaisesRegex(
+            MlflowException, "Changing param values is not allowed. Param with key="
+        ) as e:
             fs.log_param(run_id, Param(param_name, "value2"))
         assert e.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
-        self.assertIn("Changing param values is not allowed. Param with key=", e.exception.message)
         run = fs.get_run(run_id)
         assert run.data.params[param_name] == "value1"
 

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -450,6 +450,28 @@ def test_log_params():
     assert finished_run.data.params == {"name_1": "c", "name_2": "b", "nested/nested/name": "5"}
 
 
+def test_log_params_duplicate_keys_raises():
+    params = {"a": "1", "b": "2"}
+    with start_run() as active_run:
+        run_id = active_run.info.run_id
+        mlflow.log_params(params)
+        with pytest.raises(expected_exception=MlflowException) as e:
+            mlflow.log_param("a", "3")
+        assert e.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+    finished_run = tracking.MlflowClient().get_run(run_id)
+    assert finished_run.data.params == params
+
+
+def test_log_batch_duplicate_entries_raises():
+    with start_run() as active_run:
+        run_id = active_run.info.run_id
+        with pytest.raises(MlflowException) as e:
+            tracking.MlflowClient().log_batch(
+                run_id=run_id, params=[Param("a", "1"), Param("a", "2")]
+            )
+        assert e.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+
+
 def test_log_batch_validates_entity_names_and_values():
     bad_kwargs = {
         "metrics": [

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -455,7 +455,10 @@ def test_log_params_duplicate_keys_raises():
     with start_run() as active_run:
         run_id = active_run.info.run_id
         mlflow.log_params(params)
-        with pytest.raises(expected_exception=MlflowException) as e:
+        with pytest.raises(
+            expected_exception=MlflowException,
+            match=r"Changing param values is not allowed. Param with key=",
+        ) as e:
             mlflow.log_param("a", "3")
         assert e.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
     finished_run = tracking.MlflowClient().get_run(run_id)
@@ -465,7 +468,9 @@ def test_log_params_duplicate_keys_raises():
 def test_log_batch_duplicate_entries_raises():
     with start_run() as active_run:
         run_id = active_run.info.run_id
-        with pytest.raises(MlflowException) as e:
+        with pytest.raises(
+            MlflowException, match=r"Duplicate parameter keys have been submitted."
+        ) as e:
             tracking.MlflowClient().log_batch(
                 run_id=run_id, params=[Param("a", "1"), Param("a", "2")]
             )


### PR DESCRIPTION
Signed-off-by: Ben Wilson <benjamin.wilson@databricks.com>

## What changes are proposed in this pull request?

For a parameter collision Exception (attempting to write to an existing parameter key for a run with a different value), the current error message is:

```python
Changing param values is not allowed. Param with key='<key>' was already logged
with value='<value>' for run ID='<run_id'
```

Which is potentially misleading and has confused a number of end-users. 
This change provides an example block comment that shows a likely reason for this error and an example of how to use the `with mlflow.start_run(nested=True)` syntax to alleviate the issue exposed in the Exception.

## How is this patch tested?

Unit tests in test_file_store.py and test_sqlalchemy_store.py

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
