### PR TITLE
convert nan's in input examples to None before converting to JSON

### DIFF
--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -61,14 +61,20 @@ class _Example(object):
                 isinstance(x, dict) and all([isinstance(ary, np.ndarray) for ary in x.values()])
             )
 
+        def _handle_tensor_nans(x: np.ndarray):
+            if np.issubdtype(x.dtype, np.number):
+                return np.where(np.isnan(x), None, x)
+            else:
+                return x
+
         def _handle_tensor_input(input_tensor: Union[np.ndarray, dict]):
             if isinstance(input_tensor, dict):
                 result = {}
                 for name in input_tensor.keys():
-                    result[name] = input_tensor[name].where(input_ex.notnull(), None).tolist()
+                    result[name] = _handle_tensor_nans(input_tensor[name]).tolist()
                 return {"inputs": result}
             else:
-                return {"inputs": input_tensor.where(input_ex.notnull(), None).tolist()}
+                return {"inputs": _handle_tensor_nans(input_tensor).tolist()}
 
         def _handle_dataframe_input(input_ex):
             if isinstance(input_ex, dict):

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -65,10 +65,10 @@ class _Example(object):
             if isinstance(input_tensor, dict):
                 result = {}
                 for name in input_tensor.keys():
-                    result[name] = input_tensor[name].tolist()
+                    result[name] = input_tensor[name].where(input_ex.notnull(), None).tolist()
                 return {"inputs": result}
             else:
-                return {"inputs": input_tensor.tolist()}
+                return {"inputs": input_tensor.where(input_ex.notnull(), None).tolist()}
 
         def _handle_dataframe_input(input_ex):
             if isinstance(input_ex, dict):

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -76,6 +76,9 @@ class _Example(object):
             else:
                 return {"inputs": _handle_tensor_nans(input_tensor).tolist()}
 
+        def _handle_dataframe_nans(df: pd.DataFrame):
+            return df.where(df.notnull(), None)
+
         def _handle_dataframe_input(input_ex):
             if isinstance(input_ex, dict):
                 if all([_is_scalar(x) for x in input_ex.values()]):
@@ -111,7 +114,7 @@ class _Example(object):
                     "(pandas.DataFrame, numpy.ndarray, dict, list), "
                     "got {}".format(type(input_example))
                 )
-            result = input_ex.where(input_ex.notnull(), None).to_dict(orient="split")
+            result = _handle_dataframe_nans(input_ex).to_dict(orient="split")
             # Do not include row index
             del result["index"]
             if all(input_ex.columns == range(len(input_ex.columns))):

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -105,7 +105,7 @@ class _Example(object):
                     "(pandas.DataFrame, numpy.ndarray, dict, list), "
                     "got {}".format(type(input_example))
                 )
-            result = input_ex.to_dict(orient="split")
+            result = input_ex.where(input_ex.notnull(), None).to_dict(orient="split")
             # Do not include row index
             del result["index"]
             if all(input_ex.columns == range(len(input_ex.columns))):

--- a/tests/models/test_model_input_examples.py
+++ b/tests/models/test_model_input_examples.py
@@ -33,6 +33,7 @@ def pandas_df_with_all_types():
     df["string_ext"] = df["string_ext"].astype("string")
     return df
 
+
 @pytest.fixture
 def df_with_nan():
     return pd.DataFrame(
@@ -57,12 +58,13 @@ def dict_of_ndarrays():
         "4D": np.arange(0, 12, 0.5).reshape(3, 2, 2, 2),
     }
 
+
 @pytest.fixture
 def dict_of_ndarrays_with_nans():
     return {
         "1D": np.array([0.5, np.nan, 2.0]),
         "2D": np.array([[0.1, 0.2], [np.nan, 0.5]]),
-        "3D": np.array([[[0.1, np.nan],[0.3, 0.4]], [[np.nan, 0.6],[0.7,np.nan]]])
+        "3D": np.array([[[0.1, np.nan], [0.3, 0.4]], [[np.nan, 0.6], [0.7, np.nan]]]),
     }
 
 
@@ -140,6 +142,7 @@ def test_input_examples(pandas_df_with_all_types, dict_of_ndarrays):
         parsed_df = _dataframe_from_json(tmp.path(filename))
         assert example == parsed_df.to_dict(orient="records")[0]
 
+
 def test_input_examples_with_nan(df_with_nan, dict_of_ndarrays_with_nans):
     # test setting example with data frame with NaN values in it
     sig = infer_signature(df_with_nan)
@@ -152,7 +155,11 @@ def test_input_examples_with_nan(df_with_nan, dict_of_ndarrays_with_nans):
             assert set(data.keys()) == set(("columns", "data"))
         parsed_df = _dataframe_from_json(tmp.path(filename), schema=sig.inputs)
         # by definition of NaN, NaN == NaN is False but NaN != NaN is True
-        assert ((df_with_nan == parsed_df) | ((df_with_nan != df_with_nan) & (parsed_df != parsed_df))).all().all()
+        assert (
+            ((df_with_nan == parsed_df) | ((df_with_nan != df_with_nan) & (parsed_df != parsed_df)))
+            .all()
+            .all()
+        )
         # the frame read without schema should match except for the binary values
         no_schema_df = _dataframe_from_json(tmp.path(filename))
         # the frame read without schema should match except for the binary values
@@ -173,4 +180,6 @@ def test_input_examples_with_nan(df_with_nan, dict_of_ndarrays_with_nans):
 
             # without a schema/dtype specified, the resulting tensor will keep the None type
             no_schema_df = _read_tensor_input_from_json(tmp.path(filename))
-            assert np.array_equal(no_schema_df, np.where(np.isnan(input_example), None, input_example))
+            assert np.array_equal(
+                no_schema_df, np.where(np.isnan(input_example), None, input_example)
+            )

--- a/tests/models/test_model_input_examples.py
+++ b/tests/models/test_model_input_examples.py
@@ -162,7 +162,6 @@ def test_input_examples_with_nan(df_with_nan, dict_of_ndarrays_with_nans):
         )
         # the frame read without schema should match except for the binary values
         no_schema_df = _dataframe_from_json(tmp.path(filename))
-        # the frame read without schema should match except for the binary values
         a = parsed_df.drop(columns=["binary"])
         b = no_schema_df.drop(columns=["binary"])
         assert ((a == b) | ((a != a) & (b != b))).all().all()


### PR DESCRIPTION
Signed-off-by: Wendy Hu <wendy.hu@databricks.com>

## What changes are proposed in this pull request?

Null values (e.g np.nan, None, etc.) are converted to Python's `None` value in column-based/dataframe and tensor-based input examples before saving them to JSON.
This is to prevent saving NaN's to JSON, resulting in an invalid JSON.

## How is this patch tested?
- added unit tests
- Logged a model with input example containing `np.nan`, opened the logged `input_example.json` to confirm the `np.nan`s were converted successfully to `null` in JSON, that it could be loaded via "Show Example" button in serving, and the model could be invoked with the input example containing null values.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
