### PR TITLE
Fix/azure auth

### DIFF
--- a/mlflow/store/artifact/azure_blob_artifact_repo.py
+++ b/mlflow/store/artifact/azure_blob_artifact_repo.py
@@ -17,7 +17,7 @@ class AzureBlobArtifactRepository(ArtifactRepository):
     following the same URI scheme as Hadoop on Azure blob storage. It requires either that:
     - Azure storage connection string is in the env var ``AZURE_STORAGE_CONNECTION_STRING``
     - Azure storage access key is in the env var ``AZURE_STORAGE_ACCESS_KEY``
-    - DefaultAzureCredential is configured
+    - ChainedTokenCredential is configured
     """
 
     def __init__(self, artifact_uri, client=None):
@@ -44,10 +44,10 @@ class AzureBlobArtifactRepository(ArtifactRepository):
             )
         else:
             try:
-                from azure.identity import DefaultAzureCredential
+                from azure.identity import ChainedTokenCredential, AzureCliCredential, EnvironmentCredential
             except ImportError as exc:
                 raise ImportError(
-                    "Using DefaultAzureCredential requires the azure-identity package. "
+                    "Using ChainedTokenCredential requires the azure-identity package. "
                     "Please install it via: pip install azure-identity"
                 ) from exc
 
@@ -55,7 +55,10 @@ class AzureBlobArtifactRepository(ArtifactRepository):
                 account=account, api_uri_suffix=api_uri_suffix
             )
             self.client = BlobServiceClient(
-                account_url=account_url, credential=DefaultAzureCredential()
+                account_url=account_url, credential=ChainedTokenCredential(
+                    EnvironmentCredential(),
+                    AzureCliCredential()
+                )
             )
 
     @staticmethod

--- a/tests/store/artifact/test_azure_blob_artifact_repo.py
+++ b/tests/store/artifact/test_azure_blob_artifact_repo.py
@@ -52,7 +52,7 @@ def test_artifact_uri_factory(mock_client):
     del os.environ["AZURE_STORAGE_ACCESS_KEY"]
 
 
-@mock.patch("azure.identity.DefaultAzureCredential")
+@mock.patch("azure.identity.ChainedTokenCredential")
 def test_default_az_cred_if_no_env_vars(mock_default_azure_credential, mock_client):
     # pylint: disable=unused-argument
     # We pass in the mock_client here to clear Azure environment variables, but we don't use it


### PR DESCRIPTION
## What changes are proposed in this pull request?
Changes the azure client from DefaultCredentials to ChainedTokenCredential. This is due to the 
issues with the former.

## How is this patch tested?
Local tests (small)

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
