### PR TITLE
Clean up CI job for R

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -77,10 +77,10 @@ jobs:
         # We cache R dependencies based on a tuple of the current OS, the R version, and the list of
         # R dependencies
         key: ${{ steps.os-name.outputs.os-name }}-${{ hashFiles('mlflow/R/mlflow/R-version') }}-1-${{ hashFiles('mlflow/R/mlflow/depends.Rds') }}
-    - name: Install system dependencies
-      run: |
-        sudo apt-get update -y
-        sudo apt-get install -y libcurl4-openssl-dev pandoc
+    # - name: Install system dependencies
+    #   run: |
+    #     sudo apt-get update -y
+    #     sudo apt-get install -y libcurl4-openssl-dev pandoc
     - name: Install dependencies
       run: |
         Rscript -e 'source(".install-deps.R", echo=TRUE)'

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -85,16 +85,8 @@ jobs:
       run: |
         Rscript -e 'source(".install-deps.R", echo=TRUE)'
     - name: Build package
-      env:
-        # Hack to get around this issue:
-        # https://stat.ethz.ch/pipermail/r-package-devel/2020q3/005930.html
-        #
-        # The system clock check during `R CMD check` relies on two external web APIs and fails
-        # when they are unavailable. By setting `_R_CHECK_SYSTEM_CLOCK_` to FALSE, we can skip it:
-        # https://github.com/wch/r-source/blob/59a1965239143ca6242b9cc948d8834e1194e84a/src/library/tools/R/check.R#L511
-        _R_CHECK_SYSTEM_CLOCK_: FALSE
       run: |
-        Rscript -e 'source(".build-package.R", echo=TRUE)'
+        ./build-package.sh
     - name: Create test environment
       run: |
         Rscript -e 'source(".create-test-env.R", echo=TRUE)'
@@ -104,9 +96,6 @@ jobs:
       run: |
         cd tests
         Rscript -e 'source("../.run-tests.R", echo=TRUE)'
-    - name: Test package build
-      run: |
-        ./build-package.sh
 
   # python-skinny tests cover a subset of mlflow functionality
   # that is meant to be supported with a smaller dependency footprint.

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -49,32 +49,21 @@ jobs:
         ./dev/lint.sh
   r:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: mlflow/R/mlflow
     steps:
-    - name: Uninstall default-jdk and adoptopenjdk-11-hotspot if present
-      run: |
-        # deleting other version(s) of JDK because they are not needed and they might interfere with JNI linker configuration in the 'setup-r' step
-        sudo apt-get -y remove --purge default-jdk adoptopenjdk-11-hotspot || :
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
     - uses: actions/setup-java@v2
       with:
         java-version: 11
         distribution: 'adopt'
-    - name: Re-configure dynamic linker run-time bindings for adoptopenjdk-8-hotspot-amd64
-      run: |
-        sudo mkdir -p /etc/ld.so.conf.d
-        sudo bash -c "cat > /etc/ld.so.conf.d/jre.conf <<< '/usr/lib/jvm/adoptopenjdk-8-hotspot-amd64/jre/lib/amd64/server'"
-        sudo ldconfig -v
     - uses: r-lib/actions/setup-r@v1
     # This step dumps the current set of R dependencies and R version into files to be used
     # as a cache key when caching/restoring R dependencies.
-    - name: Query dependencies
+    - name: Dump dependencies
       run: |
-        print(R.version)
-        install.packages('remotes')
-        saveRDS(remotes::dev_package_deps("mlflow/R/mlflow", dependencies = TRUE), ".github/depends.Rds", version = 2)
-        writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-      shell: Rscript {0}
-
+        Rscript -e 'source(".dump-r-dependencies.R", echo = TRUE)'
     - name: Get OS name
       id: os-name
       run: |
@@ -87,25 +76,15 @@ jobs:
         path: ${{ env.R_LIBS_USER }}
         # We cache R dependencies based on a tuple of the current OS, the R version, and the list of
         # R dependencies
-        key: ${{ steps.os-name.outputs.os-name }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+        key: ${{ steps.os-name.outputs.os-name }}-${{ hashFiles('mlflow/R/mlflow/R-version') }}-1-${{ hashFiles('mlflow/R/mlflow/depends.Rds') }}
     - name: Install system dependencies
       run: |
-        sudo apt-get install -y libcurl4-openssl-dev
-        sudo R CMD javareconf
+        sudo apt-get update -y
+        sudo apt-get install -y libcurl4-openssl-dev pandoc
     - name: Install dependencies
-      working-directory: mlflow/R/mlflow
       run: |
-        install.packages("devtools")
-        remotes::install_deps('.', dependencies = TRUE, upgrade = FALSE)
-      shell: Rscript {0}
-    - name: Create test environment
-      run: |
-        source ./dev/install-common-deps.sh
-        cd mlflow/R/mlflow
-        R CMD build .
-        cd tests
-        Rscript -e 'source("../.create-test-env.R", echo=TRUE)'
-    - name: Run tests
+        Rscript -e 'source(".install-deps.R", echo=TRUE)'
+    - name: Build package
       env:
         # Hack to get around this issue:
         # https://stat.ethz.ch/pipermail/r-package-devel/2020q3/005930.html
@@ -115,34 +94,19 @@ jobs:
         # https://github.com/wch/r-source/blob/59a1965239143ca6242b9cc948d8834e1194e84a/src/library/tools/R/check.R#L511
         _R_CHECK_SYSTEM_CLOCK_: FALSE
       run: |
-        export LINTR_COMMENT_BOT=false
-        cd mlflow/R/mlflow/tests
-        # `devtools::check_built` requires `pandoc` to analyze README.md
-        sudo apt-get install pandoc -y
-        Rscript -e 'source("../.run-tests.R", echo=TRUE)'
-    - name: Calculate code coverage
-      if: ${{ success() }}
+        Rscript -e 'source(".build-package.R", echo=TRUE)'
+    - name: Create test environment
       run: |
-        export MLFLOW_HOME=$(pwd)
-        cd mlflow/R/mlflow/tests
-        Rscript -e 'covr::codecov()' || :
+        Rscript -e 'source(".create-test-env.R", echo=TRUE)'
+    - name: Run tests
       env:
-        COVR_RUNNING: true
+        LINTR_COMMENT_BOT: false
+      run: |
+        cd tests
+        Rscript -e 'source("../.run-tests.R", echo=TRUE)'
     - name: Test package build
-      working-directory: mlflow/R/mlflow
       run: |
         ./build-package.sh
-    - name: Show 00check.log on failure
-      if: ${{ failure() }}
-      run: |
-        LOG_FILE="${HOME}/build/mlflow/mlflow/mlflow/R/mlflow/mlflow.Rcheck/00check.log"
-        [ -r "${LOG_FILE}" ] && cat "${LOG_FILE}"
-        cp "${LOG_FILE}" /tmp
-    - uses: actions/upload-artifact@v1
-      if: failure()
-      with:
-        name: 00check.log
-        path: /tmp/00check.log
 
   # python-skinny tests cover a subset of mlflow functionality
   # that is meant to be supported with a smaller dependency footprint.

--- a/mlflow/R/mlflow/.build-package.R
+++ b/mlflow/R/mlflow/.build-package.R
@@ -9,7 +9,7 @@ package_path <- devtools::build(".", path = ".")
 # The system clock check during `R CMD check` relies on two external web APIs and fails
 # when they are unavailable. By setting `_R_CHECK_SYSTEM_CLOCK_` to FALSE, we can skip it:
 # https://github.com/wch/r-source/blob/59a1965239143ca6242b9cc948d8834e1194e84a/src/library/tools/R/check.R#L511
-Sys.setenv(_R_CHECK_SYSTEM_CLOCK_ = "FALSE")
+Sys.setenv("_R_CHECK_SYSTEM_CLOCK_" = "FALSE")
 
 # Run the check with `cran = TRUE`
 devtools::check_built(

--- a/mlflow/R/mlflow/.build-package.R
+++ b/mlflow/R/mlflow/.build-package.R
@@ -4,8 +4,18 @@ source(".utils.R")
 package_path <- devtools::build(".", path = ".")
 # Run the submission check against the built package.
 devtools::check_built(
-    path = normalizePath(package_path),
+    path = package_path,
+    cran = TRUE,
     remote = should_enable_cran_incoming_checks(),
     error_on = "note",
-    args = c("--no-tests", "--as-cran"),
+    check_dir = getwd(),
+    args = "--no-tests",
+)
+# This runs checks that are disabled when `cran` is TRUE (e.g. unused import check).
+devtools::check_built(
+    path = package_path,
+    cran = FALSE,
+    error_on = "note",
+    check_dir = getwd(),
+    args = "--no-tests",
 )

--- a/mlflow/R/mlflow/.build-package.R
+++ b/mlflow/R/mlflow/.build-package.R
@@ -1,8 +1,17 @@
 source(".utils.R")
 
-# Bundle up the package into a .tar.gz file. This file will be submitted to CRAN.
+# Bundle up the package into a .tar.gz file.
 package_path <- devtools::build(".", path = ".")
-# Run the submission check against the built package.
+
+# Hack to get around this issue:
+# https://stat.ethz.ch/pipermail/r-package-devel/2020q3/005930.html
+#
+# The system clock check during `R CMD check` relies on two external web APIs and fails
+# when they are unavailable. By setting `_R_CHECK_SYSTEM_CLOCK_` to FALSE, we can skip it:
+# https://github.com/wch/r-source/blob/59a1965239143ca6242b9cc948d8834e1194e84a/src/library/tools/R/check.R#L511
+Sys.setenv(_R_CHECK_SYSTEM_CLOCK_ = "FALSE")
+
+# Run the check with `cran = TRUE`
 devtools::check_built(
     path = package_path,
     cran = TRUE,
@@ -11,7 +20,9 @@ devtools::check_built(
     check_dir = getwd(),
     args = "--no-tests",
 )
-# This runs checks that are disabled when `cran` is TRUE (e.g. unused import check).
+
+# Run the check with `cran = FALSE` to detect unused imports:
+# https://github.com/wch/r-source/blob/b12ffba7584825d6b11bba8b7dbad084a74c1c20/src/library/tools/R/check.R#L6070
 devtools::check_built(
     path = package_path,
     cran = FALSE,

--- a/mlflow/R/mlflow/.create-test-env.R
+++ b/mlflow/R/mlflow/.create-test-env.R
@@ -1,15 +1,15 @@
-parent_dir <- dir("../", full.names = TRUE)
-package <- parent_dir[grepl("mlflow_", parent_dir)]
+# Install MLflow for R
+files <- dir(".", full.names = TRUE)
+package <- files[grepl("mlflow_.+\\.tar\\.gz$", files)]
 install.packages(package)
 
 mlflow:::mlflow_maybe_create_conda_env(python_version = "3.7")
-library(reticulate)
-use_condaenv(mlflow:::mlflow_conda_env_name())
+# Install python dependencies
+reticulate::conda_install(Sys.getenv("MLFLOW_HOME", "../../.."), envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
 # pinning tensorflow version to 1.14 until test_keras_model.R is fixed
 keras::install_keras(method = "conda", envname = mlflow:::mlflow_conda_env_name(), tensorflow="1.15.2")
 # pinning h5py < 3.0.0 to avoid this issue:  https://github.com/tensorflow/tensorflow/issues/44467
 # TODO: unpin after we use tensorflow >= 2.4
 reticulate::conda_install("'h5py<3.0.0'", envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
-reticulate::conda_install(Sys.getenv("MLFLOW_HOME", "../../../../."), envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
 reticulate::conda_install("xgboost", envname = mlflow:::mlflow_conda_env_name())
 reticulate::conda_install(paste0("h2o==", packageVersion("h2o")), envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)

--- a/mlflow/R/mlflow/.run-tests.R
+++ b/mlflow/R/mlflow/.run-tests.R
@@ -1,23 +1,3 @@
-source("../.utils.R")
+reticulate::use_condaenv(mlflow:::mlflow_conda_env_name())
 
-parent_dir <- dir("../", full.names = TRUE)
-package <- parent_dir[grepl("mlflow_", parent_dir)]
-
-library(reticulate)
-use_condaenv(mlflow:::mlflow_conda_env_name())
-
-devtools::check_built(
-    path = package,
-    cran = TRUE,
-    remote = should_enable_cran_incoming_checks(),
-    error_on = "note",
-    args = "--no-tests"
-)
-# This runs checks that are disabled when `cran` is TRUE (e.g. unused import check).
-devtools::check_built(
-    path = package,
-    cran = FALSE,
-    error_on = "note",
-    args = "--no-tests"
-)
-source("testthat.R")
+source("testthat.R", echo = TRUE)

--- a/mlflow/R/mlflow/tests/testthat.R
+++ b/mlflow/R/mlflow/tests/testthat.R
@@ -21,7 +21,7 @@ library(mlflow)
 
 if (identical(Sys.getenv("NOT_CRAN"), "true")) {
   message("Current working directory: ", getwd())
-  mlflow_home <- Sys.getenv("MLFLOW_HOME", "../../../../.")
+  mlflow_home <- Sys.getenv("MLFLOW_HOME", "../../../..")
   message('MLFLOW_HOME: ', mlflow_home)
   test_check("mlflow")
 }

--- a/mlflow/R/mlflow/tests/testthat/test-model-h2o.R
+++ b/mlflow/R/mlflow/tests/testthat/test-model-h2o.R
@@ -40,7 +40,7 @@ test_that("can print model correctly after it is loaded", {
 })
 
 test_that("can load and predict with python pyfunct and h2o backend", {
-  pyfunc <- import("mlflow.pyfunc")
+  pyfunc <- reticulate::import("mlflow.pyfunc")
   py_model <- pyfunc$load_model(testthat_model_dir)
 
   expected <- as.data.frame(h2o::h2o.predict(model, h2o::as.h2o(test)))
@@ -50,9 +50,9 @@ test_that("can load and predict with python pyfunct and h2o backend", {
     as.data.frame(py_model$predict(test)), expected
   )
 
-  mlflow.h2o <- import("mlflow.h2o")
+  mlflow.h2o <- reticulate::import("mlflow.h2o")
   h2o_native_model <- mlflow.h2o$load_model(testthat_model_dir)
-  h2o <- import("h2o")
+  h2o <- reticulate::import("h2o")
 
   expect_equivalent(
     as.data.frame(

--- a/mlflow/R/mlflow/tests/testthat/test-model-xgboost.R
+++ b/mlflow/R/mlflow/tests/testthat/test-model-xgboost.R
@@ -40,16 +40,16 @@ test_that("can load model and predict with rfunc backend", {
 })
 
 test_that("can load and predict with python pyfunct and xgboost backend", {
-  pyfunc <- import("mlflow.pyfunc")
+  pyfunc <- reticulate::import("mlflow.pyfunc")
   py_model <- pyfunc$load_model(testthat_model_dir)
   expect_equal(
     as.numeric(py_model$predict(test$data)),
     unname(predict(model, as.matrix(test$data)))
   )
 
-  mlflow.xgboost <- import("mlflow.xgboost")
+  mlflow.xgboost <- reticulate::import("mlflow.xgboost")
   xgboost_native_model <- mlflow.xgboost$load_model(testthat_model_dir)
-  xgboost <- import("xgboost")
+  xgboost <- reticulate::import("xgboost")
 
   expect_equivalent(
     as.numeric(xgboost_native_model$predict(xgboost$DMatrix(test$data))),


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Clean up R job.

- Remove spark related commands since we've removed mleap.
- Fix paths in R scripts so we can run everything in `mlflow/R/mlflow`.
- Remove codecov

## How is this patch tested?

Existing checks

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
