### PR TITLE
Resolve getting-started package install issues #4987

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -147,8 +147,9 @@ If you plan on doing development and testing, you will also need to install the 
 
 .. code-block:: bash
 
-    pip install -r dev-requirements.txt
-    pip install -r test-requirements.txt
+    pip install pip-tools
+    pip-compile --output-file compiled-requirements.txt dev-requirements.txt test-requirements.txt
+    pip install -r compiled-requirements.txt
     pip install -e .[extras]  # installs mlflow from current checkout
     pip install -e tests/resources/mlflow-test-plugin # installs `mlflow-test-plugin` that is required for running certain MLflow tests
 
@@ -156,11 +157,7 @@ You may need to run ``conda install cmake`` for the test requirements to properl
 
 Ensure `Docker <https://www.docker.com/>`_ is installed.
 
-Finally, we use ``pytest`` to test all Python contributed code. Install ``pytest``:
-
-.. code-block:: bash
-
-    pip install pytest
+Finally, we use ``pytest`` to test all Python contributed code.
 
 JavaScript and UI
 ~~~~~~~~~~~~~~~~~

--- a/dev/extra-ml-requirements.txt
+++ b/dev/extra-ml-requirements.txt
@@ -8,14 +8,13 @@ keras
 # Required by mlflow.sklearn
 scikit-learn
 # Required by mlflow.gluon
-# TODO: Unpin once https://github.com/apache/incubator-mxnet/issues/20068 is fixed
-mxnet!=1.8.0
+mxnet==1.8.0.post0
 # Required by mlflow.fastai
 fastai>=2.4.1
 # Required by mlflow.spacy
 spacy
 # Required by mlflow.tensorflow
-tensorflow
+tensorflow==2.4.4
 # TODO: Stop excluding tensorflow-estimator 2.7.0 once tensorflow 2.7.0 is released:
 # https://github.com/tensorflow/tensorflow/issues/52883#issuecomment-955802164
 tensorflow-estimator!=2.7.0

--- a/dev/lint-requirements.txt
+++ b/dev/lint-requirements.txt
@@ -1,5 +1,6 @@
 pyarrow==0.17.0
-pylint==2.11.1
+pylint==2.1.0
+astroid==2.7.3
 rstcheck==3.2
 black==19.10b0
 # Pin isort version to prevent pylint from raising an error


### PR DESCRIPTION
Signed-off-by: Matthieu Maitre <mmaitre@microsoft.com>

## What changes are proposed in this pull request?

The change addresses the near-infinite pip backtracking when following the getting-started instructions (#4987). `pip-compile` is introduced in the getting-started steps to resolve all the dependencies at once. Dependencies are pinned and adjusted to resolve conflicts.

Caveats:
- I was not able to install on Windows as PyStan was not building.
- I was able to install on Ubuntu on Windows (WSL). There I ended up having to elevate `sudo pip install -e .[extras]` to resolve access-denied errors on output directories. Not sure if this is specific to my setup or something that should be mentioned in the getting-started.

I removed the `pip install pytest` as it is already covered by `test-requirements.txt`.

## How is this patch tested?

Ran the getting-started steps on Ubuntu in WSL.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
