### PR TITLE
Avoid using `tensorflow-estimator` 2.7

### DIFF
--- a/dev/extra-ml-requirements.txt
+++ b/dev/extra-ml-requirements.txt
@@ -16,6 +16,8 @@ fastai>=2.4.1
 spacy
 # Required by mlflow.tensorflow
 tensorflow
+# Avoid using tensorflow-estimator 2.7 due to https://github.com/tensorflow/tensorflow/issues/52883
+tensorflow-estimator!=2.7.0
 # Required by mlflow.pytorch
 torch
 torchvision

--- a/dev/extra-ml-requirements.txt
+++ b/dev/extra-ml-requirements.txt
@@ -16,7 +16,8 @@ fastai>=2.4.1
 spacy
 # Required by mlflow.tensorflow
 tensorflow
-# Avoid using tensorflow-estimator 2.7 due to https://github.com/tensorflow/tensorflow/issues/52883
+# TODO: Stop excluding tensorflow-estimator 2.7.0 once tensorflow 2.7.0 is released:
+# https://github.com/tensorflow/tensorflow/issues/52883#issuecomment-955802164
 tensorflow-estimator!=2.7.0
 # Required by mlflow.pytorch
 torch


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

It appears tensorflow-estimator 2.7 (released on 2021/10/31) broke several tests:

https://github.com/mlflow/mlflow/runs/4054183145?check_suite_focus=true#step:8:15715

```
      For more details on warm-start configuration, see
      `tf.estimator.WarmStartSettings`.
    
      @compatibility(eager)
      Calling methods of `Estimator` will work while eager execution is enabled.
      However, the `model_fn` and `input_fn` is not executed eagerly, `Estimator`
      will switch to graph mode before calling all user-provided functions (incl.
      hooks), so their code has to be compatible with graph mode execution. Note
      that `input_fn` code using `tf.data` generally works in both graph and eager
      modes.
      @end_compatibility
E     AttributeError: module 'tensorflow.tools.docs.doc_controls' has no attribute 'inheritable_header'
```

Similar issues have been reported in other repositories:

https://github.com/search?q=inheritable_header&type=issues

## How is this patch tested?

NA

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
