### PR TITLE
Render code to load model when pyfunc flavor is unavailable

### DIFF
--- a/mlflow/server/js/src/common/constants.js
+++ b/mlflow/server/js/src/common/constants.js
@@ -25,6 +25,9 @@ export const RegisteringModelDocUrl =
 
 export const ExperimentTrackingDocUrl = 'https://www.mlflow.org/docs/latest/tracking.html';
 
+export const CustomPyfuncModelsDocUrl =
+  'https://www.mlflow.org/docs/latest/python_api/mlflow.pyfunc.html#creating-custom-pyfunc-models';
+
 export const LoggingRunsDocUrl =
   'https://www.mlflow.org/docs/latest/tracking.html#logging-data-to-runs';
 

--- a/mlflow/server/js/src/common/constants.js
+++ b/mlflow/server/js/src/common/constants.js
@@ -25,6 +25,7 @@ export const RegisteringModelDocUrl =
 
 export const ExperimentTrackingDocUrl = 'https://www.mlflow.org/docs/latest/tracking.html';
 
+export const PyfuncDocUrl = 'https://www.mlflow.org/docs/latest/python_api/mlflow.pyfunc.html';
 export const CustomPyfuncModelsDocUrl =
   'https://www.mlflow.org/docs/latest/python_api/mlflow.pyfunc.html#creating-custom-pyfunc-models';
 

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.js
@@ -155,8 +155,8 @@ class ShowArtifactLoggedModelView extends Component {
                 <br />
               </pre>
             </Paragraph>
-            See <a href={CustomPyfuncModelsDocUrl}>Creating custom Pyfunc models</a> for how to log
-            this model as a PyFuncModel.
+            See <a href={CustomPyfuncModelsDocUrl}>creating custom Pyfunc models</a> to learn how
+            to customize this model and deploy it for batch or real-time scoring using the ``pyfunc`` model flavor.
           </div>
         </div>
       </>

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.js
@@ -35,6 +35,7 @@ class ShowArtifactLoggedModelView extends Component {
     error: undefined,
     inputs: undefined,
     outputs: undefined,
+    hasPyfuncFlavor: undefined,
   };
 
   componentDidMount() {
@@ -221,6 +222,15 @@ class ShowArtifactLoggedModelView extends Component {
           />
         </div>
       );
+    } else if (!this.state.hasPyfuncFlavor) {
+      return (
+        <div className='artifact-logged-model-view-no-pyfunc-flavor'>
+          <FormattedMessage
+            defaultMessage="This model doesn't have the pyfunc flavor"
+            description="Error state text when the model doesn't have the pyfunc flavor"
+          />
+        </div>
+      );
     } else {
       return (
         <div className='ShowArtifactPage'>
@@ -311,6 +321,11 @@ class ShowArtifactLoggedModelView extends Component {
           });
         } else {
           this.setState({ inputs: '', outputs: '' });
+        }
+        if (parsedJson.flavors && parsedJson.flavors.python_function) {
+          this.setState({ hasPyfuncFlavor: true });
+        } else {
+          this.setState({ hasPyfuncFlavor: false });
         }
         this.setState({ loading: false });
       })

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.js
@@ -155,8 +155,9 @@ class ShowArtifactLoggedModelView extends Component {
                 <br />
               </pre>
             </Paragraph>
-            See <a href={CustomPyfuncModelsDocUrl}>creating custom Pyfunc models</a> to learn how
-            to customize this model and deploy it for batch or real-time scoring using the ``pyfunc`` model flavor.
+            See <a href={CustomPyfuncModelsDocUrl}>creating custom Pyfunc models</a> to learn how to
+            customize this model and deploy it for batch or real-time scoring using the ``pyfunc``
+            model flavor.
           </div>
         </div>
       </>

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.js
@@ -163,10 +163,10 @@ class ShowArtifactLoggedModelView extends Component {
               </pre>
             </Paragraph>
             <FormattedMessage
-              defaultMessage={`See the documents below to learn how to customize this model
-                               and deploy it for batch or real-time scoring using the pyfunc
-                               model flavor.`}
-              description='Subtext heading'
+              // eslint-disable-next-line max-len
+              defaultMessage='See the documents below to learn how to customize this model and deploy it for batch or real-time scoring using the pyfunc model flavor.'
+              // eslint-disable-next-line max-len
+              description='Subtext heading for a list of documents that describe how to customize the model using the mlflow.pyfunc module'
             />
             <ul>
               <li>

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.test.js
@@ -183,12 +183,12 @@ flavors:
     expect(instance.props.getArtifact).toBeCalled();
   });
 
-  test('should render code when model does not have pyfunc flavor', (done) => {
+  test('should render code snippet with original flavor when no pyfunc flavor', (done) => {
     const getArtifact = jest.fn((artifactLocation) => {
       return Promise.resolve(`
 flavors:
   sklearn:
-    version: 1.1.1
+    version: 1.2.3
 `);
     });
     const props = { ...minimalProps, getArtifact };
@@ -196,17 +196,19 @@ flavors:
     setImmediate(() => {
       wrapper.update();
       expect(wrapper.state().flavor).toBe('sklearn');
-      expect(wrapper.find('.artifact-logged-model-view-code-content').length).toBe(1);
+      const codeContent = wrapper.find('.artifact-logged-model-view-code-content');
+      expect(codeContent.length).toBe(1);
+      expect(codeContent.text().includes('mlflow.sklearn.load_model')).toBe(true);
       done();
     });
   });
 
-  test('should not render code when model does not have pyfunc flavor', (done) => {
+  test('should not render code snippet for mleap flavor', (done) => {
     const getArtifact = jest.fn((artifactLocation) => {
       return Promise.resolve(`
 flavors:
   mleap:
-    version: 1.1.1
+    version: 1.2.3
 `);
     });
     const props = { ...minimalProps, getArtifact };

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.test.js
@@ -174,4 +174,22 @@ describe('ShowArtifactLoggedModelView', () => {
     expect(instance.fetchLoggedModelMetadata).toBeCalled();
     expect(instance.props.getArtifact).toBeCalled();
   });
+
+  test('should not render code snippets when model does not have pyfunc flavor', (done) => {
+    const getArtifact = jest.fn((artifactLocation) => {
+      return Promise.resolve(`
+flavors:
+  sklearn:
+    pickled_model: model.pkl
+`);
+    });
+    const props = { ...minimalProps, getArtifact };
+    wrapper = mountWithIntl(<ShowArtifactLoggedModelView {...props} />);
+    setImmediate(() => {
+      wrapper.update();
+      expect(wrapper.state().hasPyfuncFlavor).toBe(false);
+      expect(wrapper.find('.artifact-logged-model-view-no-pyfunc-flavor').length).toBe(1);
+      done();
+    });
+  });
 });

--- a/mlflow/server/js/src/i18n/default/en.json
+++ b/mlflow/server/js/src/i18n/default/en.json
@@ -79,6 +79,10 @@
     "defaultMessage": "Creator",
     "description": "Lable name for the creator under details tab on the model view page"
   },
+  "25EUlg": {
+    "defaultMessage": "The code snippets below demonstrate how to load the logged model.",
+    "description": "Subtext heading explaining the below section of the model artifact view on how users can load the registered logged model"
+  },
   "27oNFE": {
     "defaultMessage": "Model schema",
     "description": "Heading text for the model schema of the registered model from the experiment run"
@@ -90,6 +94,10 @@
   "2Exf7S": {
     "defaultMessage": "Supported formats: image, text, html, pdf, geojson files",
     "description": "Text to explain users which formats are supported to display the artifacts"
+  },
+  "2NfDVN": {
+    "defaultMessage": "Load the model",
+    "description": "Heading text for stating how to load the model from the experiment run"
   },
   "2f2qeb": {
     "defaultMessage": "Type",
@@ -162,6 +170,10 @@
   "6b6fTN": {
     "defaultMessage": "Select a file to preview",
     "description": "Label to suggests users to select a file to preview the output"
+  },
+  "6bmLqb": {
+    "defaultMessage": "Load model",
+    "description": "Code comment which states how to load the model"
   },
   "6kSKRk": {
     "defaultMessage": "Comparing {numVersions} Versions",
@@ -714,6 +726,10 @@
   "axF2gD": {
     "defaultMessage": "Full Path:",
     "description": "Label to display the full path of where the artifact of the experiment runs is located"
+  },
+  "bHuphj": {
+    "defaultMessage": "See the documents below to learn how to customize this model and deploy it for batch or real-time scoring using the pyfunc model flavor.",
+    "description": "Subtext heading for a list of documents that describe how to customize the model using the mlflow.pyfunc module"
   },
   "bSx/er": {
     "defaultMessage": "Parameters",


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

Currently, the model artifact viewer renders code to load the logged model as a pyfunc model and make predictions even when the logged model doesn't contain the pyfunc flavor. This PR fixes the issue by rendering code to load the logged model using the original flavor module.

### Before

https://user-images.githubusercontent.com/17039389/140316284-779ea059-7e50-461f-b525-e4d9d34c18a3.mov

- The logged model doesn't contain the pyfunc flavor.
- The model artifact viewer renders code that loads the model as a pyfunc model.

### After

![image](https://user-images.githubusercontent.com/17039389/140680628-c034422e-3d1c-4363-a89f-fb351c7e2a1d.png)

- The model artifact viewer renders code that loads the model using `mlflow.sklearn`.


```python
import numpy as np
from sklearn.decomposition import PCA

X = np.array([[-1, -1], [-2, -1], [-3, -2], [1, 1], [2, 1], [3, 2]])
pca = PCA(n_components=2)
pca.fit(X)

import mlflow

with mlflow.start_run():
    mlflow.sklearn.log_model(pca, "model")
```

## How is this patch tested?

Unit tests

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
