### PR TITLE
Change the deafult value of `python_version` for `install_mlflow` in MLflow R to `3.7`

### DIFF
--- a/docs/source/R-api.rst
+++ b/docs/source/R-api.rst
@@ -23,7 +23,7 @@ dependencies before calling other MLflow APIs.
 
 .. code:: r
 
-   install_mlflow(python_version = "3.6")
+   install_mlflow(python_version = "3.7")
 
 Arguments
 ---------

--- a/mlflow/R/mlflow/R/install.R
+++ b/mlflow/R/mlflow/R/install.R
@@ -49,7 +49,7 @@ mlflow_maybe_create_conda_env <- function(python_version) {
 #' @param python_version Optional Python version to use within conda environment created for
 #' installing the MLflow CLI. If unspecified, defaults to using Python 3.6
 #' @export
-install_mlflow <- function(python_version = "3.6") {
+install_mlflow <- function(python_version = "3.7") {
   mlflow_maybe_create_conda_env(python_version)
   # Install the Python MLflow package with version == the current R package version
   packages <- c(paste("mlflow", "==", mlflow_version(), sep = ""))

--- a/mlflow/R/mlflow/man/install_mlflow.Rd
+++ b/mlflow/R/mlflow/man/install_mlflow.Rd
@@ -4,7 +4,7 @@
 \alias{install_mlflow}
 \title{Install MLflow}
 \usage{
-install_mlflow(python_version = "3.6")
+install_mlflow(python_version = "3.7")
 }
 \arguments{
 \item{python_version}{Optional Python version to use within conda environment created for


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

`conda-forge` no longer supports python 3.6:

https://conda-forge.org/docs/user/announcements.html

![image](https://user-images.githubusercontent.com/17039389/141443266-27051828-6558-4678-9341-4b39f2f29529.png)

We need to change the deafult value of `python_version` for `install_mlflow` in MLflow R to 3.7.

## How is this patch tested?

NA

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
