### PR TITLE
Checkout to fork branch  when running autoformat bot

### DIFF
--- a/.github/workflows/autoformat.js
+++ b/.github/workflows/autoformat.js
@@ -18,9 +18,10 @@ const createStatus = async (context, github) => {
   const pull_number = context.issue.number;
   const pr = await github.pulls.get({ owner, repo, pull_number });
   const { sha, ref } = pr.data.head;
+  const repository = pr.data.repo.full_name;
   await createCommitStatus(context, github, sha, 'pending');
   return {
-    repository: `${owner}/${repo}`,
+    repository,
     pull_number,
     sha,
     ref,

--- a/.github/workflows/autoformat.js
+++ b/.github/workflows/autoformat.js
@@ -13,13 +13,16 @@ const createCommitStatus = async (context, github, sha, state) => {
   });
 };
 
-const createStatus = async (context, github) => {
+const createStatus = async (context, github, core) => {
   const { owner, repo } = context.repo;
   const pull_number = context.issue.number;
   const pr = await github.pulls.get({ owner, repo, pull_number });
   const { sha, ref } = pr.data.head;
   const repository = pr.data.repo.full_name;
   await createCommitStatus(context, github, sha, 'pending');
+  if (repository === 'mlflow/mlflow' && ref === 'master') {
+    core.setFailed('Running autoformat bot against master branch of mlflow/mlflow is not allowed.');
+  }
   return {
     repository,
     pull_number,

--- a/.github/workflows/autoformat.js
+++ b/.github/workflows/autoformat.js
@@ -17,14 +17,17 @@ const createStatus = async (context, github, core) => {
   const { owner, repo } = context.repo;
   const pull_number = context.issue.number;
   const pr = await github.pulls.get({ owner, repo, pull_number });
-  const { sha, ref } = pr.data.head;
-  const repository = pr.data.repo.full_name;
+  const {
+    sha,
+    ref,
+    repo: { full_name },
+  } = pr.data.head;
   await createCommitStatus(context, github, sha, 'pending');
-  if (repository === 'mlflow/mlflow' && ref === 'master') {
+  if (full_name === 'mlflow/mlflow' && ref === 'master') {
     core.setFailed('Running autoformat bot against master branch of mlflow/mlflow is not allowed.');
   }
   return {
-    repository,
+    repository: full_name,
     pull_number,
     sha,
     ref,

--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -36,7 +36,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const autoformat = require('./.github/workflows/autoformat.js');
-            return await autoformat.createStatus(context, github);
+            return await autoformat.createStatus(context, github, core);
 
   check-diff:
     runs-on: ubuntu-latest

--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Check diff
         id: check-diff
         run: |
-          repository="${{ needs.check-comment.outputs.repository }}"
+          repository="${{ github.repository }}"
           pull_number="${{ needs.check-comment.outputs.pull_number }}"
           changed_files="$(python dev/list_changed_files.py --repository $repository --pr-num $pull_number)"
           py_changed=$([[ -z $(echo "$changed_files" | grep '\.py$') ]] && echo "false" || echo "true")


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

Checkout to fork branch when running autoformatting bot.

## How is this patch tested?

NA

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
