### PR TITLE
Show how to apply black formatting when `black --check .` fails

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -35,7 +35,7 @@ black --check .
 
 if [ $? -ne 0 ]; then
   echo 'Run this command to apply Black formatting:'
-  echo 'pip install $(cat dev/lint-requirements.txt | grep "black==") && black .'
+  echo '$ pip install $(cat dev/lint-requirements.txt | grep "black==") && black .'
 fi
 
 echo -e "\n========== pycodestyle ==========\n"

--- a/lint.sh
+++ b/lint.sh
@@ -33,6 +33,11 @@ echo -e "\n========== black ==========\n"
 # Exclude proto files because they are auto-generated
 black --check .
 
+if [ $? -ne 0 ]; then
+  echo 'Run this command to apply Black formatting:'
+  echo 'pip install $(cat dev/lint-requirements.txt | grep "black==") && black .'
+fi
+
 echo -e "\n========== pycodestyle ==========\n"
 exclude=$(join "," "${exclude_dirs[@]}")
 include=$(join " " "${include_dirs[@]}")

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -156,7 +156,6 @@ autolog = mlflow.tracking.fluent.autolog
 run = projects.run
 
 __all__ = [
-    
     "ActiveRun",
     "log_param",
     "log_params",

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -156,6 +156,7 @@ autolog = mlflow.tracking.fluent.autolog
 run = projects.run
 
 __all__ = [
+    
     "ActiveRun",
     "log_param",
     "log_params",


### PR DESCRIPTION
## What changes are proposed in this pull request?

Show how to apply black formatting when `black --check .` fails to allow contributors to fix black errors by themselves.

## How is this patch tested?

NA

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
