### PR TITLE
clarifying the docs to specify that strings must be passed into the c…

### DIFF
--- a/mlflow/R/mlflow/R/tracking-experiments.R
+++ b/mlflow/R/mlflow/R/tracking-experiments.R
@@ -2,7 +2,7 @@
 #'
 #' Creates an MLflow experiment and returns its id.
 #'
-#' @param name The experiment name to create, which must be unique, a string, and is case sensitive
+#' @param name The name of the experiment to create.
 #' @param artifact_location Location where all artifacts for this experiment are stored. If
 #'   not provided, the remote server will select an appropriate default.
 #' @param tags Experiment tags to set on the experiment upon experiment creation.

--- a/mlflow/R/mlflow/R/tracking-experiments.R
+++ b/mlflow/R/mlflow/R/tracking-experiments.R
@@ -2,7 +2,7 @@
 #'
 #' Creates an MLflow experiment and returns its id.
 #'
-#' @param name The name of the experiment to create.
+#' @param name The experiment name to create, which must be unique, a string, and is case sensitive
 #' @param artifact_location Location where all artifacts for this experiment are stored. If
 #'   not provided, the remote server will select an appropriate default.
 #' @param tags Experiment tags to set on the experiment upon experiment creation.

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -169,7 +169,7 @@ class TrackingServiceClient(object):
     def create_experiment(self, name, artifact_location=None, tags=None):
         """Create an experiment.
 
-        :param name: The experiment name. Must be unique.
+        :param name: The experiment name to create, which must be unique, a string, and is case sensitive
         :param artifact_location: The location to store run artifacts.
                                   If not provided, the server picks an appropriate default.
         :param tags: A dictionary of key-value pairs that are converted into

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -169,7 +169,8 @@ class TrackingServiceClient(object):
     def create_experiment(self, name, artifact_location=None, tags=None):
         """Create an experiment.
 
-        :param name: The experiment name to create, which must be unique, a string, and is case sensitive
+        :param name: The experiment name to create, which must be unique, a string,
+                     and is case sensitive
         :param artifact_location: The location to store run artifacts.
                                   If not provided, the server picks an appropriate default.
         :param tags: A dictionary of key-value pairs that are converted into

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -469,7 +469,8 @@ class MlflowClient(object):
     ) -> str:
         """Create an experiment.
 
-        :param name: The experiment name to create, which must be unique, a string, and is case sensitive
+        :param name: The experiment name to create, which must be unique, a string,
+                     and is case sensitive
         :param artifact_location: The location to store run artifacts.
                                   If not provided, the server picks an appropriate default.
         :param tags: A dictionary of key-value pairs that are converted into

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -469,7 +469,7 @@ class MlflowClient(object):
     ) -> str:
         """Create an experiment.
 
-        :param name: The experiment name. Must be unique.
+        :param name: The experiment name to create, which must be unique, a string, and is case sensitive
         :param artifact_location: The location to store run artifacts.
                                   If not provided, the server picks an appropriate default.
         :param tags: A dictionary of key-value pairs that are converted into

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -903,7 +903,8 @@ def create_experiment(
     """
     Create an experiment.
 
-    :param name: The experiment name to create, which must be unique, a string, and is case sensitive
+    :param name: The experiment name to create, which must be unique, a string,
+                 and is case sensitive
     :param artifact_location: The location to store run artifacts.
                               If not provided, the server picks an appropriate default.
     :param tags: An optional dictionary of string keys and values to set as

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -903,7 +903,7 @@ def create_experiment(
     """
     Create an experiment.
 
-    :param name: The experiment name, which must be unique and is case sensitive
+    :param name: The experiment name to create, which must be unique, a string, and is case sensitive
     :param artifact_location: The location to store run artifacts.
                               If not provided, the server picks an appropriate default.
     :param tags: An optional dictionary of string keys and values to set as


### PR DESCRIPTION
…reate_experiment functions

Signed-off-by: westford14 <westford14@gmail.com>

## What changes are proposed in this pull request?

This updates documentation to address issue #4199 

## How is this patch tested?

(Details)

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [X] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [X] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
