### PR TITLE
Clarify how cross version testing works

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -10,8 +10,10 @@
 
 ## Automation
 
-| File                        | Role                                                      |
-| :-------------------------- | :-------------------------------------------------------- |
-| `labeling.yml`              | Automatically apply labels on issues and PRs              |
-| `notify-dco-failure.yml`    | Notify a DCO check failure                                |
-| `release-note-category.yml` | Validate a release-note category label is applied on a PR |
+| File                        | Role                                                        |
+| :-------------------------- | :---------------------------------------------------------- |
+| `labeling.yml`              | Automatically apply labels on issues and PRs                |
+| `notify-dco-failure.yml`    | Notify a DCO check failure                                  |
+| `notify-dco-failure.js`     | The main script of the `notify-dco-failure.yml` workflow    |
+| `release-note-category.yml` | Validate a release-note category label is applied on a PR   |
+| `release-note-category.js`  | The main script of the `release-note-category.yml` workflow |

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,60 +1,17 @@
-# Cross version tests
+# GitHub Actions workflows
 
-## Files & Roles
+## Testing
 
-### `ml-package-versions.yml`
+| File                      | Role                                                                 |
+| :------------------------ | :------------------------------------------------------------------- |
+| `cross-version-tests.yml` | Run cross version tests. See `cross-version-testing.md` for details. |
+| `examples.yml`            | Run tests for example scripts & projects                             |
+| `master.yml `             | Run unit and integration tests                                       |
 
-Define package versions to test for each flavor.
+## Automation
 
-### `dev/set_matrix.py`
-
-Read `ml-package-versions.yml` and set a test matrix.
-
-### `cross-versions-tests.yml`
-
-Run the following two jobs.
-
-- `set-matrix`: Run `set_matrix.py` to set a test matrix.
-- `test`: Sweep the test matrix set by `set-matrix`.
-
-## When is `cross-versions-tests.yml` triggered?
-
-1. When a pull request is created (run tests affected by the PR)
-2. Everyday at 7:00 UTC (run all tests)
-
-## How to run `dev/set_matrix.py`
-
-```sh
-# ===== Include all items =====
-
-python dev/set_matrix.py
-
-# ===== Include only `ml-package-versions.yml` updates =====
-
-REF_VERSIONS_YAML="https://raw.githubusercontent.com/mlflow/mlflow/master/ml-package-versions.yml"
-python dev/set_matrix.py --ref-versions-yaml $REF_VERSIONS_YAML
-
-# ===== Include only flavor file updates =====
-
-CHANGED_FILES="
-mlflow/keras.py
-tests/xgboost/test_xgboost_autolog.py
-"
-python dev/set_matrix.py --changed-files $CHANGED_FILES
-
-# ===== Include both `ml-package-versions.yml` & flavor file updates =====
-
-python dev/set_matrix.py --ref-versions-yaml $REF_VERSIONS_YAML --changed-files $CHANGED_FILES
-```
-
-## How to run doctests in `dev/set_matrix.py`
-
-```sh
-pytest dev/set_matrix.py --doctest-modules
-```
-
-## How to run tests for dev versions on a pull request:
-
-1. Click `Labels` in the right sidebar.
-2. Select the `enable-dev-tests` label.
-3. Push a commit or re-run the `Cross version tests` workflow.
+| File                        | Role                                                      |
+| :-------------------------- | :-------------------------------------------------------- |
+| `labeling.yml`              | Automatically apply labels on issues and PRs              |
+| `notify-dco-failure.yml`    | Notify a DCO check failure                                |
+| `release-note-category.yml` | Validate a release-note category label is applied on a PR |

--- a/.github/workflows/cross-version-testing.md
+++ b/.github/workflows/cross-version-testing.md
@@ -123,7 +123,10 @@ the previous section:
 [badge-img]: https://github.com/mlflow/mlflow/workflows/Cross%20version%20tests/badge.svg?event=schedule
 [badge-target]: https://github.com/mlflow/mlflow/actions?query=workflow%3ACross%2Bversion%2Btests+event%3Aschedule
 
-## How to run dev tests on a pull request
+## How to run cross version test for dev versions on a pull request
+
+By default, cross version tests for dev versions are disabled on a pull request.
+To enable them, the following steps are required.
 
 Steps:
 

--- a/.github/workflows/cross-version-testing.md
+++ b/.github/workflows/cross-version-testing.md
@@ -128,10 +128,8 @@ the previous section:
 By default, cross version tests for dev versions are disabled on a pull request.
 To enable them, the following steps are required.
 
-Steps:
-
 1. Click `Labels` in the right sidebar.
-2. Select the `enable-dev-tests` label and make sure it's applied.
+2. Click the `enable-dev-tests` label and make sure it's applied on the pull request.
 3. Push a new commit or re-run the `cross-version-tests` workflow.
 
 See also:
@@ -141,12 +139,10 @@ See also:
 
 ## How to run cross version tests manually
 
-Steps:
-
 1. Open https://github.com/mlflow/mlflow/actions/workflows/cross-version-tests.yml.
-2. Select `Run workflow`.
+2. Click `Run workflow`.
 3. Fill in the required input parameters.
-4. Click `Run workflow` at the bottom.
+4. Click `Run workflow` at the bottom of the parameter input form.
 
 See also:
 

--- a/.github/workflows/cross-version-testing.md
+++ b/.github/workflows/cross-version-testing.md
@@ -2,17 +2,22 @@
 
 ## What is cross version testing?
 
-Cross version testing is to ensure ML integrations in MLflow (e.g. `mlflow.sklearn`)
-work properly with their associated packages across various versions.
+Cross version testing is a testing strategy to ensure ML integrations in MLflow such as
+`mlflow.sklearn` work properly with their associated packages across various versions.
 
 ## Key files
 
-| File                                        | Role                                                           |
-| :------------------------------------------ | :------------------------------------------------------------- |
-| `mlflow/ml-package-versions.yml`            | Define which versions to test for each ML package.             |
-| `dev/set_matrix.py`                         | Generate a test matrix from `ml-package-versions.yml`.         |
-| `dev/update_ml_package_versions.py`         | Update `ml-package-versions.yml` when releasing a new version. |
-| `.github/workflows/cross-version-tests.yml` | Define a Github Actions workflow for cross version testing.    |
+| File (relative path from the root)              | Role                                                           |
+| :---------------------------------------------- | :------------------------------------------------------------- |
+| [`mlflow/ml-package-versions.yml`][]            | Define which versions to test for each ML package.             |
+| [`dev/set_matrix.py`][]                         | Generate a test matrix from `ml-package-versions.yml`.         |
+| [`dev/update_ml_package_versions.py`][]         | Update `ml-package-versions.yml` when releasing a new version. |
+| [`.github/workflows/cross-version-tests.yml`][] | Define a Github Actions workflow for cross version testing.    |
+
+[`mlflow/ml-package-versions.yml`]: ../../mlflow/ml-package-versions.yml
+[`dev/set_matrix.py`]: ../../dev/set_matrix.py
+[`dev/update_ml_package_versions.py`]: ../../dev/update_ml_package_versions.py
+[`.github/workflows/cross-version-tests.yml`]: ./cross-version-tests.yml
 
 ## Configuration keys in `ml-package-versions.yml`
 
@@ -107,9 +112,13 @@ the previous section:
 ## When do we run cross version tests?
 
 1. Daily at 7:00 UTC using a cron scheduler.
+   [README on the repository root](../../README.rst) has a badge ([![badge-img][]][badge-target]) that indicates the status of the most recent run.
 2. When a PR that affects the ML integrations is created. Note we only run tests relevant to
    the affected ML integrations. For example, a PR that affects files in `mlflow/sklearn` triggers
    cross version tests for `sklearn`.
+
+[badge-img]: https://github.com/mlflow/mlflow/workflows/Cross%20version%20tests/badge.svg?event=schedule
+[badge-target]: https://github.com/mlflow/mlflow/actions?query=workflow%3ACross%2Bversion%2Btests+event%3Aschedule
 
 ## How to run dev tests on a pull request
 

--- a/.github/workflows/cross-version-testing.md
+++ b/.github/workflows/cross-version-testing.md
@@ -1,0 +1,132 @@
+# Cross version testing
+
+## What is cross version testing?
+
+Cross version testing is a testing strategy we adopt to ensure ML integrations in MLflow
+(e.g. `mlflow.sklearn`) work properly with their associated packages across different versions.
+
+## Key files
+
+| File                                        | Role                                                           |
+| :------------------------------------------ | :------------------------------------------------------------- |
+| `mlflow/ml-package-versions.yml`            | Define which versions to test for each ML package.             |
+| `dev/set_matrix.py`                         | Generate a test matrix from `ml-package-versions.yml`.         |
+| `dev/update_ml_package_versions.py`         | Update `ml-package-versions.yml` when releasing a new version. |
+| `.github/workflows/cross-version-tests.yml` | Define a Github Actions workflow for cross version testing.    |
+
+## Configuration keys in `ml-package-versions.yml`
+
+```yml
+# The top-level key specifies the integration name.
+sklearn:
+  package_info:
+    # [Required] `pip_release` specifies the package this integration depends on.
+    pip_release: "scikit-learn"
+
+    # [Optional] `install_dev` specifies a set of commands to install the dev version of the package.
+    # For example, the command below builds a wheel from the latest main branch of
+    # the scikit-learn repository and installs it.
+    install_dev: |
+      pip install git+https://github.com/scikit-learn/scikit-learn.git
+
+  # [At least one of `models` and `autologging` must be specified]
+  # `models` specifies the configuration for model serialization and serving tests.
+  # `autologging` specifies the configuration for autologging tests.
+  models or autologging:
+    # [Optional] `requirements` specifies additional pip requirements required for running tests.
+    # For example, '">= 0.24.0": ["xgboost"]' is interpreted as 'if the version of scikit-learn
+    # to install is newer than or equal to 0.24.0, install xgboost'.
+    requirements:
+      ">= 0.24.0": ["xgboost"]
+
+    # [Required] `minimum` specifies the minimum supported version for the latest release of MLflow.
+    minimum: "0.20.3"
+
+    # [Required] `maximum` specifies the maximum supported version for the latest release of MLflow.
+    # Our CI will still test all the way up through the current maximum version that's been released
+    # on PyPI. For example, if scikit-learn 1.0.1 is available on PyPI, our CI will pick it up.
+    maximum: "1.0"
+
+    # [Optional] `unsupported` specifies a list of versions that should NOT be supported due to
+    # unacceptable issues or bugs.
+    unsupported: ["0.21.3"]
+
+    # [Required] `run` specifies a set of commands to run tests.
+    run: |
+      pytest tests/sklearn/test_sklearn_model_export.py --large
+```
+
+## How do we determine which versions to test?
+
+We determine which versions to test by filtering candidates between `minimum` and `maximum` based
+on the following rules:
+
+1. Only test the latest micro version of each minor version.
+2. Skip [pre-releases](https://www.python.org/dev/peps/pep-0440/#pre-releases) (e.g. `1.0rc1`).
+3. Always test the `minimum` version.
+
+The table below describes which `scikit-learn` versions to test for the example configuration in
+the previous section:
+
+| Version       | Tested | Comment                                |
+| :------------ | :----- | -------------------------------------- |
+| 0.20.3        | ✅     | The value of `minimum`                 |
+| 0.20.4        | ✅     | The latest micro version of `0.20`     |
+| 0.21rc2       |        |                                        |
+| 0.21.0        |        |                                        |
+| 0.21.1        |        |                                        |
+| 0.21.2        |        |                                        |
+| 0.21.3        |        | Excluded by `unsupported`              |
+| 0.22rc2.post1 |        |                                        |
+| 0.22rc3       |        |                                        |
+| 0.22          |        |                                        |
+| 0.22.1        |        |                                        |
+| 0.22.2        |        |                                        |
+| 0.22.2.post1  | ✅     | The latest micro version of `0.22`     |
+| 0.23.0rc1     |        |                                        |
+| 0.23.0        |        |                                        |
+| 0.23.1        |        |                                        |
+| 0.23.2        | ✅     | The latest micro version of `0.23`     |
+| 0.24.dev0     |        |                                        |
+| 0.24.0rc1     |        |                                        |
+| 0.24.0        |        |                                        |
+| 0.24.1        |        |                                        |
+| 0.24.2        | ✅     | The latest micro version of `0.24`     |
+| 1.0rc1        |        |                                        |
+| 1.0rc2        |        |                                        |
+| 1.0           |        | The value of `maximum`                 |
+| 1.0.1         | ✅     | The latest micro version of `1.0`      |
+| 1.1.dev       | ✅     | The version installed by `install_dev` |
+
+## When do we run cross version tests?
+
+1. Daily at 7:00 UTC using a cron scheduler.
+2. When a PR that affects the ML integrations is filed. Note we only run tests relevant to
+   the affected ML integrations. For example, a PR that affects files in `mlflow/sklearn` triggers
+   cross version tests for `sklearn`.
+
+## How to run dev tests on a pull request
+
+Steps:
+
+1. Click `Labels` in the right sidebar.
+2. Select the `enable-dev-tests` label and make sure it's applied.
+3. Push a new commit or re-run the `cross-version-tests` workflow.
+
+See also:
+
+- https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#applying-a-label
+- https://docs.github.com/en/actions/managing-workflow-runs/re-running-workflows-and-jobs
+
+## How to run cross version tests manually
+
+Steps:
+
+1. Open https://github.com/mlflow/mlflow/actions/workflows/cross-version-tests.yml.
+2. Select `Run workflow`.
+3. Fill in the required input parameters.
+4. Click `Run workflow` at the bottom.
+
+See also:
+
+- https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow

--- a/.github/workflows/cross-version-testing.md
+++ b/.github/workflows/cross-version-testing.md
@@ -82,35 +82,35 @@ We determine which versions to test based on the following rules:
 The table below describes which `scikit-learn` versions to test for the example configuration in
 the previous section:
 
-| Version       | Tested | Comment                                |
-| :------------ | :----- | -------------------------------------- |
-| 0.20.3        | ✅     | The value of `minimum`                 |
-| 0.20.4        | ✅     | The latest micro version of `0.20`     |
-| 0.21rc2       |        |                                        |
-| 0.21.0        |        |                                        |
-| 0.21.1        |        |                                        |
-| 0.21.2        |        |                                        |
-| 0.21.3        |        | Excluded by `unsupported`              |
-| 0.22rc2.post1 |        |                                        |
-| 0.22rc3       |        |                                        |
-| 0.22          |        |                                        |
-| 0.22.1        |        |                                        |
-| 0.22.2        |        |                                        |
-| 0.22.2.post1  | ✅     | The latest micro version of `0.22`     |
-| 0.23.0rc1     |        |                                        |
-| 0.23.0        |        |                                        |
-| 0.23.1        |        |                                        |
-| 0.23.2        | ✅     | The latest micro version of `0.23`     |
-| 0.24.dev0     |        |                                        |
-| 0.24.0rc1     |        |                                        |
-| 0.24.0        |        |                                        |
-| 0.24.1        |        |                                        |
-| 0.24.2        | ✅     | The latest micro version of `0.24`     |
-| 1.0rc1        |        |                                        |
-| 1.0rc2        |        |                                        |
-| 1.0           |        | The value of `maximum`                 |
-| 1.0.1         | ✅     | The latest micro version of `1.0`      |
-| 1.1.dev       | ✅     | The version installed by `install_dev` |
+| Version       | Tested | Comment                                            |
+| :------------ | :----- | -------------------------------------------------- |
+| 0.20.3        | ✅     | The value of `minimum`                             |
+| 0.20.4        | ✅     | The latest micro version of `0.20`                 |
+| 0.21rc2       |        |                                                    |
+| 0.21.0        |        |                                                    |
+| 0.21.1        |        |                                                    |
+| 0.21.2        | ✅     | The latest micro version of `0.21` without`0.21.3` |
+| 0.21.3        |        | Excluded by `unsupported`                          |
+| 0.22rc2.post1 |        |                                                    |
+| 0.22rc3       |        |                                                    |
+| 0.22          |        |                                                    |
+| 0.22.1        |        |                                                    |
+| 0.22.2        |        |                                                    |
+| 0.22.2.post1  | ✅     | The latest micro version of `0.22`                 |
+| 0.23.0rc1     |        |                                                    |
+| 0.23.0        |        |                                                    |
+| 0.23.1        |        |                                                    |
+| 0.23.2        | ✅     | The latest micro version of `0.23`                 |
+| 0.24.dev0     |        |                                                    |
+| 0.24.0rc1     |        |                                                    |
+| 0.24.0        |        |                                                    |
+| 0.24.1        |        |                                                    |
+| 0.24.2        | ✅     | The latest micro version of `0.24`                 |
+| 1.0rc1        |        |                                                    |
+| 1.0rc2        |        |                                                    |
+| 1.0           |        | The value of `maximum`                             |
+| 1.0.1         | ✅     | The latest micro version of `1.0`                  |
+| 1.1.dev       | ✅     | The version installed by `install_dev`             |
 
 ## When do we run cross version tests?
 

--- a/.github/workflows/cross-version-testing.md
+++ b/.github/workflows/cross-version-testing.md
@@ -115,7 +115,7 @@ the previous section:
 ## When do we run cross version tests?
 
 1. Daily at 7:00 UTC using a cron scheduler.
-   [README on the repository root](../../README.rst) has a badge ([![badge-img][]][badge-target]) that indicates the status of the most recent run.
+   [README on the repository root](../../README.rst) has a badge ([![badge-img][]][badge-target]) that indicates the status of the most recent cron run.
 2. When a PR that affects the ML integrations is created. Note we only run tests relevant to
    the affected ML integrations. For example, a PR that affects files in `mlflow/sklearn` triggers
    cross version tests for `sklearn`.

--- a/.github/workflows/cross-version-testing.md
+++ b/.github/workflows/cross-version-testing.md
@@ -139,9 +139,11 @@ See also:
 
 ## How to run cross version tests manually
 
+The `cross-version-tests.yml` workflow can be run manually without creating a pull request.
+
 1. Open https://github.com/mlflow/mlflow/actions/workflows/cross-version-tests.yml.
 2. Click `Run workflow`.
-3. Fill in the required input parameters.
+3. Fill in the input parameters.
 4. Click `Run workflow` at the bottom of the parameter input form.
 
 See also:

--- a/.github/workflows/cross-version-testing.md
+++ b/.github/workflows/cross-version-testing.md
@@ -69,12 +69,15 @@ sklearn:
 
 We determine which versions to test based on the following rules:
 
-1. Only test final (e.g. `1.0.0`) and post (`1.0.0.post0`) releases (see [PEP 440](https://www.python.org/dev/peps/pep-0440/) for details).
+1. Only test [final][] (e.g. `1.0.0`) and [post][] (`1.0.0.post0`) releases.
 2. Only test the latest micro version in each minor version.
    For example, if `1.0.0`, `1.0.1`, and `1.0.2` are available, we only test `1.0.2`.
 3. The `maximum` version defines the maximum **major** version to test.
-   For example, if `maximum` is `1.0.0`, we test `1.1.0` but not `2.0.0`.
+   For example, if the value of `maximum` is `1.0.0`, we test `1.1.0` (if available) but not `2.0.0`.
 4. Always test the `minimum` version.
+
+[final]: https://www.python.org/dev/peps/pep-0440/#final-releases
+[post]: https://www.python.org/dev/peps/pep-0440/#final-releases
 
 The table below describes which `scikit-learn` versions to test for the example configuration in
 the previous section:
@@ -130,8 +133,8 @@ Steps:
 
 See also:
 
-- https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#applying-a-label
-- https://docs.github.com/en/actions/managing-workflow-runs/re-running-workflows-and-jobs
+- [GitHub Docs - Applying a label](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#applying-a-label)
+- [GitHub Docs - Re-running workflows and jobs](https://docs.github.com/en/actions/managing-workflow-runs/re-running-workflows-and-jobs)
 
 ## How to run cross version tests manually
 
@@ -144,4 +147,4 @@ Steps:
 
 See also:
 
-- https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
+- [GitHub Docs - Manually running a workflow](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow)

--- a/.github/workflows/cross-version-testing.md
+++ b/.github/workflows/cross-version-testing.md
@@ -77,7 +77,7 @@ We determine which versions to test based on the following rules:
 4. Always test the `minimum` version.
 
 [final]: https://www.python.org/dev/peps/pep-0440/#final-releases
-[post]: https://www.python.org/dev/peps/pep-0440/#final-releases
+[post]: https://www.python.org/dev/peps/pep-0440/#post-releases
 
 The table below describes which `scikit-learn` versions to test for the example configuration in
 the previous section:


### PR DESCRIPTION
## What changes are proposed in this pull request?

As the PR title indicates, clarify how cross version testing works.

## How is this patch tested?

NA

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
