### PR TITLE
Support specifying 'latest' in model URI to get the latest version of a model regardless of the stage

### DIFF
--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/ModelRegistryMlflowClientTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/ModelRegistryMlflowClientTest.java
@@ -87,9 +87,10 @@ public class ModelRegistryMlflowClientTest {
 
         client.sendPatch("model-versions/update", mapper.makeUpdateModelVersion(modelName,
                 "1"));
-        // default stages (does not include "None")
+        // get the latest version of all stages
         List<ModelVersion> modelVersion = client.getLatestVersions(modelName);
-        Assert.assertEquals(modelVersion.size(), 0);
+        Assert.assertEquals(modelVersion.size(), 1);
+        validateDetailedModelVersion(modelVersion.get(0), modelName, "None", "1");
         client.sendPost("model-versions/transition-stage",
                 mapper.makeTransitionModelVersionStage(modelName, "1", "Staging"));
         modelVersion = client.getLatestVersions(modelName);

--- a/mlflow/store/artifact/databricks_models_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_models_artifact_repo.py
@@ -31,7 +31,8 @@ class DatabricksModelsArtifactRepository(ArtifactRepository):
     The artifact_uri is expected to be of the form
     - `models:/<model_name>/<model_version>`
     - `models:/<model_name>/<stage>`  (refers to the latest model version in the given stage)
-    - `models://<profile>/<model_name>/<model_version or stage>`
+    - `models:/<model_name>/latest`  (refers to the latest of all model versions)
+    - `models://<profile>/<model_name>/<model_version or stage or 'latest'>`
 
     Note : This artifact repository is meant is to be instantiated by the ModelsArtifactRepository
     when the client is pointing to a Databricks-hosted model registry.

--- a/mlflow/store/artifact/models_artifact_repo.py
+++ b/mlflow/store/artifact/models_artifact_repo.py
@@ -19,6 +19,7 @@ class ModelsArtifactRepository(ArtifactRepository):
     Handles artifacts associated with a model version in the model registry via URIs of the form:
       - `models:/<model_name>/<model_version>`
       - `models:/<model_name>/<stage>`  (refers to the latest model version in the given stage)
+      - `models:/<model_name>/latest` (refers to the latest of all model versions)
     It is a light wrapper that resolves the artifact path to an absolute URI then instantiates
     and uses the artifact repository for that URI.
     """

--- a/mlflow/store/artifact/utils/models.py
+++ b/mlflow/store/artifact/utils/models.py
@@ -17,7 +17,7 @@ def _improper_model_uri_msg(uri):
     return (
         "Not a proper models:/ URI: %s. " % uri
         + "Models URIs must be of the form 'models:/<model_name>/suffix' "
-        + "where suffix is a model version, stage, or string '%s'." % _MODELS_URI_SUFFIX_LATEST
+        + "where suffix is a model version, stage, or the string '%s'." % _MODELS_URI_SUFFIX_LATEST
     )
 
 
@@ -58,12 +58,15 @@ def _parse_model_uri(uri):
         raise MlflowException(_improper_model_uri_msg(uri))
 
     if parts[1].isdigit():
+        # The suffix is a specific version, e.g. "models:/AdsModel1/123"
         return parts[0], int(parts[1]), None
     elif parts[1] == _MODELS_URI_SUFFIX_LATEST:
+        # The suffix is exactly the 'latest' string, e.g. "models:/AdsModel1/latest"
         return parts[0], None, None
     elif parts[1] not in ALL_STAGES:
         raise MlflowException(_improper_model_uri_msg(uri))
     else:
+        # The suffix is a specific stage, e.g. "models:/AdsModel1/Production"
         return parts[0], None, parts[1]
 
 

--- a/mlflow/store/model_registry/abstract_store.py
+++ b/mlflow/store/model_registry/abstract_store.py
@@ -116,7 +116,7 @@ class AbstractStore:
 
         :param name: Registered model name.
         :param stages: List of desired stages. If input list is None, return latest versions for
-                       for 'Staging' and 'Production' stages.
+                       each stage.
         :return: List of :py:class:`mlflow.entities.model_registry.ModelVersion` objects.
         """
         pass

--- a/mlflow/store/model_registry/rest_store.py
+++ b/mlflow/store/model_registry/rest_store.py
@@ -184,7 +184,7 @@ class RestStore(AbstractStore):
 
         :param name: Registered model name.
         :param stages: List of desired stages. If input list is None, return latest versions for
-                       for 'Staging' and 'Production' stages.
+                       each stage.
         :return: List of :py:class:`mlflow.entities.model_registry.ModelVersion` objects.
         """
         req_body = message_to_json(GetLatestVersions(name=name, stages=stages))

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -5,6 +5,7 @@ import sqlalchemy
 
 from mlflow.entities.model_registry.model_version_stages import (
     get_canonical_stage,
+    ALL_STAGES,
     DEFAULT_STAGES_FOR_GET_LATEST_VERSIONS,
     STAGE_DELETED_INTERNAL,
     STAGE_ARCHIVED,
@@ -432,7 +433,7 @@ class SqlAlchemyStore(AbstractStore):
 
         :param name: Registered model name.
         :param stages: List of desired stages. If input list is None, return latest versions for
-                       for 'Staging' and 'Production' stages.
+                       each stage.
         :return: List of :py:class:`mlflow.entities.model_registry.ModelVersion` objects.
         """
         with self.ManagedSessionMaker() as session:
@@ -440,9 +441,7 @@ class SqlAlchemyStore(AbstractStore):
             # Convert to RegisteredModel entity first and then extract latest_versions
             latest_versions = sql_registered_model.to_mlflow_entity().latest_versions
             if stages is None or len(stages) == 0:
-                expected_stages = set(
-                    [get_canonical_stage(stage) for stage in DEFAULT_STAGES_FOR_GET_LATEST_VERSIONS]
-                )
+                expected_stages = set([get_canonical_stage(stage) for stage in ALL_STAGES])
             else:
                 expected_stages = set([get_canonical_stage(stage) for stage in stages])
             return [mv for mv in latest_versions if mv.current_stage in expected_stages]

--- a/tests/store/artifact/utils/test_model_utils.py
+++ b/tests/store/artifact/utils/test_model_utils.py
@@ -1,7 +1,10 @@
 import pytest
+from unittest import mock
 
 from mlflow.exceptions import MlflowException
-from mlflow.store.artifact.utils.models import _parse_model_uri
+from mlflow.store.artifact.utils.models import _parse_model_uri, get_model_name_and_version
+from mlflow.tracking import MlflowClient
+from mlflow.entities.model_registry import ModelVersion
 
 
 @pytest.mark.parametrize(
@@ -36,12 +39,29 @@ def test_parse_models_uri_with_stage(uri, expected_name, expected_stage):
 
 
 @pytest.mark.parametrize(
+    "uri, expected_name",
+    [
+        ("models:/AdsModel1/latest", "AdsModel1"),
+        ("models:/Ads Model 1/latest", "Ads Model 1"),
+        ("models://scope:key@databricks/Ads Model 1/latest", "Ads Model 1"),
+    ],
+)
+def test_parse_models_uri_with_latest(uri, expected_name):
+    (name, version, stage) = _parse_model_uri(uri)
+    assert name == expected_name
+    assert version is None
+    assert stage is None
+
+
+@pytest.mark.parametrize(
     "uri",
     [
         "notmodels:/NameOfModel/12345",  # wrong scheme with version
         "notmodels:/NameOfModel/StageName",  # wrong scheme with stage
         "models:/",  # no model name
         "models:/Name/Stage/0",  # too many specifiers
+        "models:/Name/production",  # should be 'Production'
+        "models:/Name/LATEST",  # not lower case 'latest'
         "models:Name/Stage",  # missing slash
         "models://Name/Stage",  # hostnames are ignored, path too short
     ],
@@ -49,3 +69,53 @@ def test_parse_models_uri_with_stage(uri, expected_name, expected_stage):
 def test_parse_models_uri_invalid_input(uri):
     with pytest.raises(MlflowException):
         _parse_model_uri(uri)
+
+
+def test_get_model_name_and_version_with_version():
+    with mock.patch.object(
+        MlflowClient, "get_latest_versions", return_value=[]
+    ) as mlflow_client_mock:
+        assert get_model_name_and_version(MlflowClient(), "models:/AdsModel1/123") == (
+            "AdsModel1",
+            "123",
+        )
+        mlflow_client_mock.assert_not_called()
+
+
+def test_get_model_name_and_version_with_stage():
+    with mock.patch.object(
+        MlflowClient,
+        "get_latest_versions",
+        return_value=[
+            ModelVersion(
+                name="mv1", version="10", creation_timestamp=123, current_stage="Production"
+            ),
+            ModelVersion(
+                name="mv2", version="15", creation_timestamp=124, current_stage="Production"
+            ),
+        ],
+    ) as mlflow_client_mock:
+        assert get_model_name_and_version(MlflowClient(), "models:/AdsModel1/Production") == (
+            "AdsModel1",
+            "15",
+        )
+        mlflow_client_mock.assert_called_once_with("AdsModel1", ["Production"])
+
+
+def test_get_model_name_and_version_with_latest():
+    with mock.patch.object(
+        MlflowClient,
+        "get_latest_versions",
+        return_value=[
+            ModelVersion(
+                name="mv1", version="10", creation_timestamp=123, current_stage="Production"
+            ),
+            ModelVersion(name="mv3", version="20", creation_timestamp=125, current_stage="None"),
+            ModelVersion(name="mv2", version="15", creation_timestamp=124, current_stage="Staging"),
+        ],
+    ) as mlflow_client_mock:
+        assert get_model_name_and_version(MlflowClient(), "models:/AdsModel1/latest") == (
+            "AdsModel1",
+            "20",
+        )
+        mlflow_client_mock.assert_called_once_with("AdsModel1", None)

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -333,6 +333,26 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
             self._extract_latest_by_stage(rmd4.latest_versions),
             {"None": 1, "Production": 3, "Staging": 4},
         )
+        self.assertEqual(
+            self._extract_latest_by_stage(self.store.get_latest_versions(name=name, stages=None)),
+            {"None": 1, "Production": 3, "Staging": 4},
+        )
+        self.assertEqual(
+            self._extract_latest_by_stage(self.store.get_latest_versions(name=name, stages=[])),
+            {"None": 1, "Production": 3, "Staging": 4},
+        )
+        self.assertEqual(
+            self._extract_latest_by_stage(
+                self.store.get_latest_versions(name=name, stages=["Production"])
+            ),
+            {"Production": 3},
+        )
+        self.assertEqual(
+            self._extract_latest_by_stage(
+                self.store.get_latest_versions(name=name, stages=["None", "Production"])
+            ),
+            {"None": 1, "Production": 3},
+        )
 
         # delete latest Production, and should point to previous one
         self.store.delete_model_version(name=mv3.name, version=mv3.version)
@@ -340,6 +360,16 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self.assertEqual(
             self._extract_latest_by_stage(rmd5.latest_versions),
             {"None": 1, "Production": 2, "Staging": 4},
+        )
+        self.assertEqual(
+            self._extract_latest_by_stage(self.store.get_latest_versions(name=name, stages=None)),
+            {"None": 1, "Production": 2, "Staging": 4},
+        )
+        self.assertEqual(
+            self._extract_latest_by_stage(
+                self.store.get_latest_versions(name=name, stages=["Production"])
+            ),
+            {"Production": 2},
         )
 
     def test_set_registered_model_tag(self):

--- a/tests/tracking/test_model_registry.py
+++ b/tests/tracking/test_model_registry.py
@@ -484,8 +484,8 @@ def test_latest_models(mlflow_client, backend_store_uri):
     assert {"None": "7"} == get_latest(["None"])
     assert {"Staging": "6"} == get_latest(["Staging"])
     assert {"None": "7", "Staging": "6"} == get_latest(["None", "Staging"])
-    assert {"Production": "4", "Staging": "6"} == get_latest(None)
-    assert {"Production": "4", "Staging": "6"} == get_latest([])
+    assert {"Production": "4", "Staging": "6", "Archived": "3", "None": "7"} == get_latest(None)
+    assert {"Production": "4", "Staging": "6", "Archived": "3", "None": "7"} == get_latest([])
 
 
 def test_delete_model_version_flow(mlflow_client, backend_store_uri):


### PR DESCRIPTION
Signed-off-by: Chenran Li <chenran.li@databricks.com>

## What changes are proposed in this pull request?

Support specifying 'latest' in model URI like `models:/<model_name>/latest` to get the latest version of a model regardless of the stage.

Also fix a bug in `sqlalchemy_store.get_latest_versions()`: when no `stage` argument is specified, it should return the latest versions of all stages. Now it's only returning latest versions for active stages.
* according to the [top-level comment](https://sourcegraph.com/github.com/mlflow/mlflow@027f75436c514bbfb8eb44607bdad07737cd5736/-/blob/mlflow/protos/model_registry.proto?L521) in the proto file, it should return the latest version of all stages when no `stage` argument is specified
* also fixed the contradictory comments in the docstring of the function:
<img width="763" alt="Screen Shot 2021-11-08 at 17 48 52" src="https://user-images.githubusercontent.com/5786126/140846916-b93f6766-c5a6-46c5-8bf9-8e3d75edee97.png">

In #4250, Anil also suggested supporting model URI formats like `models:/<model_name>/latest-n` to get the nth to last model version. But it requires too big of a change (e.g. extending the [`RegisteredModel`](https://sourcegraph.com/github.com/mlflow/mlflow@b6eaafdfce2d586aaa39185a36edaa7ec343a7c5/-/blob/mlflow/entities/model_registry/registered_model.py?L10) class and the corresponding proto message to store not only the latest versions of a model, but also all versions). It may not be worth it to make such a big change for this small "latest-n" feature. So I'm not doing this in this PR.

## How is this patch tested?

unit tests

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Now users can specify 'latest' in model URI like `models:/<model_name>/latest` to get the latest version of a model regardless of the stage. Previously users can only specify `models:/<model_name>/<Stage>` to get the latest version of a model on a specific stage.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [x] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
