### PR TITLE
Pytorch examples - Pytorch Lightning 1.5.1 support

### DIFF
--- a/examples/pytorch/AxHyperOptimizationPTL/conda.yaml
+++ b/examples/pytorch/AxHyperOptimizationPTL/conda.yaml
@@ -5,7 +5,7 @@ dependencies:
 - pip
 - pip:
   - mlflow
-  - pytorch-lightning==1.4.9
+  - pytorch-lightning==1.5.1
   - ax-platform
   - torchvision>=0.9.1
   - torch>=1.9.0

--- a/examples/pytorch/BertNewsClassification/bert_classification.py
+++ b/examples/pytorch/BertNewsClassification/bert_classification.py
@@ -408,4 +408,4 @@ if __name__ == "__main__":
         args, callbacks=[lr_logger, early_stopping, checkpoint_callback], checkpoint_callback=True
     )
     trainer.fit(model, dm)
-    trainer.test()
+    trainer.test(datamodule=dm)

--- a/examples/pytorch/BertNewsClassification/conda.yaml
+++ b/examples/pytorch/BertNewsClassification/conda.yaml
@@ -13,4 +13,4 @@ dependencies:
   - torchvision>=0.9.1
   - torch>=1.9.0
   - torchtext==0.10.0
-  - pytorch-lightning==1.4.9
+  - pytorch-lightning==1.5.1

--- a/examples/pytorch/IterativePruning/conda.yaml
+++ b/examples/pytorch/IterativePruning/conda.yaml
@@ -7,7 +7,7 @@ dependencies:
   - mlflow
   - torchvision>=0.9.1
   - cloudpickle==1.6.0
-  - pytorch_lightning==1.4.9
+  - pytorch_lightning==1.5.1
   - ax-platform
   - prettytable
   - torch>=1.9.0

--- a/examples/pytorch/IterativePruning/iterative_prune_mnist.py
+++ b/examples/pytorch/IterativePruning/iterative_prune_mnist.py
@@ -37,7 +37,7 @@ class IterativePrune:
         model = LightningMNISTClassifier(**parser_dict)
         trainer = pl.Trainer.from_argparse_args(self.parser_args)
         trainer.fit(model, dm)
-        trainer.test()
+        trainer.test(datamodule=dm)
         if os.path.exists(self.base_model_path):
             shutil.rmtree(self.base_model_path)
         mlflow.pytorch.save_model(trainer.lightning_module, self.base_model_path)

--- a/examples/pytorch/IterativePruning/mnist.py
+++ b/examples/pytorch/IterativePruning/mnist.py
@@ -261,4 +261,4 @@ if __name__ == "__main__":
     model = LightningMNISTClassifier(**dict_args)
     trainer = pl.Trainer.from_argparse_args(args)
     trainer.fit(model, dm)
-    trainer.test()
+    trainer.test(datamodule=dm)

--- a/examples/pytorch/MNIST/conda.yaml
+++ b/examples/pytorch/MNIST/conda.yaml
@@ -7,4 +7,4 @@ dependencies:
   - mlflow
   - torchvision>=0.9.1
   - torch>=1.9.0
-  - pytorch-lightning==1.4.9
+  - pytorch-lightning==1.5.1

--- a/examples/pytorch/MNIST/mnist_autolog_example.py
+++ b/examples/pytorch/MNIST/mnist_autolog_example.py
@@ -295,4 +295,4 @@ if __name__ == "__main__":
         args, callbacks=[lr_logger, early_stopping, checkpoint_callback], checkpoint_callback=True
     )
     trainer.fit(model, dm)
-    trainer.test()
+    trainer.test(datamodule=dm)


### PR DESCRIPTION
Signed-off-by: Shrinath Suresh <shrinath@ideas2it.com>

## What changes are proposed in this pull request?

Pytorch Lightning 1.5.x major release is out - https://pypi.org/project/pytorch-lightning/ 

Changing examples for compatibility

## How is this patch tested?

Existing unit tests should pass

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [x] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
