### PR TITLE
Replace `searchPlaceholder` for `TreeSelect` with `placeholder`

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/MetricsPlotControls.js
+++ b/mlflow/server/js/src/experiment-tracking/components/MetricsPlotControls.js
@@ -143,7 +143,7 @@ export class MetricsPlotControlsImpl extends React.Component {
           </div>
           <TreeSelect
             className='metrics-select'
-            searchPlaceholder={this.props.intl.formatMessage({
+            placeholder={this.props.intl.formatMessage({
               defaultMessage: 'Please select metric',
               description:
                 // eslint-disable-next-line max-len

--- a/mlflow/server/js/src/experiment-tracking/components/ParallelCoordinatesPlotControls.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ParallelCoordinatesPlotControls.js
@@ -37,7 +37,7 @@ export class ParallelCoordinatesPlotControls extends React.Component {
         </div>
         <TreeSelect
           className='metrics-select'
-          searchPlaceholder={
+          placeholder={
             <FormattedMessage
               defaultMessage='Please select parameters'
               description='Placeholder text for parameters in parallel coordinates plot in MLflow'
@@ -58,7 +58,7 @@ export class ParallelCoordinatesPlotControls extends React.Component {
         </div>
         <TreeSelect
           className='metrics-select'
-          searchPlaceholder={
+          placeholder={
             <FormattedMessage
               defaultMessage='Please select metrics'
               description='Placeholder text for metrics in parallel coordinates plot in MLflow'


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

The `searchPlaceholder` prop for the `TreeSelect` component no longer exists in ant-design 4.x (https://github.com/ant-design/ant-design/pull/21243 removed it). We should use `placeholder` instead.

<img width="776" alt="Screen Shot 2021-11-29 at 17 02 25" src="https://user-images.githubusercontent.com/17039389/143829902-10a37041-fe7f-4524-be14-0576ab292720.png">

### Before

No placeholder shows up in the Y-axis selector.

<img width="377" alt="Screen Shot 2021-11-29 at 17 02 11" src="https://user-images.githubusercontent.com/17039389/143829824-f32f895d-eb60-487d-b0ab-f5e21f077c22.png">

### After

<img width="377" alt="Screen Shot 2021-11-29 at 17 01 36" src="https://user-images.githubusercontent.com/17039389/143829855-59b4f398-769c-4171-8b23-3b5ccf017483.png">

## How is this patch tested?

Manually verified that the placeholder shows up and the warning message doesn't.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
