### PR TITLE
Wrap flaky test in a retry

### DIFF
--- a/mlflow/R/mlflow/tests/testthat/test-model-mleap.R
+++ b/mlflow/R/mlflow/tests/testthat/test-model-mleap.R
@@ -7,7 +7,7 @@ for (i in 0:4){
         expr = {
             config <- spark_config()
             config$sparklyr.gateway.port <- httpuv::randomPort()
-            sc <- sparklyr::spark_connect(master = host, version = "2.4.5", config=config)
+            sc <- sparklyr::spark_connect(master = "local", version = "2.4.5", config=config)
         },
         error = function(e){
             if (i == 4){

--- a/mlflow/R/mlflow/tests/testthat/test-model-mleap.R
+++ b/mlflow/R/mlflow/tests/testthat/test-model-mleap.R
@@ -5,7 +5,8 @@ library(mleap)
 for (i in 0:4){
     tryCatch(
         expr = {
-            sc <- sparklyr::spark_connect(master = "local", version = "2.4.5")
+            host <- sprintf("local:%s"), 8881 + i)
+            sc <- sparklyr::spark_connect(master = host, version = "2.4.5")
         },
         error = function(e){
             if (i == 4){

--- a/mlflow/R/mlflow/tests/testthat/test-model-mleap.R
+++ b/mlflow/R/mlflow/tests/testthat/test-model-mleap.R
@@ -5,7 +5,7 @@ library(mleap)
 for (i in 0:4){
     tryCatch(
         expr = {
-            config <- spark_config()
+            config <- sparklyr::spark_config()
             config$sparklyr.gateway.port <- httpuv::randomPort()
             sc <- sparklyr::spark_connect(master = "local", version = "2.4.5", config=config)
         },

--- a/mlflow/R/mlflow/tests/testthat/test-model-mleap.R
+++ b/mlflow/R/mlflow/tests/testthat/test-model-mleap.R
@@ -14,7 +14,7 @@ for (i in 0:4){
             message("An error occured while getting a SparkContext:")
             print(e)
             sleep_duration = (2 * i) + 1
-            message(sprintf("\nSleeping for %s seconds and retrying...", sleep_duration)
+            message(sprintf("\nSleeping for %s seconds and retrying...", sleep_duration))
             Sys.sleep(sleep_duration)
         },
         warning = function(w){

--- a/mlflow/R/mlflow/tests/testthat/test-model-mleap.R
+++ b/mlflow/R/mlflow/tests/testthat/test-model-mleap.R
@@ -2,7 +2,28 @@ context("Model mleap")
 
 library(mleap)
 
-sc <- sparklyr::spark_connect(master = "local", version = "2.4.5")
+for (i in 0:4){
+    tryCatch(
+        expr = {
+            sc <- sparklyr::spark_connect(master = "local", version = "2.4.5")
+        },
+        error = function(e){
+            if (i == 4){
+                stop("Exhausted retries in getting SparkContext. Aborting.")
+            }
+            message("An error occured while getting a SparkContext:")
+            print(e)
+            sleep_duration = (2 * i) + 1
+            message(sprintf("\nSleeping for %s seconds and retrying...", sleep_duration)
+            Sys.sleep(sleep_duration)
+        },
+        warning = function(w){
+            message("A warning occurred:")
+            print(w)
+        }
+    )
+}
+
 testthat_model_dir <- basename(tempfile("model_"))
 
 teardown({

--- a/mlflow/R/mlflow/tests/testthat/test-model-mleap.R
+++ b/mlflow/R/mlflow/tests/testthat/test-model-mleap.R
@@ -5,8 +5,9 @@ library(mleap)
 for (i in 0:4){
     tryCatch(
         expr = {
-            host <- sprintf("local:%s", 8881 + i)
-            sc <- sparklyr::spark_connect(master = host, version = "2.4.5")
+            config <- spark_config()
+            config$sparklyr.gateway.port <- httpuv::randomPort()
+            sc <- sparklyr::spark_connect(master = host, version = "2.4.5", config=config)
         },
         error = function(e){
             if (i == 4){

--- a/mlflow/R/mlflow/tests/testthat/test-model-mleap.R
+++ b/mlflow/R/mlflow/tests/testthat/test-model-mleap.R
@@ -5,7 +5,7 @@ library(mleap)
 for (i in 0:4){
     tryCatch(
         expr = {
-            host <- sprintf("local:%s"), 8881 + i)
+            host <- sprintf("local:%s", 8881 + i)
             sc <- sparklyr::spark_connect(master = host, version = "2.4.5")
         },
         error = function(e){


### PR DESCRIPTION
Signed-off-by: Ben Wilson <benjamin.wilson@databricks.com>

## What changes are proposed in this pull request?

Wrap an infrequently failing R test SparkContext getter in mlflow.R.mlflow.tests.testthat.test-model-mleap.R in a retry loop with increasing wait times for each iteration to limit CI failures in this test suite.

## How is this patch tested?

locally

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [x] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
