### PR TITLE
Use python 3.8 for when running tests for dev version of `statsmodels`

### DIFF
--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -24,8 +24,10 @@ runs:
           python_version="3.6.13"
         elif [[ "$python_version" == "3.7" ]]; then
           python_version="3.7.12"
+        elif [[ "$python_version" == "3.8" ]]; then
+          python_version="3.8.12"
         else
-          echo "Invalid python version: '$python_version'. Must be one of ['3.6', '3.7']"
+          echo "Invalid python version: '$python_version'. Must be one of ['3.6', '3.7', '3.8']"
           exit 1
         fi
         echo "::set-output name=version::$python_version"

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -112,12 +112,14 @@ jobs:
       - name: Get python version
         id: get-python-version
         run: |
-          if [[ "${{ matrix.version }}" = "dev" ]] || \
+          if [[ "${{ matrix.package }}" = "statsmodels" && "${{ matrix.version }}" = "dev" ]]
+          then
+            python_version=3.8
+          elif [[ "${{ matrix.version }}" = "dev" ]] || \
              [[ "${{ matrix.package }}" = "scikit-learn" && ! "${{ matrix.version }}" =~ ^0\.* ]] || \
              [[ "${{ matrix.package }}" = "statsmodels" ]] || \
              [[ "${{ matrix.package }}" = "tensorflow" && ! "${{ matrix.version }}" =~ ^2\.[0-6] ]] || \
              [[ "${{ matrix.package }}" = "keras" && ! "${{ matrix.version }}" =~ ^2\.[0-6] ]]
-          then
             python_version=3.7
           else
             python_version=3.6

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -120,6 +120,7 @@ jobs:
              [[ "${{ matrix.package }}" = "statsmodels" ]] || \
              [[ "${{ matrix.package }}" = "tensorflow" && ! "${{ matrix.version }}" =~ ^2\.[0-6] ]] || \
              [[ "${{ matrix.package }}" = "keras" && ! "${{ matrix.version }}" =~ ^2\.[0-6] ]]
+          then
             python_version=3.7
           else
             python_version=3.6

--- a/mlflow/statsmodels.py
+++ b/mlflow/statsmodels.py
@@ -12,9 +12,9 @@ statsmodels (native) format
     https://www.statsmodels.org/stable/_modules/statsmodels/base/model.html#Results
 
 """
+import logging
 import os
 import yaml
-import logging
 
 import mlflow
 from mlflow import pyfunc


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

`statsmodels` will drop support for python 3.8 in this PR:
https://github.com/statsmodels/statsmodels/pull/7993

This PR updates the cross version tests config to use python 3.8 for dev version of statsmodels.

## How is this patch tested?

Existing tests

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
