### PR TITLE
gRPC grammar generation for MLflow models #4911

### DIFF
--- a/mlflow/models/grpc.py
+++ b/mlflow/models/grpc.py
@@ -1,0 +1,119 @@
+"""
+The :py:mod:`mlflow.models.grpc` module provides an API to generate the model gRPC grammar.
+
+The grammar is generated using the Model Signature. See :py:class:`mlflow.models.signature.ModelSignature`
+for more details on the signature.
+"""
+from typing import List, Tuple
+
+from jinja2 import Template
+
+from mlflow.exceptions import MlflowException
+from mlflow.models.signature import ModelSignature
+from mlflow.types import Schema, ColSpec, DataType
+from mlflow.types.utils import TensorsNotSupportedException
+
+_TEMPLATE = """
+syntax = "proto3";
+
+package {{ package }};
+
+{% if importTimestamp %}
+import "google/protobuf/timestamp.proto";
+{% endif %}
+        
+message ModelInput {
+    {% for input in inputs %}
+        {{ input[0] }} {{ input[1] }} = {{loop.index}};
+    {% endfor %}
+}
+
+message ModelOutput {
+    {% for output in outputs %}
+        {{ output[0] }} {{ output[1] }} = {{loop.index}};
+    {% endfor %}
+}
+
+service ModelService {
+  rpc predict (ModelInput) returns (ModelOutput) {}
+}
+"""
+
+_DEFAULT_PACKAGE = 'org.mlflow.models.grpc'
+
+_NUMPY_TO_PROTO_TYPE = {
+    DataType.boolean.name: 'bool',
+    DataType.integer.name: 'int32',
+    DataType.long.name: 'int64',
+    DataType.float.name: 'float',
+    DataType.double.name: 'double',
+    DataType.string.name: 'string',
+    DataType.binary.name: 'bytes',
+    DataType.datetime.name: 'google.protobuf.Timestamp'
+}
+
+
+def generate_grammar(signature: ModelSignature, package: str = _DEFAULT_PACKAGE) -> str:
+    """
+    Generates the gRPC grammar based on the Model Signature.
+    The schema types are converted into protobuf types.
+
+    This method will raise an exception if any of the following conditions is matched:
+    - the signature does not have the output schema
+    - the signature contains tensors or columns with unsupported types
+    - the signature contains columns without name
+
+    :param signature: the Model Signature.
+    :param package: an optional string to override the default package `org.mlflow.models.grpc` in the gRPC grammar.
+
+    :return: The gRPC grammar as string.
+    """
+    if signature.outputs is None:
+        raise MlflowException('Output signature is not present for signature {}'.format(signature.to_dict()))
+
+    input_signature: List[Tuple[str, str]] = _map_to_proto_types(signature.inputs)
+    output_signature: List[Tuple[str, str]] = _map_to_proto_types(signature.outputs)
+
+    has_datetime = any(map(lambda t: t[0] == _NUMPY_TO_PROTO_TYPE[DataType.datetime.name],
+                           input_signature + output_signature))
+
+    template = Template(_TEMPLATE, trim_blocks=True, lstrip_blocks=True)
+    return template.render(package=package, importTimestamp=has_datetime, inputs=input_signature,
+                           outputs=output_signature)
+
+
+def _map_to_proto_types(schema: Schema) -> List[Tuple[str, str]]:
+    """
+    Transforms the schema into a list of tuples (protobuf-type, name).
+
+    This method will raise an exception if the schema is a tensor.
+
+    :param schema: the Schema.
+
+    :return: A list of tuples containing the column protobuf type and the column name.
+    """
+    if schema.is_tensor_spec():
+        raise TensorsNotSupportedException("Invalid schema '{}'".format(schema.to_json()))
+
+    return list(map(_map_col_spec, schema.inputs))
+
+
+def _map_col_spec(input: ColSpec) -> Tuple[str, str]:
+    """
+    Transforms a :py:class:`mlflow.types.ColSpec` into a tuple (protobuf-type, name).
+
+    This method will raise an exception if either the column type can't be mapped to one
+    of :py:class:`mlflow.types.DataType` or the column name is not present.
+
+    :param input: the column to transform.
+
+    :return: A tuple containing the protobuf type and the name.
+    """
+    if input.type.name not in _NUMPY_TO_PROTO_TYPE:
+        raise MlflowException('Invalid type for ColSpec {}'.format(input.to_dict()))
+
+    if input.name is None:
+        raise MlflowException('Missing name for ColSpec {}'.format(input.to_dict()))
+
+    return _NUMPY_TO_PROTO_TYPE.get(input.type.name), input.name
+

--- a/mlflow/models/grpc.py
+++ b/mlflow/models/grpc.py
@@ -1,7 +1,8 @@
 """
 The :py:mod:`mlflow.models.grpc` module provides an API to generate the model gRPC grammar.
 
-The grammar is generated using the Model Signature. See :py:class:`mlflow.models.signature.ModelSignature`
+The grammar is generated using the Model Signature.
+See :py:class:`mlflow.models.signature.ModelSignature`
 for more details on the signature.
 """
 from typing import List, Tuple
@@ -21,7 +22,7 @@ package {{ package }};
 {% if importTimestamp %}
 import "google/protobuf/timestamp.proto";
 {% endif %}
-        
+
 message ModelInput {
     {% for input in inputs %}
         {{ input[0] }} {{ input[1] }} = {{loop.index}};
@@ -64,7 +65,8 @@ def generate_grammar(signature: ModelSignature, package: str = _DEFAULT_PACKAGE)
     - the signature contains columns without name
 
     :param signature: the Model Signature.
-    :param package: an optional string to override the default package `org.mlflow.models.grpc` in the gRPC grammar.
+    :param package: an optional string to override the default package
+    `org.mlflow.models.grpc` in the gRPC grammar.
 
     :return: The gRPC grammar as string.
     """
@@ -73,8 +75,8 @@ def generate_grammar(signature: ModelSignature, package: str = _DEFAULT_PACKAGE)
             "Output signature is not present for signature {}".format(signature.to_dict())
         )
 
-    input_signature: List[Tuple[str, str]] = _map_to_proto_types(signature.inputs)
-    output_signature: List[Tuple[str, str]] = _map_to_proto_types(signature.outputs)
+    input_signature = _map_to_proto_types(signature.inputs)
+    output_signature = _map_to_proto_types(signature.outputs)
 
     has_datetime = any(
         map(
@@ -108,21 +110,21 @@ def _map_to_proto_types(schema: Schema) -> List[Tuple[str, str]]:
     return list(map(_map_col_spec, schema.inputs))
 
 
-def _map_col_spec(input: ColSpec) -> Tuple[str, str]:
+def _map_col_spec(col: ColSpec) -> Tuple[str, str]:
     """
     Transforms a :py:class:`mlflow.types.ColSpec` into a tuple (protobuf-type, name).
 
     This method will raise an exception if either the column type can't be mapped to one
     of :py:class:`mlflow.types.DataType` or the column name is not present.
 
-    :param input: the column to transform.
+    :param col: the column to transform.
 
     :return: A tuple containing the protobuf type and the name.
     """
-    if input.type.name not in _NUMPY_TO_PROTO_TYPE:
-        raise MlflowException("Invalid type for ColSpec {}".format(input.to_dict()))
+    if col.type.name not in _NUMPY_TO_PROTO_TYPE:
+        raise MlflowException("Invalid type for ColSpec {}".format(col.to_dict()))
 
-    if input.name is None:
-        raise MlflowException("Missing name for ColSpec {}".format(input.to_dict()))
+    if col.name is None:
+        raise MlflowException("Missing name for ColSpec {}".format(col.to_dict()))
 
-    return _NUMPY_TO_PROTO_TYPE.get(input.type.name), input.name
+    return _NUMPY_TO_PROTO_TYPE.get(col.type.name), col.name

--- a/mlflow/models/grpc.py
+++ b/mlflow/models/grpc.py
@@ -39,17 +39,17 @@ service ModelService {
 }
 """
 
-_DEFAULT_PACKAGE = 'org.mlflow.models.grpc'
+_DEFAULT_PACKAGE = "org.mlflow.models.grpc"
 
 _NUMPY_TO_PROTO_TYPE = {
-    DataType.boolean.name: 'bool',
-    DataType.integer.name: 'int32',
-    DataType.long.name: 'int64',
-    DataType.float.name: 'float',
-    DataType.double.name: 'double',
-    DataType.string.name: 'string',
-    DataType.binary.name: 'bytes',
-    DataType.datetime.name: 'google.protobuf.Timestamp'
+    DataType.boolean.name: "bool",
+    DataType.integer.name: "int32",
+    DataType.long.name: "int64",
+    DataType.float.name: "float",
+    DataType.double.name: "double",
+    DataType.string.name: "string",
+    DataType.binary.name: "bytes",
+    DataType.datetime.name: "google.protobuf.Timestamp",
 }
 
 
@@ -69,17 +69,27 @@ def generate_grammar(signature: ModelSignature, package: str = _DEFAULT_PACKAGE)
     :return: The gRPC grammar as string.
     """
     if signature.outputs is None:
-        raise MlflowException('Output signature is not present for signature {}'.format(signature.to_dict()))
+        raise MlflowException(
+            "Output signature is not present for signature {}".format(signature.to_dict())
+        )
 
     input_signature: List[Tuple[str, str]] = _map_to_proto_types(signature.inputs)
     output_signature: List[Tuple[str, str]] = _map_to_proto_types(signature.outputs)
 
-    has_datetime = any(map(lambda t: t[0] == _NUMPY_TO_PROTO_TYPE[DataType.datetime.name],
-                           input_signature + output_signature))
+    has_datetime = any(
+        map(
+            lambda t: t[0] == _NUMPY_TO_PROTO_TYPE[DataType.datetime.name],
+            input_signature + output_signature,
+        )
+    )
 
     template = Template(_TEMPLATE, trim_blocks=True, lstrip_blocks=True)
-    return template.render(package=package, importTimestamp=has_datetime, inputs=input_signature,
-                           outputs=output_signature)
+    return template.render(
+        package=package,
+        importTimestamp=has_datetime,
+        inputs=input_signature,
+        outputs=output_signature,
+    )
 
 
 def _map_to_proto_types(schema: Schema) -> List[Tuple[str, str]]:
@@ -110,10 +120,9 @@ def _map_col_spec(input: ColSpec) -> Tuple[str, str]:
     :return: A tuple containing the protobuf type and the name.
     """
     if input.type.name not in _NUMPY_TO_PROTO_TYPE:
-        raise MlflowException('Invalid type for ColSpec {}'.format(input.to_dict()))
+        raise MlflowException("Invalid type for ColSpec {}".format(input.to_dict()))
 
     if input.name is None:
-        raise MlflowException('Missing name for ColSpec {}'.format(input.to_dict()))
+        raise MlflowException("Missing name for ColSpec {}".format(input.to_dict()))
 
     return _NUMPY_TO_PROTO_TYPE.get(input.type.name), input.name
-

--- a/tests/models/test_grpc.py
+++ b/tests/models/test_grpc.py
@@ -1,0 +1,147 @@
+import pytest
+import numpy as np
+
+import mlflow.models.grpc as grpc
+from mlflow.exceptions import MlflowException
+from mlflow.models import ModelSignature
+from mlflow.types import Schema, ColSpec, DataType, TensorSpec
+from mlflow.types.utils import TensorsNotSupportedException
+
+
+@pytest.fixture()
+def sample_schema():
+    return Schema([ColSpec(name='c1', type=DataType.boolean), ColSpec(name='c2', type=DataType.integer)])
+
+
+@pytest.fixture()
+def sample_schema_with_datetime():
+    return Schema([ColSpec(name='c1', type=DataType.boolean), ColSpec(name='c2', type=DataType.datetime)])
+
+
+@pytest.fixture
+def schema_with_all_types_dynamic():
+    s = Schema([])
+    for t in DataType:
+        s.inputs.append(ColSpec(name='col_{}'.format(t.name), type=t))
+    return s
+
+
+def _clean_string(s: str):
+    return s.replace(' ', '').replace('\n', '')
+
+
+def test_grpc_grammar_generation(sample_schema):
+    signature = ModelSignature(inputs=sample_schema, outputs=sample_schema)
+    grpc_grammar = grpc.generate_grammar(signature)
+
+    expected_grammar = """
+        syntax = "proto3";
+        
+        package org.mlflow.models.grpc;
+        
+        message ModelInput {
+                bool c1 = 1;
+                int32 c2 = 2;
+        }
+        
+        message ModelOutput {
+                bool c1 = 1;
+                int32 c2 = 2;
+        }
+        
+        service ModelService {
+          rpc predict (ModelInput) returns (ModelOutput) {}
+        }
+    """
+
+    assert _clean_string(expected_grammar) == _clean_string(grpc_grammar)
+
+
+def test_grpc_grammar_generation_with_datetime(sample_schema_with_datetime):
+    signature = ModelSignature(inputs=sample_schema_with_datetime, outputs=sample_schema_with_datetime)
+    grpc_grammar = grpc.generate_grammar(signature)
+
+    expected_grammar = """
+        syntax = "proto3";
+        
+        package org.mlflow.models.grpc;
+        
+        import "google/protobuf/timestamp.proto";
+        
+        message ModelInput {
+                bool c1 = 1;
+                google.protobuf.Timestamp c2 = 2;
+        }
+        
+        message ModelOutput {
+                bool c1 = 1;
+                google.protobuf.Timestamp c2 = 2;
+        }
+        
+        service ModelService {
+          rpc predict (ModelInput) returns (ModelOutput) {}
+        }
+    """
+
+    assert _clean_string(expected_grammar) == _clean_string(grpc_grammar)
+
+
+def test_grpc_type_mapping():
+    schema_with_all_types = Schema([
+        ColSpec(name='feature1', type=DataType.boolean),
+        ColSpec(name='feature2', type=DataType.integer),
+        ColSpec(name='feature3', type=DataType.long),
+        ColSpec(name='feature4', type=DataType.float),
+        ColSpec(name='feature5', type=DataType.double),
+        ColSpec(name='feature6', type=DataType.string),
+        ColSpec(name='feature7', type=DataType.binary),
+        ColSpec(name='feature8', type=DataType.datetime)
+    ])
+    expected_mappings = [
+        ('bool', 'feature1'),
+        ('int32', 'feature2'),
+        ('int64', 'feature3'),
+        ('float', 'feature4'),
+        ('double', 'feature5'),
+        ('string', 'feature6'),
+        ('bytes', 'feature7'),
+        ('google.protobuf.Timestamp', 'feature8')
+    ]
+    mappings = grpc._map_to_proto_types(schema_with_all_types)
+
+    assert sorted(expected_mappings) == sorted(mappings)
+
+
+def test_all_data_types_are_supported(schema_with_all_types_dynamic, sample_schema):
+    try:
+        signature_with_all_types = ModelSignature(inputs=schema_with_all_types_dynamic, outputs=sample_schema)
+        _ = grpc.generate_grammar(signature_with_all_types)
+    except MlflowException:
+        assert False, "gRPC grammar generation raised an exception: unsupported type"
+
+
+def test_exception_for_missing_signature_output(sample_schema):
+    signature_without_outputs = ModelSignature(inputs=sample_schema, outputs=None)
+
+    with pytest.raises(MlflowException):
+        _ = grpc.generate_grammar(signature_without_outputs)
+
+
+def test_exception_for_signature_with_tensors(sample_schema):
+    schema_with_tensor = Schema([TensorSpec(np.dtype("str"), [-1], "a")])
+
+    signature_with_input_tensor = ModelSignature(inputs=schema_with_tensor, outputs=sample_schema)
+    with pytest.raises(TensorsNotSupportedException):
+        _ = grpc.generate_grammar(signature_with_input_tensor)
+
+    signature_with_output_tensor = ModelSignature(inputs=sample_schema, outputs=schema_with_tensor)
+    with pytest.raises(TensorsNotSupportedException):
+        _ = grpc.generate_grammar(signature_with_output_tensor)
+
+
+def test_exception_for_missing_feature_name(sample_schema):
+    schema_with_no_feature_name = Schema([ColSpec(type=DataType.boolean)])
+    signature_with_no_feature_name = ModelSignature(inputs=schema_with_no_feature_name, outputs=sample_schema)
+
+    with pytest.raises(MlflowException):
+        _ = grpc.generate_grammar(signature_with_no_feature_name)

--- a/tests/models/test_grpc.py
+++ b/tests/models/test_grpc.py
@@ -40,19 +40,19 @@ def test_grpc_grammar_generation(sample_schema):
 
     expected_grammar = """
         syntax = "proto3";
-        
+
         package org.mlflow.models.grpc;
-        
+
         message ModelInput {
                 bool c1 = 1;
                 int32 c2 = 2;
         }
-        
+
         message ModelOutput {
                 bool c1 = 1;
                 int32 c2 = 2;
         }
-        
+
         service ModelService {
           rpc predict (ModelInput) returns (ModelOutput) {}
         }
@@ -69,21 +69,21 @@ def test_grpc_grammar_generation_with_datetime(sample_schema_with_datetime):
 
     expected_grammar = """
         syntax = "proto3";
-        
+
         package org.mlflow.models.grpc;
-        
+
         import "google/protobuf/timestamp.proto";
-        
+
         message ModelInput {
                 bool c1 = 1;
                 google.protobuf.Timestamp c2 = 2;
         }
-        
+
         message ModelOutput {
                 bool c1 = 1;
                 google.protobuf.Timestamp c2 = 2;
         }
-        
+
         service ModelService {
           rpc predict (ModelInput) returns (ModelOutput) {}
         }

--- a/tests/models/test_grpc.py
+++ b/tests/models/test_grpc.py
@@ -10,24 +10,28 @@ from mlflow.types.utils import TensorsNotSupportedException
 
 @pytest.fixture()
 def sample_schema():
-    return Schema([ColSpec(name='c1', type=DataType.boolean), ColSpec(name='c2', type=DataType.integer)])
+    return Schema(
+        [ColSpec(name="c1", type=DataType.boolean), ColSpec(name="c2", type=DataType.integer)]
+    )
 
 
 @pytest.fixture()
 def sample_schema_with_datetime():
-    return Schema([ColSpec(name='c1', type=DataType.boolean), ColSpec(name='c2', type=DataType.datetime)])
+    return Schema(
+        [ColSpec(name="c1", type=DataType.boolean), ColSpec(name="c2", type=DataType.datetime)]
+    )
 
 
 @pytest.fixture
 def schema_with_all_types_dynamic():
     s = Schema([])
     for t in DataType:
-        s.inputs.append(ColSpec(name='col_{}'.format(t.name), type=t))
+        s.inputs.append(ColSpec(name="col_{}".format(t.name), type=t))
     return s
 
 
 def _clean_string(s: str):
-    return s.replace(' ', '').replace('\n', '')
+    return s.replace(" ", "").replace("\n", "")
 
 
 def test_grpc_grammar_generation(sample_schema):
@@ -58,7 +62,9 @@ def test_grpc_grammar_generation(sample_schema):
 
 
 def test_grpc_grammar_generation_with_datetime(sample_schema_with_datetime):
-    signature = ModelSignature(inputs=sample_schema_with_datetime, outputs=sample_schema_with_datetime)
+    signature = ModelSignature(
+        inputs=sample_schema_with_datetime, outputs=sample_schema_with_datetime
+    )
     grpc_grammar = grpc.generate_grammar(signature)
 
     expected_grammar = """
@@ -87,25 +93,27 @@ def test_grpc_grammar_generation_with_datetime(sample_schema_with_datetime):
 
 
 def test_grpc_type_mapping():
-    schema_with_all_types = Schema([
-        ColSpec(name='feature1', type=DataType.boolean),
-        ColSpec(name='feature2', type=DataType.integer),
-        ColSpec(name='feature3', type=DataType.long),
-        ColSpec(name='feature4', type=DataType.float),
-        ColSpec(name='feature5', type=DataType.double),
-        ColSpec(name='feature6', type=DataType.string),
-        ColSpec(name='feature7', type=DataType.binary),
-        ColSpec(name='feature8', type=DataType.datetime)
-    ])
+    schema_with_all_types = Schema(
+        [
+            ColSpec(name="feature1", type=DataType.boolean),
+            ColSpec(name="feature2", type=DataType.integer),
+            ColSpec(name="feature3", type=DataType.long),
+            ColSpec(name="feature4", type=DataType.float),
+            ColSpec(name="feature5", type=DataType.double),
+            ColSpec(name="feature6", type=DataType.string),
+            ColSpec(name="feature7", type=DataType.binary),
+            ColSpec(name="feature8", type=DataType.datetime),
+        ]
+    )
     expected_mappings = [
-        ('bool', 'feature1'),
-        ('int32', 'feature2'),
-        ('int64', 'feature3'),
-        ('float', 'feature4'),
-        ('double', 'feature5'),
-        ('string', 'feature6'),
-        ('bytes', 'feature7'),
-        ('google.protobuf.Timestamp', 'feature8')
+        ("bool", "feature1"),
+        ("int32", "feature2"),
+        ("int64", "feature3"),
+        ("float", "feature4"),
+        ("double", "feature5"),
+        ("string", "feature6"),
+        ("bytes", "feature7"),
+        ("google.protobuf.Timestamp", "feature8"),
     ]
     mappings = grpc._map_to_proto_types(schema_with_all_types)
 
@@ -114,7 +122,9 @@ def test_grpc_type_mapping():
 
 def test_all_data_types_are_supported(schema_with_all_types_dynamic, sample_schema):
     try:
-        signature_with_all_types = ModelSignature(inputs=schema_with_all_types_dynamic, outputs=sample_schema)
+        signature_with_all_types = ModelSignature(
+            inputs=schema_with_all_types_dynamic, outputs=sample_schema
+        )
         _ = grpc.generate_grammar(signature_with_all_types)
     except MlflowException:
         assert False, "gRPC grammar generation raised an exception: unsupported type"
@@ -141,7 +151,9 @@ def test_exception_for_signature_with_tensors(sample_schema):
 
 def test_exception_for_missing_feature_name(sample_schema):
     schema_with_no_feature_name = Schema([ColSpec(type=DataType.boolean)])
-    signature_with_no_feature_name = ModelSignature(inputs=schema_with_no_feature_name, outputs=sample_schema)
+    signature_with_no_feature_name = ModelSignature(
+        inputs=schema_with_no_feature_name, outputs=sample_schema
+    )
 
     with pytest.raises(MlflowException):
         _ = grpc.generate_grammar(signature_with_no_feature_name)


### PR DESCRIPTION
## What changes are proposed in this pull request?
This PR adds the possibility to generate the gRPC grammar of an MLflow Model.
It addresses the Feature Request #4911 

## How is this patch tested?
Unit-tests.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Possibility to generate the gRPC grammar of an MLflow Model

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<a name="grpc-grammar-for-mlflow-model"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
