### PR TITLE
Propagate API response error to client for list_artifacts

### DIFF
--- a/mlflow/store/artifact/databricks_models_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_models_artifact_repo.py
@@ -71,8 +71,9 @@ class DatabricksModelsArtifactRepository(ArtifactRepository):
             json_body = self._make_json_body(path, page_token)
             response = self._call_endpoint(json_body, REGISTRY_LIST_ARTIFACTS_ENDPOINT)
             try:
+                response.raise_for_status()
                 json_response = json.loads(response.text)
-            except ValueError:
+            except Exception:
                 raise MlflowException(
                     "API request to list files under path `%s` failed with status code %s. "
                     "Response body: %s" % (path, response.status_code, response.text)

--- a/tests/store/artifact/test_databricks_models_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_models_artifact_repo.py
@@ -179,7 +179,7 @@ class TestDatabricksModelArtifactRepository(object):
         list_artifact_dir_bad_response_mock = mock.MagicMock()
         status_code = 404
         list_artifact_dir_bad_response_mock.status_code = status_code
-        list_artifact_dir_bad_response_mock.text = "{}"
+        list_artifact_dir_bad_response_mock.text = "An error occurred"
         list_artifact_dir_bad_response_mock.raise_for_status.side_effect = _raise_for_status
         with mock.patch(
             DATABRICKS_MODEL_ARTIFACT_REPOSITORY + "._call_endpoint"
@@ -187,7 +187,7 @@ class TestDatabricksModelArtifactRepository(object):
             call_endpoint_mock.return_value = list_artifact_dir_bad_response_mock
             with pytest.raises(
                 MlflowException,
-                match=r"API request to list files under path `` failed with status code 404. *",
+                match=r"API request to list files under path `` failed with status code 404. Response body: An error occurred",
             ):
                 databricks_model_artifact_repo.list_artifacts("")
             call_endpoint_mock.assert_called_once_with(ANY, REGISTRY_LIST_ARTIFACTS_ENDPOINT)

--- a/tests/store/artifact/test_databricks_models_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_models_artifact_repo.py
@@ -142,8 +142,16 @@ class TestDatabricksModelArtifactRepository(object):
                 DatabricksModelsArtifactRepository(valid_profileless_artifact_uri)
 
     def test_list_artifacts(self, databricks_model_artifact_repo):
+        status_code = 200
+
+        def _raise_for_status():
+            if status_code == 404:
+                raise Exception(
+                    "404 Client Error: Not Found for url: https://shard-uri/api/2.0/mlflow/model-versions/list-artifacts?name=model&version=1"
+                )
+
         list_artifact_dir_response_mock = mock.MagicMock()
-        list_artifact_dir_response_mock.status_code = 200
+        list_artifact_dir_response_mock.status_code = status_code
         list_artifact_dir_json_mock = {
             "files": [
                 {"path": "MLmodel", "is_dir": False, "file_size": 294},
@@ -151,6 +159,7 @@ class TestDatabricksModelArtifactRepository(object):
             ]
         }
         list_artifact_dir_response_mock.text = json.dumps(list_artifact_dir_json_mock)
+        list_artifact_dir_response_mock.raise_for_status.side_effect = _raise_for_status
         with mock.patch(
             DATABRICKS_MODEL_ARTIFACT_REPOSITORY + "._call_endpoint"
         ) as call_endpoint_mock:
@@ -164,6 +173,23 @@ class TestDatabricksModelArtifactRepository(object):
             assert artifacts[1].path == "data"
             assert artifacts[1].is_dir is True
             assert artifacts[1].file_size is None
+            call_endpoint_mock.assert_called_once_with(ANY, REGISTRY_LIST_ARTIFACTS_ENDPOINT)
+
+        # errors from API are propagated through to cli response
+        list_artifact_dir_bad_response_mock = mock.MagicMock()
+        status_code = 404
+        list_artifact_dir_bad_response_mock.status_code = status_code
+        list_artifact_dir_bad_response_mock.text = "{}"
+        list_artifact_dir_bad_response_mock.raise_for_status.side_effect = _raise_for_status
+        with mock.patch(
+            DATABRICKS_MODEL_ARTIFACT_REPOSITORY + "._call_endpoint"
+        ) as call_endpoint_mock:
+            call_endpoint_mock.return_value = list_artifact_dir_bad_response_mock
+            with pytest.raises(
+                MlflowException,
+                match=r"API request to list files under path `` failed with status code 404. *",
+            ):
+                databricks_model_artifact_repo.list_artifacts("")
             call_endpoint_mock.assert_called_once_with(ANY, REGISTRY_LIST_ARTIFACTS_ENDPOINT)
 
     def test_list_artifacts_for_single_file(self, databricks_model_artifact_repo):

--- a/tests/store/artifact/test_databricks_models_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_models_artifact_repo.py
@@ -187,7 +187,8 @@ class TestDatabricksModelArtifactRepository(object):
             call_endpoint_mock.return_value = list_artifact_dir_bad_response_mock
             with pytest.raises(
                 MlflowException,
-                match=r"API request to list files under path `` failed with status code 404. Response body: An error occurred",
+                match=r"API request to list files under path `` failed with status code 404. "
+                "Response body: An error occurred",
             ):
                 databricks_model_artifact_repo.list_artifacts("")
             call_endpoint_mock.assert_called_once_with(ANY, REGISTRY_LIST_ARTIFACTS_ENDPOINT)


### PR DESCRIPTION
Signed-off-by: Wendy Hu <wendy.hu@databricks.com>

## What changes are proposed in this pull request?

Currently, if we instantiate a models repo with an invalid model URI and list artifacts on it, an empty list is returned. This PR changes this behavior such that the error returned by the API is surfaced to the user.

## How is this patch tested?

- Added unit tests
- built wheel with changes and ran the below commands to confirm that an error was raised
![image](https://user-images.githubusercontent.com/8772750/146984768-b50c30b2-d3b1-455e-8e10-9af7e8647956.png)

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Propagate API errors to the client when listing artifacts in a repo. This is so that when we attempt to list artifacts on a non-existent repo, the user gets an appropriate error message instead of an empty list.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [x] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
