### PR TITLE
Add `model_uuid` to Java `Model`

### DIFF
--- a/mlflow/java/scoring/src/main/java/org/mlflow/models/Model.java
+++ b/mlflow/java/scoring/src/main/java/org/mlflow/models/Model.java
@@ -41,8 +41,8 @@ public class Model {
   @JsonProperty("input_example")
   private Map<String, Object> input_example;
 
-  @JsonProperty("model_uuid")
-  private String modelUuid;
+  // @JsonProperty("model_uuid")
+  // private String modelUuid;
 
   private String rootPath;
 

--- a/mlflow/java/scoring/src/main/java/org/mlflow/models/Model.java
+++ b/mlflow/java/scoring/src/main/java/org/mlflow/models/Model.java
@@ -42,7 +42,7 @@ public class Model {
   private Map<String, Object> input_example;
 
   @JsonProperty("model_uuid")
-  private String runId;
+  private String modelUuid;
 
   private String rootPath;
 

--- a/mlflow/java/scoring/src/main/java/org/mlflow/models/Model.java
+++ b/mlflow/java/scoring/src/main/java/org/mlflow/models/Model.java
@@ -85,6 +85,11 @@ public class Model {
     return Optional.ofNullable(this.runId);
   }
 
+    /** @return The MLflow model's uuid */
+  public Optional<String> getModelUuid() {
+    return Optional.ofNullable(this.modelUuid);
+  }
+
   /** @return The path to the root directory of the MLflow model */
   public Optional<String> getRootPath() {
     return Optional.ofNullable(this.rootPath);

--- a/mlflow/java/scoring/src/main/java/org/mlflow/models/Model.java
+++ b/mlflow/java/scoring/src/main/java/org/mlflow/models/Model.java
@@ -41,8 +41,8 @@ public class Model {
   @JsonProperty("input_example")
   private Map<String, Object> input_example;
 
-  // @JsonProperty("model_uuid")
-  // private String modelUuid;
+  @JsonProperty("model_uuid")
+  private String modelUuid;
 
   private String rootPath;
 

--- a/mlflow/java/scoring/src/main/java/org/mlflow/models/Model.java
+++ b/mlflow/java/scoring/src/main/java/org/mlflow/models/Model.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import org.mlflow.Flavor;
 import org.mlflow.utils.FileUtils;
 import org.mlflow.utils.SerializationUtils;
@@ -64,6 +65,11 @@ public class Model {
   public static Model fromConfigPath(String configPath) throws IOException {
     File configFile = new File(configPath);
     Model model = SerializationUtils.parseYamlFromFile(configFile, Model.class);
+    // Set the model uuid if it's absent.
+    if (!model.getModelUuid().isPresent()) {
+      String uuid = UUID.randomUUID().toString().replace("-", "");
+      model.setModelUuid(uuid);
+    }
     // Set the root path to the directory containing the configuration file.
     // This will be used to create an absolute path to the serialized model
     model.setRootPath(configFile.getParentFile().getAbsolutePath());
@@ -111,5 +117,9 @@ public class Model {
 
   private void setRootPath(String rootPath) {
     this.rootPath = rootPath;
+  }
+
+  private void setModelUuid(String modelUuid) {
+    this.modelUuid = modelUuid;
   }
 }

--- a/mlflow/java/scoring/src/main/java/org/mlflow/models/Model.java
+++ b/mlflow/java/scoring/src/main/java/org/mlflow/models/Model.java
@@ -41,6 +41,9 @@ public class Model {
   @JsonProperty("input_example")
   private Map<String, Object> input_example;
 
+  @JsonProperty("model_uuid")
+  private String runId;
+
   private String rootPath;
 
   /**

--- a/mlflow/java/scoring/src/main/java/org/mlflow/models/Model.java
+++ b/mlflow/java/scoring/src/main/java/org/mlflow/models/Model.java
@@ -65,11 +65,6 @@ public class Model {
   public static Model fromConfigPath(String configPath) throws IOException {
     File configFile = new File(configPath);
     Model model = SerializationUtils.parseYamlFromFile(configFile, Model.class);
-    // Set the model uuid if it's absent.
-    if (!model.getModelUuid().isPresent()) {
-      String uuid = UUID.randomUUID().toString().replace("-", "");
-      model.setModelUuid(uuid);
-    }
     // Set the root path to the directory containing the configuration file.
     // This will be used to create an absolute path to the serialized model
     model.setRootPath(configFile.getParentFile().getAbsolutePath());
@@ -117,9 +112,5 @@ public class Model {
 
   private void setRootPath(String rootPath) {
     this.rootPath = rootPath;
-  }
-
-  private void setModelUuid(String modelUuid) {
-    this.modelUuid = modelUuid;
   }
 }

--- a/mlflow/java/scoring/src/test/java/org/mlflow/ModelTest.java
+++ b/mlflow/java/scoring/src/test/java/org/mlflow/ModelTest.java
@@ -25,6 +25,18 @@ public class ModelTest {
   }
 
   @Test
+  public void testModelIsLoadedCorrectlyWhenModelUuidDoesNotExist() {
+    String configPath = getClass().getResource("sample_model_root/MLmodel.no.model_uuid").getFile();
+    try {
+      Model model = Model.fromConfigPath(configPath);
+      Assert.assertFalse(model.getModelUuid().isPresent());
+    } catch (IOException e) {
+      e.printStackTrace();
+      Assert.fail("Encountered an exception while reading the model from a configuration path!");
+    }
+  }
+
+  @Test
   public void testModelIsLoadedFromYamlUsingRootPathCorrectly() {
     String rootPath = getClass().getResource("sample_model_root").getFile();
     try {

--- a/mlflow/java/scoring/src/test/java/org/mlflow/ModelTest.java
+++ b/mlflow/java/scoring/src/test/java/org/mlflow/ModelTest.java
@@ -29,7 +29,7 @@ public class ModelTest {
     String configPath = getClass().getResource("sample_model_root/MLmodel.no.model_uuid").getFile();
     try {
       Model model = Model.fromConfigPath(configPath);
-      Assert.assertFalse(model.getModelUuid().isPresent());
+      Assert.assertTrue(model.getModelUuid().isPresent());
     } catch (IOException e) {
       e.printStackTrace();
       Assert.fail("Encountered an exception while reading the model from a configuration path!");

--- a/mlflow/java/scoring/src/test/java/org/mlflow/ModelTest.java
+++ b/mlflow/java/scoring/src/test/java/org/mlflow/ModelTest.java
@@ -17,6 +17,7 @@ public class ModelTest {
       Model model = Model.fromConfigPath(configPath);
       Assert.assertTrue(model.getFlavor(MLeapFlavor.FLAVOR_NAME, MLeapFlavor.class).isPresent());
       Assert.assertTrue(model.getUtcTimeCreated().isPresent());
+      Assert.assertTrue(model.getModelUuid().isPresent());
     } catch (IOException e) {
       e.printStackTrace();
       Assert.fail("Encountered an exception while reading the model from a configuration path!");

--- a/mlflow/java/scoring/src/test/java/org/mlflow/ModelTest.java
+++ b/mlflow/java/scoring/src/test/java/org/mlflow/ModelTest.java
@@ -29,7 +29,7 @@ public class ModelTest {
     String configPath = getClass().getResource("sample_model_root/MLmodel.no.model_uuid").getFile();
     try {
       Model model = Model.fromConfigPath(configPath);
-      Assert.assertTrue(model.getModelUuid().isPresent());
+      Assert.assertFalse(model.getModelUuid().isPresent());
     } catch (IOException e) {
       e.printStackTrace();
       Assert.fail("Encountered an exception while reading the model from a configuration path!");

--- a/mlflow/java/scoring/src/test/resources/org/mlflow/models/sample_model_root/MLmodel
+++ b/mlflow/java/scoring/src/test/resources/org/mlflow/models/sample_model_root/MLmodel
@@ -5,7 +5,7 @@ flavors:
 utc_time_created: '2018-08-10 18:34:28.720095'
 run_id: c228016dea284522882b657d91eeffa6
 artifact_path: model
-
+model_uuid: 4ab08bf9d91e4535bc2719f9210840c3
 signature:
   inputs: '[{"name": "fixed acidity", "type": "double"}, {"name": "volatile acidity",
     "type": "double"}, {"name": "citric acid", "type": "double"}, {"name": "residual

--- a/mlflow/java/scoring/src/test/resources/org/mlflow/models/sample_model_root/MLmodel.no.model_uuid
+++ b/mlflow/java/scoring/src/test/resources/org/mlflow/models/sample_model_root/MLmodel.no.model_uuid
@@ -1,0 +1,7 @@
+flavors:
+  mleap:
+    mleap_version: 0.8.1
+    model_data: mleap/model
+utc_time_created: "2018-08-10 18:34:28.720095"
+run_id: c228016dea284522882b657d91eeffa6
+artifact_path: model

--- a/mlflow/mleap.py
+++ b/mlflow/mleap.py
@@ -182,8 +182,6 @@ def save_model(
                           model. The given example will be converted to a Pandas DataFrame and then
                           serialized to json using the Pandas split-oriented format. Bytes are
                           base64-encoded.
-
-
     """
     if mlflow_model is None:
         mlflow_model = Model()

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -164,3 +164,24 @@ def test_model_log_with_input_example_succeeds():
         # date column will get deserialized into string
         input_example["d"] = input_example["d"].apply(lambda x: x.isoformat())
         assert x.equals(input_example)
+
+
+def test_model_can_be_loaded_without_model_uuid(tmpdir):
+    ml_model_file = tmpdir.join("MLmodel")
+    ml_model_file.write(
+        """
+artifact_path: model
+flavors:
+  python_function:
+    env: conda.yaml
+    loader_module: mlflow.sklearn
+    model_path: model.pkl
+    python_version: 3.7.9
+  sklearn:
+    pickled_model: model.pkl
+    serialization_format: cloudpickle
+    sklearn_version: 0.24.1
+"""
+    )
+    model = Model.load(ml_model_file)
+    assert model.model_uuid is not None

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -164,24 +164,3 @@ def test_model_log_with_input_example_succeeds():
         # date column will get deserialized into string
         input_example["d"] = input_example["d"].apply(lambda x: x.isoformat())
         assert x.equals(input_example)
-
-
-def test_model_can_be_loaded_without_model_uuid(tmpdir):
-    ml_model_file = tmpdir.join("MLmodel")
-    ml_model_file.write(
-        """
-artifact_path: model
-flavors:
-  python_function:
-    env: conda.yaml
-    loader_module: mlflow.sklearn
-    model_path: model.pkl
-    python_version: 3.7.9
-  sklearn:
-    pickled_model: model.pkl
-    serialization_format: cloudpickle
-    sklearn_version: 0.24.1
-"""
-    )
-    model = Model.load(ml_model_file)
-    assert model.model_uuid is not None


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Add `model_uuid` to Java `Model` as a follow-up for #5149.

## How is this patch tested?

Unit tests

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
