### PR TITLE
Add optional experiment_id parameter to `mlflow.set_experiment`

### DIFF
--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -89,7 +89,9 @@ def set_experiment(experiment_name: str = None, experiment_id: str = None) -> No
         Tags: {}
         Lifecycle_stage: active
     """
-    if (experiment_name is not None and experiment_id is not None) or (experiment_name is None and experiment_id is None):
+    if (experiment_name is not None and experiment_id is not None) or (
+        experiment_name is None and experiment_id is None
+    ):
         raise MlflowException(
             message="Must specify exactly one of: `experiment_id` or `experiment_name`.",
             error_code=INVALID_PARAMETER_VALUE,

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -98,7 +98,7 @@ def set_experiment(experiment_name: str = None, experiment_id: str = None) -> No
         )
 
     def verify_experiment_active(experiment):
-        if experiment.lifecycle_stage == LifecycleStage.DELETED:
+        if experiment.lifecycle_stage != LifecycleStage.ACTIVE:
             raise MlflowException(
                 message=(
                     "Cannot set a deleted experiment '%s' as the active experiment."
@@ -119,6 +119,9 @@ def set_experiment(experiment_name: str = None, experiment_id: str = None) -> No
                 "Experiment with name '%s' does not exist. Creating a new experiment.",
                 experiment_name,
             )
+            # NB: If two simultaneous threads or processes attempt to set the same experiment
+            # simultaneously, a race condition may be encountered here wherein experiment creation
+            # fails
             experiment_id = client.create_experiment(experiment_name)
     else:
         experiment = client.get_experiment(experiment_id)

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -14,6 +14,10 @@ from typing import Any, Dict, List, Optional, Union, TYPE_CHECKING
 from mlflow.entities import Experiment, Run, RunInfo, RunStatus, Param, RunTag, Metric, ViewType
 from mlflow.entities.lifecycle_stage import LifecycleStage
 from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import (
+    INVALID_PARAMETER_VALUE,
+    RESOURCE_DOES_NOT_EXIST,
+)
 from mlflow.tracking.client import MlflowClient
 from mlflow.tracking import artifact_utils, _get_store
 from mlflow.tracking.context import registry as context_registry
@@ -50,12 +54,17 @@ NUM_RUNS_PER_PAGE_PANDAS = 10000
 _logger = logging.getLogger(__name__)
 
 
-def set_experiment(experiment_name: str) -> None:
+def set_experiment(experiment_name: str = None, experiment_id: str = None) -> None:
     """
-    Set given experiment as active experiment. If experiment does not exist, create an experiment
-    with provided name.
+    Set the given experiment as the active experiment. The experiment must either be specified by
+    name via `experiment_name` or by ID via `experiment_id`. The experiment name and ID cannot
+    both be specified.
 
-    :param experiment_name: Case sensitive name of an experiment to be activated.
+    :param experiment_name: Case sensitive name of the experiment to be activated. If an experiment
+                            with this name does not exist, a new experiment wth this name is
+                            created.
+    :param experiment_id: ID of the experiment to be activated. If an experiment with this ID
+                          does not exist, an exception is thrown.
 
     .. code-block:: python
         :caption: Example
@@ -80,20 +89,43 @@ def set_experiment(experiment_name: str) -> None:
         Tags: {}
         Lifecycle_stage: active
     """
-    client = MlflowClient()
-    experiment = client.get_experiment_by_name(experiment_name)
-    exp_id = experiment.experiment_id if experiment else None
-    if exp_id is None:  # id can be 0
-        print("INFO: '{}' does not exist. Creating a new experiment".format(experiment_name))
-        exp_id = client.create_experiment(experiment_name)
-    elif experiment.lifecycle_stage == LifecycleStage.DELETED:
+    if (experiment_name is not None and experiment_id is not None) or (experiment_name is None and experiment_id is None):
         raise MlflowException(
-            "Cannot set a deleted experiment '%s' as the active experiment."
-            " You can restore the experiment, or permanently delete the "
-            " experiment to create a new one." % experiment.name
+            message="Must specify exactly one of: `experiment_id` or `experiment_name`.",
+            error_code=INVALID_PARAMETER_VALUE,
         )
+
+
+    client = MlflowClient()
+    if experiment_id is None:
+        experiment = client.get_experiment_by_name(experiment_name)
+        if experiment:
+            experiment_id = experiment.experiment_id
+        else:
+            _logger.info(
+                "Experiment with name '%s' does not exist. Creating a new experiment.",
+                experiment_name,
+            )
+            experiment_id = client.create_experiment(experiment_name)
+    else:
+        experiment = client.get_experiment(experiment_id)
+        if experiment is None:
+            raise MlflowException(
+                message=f"Experiment with ID '{experiment_id}' does not exist.",
+                error_code=RESOURCE_DOES_NOT_EXIST,
+            )
+        elif experiment.lifecycle_stage == LifecycleStage.DELETED:
+            raise MlflowException(
+                message=(
+                    "Cannot set a deleted experiment '%s' as the active experiment."
+                    " You can restore the experiment, or permanently delete the "
+                    " experiment to create a new one." % experiment.name
+                ),
+                error_code=INVALID_PARAMETER_VALUE,
+            )
+
     global _active_experiment_id
-    _active_experiment_id = exp_id
+    _active_experiment_id = experiment_id
 
 
 class ActiveRun(Run):  # pylint: disable=W0223

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -108,30 +108,21 @@ def test_set_experiment_by_id():
 
 
 def test_set_experiment_parameter_validation():
-    with pytest.raises(MlflowException) as exc:
+    with pytest.raises(MlflowException, match="Must specify exactly one") as exc:
         mlflow.set_experiment()
     assert exc.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
-    assert "Must specify exactly one" in str(exc.value)
 
-    with pytest.raises(MlflowException) as exc:
+    with pytest.raises(MlflowException, match="Must specify exactly one") as exc:
         mlflow.set_experiment(None)
     assert exc.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
-    assert "Must specify exactly one" in str(exc.value)
 
-    with pytest.raises(MlflowException) as exc:
+    with pytest.raises(MlflowException, match="Must specify exactly one") as exc:
         mlflow.set_experiment(None, None)
     assert exc.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
-    assert "Must specify exactly one" in str(exc.value)
 
-    with pytest.raises(MlflowException) as exc:
+    with pytest.raises(MlflowException, match="Must specify exactly one") as exc:
         mlflow.set_experiment("name", "id")
     assert exc.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
-    assert "Must specify exactly one" in str(exc.value)
-
-    with pytest.raises(MlflowException) as exc:
-        mlflow.set_experiment("")
-    assert exc.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
-    assert "Invalid experiment name" in str(exc.value)
 
 
 def test_set_experiment_with_deleted_experiment():
@@ -142,15 +133,13 @@ def test_set_experiment_with_deleted_experiment():
 
     tracking.MlflowClient().delete_experiment(exp_id)
 
-    with pytest.raises(MlflowException) as exc:
+    with pytest.raises(MlflowException, match="Cannot set a deleted experiment") as exc:
         mlflow.set_experiment(name)
     assert exc.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
-    assert "Cannot set a deleted experiment" in str(exc.value)
 
-    with pytest.raises(MlflowException) as exc:
+    with pytest.raises(MlflowException, match="Cannot set a deleted experiment") as exc:
         mlflow.set_experiment(experiment_id=exp_id)
     assert exc.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
-    assert "Cannot set a deleted experiment" in str(exc.value)
 
 
 def test_list_experiments():

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -80,22 +80,23 @@ def test_create_experiments_with_bad_name_types(name):
 def test_set_experiment_by_name():
     name = "random_exp"
     exp_id = mlflow.create_experiment(name)
-    mlflow.set_experiment(name)
+    exp1 = mlflow.set_experiment(name)
+    assert exp1.experiment_id == exp_id
     with start_run() as run:
         assert run.info.experiment_id == exp_id
 
     another_name = "another_experiment"
-    mlflow.set_experiment(another_name)
-    exp_id2 = mlflow.tracking.MlflowClient().get_experiment_by_name(another_name)
+    exp2 = mlflow.set_experiment(another_name)
     with start_run() as another_run:
-        assert another_run.info.experiment_id == exp_id2.experiment_id
+        assert another_run.info.experiment_id == exp2.experiment_id
 
 
 @pytest.mark.usefixtures("reset_active_experiment")
 def test_set_experiment_by_id():
     name = "random_exp"
     exp_id = mlflow.create_experiment(name)
-    mlflow.set_experiment(experiment_id=exp_id)
+    active_exp = mlflow.set_experiment(experiment_id=exp_id)
+    assert active_exp.experiment_id == exp_id
     with start_run() as run:
         assert run.info.experiment_id == exp_id
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add optional experiment_id parameter to `mlflow.set_experiment`, allowing users to set an experiment by ID.

## How is this patch tested?

Included unit tests

## Release Notes

Add an optional `experiment_id` parameter to `mlflow.set_experiment()`, enabling users to set an experiment by ID.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
