### PR TITLE
updating docs to address issue 4202 Signed-off-by: Alex Lee <westford…

### DIFF
--- a/.github/actions/cache-pip/action.yml
+++ b/.github/actions/cache-pip/action.yml
@@ -1,0 +1,16 @@
+name: "cache-pip"
+description: "Cache pip dependencies"
+runs:
+  using: "composite"
+  steps:
+    - name: Get cache key prefix
+      id: get-cache-key-prefix
+      shell: bash
+      run: |
+        echo "::set-output name=prefix::$ImageOS-$ImageVersion"
+    - uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ steps.get-cache-key-prefix.outputs.prefix }}-pip-${{ hashFiles('**/*-requirements.txt') }}
+        restore-keys: |
+          ${{ steps.get-cache-key-prefix.outputs.prefix }}-pip-

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -37,6 +37,7 @@ jobs:
     - uses: ./.github/actions/setup-python
       with:
         python-version: 3.6
+    - uses: ./.github/actions/cache-pip
     - name: Install dependencies
       env:
         INSTALL_LARGE_PYTHON_DEPS: true
@@ -202,6 +203,7 @@ jobs:
         # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md#java
         java-version: 8
         distribution: 'adopt'
+    - uses: ./.github/actions/cache-pip
     - name: Install dependencies
       env:
         INSTALL_LARGE_PYTHON_DEPS: true
@@ -314,6 +316,7 @@ jobs:
         with:
           java-version: 8
           distribution: 'adopt'
+      - uses: ./.github/actions/cache-pip
       - name: Install dependencies
         env:
           INSTALL_LARGE_PYTHON_DEPS: true

--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -22,7 +22,6 @@ import yaml
 import json
 import tempfile
 import shutil
-import inspect
 import logging
 from copy import deepcopy
 
@@ -48,6 +47,7 @@ from mlflow.utils.docstring_utils import format_docstring, LOG_MODEL_PARAM_DOCS
 from mlflow.utils.model_utils import _get_flavor_configuration
 from mlflow.exceptions import MlflowException
 from mlflow.utils.annotations import experimental
+from mlflow.utils.arguments_utils import _get_arg_names
 from mlflow.utils.autologging_utils import (
     autologging_integration,
     safe_patch,
@@ -452,7 +452,7 @@ def autolog(
 
         param_logging_operations = autologging_client.flush(synchronous=False)
 
-        all_arg_names = inspect.getfullargspec(original)[0]
+        all_arg_names = _get_arg_names(original)
         num_pos_args = len(args)
 
         # adding a callback that records evaluation results.

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -1158,7 +1158,6 @@ def autolog(
         _get_args_for_metrics,
         _log_estimator_content,
         _all_estimators,
-        _get_arg_names,
         _get_estimator_info_tags,
         _get_meta_estimators_for_autologging,
         _is_parameter_search_estimator,

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -10,6 +10,7 @@ import warnings
 from mlflow.tracking.client import MlflowClient
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils.mlflow_tags import MLFLOW_PARENT_RUN_ID
+from mlflow.utils.arguments_utils import _get_arg_names
 
 _logger = logging.getLogger(__name__)
 
@@ -42,12 +43,6 @@ def _get_estimator_info_tags(estimator):
         "estimator_name": estimator.__class__.__name__,
         "estimator_class": (estimator.__class__.__module__ + "." + estimator.__class__.__name__),
     }
-
-
-def _get_arg_names(f):
-    # `inspect.getargspec` doesn't return a wrapped function's argspec
-    # See: https://hynek.me/articles/decorators#mangled-signatures
-    return list(inspect.signature(f).parameters.keys())
 
 
 def _get_args_for_metrics(fit_func, fit_args, fit_kwargs):

--- a/mlflow/statsmodels.py
+++ b/mlflow/statsmodels.py
@@ -15,7 +15,6 @@ statsmodels (native) format
 import os
 import yaml
 import logging
-import numpy as np
 
 import mlflow
 from mlflow import pyfunc
@@ -74,6 +73,12 @@ def get_default_conda_env():
              :func:`save_model()` and :func:`log_model()`.
     """
     return _mlflow_conda_env(additional_pip_deps=get_default_pip_requirements())
+
+
+_model_size_threshold_for_emitting_warning = 100 * 1024 * 1024  # 100 MB
+
+
+_save_model_called_from_autolog = False
 
 
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
@@ -140,6 +145,17 @@ def save_model(
 
     # Save a statsmodels model
     statsmodels_model.save(model_data_path, remove_data)
+    if _save_model_called_from_autolog and not remove_data:
+        saved_model_size = os.path.getsize(model_data_path)
+        if saved_model_size >= _model_size_threshold_for_emitting_warning:
+            _logger.warning(
+                "The fitted model is larger than "
+                f"{_model_size_threshold_for_emitting_warning // (1024 * 1024)} MB, "
+                f"saving it as artifacts is time consuming.\n"
+                "To reduce model size, use `mlflow.statsmodels.autolog(log_models=False)` and "
+                "manually log model by "
+                '`mlflow.statsmodels.log_model(model, remove_data=True, artifact_path="model")`'
+            )
 
     pyfunc.add_to_model(
         mlflow_model,
@@ -192,7 +208,7 @@ def log_model(
     await_registration_for=DEFAULT_AWAIT_MAX_SLEEP_SECONDS,
     pip_requirements=None,
     extra_pip_requirements=None,
-    **kwargs
+    **kwargs,
 ):
     """
     Log a statsmodels model as an MLflow artifact for the current run.
@@ -246,7 +262,7 @@ def log_model(
         remove_data=remove_data,
         pip_requirements=pip_requirements,
         extra_pip_requirements=extra_pip_requirements,
-        **kwargs
+        **kwargs,
     )
 
 
@@ -323,6 +339,49 @@ class AutologHelpers:
     should_autolog = True
 
 
+# Currently we only autolog basic metrics
+_autolog_metric_allowlist = [
+    "aic",
+    "bic",
+    "centered_tss",
+    "condition_number",
+    "df_model",
+    "df_resid",
+    "ess",
+    "f_pvalue",
+    "fvalue",
+    "llf",
+    "mse_model",
+    "mse_resid",
+    "mse_total",
+    "rsquared",
+    "rsquared_adj",
+    "scale",
+    "ssr",
+    "uncentered_tss",
+]
+
+
+def _get_autolog_metrics(fitted_model):
+    result_metrics = {}
+
+    failed_evaluating_metrics = set()
+    for metric in _autolog_metric_allowlist:
+        try:
+            if hasattr(fitted_model, metric):
+                metric_value = getattr(fitted_model, metric)
+                if _is_numeric(metric_value):
+                    result_metrics[metric] = metric_value
+        except Exception:
+            failed_evaluating_metrics.add(metric)
+
+    if len(failed_evaluating_metrics) > 0:
+        _logger.warning(
+            f"Failed to autolog metrics: {', '.join(sorted(failed_evaluating_metrics))}."
+        )
+    return result_metrics
+
+
 @experimental
 @autologging_integration(FLAVOR_NAME)
 def autolog(
@@ -336,8 +395,11 @@ def autolog(
     Enables (or disables) and configures automatic logging from statsmodels to MLflow.
     Logs the following:
 
-    - results metrics returned by method `fit` of any subclass of statsmodels.base.model.Model
+    - allowlisted metrics returned by method `fit` of any subclass of
+      statsmodels.base.model.Model, the allowlisted metrics including: {autolog_metric_allowlist}
     - trained model.
+    - an html artifact which shows the model summary.
+
 
     :param log_models: If ``True``, trained models are logged as MLflow model artifacts.
                        If ``False``, trained models are not logged.
@@ -420,68 +482,6 @@ def autolog(
         for clazz, method_name, patch_impl in patches_list:
             safe_patch(FLAVOR_NAME, clazz, method_name, patch_impl, manage_run=True)
 
-    def prepend_to_keys(dictionary: dict, preffix="_"):
-        """
-        Modifies all keys of a dictionary by adding a preffix string to all of them
-        and make them compliant with mlflow params & metrics naming rules.
-        :param dictionary:
-        :param preffix: a string to be prepended to existing keys, using _ as separator
-        :return: a new dictionary where all keys have been modified. No changes are
-            made to the input dictionary
-        """
-        import re
-
-        keys = list(dictionary.keys())
-        d2 = {}
-        for k in keys:
-            newkey = re.sub(r"[(|)|[|\]|.]+", "_", preffix + "_" + k)
-            d2[newkey] = dictionary.get(k)
-        return d2
-
-    def results_to_dict(results):
-        """
-        Turns a ResultsWrapper object into a python dict
-        :param results: instance of a ResultsWrapper returned by a call to `fit`
-        :return: a python dictionary with those metrics that are (a) a real number, or (b) an array
-                 of the same length of the number of coefficients
-        """
-        has_features = False
-        features = results.model.exog_names
-        if features is not None:
-            has_features = True
-            nfeat = len(features)
-
-        results_dict = {}
-        for f in dir(results):
-            try:
-                field = getattr(results, f)
-                # Get all fields except covariances and private ones
-                if (
-                    not callable(field)
-                    and not f.startswith("__")
-                    and not f.startswith("_")
-                    and not f.startswith("cov_")
-                ):
-
-                    if (
-                        has_features
-                        and isinstance(field, np.ndarray)
-                        and field.ndim == 1
-                        and field.shape[0] == nfeat
-                    ):
-
-                        d = dict(zip(features, field))
-                        renamed_keys_dict = prepend_to_keys(d, f)
-                        results_dict.update(renamed_keys_dict)
-
-                    elif _is_numeric(field):
-                        results_dict[f] = field
-
-            except Exception:
-                pass
-
-        return results_dict
-
     def wrapper_fit(original, self, *args, **kwargs):
 
         should_autolog = False
@@ -500,12 +500,20 @@ def autolog(
             if should_autolog:
                 # Log the model
                 if get_autologging_config(FLAVOR_NAME, "log_models", True):
-                    try_mlflow_log(log_model, model, artifact_path="model")
+                    global _save_model_called_from_autolog
+                    _save_model_called_from_autolog = True
+                    try:
+                        try_mlflow_log(log_model, model, artifact_path="model")
+                    finally:
+                        _save_model_called_from_autolog = False
 
                 # Log the most common metrics
                 if isinstance(model, statsmodels.base.wrapper.ResultsWrapper):
-                    metrics_dict = results_to_dict(model)
+                    metrics_dict = _get_autolog_metrics(model)
                     try_mlflow_log(mlflow.log_metrics, metrics_dict)
+
+                    model_summary = model.summary().as_text()
+                    try_mlflow_log(mlflow.log_text, model_summary, "model_summary.txt")
 
             return model
 
@@ -515,3 +523,8 @@ def autolog(
                 AutologHelpers.should_autolog = True
 
     patch_class_tree(statsmodels.base.model.Model)
+
+
+autolog.__doc__ = autolog.__doc__.format(
+    autolog_metric_allowlist=", ".join(_autolog_metric_allowlist)
+)

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -210,7 +210,8 @@ class TrackingServiceClient(object):
         Log a metric against the run ID.
 
         :param run_id: The run id to which the metric should be logged.
-        :param key: Metric name.
+        :param key: Metric name (string). This string may only contain alphanumerics, underscores (_),
+                    dashes (-), periods (.), spaces ( ), and slashes (/).
         :param value: Metric value (float). Note that some special values such
                       as +/- Infinity may be replaced by other values depending on the store. For
                       example, the SQLAlchemy store replaces +/- Inf with max / min float values.
@@ -248,8 +249,11 @@ class TrackingServiceClient(object):
         Set a tag on the run with the specified ID. Value is converted to a string.
 
         :param run_id: String ID of the run.
-        :param key: Name of the tag.
-        :param value: Tag value (converted to a string)
+        :param key: Tag name (string). This string may only contain alphanumerics, underscores (_), dashes (-),
+                    periods (.), spaces ( ), and slashes (/).
+                    Maximum length: 250 characters.
+        :param value: Tag value (string, but will be string-ified if not).
+                      Maximum length: 5000 characters.
         """
         _validate_tag_name(key)
         tag = RunTag(key, str(value))

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -210,8 +210,8 @@ class TrackingServiceClient(object):
         Log a metric against the run ID.
 
         :param run_id: The run id to which the metric should be logged.
-        :param key: Metric name (string). This string may only contain alphanumerics, underscores (_),
-                    dashes (-), periods (.), spaces ( ), and slashes (/).
+        :param key: Metric name (string). This string may only contain alphanumerics, 
+                    underscores (_), dashes (-), periods (.), spaces ( ), and slashes (/).
         :param value: Metric value (float). Note that some special values such
                       as +/- Infinity may be replaced by other values depending on the store. For
                       example, the SQLAlchemy store replaces +/- Inf with max / min float values.
@@ -249,11 +249,13 @@ class TrackingServiceClient(object):
         Set a tag on the run with the specified ID. Value is converted to a string.
 
         :param run_id: String ID of the run.
-        :param key: Tag name (string). This string may only contain alphanumerics, underscores (_), dashes (-),
-                    periods (.), spaces ( ), and slashes (/).
-                    Maximum length: 250 characters.
+        :param key: Tag name (string). This string may only contain alphanumerics, underscores 
+                    (_), dashes (-), periods (.), spaces ( ), and slashes (/).
+                    All backend stores will support keys up to length 250 but some may 
+                    support larger key values.
         :param value: Tag value (string, but will be string-ified if not).
-                      Maximum length: 5000 characters.
+                      All backend stores will support values up to length 5000 but some 
+                      may support larger key values.
         """
         _validate_tag_name(key)
         tag = RunTag(key, str(value))

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -636,8 +636,8 @@ class MlflowClient(object):
         Log a metric against the run ID.
 
         :param run_id: The run id to which the metric should be logged.
-        :param key: Metric name (string). This string may only contain alphanumerics, underscores (_),
-                    dashes (-), periods (.), spaces ( ), and slashes (/).
+        :param key: Metric name (string). This string may only contain alphanumerics, underscores 
+                    (_), dashes (-), periods (.), spaces ( ), and slashes (/).
         :param value: Metric value (float). Note that some special values such
                       as +/- Infinity may be replaced by other values depending on the store. For
                       example, the SQLAlchemy store replaces +/- Inf with max / min float values.
@@ -690,11 +690,13 @@ class MlflowClient(object):
         Log a parameter against the run ID.
 
         :param run_id: The run id to which the param should be logged.
-        :param key: Parameter name (string). This string may only contain alphanumerics, underscores (_), dashes (-),
-                    periods (.), spaces ( ), and slashes (/).
-                    Maximum length: 250 characters.
+        :param key: Parameter name (string). This string may only contain alphanumerics, underscores 
+                    (_), dashes (-), periods (.), spaces ( ), and slashes (/).
+                    All backend stores will support keys up to length 250 but some may 
+                    support larger key values.
         :param value: Parameter value (string, but will be string-ified if not).
-                      Maximum length: 250 characters.
+                      All backend stores will support values up to length 5000 but some 
+                      may support larger key values.
 
         .. code-block:: python
             :caption: Example
@@ -772,11 +774,13 @@ class MlflowClient(object):
         Set a tag on the run with the specified ID. Value is converted to a string.
 
         :param run_id: String ID of the run.
-        :param key: Tag name (string).
-                    This string may only contain alphanumerics, underscores (_), dashes (-), periods (.), spaces ( ), and slashes (/).
-                    Maximum length: 250 characters.
+        :param key: Tag name (string). This string may only contain alphanumerics, 
+                    underscores (_), dashes (-), periods (.), spaces ( ), and slashes (/). 
+                    All backend stores will support keys up to length 250 but some may 
+                    support larger key values.
         :param value: Tag value (string, but will be string-ified if not).
-                      Maximum length: 5000 characters.
+                      All backend stores will support values up to length 5000 but some 
+                      may support larger key values.
 
         .. code-block:: python
             :caption: Example

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -636,7 +636,8 @@ class MlflowClient(object):
         Log a metric against the run ID.
 
         :param run_id: The run id to which the metric should be logged.
-        :param key: Metric name.
+        :param key: Metric name (string). This string may only contain alphanumerics, underscores (_),
+                    dashes (-), periods (.), spaces ( ), and slashes (/).
         :param value: Metric value (float). Note that some special values such
                       as +/- Infinity may be replaced by other values depending on the store. For
                       example, the SQLAlchemy store replaces +/- Inf with max / min float values.
@@ -689,7 +690,11 @@ class MlflowClient(object):
         Log a parameter against the run ID.
 
         :param run_id: The run id to which the param should be logged.
-        :param value: Value is converted to a string.
+        :param key: Parameter name (string). This string may only contain alphanumerics, underscores (_), dashes (-),
+                    periods (.), spaces ( ), and slashes (/).
+                    Maximum length: 250 characters.
+        :param value: Parameter value (string, but will be string-ified if not).
+                      Maximum length: 250 characters.
 
         .. code-block:: python
             :caption: Example
@@ -767,8 +772,11 @@ class MlflowClient(object):
         Set a tag on the run with the specified ID. Value is converted to a string.
 
         :param run_id: String ID of the run.
-        :param key: Name of the tag.
-        :param value: Tag value (converted to a string)
+        :param key: Tag name (string).
+                    This string may only contain alphanumerics, underscores (_), dashes (-), periods (.), spaces ( ), and slashes (/).
+                    Maximum length: 250 characters.
+        :param value: Tag value (string, but will be string-ified if not).
+                      Maximum length: 5000 characters.
 
         .. code-block:: python
             :caption: Example

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -358,11 +358,13 @@ def log_param(key: str, value: Any) -> None:
     Log a parameter under the current run. If no run is active, this method will create
     a new active run.
 
-    :param key: Parameter name (string). This string may only contain alphanumerics, underscores (_), dashes (-),
-                periods (.), spaces ( ), and slashes (/).
-                Maximum length: 250 characters.
+    :param key: Parameter name (string). This string may only contain alphanumerics, 
+                underscores (_), dashes (-), periods (.), spaces ( ), and slashes (/).
+                All backend stores will support keys up to length 250 but some may 
+                support larger key values.
     :param value: Parameter value (string, but will be string-ified if not).
-                  Maximum length: 250 characters.
+                  All backend stores will support values up to length 5000 but some 
+                  may support larger key values.
 
     .. code-block:: python
         :caption: Example
@@ -381,11 +383,13 @@ def set_tag(key: str, value: Any) -> None:
     Set a tag under the current run. If no run is active, this method will create a
     new active run.
 
-    :param key: Tag name (string). This string may only contain alphanumerics, underscores (_), dashes (-),
-                periods (.), spaces ( ), and slashes (/).
-                Maximum length: 250 characters.
+    :param key: Tag name (string). This string may only contain alphanumerics, underscores 
+                (_), dashes (-), periods (.), spaces ( ), and slashes (/).
+                All backend stores will support keys up to length 250 but some may 
+                support larger key values.
     :param value: Tag value (string, but will be string-ified if not).
-                  Maximum length: 5000 characters.
+                  All backend stores will support values up to length 5000 but some 
+                  may support larger key values.
 
     .. code-block:: python
         :caption: Example

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -358,8 +358,11 @@ def log_param(key: str, value: Any) -> None:
     Log a parameter under the current run. If no run is active, this method will create
     a new active run.
 
-    :param key: Parameter name (string)
-    :param value: Parameter value (string, but will be string-ified if not)
+    :param key: Parameter name (string). This string may only contain alphanumerics, underscores (_), dashes (-),
+                periods (.), spaces ( ), and slashes (/).
+                Maximum length: 250 characters.
+    :param value: Parameter value (string, but will be string-ified if not).
+                  Maximum length: 250 characters.
 
     .. code-block:: python
         :caption: Example
@@ -378,8 +381,11 @@ def set_tag(key: str, value: Any) -> None:
     Set a tag under the current run. If no run is active, this method will create a
     new active run.
 
-    :param key: Tag name (string)
-    :param value: Tag value (string, but will be string-ified if not)
+    :param key: Tag name (string). This string may only contain alphanumerics, underscores (_), dashes (-),
+                periods (.), spaces ( ), and slashes (/).
+                Maximum length: 250 characters.
+    :param value: Tag value (string, but will be string-ified if not).
+                  Maximum length: 5000 characters.
 
     .. code-block:: python
         :caption: Example
@@ -423,7 +429,8 @@ def log_metric(key: str, value: float, step: Optional[int] = None) -> None:
     Log a metric under the current run. If no run is active, this method will create
     a new active run.
 
-    :param key: Metric name (string).
+    :param key: Metric name (string). This string may only contain alphanumerics, underscores (_),
+                dashes (-), periods (.), spaces ( ), and slashes (/).
     :param value: Metric value (float). Note that some special values such as +/- Infinity may be
                   replaced by other values depending on the store. For example, the
                   SQLAlchemy store replaces +/- Infinity with max / min float values.

--- a/mlflow/utils/arguments_utils.py
+++ b/mlflow/utils/arguments_utils.py
@@ -1,0 +1,13 @@
+import inspect
+
+
+def _get_arg_names(f):
+    """
+    Get the argument names of a function.
+
+    :param f: A function.
+    :return: A list of argument names.
+    """
+    # `inspect.getargspec` or `inspect.getfullargspec` doesn't work properly for a wrapped function.
+    # See https://hynek.me/articles/decorators#mangled-signatures for details.
+    return list(inspect.signature(f).parameters.keys())

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -22,7 +22,6 @@ import shutil
 import json
 import yaml
 import tempfile
-import inspect
 import logging
 from copy import deepcopy
 
@@ -48,6 +47,7 @@ from mlflow.utils.model_utils import _get_flavor_configuration
 from mlflow.exceptions import MlflowException
 from mlflow.utils.annotations import experimental
 from mlflow.utils.docstring_utils import format_docstring, LOG_MODEL_PARAM_DOCS
+from mlflow.utils.arguments_utils import _get_arg_names
 from mlflow.utils.autologging_utils import (
     autologging_integration,
     safe_patch,
@@ -562,7 +562,7 @@ def autolog(
 
         param_logging_operations = autologging_client.flush(synchronous=False)
 
-        all_arg_names = inspect.getfullargspec(original)[0]  # pylint: disable=W1505
+        all_arg_names = _get_arg_names(original)
         num_pos_args = len(args)
 
         # adding a callback that records evaluation results.

--- a/tests/pytorch/test_pytorch_autolog.py
+++ b/tests/pytorch/test_pytorch_autolog.py
@@ -110,7 +110,7 @@ def test_pytorch_autolog_persists_manually_created_run():
         dm.setup(stage="fit")
         trainer = pl.Trainer(max_epochs=NUM_EPOCHS)
         trainer.fit(model, dm)
-        trainer.test()
+        trainer.test(datamodule=dm)
         assert mlflow.active_run() is not None
         assert mlflow.active_run().info.run_id == manual_run.info.run_id
 

--- a/tests/utils/test_arguments_utils.py
+++ b/tests/utils/test_arguments_utils.py
@@ -1,0 +1,60 @@
+import functools
+
+import pytest
+
+from mlflow.utils.arguments_utils import _get_arg_names
+
+
+def no_args():
+    pass
+
+
+def positional(a, b):
+    return a, b
+
+
+def keyword(a=0, b=0):
+    return a, b
+
+
+def positional_and_keyword(a, b=0):
+    return a, b
+
+
+def keyword_only(*, a, b=0):
+    return a, b
+
+
+def var_positional(*args):
+    return args
+
+
+def var_keyword(**kwargs):
+    return kwargs
+
+
+def var_positional_and_keyword(*args, **kwargs):
+    return args, kwargs
+
+
+@functools.wraps(positional)
+def wrapper(*args, **kwargs):
+    return positional(*args, **kwargs)
+
+
+@pytest.mark.parametrize(
+    "func, expected_args",
+    [
+        (no_args, []),
+        (positional, ["a", "b"]),
+        (keyword, ["a", "b"]),
+        (positional_and_keyword, ["a", "b"]),
+        (keyword_only, ["a", "b"]),
+        (var_positional, ["args"]),
+        (var_keyword, ["kwargs"]),
+        (var_positional_and_keyword, ["args", "kwargs"]),
+        (wrapper, ["a", "b"]),
+    ],
+)
+def test_get_arg_names(func, expected_args):
+    assert _get_arg_names(func) == expected_args


### PR DESCRIPTION
## What changes are proposed in this pull request?

This updates documentation to address issue #4202 

## How is this patch tested?

By visually inspecting the generated documentation

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [X] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [X] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
