### PR TITLE
Change pathing in test harness for windows

### DIFF
--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -44,7 +44,11 @@ def random_int(lo=1, hi=1e10):
 
 
 def random_str(size=10):
-    return uuid.uuid4().hex[:size]
+    """UUID4 generated strings have a high potential for collision at small sizes.
+    10 is lower bounds for this test harness utility."""
+    generated_string = uuid.uuid4().hex[:size]
+    assert len(generated_string) >= 10
+    return generated_string
 
 
 def random_file(ext):

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -44,8 +44,8 @@ def random_int(lo=1, hi=1e10):
     return random.randint(lo, hi)
 
 
-def random_str(size=10, chars=string.ascii_uppercase + string.digits):
-    return "".join(random.choice(chars) for _ in range(size))
+def random_str(size=10):
+    return uuid.uuid4().hex[:size]
 
 
 def random_file(ext):

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -44,11 +44,13 @@ def random_int(lo=1, hi=1e10):
 
 
 def random_str(size=10):
-    """UUID4 generated strings have a high potential for collision at small sizes.
-    10 is lower bounds for this test harness utility."""
-    generated_string = uuid.uuid4().hex[:size]
-    assert len(generated_string) >= 10
-    return generated_string
+    msg = (
+        "UUID4 generated strings have a high potential for collision at small sizes."
+        "10 is set as the lower bounds for random string generation to prevent non-deterministic"
+        "test failures."
+    )
+    assert size >= 10, msg
+    return uuid.uuid4().hex[:size]
 
 
 def random_file(ext):

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -3,7 +3,6 @@ import random
 from unittest import mock
 
 import requests
-import string
 import time
 import signal
 import socket

--- a/tests/pyfunc/test_scoring_server.py
+++ b/tests/pyfunc/test_scoring_server.py
@@ -350,7 +350,7 @@ def test_parse_json_input_records_oriented():
     size = 2
     data = {
         "col_m": [random_int(0, 1000) for _ in range(size)],
-        "col_z": [random_str(4) for _ in range(size)],
+        "col_z": [random_str() for _ in range(size)],
         "col_a": [random_int() for _ in range(size)],
     }
     p1 = pd.DataFrame.from_dict(data)
@@ -365,7 +365,7 @@ def test_parse_json_input_split_oriented():
     size = 200
     data = {
         "col_m": [random_int(0, 1000) for _ in range(size)],
-        "col_z": [random_str(4) for _ in range(size)],
+        "col_z": [random_str() for _ in range(size)],
         "col_a": [random_int() for _ in range(size)],
     }
     p1 = pd.DataFrame.from_dict(data)
@@ -379,7 +379,7 @@ def test_parse_json_input_split_oriented_to_numpy_array():
     data = OrderedDict(
         [
             ("col_m", [random_int(0, 1000) for _ in range(size)]),
-            ("col_z", [random_str(4) for _ in range(size)]),
+            ("col_z", [random_str() for _ in range(size)]),
             ("col_a", [random_int() for _ in range(size)]),
         ]
     )
@@ -478,7 +478,7 @@ def test_infer_and_parse_json_input():
     # input is correctly recognized as list, and parsed as pd df with orient 'records'
     data = {
         "col_m": [random_int(0, 1000) for _ in range(size)],
-        "col_z": [random_str(4) for _ in range(size)],
+        "col_z": [random_str() for _ in range(size)],
         "col_a": [random_int() for _ in range(size)],
     }
     p1 = pd.DataFrame.from_dict(data)
@@ -488,7 +488,7 @@ def test_infer_and_parse_json_input():
     # input is correctly recognized as a dict, and parsed as pd df with orient 'split'
     data = {
         "col_m": [random_int(0, 1000) for _ in range(size)],
-        "col_z": [random_str(4) for _ in range(size)],
+        "col_z": [random_str() for _ in range(size)],
         "col_a": [random_int() for _ in range(size)],
     }
     p1 = pd.DataFrame.from_dict(data)

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -94,7 +94,7 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
                 os.makedirs(params_folder)
                 params = {}
                 for _ in range(5):
-                    param_name = random_str(random_int(4, 12))
+                    param_name = random_str(random_int(10, 12))
                     param_value = random_str(random_int(10, 15))
                     param_file = os.path.join(params_folder, param_name)
                     with open(param_file, "w") as f:
@@ -106,7 +106,7 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
                 os.makedirs(metrics_folder)
                 metrics = {}
                 for _ in range(3):
-                    metric_name = random_str(random_int(6, 10))
+                    metric_name = random_str(random_int(10, 12))
                     timestamp = int(time.time())
                     metric_file = os.path.join(metrics_folder, metric_name)
                     values = []
@@ -205,7 +205,7 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         fs = FileStore(self.test_root)
         fs.list_experiments = mock.Mock(return_value=[])
         fs._create_experiment_with_id = mock.Mock()
-        fs.create_experiment(random_str(1))
+        fs.create_experiment(random_str())
         fs._create_experiment_with_id.assert_called_once()
         experiment_id = fs._create_experiment_with_id.call_args[0][1]
         self.assertEqual(experiment_id, FileStore.DEFAULT_EXPERIMENT_ID)

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -83,7 +83,7 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
                     "start_time": random_int(1, 10),
                     "end_time": random_int(20, 30),
                     "tags": [],
-                    "artifact_uri": "%s/%s" % (run_folder, FileStore.ARTIFACTS_FOLDER_NAME),
+                    "artifact_uri": os.path.join(run_folder, FileStore.ARTIFACTS_FOLDER_NAME),
                 }
                 write_yaml(run_folder, FileStore.META_DATA_FILE_NAME, run_info)
                 self.run_data[run_id] = run_info


### PR DESCRIPTION
Signed-off-by: Ben Wilson <benjamin.wilson@databricks.com>

## What changes are proposed in this pull request?

Change the pathing to use os.path.join() instead of string interpolation for windows tests in test_file_store.py

## How is this patch tested?

unit tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
