### PR TITLE
Remove try_mlflow_log() and unwanted tests

### DIFF
--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -21,7 +21,6 @@ from mlflow.utils.autologging_utils.logging_and_warnings import (  # noqa: E402
     set_non_mlflow_warnings_behavior_for_current_thread,
 )
 from mlflow.utils.autologging_utils.safety import (  # noqa: E402
-    try_mlflow_log,
     update_wrapper_extended,
     revert_patches,
 )
@@ -224,7 +223,7 @@ class BatchMetricsLogger:
             for i in range(0, len(self.data), MAX_METRICS_PER_BATCH)
         ]
         for metrics_slice in metrics_slices:
-            try_mlflow_log(self.client.log_batch, run_id=current_run_id, metrics=metrics_slice)
+            self.client.log_batch(run_id=current_run_id, metrics=metrics_slice)
         end = time.time()
         self.total_log_batch_time += end - start
 

--- a/mlflow/utils/autologging_utils/safety.py
+++ b/mlflow/utils/autologging_utils/safety.py
@@ -4,7 +4,6 @@ import itertools
 import functools
 import os
 import uuid
-import warnings
 from abc import abstractmethod
 from contextlib import contextmanager
 
@@ -24,19 +23,6 @@ from mlflow.utils.mlflow_tags import MLFLOW_AUTOLOGGING
 _AUTOLOGGING_TEST_MODE_ENV_VAR = "MLFLOW_AUTOLOGGING_TESTING"
 
 _AUTOLOGGING_PATCHES = {}
-
-
-def try_mlflow_log(fn, *args, **kwargs):
-    """
-    Catch exceptions and log a warning to avoid autolog throwing.
-    """
-    try:
-        return fn(*args, **kwargs)
-    except Exception as e:
-        if is_testing():
-            raise
-        else:
-            warnings.warn("Logging to MLflow failed: " + str(e), stacklevel=2)
 
 
 # Function attribute used for testing purposes to verify that a given function
@@ -859,7 +845,6 @@ def _validate_args(
 
 
 __all__ = [
-    "try_mlflow_log",
     "safe_patch",
     "is_testing",
     "exception_safe_function",

--- a/tests/autologging/test_autologging_safety_unit.py
+++ b/tests/autologging/test_autologging_safety_unit.py
@@ -22,7 +22,6 @@ from mlflow.utils.autologging_utils import (
     PatchFunction,
     with_managed_run,
     is_testing,
-    try_mlflow_log,
 )
 from mlflow.utils.autologging_utils.safety import (
     _AutologgingSessionManager,
@@ -1375,27 +1374,6 @@ def test_validate_autologging_run_validates_run_status_correctly():
     )
     with pytest.raises(AssertionError, match="has a non-terminal status"):
         _validate_autologging_run("test_integration", run_id_non_terminal)
-
-
-def test_try_mlflow_log_emits_exceptions_as_warnings_in_standard_mode():
-    assert not autologging_utils.is_testing()
-
-    def throwing_function():
-        raise Exception("bad implementation")
-
-    with pytest.warns(UserWarning, match="bad implementation"):
-        try_mlflow_log(throwing_function)
-
-
-@pytest.mark.usefixtures(test_mode_on.__name__)
-def test_try_mlflow_log_propagates_exceptions_in_test_mode():
-    assert autologging_utils.is_testing()
-
-    def throwing_function():
-        raise Exception("bad implementation")
-
-    with pytest.raises(Exception, match="bad implementation"):
-        try_mlflow_log(throwing_function)
 
 
 def test_session_manager_creates_session_before_patch_executes(


### PR DESCRIPTION
Signed-off-by: Liang Zhang <liang.zhang@databricks.com>

## What changes are proposed in this pull request?

Follow-up for #4964.

## How is this patch tested?

Existing tests.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
