### PR TITLE
Replace pytorch_lightning.metrics by torchmetrics

### DIFF
--- a/examples/pytorch/AxHyperOptimizationPTL/iris.py
+++ b/examples/pytorch/AxHyperOptimizationPTL/iris.py
@@ -6,7 +6,11 @@ import pytorch_lightning as pl
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from pytorch_lightning.metrics import Accuracy
+
+try:
+    from torchmetrics import Accuracy
+except ImportError:
+    from pytorch_lightning.metrics import Accuracy
 
 
 class IrisClassification(pl.LightningModule):

--- a/examples/pytorch/IterativePruning/conda.yaml
+++ b/examples/pytorch/IterativePruning/conda.yaml
@@ -6,8 +6,6 @@ dependencies:
 - pip:
   - mlflow
   - torchvision>=0.9.1
-  # Avoid using torchmetrics 0.6.0 due to https://github.com/PyTorchLightning/pytorch-lightning/discussions/10253
-  - torchmetrics!=0.6.0
   - cloudpickle==1.6.0
   - pytorch_lightning==1.4.9
   - ax-platform

--- a/examples/pytorch/IterativePruning/mnist.py
+++ b/examples/pytorch/IterativePruning/mnist.py
@@ -17,9 +17,9 @@ from torch.utils.data import DataLoader, random_split
 from torchvision import datasets, transforms
 
 try:
-    from torchmetrics import accuracy
+    from torchmetrics.functional import accuracy
 except ImportError:
-    from pytorch_lightning.metrics import accuracy
+    from pytorch_lightning.metrics.functional import accuracy
 
 
 class MNISTDataModule(pl.LightningDataModule):

--- a/examples/pytorch/IterativePruning/mnist.py
+++ b/examples/pytorch/IterativePruning/mnist.py
@@ -12,10 +12,14 @@ import pytorch_lightning as pl
 import torch
 import mlflow.pytorch
 from argparse import ArgumentParser
-from pytorch_lightning.metrics.functional import accuracy
 from torch.nn import functional as F
 from torch.utils.data import DataLoader, random_split
 from torchvision import datasets, transforms
+
+try:
+    from torchmetrics import accuracy
+except ImportError:
+    from pytorch_lightning.metrics import accuracy
 
 
 class MNISTDataModule(pl.LightningDataModule):

--- a/examples/pytorch/MNIST/conda.yaml
+++ b/examples/pytorch/MNIST/conda.yaml
@@ -7,6 +7,4 @@ dependencies:
   - mlflow
   - torchvision>=0.9.1
   - torch>=1.9.0
-    # Avoid using torchmetrics 0.6.0 due to https://github.com/PyTorchLightning/pytorch-lightning/discussions/10253
-  - torchmetrics!=0.6.0
   - pytorch-lightning==1.4.9

--- a/examples/pytorch/MNIST/mnist_autolog_example.py
+++ b/examples/pytorch/MNIST/mnist_autolog_example.py
@@ -16,10 +16,14 @@ from argparse import ArgumentParser
 from pytorch_lightning.callbacks.early_stopping import EarlyStopping
 from pytorch_lightning.callbacks import ModelCheckpoint
 from pytorch_lightning.callbacks import LearningRateMonitor
-from pytorch_lightning.metrics.functional import accuracy
 from torch.nn import functional as F
 from torch.utils.data import DataLoader, random_split
 from torchvision import datasets, transforms
+
+try:
+    from torchmetrics import accuracy
+except ImportError:
+    from pytorch_lightning.metrics import accuracy
 
 
 class MNISTDataModule(pl.LightningDataModule):

--- a/examples/pytorch/MNIST/mnist_autolog_example.py
+++ b/examples/pytorch/MNIST/mnist_autolog_example.py
@@ -21,9 +21,9 @@ from torch.utils.data import DataLoader, random_split
 from torchvision import datasets, transforms
 
 try:
-    from torchmetrics import accuracy
+    from torchmetrics.functional import accuracy
 except ImportError:
-    from pytorch_lightning.metrics import accuracy
+    from pytorch_lightning.metrics.functional import accuracy
 
 
 class MNISTDataModule(pl.LightningDataModule):

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -924,9 +924,9 @@ def autolog(
         from torchvision.datasets import MNIST
 
         try:
-            from torchmetrics import accuracy
+            from torchmetrics.functional import accuracy
         except ImportError:
-            from pytorch_lightning.metrics import accuracy
+            from pytorch_lightning.metrics.functional import accuracy
 
         import mlflow.pytorch
         from mlflow.tracking import MlflowClient

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -922,7 +922,11 @@ def autolog(
         from torch.utils.data import DataLoader
         from torchvision import transforms
         from torchvision.datasets import MNIST
-        from pytorch_lightning.metrics.functional import accuracy
+
+        try:
+            from torchmetrics import accuracy
+        except ImportError:
+            from pytorch_lightning.metrics import accuracy
 
         import mlflow.pytorch
         from mlflow.tracking import MlflowClient


### PR DESCRIPTION
Signed-off-by: Liang Zhang <liang.zhang@databricks.com>

## What changes are proposed in this pull request?

It appears that torchmetrics 0.6.0 (released on 2021/10/29) introduced breaking changes and broke our example tests:

https://github.com/mlflow/mlflow/runs/4058853498?check_suite_focus=true#step:7:751

```
Traceback (most recent call last):
  File "iterative_prune_mnist.py", line 15, in <module>
    from mnist import (
  File "/tmp/pytest-of-runner/pytest-0/test_mlflow_run_example_pytorc4/pytorch/IterativePruning/mnist.py", line 15, in <module>
    from pytorch_lightning.metrics.functional import accuracy
  File "/usr/share/miniconda/envs/mlflow-4be2c887adb73537631be3a364e2cad20927ca38/lib/python3.8/site-packages/pytorch_lightning/metrics/functional/__init__.py", line 31, in <module>
    from pytorch_lightning.metrics.functional.r2score import r2score  # noqa: F401
  File "/usr/share/miniconda/envs/mlflow-4be2c887adb73537631be3a364e2cad20927ca38/lib/python3.8/site-packages/pytorch_lightning/metrics/functional/r2score.py", line 16, in <module>
    from torchmetrics.functional import r2score as _r2score
ImportError: cannot import name 'r2score' from 'torchmetrics.functional' (/usr/share/miniconda/envs/mlflow-4be2c887adb73537631be3a364e2cad20927ca38/lib/python3.8/site-packages/torchmetrics/functional/__init__.py)
```

It can be fixed by replacing pytorch_lightning.metrics by torchmetrics in the import.

This PR also reverted #4976, which is a temporary workaround. 

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
