### PR TITLE
Return project for fetch_and_validate_project().

### DIFF
--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -103,8 +103,7 @@ def _run(
             )
             return submitted_run
 
-    work_dir = fetch_and_validate_project(uri, version, entry_point, parameters)
-    project = load_project(work_dir)
+    work_dir, project = fetch_and_validate_project(uri, version, entry_point, parameters)
     _validate_execution_environment(project, backend_name)
 
     active_run = get_or_create_run(

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -17,7 +17,6 @@ from mlflow.projects.utils import (
     get_run_env_vars,
     fetch_and_validate_project,
     get_or_create_run,
-    load_project,
     MLFLOW_LOCAL_BACKEND_RUN_ID_CONFIG,
     PROJECT_USE_CONDA,
     PROJECT_STORAGE_DIR,

--- a/mlflow/projects/backend/local.py
+++ b/mlflow/projects/backend/local.py
@@ -13,7 +13,6 @@ from mlflow.projects.backend.abstract_backend import AbstractBackend
 from mlflow.projects.utils import (
     fetch_and_validate_project,
     get_or_create_run,
-    load_project,
     get_run_env_vars,
     get_databricks_env_vars,
     get_entry_point_command,

--- a/mlflow/projects/backend/local.py
+++ b/mlflow/projects/backend/local.py
@@ -42,8 +42,7 @@ class LocalBackend(AbstractBackend):
     def run(
         self, project_uri, entry_point, params, version, backend_config, tracking_uri, experiment_id
     ):
-        work_dir = fetch_and_validate_project(project_uri, version, entry_point, params)
-        project = load_project(work_dir)
+        work_dir, project = fetch_and_validate_project(project_uri, version, entry_point, params)
         if MLFLOW_LOCAL_BACKEND_RUN_ID_CONFIG in backend_config:
             run_id = backend_config[MLFLOW_LOCAL_BACKEND_RUN_ID_CONFIG]
         else:

--- a/mlflow/projects/utils.py
+++ b/mlflow/projects/utils.py
@@ -128,6 +128,10 @@ def fetch_and_validate_project(uri, version, entry_point, parameters):
     return work_dir, project
 
 
+def load_project(work_dir):
+    return _project_spec.load_project(work_dir)
+
+
 def _fetch_project(uri, version=None):
     """
     Fetch a project into a local directory, returning the path to the local project directory.

--- a/mlflow/projects/utils.py
+++ b/mlflow/projects/utils.py
@@ -128,10 +128,6 @@ def fetch_and_validate_project(uri, version, entry_point, parameters):
     return work_dir, project
 
 
-def load_project(work_dir):
-    return _project_spec.load_project(work_dir)
-
-
 def _fetch_project(uri, version=None):
     """
     Fetch a project into a local directory, returning the path to the local project directory.

--- a/mlflow/projects/utils.py
+++ b/mlflow/projects/utils.py
@@ -125,11 +125,7 @@ def fetch_and_validate_project(uri, version, entry_point, parameters):
     work_dir = _fetch_project(uri=uri, version=version)
     project = _project_spec.load_project(work_dir)
     project.get_entry_point(entry_point)._validate_parameters(parameters)
-    return work_dir
-
-
-def load_project(work_dir):
-    return _project_spec.load_project(work_dir)
+    return work_dir, project
 
 
 def _fetch_project(uri, version=None):

--- a/tests/projects/test_utils.py
+++ b/tests/projects/test_utils.py
@@ -17,7 +17,6 @@ from mlflow.projects.utils import (
     _parse_subdirectory,
     get_or_create_run,
     fetch_and_validate_project,
-    load_project,
 )
 from mlflow.utils.mlflow_tags import MLFLOW_PROJECT_ENTRY_POINT, MLFLOW_SOURCE_NAME
 from tests.projects.utils import (

--- a/tests/projects/test_utils.py
+++ b/tests/projects/test_utils.py
@@ -174,8 +174,7 @@ def test_fetch_create_and_log(tmpdir):
         with mock.patch(
             "mlflow.projects._project_spec.load_project", return_value=mock_fetched_project
         ):
-            work_dir = fetch_and_validate_project("", "", entry_point_name, user_param)
-            project = load_project(work_dir)
+            work_dir, project = fetch_and_validate_project("", "", entry_point_name, user_param)
             assert mock_fetched_project == project
             assert expected_dir == work_dir
             # Create a run

--- a/tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_backend.py
+++ b/tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_backend.py
@@ -30,7 +30,7 @@ class PluginDummyProjectBackend(AbstractBackend):
     def run(
         self, project_uri, entry_point, params, version, backend_config, tracking_uri, experiment_id
     ):
-        work_dir = fetch_and_validate_project(project_uri, version, entry_point, params)
+        work_dir, _ = fetch_and_validate_project(project_uri, version, entry_point, params)
         active_run = get_or_create_run(
             None, project_uri, experiment_id, work_dir, version, entry_point, params
         )


### PR DESCRIPTION
Signed-off-by: Xuan Hu <i@huxuan.org>

## What changes are proposed in this pull request?

Reduce redundant parsing.

## How is this patch tested?

Whole test.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
