### PR TITLE
Track server metrics for all endpoints, remove high cardinality path label

### DIFF
--- a/mlflow/server/prometheus_exporter.py
+++ b/mlflow/server/prometheus_exporter.py
@@ -1,32 +1,19 @@
 from prometheus_flask_exporter.multiprocess import GunicornInternalPrometheusMetrics
 from flask import request
 
+import mlflow
+
 
 def activate_prometheus_exporter(app):
-    metrics = GunicornInternalPrometheusMetrics(app, export_defaults=False)
+    def mlflow_version(req: request):
+        return mlflow.__version__
 
-    endpoint = app.view_functions
-    histogram = metrics.histogram(
-        "mlflow_requests_by_status_and_path",
-        "Request latencies and count by status and path",
-        labels={
-            "status": lambda r: r.status_code,
-            "path": lambda: change_path_for_metric(request.path),
-        },
+    metrics = GunicornInternalPrometheusMetrics(
+        app, 
+        export_defaults=True, 
+        defaults_prefix="mlflow",
+        excluded_paths=["/health"],
+        group_by=mlflow_version
     )
-    for func_name, func in endpoint.items():
-        if func_name in ["_search_runs", "_log_metric", "_log_param", "_set_tag", "_create_run"]:
-            app.view_functions[func_name] = histogram(func)
 
     return app
-
-
-def change_path_for_metric(path):
-    """
-    Replace the '/' in the metric path by '_' so grafana can correctly use it.
-    :param path: path of the metric (example: runs/search)
-    :return: path with '_' instead of '/'
-    """
-    if "mlflow/" in path:
-        path = path.split("mlflow/")[-1]
-    return path.replace("/", "_")

--- a/mlflow/server/prometheus_exporter.py
+++ b/mlflow/server/prometheus_exporter.py
@@ -1,12 +1,11 @@
 from prometheus_flask_exporter.multiprocess import GunicornInternalPrometheusMetrics
 from flask import request
 
-import mlflow
-
+from mlflow.version import VERSION
 
 def activate_prometheus_exporter(app):
     def mlflow_version(req: request):
-        return mlflow.__version__
+        return VERSION
 
     metrics = GunicornInternalPrometheusMetrics(
         app,

--- a/mlflow/server/prometheus_exporter.py
+++ b/mlflow/server/prometheus_exporter.py
@@ -5,7 +5,7 @@ from mlflow.version import VERSION
 
 
 def activate_prometheus_exporter(app):
-    def mlflow_version(req: request):  # noqa: W0613
+    def mlflow_version(req: request):  # pylint: disable=unused-argument
         return VERSION
 
     metrics = GunicornInternalPrometheusMetrics(

--- a/mlflow/server/prometheus_exporter.py
+++ b/mlflow/server/prometheus_exporter.py
@@ -3,8 +3,9 @@ from flask import request
 
 from mlflow.version import VERSION
 
+
 def activate_prometheus_exporter(app):
-    def mlflow_version(req: request):
+    def mlflow_version(req: request):  # noqa: W0613
         return VERSION
 
     metrics = GunicornInternalPrometheusMetrics(

--- a/mlflow/server/prometheus_exporter.py
+++ b/mlflow/server/prometheus_exporter.py
@@ -9,11 +9,11 @@ def activate_prometheus_exporter(app):
         return mlflow.__version__
 
     metrics = GunicornInternalPrometheusMetrics(
-        app, 
-        export_defaults=True, 
+        app,
+        export_defaults=True,
         defaults_prefix="mlflow",
         excluded_paths=["/health"],
-        group_by=mlflow_version
+        group_by=mlflow_version,
     )
 
-    return app
+    return metrics

--- a/mlflow/server/prometheus_exporter.py
+++ b/mlflow/server/prometheus_exporter.py
@@ -5,7 +5,7 @@ from mlflow.version import VERSION
 
 
 def activate_prometheus_exporter(app):
-    def mlflow_version(req: request):  # pylint: disable=unused-argument
+    def mlflow_version(_: request):
         return VERSION
 
     metrics = GunicornInternalPrometheusMetrics(

--- a/tests/server/test_prometheus_exporter.py
+++ b/tests/server/test_prometheus_exporter.py
@@ -1,0 +1,50 @@
+import os
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+import pytest
+
+from mlflow.server.prometheus_exporter import activate_prometheus_exporter
+
+tmpdir = TemporaryDirectory()
+
+
+@pytest.fixture()
+def app():
+    from mlflow.server import app
+
+    ctx = app.app_context()
+    ctx.push()
+    yield app
+    ctx.pop()
+
+
+@mock.patch.dict(os.environ, {"PROMETHEUS_MULTIPROC_DIR": tmpdir.name})
+def test_metrics(app):
+    metrics = activate_prometheus_exporter(app)
+    metric_labels = {"method": "GET", "status": "200"}
+
+    with app.test_client() as c:
+        assert (
+            metrics.registry.get_sample_value("mlflow_http_request_total", labels=metric_labels)
+            is None
+        )
+        c.get("/")
+        assert (
+            metrics.registry.get_sample_value("mlflow_http_request_total", labels=metric_labels)
+            == 1
+        )
+
+        # calling the metrics endpoint should not increment the counter
+        c.get("/metrics")
+        assert (
+            metrics.registry.get_sample_value("mlflow_http_request_total", labels=metric_labels)
+            == 1
+        )
+
+        # calling the health endpoint should not increment the counter
+        c.get("/health")
+        assert (
+            metrics.registry.get_sample_value("mlflow_http_request_total", labels=metric_labels)
+            == 1
+        )


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR updates the Prometheus metrics exporter to include all routes (except for the health endpoint) and removes the path label due to its high cardinality.

Fixes #5025

## How is this patch tested?

Added unit tests to ensure metrics are being exported with the appropriate labels.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Prometheus metrics are now tracked for **_all_** endpoints; previously, metrics were only recorded for `["_search_runs", "_log_metric", "_log_param", "_set_tag", "_create_run"]`. Additionally, the metrics names are slightly different so you'll want to be sure to update your PromQL queries appropriately. `mlflow_requests_by_status_and_path_{bucket/count/sum}` metrics are now named `mlflow_http_request_duration_seconds_{bucket/count/sum}`. Finally, we no longer include the `path` label due to its high cardinality now that all endpoints (currently 46) are tracked.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [x] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
