### PR TITLE
Bugfix: Truncated values in sortBy column

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentView.css
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentView.css
@@ -373,7 +373,7 @@ span.error-message {
 }
 
 .ExperimentView .sort-select {
-    width: 200px;
+    width: auto;
 }
 
 .ExperimentView .start-time-select {

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentView.js
@@ -669,7 +669,7 @@ export class ExperimentView extends Component {
                       size='large'
                       onChange={this.onHandleSortByDropdown}
                       data-test-id='sort-select-dropdown'
-                      dropdownStyle={{ minWidth: "20%"}}
+                      dropdownStyle={{ minWidth: '30%' }}
                     >
                       {Object.keys(ATTRIBUTE_COLUMN_SORT_LABEL).reduce(
                         (sortOptions, sortLabelKey) => {

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentView.js
@@ -669,6 +669,7 @@ export class ExperimentView extends Component {
                       size='large'
                       onChange={this.onHandleSortByDropdown}
                       data-test-id='sort-select-dropdown'
+                      dropdownStyle={{ minWidth: "25%"}}
                     >
                       {Object.keys(ATTRIBUTE_COLUMN_SORT_LABEL).reduce(
                         (sortOptions, sortLabelKey) => {

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentView.js
@@ -669,7 +669,7 @@ export class ExperimentView extends Component {
                       size='large'
                       onChange={this.onHandleSortByDropdown}
                       data-test-id='sort-select-dropdown'
-                      dropdownStyle={{ minWidth: "25%"}}
+                      dropdownStyle={{ minWidth: "20%"}}
                     >
                       {Object.keys(ATTRIBUTE_COLUMN_SORT_LABEL).reduce(
                         (sortOptions, sortLabelKey) => {


### PR DESCRIPTION
 ## What changes are proposed in this pull request?
 
 Increase the width of the dropdown so that sort by options do not get truncated in case of long names. (see issue #4822)
 ## How is this patch tested?
 
 Ran the unit tests using pytest
 ## Release Notes
 ### Is this a user-facing change?
 
   * [ ]  No. You can skip the rest of this section.
 
   * [x]  Yes. Give a description of this change to be included in the release notes for MLflow users.
 
-->Increase width of "sort by" column such that bigger parameter keys are not truncated. (Also include @coder-freestyle in the release note)
 
### What component(s), interfaces, languages, and integrations does this PR affect?
 
 Components



- [ ]  `area/artifacts`: Artifact stores and artifact logging

- [ ]  `area/build`: Build and test infrastructure for MLflow

- [ ]  `area/docs`: MLflow documentation pages

- [ ]  `area/examples`: Example code

- [ ]  `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry

- [ ]  `area/models`: MLmodel format, model serialization/deserialization, flavors

- [ ]  `area/projects`: MLproject format, project running backends

- [ ]  `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs

- [ ]  `area/server-infra`: MLflow Tracking server backend

- [ ]  `area/tracking`: Tracking Service, tracking client APIs, autologging


  Interface

     * [x]  `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

- [ ]  `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models

- [ ]  `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry

- [ ]  `area/windows`: Windows support


 Language

- [ ]  `language/r`: R APIs and clients

- [ ]  `language/java`: Java APIs and clients

- [ ]  `language/new`: Proposals for new client languages


 Integrations

- [ ]  `integrations/azure`: Azure and Azure ML integrations

- [ ]  `integrations/sagemaker`: SageMaker integrations

- [ ]  `integrations/databricks`: Databricks integrations


 ### How should the PR be classified in the release notes? Choose one:

- [ ]  `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section

- [ ]  `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

- [ ]  `rn/feature` - A new user-facing feature worth mentioning in the release notes

     * [x]  `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

- [ ]  `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

