### PR TITLE
Fix issue #2804 - Set run name in MLProject execution

### DIFF
--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -124,7 +124,8 @@ def cli():
 @click.option(
     "--run-name",
     metavar="RUN_NAME",
-    help="If specified, the name of the run will be stored (as a `mlflow.runName` tag).",
+    help="The name to give the MLflow Run associated with the project execution. If not specified, "
+    "the MLflow Run name is left unset."
 )
 def run(
     uri,

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -121,6 +121,11 @@ def cli():
     "Note: this argument is used internally by the MLflow project APIs "
     "and should not be specified.",
 )
+@click.option(
+    "--run-name",
+    metavar="MLFLOW_RUN_NAME",
+    help="If specified, the name of the run will be stored (as a `mlflow.runName` tag).",
+)
 def run(
     uri,
     entry_point,
@@ -134,6 +139,7 @@ def run(
     no_conda,
     storage_dir,
     run_id,
+    run_name,
 ):
     """
     Run an MLflow project from the given URI.
@@ -179,6 +185,7 @@ def run(
             storage_dir=storage_dir,
             synchronous=backend in ("local", "kubernetes") or backend is None,
             run_id=run_id,
+            run_name=run_name,
         )
     except projects.ExecutionException as e:
         _logger.error("=== %s ===", e)

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -123,7 +123,7 @@ def cli():
 )
 @click.option(
     "--run-name",
-    metavar="MLFLOW_RUN_NAME",
+    metavar="RUN_NAME",
     help="If specified, the name of the run will be stored (as a `mlflow.runName` tag).",
 )
 def run(

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -125,7 +125,7 @@ def cli():
     "--run-name",
     metavar="RUN_NAME",
     help="The name to give the MLflow Run associated with the project execution. If not specified, "
-    "the MLflow Run name is left unset."
+    "the MLflow Run name is left unset.",
 )
 def run(
     uri,


### PR DESCRIPTION
Signed-off-by: bramrodenburg <14278376+bramrodenburg@users.noreply.github.com>

## What changes are proposed in this pull request?

Fixed issue #2804 in which users cannot specify the `run_name` when running an MLproject. 

## How is this patch tested?



## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

User can now specify the run_name when running an MLflow Project.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
