### PR TITLE
Add support for azure china

### DIFF
--- a/mlflow/store/artifact/azure_blob_artifact_repo.py
+++ b/mlflow/store/artifact/azure_blob_artifact_repo.py
@@ -30,13 +30,13 @@ class AzureBlobArtifactRepository(ArtifactRepository):
 
         from azure.storage.blob import BlobServiceClient
 
-        (_, account, _) = AzureBlobArtifactRepository.parse_wasbs_uri(artifact_uri)
+        (_, account, _, api_uri) = AzureBlobArtifactRepository.parse_wasbs_uri(artifact_uri)
         if "AZURE_STORAGE_CONNECTION_STRING" in os.environ:
             self.client = BlobServiceClient.from_connection_string(
                 conn_str=os.environ.get("AZURE_STORAGE_CONNECTION_STRING")
             )
         elif "AZURE_STORAGE_ACCESS_KEY" in os.environ:
-            account_url = "https://{account}.blob.core.windows.net".format(account=account)
+            account_url = "https://{account}.{api_uri}".format(account=account, api_uri=api_uri)
             self.client = BlobServiceClient(
                 account_url=account_url, credential=os.environ.get("AZURE_STORAGE_ACCESS_KEY")
             )
@@ -49,7 +49,7 @@ class AzureBlobArtifactRepository(ArtifactRepository):
                     "Please install it via: pip install azure-identity"
                 ) from exc
 
-            account_url = "https://{account}.blob.core.windows.net".format(account=account)
+            account_url = "https://{account}.{api_uri}".format(account=account, api_uri=api_uri)
             self.client = BlobServiceClient(
                 account_url=account_url, credential=DefaultAzureCredential()
             )
@@ -60,20 +60,21 @@ class AzureBlobArtifactRepository(ArtifactRepository):
         parsed = urllib.parse.urlparse(uri)
         if parsed.scheme != "wasbs":
             raise Exception("Not a WASBS URI: %s" % uri)
-        match = re.match("([^@]+)@([^.]+)\\.blob\\.core\\.windows\\.net", parsed.netloc)
+        match = re.match("([^@]+)@([^.]+)\\.(blob\\.core\\.(windows\\.net|chinacloudapi\\.cn))", parsed.netloc)
         if match is None:
             raise Exception(
-                "WASBS URI must be of the form " "<container>@<account>.blob.core.windows.net"
+                "WASBS URI must be of the form " "<container>@<account>.blob.core.windows.net" " or <container>@<account>.blob.core.chinacloudapi.cn"
             )
         container = match.group(1)
         storage_account = match.group(2)
+        api_uri = match.group(3)
         path = parsed.path
         if path.startswith("/"):
             path = path[1:]
-        return container, storage_account, path
+        return container, storage_account, path, api_uri
 
     def log_artifact(self, local_file, artifact_path=None):
-        (container, _, dest_path) = self.parse_wasbs_uri(self.artifact_uri)
+        (container, _, dest_path, _) = self.parse_wasbs_uri(self.artifact_uri)
         container_client = self.client.get_container_client(container)
         if artifact_path:
             dest_path = posixpath.join(dest_path, artifact_path)
@@ -82,7 +83,7 @@ class AzureBlobArtifactRepository(ArtifactRepository):
             container_client.upload_blob(dest_path, file, overwrite=True)
 
     def log_artifacts(self, local_dir, artifact_path=None):
-        (container, _, dest_path) = self.parse_wasbs_uri(self.artifact_uri)
+        (container, _, dest_path, _) = self.parse_wasbs_uri(self.artifact_uri)
         container_client = self.client.get_container_client(container)
         if artifact_path:
             dest_path = posixpath.join(dest_path, artifact_path)
@@ -108,7 +109,7 @@ class AzureBlobArtifactRepository(ArtifactRepository):
         except ImportError:
             from azure.storage.blob._models import BlobPrefix
 
-        (container, _, artifact_path) = self.parse_wasbs_uri(self.artifact_uri)
+        (container, _, artifact_path, _) = self.parse_wasbs_uri(self.artifact_uri)
         container_client = self.client.get_container_client(container)
         dest_path = artifact_path
         if path:
@@ -139,7 +140,7 @@ class AzureBlobArtifactRepository(ArtifactRepository):
         return sorted(infos, key=lambda f: f.path)
 
     def _download_file(self, remote_file_path, local_path):
-        (container, _, remote_root_path) = self.parse_wasbs_uri(self.artifact_uri)
+        (container, _, remote_root_path, _) = self.parse_wasbs_uri(self.artifact_uri)
         container_client = self.client.get_container_client(container)
         remote_full_path = posixpath.join(remote_root_path, remote_file_path)
         with open(local_path, "wb") as file:

--- a/mlflow/store/artifact/azure_blob_artifact_repo.py
+++ b/mlflow/store/artifact/azure_blob_artifact_repo.py
@@ -36,7 +36,9 @@ class AzureBlobArtifactRepository(ArtifactRepository):
                 conn_str=os.environ.get("AZURE_STORAGE_CONNECTION_STRING")
             )
         elif "AZURE_STORAGE_ACCESS_KEY" in os.environ:
-            account_url = "https://{account}.{api_uri_suffix}".format(account=account, api_uri_suffix=api_uri_suffix)
+            account_url = "https://{account}.{api_uri_suffix}".format(
+                account=account, api_uri_suffix=api_uri_suffix
+            )
             self.client = BlobServiceClient(
                 account_url=account_url, credential=os.environ.get("AZURE_STORAGE_ACCESS_KEY")
             )
@@ -49,7 +51,9 @@ class AzureBlobArtifactRepository(ArtifactRepository):
                     "Please install it via: pip install azure-identity"
                 ) from exc
 
-            account_url = "https://{account}.{api_uri_suffix}".format(account=account, api_uri_suffix=api_uri_suffix)
+            account_url = "https://{account}.{api_uri_suffix}".format(
+                account=account, api_uri_suffix=api_uri_suffix
+            )
             self.client = BlobServiceClient(
                 account_url=account_url, credential=DefaultAzureCredential()
             )
@@ -60,10 +64,16 @@ class AzureBlobArtifactRepository(ArtifactRepository):
         parsed = urllib.parse.urlparse(uri)
         if parsed.scheme != "wasbs":
             raise Exception("Not a WASBS URI: %s" % uri)
-        match = re.match(r"([^@]+)@([^.]+)\.(blob\.core\.(windows\.net|chinacloudapi\.cn))", parsed.netloc)
+
+        match = re.match(
+            r"([^@]+)@([^.]+)\.(blob\.core\.(windows\.net|chinacloudapi\.cn))", parsed.netloc
+        )
+
         if match is None:
             raise Exception(
-                "WASBS URI must be of the form " "<container>@<account>.blob.core.windows.net" " or <container>@<account>.blob.core.chinacloudapi.cn"
+                "WASBS URI must be of the form "
+                "<container>@<account>.blob.core.windows.net"
+                " or <container>@<account>.blob.core.chinacloudapi.cn"
             )
         container = match.group(1)
         storage_account = match.group(2)

--- a/mlflow/store/artifact/azure_blob_artifact_repo.py
+++ b/mlflow/store/artifact/azure_blob_artifact_repo.py
@@ -60,7 +60,7 @@ class AzureBlobArtifactRepository(ArtifactRepository):
         parsed = urllib.parse.urlparse(uri)
         if parsed.scheme != "wasbs":
             raise Exception("Not a WASBS URI: %s" % uri)
-        match = re.match("([^@]+)@([^.]+)\\.(blob\\.core\\.(windows\\.net|chinacloudapi\\.cn))", parsed.netloc)
+        match = re.match(r"([^@]+)@([^.]+)\.(blob\.core\.(windows\.net|chinacloudapi\.cn))", parsed.netloc)
         if match is None:
             raise Exception(
                 "WASBS URI must be of the form " "<container>@<account>.blob.core.windows.net" " or <container>@<account>.blob.core.chinacloudapi.cn"

--- a/mlflow/store/artifact/azure_blob_artifact_repo.py
+++ b/mlflow/store/artifact/azure_blob_artifact_repo.py
@@ -56,7 +56,7 @@ class AzureBlobArtifactRepository(ArtifactRepository):
 
     @staticmethod
     def parse_wasbs_uri(uri):
-        """Parse a wasbs:// URI, returning (container, storage_account, path)."""
+        """Parse a wasbs:// URI, returning (container, storage_account, path, api_uri_suffix)."""
         parsed = urllib.parse.urlparse(uri)
         if parsed.scheme != "wasbs":
             raise Exception("Not a WASBS URI: %s" % uri)
@@ -67,11 +67,11 @@ class AzureBlobArtifactRepository(ArtifactRepository):
             )
         container = match.group(1)
         storage_account = match.group(2)
-        api_uri = match.group(3)
+        api_uri_suffix = match.group(3)
         path = parsed.path
         if path.startswith("/"):
             path = path[1:]
-        return container, storage_account, path, api_uri
+        return container, storage_account, path, api_uri_suffix
 
     def log_artifact(self, local_file, artifact_path=None):
         (container, _, dest_path, _) = self.parse_wasbs_uri(self.artifact_uri)

--- a/mlflow/store/artifact/azure_blob_artifact_repo.py
+++ b/mlflow/store/artifact/azure_blob_artifact_repo.py
@@ -30,13 +30,13 @@ class AzureBlobArtifactRepository(ArtifactRepository):
 
         from azure.storage.blob import BlobServiceClient
 
-        (_, account, _, api_uri) = AzureBlobArtifactRepository.parse_wasbs_uri(artifact_uri)
+        (_, account, _, api_uri_suffix) = AzureBlobArtifactRepository.parse_wasbs_uri(artifact_uri)
         if "AZURE_STORAGE_CONNECTION_STRING" in os.environ:
             self.client = BlobServiceClient.from_connection_string(
                 conn_str=os.environ.get("AZURE_STORAGE_CONNECTION_STRING")
             )
         elif "AZURE_STORAGE_ACCESS_KEY" in os.environ:
-            account_url = "https://{account}.{api_uri}".format(account=account, api_uri=api_uri)
+            account_url = "https://{account}.{api_uri_suffix}".format(account=account, api_uri_suffix=api_uri_suffix)
             self.client = BlobServiceClient(
                 account_url=account_url, credential=os.environ.get("AZURE_STORAGE_ACCESS_KEY")
             )
@@ -49,7 +49,7 @@ class AzureBlobArtifactRepository(ArtifactRepository):
                     "Please install it via: pip install azure-identity"
                 ) from exc
 
-            account_url = "https://{account}.{api_uri}".format(account=account, api_uri=api_uri)
+            account_url = "https://{account}.{api_uri_suffix}".format(account=account, api_uri_suffix=api_uri_suffix)
             self.client = BlobServiceClient(
                 account_url=account_url, credential=DefaultAzureCredential()
             )

--- a/tests/store/artifact/test_azure_blob_artifact_repo.py
+++ b/tests/store/artifact/test_azure_blob_artifact_repo.py
@@ -62,10 +62,20 @@ def test_default_az_cred_if_no_env_vars(mock_default_azure_credential, mock_clie
 
 def test_parse_global_wasbs_uri():
     parse = AzureBlobArtifactRepository.parse_wasbs_uri
-    assert parse("wasbs://cont@acct.blob.core.windows.net/path") == ("cont", "acct", "path", "blob.core.windows.net")
-    assert parse("wasbs://cont@acct.blob.core.windows.net") == ("cont", "acct", "", "blob.core.windows.net")
-    assert parse("wasbs://cont@acct.blob.core.windows.net/") == ("cont", "acct", "", "blob.core.windows.net")
-    assert parse("wasbs://cont@acct.blob.core.windows.net/a/b") == ("cont", "acct", "a/b", "blob.core.windows.net")
+    global_api_suffix = "blob.core.windows.net"
+
+    global_wasb_with_short_path = "wasbs://cont@acct.blob.core.windows.net/path"
+    assert parse(global_wasb_with_short_path) == ("cont", "acct", "path", global_api_suffix)
+
+    global_wasb_without_path = "wasbs://cont@acct.blob.core.windows.net"
+    assert parse(global_wasb_without_path) == ("cont", "acct", "", global_api_suffix)
+
+    global_wasb_without_path2 = "wasbs://cont@acct.blob.core.windows.net/"
+    assert parse(global_wasb_without_path2) == ("cont", "acct", "", global_api_suffix)
+
+    global_wasb_with_multi_path = "wasbs://cont@acct.blob.core.windows.net/a/b"
+    assert parse(global_wasb_with_multi_path) == ("cont", "acct", "a/b", global_api_suffix)
+
     with pytest.raises(Exception, match="WASBS URI must be of the form"):
         parse("wasbs://cont@acct.blob.core.evil.net/path")
     with pytest.raises(Exception, match="WASBS URI must be of the form"):
@@ -82,12 +92,22 @@ def test_parse_global_wasbs_uri():
 
 def test_parse_cn_wasbs_uri():
     parse = AzureBlobArtifactRepository.parse_wasbs_uri
-    assert parse("wasbs://cont@acct.blob.core.chinacloudapi.cn/path") == ("cont", "acct", "path", "blob.core.chinacloudapi.cn")
-    assert parse("wasbs://cont@acct.blob.core.chinacloudapi.cn") == ("cont", "acct", "", "blob.core.chinacloudapi.cn")
-    assert parse("wasbs://cont@acct.blob.core.chinacloudapi.cn/") == ("cont", "acct", "", "blob.core.chinacloudapi.cn")
-    assert parse("wasbs://cont@acct.blob.core.chinacloudapi.cn/a/b") == ("cont", "acct", "a/b", "blob.core.chinacloudapi.cn")
+    cn_api_suffix = "blob.core.chinacloudapi.cn"
+
+    cn_wasb_with_short_path = "wasbs://cont@acct.blob.core.chinacloudapi.cn/path"
+    assert parse(cn_wasb_with_short_path) == ("cont", "acct", "path", cn_api_suffix)
+
+    cn_wasb_without_path = "wasbs://cont@acct.blob.core.chinacloudapi.cn"
+    assert parse(cn_wasb_without_path) == ("cont", "acct", "", cn_api_suffix)
+
+    cn_wasb_without_path2 = "wasbs://cont@acct.blob.core.chinacloudapi.cn/"
+    assert parse(cn_wasb_without_path2) == ("cont", "acct", "", cn_api_suffix)
+
+    cn_wasb_with_multi_path = "wasbs://cont@acct.blob.core.chinacloudapi.cn/a/b"
+    assert parse(cn_wasb_with_multi_path) == ("cont", "acct", "a/b", cn_api_suffix)
+
     with pytest.raises(Exception, match="WASBS URI must be of the form"):
-        parse("wasbs://cont@acct.blob.core.chinacloudapi.cn/path")
+        parse("wasbs://cont@acct.blob.core.evil.cn/path")
     with pytest.raises(Exception, match="WASBS URI must be of the form"):
         parse("wasbs://cont@acct/path")
     with pytest.raises(Exception, match="WASBS URI must be of the form"):

--- a/tests/store/artifact/test_azure_blob_artifact_repo.py
+++ b/tests/store/artifact/test_azure_blob_artifact_repo.py
@@ -60,12 +60,12 @@ def test_default_az_cred_if_no_env_vars(mock_default_azure_credential, mock_clie
     assert mock_default_azure_credential.call_count == 1
 
 
-def test_parse_wasbs_uri():
+def test_parse_global_wasbs_uri():
     parse = AzureBlobArtifactRepository.parse_wasbs_uri
-    assert parse("wasbs://cont@acct.blob.core.windows.net/path") == ("cont", "acct", "path")
-    assert parse("wasbs://cont@acct.blob.core.windows.net") == ("cont", "acct", "")
-    assert parse("wasbs://cont@acct.blob.core.windows.net/") == ("cont", "acct", "")
-    assert parse("wasbs://cont@acct.blob.core.windows.net/a/b") == ("cont", "acct", "a/b")
+    assert parse("wasbs://cont@acct.blob.core.windows.net/path") == ("cont", "acct", "path", "blob.core.windows.net")
+    assert parse("wasbs://cont@acct.blob.core.windows.net") == ("cont", "acct", "", "blob.core.windows.net")
+    assert parse("wasbs://cont@acct.blob.core.windows.net/") == ("cont", "acct", "", "blob.core.windows.net")
+    assert parse("wasbs://cont@acct.blob.core.windows.net/a/b") == ("cont", "acct", "a/b", "blob.core.windows.net")
     with pytest.raises(Exception, match="WASBS URI must be of the form"):
         parse("wasbs://cont@acct.blob.core.evil.net/path")
     with pytest.raises(Exception, match="WASBS URI must be of the form"):
@@ -78,6 +78,26 @@ def test_parse_wasbs_uri():
         parse("wasbs://cont@acctxblob.core.windows.net/path")
     with pytest.raises(Exception, match="Not a WASBS URI"):
         parse("wasb://cont@acct.blob.core.windows.net/path")
+
+
+def test_parse_cn_wasbs_uri():
+    parse = AzureBlobArtifactRepository.parse_wasbs_uri
+    assert parse("wasbs://cont@acct.blob.core.chinacloudapi.cn/path") == ("cont", "acct", "path", "blob.core.chinacloudapi.cn")
+    assert parse("wasbs://cont@acct.blob.core.chinacloudapi.cn") == ("cont", "acct", "", "blob.core.chinacloudapi.cn")
+    assert parse("wasbs://cont@acct.blob.core.chinacloudapi.cn/") == ("cont", "acct", "", "blob.core.chinacloudapi.cn")
+    assert parse("wasbs://cont@acct.blob.core.chinacloudapi.cn/a/b") == ("cont", "acct", "a/b", "blob.core.chinacloudapi.cn")
+    with pytest.raises(Exception, match="WASBS URI must be of the form"):
+        parse("wasbs://cont@acct.blob.core.chinacloudapi.cn/path")
+    with pytest.raises(Exception, match="WASBS URI must be of the form"):
+        parse("wasbs://cont@acct/path")
+    with pytest.raises(Exception, match="WASBS URI must be of the form"):
+        parse("wasbs://acct.blob.core.chinacloudapi.cn/path")
+    with pytest.raises(Exception, match="WASBS URI must be of the form"):
+        parse("wasbs://@acct.blob.core.chinacloudapi.cn/path")
+    with pytest.raises(Exception, match="WASBS URI must be of the form"):
+        parse("wasbs://cont@acctxblob.core.chinacloudapi.cn/path")
+    with pytest.raises(Exception, match="Not a WASBS URI"):
+        parse("wasb://cont@acct.blob.core.chinacloudapi.cn/path")
 
 
 def test_list_artifacts_empty(mock_client):


### PR DESCRIPTION
## What changes are proposed in this pull request?

Update the regex pattern to parse azure wasbs uri for azure china.

## How is this patch tested?

Unit tests (tests/store/artifact/test_azure_blob_artifact_repo.py)

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
