### PR TITLE
Log model uuid

### DIFF
--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -4,6 +4,7 @@ import logging
 
 import yaml
 import os
+import uuid
 
 from typing import Any, Dict, Optional
 
@@ -41,6 +42,7 @@ class Model(object):
         flavors=None,
         signature=None,  # ModelSignature
         saved_input_example_info: Dict[str, Any] = None,
+        model_uuid=None,
         **kwargs,
     ):
         # store model id instead of run_id and path to avoid confusion when model gets exported
@@ -52,6 +54,10 @@ class Model(object):
         self.flavors = flavors if flavors is not None else {}
         self.signature = signature
         self.saved_input_example_info = saved_input_example_info
+        if self.model_uuid is None:
+            self.model_uuid = uuid.uuid4()
+        else:
+            self.model_uuid = model_uuid
         self.__dict__.update(kwargs)
 
     def __eq__(self, other):
@@ -98,6 +104,8 @@ class Model(object):
             res["signature"] = self.signature.to_dict()
         if self.saved_input_example_info is not None:
             res["saved_input_example_info"] = self.saved_input_example_info
+
+        res["model_uuid"] = self.model_uuid
         return res
 
     def to_yaml(self, stream=None):

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -54,8 +54,8 @@ class Model(object):
         self.flavors = flavors if flavors is not None else {}
         self.signature = signature
         self.saved_input_example_info = saved_input_example_info
-        if self.model_uuid is None:
-            self.model_uuid = uuid.uuid4()
+        if model_uuid is None:
+            self.model_uuid = str(uuid.uuid4())
         else:
             self.model_uuid = model_uuid
         self.__dict__.update(kwargs)

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -54,10 +54,7 @@ class Model(object):
         self.flavors = flavors if flavors is not None else {}
         self.signature = signature
         self.saved_input_example_info = saved_input_example_info
-        if model_uuid is None:
-            self.model_uuid = str(uuid.uuid4())
-        else:
-            self.model_uuid = model_uuid
+        self.model_uuid = uuid.uuid4().hex if model_uuid is None else model_uuid
         self.__dict__.update(kwargs)
 
     def __eq__(self, other):
@@ -104,8 +101,6 @@ class Model(object):
             res["signature"] = self.signature.to_dict()
         if self.saved_input_example_info is not None:
             res["saved_input_example_info"] = self.saved_input_example_info
-
-        res["model_uuid"] = self.model_uuid
         return res
 
     def to_yaml(self, stream=None):

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -44,6 +44,7 @@ def test_model_save_load():
         saved_input_example_info={"x": 1, "y": 2},
     )
     n.utc_time_created = m.utc_time_created
+    n.model_uuid = m.model_uuid
     assert m == n
     n.signature = None
     assert m != n

--- a/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
+++ b/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
@@ -567,7 +567,8 @@ def _is_valid_uuid(val):
 
 def test_model_uuid():
     m = Model()
-    assert m.model_uuid and _is_valid_uuid(m.model_uuid)
+    assert m.model_uuid is not None
+    assert _is_valid_uuid(m.model_uuid)
     m_dict = m.to_dict()
     assert m_dict['model_uuid'] == m.model_uuid
     m2 = Model.from_dict(m_dict)

--- a/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
+++ b/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
@@ -556,9 +556,18 @@ def test_column_schema_enforcement_no_col_names():
     assert pyfunc_model.predict(d).equals(pd.DataFrame(d))
 
 
+def _is_valid_uuid(val):
+    import uuid
+    try:
+        uuid.UUID(str(val))
+        return True
+    except ValueError:
+        return False
+
+
 def test_model_uuid():
     m = Model()
-    assert m.model_uuid and len(m.model_uuid) == 32
+    assert m.model_uuid and _is_valid_uuid(m.model_uuid)
     m_dict = m.to_dict()
     assert m_dict['model_uuid'] == m.model_uuid
     m2 = Model.from_dict(m_dict)

--- a/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
+++ b/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
@@ -556,6 +556,15 @@ def test_column_schema_enforcement_no_col_names():
     assert pyfunc_model.predict(d).equals(pd.DataFrame(d))
 
 
+def test_model_uuid():
+    m = Model()
+    assert m.model_uuid and len(m.model_uuid) == 32
+    m_dict = m.to_dict()
+    assert m_dict['model_uuid'] == m.model_uuid
+    m2 = Model.from_dict(m_dict)
+    assert m2.model_uuid == m.model_uuid
+
+
 def test_tensor_schema_enforcement_no_col_names():
     m = Model()
     input_schema = Schema([TensorSpec(np.dtype(np.float32), (-1, 3))])

--- a/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
+++ b/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
@@ -558,6 +558,7 @@ def test_column_schema_enforcement_no_col_names():
 
 def _is_valid_uuid(val):
     import uuid
+
     try:
         uuid.UUID(str(val))
         return True
@@ -570,7 +571,7 @@ def test_model_uuid():
     assert m.model_uuid is not None
     assert _is_valid_uuid(m.model_uuid)
     m_dict = m.to_dict()
-    assert m_dict['model_uuid'] == m.model_uuid
+    assert m_dict["model_uuid"] == m.model_uuid
     m2 = Model.from_dict(m_dict)
     assert m2.model_uuid == m.model_uuid
 

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -386,7 +386,12 @@ def test_log_model(mlflow_client, backend_store_uri):
                 tag = run.data.tags["mlflow.log-model.history"]
                 models = json.loads(tag)
                 model.utc_time_created = models[i]["utc_time_created"]
-                assert models[i] == model.to_dict()
+
+                history_model_meta = models[i].copy()
+                history_model_meta.pop("model_uuid")
+                model_meta = model.to_dict().copy()
+                model_meta.pop(("model_uuid"))
+                assert history_model_meta == model_meta
                 assert len(models) == i + 1
                 for j in range(0, i + 1):
                     assert models[j]["artifact_path"] == model_paths[j]

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -388,10 +388,11 @@ def test_log_model(mlflow_client, backend_store_uri):
                 model.utc_time_created = models[i]["utc_time_created"]
 
                 history_model_meta = models[i].copy()
-                history_model_meta.pop("model_uuid")
+                original_model_uuid = history_model_meta.pop("model_uuid")
                 model_meta = model.to_dict().copy()
-                model_meta.pop(("model_uuid"))
+                new_model_uuid = model_meta.pop(("model_uuid"))
                 assert history_model_meta == model_meta
+                assert original_model_uuid != new_model_uuid
                 assert len(models) == i + 1
                 for j in range(0, i + 1):
                     assert models[j]["artifact_path"] == model_paths[j]


### PR DESCRIPTION
Signed-off-by: Weichen Xu <weichen.xu@databricks.com>

## What changes are proposed in this pull request?

Testing code:
```
import numpy as np
from sklearn.linear_model import LinearRegression

import mlflow
from mlflow.tracking.artifact_utils import get_artifact_uri

import os
os.environ['MLFLOW_AUTOLOGGING_TESTING'] = 'true'
# enable autologging
mlflow.sklearn.autolog(log_models=True)

# prepare training data
X = np.array([[1, 1], [1, 2], [2, 2], [2, 3]])
y = np.dot(X, np.array([1, 2])) + 3

# train a model
model = LinearRegression()
with mlflow.start_run() as run:
    model.fit(X, y)
    print("Logged data and model in run {}".format(run.info.run_id))

model_uri = get_artifact_uri(run.info.run_id, 'model')

pymodel = mlflow.pyfunc.load_model(model_uri)
print('uuid=' + pymodel.metadata.model_uuid)
```

## How is this patch tested?

Unit test.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Log model uuid when logging model. The uuid is randomly generated when logging model.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
