### PR TITLE
Avoid using `torchmetrics` 0.6.0

### DIFF
--- a/examples/pytorch/IterativePruning/conda.yaml
+++ b/examples/pytorch/IterativePruning/conda.yaml
@@ -6,6 +6,8 @@ dependencies:
 - pip:
   - mlflow
   - torchvision>=0.9.1
+  # Avoid using torchmetrics 0.6.0 due to https://github.com/PyTorchLightning/pytorch-lightning/discussions/10253
+  - torchmetrics!=0.6.0
   - cloudpickle==1.6.0
   - pytorch_lightning==1.4.9
   - ax-platform

--- a/examples/pytorch/MNIST/conda.yaml
+++ b/examples/pytorch/MNIST/conda.yaml
@@ -7,4 +7,6 @@ dependencies:
   - mlflow
   - torchvision>=0.9.1
   - torch>=1.9.0
+    # Avoid using torchmetrics 0.6.0 due to https://github.com/PyTorchLightning/pytorch-lightning/discussions/10253
+  - torchmetrics!=0.6.0
   - pytorch-lightning==1.4.9

--- a/examples/pytorch/MNIST/example2/conda.yaml
+++ b/examples/pytorch/MNIST/example2/conda.yaml
@@ -7,4 +7,6 @@ dependencies:
   - mlflow
   - torch==1.8.0
   - torchvision==0.9.1
+  # Avoid using torchmetrics 0.6.0 due to https://github.com/PyTorchLightning/pytorch-lightning/discussions/10253
+  - torchmetrics!=0.6.0
   - pytorch-lightning==1.0.2

--- a/examples/pytorch/MNIST/example2/conda.yaml
+++ b/examples/pytorch/MNIST/example2/conda.yaml
@@ -7,6 +7,4 @@ dependencies:
   - mlflow
   - torch==1.8.0
   - torchvision==0.9.1
-  # Avoid using torchmetrics 0.6.0 due to https://github.com/PyTorchLightning/pytorch-lightning/discussions/10253
-  - torchmetrics!=0.6.0
   - pytorch-lightning==1.0.2


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

It appears that torchmetrics 0.6.0 (released on 2021/10/29) introduced breaking changes and broke our example tests:

https://github.com/mlflow/mlflow/runs/4058853498?check_suite_focus=true#step:7:751

```
Traceback (most recent call last):
  File "iterative_prune_mnist.py", line 15, in <module>
    from mnist import (
  File "/tmp/pytest-of-runner/pytest-0/test_mlflow_run_example_pytorc4/pytorch/IterativePruning/mnist.py", line 15, in <module>
    from pytorch_lightning.metrics.functional import accuracy
  File "/usr/share/miniconda/envs/mlflow-4be2c887adb73537631be3a364e2cad20927ca38/lib/python3.8/site-packages/pytorch_lightning/metrics/functional/__init__.py", line 31, in <module>
    from pytorch_lightning.metrics.functional.r2score import r2score  # noqa: F401
  File "/usr/share/miniconda/envs/mlflow-4be2c887adb73537631be3a364e2cad20927ca38/lib/python3.8/site-packages/pytorch_lightning/metrics/functional/r2score.py", line 16, in <module>
    from torchmetrics.functional import r2score as _r2score
ImportError: cannot import name 'r2score' from 'torchmetrics.functional' (/usr/share/miniconda/envs/mlflow-4be2c887adb73537631be3a364e2cad20927ca38/lib/python3.8/site-packages/torchmetrics/functional/__init__.py)
```

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
