### PR TITLE
Add `--artifacts-destination` option to `mlflow ui`

### DIFF
--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -243,9 +243,10 @@ def _validate_server_args(gunicorn_opts=None, workers=None, waitress_opts=None):
     "Note that this flag does not impact already-created experiments. "
     "Default: " + DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH,
 )
+@cli_args.ARTIFACTS_DESTINATION
 @cli_args.PORT
 @cli_args.HOST
-def ui(backend_store_uri, default_artifact_root, port, host):
+def ui(backend_store_uri, default_artifact_root, artifacts_destination, port, host):
     """
     Launch the MLflow tracking UI for local viewing of run results. To launch a production
     server, use the "mlflow server" command instead.
@@ -277,7 +278,9 @@ def ui(backend_store_uri, default_artifact_root, port, host):
 
     # TODO: We eventually want to disable the write path in this version of the server.
     try:
-        _run_server(backend_store_uri, default_artifact_root, host, port, None, 1)
+        _run_server(
+            backend_store_uri, default_artifact_root, artifacts_destination, host, port, None, 1
+        )
     except ShellCommandException:
         eprint("Running the mlflow server failed. Please see the logs above for details.")
         sys.exit(1)
@@ -317,17 +320,7 @@ def _validate_static_prefix(ctx, param, value):  # pylint: disable=unused-argume
     "Default: Within file store, if a file:/ URI is provided. If a sql backend is"
     " used, then this option is required.",
 )
-@click.option(
-    "--artifacts-destination",
-    metavar="URI",
-    default="./mlartifacts",
-    help=(
-        "The base artifact location from which to resolve artifact upload/download/list requests "
-        "(e.g. 's3://my-bucket'). Defaults to a local './mlartifacts' directory. This option only "
-        "applies when the tracking server is configured to stream artifacts and the experiment's "
-        "artifact root location is http or mlflow-artifacts URI."
-    ),
-)
+@cli_args.ARTIFACTS_DESTINATION
 @cli_args.HOST
 @cli_args.PORT
 @cli_args.WORKERS

--- a/mlflow/utils/cli_args.py
+++ b/mlflow/utils/cli_args.py
@@ -87,3 +87,15 @@ ENABLE_MLSERVER = click.option(
     default=False,
     help="Enable serving with MLServer through the v2 inference protocol.",
 )
+
+ARTIFACTS_DESTINATION = click.option(
+    "--artifacts-destination",
+    metavar="URI",
+    default="./mlartifacts",
+    help=(
+        "The base artifact location from which to resolve artifact upload/download/list requests "
+        "(e.g. 's3://my-bucket'). Defaults to a local './mlartifacts' directory. This option only "
+        "applies when the tracking server is configured to stream artifacts and the experiment's "
+        "artifact root location is http or mlflow-artifacts URI."
+    ),
+)


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

I forgot to add `--artifacts-destination` to `mlflow ui` command. This should fix the issue @WeichenXu123 reported in  https://github.com/mlflow/mlflow/pull/5022#issuecomment-964120766

## How is this patch tested?

Locally tested `mlflow ui` works. 

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
