### PR TITLE
Update `defaults.run.shell` to show  executed command by default

### DIFF
--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -37,7 +37,7 @@ concurrency:
 
 defaults:
   run:
-    shell: bash --noprofile --norc -euxo pipefail {0}
+    shell: bash --noprofile --norc -exo pipefail {0}
 
 jobs:
   set-matrix:

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -37,7 +37,7 @@ concurrency:
 
 defaults:
   run:
-    shell: bash
+    shell: bash --noprofile --norc -euxo pipefail {0}
 
 jobs:
   set-matrix:
@@ -142,7 +142,6 @@ jobs:
             ${{ steps.get-cache-key.outputs.key }}
       - name: Install mlflow & test dependencies
         run: |
-          set -x
           python --version
           pip install --upgrade pip wheel
           pip install -e .
@@ -151,7 +150,6 @@ jobs:
         env:
           CACHE_DIR: /home/runner/.cache/wheels
         run: |
-          set -x
           ${{ matrix.install }}
       - name: Check package versions
         run: |

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -13,7 +13,7 @@ concurrency:
 
 defaults:
   run:
-    shell: bash --noprofile --norc -euxo pipefail {0}
+    shell: bash --noprofile --norc -exo pipefail {0}
 
 env:
   MLFLOW_CONDA_HOME: /usr/share/miniconda

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -13,7 +13,7 @@ concurrency:
 
 defaults:
   run:
-    shell: bash
+    shell: bash --noprofile --norc -euxo pipefail {0}
 
 env:
   MLFLOW_CONDA_HOME: /usr/share/miniconda

--- a/.github/workflows/labeling.yml
+++ b/.github/workflows/labeling.yml
@@ -12,7 +12,7 @@ on:
 
 defaults:
   run:
-    shell: bash --noprofile --norc -euxo pipefail {0}
+    shell: bash --noprofile --norc -exo pipefail {0}
 
 jobs:
   labeling:

--- a/.github/workflows/labeling.yml
+++ b/.github/workflows/labeling.yml
@@ -12,7 +12,7 @@ on:
 
 defaults:
   run:
-    shell: bash
+    shell: bash --noprofile --norc -euxo pipefail {0}
 
 jobs:
   labeling:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -14,15 +14,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-# Use `bash` by default for all `run` steps in this workflow:
+# Use `bash --noprofile --norc -euxo pipefail` by default for all `run` steps in this workflow:
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#defaultsrun
 defaults:
   run:
-    # GitHub Actions runner executes commands specified in a run step via:
-    # $ bash --noprofile --norc -eo pipefail < commands >
-    #
-    # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#using-a-specific-shell
-    shell: bash
+    shell: bash --noprofile --norc -euxo pipefail {0}
 
 env:
   # Note miniconda is pre-installed in the virtual environments for GitHub Actions:
@@ -218,7 +214,6 @@ jobs:
         ./dev/run-large-python-tests.sh
     - name: Run database initialization tests
       run: |
-        set -x
         # Build wheel and copy it under tests/db
         python setup.py bdist_wheel
         cp -r dist tests/db

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -18,7 +18,7 @@ concurrency:
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#defaultsrun
 defaults:
   run:
-    shell: bash --noprofile --norc -euxo pipefail {0}
+    shell: bash --noprofile --norc -exo pipefail {0}
 
 env:
   # Note miniconda is pre-installed in the virtual environments for GitHub Actions:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -14,7 +14,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-# Use `bash --noprofile --norc -euxo pipefail` by default for all `run` steps in this workflow:
+# Use `bash --noprofile --norc -exo pipefail` by default for all `run` steps in this workflow:
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#defaultsrun
 defaults:
   run:

--- a/.github/workflows/release-note-category.yml
+++ b/.github/workflows/release-note-category.yml
@@ -17,7 +17,7 @@ concurrency:
 
 defaults:
   run:
-    shell: bash --noprofile --norc -euxo pipefail {0}
+    shell: bash --noprofile --norc -exo pipefail {0}
 
 jobs:
   validate:

--- a/.github/workflows/release-note-category.yml
+++ b/.github/workflows/release-note-category.yml
@@ -17,7 +17,7 @@ concurrency:
 
 defaults:
   run:
-    shell: bash
+    shell: bash --noprofile --norc -euxo pipefail {0}
 
 jobs:
   validate:

--- a/.github/workflows/test-package-build.yml
+++ b/.github/workflows/test-package-build.yml
@@ -12,7 +12,7 @@ concurrency:
 
 defaults:
   run:
-    shell: bash
+    shell: bash --noprofile --norc -euxo pipefail {0}
 
 jobs:
   build:

--- a/.github/workflows/test-package-build.yml
+++ b/.github/workflows/test-package-build.yml
@@ -12,7 +12,7 @@ concurrency:
 
 defaults:
   run:
-    shell: bash --noprofile --norc -euxo pipefail {0}
+    shell: bash --noprofile --norc -exo pipefail {0}
 
 jobs:
   build:


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

This PR updates `defaults.run.shell` to show executed commands by default.


### Before

https://github.com/mlflow/mlflow/runs/4070952347?check_suite_focus=true#step:5:3

![image](https://user-images.githubusercontent.com/17039389/139794058-edd332d6-cb62-4818-98c9-29722aabb5fc.png)

### After

https://github.com/mlflow/mlflow/runs/4076358271?check_suite_focus=true#step:4:3

![image](https://user-images.githubusercontent.com/17039389/139794091-14e55153-f699-45a9-83d4-7598004842d2.png)

### Motivation

This change allows us to quickly find the location of the desired logs. For example, if we want to check the output of `pytest tests/xgboost`, we can just search `pytest tests/xgboost`.

## How is this patch tested?

Manually verified executed commands show up on the terminal.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
