### PR TITLE
Improve load_model() by adding param dst_path

### DIFF
--- a/mlflow/catboost.py
+++ b/mlflow/catboost.py
@@ -272,7 +272,7 @@ def _load_pyfunc(path):
     )
 
 
-def load_model(model_uri, artifact_path=None):
+def load_model(model_uri, dst_path=None):
     """
     Load a CatBoost model from a local file or a run.
 
@@ -286,16 +286,14 @@ def load_model(model_uri, artifact_path=None):
                       For more information about supported URI schemes, see
                       `Referencing Artifacts <https://www.mlflow.org/docs/latest/tracking.html#
                       artifact-locations>`_.
-    :param artifact_path: The local filesystem path to which to download the model artifact.
-                          This directory must already exist. If unspecified, a local output
-                          path will be created.
+    :param dst_path: The local filesystem path to which to download the model artifact.
+                     This directory must already exist. If unspecified, a local output
+                     path will be created.
 
     :return: A CatBoost model (an instance of `CatBoost`_, `CatBoostClassifier`_,
              or `CatBoostRegressor`_)
     """
-    local_model_path = _download_artifact_from_uri(
-        artifact_uri=model_uri, output_path=artifact_path
-    )
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     cb_model_file_path = os.path.join(
         local_model_path, flavor_conf.get(_MODEL_BINARY_KEY, _MODEL_BINARY_FILE_NAME)

--- a/mlflow/catboost.py
+++ b/mlflow/catboost.py
@@ -272,7 +272,7 @@ def _load_pyfunc(path):
     )
 
 
-def load_model(model_uri):
+def load_model(model_uri, artifact_path=None):
     """
     Load a CatBoost model from a local file or a run.
 
@@ -286,11 +286,14 @@ def load_model(model_uri):
                       For more information about supported URI schemes, see
                       `Referencing Artifacts <https://www.mlflow.org/docs/latest/tracking.html#
                       artifact-locations>`_.
+    :param artifact_path: The local filesystem path to which to download the model artifact.
+                          This directory must already exist. If unspecified, a local output
+                          path will be created.
 
     :return: A CatBoost model (an instance of `CatBoost`_, `CatBoostClassifier`_,
              or `CatBoostRegressor`_)
     """
-    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri)
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=artifact_path)
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     cb_model_file_path = os.path.join(
         local_model_path, flavor_conf.get(_MODEL_BINARY_KEY, _MODEL_BINARY_FILE_NAME)

--- a/mlflow/catboost.py
+++ b/mlflow/catboost.py
@@ -293,7 +293,9 @@ def load_model(model_uri, artifact_path=None):
     :return: A CatBoost model (an instance of `CatBoost`_, `CatBoostClassifier`_,
              or `CatBoostRegressor`_)
     """
-    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=artifact_path)
+    local_model_path = _download_artifact_from_uri(
+        artifact_uri=model_uri, output_path=artifact_path
+    )
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     cb_model_file_path = os.path.join(
         local_model_path, flavor_conf.get(_MODEL_BINARY_KEY, _MODEL_BINARY_FILE_NAME)

--- a/mlflow/fastai/__init__.py
+++ b/mlflow/fastai/__init__.py
@@ -325,7 +325,7 @@ def _load_pyfunc(path):
     return _FastaiModelWrapper(_load_model(path))
 
 
-def load_model(model_uri):
+def load_model(model_uri, artifact_path=None):
     """
     Load a fastai model from a local file or a run.
 
@@ -339,6 +339,9 @@ def load_model(model_uri):
                       For more information about supported URI schemes, see
                       `Referencing Artifacts <https://www.mlflow.org/docs/latest/tracking.html#
                       artifact-locations>`_.
+    :param artifact_path: The local filesystem path to which to download the model artifact.
+                          This directory must already exist. If unspecified, a local output
+                          path will be created.
 
     :return: A fastai model (an instance of `fastai.Learner`_).
 
@@ -360,7 +363,7 @@ def load_model(model_uri):
         loaded_model = mlflow.fastai.load_model(model_uri)
         results = loaded_model.predict(predict_data)
     """
-    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri)
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=artifact_path)
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     model_file_path = os.path.join(local_model_path, flavor_conf.get("data", "model.fastai"))
     return _load_model(path=model_file_path)

--- a/mlflow/fastai/__init__.py
+++ b/mlflow/fastai/__init__.py
@@ -363,7 +363,9 @@ def load_model(model_uri, artifact_path=None):
         loaded_model = mlflow.fastai.load_model(model_uri)
         results = loaded_model.predict(predict_data)
     """
-    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=artifact_path)
+    local_model_path = _download_artifact_from_uri(
+        artifact_uri=model_uri, output_path=artifact_path
+    )
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     model_file_path = os.path.join(local_model_path, flavor_conf.get("data", "model.fastai"))
     return _load_model(path=model_file_path)

--- a/mlflow/fastai/__init__.py
+++ b/mlflow/fastai/__init__.py
@@ -325,7 +325,7 @@ def _load_pyfunc(path):
     return _FastaiModelWrapper(_load_model(path))
 
 
-def load_model(model_uri, artifact_path=None):
+def load_model(model_uri, dst_path=None):
     """
     Load a fastai model from a local file or a run.
 
@@ -339,9 +339,9 @@ def load_model(model_uri, artifact_path=None):
                       For more information about supported URI schemes, see
                       `Referencing Artifacts <https://www.mlflow.org/docs/latest/tracking.html#
                       artifact-locations>`_.
-    :param artifact_path: The local filesystem path to which to download the model artifact.
-                          This directory must already exist. If unspecified, a local output
-                          path will be created.
+    :param dst_path: The local filesystem path to which to download the model artifact.
+                     This directory must already exist. If unspecified, a local output
+                     path will be created.
 
     :return: A fastai model (an instance of `fastai.Learner`_).
 
@@ -363,9 +363,7 @@ def load_model(model_uri, artifact_path=None):
         loaded_model = mlflow.fastai.load_model(model_uri)
         results = loaded_model.predict(predict_data)
     """
-    local_model_path = _download_artifact_from_uri(
-        artifact_uri=model_uri, output_path=artifact_path
-    )
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     model_file_path = os.path.join(local_model_path, flavor_conf.get("data", "model.fastai"))
     return _load_model(path=model_file_path)

--- a/mlflow/gluon.py
+++ b/mlflow/gluon.py
@@ -39,7 +39,7 @@ _MODEL_SAVE_PATH = "net"
 
 
 @experimental
-def load_model(model_uri, ctx, artifact_path=None):
+def load_model(model_uri, ctx, dst_path=None):
     """
     Load a Gluon model from a local file or a run.
 
@@ -56,9 +56,9 @@ def load_model(model_uri, ctx, artifact_path=None):
                       `Referencing Artifacts <https://www.mlflow.org/docs/latest/concepts.html#
                       artifact-locations>`_.
     :param ctx: Either CPU or GPU.
-    :param artifact_path: The local filesystem path to which to download the model artifact.
-                          This directory must already exist. If unspecified, a local output
-                          path will be created.
+    :param dst_path: The local filesystem path to which to download the model artifact.
+                     This directory must already exist. If unspecified, a local output
+                     path will be created.
 
     :return: A Gluon model instance.
 
@@ -73,9 +73,7 @@ def load_model(model_uri, ctx, artifact_path=None):
     from mxnet import gluon
     from mxnet import sym
 
-    local_model_path = _download_artifact_from_uri(
-        artifact_uri=model_uri, output_path=artifact_path
-    )
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
 
     model_arch_path = os.path.join(local_model_path, "data", _MODEL_SAVE_PATH) + "-symbol.json"
     model_params_path = os.path.join(local_model_path, "data", _MODEL_SAVE_PATH) + "-0000.params"

--- a/mlflow/gluon.py
+++ b/mlflow/gluon.py
@@ -39,7 +39,7 @@ _MODEL_SAVE_PATH = "net"
 
 
 @experimental
-def load_model(model_uri, ctx):
+def load_model(model_uri, ctx, artifact_path=None):
     """
     Load a Gluon model from a local file or a run.
 
@@ -56,6 +56,9 @@ def load_model(model_uri, ctx):
                       `Referencing Artifacts <https://www.mlflow.org/docs/latest/concepts.html#
                       artifact-locations>`_.
     :param ctx: Either CPU or GPU.
+    :param artifact_path: The local filesystem path to which to download the model artifact.
+                          This directory must already exist. If unspecified, a local output
+                          path will be created.
 
     :return: A Gluon model instance.
 
@@ -70,7 +73,7 @@ def load_model(model_uri, ctx):
     from mxnet import gluon
     from mxnet import sym
 
-    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri)
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=artifact_path)
 
     model_arch_path = os.path.join(local_model_path, "data", _MODEL_SAVE_PATH) + "-symbol.json"
     model_params_path = os.path.join(local_model_path, "data", _MODEL_SAVE_PATH) + "-0000.params"

--- a/mlflow/gluon.py
+++ b/mlflow/gluon.py
@@ -73,7 +73,9 @@ def load_model(model_uri, ctx, artifact_path=None):
     from mxnet import gluon
     from mxnet import sym
 
-    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=artifact_path)
+    local_model_path = _download_artifact_from_uri(
+        artifact_uri=model_uri, output_path=artifact_path
+    )
 
     model_arch_path = os.path.join(local_model_path, "data", _MODEL_SAVE_PATH) + "-symbol.json"
     model_params_path = os.path.join(local_model_path, "data", _MODEL_SAVE_PATH) + "-0000.params"

--- a/mlflow/h2o.py
+++ b/mlflow/h2o.py
@@ -265,7 +265,7 @@ def _load_pyfunc(path):
     return _H2OModelWrapper(_load_model(path, init=True))
 
 
-def load_model(model_uri, artifact_path=None):
+def load_model(model_uri, dst_path=None):
     """
     Load an H2O model from a local file (if ``run_id`` is ``None``) or a run.
     This function expects there is an H2O instance initialised with ``h2o.init``.
@@ -282,16 +282,14 @@ def load_model(model_uri, artifact_path=None):
                       For more information about supported URI schemes, see
                       `Referencing Artifacts <https://www.mlflow.org/docs/latest/concepts.html#
                       artifact-locations>`_.
-    :param artifact_path: The local filesystem path to which to download the model artifact.
-                          This directory must already exist. If unspecified, a local output
-                          path will be created.
+    :param dst_path: The local filesystem path to which to download the model artifact.
+                     This directory must already exist. If unspecified, a local output
+                     path will be created.
 
     :return: An `H2OEstimator model object
              <http://docs.h2o.ai/h2o/latest-stable/h2o-py/docs/intro.html#models>`_.
     """
-    local_model_path = _download_artifact_from_uri(
-        artifact_uri=model_uri, output_path=artifact_path
-    )
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     # Flavor configurations for models saved in MLflow version <= 0.8.0 may not contain a
     # `data` key; in this case, we assume the model artifact path to be `model.h2o`

--- a/mlflow/h2o.py
+++ b/mlflow/h2o.py
@@ -265,7 +265,7 @@ def _load_pyfunc(path):
     return _H2OModelWrapper(_load_model(path, init=True))
 
 
-def load_model(model_uri):
+def load_model(model_uri, artifact_path=None):
     """
     Load an H2O model from a local file (if ``run_id`` is ``None``) or a run.
     This function expects there is an H2O instance initialised with ``h2o.init``.
@@ -282,11 +282,14 @@ def load_model(model_uri):
                       For more information about supported URI schemes, see
                       `Referencing Artifacts <https://www.mlflow.org/docs/latest/concepts.html#
                       artifact-locations>`_.
+    :param artifact_path: The local filesystem path to which to download the model artifact.
+                          This directory must already exist. If unspecified, a local output
+                          path will be created.
 
     :return: An `H2OEstimator model object
              <http://docs.h2o.ai/h2o/latest-stable/h2o-py/docs/intro.html#models>`_.
     """
-    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri)
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=artifact_path)
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     # Flavor configurations for models saved in MLflow version <= 0.8.0 may not contain a
     # `data` key; in this case, we assume the model artifact path to be `model.h2o`

--- a/mlflow/h2o.py
+++ b/mlflow/h2o.py
@@ -289,7 +289,9 @@ def load_model(model_uri, artifact_path=None):
     :return: An `H2OEstimator model object
              <http://docs.h2o.ai/h2o/latest-stable/h2o-py/docs/intro.html#models>`_.
     """
-    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=artifact_path)
+    local_model_path = _download_artifact_from_uri(
+        artifact_uri=model_uri, output_path=artifact_path
+    )
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     # Flavor configurations for models saved in MLflow version <= 0.8.0 may not contain a
     # `data` key; in this case, we assume the model artifact path to be `model.h2o`

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -509,7 +509,7 @@ def _load_pyfunc(path):
         raise MlflowException("Unsupported backend '%s'" % K._BACKEND)
 
 
-def load_model(model_uri, artifact_path=None, **kwargs):
+def load_model(model_uri, dst_path=None, **kwargs):
     """
     Load a Keras model from a local file or a run.
 
@@ -527,9 +527,9 @@ def load_model(model_uri, artifact_path=None, **kwargs):
                       For more information about supported URI schemes, see
                       `Referencing Artifacts <https://www.mlflow.org/docs/latest/concepts.html#
                       artifact-locations>`_.
-    :param artifact_path: The local filesystem path to which to download the model artifact.
-                          This directory must already exist. If unspecified, a local output
-                          path will be created.
+    :param dst_path: The local filesystem path to which to download the model artifact.
+                     This directory must already exist. If unspecified, a local output
+                     path will be created.
 
     :return: A Keras model instance.
 
@@ -540,9 +540,7 @@ def load_model(model_uri, artifact_path=None, **kwargs):
         keras_model = mlflow.keras.load_model("runs:/96771d893a5e46159d9f3b49bf9013e2" + "/models")
         predictions = keras_model.predict(x_test)
     """
-    local_model_path = _download_artifact_from_uri(
-        artifact_uri=model_uri, output_path=artifact_path
-    )
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     keras_module = importlib.import_module(flavor_conf.get("keras_module", "keras"))
     keras_model_artifacts_path = os.path.join(

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -509,7 +509,7 @@ def _load_pyfunc(path):
         raise MlflowException("Unsupported backend '%s'" % K._BACKEND)
 
 
-def load_model(model_uri, **kwargs):
+def load_model(model_uri, artifact_path=None, **kwargs):
     """
     Load a Keras model from a local file or a run.
 
@@ -527,6 +527,9 @@ def load_model(model_uri, **kwargs):
                       For more information about supported URI schemes, see
                       `Referencing Artifacts <https://www.mlflow.org/docs/latest/concepts.html#
                       artifact-locations>`_.
+    :param artifact_path: The local filesystem path to which to download the model artifact.
+                          This directory must already exist. If unspecified, a local output
+                          path will be created.
 
     :return: A Keras model instance.
 
@@ -537,7 +540,7 @@ def load_model(model_uri, **kwargs):
         keras_model = mlflow.keras.load_model("runs:/96771d893a5e46159d9f3b49bf9013e2" + "/models")
         predictions = keras_model.predict(x_test)
     """
-    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri)
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=artifact_path)
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     keras_module = importlib.import_module(flavor_conf.get("keras_module", "keras"))
     keras_model_artifacts_path = os.path.join(

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -540,7 +540,9 @@ def load_model(model_uri, artifact_path=None, **kwargs):
         keras_model = mlflow.keras.load_model("runs:/96771d893a5e46159d9f3b49bf9013e2" + "/models")
         predictions = keras_model.predict(x_test)
     """
-    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=artifact_path)
+    local_model_path = _download_artifact_from_uri(
+        artifact_uri=model_uri, output_path=artifact_path
+    )
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     keras_module = importlib.import_module(flavor_conf.get("keras_module", "keras"))
     keras_model_artifacts_path = os.path.join(

--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -261,7 +261,7 @@ def _load_pyfunc(path):
     return _LGBModelWrapper(_load_model(path))
 
 
-def load_model(model_uri, artifact_path=None):
+def load_model(model_uri, dst_path=None):
     """
     Load a LightGBM model from a local file or a run.
 
@@ -275,15 +275,13 @@ def load_model(model_uri, artifact_path=None):
                       For more information about supported URI schemes, see
                       `Referencing Artifacts <https://www.mlflow.org/docs/latest/tracking.html#
                       artifact-locations>`_.
-    :param artifact_path: The local filesystem path to which to download the model artifact.
-                          This directory must already exist. If unspecified, a local output
-                          path will be created.
+    :param dst_path: The local filesystem path to which to download the model artifact.
+                     This directory must already exist. If unspecified, a local output
+                     path will be created.
 
     :return: A LightGBM model (an instance of `lightgbm.Booster`_).
     """
-    local_model_path = _download_artifact_from_uri(
-        artifact_uri=model_uri, output_path=artifact_path
-    )
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     lgb_model_file_path = os.path.join(local_model_path, flavor_conf.get("data", "model.lgb"))
     return _load_model(path=lgb_model_file_path)

--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -281,7 +281,9 @@ def load_model(model_uri, artifact_path=None):
 
     :return: A LightGBM model (an instance of `lightgbm.Booster`_).
     """
-    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=artifact_path)
+    local_model_path = _download_artifact_from_uri(
+        artifact_uri=model_uri, output_path=artifact_path
+    )
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     lgb_model_file_path = os.path.join(local_model_path, flavor_conf.get("data", "model.lgb"))
     return _load_model(path=lgb_model_file_path)

--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -261,7 +261,7 @@ def _load_pyfunc(path):
     return _LGBModelWrapper(_load_model(path))
 
 
-def load_model(model_uri):
+def load_model(model_uri, artifact_path=None):
     """
     Load a LightGBM model from a local file or a run.
 
@@ -275,10 +275,13 @@ def load_model(model_uri):
                       For more information about supported URI schemes, see
                       `Referencing Artifacts <https://www.mlflow.org/docs/latest/tracking.html#
                       artifact-locations>`_.
+    :param artifact_path: The local filesystem path to which to download the model artifact.
+                          This directory must already exist. If unspecified, a local output
+                          path will be created.
 
     :return: A LightGBM model (an instance of `lightgbm.Booster`_).
     """
-    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri)
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=artifact_path)
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     lgb_model_file_path = os.path.join(local_model_path, flavor_conf.get("data", "model.lgb"))
     return _load_model(path=lgb_model_file_path)

--- a/mlflow/onnx.py
+++ b/mlflow/onnx.py
@@ -282,7 +282,7 @@ def _load_pyfunc(path):
 
 
 @experimental
-def load_model(model_uri):
+def load_model(model_uri, artifact_path=None):
     """
     Load an ONNX model from a local file or a run.
 
@@ -298,11 +298,14 @@ def load_model(model_uri):
                       For more information about supported URI schemes, see the
                       `Artifacts Documentation <https://www.mlflow.org/docs/latest/
                       tracking.html#artifact-stores>`_.
+    :param artifact_path: The local filesystem path to which to download the model artifact.
+                          This directory must already exist. If unspecified, a local output
+                          path will be created.
 
     :return: An ONNX model instance.
 
     """
-    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri)
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=artifact_path)
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     onnx_model_artifacts_path = os.path.join(local_model_path, flavor_conf["data"])
     return _load_model(model_file=onnx_model_artifacts_path)

--- a/mlflow/onnx.py
+++ b/mlflow/onnx.py
@@ -282,7 +282,7 @@ def _load_pyfunc(path):
 
 
 @experimental
-def load_model(model_uri, artifact_path=None):
+def load_model(model_uri, dst_path=None):
     """
     Load an ONNX model from a local file or a run.
 
@@ -298,16 +298,14 @@ def load_model(model_uri, artifact_path=None):
                       For more information about supported URI schemes, see the
                       `Artifacts Documentation <https://www.mlflow.org/docs/latest/
                       tracking.html#artifact-stores>`_.
-    :param artifact_path: The local filesystem path to which to download the model artifact.
-                          This directory must already exist. If unspecified, a local output
-                          path will be created.
+    :param dst_path: The local filesystem path to which to download the model artifact.
+                     This directory must already exist. If unspecified, a local output
+                     path will be created.
 
     :return: An ONNX model instance.
 
     """
-    local_model_path = _download_artifact_from_uri(
-        artifact_uri=model_uri, output_path=artifact_path
-    )
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     onnx_model_artifacts_path = os.path.join(local_model_path, flavor_conf["data"])
     return _load_model(model_file=onnx_model_artifacts_path)

--- a/mlflow/onnx.py
+++ b/mlflow/onnx.py
@@ -305,7 +305,9 @@ def load_model(model_uri, artifact_path=None):
     :return: An ONNX model instance.
 
     """
-    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=artifact_path)
+    local_model_path = _download_artifact_from_uri(
+        artifact_uri=model_uri, output_path=artifact_path
+    )
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     onnx_model_artifacts_path = os.path.join(local_model_path, flavor_conf["data"])
     return _load_model(model_file=onnx_model_artifacts_path)

--- a/mlflow/paddle/__init__.py
+++ b/mlflow/paddle/__init__.py
@@ -254,7 +254,7 @@ def save_model(
     write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME), "\n".join(pip_requirements))
 
 
-def load_model(model_uri, model=None, **kwargs):
+def load_model(model_uri, model=None, artifact_path=None, **kwargs):
     """
     Load a paddle model from a local file or a run.
     :param model_uri: The location, in URI format, of the MLflow model, for example:
@@ -267,6 +267,9 @@ def load_model(model_uri, model=None, **kwargs):
             - ``models:/<model_name>/<stage>``
 
     :param model: Required when loading a `paddle.Model` model saved with `training=True`.
+    :param artifact_path: The local filesystem path to which to download the model artifact.
+                          This directory must already exist. If unspecified, a local output
+                          path will be created.
     :param kwargs: The keyword arguments to pass to `paddle.jit.load`
                    or `model.load`.
 
@@ -287,7 +290,7 @@ def load_model(model_uri, model=None, **kwargs):
     """
     import paddle
 
-    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri)
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=artifact_path)
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     pd_model_artifacts_path = os.path.join(local_model_path, flavor_conf["pickled_model"])
     if model is None:

--- a/mlflow/paddle/__init__.py
+++ b/mlflow/paddle/__init__.py
@@ -254,7 +254,7 @@ def save_model(
     write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME), "\n".join(pip_requirements))
 
 
-def load_model(model_uri, model=None, artifact_path=None, **kwargs):
+def load_model(model_uri, model=None, dst_path=None, **kwargs):
     """
     Load a paddle model from a local file or a run.
     :param model_uri: The location, in URI format, of the MLflow model, for example:
@@ -267,9 +267,9 @@ def load_model(model_uri, model=None, artifact_path=None, **kwargs):
             - ``models:/<model_name>/<stage>``
 
     :param model: Required when loading a `paddle.Model` model saved with `training=True`.
-    :param artifact_path: The local filesystem path to which to download the model artifact.
-                          This directory must already exist. If unspecified, a local output
-                          path will be created.
+    :param dst_path: The local filesystem path to which to download the model artifact.
+                     This directory must already exist. If unspecified, a local output
+                     path will be created.
     :param kwargs: The keyword arguments to pass to `paddle.jit.load`
                    or `model.load`.
 
@@ -290,9 +290,7 @@ def load_model(model_uri, model=None, artifact_path=None, **kwargs):
     """
     import paddle
 
-    local_model_path = _download_artifact_from_uri(
-        artifact_uri=model_uri, output_path=artifact_path
-    )
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     pd_model_artifacts_path = os.path.join(local_model_path, flavor_conf["pickled_model"])
     if model is None:

--- a/mlflow/paddle/__init__.py
+++ b/mlflow/paddle/__init__.py
@@ -290,7 +290,9 @@ def load_model(model_uri, model=None, artifact_path=None, **kwargs):
     """
     import paddle
 
-    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=artifact_path)
+    local_model_path = _download_artifact_from_uri(
+        artifact_uri=model_uri, output_path=artifact_path
+    )
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     pd_model_artifacts_path = os.path.join(local_model_path, flavor_conf["pickled_model"])
     if model is None:

--- a/mlflow/prophet.py
+++ b/mlflow/prophet.py
@@ -258,7 +258,7 @@ def _load_pyfunc(path):
     return _ProphetModelWrapper(_load_model(path))
 
 
-def load_model(model_uri, artifact_path=None):
+def load_model(model_uri, dst_path=None):
     """
     Load a Prophet model from a local file or a run.
 
@@ -272,15 +272,13 @@ def load_model(model_uri, artifact_path=None):
                       For more information about supported URI schemes, see
                       `Referencing Artifacts <https://www.mlflow.org/docs/latest/tracking.html#
                       artifact-locations>`_.
-    :param artifact_path: The local filesystem path to which to download the model artifact.
-                          This directory must already exist. If unspecified, a local output
-                          path will be created.
+    :param dst_path: The local filesystem path to which to download the model artifact.
+                     This directory must already exist. If unspecified, a local output
+                     path will be created.
 
     :return: A Prophet model instance
     """
-    local_model_path = _download_artifact_from_uri(
-        artifact_uri=model_uri, output_path=artifact_path
-    )
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     pr_model_path = os.path.join(
         local_model_path, flavor_conf.get(_MODEL_BINARY_KEY, _MODEL_BINARY_FILE_NAME)

--- a/mlflow/prophet.py
+++ b/mlflow/prophet.py
@@ -278,7 +278,9 @@ def load_model(model_uri, artifact_path=None):
 
     :return: A Prophet model instance
     """
-    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=artifact_path)
+    local_model_path = _download_artifact_from_uri(
+        artifact_uri=model_uri, output_path=artifact_path
+    )
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     pr_model_path = os.path.join(
         local_model_path, flavor_conf.get(_MODEL_BINARY_KEY, _MODEL_BINARY_FILE_NAME)

--- a/mlflow/prophet.py
+++ b/mlflow/prophet.py
@@ -258,7 +258,7 @@ def _load_pyfunc(path):
     return _ProphetModelWrapper(_load_model(path))
 
 
-def load_model(model_uri):
+def load_model(model_uri, artifact_path=None):
     """
     Load a Prophet model from a local file or a run.
 
@@ -272,10 +272,13 @@ def load_model(model_uri):
                       For more information about supported URI schemes, see
                       `Referencing Artifacts <https://www.mlflow.org/docs/latest/tracking.html#
                       artifact-locations>`_.
+    :param artifact_path: The local filesystem path to which to download the model artifact.
+                          This directory must already exist. If unspecified, a local output
+                          path will be created.
 
     :return: A Prophet model instance
     """
-    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri)
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=artifact_path)
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     pr_model_path = os.path.join(
         local_model_path, flavor_conf.get(_MODEL_BINARY_KEY, _MODEL_BINARY_FILE_NAME)

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -628,7 +628,11 @@ class PyFuncModel(object):
         return yaml.safe_dump({"mlflow.pyfunc.loaded_model": info}, default_flow_style=False)
 
 
-def load_model(model_uri: str, suppress_warnings: bool = True) -> PyFuncModel:
+def load_model(
+        model_uri: str,
+        suppress_warnings: bool = True,
+        artifact_path: str = None
+    ) -> PyFuncModel:
     """
     Load a model stored in Python function format.
 
@@ -647,8 +651,11 @@ def load_model(model_uri: str, suppress_warnings: bool = True) -> PyFuncModel:
     :param suppress_warnings: If ``True``, non-fatal warning messages associated with the model
                               loading process will be suppressed. If ``False``, these warning
                               messages will be emitted.
+    :param artifact_path: The local filesystem path to which to download the model artifact.
+                          This directory must already exist. If unspecified, a local output
+                          path will be created.
     """
-    local_path = _download_artifact_from_uri(artifact_uri=model_uri)
+    local_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=artifact_path)
     model_meta = Model.load(os.path.join(local_path, MLMODEL_FILE_NAME))
 
     conf = model_meta.flavors.get(FLAVOR_NAME)

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -628,9 +628,7 @@ class PyFuncModel(object):
         return yaml.safe_dump({"mlflow.pyfunc.loaded_model": info}, default_flow_style=False)
 
 
-def load_model(
-    model_uri: str, suppress_warnings: bool = True, artifact_path: str = None
-) -> PyFuncModel:
+def load_model(model_uri: str, suppress_warnings: bool = True, dst_path: str = None) -> PyFuncModel:
     """
     Load a model stored in Python function format.
 
@@ -649,11 +647,11 @@ def load_model(
     :param suppress_warnings: If ``True``, non-fatal warning messages associated with the model
                               loading process will be suppressed. If ``False``, these warning
                               messages will be emitted.
-    :param artifact_path: The local filesystem path to which to download the model artifact.
-                          This directory must already exist. If unspecified, a local output
-                          path will be created.
+    :param dst_path: The local filesystem path to which to download the model artifact.
+                     This directory must already exist. If unspecified, a local output
+                     path will be created.
     """
-    local_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=artifact_path)
+    local_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
     model_meta = Model.load(os.path.join(local_path, MLMODEL_FILE_NAME))
 
     conf = model_meta.flavors.get(FLAVOR_NAME)

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -629,10 +629,8 @@ class PyFuncModel(object):
 
 
 def load_model(
-        model_uri: str,
-        suppress_warnings: bool = True,
-        artifact_path: str = None
-    ) -> PyFuncModel:
+    model_uri: str, suppress_warnings: bool = True, artifact_path: str = None
+) -> PyFuncModel:
     """
     Load a model stored in Python function format.
 

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -693,7 +693,9 @@ def load_model(model_uri, artifact_path=None, **kwargs):
     """
     import torch
 
-    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=artifact_path)
+    local_model_path = _download_artifact_from_uri(
+        artifact_uri=model_uri, output_path=artifact_path
+    )
     try:
         pyfunc_conf = _get_flavor_configuration(
             model_path=local_model_path, flavor_name=pyfunc.FLAVOR_NAME

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -633,7 +633,7 @@ def _load_model(path, **kwargs):
             return torch.jit.load(model_path)
 
 
-def load_model(model_uri, artifact_path=None, **kwargs):
+def load_model(model_uri, dst_path=None, **kwargs):
     """
     Load a PyTorch model from a local file or a run.
 
@@ -649,9 +649,9 @@ def load_model(model_uri, artifact_path=None, **kwargs):
                       For more information about supported URI schemes, see
                       `Referencing Artifacts <https://www.mlflow.org/docs/latest/concepts.html#
                       artifact-locations>`_.
-    :param artifact_path: The local filesystem path to which to download the model artifact.
-                          This directory must already exist. If unspecified, a local output
-                          path will be created.
+    :param dst_path: The local filesystem path to which to download the model artifact.
+                     This directory must already exist. If unspecified, a local output
+                     path will be created.
 
     :param kwargs: kwargs to pass to ``torch.load`` method.
     :return: A PyTorch model.
@@ -693,9 +693,7 @@ def load_model(model_uri, artifact_path=None, **kwargs):
     """
     import torch
 
-    local_model_path = _download_artifact_from_uri(
-        artifact_uri=model_uri, output_path=artifact_path
-    )
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
     try:
         pyfunc_conf = _get_flavor_configuration(
             model_path=local_model_path, flavor_name=pyfunc.FLAVOR_NAME

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -633,7 +633,7 @@ def _load_model(path, **kwargs):
             return torch.jit.load(model_path)
 
 
-def load_model(model_uri, **kwargs):
+def load_model(model_uri, artifact_path=None, **kwargs):
     """
     Load a PyTorch model from a local file or a run.
 
@@ -649,6 +649,9 @@ def load_model(model_uri, **kwargs):
                       For more information about supported URI schemes, see
                       `Referencing Artifacts <https://www.mlflow.org/docs/latest/concepts.html#
                       artifact-locations>`_.
+    :param artifact_path: The local filesystem path to which to download the model artifact.
+                          This directory must already exist. If unspecified, a local output
+                          path will be created.
 
     :param kwargs: kwargs to pass to ``torch.load`` method.
     :return: A PyTorch model.
@@ -690,7 +693,7 @@ def load_model(model_uri, **kwargs):
     """
     import torch
 
-    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri)
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=artifact_path)
     try:
         pyfunc_conf = _get_flavor_configuration(
             model_path=local_model_path, flavor_name=pyfunc.FLAVOR_NAME

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -505,7 +505,7 @@ def _save_model(sk_model, output_path, serialization_format):
             )
 
 
-def load_model(model_uri):
+def load_model(model_uri, artifact_path=None):
     """
     Load a scikit-learn model from a local file or a run.
 
@@ -521,6 +521,9 @@ def load_model(model_uri):
                       For more information about supported URI schemes, see
                       `Referencing Artifacts <https://www.mlflow.org/docs/latest/concepts.html#
                       artifact-locations>`_.
+    :param artifact_path: The local filesystem path to which to download the model artifact.
+                          This directory must already exist. If unspecified, a local output
+                          path will be created.
 
     :return: A scikit-learn model.
 
@@ -534,7 +537,7 @@ def load_model(model_uri):
         pandas_df = ...
         predictions = sk_model.predict(pandas_df)
     """
-    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri)
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=artifact_path)
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     sklearn_model_artifacts_path = os.path.join(local_model_path, flavor_conf["pickled_model"])
     serialization_format = flavor_conf.get("serialization_format", SERIALIZATION_FORMAT_PICKLE)

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -537,7 +537,9 @@ def load_model(model_uri, artifact_path=None):
         pandas_df = ...
         predictions = sk_model.predict(pandas_df)
     """
-    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=artifact_path)
+    local_model_path = _download_artifact_from_uri(
+        artifact_uri=model_uri, output_path=artifact_path
+    )
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     sklearn_model_artifacts_path = os.path.join(local_model_path, flavor_conf["pickled_model"])
     serialization_format = flavor_conf.get("serialization_format", SERIALIZATION_FORMAT_PICKLE)

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -505,7 +505,7 @@ def _save_model(sk_model, output_path, serialization_format):
             )
 
 
-def load_model(model_uri, artifact_path=None):
+def load_model(model_uri, dst_path=None):
     """
     Load a scikit-learn model from a local file or a run.
 
@@ -521,9 +521,9 @@ def load_model(model_uri, artifact_path=None):
                       For more information about supported URI schemes, see
                       `Referencing Artifacts <https://www.mlflow.org/docs/latest/concepts.html#
                       artifact-locations>`_.
-    :param artifact_path: The local filesystem path to which to download the model artifact.
-                          This directory must already exist. If unspecified, a local output
-                          path will be created.
+    :param dst_path: The local filesystem path to which to download the model artifact.
+                     This directory must already exist. If unspecified, a local output
+                     path will be created.
 
     :return: A scikit-learn model.
 
@@ -537,9 +537,7 @@ def load_model(model_uri, artifact_path=None):
         pandas_df = ...
         predictions = sk_model.predict(pandas_df)
     """
-    local_model_path = _download_artifact_from_uri(
-        artifact_uri=model_uri, output_path=artifact_path
-    )
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     sklearn_model_artifacts_path = os.path.join(local_model_path, flavor_conf["pickled_model"])
     serialization_format = flavor_conf.get("serialization_format", SERIALIZATION_FORMAT_PICKLE)

--- a/mlflow/spacy.py
+++ b/mlflow/spacy.py
@@ -270,7 +270,7 @@ def _load_pyfunc(path):
     return _SpacyModelWrapper(_load_model(path))
 
 
-def load_model(model_uri, artifact_path=None):
+def load_model(model_uri, dst_path=None):
     """
     Load a spaCy model from a local file (if ``run_id`` is ``None``) or a run.
 
@@ -286,15 +286,13 @@ def load_model(model_uri, artifact_path=None):
                       For more information about supported URI schemes, see
                       `Referencing Artifacts <https://www.mlflow.org/docs/latest/concepts.html#
                       artifact-locations>`_.
-    :param artifact_path: The local filesystem path to which to download the model artifact.
-                          This directory must already exist. If unspecified, a local output
-                          path will be created.
+    :param dst_path: The local filesystem path to which to download the model artifact.
+                     This directory must already exist. If unspecified, a local output
+                     path will be created.
 
     :return: A spaCy loaded model
     """
-    local_model_path = _download_artifact_from_uri(
-        artifact_uri=model_uri, output_path=artifact_path
-    )
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     # Flavor configurations for models saved in MLflow version <= 0.8.0 may not contain a
     # `data` key; in this case, we assume the model artifact path to be `model.spacy`

--- a/mlflow/spacy.py
+++ b/mlflow/spacy.py
@@ -292,7 +292,9 @@ def load_model(model_uri, artifact_path=None):
 
     :return: A spaCy loaded model
     """
-    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=artifact_path)
+    local_model_path = _download_artifact_from_uri(
+        artifact_uri=model_uri, output_path=artifact_path
+    )
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     # Flavor configurations for models saved in MLflow version <= 0.8.0 may not contain a
     # `data` key; in this case, we assume the model artifact path to be `model.spacy`

--- a/mlflow/spacy.py
+++ b/mlflow/spacy.py
@@ -270,7 +270,7 @@ def _load_pyfunc(path):
     return _SpacyModelWrapper(_load_model(path))
 
 
-def load_model(model_uri):
+def load_model(model_uri, artifact_path=None):
     """
     Load a spaCy model from a local file (if ``run_id`` is ``None``) or a run.
 
@@ -286,10 +286,13 @@ def load_model(model_uri):
                       For more information about supported URI schemes, see
                       `Referencing Artifacts <https://www.mlflow.org/docs/latest/concepts.html#
                       artifact-locations>`_.
+    :param artifact_path: The local filesystem path to which to download the model artifact.
+                          This directory must already exist. If unspecified, a local output
+                          path will be created.
 
     :return: A spaCy loaded model
     """
-    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri)
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=artifact_path)
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     # Flavor configurations for models saved in MLflow version <= 0.8.0 may not contain a
     # `data` key; in this case, we assume the model artifact path to be `model.spacy`

--- a/mlflow/statsmodels.py
+++ b/mlflow/statsmodels.py
@@ -281,7 +281,7 @@ def _load_pyfunc(path):
     return _StatsmodelsModelWrapper(_load_model(path))
 
 
-def load_model(model_uri, artifact_path=None):
+def load_model(model_uri, dst_path=None):
     """
     Load a statsmodels model from a local file or a run.
 
@@ -295,15 +295,13 @@ def load_model(model_uri, artifact_path=None):
                       For more information about supported URI schemes, see
                       `Referencing Artifacts <https://www.mlflow.org/docs/latest/tracking.html#
                       artifact-locations>`_.
-    :param artifact_path: The local filesystem path to which to download the model artifact.
-                          This directory must already exist. If unspecified, a local output
-                          path will be created.
+    :param dst_path: The local filesystem path to which to download the model artifact.
+                     This directory must already exist. If unspecified, a local output
+                     path will be created.
 
     :return: A statsmodels model (an instance of `statsmodels.base.model.Results`_).
     """
-    local_model_path = _download_artifact_from_uri(
-        artifact_uri=model_uri, output_path=artifact_path
-    )
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     statsmodels_model_file_path = os.path.join(
         local_model_path, flavor_conf.get("data", STATSMODELS_DATA_SUBPATH)

--- a/mlflow/statsmodels.py
+++ b/mlflow/statsmodels.py
@@ -281,7 +281,7 @@ def _load_pyfunc(path):
     return _StatsmodelsModelWrapper(_load_model(path))
 
 
-def load_model(model_uri):
+def load_model(model_uri, artifact_path=None):
     """
     Load a statsmodels model from a local file or a run.
 
@@ -295,10 +295,13 @@ def load_model(model_uri):
                       For more information about supported URI schemes, see
                       `Referencing Artifacts <https://www.mlflow.org/docs/latest/tracking.html#
                       artifact-locations>`_.
+    :param artifact_path: The local filesystem path to which to download the model artifact.
+                          This directory must already exist. If unspecified, a local output
+                          path will be created.
 
     :return: A statsmodels model (an instance of `statsmodels.base.model.Results`_).
     """
-    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri)
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=artifact_path)
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     statsmodels_model_file_path = os.path.join(
         local_model_path, flavor_conf.get("data", STATSMODELS_DATA_SUBPATH)

--- a/mlflow/statsmodels.py
+++ b/mlflow/statsmodels.py
@@ -301,7 +301,9 @@ def load_model(model_uri, artifact_path=None):
 
     :return: A statsmodels model (an instance of `statsmodels.base.model.Results`_).
     """
-    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=artifact_path)
+    local_model_path = _download_artifact_from_uri(
+        artifact_uri=model_uri, output_path=artifact_path
+    )
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     statsmodels_model_file_path = os.path.join(
         local_model_path, flavor_conf.get("data", STATSMODELS_DATA_SUBPATH)

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -365,7 +365,9 @@ def load_model(model_uri, artifact_path=None):
             output_tensors = [tf_graph.get_tensor_by_name(output_signature.name)
                                 for _, output_signature in signature_definition.outputs.items()]
     """
-    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=artifact_path)
+    local_model_path = _download_artifact_from_uri(
+        artifact_uri=model_uri, output_path=artifact_path
+    )
     (
         tf_saved_model_dir,
         tf_meta_graph_tags,

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -328,7 +328,7 @@ def _validate_saved_model(tf_saved_model_dir, tf_meta_graph_tags, tf_signature_d
     )
 
 
-def load_model(model_uri):
+def load_model(model_uri, artifact_path=None):
     """
     Load an MLflow model that contains the TensorFlow flavor from the specified path.
 
@@ -344,6 +344,9 @@ def load_model(model_uri):
                       For more information about supported URI schemes, see
                       `Referencing Artifacts <https://www.mlflow.org/docs/latest/concepts.html#
                       artifact-locations>`_.
+    :param artifact_path: The local filesystem path to which to download the model artifact.
+                          This directory must already exist. If unspecified, a local output
+                          path will be created.
 
     :return: A callable graph (tf.function) that takes inputs and returns inferences.
 
@@ -362,7 +365,7 @@ def load_model(model_uri):
             output_tensors = [tf_graph.get_tensor_by_name(output_signature.name)
                                 for _, output_signature in signature_definition.outputs.items()]
     """
-    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri)
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=artifact_path)
     (
         tf_saved_model_dir,
         tf_meta_graph_tags,

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -328,7 +328,7 @@ def _validate_saved_model(tf_saved_model_dir, tf_meta_graph_tags, tf_signature_d
     )
 
 
-def load_model(model_uri, artifact_path=None):
+def load_model(model_uri, dst_path=None):
     """
     Load an MLflow model that contains the TensorFlow flavor from the specified path.
 
@@ -344,9 +344,9 @@ def load_model(model_uri, artifact_path=None):
                       For more information about supported URI schemes, see
                       `Referencing Artifacts <https://www.mlflow.org/docs/latest/concepts.html#
                       artifact-locations>`_.
-    :param artifact_path: The local filesystem path to which to download the model artifact.
-                          This directory must already exist. If unspecified, a local output
-                          path will be created.
+    :param dst_path: The local filesystem path to which to download the model artifact.
+                     This directory must already exist. If unspecified, a local output
+                     path will be created.
 
     :return: A callable graph (tf.function) that takes inputs and returns inferences.
 
@@ -365,9 +365,7 @@ def load_model(model_uri, artifact_path=None):
             output_tensors = [tf_graph.get_tensor_by_name(output_signature.name)
                                 for _, output_signature in signature_definition.outputs.items()]
     """
-    local_model_path = _download_artifact_from_uri(
-        artifact_uri=model_uri, output_path=artifact_path
-    )
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
     (
         tf_saved_model_dir,
         tf_meta_graph_tags,

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -271,7 +271,7 @@ def _load_pyfunc(path):
     return _XGBModelWrapper(_load_model(path))
 
 
-def load_model(model_uri, artifact_path=None):
+def load_model(model_uri, dst_path=None):
     """
     Load an XGBoost model from a local file or a run.
 
@@ -285,15 +285,13 @@ def load_model(model_uri, artifact_path=None):
                       For more information about supported URI schemes, see
                       `Referencing Artifacts <https://www.mlflow.org/docs/latest/tracking.html#
                       artifact-locations>`_.
-    :param artifact_path: The local filesystem path to which to download the model artifact.
-                          This directory must already exist. If unspecified, a local output
-                          path will be created.
+    :param dst_path: The local filesystem path to which to download the model artifact.
+                     This directory must already exist. If unspecified, a local output
+                     path will be created.
 
     :return: An XGBoost model (an instance of `xgboost.Booster`_)
     """
-    local_model_path = _download_artifact_from_uri(
-        artifact_uri=model_uri, output_path=artifact_path
-    )
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     xgb_model_file_path = os.path.join(local_model_path, flavor_conf.get("data", "model.xgb"))
     return _load_model(path=xgb_model_file_path)

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -271,7 +271,7 @@ def _load_pyfunc(path):
     return _XGBModelWrapper(_load_model(path))
 
 
-def load_model(model_uri):
+def load_model(model_uri, artifact_path=None):
     """
     Load an XGBoost model from a local file or a run.
 
@@ -285,10 +285,13 @@ def load_model(model_uri):
                       For more information about supported URI schemes, see
                       `Referencing Artifacts <https://www.mlflow.org/docs/latest/tracking.html#
                       artifact-locations>`_.
+    :param artifact_path: The local filesystem path to which to download the model artifact.
+                          This directory must already exist. If unspecified, a local output
+                          path will be created.
 
     :return: An XGBoost model (an instance of `xgboost.Booster`_)
     """
-    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri)
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=artifact_path)
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     xgb_model_file_path = os.path.join(local_model_path, flavor_conf.get("data", "model.xgb"))
     return _load_model(path=xgb_model_file_path)

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -291,7 +291,9 @@ def load_model(model_uri, artifact_path=None):
 
     :return: An XGBoost model (an instance of `xgboost.Booster`_)
     """
-    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=artifact_path)
+    local_model_path = _download_artifact_from_uri(
+        artifact_uri=model_uri, output_path=artifact_path
+    )
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     xgb_model_file_path = os.path.join(local_model_path, flavor_conf.get("data", "model.xgb"))
     return _load_model(path=xgb_model_file_path)


### PR DESCRIPTION
Signed-off-by: Liang Zhang <liang.zhang@databricks.com>

## What changes are proposed in this pull request?

This PR is to resolve issue #4852.

## How is this patch tested?

Existing tests.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

You can specify the directory where model artifacts are downloaded to by using the parameter `dst_path` in `load_model()`.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
