### PR TITLE
Fix pytest options to show skipped tests and how to unskip them rather than deselecting them

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -56,21 +56,19 @@ def pytest_configure(config):
 
 
 def pytest_runtest_setup(item):
-    marked_as_large = len([mark for mark in item.iter_markers(name="large")]) > 0
-    if marked_as_large and not (
-        item.config.getoption("--large") or item.config.getoption("--large-only")
-    ):
+    markers = [mark.name for mark in item.iter_markers()]
+    marked_as_large = "large" in markers
+    large_option = item.config.getoption("--large")
+    large_only_option = item.config.getoption("--large-only")
+    if marked_as_large and not (large_option or large_only_option):
         pytest.skip("use `--large` or `--large-only` to run this test")
-
-    if not marked_as_large and item.config.getoption("--large-only"):
+    if not marked_as_large and large_only_option:
         pytest.skip("remove `--large-only` to run this test")
 
-    marked_as_requires_ssh = len([mark for mark in item.iter_markers(name="requires_ssh")]) > 0
-    if marked_as_requires_ssh and not item.config.getoption("--requires-ssh"):
+    if "requires_ssh" in markers and not item.config.getoption("--requires-ssh"):
         pytest.skip("use `--requires-ssh` to run this test")
 
-    marked_as_lazy_import = len([mark for mark in item.iter_markers(name="lazy_import")]) > 0
-    if marked_as_lazy_import and not item.config.getoption("--lazy-import"):
+    if "lazy_import" in markers and not item.config.getoption("--lazy-import"):
         pytest.skip("use `--lazy-import` to run this test")
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -48,9 +48,11 @@ def pytest_addoption(parser):
 
 def pytest_configure(config):
     # Register markers to suppress `PytestUnknownMarkWarning`
-    config.addinivalue_line("markers", "large: mark test as large")
-    config.addinivalue_line("markers", "requires_ssh: mark test as requires_ssh")
-    config.addinivalue_line("markers", "lazy_import: mark test as lazy_import")
+    config.addinivalue_line("markers", "large")
+    config.addinivalue_line("markers", "requires_ssh")
+    config.addinivalue_line("markers", "lazy_import")
+    config.addinivalue_line("markers", "notrackingurimock")
+    config.addinivalue_line("markers", "allow_infer_pip_requirements_fallback")
 
 
 def pytest_runtest_setup(item):


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

Fix `pytest` options to show skipped tests and how to unskip them for the first-time contributors or new team members who are not familiar with options for running tests:

![image](https://user-images.githubusercontent.com/17039389/139525339-b893ec48-3cf5-4b36-8888-dc80a84f9aec.png)


## How is this patch tested?

Existing tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
