### PR TITLE
Model creation timestamp for log model in R

### DIFF
--- a/mlflow/R/mlflow/R/model.R
+++ b/mlflow/R/mlflow/R/model.R
@@ -59,7 +59,7 @@ mlflow_timestamp <- function() {
     c(digits.secs = 2),
     format(
       as.POSIXlt(Sys.time(), tz = "GMT"),
-      "%y-%m-%dT%H:%M:%OS"
+      "%y-%m-%d %H:%M:%OS6"
     )
   )
 }

--- a/mlflow/R/mlflow/R/model.R
+++ b/mlflow/R/mlflow/R/model.R
@@ -59,7 +59,7 @@ mlflow_timestamp <- function() {
     c(digits.secs = 2),
     format(
       as.POSIXlt(Sys.time(), tz = "GMT"),
-      "%y-%m-%d %H:%M:%OS6"
+      "%Y-%m-%d %H:%M:%OS6"
     )
   )
 }

--- a/mlflow/R/mlflow/R/model.R
+++ b/mlflow/R/mlflow/R/model.R
@@ -59,7 +59,7 @@ mlflow_timestamp <- function() {
     c(digits.secs = 2),
     format(
       as.POSIXlt(Sys.time(), tz = "GMT"),
-      "%y-%m-%dT%H:%M:%S.%OS"
+      "%y-%m-%dT%H:%M:%OS"
     )
   )
 }

--- a/mlflow/R/mlflow/tests/testthat/test-model.R
+++ b/mlflow/R/mlflow/tests/testthat/test-model.R
@@ -17,7 +17,7 @@ test_that("mlflow model creation time format", {
   ))
   
   expect_true(dir.exists(testthat_model_name))
-  expect_match(model_spec$utc_time_created, "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{6}")
+  expect_match(model_spec$utc_time_created, "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{6}")
 })
 
 test_that("mlflow can save model function", {

--- a/mlflow/R/mlflow/tests/testthat/test-model.R
+++ b/mlflow/R/mlflow/tests/testthat/test-model.R
@@ -8,6 +8,18 @@ teardown({
   mlflow_clear_test_dir(testthat_model_name)
 })
 
+test_that("mlflow model creation time format", {
+  mlflow_clear_test_dir(testthat_model_name)
+  model <- lm(Sepal.Width ~ Sepal.Length, iris)
+  fn <- crate(~ stats::predict(model, .x), model = model)
+  model_spec <- mlflow_save_model(fn, testthat_model_name, model_spec = list(
+    utc_time_created = mlflow_timestamp()
+  ))
+  
+  expect_true(dir.exists(testthat_model_name))
+  expect_match(model_spec$utc_time_created, "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{6}")
+})
+
 test_that("mlflow can save model function", {
   mlflow_clear_test_dir(testthat_model_name)
   model <- lm(Sepal.Width ~ Sepal.Length, iris)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Model creation timestamp for log model in R is formatted as in Python API

## How is this patch tested?

(Details)

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [X] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
