### PR TITLE
Use `pull_request.user` rather than `pull_request.head.user` in `notify-dco-failure` workflow

### DIFF
--- a/.github/workflows/notify-dco-failure.js
+++ b/.github/workflows/notify-dco-failure.js
@@ -1,7 +1,8 @@
 module.exports = async ({ context, github }) => {
   const { owner, repo } = context.repo;
   const { number: issue_number } = context.issue;
-  const { sha: ref, user } = context.payload.pull_request.head;
+  const ref = context.payload.pull_request.head.sha;
+  const { user } = context.payload.pull_request;
 
   function sleep(ms) {
     return new Promise(resolve => setTimeout(resolve, ms));


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

Use `pull_request.user` rather than `pull_request.head.user` in the `notify-dco-failure` workflow.

## Why do we need this change?

Here's an example. In https://github.com/mlflow/mlflow/pull/4988, @liangz1 created a PR from a branch on `mlflow/mlflow`. The DCO failure bot doesn't mention `liangz1` but `mlflow`.

```
{
  "url": "https://api.github.com/repos/mlflow/mlflow/pulls/4988",
  "id": 771697934,
  "node_id": "PR_kwDOCB5Jx84t_y0O",
  "html_url": "https://github.com/mlflow/mlflow/pull/4988",
  "diff_url": "https://github.com/mlflow/mlflow/pull/4988.diff",
  "patch_url": "https://github.com/mlflow/mlflow/pull/4988.patch",
  "issue_url": "https://api.github.com/repos/mlflow/mlflow/issues/4988",
  "number": 4988,
  "state": "closed",
  "locked": false,
  "title": "Revert \"Avoid using `torchmetrics` 0.6.0\"",
  "user": {
    "login": "liangz1",  👈👈👈 use this field
    ...
  },
  ...
  "head": {
    ...
    "user": {
      "login": "mlflow",  👈👈👈 don't use this field
      ...
```

## How is this patch tested?

NA

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
