### PR TITLE
Use `globalSetup` to set timezone when running JS tests

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -408,12 +408,26 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.7
-      - name: Install dependecies
+      - name: Install python dependencies
         run: |
           pip install -r dev-requirements.txt
           pip install -r dev/small-requirements.txt
           pip install --no-dependencies tests/resources/mlflow-test-plugin
           pip install -e .[extras]
-      - name: Run tests
+      - name: Run python tests
         run: |
           pytest --ignore-flavors --ignore=tests/projects tests
+      - name: Set up Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 10.x
+      - name: Install JS dependencies
+        working-directory: mlflow/server/js
+        shell: pwsh
+        run: |
+          npm i
+      - name: Run JS tests
+        working-directory: mlflow/server/js
+        shell: pwsh
+        run: |
+          npm run test

--- a/mlflow/server/js/package.json
+++ b/mlflow/server/js/package.json
@@ -80,8 +80,8 @@
   "scripts": {
     "start": "react-app-rewired start",
     "build": "react-app-rewired --max_old_space_size=8192 build",
-    "test": "TZ=GMT react-app-rewired test --env=jsdom --colors",
-    "test:debug": "TZ=GMT react-app-rewired --inspect-brk test --runInBand --no-cache --env=jsdom",
+    "test": "react-app-rewired test --env=jsdom --colors",
+    "test:debug": "react-app-rewired --inspect-brk test --runInBand --no-cache --env=jsdom",
     "eject": "react-scripts eject",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
@@ -101,7 +101,8 @@
     "setupFiles": [
       "jest-canvas-mock",
       "<rootDir>/scripts/throw-on-prop-type-warning.js"
-    ]
+    ],
+    "globalSetup": "<rootDir>/scripts/global-setup.js"
   },
   "browserslist": [
     "defaults"

--- a/mlflow/server/js/scripts/global-setup.js
+++ b/mlflow/server/js/scripts/global-setup.js
@@ -1,0 +1,25 @@
+const { execSync } = require('child_process');
+const os = require('os');
+
+module.exports = () => {
+  // On windows, the timezone is not set with `TZ=GMT`. As a workaround, use `tzutil`.
+  // This approach is taken from https://www.npmjs.com/package/set-tz.
+  if (os.platform() === 'win32') {
+    const TZ = 'GMT Standard Time';
+    const previousTZ = execSync('tzutil /g').toString();
+    const cleanup = () => {
+      execSync(`tzutil /s "${previousTZ}"`);
+      console.log(`Restored timezone to ${previousTZ}`);
+    };
+    execSync(`tzutil /s "${TZ}"`);
+    console.warn(
+      `Changed timezone to ${TZ}. If process is killed, manually run: tzutil /s "${previousTZ}"`,
+    );
+    process.on('exit', cleanup);
+    process.on('SIGINT', () => {
+      process.exit(2);
+    });
+  } else {
+    process.env.TZ = 'GMT';
+  }
+};

--- a/mlflow/server/js/src/timezone.test.js
+++ b/mlflow/server/js/src/timezone.test.js
@@ -1,0 +1,4 @@
+test('timezone is GMT', () => {
+  const d = new Date();
+  expect(d.getTimezoneOffset()).toBe(0);
+});


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

A follow-up for #4941 to set the timezone using `globalSetup` for developers using windows.

## How is this patch tested?

Unit tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
