### PR TITLE
Run `extract-i18n.js --lint` to make sure `src/i18n/default/en.json` is up-to-date

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -272,10 +272,9 @@ jobs:
     - name: Run lint
       run: |
         npm run lint
-    - name: Run extract-i18n
+    - name: Run extract-i18n lint
       run: |
-        npm run extract-i18n
-        git diff --exit-code
+        node scripts/extract-i18n.js --lint
     - name: Run tests
       run: |
         npm run test

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -274,7 +274,7 @@ jobs:
         npm run lint
     - name: Run extract-i18n lint
       run: |
-        node scripts/extract-i18n.js --lint
+        npm run extract-i18n:lint
     - name: Run tests
       run: |
         npm run test

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -274,7 +274,7 @@ jobs:
         npm run lint
     - name: Run extract-i18n lint
       run: |
-        npm run extract-i18n:lint
+        npm run extract-i18n:base -- --lint
     - name: Run tests
       run: |
         npm run test

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -272,6 +272,10 @@ jobs:
     - name: Run lint
       run: |
         npm run lint
+    - name: Run extract-i18n
+      run: |
+        npm run extract-i18n
+        git diff --exit-code
     - name: Run tests
       run: |
         npm run test

--- a/mlflow/server/js/package.json
+++ b/mlflow/server/js/package.json
@@ -86,8 +86,7 @@
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "extract-i18n:base": "node scripts/extract-i18n.js",
-    "extract-i18n": "npm run extract-i18n:base",
-    "extract-i18n:lint": "node scripts/extract-i18n.js --lint"
+    "extract-i18n": "npm run extract-i18n:base"
   },
   "homepage": "static-files",
   "jest": {

--- a/mlflow/server/js/package.json
+++ b/mlflow/server/js/package.json
@@ -86,7 +86,8 @@
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "extract-i18n:base": "node scripts/extract-i18n.js",
-    "extract-i18n": "npm run extract-i18n:base"
+    "extract-i18n": "npm run extract-i18n:base",
+    "extract-i18n:lint": "node scripts/extract-i18n.js --lint"
   },
   "homepage": "static-files",
   "jest": {

--- a/mlflow/server/js/src/i18n/default/en.json
+++ b/mlflow/server/js/src/i18n/default/en.json
@@ -15,6 +15,10 @@
     "defaultMessage": "Run ID:",
     "description": "Row title for the run id on the experiment compare runs page"
   },
+  "/2m1wK": {
+    "defaultMessage": "Oops!",
+    "description": "Error modal title to rendering errors"
+  },
   "/738wy": {
     "defaultMessage": "Filter",
     "description": "String for the filter button to filter experiment runs table which match the search criteria"
@@ -167,6 +171,10 @@
     "defaultMessage": "Predict on a Spark DataFrame:",
     "description": "Section heading to display the code block on how we can use registered model to predict using spark DataFrame"
   },
+  "739thv": {
+    "defaultMessage": "Lifecycle Stage",
+    "description": "Label for displaying lifecycle stage of the experiment run to see if its active or deleted"
+  },
   "79dD5F": {
     "defaultMessage": "There was an error submitting your note.",
     "description": "Error message text when saving an editable note in MLflow"
@@ -243,9 +251,17 @@
     "defaultMessage": "Register",
     "description": "Confirmation text to register the model"
   },
+  "9fVZg8": {
+    "defaultMessage": "Delete",
+    "description": "Text for disabled delete button due to active versions on model view page header"
+  },
   "9mAGv0": {
     "defaultMessage": "Model name",
     "description": "Text for form title on creating model in the model registry"
+  },
+  "9y+yUQ": {
+    "defaultMessage": "File is too large to preview",
+    "description": "Label to indicate that the file is too large to preview"
   },
   "AEzy9w": {
     "defaultMessage": "After creation, you can register logged models as new versions.&nbsp;",
@@ -266,14 +282,6 @@
   "BQt0TQ": {
     "defaultMessage": "This model is also registered to the <link>model registry</link>.",
     "description": "Sub text to tell the users where the registered models are located "
-  },
-  "BSVpSb": {
-    "defaultMessage": "Delete",
-    "description": "Text for delete button on model view page header"
-  },
-  "Ba2hAt": {
-    "defaultMessage": "Delete",
-    "description": "Text for disabled deleted button due to inactive stage on model\n                   version view page header"
   },
   "BwyYS1": {
     "defaultMessage": "Value",
@@ -314,6 +322,10 @@
   "EKyt+3": {
     "defaultMessage": "Metrics:",
     "description": "Label text for metrics in parallel coordinates plot in MLflow"
+  },
+  "EMNpby": {
+    "defaultMessage": "Only show differences",
+    "description": "Switch to select only columns with different values across runs"
   },
   "EwcVCu": {
     "defaultMessage": "Clear",
@@ -443,13 +455,13 @@
     "defaultMessage": "Last Modified",
     "description": "Column title for last modified timestamp for a model in the registered model page"
   },
+  "K4Ujb4": {
+    "defaultMessage": "Only show columns with differences",
+    "description": "Switch to select only columns with different values across runs"
+  },
   "KEL9Js": {
     "defaultMessage": "Active",
     "description": "Tab text to view active versions under details tab\n                               on the model view page"
-  },
-  "KeuSRX": {
-    "defaultMessage": "Delete",
-    "description": "Text for disabled delete button due to active versions on\n                   model view page header"
   },
   "L26D19": {
     "defaultMessage": "X-axis:",
@@ -486,6 +498,10 @@
   "OGWg8l": {
     "defaultMessage": "State:",
     "description": "Filtering label to filter experiments based on state of active or deleted"
+  },
+  "OfLABN": {
+    "defaultMessage": "Close",
+    "description": "Error modal close button text"
   },
   "OimAJb": {
     "defaultMessage": "Scatter Plot",
@@ -843,6 +859,10 @@
     "defaultMessage": "Outputs ({numOutputs})",
     "description": "Input section header for schema table in model version page"
   },
+  "lw2NyM": {
+    "defaultMessage": "Comparing {length} Runs",
+    "description": "Breadcrumb title for metrics page when comparing multiple runs"
+  },
   "mI1o3S": {
     "defaultMessage": "Artifacts",
     "description": "Label for the collapsible area to display the artifacts page"
@@ -1006,6 +1026,10 @@
   "wBFfWW": {
     "defaultMessage": "Register",
     "description": "Register button text to register the model"
+  },
+  "wbRVln": {
+    "defaultMessage": "Metrics",
+    "description": "Title for metrics page"
   },
   "x0jbgQ": {
     "defaultMessage": "inputs",


### PR DESCRIPTION
## What changes are proposed in this pull request?

Run `extract-i18n.js --lint` in the js workflow to make sure `src/i18n/default/en.json` is up-to-date.

## How is this patch tested?

NA

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
