### PR TITLE
Parse subdirectory with quotes

### DIFF
--- a/mlflow/projects/utils.py
+++ b/mlflow/projects/utils.py
@@ -50,14 +50,19 @@ _logger = logging.getLogger(__name__)
 def _parse_subdirectory(uri):
     # Parses a uri and returns the uri and subdirectory as separate values.
     # Uses '#' as a delimiter.
+    unquoted_uri = _strip_quotes(uri)
     subdirectory = ""
-    parsed_uri = uri
-    if "#" in uri:
-        subdirectory = uri[uri.find("#") + 1 :]
-        parsed_uri = uri[: uri.find("#")]
+    parsed_uri = unquoted_uri
+    if "#" in unquoted_uri:
+        subdirectory = unquoted_uri[unquoted_uri.find("#") + 1 :]
+        parsed_uri = unquoted_uri[: unquoted_uri.find("#")]
     if subdirectory and "." in subdirectory:
         raise ExecutionException("'.' is not allowed in project subdirectory paths.")
     return parsed_uri, subdirectory
+
+
+def _strip_quotes(uri):
+    return uri.strip("'\"")
 
 
 def _get_storage_dir(storage_dir):

--- a/tests/projects/test_utils.py
+++ b/tests/projects/test_utils.py
@@ -137,6 +137,12 @@ def test_parse_subdirectory():
     assert parsed_uri == "uri"
     assert parsed_subdirectory == "subdirectory"
 
+    # Make sure the parsing works with quotes.
+    test_uri = "'uri#subdirectory'"
+    parsed_uri, parsed_subdirectory = _parse_subdirectory(test_uri)
+    assert parsed_uri == "uri"
+    assert parsed_subdirectory == "subdirectory"
+
     # Make sure periods are restricted in Git repo subdirectory paths.
     period_fail_uri = GIT_PROJECT_URI + "#.."
     with pytest.raises(ExecutionException):


### PR DESCRIPTION
Signed-off-by: dinaldoap <dinaldoap@gmail.com>

## What changes are proposed in this pull request?

Currently, mlflow.projects._parse_subdirectory splits uri by the character '#' and leaves unpaired quotes in parsed_uri and subdirectory. For example, **uri = 'parsed_uri#subdirectory'** becomes **parsed_uri='parsed_uri** and **subdirectory=subdirectory'**.

The proposed solution is to remove quotes from parsed_uri and subdirectory and add them back only when necessary.

## How is this patch tested?

The test is located in tests/projects/test_utils.py, function test_parse_subdirectory.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
Fix mlflow run to work with quoted URIs.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
