### PR TITLE
Remove param 'evals_result' 'early_stopping_rounds' in lightgbm version > 3.3.1

### DIFF
--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -25,6 +25,7 @@ import shutil
 import logging
 import functools
 from copy import deepcopy
+from packaging.version import Version
 
 import mlflow
 from mlflow import pyfunc
@@ -447,10 +448,13 @@ def autolog(
             "fobj",
             "feval",
             "init_model",
-            "evals_result",
             "learning_rates",
             "callbacks",
         ]
+        if Version(lightgbm.__version__) <= Version("3.3.1"):
+            # The parameter `evals_result` in `lightgbm.train` is removed in this PR:
+            # https://github.com/microsoft/LightGBM/pull/4882
+            unlogged_params.append("evals_result")
 
         params_to_log_for_fn = get_mlflow_run_params_for_fn_args(
             original, args, kwargs, unlogged_params

--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -487,25 +487,9 @@ def autolog(
             # training model
             model = original(*args, **kwargs)
 
-            # If early_stopping_rounds is present, logging metrics at the best iteration
+            # If early stopping is activated, logging metrics at the best iteration
             # as extra metrics with the max step + 1.
-            if Version(lightgbm.__version__) <= Version("3.3.1"):
-                # The parameter `early_stopping_rounds` in `lightgbm.train` is removed in this PR:
-                # https://github.com/microsoft/LightGBM/pull/4908
-                early_stopping_index = all_arg_names.index("early_stopping_rounds")
-                early_stopping = (
-                    num_pos_args >= early_stopping_index + 1 or "early_stopping_rounds" in kwargs
-                )
-            else:
-                early_stopping = False
-                if "callbacks" in kwargs and kwargs["callbacks"] is not None:
-                    for cb in kwargs["callbacks"]:
-                        if (
-                            hasattr(cb, "__qualname__")
-                            and cb.__qualname__ == "early_stopping.<locals>._callback"
-                        ):
-                            early_stopping = True
-                            break
+            early_stopping = model.best_iteration > 0
             if early_stopping:
                 extra_step = len(eval_results)
                 autologging_client.log_metrics(

--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -500,7 +500,10 @@ def autolog(
                 early_stopping = False
                 if "callbacks" in kwargs and kwargs["callbacks"] is not None:
                     for cb in kwargs["callbacks"]:
-                        if cb.__qualname__ == "early_stopping.<locals>._callback":
+                        if (
+                            hasattr(cb, "__qualname__")
+                            and cb.__qualname__ == "early_stopping.<locals>._callback"
+                        ):
                             early_stopping = True
                             break
             if early_stopping:

--- a/tests/sagemaker/mock/__init__.py
+++ b/tests/sagemaker/mock/__init__.py
@@ -5,7 +5,6 @@ from datetime import datetime
 
 from moto.core import BaseBackend, BaseModel
 from moto.core.responses import BaseResponse
-from moto.ec2 import ec2_backends
 
 from moto.iam.models import ACCOUNT_ID
 from moto.core.models import base_decorator
@@ -1076,10 +1075,7 @@ class TransformJobDescription:
         return response
 
 
-# Create a SageMaker backend for each EC2 region
-sagemaker_backends = {}
-for region, ec2_backend in ec2_backends.items():
-    new_backend = SageMakerBackend()
-    sagemaker_backends[region] = new_backend
+# Create a SageMaker backend for EC2 region: "us-west-2"
+sagemaker_backends = {"us-west-2": SageMakerBackend()}
 
 mock_sagemaker = base_decorator(sagemaker_backends)


### PR DESCRIPTION
Signed-off-by: Liang Zhang <liang.zhang@databricks.com>

## What changes are proposed in this pull request?

The parameter `evals_result` is removed in the master of lightgbm: https://github.com/microsoft/LightGBM/pull/4882.
The parameter `early_stopping_rounds` is removed in the master of lightgbm: https://github.com/microsoft/LightGBM/pull/4908.

We should also remove this param in our test.

This PR also fixed the sagemaker test failure.

## How is this patch tested?

Existing tests.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
