### PR TITLE
Use `...` when comparing diff between master and PR branch for cross version tests

### DIFF
--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -77,8 +77,10 @@ jobs:
         run: |
           EVENT_NAME="${{ github.event_name }}"
           if [ "$EVENT_NAME" = "pull_request" ]; then
-            REF_VERSIONS_YAML="https://raw.githubusercontent.com/${{ github.repository }}/mlflow/master/mlflow/ml-package-versions.yml"
-            API_URL="https://api.github.com/repos/${{ github.repository	}}/pulls/${{ github.event.issue.number }}/files"
+            REPO="${{ github.repository }}"
+            PR_NUMBER="${{ github.event.pull_request.number }}"
+            REF_VERSIONS_YAML="https://raw.githubusercontent.com/$REPO/master/mlflow/ml-package-versions.yml"
+            API_URL="https://api.github.com/repos/$REPO/pulls/$PR_NUMBER/files"
             CHANGED_FILES="$(curl $API_URL | jq -r '.[].filename')"
             ENABLE_DEV_TESTS="${{ steps.enable-dev-tests.outputs.result }}"
             EXCLUDE_DEV_VERSIONS_FLAG=$([ "$ENABLE_DEV_TESTS" == "true" ] && echo "" || echo "--exclude-dev-versions")

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -76,15 +76,11 @@ jobs:
       - id: set-matrix
         name: Set matrix
         run: |
-          if [ ! "$(git branch --show-current)" == "master" ]; then
-            git fetch origin master:master
-          fi
-
           EVENT_NAME="${{ github.event_name }}"
           if [ "$EVENT_NAME" = "pull_request" ]; then
-            REF_VERSIONS_YAML="https://raw.githubusercontent.com/mlflow/mlflow/master/mlflow/ml-package-versions.yml"
-            git log -n 1 $(git merge-base master HEAD)
-            CHANGED_FILES="$(git diff --name-only master...HEAD)"
+            REF_VERSIONS_YAML="https://raw.githubusercontent.com/${{ github.repository	}}/mlflow/master/mlflow/ml-package-versions.yml"
+            API_URL="https://api.github.com/repos/${{ github.repository	}}/pulls/${{ github.event.issue.number }}/files"
+            CHANGED_FILES="$(curl $API_URL | jq -r '.[].filename')"
             ENABLE_DEV_TESTS="${{ steps.enable-dev-tests.outputs.result }}"
             EXCLUDE_DEV_VERSIONS_FLAG=$([ "$ENABLE_DEV_TESTS" == "true" ] && echo "" || echo "--exclude-dev-versions")
             python dev/set_matrix.py --ref-versions-yaml "$REF_VERSIONS_YAML" --changed-files "$CHANGED_FILES" $EXCLUDE_DEV_VERSIONS_FLAG

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -48,7 +48,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 1000
           repository: ${{ github.event.inputs.repository }}
           ref: ${{ github.event.inputs.ref }}
       - uses: actions/setup-python@v2
@@ -78,7 +77,7 @@ jobs:
         run: |
           EVENT_NAME="${{ github.event_name }}"
           if [ "$EVENT_NAME" = "pull_request" ]; then
-            REF_VERSIONS_YAML="https://raw.githubusercontent.com/${{ github.repository	}}/mlflow/master/mlflow/ml-package-versions.yml"
+            REF_VERSIONS_YAML="https://raw.githubusercontent.com/${{ github.repository }}/mlflow/master/mlflow/ml-package-versions.yml"
             API_URL="https://api.github.com/repos/${{ github.repository	}}/pulls/${{ github.event.issue.number }}/files"
             CHANGED_FILES="$(curl $API_URL | jq -r '.[].filename')"
             ENABLE_DEV_TESTS="${{ steps.enable-dev-tests.outputs.result }}"

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -48,6 +48,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          fetch-depth: 0
           repository: ${{ github.event.inputs.repository }}
           ref: ${{ github.event.inputs.ref }}
       - uses: actions/setup-python@v2

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -84,6 +84,7 @@ jobs:
           if [ "$EVENT_NAME" = "pull_request" ]; then
             REF_VERSIONS_YAML="https://raw.githubusercontent.com/mlflow/mlflow/master/mlflow/ml-package-versions.yml"
             CHANGED_FILES="$(git diff --name-only master...HEAD)"
+            git log -n 1 $(git merge-base master HEAD)
             ENABLE_DEV_TESTS="${{ steps.enable-dev-tests.outputs.result }}"
             EXCLUDE_DEV_VERSIONS_FLAG=$([ "$ENABLE_DEV_TESTS" == "true" ] && echo "" || echo "--exclude-dev-versions")
             python dev/set_matrix.py --ref-versions-yaml "$REF_VERSIONS_YAML" --changed-files "$CHANGED_FILES" $EXCLUDE_DEV_VERSIONS_FLAG

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -82,7 +82,7 @@ jobs:
           EVENT_NAME="${{ github.event_name }}"
           if [ "$EVENT_NAME" = "pull_request" ]; then
             REF_VERSIONS_YAML="https://raw.githubusercontent.com/mlflow/mlflow/master/mlflow/ml-package-versions.yml"
-            CHANGED_FILES="$(git diff --name-only master..HEAD)"
+            CHANGED_FILES="$(git diff --name-only master...HEAD)"
             ENABLE_DEV_TESTS="${{ steps.enable-dev-tests.outputs.result }}"
             EXCLUDE_DEV_VERSIONS_FLAG=$([ "$ENABLE_DEV_TESTS" == "true" ] && echo "" || echo "--exclude-dev-versions")
             python dev/set_matrix.py --ref-versions-yaml "$REF_VERSIONS_YAML" --changed-files "$CHANGED_FILES" $EXCLUDE_DEV_VERSIONS_FLAG

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -83,8 +83,8 @@ jobs:
           EVENT_NAME="${{ github.event_name }}"
           if [ "$EVENT_NAME" = "pull_request" ]; then
             REF_VERSIONS_YAML="https://raw.githubusercontent.com/mlflow/mlflow/master/mlflow/ml-package-versions.yml"
-            CHANGED_FILES="$(git diff --name-only master...HEAD)"
             git log -n 1 $(git merge-base master HEAD)
+            CHANGED_FILES="$(git diff --name-only master...HEAD)"
             ENABLE_DEV_TESTS="${{ steps.enable-dev-tests.outputs.result }}"
             EXCLUDE_DEV_VERSIONS_FLAG=$([ "$ENABLE_DEV_TESTS" == "true" ] && echo "" || echo "--exclude-dev-versions")
             python dev/set_matrix.py --ref-versions-yaml "$REF_VERSIONS_YAML" --changed-files "$CHANGED_FILES" $EXCLUDE_DEV_VERSIONS_FLAG

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 0
+          fetch-depth: 1000
           repository: ${{ github.event.inputs.repository }}
           ref: ${{ github.event.inputs.ref }}
       - uses: actions/setup-python@v2


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

Use `...` when comparing diff between master and PR branch for cross version tests.

## Why `...`?


<img src="https://user-images.githubusercontent.com/17039389/141092492-226028ab-43be-4630-bc22-36401b868e6a.png" width="70%"/>

Source: https://stackoverflow.com/a/7256391

- `..`: might include files the PR hasn't changed (example: https://github.com/mlflow/mlflow/pull/5017 only changes js files but triggers some cross version tests).
- `...`: only include files the PR has changed.

## How is this patch tested?

NA

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
