### PR TITLE
Dockerize R package build

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -137,6 +137,10 @@ jobs:
         Rscript -e 'covr::codecov()' || :
       env:
         COVR_RUNNING: true
+    - name: Test package build
+      working-directory: mlflow/R/mlflow
+      run: |
+        ./build-package.sh
     - name: Show 00check.log on failure
       if: ${{ failure() }}
       run: |

--- a/mlflow/R/mlflow/.Rbuildignore
+++ b/mlflow/R/mlflow/.Rbuildignore
@@ -19,3 +19,7 @@ Reference_Manual_mlflow.md
 ^logs/
 ^depends\.Rds
 ^R-version
+^\.utils\.R$
+^\.build-package\.R$
+^build-package\.sh$
+^Dockerfile\.build$

--- a/mlflow/R/mlflow/.build-package.R
+++ b/mlflow/R/mlflow/.build-package.R
@@ -6,10 +6,10 @@ options(timeout=300)
 # Install dependencies required for the submission check.
 devtools::install_deps(".", dependencies = TRUE)
 # Bundle up the package into a .tar.gz file. This file will be submitted to CRAN.
-package_path <- devtools::build(".")
+package_path <- devtools::build(".", path = ".")
 # Run the submission check against the built package.
 devtools::check_built(
-    package_path,
+    pkg = normalizePath(package_path),
     remote = should_enable_cran_incoming_checks(),
     error_on = "note",
     args = c("--no-tests", "--as-cran"),

--- a/mlflow/R/mlflow/.build-package.R
+++ b/mlflow/R/mlflow/.build-package.R
@@ -1,0 +1,16 @@
+source(".utils.R")
+
+# Increase the timeout length for `utils::download.file` because the default value (60 seconds)
+# could be too short to download large packages such as h2o.
+options(timeout=300)
+# Install dependencies required for the submission check.
+devtools::install_deps(".", dependencies = TRUE)
+# Bundle up the package into a .tar.gz file. This file will be submitted to CRAN.
+package_path <- devtools::build(".")
+# Run the submission check against the built package.
+devtools::check_built(
+    package_path,
+    remote = should_enable_cran_incoming_checks(),
+    error_on = "note",
+    args = c("--no-tests", "--as-cran"),
+)

--- a/mlflow/R/mlflow/.build-package.R
+++ b/mlflow/R/mlflow/.build-package.R
@@ -9,7 +9,7 @@ devtools::install_deps(".", dependencies = TRUE)
 package_path <- devtools::build(".", path = ".")
 # Run the submission check against the built package.
 devtools::check_built(
-    pkg = normalizePath(package_path),
+    path = normalizePath(package_path),
     remote = should_enable_cran_incoming_checks(),
     error_on = "note",
     args = c("--no-tests", "--as-cran"),

--- a/mlflow/R/mlflow/.gitignore
+++ b/mlflow/R/mlflow/.gitignore
@@ -19,3 +19,4 @@ Reference_Manual_mlflow.md
 *.Rcheck/
 depends.Rds
 R-version
+*.tar.gz

--- a/mlflow/R/mlflow/.run-tests.R
+++ b/mlflow/R/mlflow/.run-tests.R
@@ -1,4 +1,4 @@
-source("../utils.R")
+source("../.utils.R")
 
 parent_dir <- dir("../", full.names = TRUE)
 package <- parent_dir[grepl("mlflow_", parent_dir)]

--- a/mlflow/R/mlflow/.run-tests.R
+++ b/mlflow/R/mlflow/.run-tests.R
@@ -1,24 +1,15 @@
+source("../utils.R")
+
 parent_dir <- dir("../", full.names = TRUE)
 package <- parent_dir[grepl("mlflow_", parent_dir)]
 
 library(reticulate)
 use_condaenv(mlflow:::mlflow_conda_env_name())
 
-# Disable CRAN incoming feasibility check within a week after the latest release because it fails.
-#
-# Relevant code:
-# https://github.com/wch/r-source/blob/4561aea946a75425ddcc8869cdb129ed5e27af97/src/library/tools/R/QC.R#L8005-L8008
-install.packages(c("xml2", "rvest"))
-library(xml2)
-library(rvest)
-
-url <- "https://cran.r-project.org/web/packages/mlflow/index.html"
-html <- read_html(url)
-xpath <- '//td[text()="Published:"]/following-sibling::td[1]/text()'
-published_date <- as.Date(html_text(html_nodes(html, xpath=xpath)))
-today <- Sys.Date()
-days_since_last_release <- difftime(today, published_date, units="days")
-remote <- as.numeric(days_since_last_release) > 7
-
-devtools::check_built(path = package, remote = remote, error_on = "note", args = "--no-tests")
+devtools::check_built(
+    path = package,
+    remote = should_enable_cran_incoming_checks(),
+    error_on = "note",
+    args = "--no-tests"
+)
 source("testthat.R")

--- a/mlflow/R/mlflow/.utils.R
+++ b/mlflow/R/mlflow/.utils.R
@@ -1,0 +1,18 @@
+
+# This script defines utility functions only used during development.
+
+should_enable_cran_incoming_checks <- function() {
+    # The CRAN incoming feasibility check performs a package recency check (this is undocumented)
+    # that examines the number of days since the last release and raises a NOTE if it's < 7.
+    # Relevant code:
+    # https://github.com/wch/r-source/blob/4561aea946a75425ddcc8869cdb129ed5e27af97/src/library/tools/R/QC.R#L8005-L8008
+    # This check needs to be disabled for a week after releasing a new version.
+    desc_url <- url("https://cran.r-project.org/web/packages/mlflow/DESCRIPTION")
+    field <- "Date/Publication"
+    desc <- read.dcf(desc_url, fields = c(field))
+    close(desc_url)
+    publication_date <- as.Date(unname(desc[1, field]))
+    today <- Sys.Date()
+    days_since_last_release <- as.numeric(difftime(today, publication_date, units="days"))
+    days_since_last_release > 7
+}

--- a/mlflow/R/mlflow/Dockerfile.build
+++ b/mlflow/R/mlflow/Dockerfile.build
@@ -1,0 +1,5 @@
+FROM rocker/r-ver:4.1.2
+
+RUN apt-get update -y
+RUN apt-get install pandoc -y
+RUN Rscript -e 'install.packages("devtools", dependencies = TRUE)'

--- a/mlflow/R/mlflow/build-package.sh
+++ b/mlflow/R/mlflow/build-package.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -ex
+
+docker build -f Dockerfile.build -t r-build-package .
+docker run --rm --workdir /app -v $(pwd):/app r-build-package Rscript -e 'source(".build-package.R", echo = TRUE)'


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

Dockerize R package build to make it easier to debug and reproduce issues. Our internal Jenkins job also can use the dockerized package build.

## How is this patch tested?

Added a step in the r check to ensure the build script works.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
