### PR TITLE
Fix tensorflow 2.5.2 cross test failure

### DIFF
--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -929,7 +929,7 @@ def test_import_tf_keras_with_fluent_autolog_enables_tf_autologging():
     # NB: In Tensorflow >= 2.6, we redirect keras autologging to tensorflow autologging
     # so the original keras autologging is disabled
     if Version(tf.__version__) >= Version("2.6"):
-        import keras  # pylint: disable=unused-variable,unused-import
+        # NB: For TF >= 2.6, import tensorflow.keras will trigger importing keras
         assert autologging_is_disabled(mlflow.keras.FLAVOR_NAME)
 
 

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -910,8 +910,8 @@ def test_import_tensorflow_with_fluent_autolog_enables_tf_autologging():
 
     assert not autologging_is_disabled(mlflow.tensorflow.FLAVOR_NAME)
 
-    # NB: For backwards compatibility, fluent autologging enables TensorFlow and
-    # Keras autologging upon tensorflow import in TensorFlow 2.5.1
+    # NB: In Tensorflow >= 2.6, we redirect keras autologging to tensorflow autologging
+    # so the original keras autologging is disabled
     if Version(tf.__version__) >= Version("2.6"):
         assert autologging_is_disabled(mlflow.keras.FLAVOR_NAME)
 
@@ -925,8 +925,8 @@ def test_import_tf_keras_with_fluent_autolog_enables_tf_autologging():
 
     assert not autologging_is_disabled(mlflow.tensorflow.FLAVOR_NAME)
 
-    # NB: For backwards compatibility, fluent autologging enables TensorFlow and
-    # Keras autologging upon tf.keras import in TensorFlow 2.5.1
+    # NB: In Tensorflow >= 2.6, we redirect keras autologging to tensorflow autologging
+    # so the original keras autologging is disabled
     if Version(tf.__version__) >= Version("2.6"):
         assert autologging_is_disabled(mlflow.keras.FLAVOR_NAME)
 

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -913,6 +913,7 @@ def test_import_tensorflow_with_fluent_autolog_enables_tf_autologging():
     # NB: In Tensorflow >= 2.6, we redirect keras autologging to tensorflow autologging
     # so the original keras autologging is disabled
     if Version(tf.__version__) >= Version("2.6"):
+        import keras  # pylint: disable=unused-variable,unused-import
         assert autologging_is_disabled(mlflow.keras.FLAVOR_NAME)
 
 
@@ -928,6 +929,7 @@ def test_import_tf_keras_with_fluent_autolog_enables_tf_autologging():
     # NB: In Tensorflow >= 2.6, we redirect keras autologging to tensorflow autologging
     # so the original keras autologging is disabled
     if Version(tf.__version__) >= Version("2.6"):
+        import keras  # pylint: disable=unused-variable,unused-import
         assert autologging_is_disabled(mlflow.keras.FLAVOR_NAME)
 
 

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -914,6 +914,7 @@ def test_import_tensorflow_with_fluent_autolog_enables_tf_autologging():
     # so the original keras autologging is disabled
     if Version(tf.__version__) >= Version("2.6"):
         import keras  # pylint: disable=unused-variable,unused-import
+
         assert autologging_is_disabled(mlflow.keras.FLAVOR_NAME)
 
 

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -907,13 +907,12 @@ def test_import_tensorflow_with_fluent_autolog_enables_tf_autologging():
     mlflow.autolog()
 
     import tensorflow  # pylint: disable=unused-variable,unused-import,reimported
-    import keras  # pylint: disable=unused-variable,unused-import,reimported
 
     assert not autologging_is_disabled(mlflow.tensorflow.FLAVOR_NAME)
 
     # NB: For backwards compatibility, fluent autologging enables TensorFlow and
     # Keras autologging upon tensorflow import in TensorFlow 2.5.1
-    if Version(keras.__version__) >= Version('2.6'):
+    if Version(tensorflow.keras.__version__) >= Version("2.6"):
         assert autologging_is_disabled(mlflow.keras.FLAVOR_NAME)
 
 
@@ -923,13 +922,12 @@ def test_import_tf_keras_with_fluent_autolog_enables_tf_autologging():
     mlflow.autolog()
 
     import tensorflow.keras  # pylint: disable=unused-variable,unused-import
-    import keras  # pylint: disable=unused-variable,unused-import,reimported
 
     assert not autologging_is_disabled(mlflow.tensorflow.FLAVOR_NAME)
 
     # NB: For backwards compatibility, fluent autologging enables TensorFlow and
     # Keras autologging upon tf.keras import in TensorFlow 2.5.1
-    if Version(keras.__version__) >= Version('2.6'):
+    if Version(tensorflow.keras.__version__) >= Version("2.6"):
         assert autologging_is_disabled(mlflow.keras.FLAVOR_NAME)
 
 

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -912,7 +912,7 @@ def test_import_tensorflow_with_fluent_autolog_enables_tf_autologging():
 
     # NB: For backwards compatibility, fluent autologging enables TensorFlow and
     # Keras autologging upon tensorflow import in TensorFlow 2.5.1
-    if Version(tensorflow.keras.__version__) >= Version("2.6"):
+    if Version(tf.__version__) >= Version("2.6"):
         assert autologging_is_disabled(mlflow.keras.FLAVOR_NAME)
 
 
@@ -927,7 +927,7 @@ def test_import_tf_keras_with_fluent_autolog_enables_tf_autologging():
 
     # NB: For backwards compatibility, fluent autologging enables TensorFlow and
     # Keras autologging upon tf.keras import in TensorFlow 2.5.1
-    if Version(tensorflow.keras.__version__) >= Version("2.6"):
+    if Version(tf.__version__) >= Version("2.6"):
         assert autologging_is_disabled(mlflow.keras.FLAVOR_NAME)
 
 

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -907,12 +907,13 @@ def test_import_tensorflow_with_fluent_autolog_enables_tf_autologging():
     mlflow.autolog()
 
     import tensorflow  # pylint: disable=unused-variable,unused-import,reimported
+    import keras  # pylint: disable=unused-variable,unused-import,reimported
 
     assert not autologging_is_disabled(mlflow.tensorflow.FLAVOR_NAME)
 
     # NB: For backwards compatibility, fluent autologging enables TensorFlow and
     # Keras autologging upon tensorflow import in TensorFlow 2.5.1
-    if Version(tf.__version__) != Version("2.5.1"):
+    if Version(keras.__version__) >= Version('2.6'):
         assert autologging_is_disabled(mlflow.keras.FLAVOR_NAME)
 
 
@@ -922,12 +923,13 @@ def test_import_tf_keras_with_fluent_autolog_enables_tf_autologging():
     mlflow.autolog()
 
     import tensorflow.keras  # pylint: disable=unused-variable,unused-import
+    import keras  # pylint: disable=unused-variable,unused-import,reimported
 
     assert not autologging_is_disabled(mlflow.tensorflow.FLAVOR_NAME)
 
     # NB: For backwards compatibility, fluent autologging enables TensorFlow and
     # Keras autologging upon tf.keras import in TensorFlow 2.5.1
-    if Version(tf.__version__) != Version("2.5.1"):
+    if Version(keras.__version__) >= Version('2.6'):
         assert autologging_is_disabled(mlflow.keras.FLAVOR_NAME)
 
 


### PR DESCRIPTION
Signed-off-by: Weichen Xu <weichen.xu@databricks.com>

## What changes are proposed in this pull request?

Fix tensorflow 2.5.2 cross test failure
Tensorflow release 2.5.2 today https://pypi.org/project/tensorflow/2.5.2/ , and it cause this failure happen.


## How is this patch tested?

Unit tests.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
