### PR TITLE
Drop support for old ML package versions

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -8,14 +8,14 @@ sklearn:
       pip install $CACHE_DIR/scikit_learn-*.whl
 
   models:
-    minimum: "0.20.3"
-    maximum: "1.0"
+    minimum: "0.22"
+    maximum: "1.0.1"
     run: |
       pytest tests/sklearn/test_sklearn_model_export.py --large
 
   autologging:
-    minimum: "0.20.3"
-    maximum: "1.0"
+    minimum: "0.22"
+    maximum: "1.0.1"
     requirements: ["matplotlib"]
     run: |
       pytest tests/sklearn/test_sklearn_autolog.py --large
@@ -86,7 +86,7 @@ keras:
     pip_release: "keras"
 
   models:
-    minimum: "2.3.0"
+    minimum: "2.4.0"
     maximum: "2.6.0"
     requirements:
       "<= 2.3.1": ["tensorflow==2.2.1", "scikit-learn", "pyspark", "pyarrow", "transformers"]
@@ -96,7 +96,7 @@ keras:
       pytest tests/keras/test_keras_model_export.py --large
 
   autologging:
-    minimum: "2.3.0"
+    minimum: "2.4.0"
     maximum: "2.6.0"
     requirements:
       # keras 2.3.1 is incompatible with tensorflow > 2.2.1 and causes the issue reported here:
@@ -114,14 +114,14 @@ xgboost:
       pip install git+https://github.com/dmlc/xgboost.git#subdirectory=python-package
 
   models:
-    minimum: "0.90"
+    minimum: "1.0.0"
     maximum: "1.5.0"
     requirements: ["scikit-learn"]
     run: |
       pytest tests/xgboost/test_xgboost_model_export.py --large
 
   autologging:
-    minimum: "0.90"
+    minimum: "1.0.0"
     maximum: "1.5.0"
     requirements: ["scikit-learn", "matplotlib"]
     run: |
@@ -135,14 +135,14 @@ lightgbm:
 
   models:
     minimum: "2.3.1"
-    maximum: "3.3.0"
+    maximum: "3.3.1"
     requirements: ["scikit-learn"]
     run: |
       pytest tests/lightgbm/test_lightgbm_model_export.py --large
 
   autologging:
     minimum: "2.3.1"
-    maximum: "3.3.0"
+    maximum: "3.3.1"
     requirements: ["scikit-learn", "matplotlib"]
     run: |
       pytest tests/lightgbm/test_lightgbm_autolog.py --large
@@ -160,7 +160,7 @@ catboost:
 
   models:
     minimum: "0.23.1"
-    maximum: "1.0.0"
+    maximum: "1.0.1"
     requirements: ["scikit-learn"]
     run: |
       pytest tests/catboost/test_catboost_model_export.py --large
@@ -172,7 +172,7 @@ gluon:
       pip install --pre mxnet -f https://dist.mxnet.io/python/cpu
 
   models:
-    minimum: "1.5.1"
+    minimum: "1.6.0"
     maximum: "1.8.0.post0"
     unsupported: ["1.8.0"] # MXNet 1.8.0 is a flawed release that we don't expect to work with
     run: |
@@ -181,7 +181,7 @@ gluon:
       pytest tests/gluon/test_gluon_model_export.py --large
 
   autologging:
-    minimum: "1.5.1"
+    minimum: "1.6.0"
     maximum: "1.8.0.post0"
     unsupported: ["1.8.0"] # MXNet 1.8.0 is a flawed release that we don't expect to work with
     run: |
@@ -193,14 +193,14 @@ fastai:
 
   models:
     minimum: "2.4.1"
-    maximum: "2.5.2"
+    maximum: "2.5.3"
     requirements: [torch, torchvision]
     run: |
       pytest tests/fastai/test_fastai_model_export.py --large
 
   autologging:
     minimum: "2.4.1"
-    maximum: "2.5.2"
+    maximum: "2.5.3"
     requirements: [torch, torchvision]
     run: |
       pytest tests/fastai/test_fastai_autolog.py --large
@@ -227,8 +227,8 @@ onnx:
       pip install dist/*manylinux2010_x86_64.whl
 
   models:
-    minimum: "1.5.0"
-    maximum: "1.10.1"
+    minimum: "1.7.0"
+    maximum: "1.10.2"
     requirements: ["onnxruntime", "torch", "scikit-learn"]
     run: |
       pytest tests/onnx/test_onnx_model_export.py --large
@@ -241,7 +241,7 @@ spacy:
 
   models:
     minimum: "2.2.4"
-    maximum: "3.1.3"
+    maximum: "3.1.4"
     requirements: ["scikit-learn"]
     run: |
       pytest tests/spacy/test_spacy_model_export.py --large


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

Drop support for old ML package versions:

- To save the number of CI runs
- Decrease the maintenance burden

## How is this patch tested?

Unit tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
