### PR TITLE
Remove param 'verbose_eval' in lightgbm version > 3.3.1

### DIFF
--- a/tests/lightgbm/test_lightgbm_autolog.py
+++ b/tests/lightgbm/test_lightgbm_autolog.py
@@ -76,15 +76,18 @@ def test_lgb_autolog_logs_default_params(bst_params, train_set):
         "num_boost_round": 100,
         "feature_name": "auto",
         "categorical_feature": "auto",
-        "verbose_eval": (
+        "keep_training_booster": False,
+    }
+    if Version(lgb.__version__) <= Version("3.3.1"):
+        # The parameter `verbose_eval` in `lightgbm.train` is removed in this PR:
+        # https://github.com/microsoft/LightGBM/pull/4878
+        expected_params["verbose_eval"] = (
             # The default value of `verbose_eval` in `lightgbm.train` has been changed to 'warn'
             # in this PR: https://github.com/microsoft/LightGBM/pull/4577
             "warn"
             if Version(lgb.__version__) > Version("3.2.1")
             else True
-        ),
-        "keep_training_booster": False,
-    }
+        )
     expected_params.update(bst_params)
 
     for key, val in expected_params.items():
@@ -114,8 +117,11 @@ def test_lgb_autolog_logs_specified_params(bst_params, train_set):
     expected_params = {
         "num_boost_round": 10,
         "early_stopping_rounds": 5,
-        "verbose_eval": False,
     }
+    if Version(lgb.__version__) <= Version("3.3.1"):
+        # The parameter `verbose_eval` in `lightgbm.train` is removed in this PR:
+        # https://github.com/microsoft/LightGBM/pull/4878
+        expected_params["verbose_eval"] = False
     lgb.train(bst_params, train_set, valid_sets=[train_set], **expected_params)
     run = get_latest_run()
     params = run.data.params


### PR DESCRIPTION
Signed-off-by: Liang Zhang <liang.zhang@databricks.com>

## What changes are proposed in this pull request?

The parameter `verbose_eval` is removed in the master of lightgbm: https://github.com/microsoft/LightGBM/pull/4878.
We should also remove this param in our test.

## How is this patch tested?

Existing tests.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
