### PR TITLE
Show package release dates to make it easier to identify updated packages

### DIFF
--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -155,7 +155,7 @@ jobs:
           ${{ matrix.install }}
       - name: Check package versions
         run: |
-          pip freeze
+          python dev/show_package_release_dates.py
       - name: Run tests
         env:
           MLFLOW_CONDA_HOME: /usr/share/miniconda

--- a/dev/install-common-deps.sh
+++ b/dev/install-common-deps.sh
@@ -56,7 +56,7 @@ fi
 pip install --no-dependencies tests/resources/mlflow-test-plugin
 
 # Print current environment info
-pip list
+python dev/show_package_release_dates.py
 which mlflow
 echo $MLFLOW_HOME
 

--- a/dev/show_package_release_dates.py
+++ b/dev/show_package_release_dates.py
@@ -1,0 +1,56 @@
+import subprocess
+import requests
+import pandas as pd
+from concurrent.futures import ThreadPoolExecutor
+
+
+def get_distributions():
+    res = subprocess.run(["pip", "list"], stdout=subprocess.PIPE)
+    pip_list_stdout = res.stdout.decode("utf-8")
+    # `pip_list_stdout` looks like this:
+    # ``````````````````````````````````````````````````````````
+    # Package     Version             Location
+    # ----------- ------------------- --------------------------
+    # mlflow      1.21.1.dev0         /home/user/path/to/mlflow
+    # tensorflow  2.6.0
+    # ...
+    # ```````````````````````````````````````````````````````````
+    lines = pip_list_stdout.splitlines()[2:]  # `[2:]` removes the header
+    return [
+        # Extract package and version
+        line.split()[:2]
+        for line in lines
+    ]
+
+
+def get_release_date(distribution):
+    package_name, version = distribution
+    resp = requests.get(f"https://pypi.python.org/pypi/{package_name}/json")
+    if not resp.ok:
+        return None
+
+    matched = [dist_files for ver, dist_files in resp.json()["releases"].items() if ver == version]
+    if (not matched) or (not matched[0]):
+        return None
+
+    upload_time = matched[0][0]["upload_time"]
+    return upload_time.split("T")[0]  # return year-month-day
+
+
+def main():
+    distributions = get_distributions()
+
+    with ThreadPoolExecutor() as executor:
+        release_dates = list(executor.map(get_release_date, distributions))
+
+    print(
+        pd.DataFrame(distributions, columns=["package", "version"])
+        .assign(release_date=release_dates)
+        .sort_values("release_date", ascending=False)
+        .to_markdown(index=False)
+    )
+
+
+if __name__ == "__main__":
+    main()
+

--- a/dev/show_package_release_dates.py
+++ b/dev/show_package_release_dates.py
@@ -14,7 +14,7 @@ def get_distributions():
     # mlflow      1.21.1.dev0         /home/user/path/to/mlflow
     # tensorflow  2.6.0
     # ...
-    # ```````````````````````````````````````````````````````````
+    # ``````````````````````````````````````````````````````````
     lines = pip_list_stdout.splitlines()[2:]  # `[2:]` removes the header
     return [
         # Extract package and version

--- a/dev/show_package_release_dates.py
+++ b/dev/show_package_release_dates.py
@@ -24,7 +24,7 @@ def get_distributions():
 
 
 def get_release_date(package, version):
-    resp = requests.get(f"https://pypi.python.org/pypi/{package}/json")
+    resp = requests.get(f"https://pypi.python.org/pypi/{package}/json", timeout=10)
     if not resp.ok:
         return ""
 

--- a/dev/show_package_release_dates.py
+++ b/dev/show_package_release_dates.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import requests
 from concurrent.futures import ThreadPoolExecutor
@@ -50,7 +51,7 @@ def safe_result(future, if_error=""):
 
 def main():
     distributions = get_distributions()
-    with ThreadPoolExecutor() as executor:
+    with ThreadPoolExecutor(max_workers=min(32, os.cpu_count() + 4)) as executor:
         futures = [executor.submit(get_release_date, pkg, ver) for pkg, ver in distributions]
         release_dates = [safe_result(f) for f in futures]
 

--- a/dev/show_package_release_dates.py
+++ b/dev/show_package_release_dates.py
@@ -72,4 +72,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

This PR proposes to show package release dates to make it easier to identify updated packages when we encounter issues:

The output looks like this:

```
Package                              Version             Release Date
---------------------------------------------------------------------
astroid                              2.8.4               2021-10-25  
numpy                                1.21.3              2021-10-20  
xgboost                              1.5.0               2021-10-17  
mleap                                0.18.1              2021-09-27  
platformdirs                         2.4.0               2021-09-25  
pylint                               2.11.1              2021-09-16  
pytest                               6.2.5               2021-08-30  
...
```

## How is this patch tested?

NA

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
