### PR TITLE
Remove the experimental decorators on autolog() for all flavors

### DIFF
--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -341,8 +341,8 @@ The following libraries support autologging:
 For flavors that automatically save models as an artifact, `additional files <https://mlflow.org/docs/latest/models.html#storage-format>`_ for dependency management are logged.
 
 
-Scikit-learn (experimental)
----------------------------
+Scikit-learn
+------------
 
 Call :py:func:`mlflow.sklearn.autolog` before your training code to enable automatic logging of sklearn metrics, params, and models.
 See example usage `here <https://github.com/mlflow/mlflow/tree/master/examples/sklearn_autolog>`_.
@@ -389,11 +389,8 @@ containing the following data:
 .. _GridSearchCV:
     https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.GridSearchCV.html
 
-.. note::
-  This feature is experimental - the API and format of the logged data are subject to change.
-
-TensorFlow and Keras (experimental)
------------------------------------
+TensorFlow and Keras
+--------------------
 Call :py:func:`mlflow.tensorflow.autolog` or :py:func:`mlflow.keras.autolog` before your training code to enable automatic logging of metrics and parameters. See example usages with `Keras <https://github.com/mlflow/mlflow/tree/master/examples/keras>`_ and
 `TensorFlow <https://github.com/mlflow/mlflow/tree/master/examples/tensorflow>`_.
 
@@ -432,10 +429,9 @@ If a run already exists when ``autolog()`` captures data, MLflow will log to tha
 
 .. note::
   - Parameters not explicitly passed by users (parameters that use default values) while using ``keras.Model.fit_generator()`` are not currently automatically logged.
-  - This feature is experimental - the API and format of the logged data are subject to change.
 
-Gluon (experimental)
---------------------
+Gluon
+-----
 Call :py:func:`mlflow.gluon.autolog` before your training code to enable automatic logging of metrics and parameters.
 See example usages with `Gluon <https://github.com/mlflow/mlflow/tree/master/examples/gluon>`_ .
 
@@ -447,11 +443,8 @@ Autologging captures the following information:
 | Gluon            | Training loss; validation loss; user-specified metrics | Number of layers; optimizer name; learning rate; epsilon | --            | `MLflow Model <https://mlflow.org/docs/latest/models.html>`_ (Gluon model); on training end                                   |
 +------------------+--------------------------------------------------------+----------------------------------------------------------+---------------+-------------------------------------------------------------------------------------------------------------------------------+
 
-.. note::
-  This feature is experimental - the API and format of the logged data are subject to change.
-
-XGBoost (experimental)
-----------------------
+XGBoost
+-------
 Call :py:func:`mlflow.xgboost.autolog` before your training code to enable automatic logging of metrics and parameters.
 
 Autologging captures the following information:
@@ -465,15 +458,14 @@ Autologging captures the following information:
 If early stopping is activated, metrics at the best iteration will be logged as an extra step/iteration.
 
 .. note::
-  - This feature is experimental - the API and format of the logged data are subject to change.
   - The `scikit-learn API <https://xgboost.readthedocs.io/en/latest/python/python_api.html#module-xgboost.sklearn>`__ is not supported.
 
 .. _xgboost.train: https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.train
 .. _MLflow Model: https://mlflow.org/docs/latest/models.html
 
 
-LightGBM (experimental)
------------------------
+LightGBM
+--------
 Call :py:func:`mlflow.lightgbm.autolog` before your training code to enable automatic logging of metrics and parameters.
 
 Autologging captures the following information:
@@ -487,13 +479,12 @@ Autologging captures the following information:
 If early stopping is activated, metrics at the best iteration will be logged as an extra step/iteration.
 
 .. note::
-  - This feature is experimental - the API and format of the logged data are subject to change.
   - The `scikit-learn API <https://lightgbm.readthedocs.io/en/latest/Python-API.html#scikit-learn-api>`__ is not supported.
 
 .. _lightgbm.train: https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.train.html#lightgbm-train
 
-Statsmodels (experimental)
---------------------------
+Statsmodels
+-----------
 Call :py:func:`mlflow.statsmodels.autolog` before your training code to enable automatic logging of metrics and parameters.
 
 Autologging captures the following information:
@@ -505,13 +496,12 @@ Autologging captures the following information:
 +--------------+------------------------+------------------------------------------------+---------------+-----------------------------------------------------------------------------+
 
 .. note::
-  - This feature is experimental - the API and format of the logged data are subject to change.
   - Each model subclass that overrides `fit` expects and logs its own parameters.
 
 .. _statsmodels.base.model.Model.fit: https://www.statsmodels.org/dev/dev/generated/statsmodels.base.model.Model.html
 
-Spark (experimental)
---------------------
+Spark
+-----
 
 Initialize a SparkSession with the mlflow-spark JAR attached (e.g.
 ``SparkSession.builder.config("spark.jars.packages", "org.mlflow.mlflow-spark")``) and then
@@ -528,11 +518,10 @@ Autologging captures the following information:
 +------------------+---------+------------+----------------------------------------------------------------------------------------------+-----------+
 
 .. note::
-  - This feature is experimental - the API and format of the logged data are subject to change.
   - Moreover, Spark datasource autologging occurs asynchronously - as such, it's possible (though unlikely) to see race conditions when launching short-lived MLflow runs that result in datasource information not being logged.
 
-Fastai (experimental)
----------------------
+Fastai
+------
 
 Call :py:func:`mlflow.fastai.autolog` before your training code to enable automatic logging of metrics and parameters.
 See an example usage with `Fastai <https://github.com/mlflow/mlflow/tree/master/examples/fastai>`_.
@@ -551,8 +540,8 @@ Autologging captures the following information:
 |           |                        | `OneCycleScheduler`_ callbacks                           |               |                                                                                                                                                                       |
 +-----------+------------------------+----------------------------------------------------------+---------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
-Pytorch (experimental)
---------------------------
+Pytorch
+-------
 
 Call :py:func:`mlflow.pytorch.autolog` before your Pytorch Lightning training code to enable automatic logging of metrics, parameters, and models. See example usages `here <https://github.com/chauhang/mlflow/tree/master/examples/pytorch/MNIST>`__. Note
 that currently, Pytorch autologging supports only models trained using Pytorch Lightning.
@@ -586,7 +575,6 @@ If a run already exists when ``autolog()`` captures data, MLflow will log to tha
 .. note::
   - Parameters not explicitly passed by users (parameters that use default values) while using ``pytorch_lightning.trainer.Trainer.fit()`` are not currently automatically logged
   - In case of a multi-optimizer scenario (such as usage of autoencoder), only the parameters for the first optimizer are logged
-  - This feature is experimental - the API and format of the logged data are subject to change
 
 
 .. _organizing_runs_in_experiments:

--- a/mlflow/fastai/__init__.py
+++ b/mlflow/fastai/__init__.py
@@ -39,7 +39,6 @@ from mlflow.utils.requirements_utils import _get_pinned_requirement
 from mlflow.utils.file_utils import write_to
 from mlflow.utils.docstring_utils import format_docstring, LOG_MODEL_PARAM_DOCS
 from mlflow.utils.model_utils import _get_flavor_configuration
-from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import (
     log_fn_args_as_params,
     safe_patch,
@@ -368,7 +367,6 @@ def load_model(model_uri, dst_path=None):
     return _load_model(path=model_file_path)
 
 
-@experimental
 @autologging_integration(FLAVOR_NAME)
 def autolog(
     log_models=True,

--- a/mlflow/gluon.py
+++ b/mlflow/gluon.py
@@ -345,7 +345,6 @@ def log_model(
     )
 
 
-@experimental
 @autologging_integration(FLAVOR_NAME)
 def autolog(
     log_models=True,

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -39,7 +39,6 @@ from mlflow.utils.requirements_utils import _get_pinned_requirement
 from mlflow.utils.file_utils import write_to
 from mlflow.utils.docstring_utils import format_docstring, LOG_MODEL_PARAM_DOCS
 from mlflow.utils.model_utils import _get_flavor_configuration
-from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import (
     autologging_integration,
     safe_patch,
@@ -555,7 +554,6 @@ def load_model(model_uri, dst_path=None, **kwargs):
     )
 
 
-@experimental
 @autologging_integration(FLAVOR_NAME)
 def autolog(
     log_models=True,

--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -46,7 +46,6 @@ from mlflow.utils.file_utils import write_to
 from mlflow.utils.docstring_utils import format_docstring, LOG_MODEL_PARAM_DOCS
 from mlflow.utils.model_utils import _get_flavor_configuration
 from mlflow.exceptions import MlflowException
-from mlflow.utils.annotations import experimental
 from mlflow.utils.arguments_utils import _get_arg_names
 from mlflow.utils.autologging_utils import (
     autologging_integration,
@@ -295,7 +294,6 @@ class _LGBModelWrapper:
         return self.lgb_model.predict(dataframe)
 
 
-@experimental
 @autologging_integration(FLAVOR_NAME)
 def autolog(
     log_input_examples=False,

--- a/mlflow/paddle/__init__.py
+++ b/mlflow/paddle/__init__.py
@@ -24,7 +24,6 @@ from mlflow.models.signature import ModelSignature
 from mlflow.models.utils import ModelInputExample, _save_example
 from mlflow.protos.databricks_pb2 import RESOURCE_ALREADY_EXISTS
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
-from mlflow.utils.annotations import experimental
 from mlflow.utils.environment import (
     _mlflow_conda_env,
     _validate_env_arguments,
@@ -453,7 +452,6 @@ def _contains_pdparams(path):
     return any(".pdparams" in file for file in file_list)
 
 
-@experimental
 @autologging_integration(FLAVOR_NAME)
 def autolog(
     log_every_n_epoch=1, log_models=True, disable=False, exclusive=False, silent=False,

--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -14,7 +14,6 @@ from mlflow.utils import (
     _get_fully_qualified_class_name,
     _inspect_original_var_name,
 )
-from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import (
     _get_new_training_session_class,
     autologging_integration,
@@ -674,7 +673,6 @@ class _AutologgingMetricsManager:
 _AUTOLOGGING_METRICS_MANAGER = _AutologgingMetricsManager()
 
 
-@experimental
 @autologging_integration(AUTOLOGGING_INTEGRATION_NAME)
 def autolog(
     log_models=True,

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -868,7 +868,6 @@ def load_state_dict(state_dict_uri, **kwargs):
     return torch.load(state_dict_path, **kwargs)
 
 
-@experimental
 @autologging_integration(FLAVOR_NAME)
 def autolog(
     log_every_n_epoch=1,

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -33,7 +33,6 @@ from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, INTERNAL_ERROR
 from mlflow.protos.databricks_pb2 import RESOURCE_ALREADY_EXISTS
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils import _inspect_original_var_name
-from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import get_instance_method_first_arg_value
 from mlflow.utils.environment import (
     _mlflow_conda_env,
@@ -884,7 +883,6 @@ def _patch_estimator_method_if_available(flavor_name, class_def, func_name, patc
         pass
 
 
-@experimental
 @autologging_integration(FLAVOR_NAME)
 def autolog(
     log_input_examples=False,

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -58,7 +58,6 @@ from mlflow.utils.uri import (
 )
 from mlflow.utils import databricks_utils
 from mlflow.utils.model_utils import _get_flavor_configuration_from_uri
-from mlflow.utils.annotations import experimental
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.utils.autologging_utils import autologging_integration, safe_patch
 
@@ -733,7 +732,6 @@ class _PyFuncModelWrapper(object):
         ]
 
 
-@experimental
 @autologging_integration(FLAVOR_NAME)
 def autolog(disable=False, silent=False):  # pylint: disable=unused-argument
     """

--- a/mlflow/statsmodels.py
+++ b/mlflow/statsmodels.py
@@ -37,7 +37,6 @@ from mlflow.utils.file_utils import write_to
 from mlflow.utils.docstring_utils import format_docstring, LOG_MODEL_PARAM_DOCS
 from mlflow.utils.model_utils import _get_flavor_configuration
 from mlflow.exceptions import MlflowException
-from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import (
     log_fn_args_as_params,
     autologging_integration,
@@ -384,7 +383,6 @@ def _get_autolog_metrics(fitted_model):
     return result_metrics
 
 
-@experimental
 @autologging_integration(FLAVOR_NAME)
 def autolog(
     log_models=True,

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -33,7 +33,7 @@ from mlflow.models.utils import ModelInputExample, _save_example
 from mlflow.protos.databricks_pb2 import DIRECTORY_NOT_EMPTY
 from mlflow.tracking import MlflowClient
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri, get_artifact_uri
-from mlflow.utils.annotations import keyword_only, experimental
+from mlflow.utils.annotations import keyword_only
 from mlflow.utils.environment import (
     _mlflow_conda_env,
     _validate_env_arguments,
@@ -657,7 +657,6 @@ def _setup_callbacks(lst, log_models, metrics_logger):
     return out_list, log_dir
 
 
-@experimental
 @autologging_integration(FLAVOR_NAME)
 def autolog(
     every_n_iter=1,

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -45,7 +45,6 @@ from mlflow.utils.requirements_utils import _get_pinned_requirement
 from mlflow.utils.file_utils import write_to
 from mlflow.utils.model_utils import _get_flavor_configuration
 from mlflow.exceptions import MlflowException
-from mlflow.utils.annotations import experimental
 from mlflow.utils.docstring_utils import format_docstring, LOG_MODEL_PARAM_DOCS
 from mlflow.utils.arguments_utils import _get_arg_names
 from mlflow.utils.autologging_utils import (
@@ -307,7 +306,6 @@ class _XGBModelWrapper:
         return self.xgb_model.predict(xgb.DMatrix(dataframe))
 
 
-@experimental
 @autologging_integration(FLAVOR_NAME)
 def autolog(
     importance_types=None,


### PR DESCRIPTION
Signed-off-by: Liang Zhang <liang.zhang@databricks.com>

## What changes are proposed in this pull request?

Remove the experimental decorators on autolog() for all flavors because it's no longer experimental.

## How is this patch tested?

Existing tests.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The autolog() API is no longer experimental.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
