### PR TITLE
Deprecate python 3.6

### DIFF
--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -27,6 +27,8 @@ implement mutual exclusion manually.
 
 For a lower level API, see the :py:mod:`mlflow.tracking` module.
 """
+import sys
+
 from mlflow.version import VERSION as __version__  # pylint: disable=unused-import
 from mlflow.utils.logging_utils import _configure_mlflow_loggers
 import mlflow.tracking._model_registry.fluent
@@ -97,25 +99,24 @@ except ImportError as e:
 
 _configure_mlflow_loggers(root_module_name=__name__)
 
-# TODO: Uncomment this block when deprecating Python 3.6 support
-# _major = 3
-# _minor = 6
-# _deprecated_version = (_major, _minor)
-# _min_supported_version = (_major, _minor + 1)
+_major = 3
+_minor = 6
+_deprecated_version = (_major, _minor)
+_min_supported_version = (_major, _minor + 1)
 
-# if sys.version_info[:2] == _deprecated_version:
-#     warnings.warn(
-#         "MLflow support for Python {dep_ver} is deprecated and will be dropped in "
-#         "an upcoming release. At that point, existing Python {dep_ver} workflows "
-#         "that use MLflow will continue to work without modification, but Python {dep_ver} "
-#         "users will no longer get access to the latest MLflow features and bugfixes. "
-#         "We recommend that you upgrade to Python {min_ver} or newer.".format(
-#             dep_ver=".".join(map(str, _deprecated_version)),
-#             min_ver=".".join(map(str, _min_supported_version)),
-#         ),
-#         FutureWarning,
-#         stacklevel=2,
-#     )
+if sys.version_info[:2] == _deprecated_version:
+    warnings.warn(
+        "MLflow support for Python {dep_ver} is deprecated and will be dropped in "
+        "an upcoming release. At that point, existing Python {dep_ver} workflows "
+        "that use MLflow will continue to work without modification, but Python {dep_ver} "
+        "users will no longer get access to the latest MLflow features and bugfixes. "
+        "We recommend that you upgrade to Python {min_ver} or newer.".format(
+            dep_ver=".".join(map(str, _deprecated_version)),
+            min_ver=".".join(map(str, _min_supported_version)),
+        ),
+        FutureWarning,
+        stacklevel=2,
+    )
 
 ActiveRun = mlflow.tracking.fluent.ActiveRun
 log_param = mlflow.tracking.fluent.log_param


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Deprecate python 3.6 which will reach EOL on 2021/12/23.

## How is this patch tested?

Manually confirmed the warning is raised in python 3.6.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
