### PR TITLE
test `spark_connect` flakiness

### DIFF
--- a/mlflow/R/mlflow/tests/testthat/test-model-mleap.R
+++ b/mlflow/R/mlflow/tests/testthat/test-model-mleap.R
@@ -2,6 +2,7 @@ context("Model mleap")
 
 library(mleap)
 
+options(sparklyr.log.console = TRUE)
 sc <- sparklyr::spark_connect(master = "local", version = "2.4.5")
 testthat_model_dir <- basename(tempfile("model_"))
 

--- a/mlflow/R/mlflow/tests/testthat/test-model-mleap.R
+++ b/mlflow/R/mlflow/tests/testthat/test-model-mleap.R
@@ -2,6 +2,7 @@ context("Model mleap")
 
 library(mleap)
 
+mlflow:::mlflow_cli("server", "-p", "8880", background = TRUE)
 options(sparklyr.log.console = TRUE)
 sc <- sparklyr::spark_connect(master = "local", version = "2.4.5")
 testthat_model_dir <- basename(tempfile("model_"))

--- a/mlflow/R/mlflow/tests/testthat/test-serve.R
+++ b/mlflow/R/mlflow/tests/testthat/test-serve.R
@@ -94,8 +94,7 @@ test_that("mlflow models server api works with R model function", {
   fn <- crate(~ stats::predict(model, .x), model = model)
   mlflow_save_model(fn, path = "model")
   expect_true(dir.exists("model"))
-  # port <- httpuv::randomPort()
-  port <- 8880
+  port <- httpuv::randomPort()
   testthat_model_server <<- mlflow:::mlflow_cli("models", "serve", "-m", "model", "-p", as.character(port),
     background = TRUE
   )

--- a/mlflow/R/mlflow/tests/testthat/test-serve.R
+++ b/mlflow/R/mlflow/tests/testthat/test-serve.R
@@ -94,7 +94,8 @@ test_that("mlflow models server api works with R model function", {
   fn <- crate(~ stats::predict(model, .x), model = model)
   mlflow_save_model(fn, path = "model")
   expect_true(dir.exists("model"))
-  port <- httpuv::randomPort()
+  # port <- httpuv::randomPort()
+  port <- 8880
   testthat_model_server <<- mlflow:::mlflow_cli("models", "serve", "-m", "model", "-p", as.character(port),
     background = TRUE
   )


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

(Details)

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
