### PR TITLE
Add a pre-commit hook for running `black` and `pylint`

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -125,8 +125,9 @@ you can `sign your work`_ when committing code changes and opening pull requests
     git config --global user.name "Your Name"
     git config --global user.email yourname@example.com
 
-For convenience, we provide a pre-commit git hook that validates that commits are signed-off,
-auto-formats the code, and runs pylint. You can enable it by running:
+For convenience, we provide a pre-commit git hook that validates that commits are signed-off and
+runs `black --check` and `pylint` to ensure the code will pass the lint check for python.
+You can enable it by running:
 
 .. code-block:: bash
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -125,8 +125,8 @@ you can `sign your work`_ when committing code changes and opening pull requests
     git config --global user.name "Your Name"
     git config --global user.email yourname@example.com
 
-For convenience, we provide a pre-commit git hook that validates that commits are signed-off.
-Enable it by running:
+For convenience, we provide a pre-commit git hook that validates that commits are signed-off,
+auto-formats the code, and runs pylint. You can enable it by running:
 
 .. code-block:: bash
 

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,8 @@
+set -ex
+
+diff=$(git diff --cached --name-only | grep '\.py$' || true)
+
+if [ ! -z "$diff" ]; then
+  black --check $diff
+  pylint $diff
+fi


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

Add a pre-commit hook for running `black` and `pylint` to avoid re-running CI just to fix lint errors.

## How is this patch tested?

- Create a file that contains a lint error.
- Make a commit to ensure the pre-commit hook aborts it.

```sh
% git diff
diff --git a/dev/show_package_release_dates.py b/dev/show_package_release_dates.py
index 76b653792..44792ba9c 100644
--- a/dev/show_package_release_dates.py
+++ b/dev/show_package_release_dates.py
@@ -6,7 +6,7 @@ import traceback
 
 
 def get_distributions():
-    res = subprocess.run(["pip", "list"], stdout=subprocess.PIPE, check=True)
+    res = subprocess.run(["pip", "list"], stdout=subprocess.PIPE)
     pip_list_stdout = res.stdout.decode("utf-8")
     # `pip_list_stdout` looks like this:
     # ``````````````````````````````````````````````````````````
                                                                                              
% git add .
                                                                                              
% git commit --signoff -m test
+ git diff --cached --name-only
+ grep \.py$
+ diff=dev/show_package_release_dates.py
+ [ ! -z dev/show_package_release_dates.py ]
+ black --check dev/show_package_release_dates.py
All done! ✨ 🍰 ✨
1 file would be left unchanged.
+ pylint dev/show_package_release_dates.py
************* Module show_package_release_dates
dev/show_package_release_dates.py:9:10: W1510: Using subprocess.run without explicitly set `check` is not recommended. (subprocess-run-check)

------------------------------------------------------------------
Your code has been rated at 9.76/10 (previous run: 9.76/10, +0.00)
```

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
