### PR TITLE
Do not modify tags dict on start_run()

### DIFF
--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -94,18 +94,18 @@ class TrackingServiceClient(object):
         :return: :py:class:`mlflow.entities.Run` that was created.
         """
 
-        tags = tags if tags else {}
+        run_tags = tags if tags else {}
 
         # Extract user from tags
         # This logic is temporary; the user_id attribute of runs is deprecated and will be removed
         # in a later release.
-        user_id = tags.get(MLFLOW_USER, "unknown")
+        user_id = run_tags.get(MLFLOW_USER, "unknown")
 
         return self.store.create_run(
             experiment_id=experiment_id,
             user_id=user_id,
             start_time=start_time or int(time.time() * 1000),
-            tags=[RunTag(key, value) for (key, value) in tags.items()],
+            tags=[RunTag(key, value) for (key, value) in run_tags.items()],
         )
 
     def list_run_infos(

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -94,18 +94,18 @@ class TrackingServiceClient(object):
         :return: :py:class:`mlflow.entities.Run` that was created.
         """
 
-        run_tags = tags if tags else {}
+        tags = tags if tags else {}
 
         # Extract user from tags
         # This logic is temporary; the user_id attribute of runs is deprecated and will be removed
         # in a later release.
-        user_id = run_tags.get(MLFLOW_USER, "unknown")
+        user_id = tags.get(MLFLOW_USER, "unknown")
 
         return self.store.create_run(
             experiment_id=experiment_id,
             user_id=user_id,
             start_time=start_time or int(time.time() * 1000),
-            tags=[RunTag(key, value) for (key, value) in run_tags.items()],
+            tags=[RunTag(key, value) for (key, value) in tags.items()],
         )
 
     def list_run_infos(

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -8,6 +8,7 @@ import atexit
 import time
 import logging
 import inspect
+from copy import deepcopy
 from packaging.version import Version
 from typing import Any, Dict, List, Optional, Union, TYPE_CHECKING
 
@@ -278,15 +279,15 @@ def start_run(
 
         exp_id_for_run = experiment_id if experiment_id is not None else _get_experiment_id()
 
-        user_specified_tags = tags or {}
+        user_specified_tags = deepcopy(tags) or {}
         if parent_run_id is not None:
             user_specified_tags[MLFLOW_PARENT_RUN_ID] = parent_run_id
         if run_name is not None:
             user_specified_tags[MLFLOW_RUN_NAME] = run_name
 
-        tags = context_registry.resolve_tags(user_specified_tags)
+        run_tags = context_registry.resolve_tags(user_specified_tags)
 
-        active_run_obj = client.create_run(experiment_id=exp_id_for_run, tags=tags)
+        active_run_obj = client.create_run(experiment_id=exp_id_for_run, tags=run_tags)
 
     _active_run_stack.append(ActiveRun(active_run_obj))
     return _active_run_stack[-1]

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -285,9 +285,9 @@ def start_run(
         if run_name is not None:
             user_specified_tags[MLFLOW_RUN_NAME] = run_name
 
-        run_tags = context_registry.resolve_tags(user_specified_tags)
+        resolved_tags = context_registry.resolve_tags(user_specified_tags)
 
-        active_run_obj = client.create_run(experiment_id=exp_id_for_run, tags=run_tags)
+        active_run_obj = client.create_run(experiment_id=exp_id_for_run, tags=resolved_tags)
 
     _active_run_stack.append(ActiveRun(active_run_obj))
     return _active_run_stack[-1]


### PR DESCRIPTION
## What changes are proposed in this pull request?

On the `start_run()` function, make a deep copy of the tags dictionary and do not redefine the dictionary. Fixes #5190.

## How is this patch tested?

Installed MLflow from my branch, and ran the sample code in #5190. It did not raise any errors.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixes bug where dictionary variables for tags were being altered, causing runs to be incorrectly considered nested.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
