### PR TITLE
Fixing the horizonal and vertical extra scroll bar issue

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableCompactView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableCompactView.js
@@ -421,7 +421,7 @@ export class ExperimentRunsTableCompactView extends React.Component {
     return (
       <div
         id='autosizer-container'
-        className='runs-table-flex-container'
+        className='runs-table-flex-container compact-view-table-container'
         data-test-id='compact-runs-table-view'
       >
         <AutoSizer>

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.js
@@ -522,6 +522,7 @@ export class ExperimentRunsTableMultiColumnView2 extends React.Component {
           defaultColDef={defaultColDef}
           columnDefs={this.state.columnDefs}
           rowData={this.getRowData()}
+          domLayout='autoHeight'
           modules={[Grid, ClientSideRowModelModule]}
           rowSelection='multiple'
           onGridReady={this.handleGridReady}

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentView.css
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentView.css
@@ -328,9 +328,11 @@ span.error-message {
     flex: 1 1 auto;
     flex-direction: column;
     display: flex;
-    min-height: 800px;
-    overflow-x: scroll;
     border-radius: 4px;
+}
+
+.compact-view-table-container {
+    min-height: 800px;
 }
 
 .ExperimentView-runs {
@@ -396,7 +398,6 @@ span.error-message {
 
 .ExperimentView .multi-column-view {
     width: 100%;
-    height: 700px;
     margin-bottom: 50px;
 }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
- Fixing this scroll bar issue reported here: https://github.com/mlflow/mlflow/issues/5129
- Fixing the column view to automatically scale height correctly.
- Adding the min-height correctly for the compact to make sure it is set correctly

## How is this patch tested?
- Verified the code locally.

## Does this PR change the documentation?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
