### PR TITLE
Remove unused `xml2` in R

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -105,7 +105,7 @@ jobs:
         cd mlflow/R/mlflow
         R CMD build .
         cd tests
-        Rscript 'source("../.create-test-env.R", echo=TRUE)'
+        Rscript -e 'source("../.create-test-env.R", echo=TRUE)'
     - name: Run tests
       env:
         # Hack to get around this issue:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -105,7 +105,7 @@ jobs:
         cd mlflow/R/mlflow
         R CMD build .
         cd tests
-        Rscript ../.create-test-env.R
+        Rscript 'source("../.create-test-env.R", echo=TRUE)'
     - name: Run tests
       env:
         # Hack to get around this issue:
@@ -120,7 +120,7 @@ jobs:
         cd mlflow/R/mlflow/tests
         # `devtools::check_built` requires `pandoc` to analyze README.md
         sudo apt-get install pandoc -y
-        Rscript ../.run-tests.R
+        Rscript -e 'source("../.run-tests.R", echo=TRUE)'
     - name: Calculate code coverage
       if: ${{ success() }}
       run: |

--- a/mlflow/R/mlflow/.run-tests.R
+++ b/mlflow/R/mlflow/.run-tests.R
@@ -8,7 +8,15 @@ use_condaenv(mlflow:::mlflow_conda_env_name())
 
 devtools::check_built(
     path = package,
+    cran = TRUE,
     remote = should_enable_cran_incoming_checks(),
+    error_on = "note",
+    args = "--no-tests"
+)
+# This runs checks that are disabled when `cran` is TRUE (e.g. unused import check).
+devtools::check_built(
+    path = package,
+    cran = FALSE,
     error_on = "note",
     args = "--no-tests"
 )

--- a/mlflow/R/mlflow/DESCRIPTION
+++ b/mlflow/R/mlflow/DESCRIPTION
@@ -46,7 +46,6 @@ Imports:
     swagger,
     tibble (>= 2.0.0),
     withr,
-    xml2,
     yaml,
     zeallot
 Suggests:


### PR DESCRIPTION
## What changes are proposed in this pull request?

Today I found [the latest check for mlflow on CRAN](https://cran.r-project.org/web/checks/check_results_mlflow.html) says:

```
Version: 1.22.0
Check: dependencies in R code
Result: NOTE
    Namespace in Imports field not imported from: ‘xml2’
     All declared Imports should be used.
```

This PR fixes this issue.

## How is this patch tested?

Added a check to detect unused imports and confirmed it passed.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
