### PR TITLE
Remove `mlruns` directory in module teardown

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import os
 import inspect
+import shutil
 from unittest import mock
 
 import pytest
@@ -96,3 +97,12 @@ def prevent_infer_pip_requirements_fallback(request):
             yield
     else:
         yield
+
+
+@pytest.fixture(autouse=True, scope="module")
+def clean_up_mlruns_direcotry(request):
+    """
+    Clean up an `mlruns` directory in module teardown.
+    """
+    yield
+    shutil.rmtree(os.path.join(request.config.rootpath, "mlruns"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import stat
 import inspect
 import shutil
 from unittest import mock
@@ -99,6 +100,11 @@ def prevent_infer_pip_requirements_fallback(request):
         yield
 
 
+def on_rm_error(func, path, exc_info):  # pylint: disable=unused-argument
+    os.chmod(path, stat.S_IWRITE)
+    os.unlink(path)
+
+
 @pytest.fixture(autouse=True, scope="module")
 def clean_up_mlruns_direcotry(request):
     """
@@ -107,4 +113,4 @@ def clean_up_mlruns_direcotry(request):
     yield
     mlruns_dir = os.path.join(request.config.rootpath, "mlruns")
     if os.path.exists(mlruns_dir):
-        shutil.rmtree(mlruns_dir)
+        shutil.rmtree(mlruns_dir, onerror=on_rm_error)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,4 +105,6 @@ def clean_up_mlruns_direcotry(request):
     Clean up an `mlruns` directory on each test module teardown.
     """
     yield
-    shutil.rmtree(os.path.join(request.config.rootpath, "mlruns"))
+    mlruns_dir = os.path.join(request.config.rootpath, "mlruns")
+    if os.path.exists(mlruns_dir):
+        shutil.rmtree(mlruns_dir)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,7 +102,7 @@ def prevent_infer_pip_requirements_fallback(request):
 @pytest.fixture(autouse=True, scope="module")
 def clean_up_mlruns_direcotry(request):
     """
-    Clean up an `mlruns` directory in module teardown.
+    Clean up an `mlruns` directory on each test module teardown.
     """
     yield
     shutil.rmtree(os.path.join(request.config.rootpath, "mlruns"))


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

Remove `mlruns` directory in module teardown to save the disk space on CI and make it easier to reproduce failures.

## How is this patch tested?

NA

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
