### PR TITLE
Exclude `mlflow/protos` when running `black` in `hooks/pre-commit`

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -3,6 +3,12 @@ set -ex
 diff=$(git diff --cached --name-only | grep '\.py$' || true)
 
 if [ ! -z "$diff" ]; then
-  black --check $diff
+  # We specify `--exclude` option in `pyproject.toml`,
+  # but it's only consulted for recursive search, not for files passed on the command line:
+  # https://github.com/psf/black/issues/438#issuecomment-413886281
+  # `--force-exclude` option can solve this issue, but black >= 20.8b0 is required:
+  # https://black.readthedocs.io/en/stable/change_log.html#id26
+  # TODO: Upgrade black to >= 20.8b0 and use `--force-exclude`
+  black --check $(echo $diff | grep -v '^mlflow/protos')
   pylint $diff
 fi


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

The lint pre-commit hook currently runs `black` against files that should be excluded (e.g. `mlflow/protos`). This 


## How to reproduce the issue:

```
% echo "" >> mlflow/protos/mlflow_artifacts_pb2.py
                                                                                                                                      
% git diff
diff --git a/mlflow/protos/mlflow_artifacts_pb2.py b/mlflow/protos/mlflow_artifacts_pb2.py
index 92df7eb84..9d68edb8a 100644
--- a/mlflow/protos/mlflow_artifacts_pb2.py
+++ b/mlflow/protos/mlflow_artifacts_pb2.py
@@ -347,3 +347,4 @@ MlflowArtifactsService_Stub = service_reflection.GeneratedServiceStubType('Mlflo
 
 
 # @@protoc_insertion_point(module_scope)
+
                                                                                                                                      
% git add .
                                                                                                                                      
% git commit --signoff -m "test"
++ git diff --cached --name-only
++ grep '\.py$'
+ diff=mlflow/protos/mlflow_artifacts_pb2.py
+ '[' '!' -z mlflow/protos/mlflow_artifacts_pb2.py ']'
+ black --check mlflow/protos/mlflow_artifacts_pb2.py
would reformat mlflow/protos/mlflow_artifacts_pb2.py
Oh no! 💥 💔 💥
1 file would be reformatted.

black should ignore mlflow/protos/mlflow_artifacts_pb2.py but it doesn't.
```

## How is this patch tested?

(Details)

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
