### PR TITLE
Use `EXTRA_PYFUNC_SERVING_TEST_ARGS` in `test_catboost_model_export.py` to avoid attempting to install catboost version that doesn't exist on PyPI

### DIFF
--- a/tests/catboost/test_catboost_model_export.py
+++ b/tests/catboost/test_catboost_model_export.py
@@ -391,6 +391,7 @@ def test_pyfunc_serve_and_score(reg_model):
         model_uri,
         data=inference_dataframe,
         content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
+        extra_args=EXTRA_PYFUNC_SERVING_TEST_ARGS,
     )
     scores = pd.read_json(resp.content, orient="records").values.squeeze()
     np.testing.assert_array_almost_equal(scores, model.predict(inference_dataframe))
@@ -409,6 +410,7 @@ def test_pyfunc_serve_and_score_sklearn(reg_model):
         model_uri,
         inference_dataframe.head(3),
         pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
+        extra_args=EXTRA_PYFUNC_SERVING_TEST_ARGS,
     )
     scores = pd.read_json(resp.content, orient="records").values.squeeze()
     np.testing.assert_array_almost_equal(scores, model.predict(inference_dataframe.head(3)))


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

I found `EXTRA_PYFUNC_SERVING_TEST_ARGS` is not used at all in `test_catboost_model_export.py` and several `catboost` tests failed. `EXTRA_PYFUNC_SERVING_TEST_ARGS` is used to avoid attempting to install a package that doesn't exist in PyPI:

https://github.com/mlflow/mlflow/runs/4043642562?check_suite_focus=true

```
ERROR: Could not find a version that satisfies the requirement catboost==1.0.1 (from versions: 0.1.1.2, 0.1.1.5, 0.1.1.6, 0.1.1.8, 0.1.1.9, 0.2, 0.2.1, 0.2.2, 0.2.4, 0.2.5, 0.3.0, 0.3.1, 0.4, 0.4.1, 0.5, 0.5.1, 0.5.2, 0.5.2.1, 0.6, 0.6.1, 0.6.1.1, 0.6.2, 0.6.3, 0.7, 0.7.1, 0.7.2, 0.7.2.1, 0.7.2.3, 0.8, 0.8.1, 0.8.1.1, 0.9.0a0, 0.9, 0.9.1, 0.9.1.1, 0.10.0, 0.10.1, 0.10.2, 0.10.3, 0.10.4, 0.10.4.1, 0.11.0, 0.11.1, 0.11.2, 0.12.0, 0.12.1, 0.12.1.1, 0.12.2, 0.13, 0.13.1, 0.14.0, 0.14.1, 0.14.2, 0.15, 0.15.1, 0.15.2, 0.16, 0.16.1, 0.16.2, 0.16.3, 0.16.4, 0.16.5, 0.17, 0.17.1, 0.17.2, 0.17.3, 0.17.4, 0.17.5, 0.18, 0.18.1, 0.19.1, 0.20, 0.20.1, 0.20.2, 0.21, 0.22, 0.23, 0.23.1, 0.23.2, 0.24, 0.24.1, 0.24.2, 0.24.3, 0.24.4, 0.25, 0.25.1, 0.26, 0.26.1, 1.0.0)
ERROR: No matching distribution found for catboost==1.0.1
```

## How is this patch tested?

Existing checks

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
