### PR TITLE
Improve pip requrements infer error handling

### DIFF
--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -195,8 +195,7 @@ def infer_pip_requirements(model_uri, flavor, fallback=None):
         return _infer_requirements(model_uri, flavor)
     except Exception:
         if fallback is not None:
-            _logger.warning(_INFER_PIP_REQUIREMENTS_FALLBACK_MESSAGE,
-                            model_uri, flavor, fallback)
+            _logger.warning(_INFER_PIP_REQUIREMENTS_FALLBACK_MESSAGE, model_uri, flavor, fallback)
             _logger.debug("", exc_info=True)
             return fallback
         raise

--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -199,8 +199,8 @@ def infer_pip_requirements(model_uri, flavor, fallback=None):
                               model_uri, flavor, exc_info=True)
             else:
                 _logger.debug(_INFER_PIP_REQUIREMENTS_FALLBACK_MESSAGE +
-                              ', set log level to be DEBUG to get more information.'
-                              , model_uri, flavor)
+                              ', set log level to be DEBUG to get more information.',
+                              model_uri, flavor)
             return fallback
         raise
 

--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -192,9 +192,15 @@ def infer_pip_requirements(model_uri, flavor, fallback=None):
     """
     try:
         return _infer_requirements(model_uri, flavor)
-    except Exception:
+    except Exception as e:
         if fallback is not None:
-            _logger.exception(_INFER_PIP_REQUIREMENTS_FALLBACK_MESSAGE, model_uri, flavor)
+            if _logger.level <= logging.DEBUG:
+                _logger.debug(_INFER_PIP_REQUIREMENTS_FALLBACK_MESSAGE,
+                              model_uri, flavor, exc_info=True)
+            else:
+                _logger.debug(_INFER_PIP_REQUIREMENTS_FALLBACK_MESSAGE +
+                              ', set log level to be DEBUG to get more information.'
+                              , model_uri, flavor)
             return fallback
         raise
 

--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -175,7 +175,7 @@ def _parse_pip_requirements(pip_requirements):
 
 
 _INFER_PIP_REQUIREMENTS_FALLBACK_MESSAGE = (
-    "Encountered an unexpected error while inferring pip requirements (model URI: %s, flavor: %s)"
+    "Encountered an unexpected error while inferring pip requirements (model URI: %s, flavor: %s)."
 )
 
 
@@ -198,9 +198,9 @@ def infer_pip_requirements(model_uri, flavor, fallback=None):
                 _logger.debug(_INFER_PIP_REQUIREMENTS_FALLBACK_MESSAGE,
                               model_uri, flavor, exc_info=True)
             else:
-                _logger.debug(_INFER_PIP_REQUIREMENTS_FALLBACK_MESSAGE +
-                              ', set log level to be DEBUG to get more information.',
-                              model_uri, flavor)
+                _logger.warning(_INFER_PIP_REQUIREMENTS_FALLBACK_MESSAGE +
+                                ' Set log level to be DEBUG to get more information.',
+                                model_uri, flavor)
             return fallback
         raise
 

--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -175,7 +175,8 @@ def _parse_pip_requirements(pip_requirements):
 
 
 _INFER_PIP_REQUIREMENTS_FALLBACK_MESSAGE = (
-    "Encountered an unexpected error while inferring pip requirements (model URI: %s, flavor: %s)."
+    "Encountered an unexpected error while inferring pip requirements (model URI: %s, flavor: %s),"
+    " fallback to generate default pip requirements."
 )
 
 
@@ -192,7 +193,7 @@ def infer_pip_requirements(model_uri, flavor, fallback=None):
     """
     try:
         return _infer_requirements(model_uri, flavor)
-    except Exception as e:
+    except Exception:
         if fallback is not None:
             if _logger.level <= logging.DEBUG:
                 _logger.debug(_INFER_PIP_REQUIREMENTS_FALLBACK_MESSAGE,

--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -176,7 +176,7 @@ def _parse_pip_requirements(pip_requirements):
 
 _INFER_PIP_REQUIREMENTS_FALLBACK_MESSAGE = (
     "Encountered an unexpected error while inferring pip requirements (model URI: %s, flavor: %s),"
-    " fallback to generate default pip requirements."
+    " fall back to return %s. Set logging level to DEBUG to see the full traceback."
 )
 
 
@@ -195,13 +195,9 @@ def infer_pip_requirements(model_uri, flavor, fallback=None):
         return _infer_requirements(model_uri, flavor)
     except Exception:
         if fallback is not None:
-            if _logger.level <= logging.DEBUG:
-                _logger.debug(_INFER_PIP_REQUIREMENTS_FALLBACK_MESSAGE,
-                              model_uri, flavor, exc_info=True)
-            else:
-                _logger.warning(_INFER_PIP_REQUIREMENTS_FALLBACK_MESSAGE +
-                                ' Set log level to be DEBUG to get more information.',
-                                model_uri, flavor)
+            _logger.warning(_INFER_PIP_REQUIREMENTS_FALLBACK_MESSAGE,
+                            model_uri, flavor, fallback)
+            _logger.debug("", exc_info=True)
             return fallback
         raise
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Improve pip requrements infer error handling

## How is this patch tested?

Manually.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
