### PR TITLE
Only generate model uuid when logging model

### DIFF
--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -54,10 +54,7 @@ class Model(object):
         self.flavors = flavors if flavors is not None else {}
         self.signature = signature
         self.saved_input_example_info = saved_input_example_info
-        if callable(model_uuid):
-            self.model_uuid = model_uuid()
-        else:
-            self.model_uuid = model_uuid
+        self.model_uuid = model_uuid() if callable(model_uuid) else model_uuid
         self.__dict__.update(kwargs)
 
     def __eq__(self, other):

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -6,7 +6,7 @@ import yaml
 import os
 import uuid
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union, Callable
 
 import mlflow
 from mlflow.exceptions import MlflowException
@@ -42,6 +42,7 @@ class Model(object):
         flavors=None,
         signature=None,  # ModelSignature
         saved_input_example_info: Dict[str, Any] = None,
+        model_uuid: Union[str, Callable, None] = lambda: uuid.uuid4().hex,
         **kwargs,
     ):
         # store model id instead of run_id and path to avoid confusion when model gets exported
@@ -53,7 +54,10 @@ class Model(object):
         self.flavors = flavors if flavors is not None else {}
         self.signature = signature
         self.saved_input_example_info = saved_input_example_info
-        self.model_uuid = uuid.uuid4().hex
+        if callable(model_uuid):
+            self.model_uuid = model_uuid()
+        else:
+            self.model_uuid = model_uuid
         self.__dict__.update(kwargs)
 
     def __eq__(self, other):
@@ -132,15 +136,14 @@ class Model(object):
 
         from .signature import ModelSignature
 
+        model_dict = model_dict.copy()
         if "signature" in model_dict and isinstance(model_dict["signature"], dict):
-            model_dict = model_dict.copy()
             model_dict["signature"] = ModelSignature.from_dict(model_dict["signature"])
 
-        model_dict = model_dict.copy()
-        model_uuid = model_dict.pop('model_uuid', None)
-        model = cls(**model_dict)
-        model.model_uuid = model_uuid  # restore the saved model_uuid
-        return model
+        if "model_uuid" not in model_dict:
+            model_dict["model_uuid"] = None
+
+        return cls(**model_dict)
 
     @classmethod
     def log(

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -54,7 +54,7 @@ class Model(object):
         self.flavors = flavors if flavors is not None else {}
         self.signature = signature
         self.saved_input_example_info = saved_input_example_info
-        self.model_uuid = uuid.uuid4().hex if model_uuid is None else model_uuid
+        self.model_uuid = model_uuid
         self.__dict__.update(kwargs)
 
     def __eq__(self, other):
@@ -186,7 +186,8 @@ class Model(object):
         with TempDir() as tmp:
             local_path = tmp.path("model")
             run_id = mlflow.tracking.fluent._get_or_start_run().info.run_id
-            mlflow_model = cls(artifact_path=artifact_path, run_id=run_id)
+            model_uuid = uuid.uuid4().hex
+            mlflow_model = cls(artifact_path=artifact_path, run_id=run_id, model_uuid=model_uuid)
             flavor.save_model(path=local_path, mlflow_model=mlflow_model, **kwargs)
             mlflow.tracking.fluent.log_artifacts(local_path, artifact_path)
             try:

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -213,7 +213,6 @@ import pandas
 import yaml
 from copy import deepcopy
 import logging
-import uuid
 
 from typing import Any, Union, List, Dict
 import mlflow

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -213,6 +213,7 @@ import pandas
 import yaml
 from copy import deepcopy
 import logging
+import uuid
 
 from typing import Any, Union, List, Dict
 import mlflow

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -164,3 +164,28 @@ def test_model_log_with_input_example_succeeds():
         # date column will get deserialized into string
         input_example["d"] = input_example["d"].apply(lambda x: x.isoformat())
         assert x.equals(input_example)
+
+
+def _is_valid_uuid(val):
+    import uuid
+
+    try:
+        uuid.UUID(str(val))
+        return True
+    except ValueError:
+        return False
+
+
+def test_model_uuid():
+    m = Model()
+    assert m.model_uuid is not None
+    assert _is_valid_uuid(m.model_uuid)
+    m_dict = m.to_dict()
+    print(m_dict)
+    assert m_dict["model_uuid"] == m.model_uuid
+    m2 = Model.from_dict(m_dict)
+    assert m2.model_uuid == m.model_uuid
+
+    m_dict.pop("model_uuid")
+    m3 = Model.from_dict(m_dict)
+    assert m3.model_uuid is None

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -180,12 +180,15 @@ def test_model_uuid():
     m = Model()
     assert m.model_uuid is not None
     assert _is_valid_uuid(m.model_uuid)
+
+    m2 = Model()
+    assert m.model_uuid != m2.model_uuid
+
     m_dict = m.to_dict()
-    print(m_dict)
     assert m_dict["model_uuid"] == m.model_uuid
-    m2 = Model.from_dict(m_dict)
-    assert m2.model_uuid == m.model_uuid
+    m3 = Model.from_dict(m_dict)
+    assert m3.model_uuid == m.model_uuid
 
     m_dict.pop("model_uuid")
-    m3 = Model.from_dict(m_dict)
-    assert m3.model_uuid is None
+    m4 = Model.from_dict(m_dict)
+    assert m4.model_uuid is None

--- a/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
+++ b/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
@@ -85,16 +85,6 @@ def model_path(tmpdir):
     return os.path.join(str(tmpdir), "model")
 
 
-def _is_valid_uuid(val):
-    import uuid
-
-    try:
-        uuid.UUID(str(val))
-        return True
-    except ValueError:
-        return False
-
-
 @pytest.mark.large
 def test_model_save_load(sklearn_knn_model, iris_data, tmpdir, model_path):
     sk_model_path = os.path.join(str(tmpdir), "knn.pkl")
@@ -112,16 +102,12 @@ def test_model_save_load(sklearn_knn_model, iris_data, tmpdir, model_path):
 
     reloaded_model_config = Model.load(os.path.join(model_path, "MLmodel"))
     assert model_config.__dict__ == reloaded_model_config.__dict__
-    assert model_config.model_uuid is not None and _is_valid_uuid(model_config)
     assert mlflow.pyfunc.FLAVOR_NAME in reloaded_model_config.flavors
     assert mlflow.pyfunc.PY_VERSION in reloaded_model_config.flavors[mlflow.pyfunc.FLAVOR_NAME]
     reloaded_model = mlflow.pyfunc.load_pyfunc(model_path)
     np.testing.assert_array_equal(
         sklearn_knn_model.predict(iris_data[0]), reloaded_model.predict(iris_data[0])
     )
-
-    reloaded_model_config2 = Model.load(os.path.join(model_path, "MLmodel"))
-    assert reloaded_model_config.model_uuid == reloaded_model_config2.model_uuid
 
 
 @pytest.mark.large

--- a/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
+++ b/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
@@ -566,16 +566,6 @@ def _is_valid_uuid(val):
         return False
 
 
-def test_model_uuid():
-    m = Model()
-    assert m.model_uuid is not None
-    assert _is_valid_uuid(m.model_uuid)
-    m_dict = m.to_dict()
-    assert m_dict["model_uuid"] == m.model_uuid
-    m2 = Model.from_dict(m_dict)
-    assert m2.model_uuid == m.model_uuid
-
-
 def test_tensor_schema_enforcement_no_col_names():
     m = Model()
     input_schema = Schema([TensorSpec(np.dtype(np.float32), (-1, 3))])


### PR DESCRIPTION
Signed-off-by: Weichen Xu <weichen.xu@databricks.com>

## What changes are proposed in this pull request?

Only generate model uuid when logging model.

Before:
When loading model from a old version mlflow model, a new model uuid will be generated. Loading multiple times will generate multiple different model uuid.

After:
When loading model from a old version mlflow model, the model uuid attribute will be None.

## How is this patch tested?

Unit tests.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
