### PR TITLE
Removed Creator field in ModelVersionView if user_id is undefined

### DIFF
--- a/mlflow/server/js/src/model-registry/components/ModelVersionView.js
+++ b/mlflow/server/js/src/model-registry/components/ModelVersionView.js
@@ -262,7 +262,7 @@ export class ModelVersionViewImpl extends React.Component {
       this.renderLastModifiedDescription(modelVersion.last_updated_timestamp),
       this.renderSourceRunDescription(),
     ];
-    return defaultOrder.filter(x => x !== null);
+    return defaultOrder.filter((x) => x !== null);
   }
 
   renderMetadata(modelVersion) {

--- a/mlflow/server/js/src/model-registry/components/ModelVersionView.js
+++ b/mlflow/server/js/src/model-registry/components/ModelVersionView.js
@@ -213,16 +213,18 @@ export class ModelVersionViewImpl extends React.Component {
   }
 
   renderCreatorDescription(user_id) {
-    return (user_id && (
-      <Descriptions.Item
-        label={this.props.intl.formatMessage({
-          defaultMessage: 'Creator',
-          description: 'Label name for creator metadata in model version page',
-        })}
-      >
-        {user_id}
-      </Descriptions.Item>
-    ))
+    return (
+      user_id && (
+        <Descriptions.Item
+          label={this.props.intl.formatMessage({
+            defaultMessage: 'Creator',
+            description: 'Label name for creator metadata in model version page',
+          })}
+        >
+          {user_id}
+        </Descriptions.Item>
+      )
+    );
   }
 
   renderLastModifiedDescription(last_updated_timestamp) {

--- a/mlflow/server/js/src/model-registry/components/ModelVersionView.js
+++ b/mlflow/server/js/src/model-registry/components/ModelVersionView.js
@@ -213,7 +213,7 @@ export class ModelVersionViewImpl extends React.Component {
   }
 
   renderCreatorDescription(user_id) {
-    return (
+    return (user_id && (
       <Descriptions.Item
         label={this.props.intl.formatMessage({
           defaultMessage: 'Creator',
@@ -222,7 +222,7 @@ export class ModelVersionViewImpl extends React.Component {
       >
         {user_id}
       </Descriptions.Item>
-    );
+    ))
   }
 
   renderLastModifiedDescription(last_updated_timestamp) {

--- a/mlflow/server/js/src/model-registry/components/ModelVersionView.js
+++ b/mlflow/server/js/src/model-registry/components/ModelVersionView.js
@@ -262,7 +262,7 @@ export class ModelVersionViewImpl extends React.Component {
       this.renderLastModifiedDescription(modelVersion.last_updated_timestamp),
       this.renderSourceRunDescription(),
     ];
-    return defaultOrder;
+    return defaultOrder.filter(x => x !== null);
   }
 
   renderMetadata(modelVersion) {

--- a/mlflow/server/js/src/model-registry/components/ModelVersionView.test.js
+++ b/mlflow/server/js/src/model-registry/components/ModelVersionView.test.js
@@ -12,6 +12,8 @@ import { Provider } from 'react-redux';
 import { mockRunInfo } from '../../experiment-tracking/utils/test-utils/ReduxStoreFixtures';
 import Routers from '../../experiment-tracking/routes';
 import { mountWithIntl } from '../../common/utils/TestUtils';
+import {ModelView} from "./ModelView";
+import {NONE} from "draft-js/lib/SampleDraftInlineStyle";
 
 describe('ModelVersionView', () => {
   let wrapper;
@@ -230,5 +232,89 @@ describe('ModelVersionView', () => {
     );
     expect(wrapper.html()).toContain('special key');
     expect(wrapper.html()).toContain('not so special value');
+  });
+
+  test('creator description not rendered if user_id is unavailable', () => {
+    const props = {
+      ...minimalProps,
+      modelVersion: mockModelVersionDetailed('Model A', 1, Stages.NONE,
+          ModelVersionStatus.READY, [], null,
+          'b99a0fc567ae4d32994392c800c0b6ce', null),
+    };
+    wrapper = mountWithIntl(
+        <Provider store={minimalStore}>
+            <BrowserRouter>
+                <ModelVersionView {...props} />
+            </BrowserRouter>
+        </Provider>,
+    );
+
+    expect(wrapper.find('.metadata-list td.ant-descriptions-item').length).toBe(4);
+    expect(
+        wrapper
+            .find('.metadata-list span.ant-descriptions-item-label')
+            .at(0)
+            .text(),
+    ).toBe('Registered At');
+    expect(
+        wrapper
+            .find('.metadata-list span.ant-descriptions-item-label')
+            .at(1)
+            .text(),
+    ).toBe('Stage');
+    expect(
+        wrapper
+            .find('.metadata-list span.ant-descriptions-item-label')
+            .at(2)
+            .text(),
+    ).toBe('Last Modified');
+    expect(
+        wrapper
+            .find('.metadata-list span.ant-descriptions-item-label')
+            .at(3)
+            .text(),
+    ).toBe('Source Run');
+  });
+
+  test('creator description rendered if user_id is available', () => {
+    wrapper = mountWithIntl(
+        <Provider store={minimalStore}>
+          <BrowserRouter>
+            <ModelVersionView {...minimalProps} />
+          </BrowserRouter>
+        </Provider>,
+    );
+
+    expect(wrapper.find('.metadata-list td.ant-descriptions-item').length).toBe(5);
+    expect(
+        wrapper
+            .find('.metadata-list span.ant-descriptions-item-label')
+            .at(0)
+            .text(),
+    ).toBe('Registered At');
+    expect(
+        wrapper
+            .find('.metadata-list span.ant-descriptions-item-label')
+            .at(1)
+            .text(),
+    ).toBe('Creator');
+    expect(
+        wrapper
+            .find('.metadata-list span.ant-descriptions-item-label')
+            .at(2)
+            .text(),
+    ).toBe('Stage');
+    expect(
+        wrapper
+            .find('.metadata-list span.ant-descriptions-item-label')
+            .at(3)
+            .text(),
+    ).toBe('Last Modified');
+    expect(
+        wrapper
+            .find('.metadata-list span.ant-descriptions-item-label')
+            .at(4)
+            .text(),
+    ).toBe('Source Run');
   });
 });

--- a/mlflow/server/js/src/model-registry/components/ModelVersionView.test.js
+++ b/mlflow/server/js/src/model-registry/components/ModelVersionView.test.js
@@ -13,7 +13,6 @@ import { mockRunInfo } from '../../experiment-tracking/utils/test-utils/ReduxSto
 import Routers from '../../experiment-tracking/routes';
 import { mountWithIntl } from '../../common/utils/TestUtils';
 
-
 describe('ModelVersionView', () => {
   let wrapper;
   let minimalProps;
@@ -236,84 +235,91 @@ describe('ModelVersionView', () => {
   test('creator description not rendered if user_id is unavailable', () => {
     const props = {
       ...minimalProps,
-      modelVersion: mockModelVersionDetailed('Model A', 1, Stages.NONE,
-          ModelVersionStatus.READY, [], null,
-          'b99a0fc567ae4d32994392c800c0b6ce', null),
+      modelVersion: mockModelVersionDetailed(
+        'Model A',
+        1,
+        Stages.NONE,
+        ModelVersionStatus.READY,
+        [],
+        null,
+        'b99a0fc567ae4d32994392c800c0b6ce',
+        null,
+      ),
     };
     wrapper = mountWithIntl(
-        <Provider store={minimalStore}>
-            <BrowserRouter>
-                <ModelVersionView {...props} />
-            </BrowserRouter>
-        </Provider>,
+      <Provider store={minimalStore}>
+        <BrowserRouter>
+          <ModelVersionView {...props} />
+        </BrowserRouter>
+      </Provider>,
     );
 
     expect(wrapper.find('.metadata-list td.ant-descriptions-item').length).toBe(4);
     expect(
-        wrapper
-            .find('.metadata-list span.ant-descriptions-item-label')
-            .at(0)
-            .text(),
+      wrapper
+        .find('.metadata-list span.ant-descriptions-item-label')
+        .at(0)
+        .text(),
     ).toBe('Registered At');
     expect(
-        wrapper
-            .find('.metadata-list span.ant-descriptions-item-label')
-            .at(1)
-            .text(),
+      wrapper
+        .find('.metadata-list span.ant-descriptions-item-label')
+        .at(1)
+        .text(),
     ).toBe('Stage');
     expect(
-        wrapper
-            .find('.metadata-list span.ant-descriptions-item-label')
-            .at(2)
-            .text(),
+      wrapper
+        .find('.metadata-list span.ant-descriptions-item-label')
+        .at(2)
+        .text(),
     ).toBe('Last Modified');
     expect(
-        wrapper
-            .find('.metadata-list span.ant-descriptions-item-label')
-            .at(3)
-            .text(),
+      wrapper
+        .find('.metadata-list span.ant-descriptions-item-label')
+        .at(3)
+        .text(),
     ).toBe('Source Run');
   });
 
   test('creator description rendered if user_id is available', () => {
     wrapper = mountWithIntl(
-        <Provider store={minimalStore}>
-          <BrowserRouter>
-            <ModelVersionView {...minimalProps} />
-          </BrowserRouter>
-        </Provider>,
+      <Provider store={minimalStore}>
+        <BrowserRouter>
+          <ModelVersionView {...minimalProps} />
+        </BrowserRouter>
+      </Provider>,
     );
 
     expect(wrapper.find('.metadata-list td.ant-descriptions-item').length).toBe(5);
     expect(
-        wrapper
-            .find('.metadata-list span.ant-descriptions-item-label')
-            .at(0)
-            .text(),
+      wrapper
+        .find('.metadata-list span.ant-descriptions-item-label')
+        .at(0)
+        .text(),
     ).toBe('Registered At');
     expect(
-        wrapper
-            .find('.metadata-list span.ant-descriptions-item-label')
-            .at(1)
-            .text(),
+      wrapper
+        .find('.metadata-list span.ant-descriptions-item-label')
+        .at(1)
+        .text(),
     ).toBe('Creator');
     expect(
-        wrapper
-            .find('.metadata-list span.ant-descriptions-item-label')
-            .at(2)
-            .text(),
+      wrapper
+        .find('.metadata-list span.ant-descriptions-item-label')
+        .at(2)
+        .text(),
     ).toBe('Stage');
     expect(
-        wrapper
-            .find('.metadata-list span.ant-descriptions-item-label')
-            .at(3)
-            .text(),
+      wrapper
+        .find('.metadata-list span.ant-descriptions-item-label')
+        .at(3)
+        .text(),
     ).toBe('Last Modified');
     expect(
-        wrapper
-            .find('.metadata-list span.ant-descriptions-item-label')
-            .at(4)
-            .text(),
+      wrapper
+        .find('.metadata-list span.ant-descriptions-item-label')
+        .at(4)
+        .text(),
     ).toBe('Source Run');
   });
 });

--- a/mlflow/server/js/src/model-registry/components/ModelVersionView.test.js
+++ b/mlflow/server/js/src/model-registry/components/ModelVersionView.test.js
@@ -12,8 +12,7 @@ import { Provider } from 'react-redux';
 import { mockRunInfo } from '../../experiment-tracking/utils/test-utils/ReduxStoreFixtures';
 import Routers from '../../experiment-tracking/routes';
 import { mountWithIntl } from '../../common/utils/TestUtils';
-import {ModelView} from "./ModelView";
-import {NONE} from "draft-js/lib/SampleDraftInlineStyle";
+
 
 describe('ModelVersionView', () => {
   let wrapper;

--- a/mlflow/server/js/src/model-registry/test-utils.js
+++ b/mlflow/server/js/src/model-registry/test-utils.js
@@ -16,6 +16,7 @@ export const mockModelVersionDetailed = (
   tags = [],
   run_link = undefined,
   run_id = 'b99a0fc567ae4d32994392c800c0b6ce',
+  user_id = 'richard@example.com',
 ) => {
   return {
     name,
@@ -23,7 +24,7 @@ export const mockModelVersionDetailed = (
     // and prevent React duplicate key warning.
     creation_timestamp: version.toString(),
     last_updated_timestamp: (version + 1).toString(),
-    user_id: 'richard@example.com',
+    user_id: user_id,
     current_stage: stage,
     description: '',
     source: 'path/to/model',


### PR DESCRIPTION
Signed-off-by: Jin Zhang <jin.zhang@databricks.com>

## What changes are proposed in this pull request?
Removed creator field on the model version view page, if user_id is not defined.

## How is this patch tested?

Unit test

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes
Fixed an issue that creator field shows empty on the model version view page.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
