### PR TITLE
Add script to list failed cross version tests

### DIFF
--- a/dev/list_failed_cross_version_tests.py
+++ b/dev/list_failed_cross_version_tests.py
@@ -1,0 +1,61 @@
+"""
+A script to list failed jobs in the latest scheduled run of the `cross-version-tests` workflow
+using the GitHub Actions API.
+
+References:
+- https://docs.github.com/en/rest/reference/actions#list-workflow-runs
+- https://docs.github.com/en/rest/reference/actions#list-jobs-for-a-workflow-run
+"""
+import json
+import os
+import requests
+
+
+def fetch_failed_jobs(session, run_id):
+    failed_jobs = []
+    per_page = 100
+    page = 1
+    while True:
+        url = f"https://api.github.com/repos/mlflow/mlflow/actions/runs/{run_id}/jobs"
+        resp = session.get(url, params={"per_page": per_page, "page": page})
+        jobs = resp.json()["jobs"]
+        failed_jobs.extend(j for j in jobs if j["conclusion"] == "failure")
+        if len(jobs) < per_page:
+            break
+        page += 1
+
+    return failed_jobs
+
+
+class StrictSession(requests.Session):
+    """
+    A wrapper class for `requests.Session` to validate the request is successful.
+    """
+
+    def request(self, *args, **kwargs):
+        resp = super().request(*args, **kwargs)
+        resp.raise_for_status()
+        return resp
+
+
+def create_session():
+    session = StrictSession()
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        session.headers.update({"Authorization": f"token {token}"})
+    return session
+
+
+def main():
+    session = create_session()
+    url = (
+        "https://api.github.com/repos/mlflow/mlflow/actions/workflows/cross-version-tests.yml/runs"
+    )
+    resp = session.get(url, params={"event": "schedule"})
+    latest_run_id = resp.json()["workflow_runs"][0]["id"]
+    failed_jobs = fetch_failed_jobs(session, latest_run_id)
+    print(json.dumps(failed_jobs, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/list_failed_cross_version_tests.py
+++ b/dev/list_failed_cross_version_tests.py
@@ -47,14 +47,12 @@ def create_session():
 
 
 def main():
-    session = create_session()
-    url = (
-        "https://api.github.com/repos/mlflow/mlflow/actions/workflows/cross-version-tests.yml/runs"
-    )
-    resp = session.get(url, params={"event": "schedule"})
-    latest_run_id = resp.json()["workflow_runs"][0]["id"]
-    failed_jobs = fetch_failed_jobs(session, latest_run_id)
-    print(json.dumps(failed_jobs, indent=2))
+    with create_session() as session:
+        url = "https://api.github.com/repos/mlflow/mlflow/actions/workflows/cross-version-tests.yml/runs"
+        resp = session.get(url, params={"event": "schedule"})
+        latest_run_id = resp.json()["workflow_runs"][0]["id"]
+        failed_jobs = fetch_failed_jobs(session, latest_run_id)
+        print(json.dumps(failed_jobs, indent=2))
 
 
 if __name__ == "__main__":

--- a/tests/dev/test_list_failed_cross_version_tests.py
+++ b/tests/dev/test_list_failed_cross_version_tests.py
@@ -1,0 +1,70 @@
+import json
+from unittest import mock
+
+from dev import list_failed_cross_version_tests
+
+
+class MockResponse:
+    def __init__(self, data):
+        self.data = data
+
+    def json(self):
+        return self.data
+
+    def raise_for_status(self):
+        pass
+
+
+def test_some_jobs_fail(capsys):
+    side_effect = map(
+        MockResponse,
+        [
+            {"workflow_runs": [{"id": 0}]},
+            {
+                "jobs": [
+                    {"id": 1, "conclusion": "success"},
+                    {"id": 2, "conclusion": "failure"},
+                ]
+            },
+        ],
+    )
+    with mock.patch("requests.Session.get", side_effect=side_effect):
+        list_failed_cross_version_tests.main()
+        actual = json.loads(capsys.readouterr().out)
+        assert actual == [{"id": 2, "conclusion": "failure"}]
+
+
+def test_no_jobs_fail(capsys):
+    side_effect = map(
+        MockResponse,
+        [
+            {"workflow_runs": [{"id": 0}]},
+            {
+                "jobs": [
+                    {"id": 1, "conclusion": "success"},
+                    {"id": 2, "conclusion": "success"},
+                ]
+            },
+        ],
+    )
+    with mock.patch("requests.Session.get", side_effect=side_effect):
+        list_failed_cross_version_tests.main()
+        actual = json.loads(capsys.readouterr().out)
+        assert actual == []
+
+
+def test_pagination(capsys):
+    jobs = [{"id": i, "conclusion": ("failure" if i % 2 else "success")} for i in range(150)]
+    side_effect = map(
+        MockResponse,
+        [
+            {"workflow_runs": [{"id": 0}]},
+            {"jobs": jobs[:100]},  # page 1
+            {"jobs": jobs[100:]},  # page 2
+        ],
+    )
+    with mock.patch("requests.Session.get", side_effect=side_effect):
+        list_failed_cross_version_tests.main()
+        actual = json.loads(capsys.readouterr().out)
+        expected = [j for j in jobs if j["conclusion"] == "failure"]
+        assert actual == expected


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

Add a python script to list failed cross version tests. This script will be called by our internal Jenkins job that automatically files ES tickets.

## How is this patch tested?

Unit tests

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
