### PR TITLE
Clean up pylint command

### DIFF
--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -316,8 +316,7 @@ def process_requirements(requirements, version=None):
             )
             if match_all:
                 return packages
-        else:
-            return []
+        return []
 
     raise TypeError("Invalid object type for `requirements`: '{}'".format(type(requirements)))
 

--- a/dev/show_package_release_dates.py
+++ b/dev/show_package_release_dates.py
@@ -6,7 +6,7 @@ import traceback
 
 
 def get_distributions():
-    res = subprocess.run(["pip", "list"], stdout=subprocess.PIPE)
+    res = subprocess.run(["pip", "list"], stdout=subprocess.PIPE, check=True)
     pip_list_stdout = res.stdout.decode("utf-8")
     # `pip_list_stdout` looks like this:
     # ``````````````````````````````````````````````````````````

--- a/lint.sh
+++ b/lint.sh
@@ -5,30 +5,6 @@
 err=0
 trap 'err=1' ERR
 
-FWDIR="$(cd "`dirname $0`"; pwd)"
-cd "$FWDIR"
-
-# https://stackoverflow.com/a/17841619
-function join {
-  local d=$1
-  shift
-  echo -n "$1"
-  shift
-  printf "%s" "${@/#/$d}"
-}
-
-include_dirs=(
-  "mlflow"
-  "tests"
-)
-
-exclude_dirs=(
-  "mlflow/protos"
-  "mlflow/server/js"
-  "mlflow/store/db_migrations"
-  "mlflow/temporary_db_migrations_for_pre_1_users"
-)
-
 echo -e "\n========== black ==========\n"
 # Exclude proto files because they are auto-generated
 black --check .
@@ -38,23 +14,8 @@ if [ $? -ne 0 ]; then
   echo '$ pip install $(cat dev/lint-requirements.txt | grep "black==") && black .'
 fi
 
-echo -e "\n========== pycodestyle ==========\n"
-exclude=$(join "," "${exclude_dirs[@]}")
-include=$(join " " "${include_dirs[@]}")
-pycodestyle --max-line-length=100 --ignore=E203,W503 --exclude=$exclude -- $include
-
 echo -e "\n========== pylint ==========\n"
-# pylint's `--ignore` option filters files based on their base names, not paths.
-# see: http://pylint.pycqa.org/en/latest/user_guide/run.html#command-line-options
-# This behavior might cause us to unintentionally ignore some files.
-# To avoid this issue, select files to lint using `git ls-files` and `grep`.
-# Another advantage of this approach is we can apply pylint to all python scripts
-# without creating `__init__.py` in all directories.
-exclude="^\($(join "\|" "${exclude_dirs[@]}")\)/.\+\.py$"
-include="^\($(join "\|" "${include_dirs[@]}")\)/.\+\.py$"
-msg_template="{path} ({line},{column}): [{msg_id} {symbol}] {msg}"
-
-pylint --jobs=0 --msg-template="$msg_template" --rcfile="$FWDIR/pylintrc" $(git ls-files | grep $include | grep -v $exclude)
+pylint $(git ls-files | grep '\.py$')
 
 echo -e "\n========== rstcheck ==========\n"
 rstcheck README.rst

--- a/pylintrc
+++ b/pylintrc
@@ -7,19 +7,28 @@ extension-pkg-whitelist=
 
 # Add files or directories to the denylist. They should be base names, not
 # paths.
-ignore=build,protos,sdk,db_migrations,temporary_db_migrations_for_pre_1_users
-
+ignore=
 
 # Add files or directories matching the regex patterns to the denylist. The
 # regex matches against base names, not paths.
 ignore-patterns=
+
+# Add files or directories matching the regex patterns to the ignore-list.
+# The regex matches against paths.
+ignore-paths=setup.py,
+             docs,
+             examples,
+             mlflow/protos,
+             mlflow/server/js,
+             mlflow/store/db_migrations,
+             mlflow/temporary_db_migrations_for_pre_1_users
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().
 #init-hook=
 
 # Use multiple processes to speed up Pylint.
-jobs=1
+jobs=0
 
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

Clean up pylint command by specifying required options in `pylintrc`.

## How is this patch tested?

NA

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
