### PR TITLE
Remove inheritance from `object`

### DIFF
--- a/examples/flower_classifier/image_pyfunc.py
+++ b/examples/flower_classifier/image_pyfunc.py
@@ -32,7 +32,7 @@ def decode_and_resize_image(raw_bytes, size):
     return np.asarray(Image.open(BytesIO(raw_bytes)).resize(size), dtype=np.float32)
 
 
-class KerasImageClassifierPyfunc(object):
+class KerasImageClassifierPyfunc:
     """
     Image classification model with embedded pre-processing.
 

--- a/mlflow/entities/_mlflow_object.py
+++ b/mlflow/entities/_mlflow_object.py
@@ -2,7 +2,7 @@ from abc import abstractmethod
 import pprint
 
 
-class _MLflowObject(object):
+class _MLflowObject:
     def __iter__(self):
         # Iterate through list of properties and yield as key -> value
         for prop in self._properties():
@@ -38,7 +38,7 @@ def get_classname(obj):
     return type(obj).__name__
 
 
-class _MLflowObjectPrinter(object):
+class _MLflowObjectPrinter:
     def __init__(self):
         super().__init__()
         self.printer = pprint.PrettyPrinter()

--- a/mlflow/entities/lifecycle_stage.py
+++ b/mlflow/entities/lifecycle_stage.py
@@ -2,7 +2,7 @@ from mlflow.entities.view_type import ViewType
 from mlflow.exceptions import MlflowException
 
 
-class LifecycleStage(object):
+class LifecycleStage:
     ACTIVE = "active"
     DELETED = "deleted"
     _VALID_STAGES = set([ACTIVE, DELETED])

--- a/mlflow/entities/model_registry/model_version_status.py
+++ b/mlflow/entities/model_registry/model_version_status.py
@@ -1,7 +1,7 @@
 from mlflow.protos.model_registry_pb2 import ModelVersionStatus as ProtoModelVersionStatus
 
 
-class ModelVersionStatus(object):
+class ModelVersionStatus:
     """Enum for status of an :py:class:`mlflow.entities.model_registry.ModelVersion`."""
 
     PENDING_REGISTRATION = ProtoModelVersionStatus.Value("PENDING_REGISTRATION")

--- a/mlflow/entities/run_status.py
+++ b/mlflow/entities/run_status.py
@@ -1,7 +1,7 @@
 from mlflow.protos.service_pb2 import RunStatus as ProtoRunStatus
 
 
-class RunStatus(object):
+class RunStatus:
     """Enum for status of an :py:class:`mlflow.entities.Run`."""
 
     RUNNING = ProtoRunStatus.Value("RUNNING")

--- a/mlflow/entities/source_type.py
+++ b/mlflow/entities/source_type.py
@@ -1,4 +1,4 @@
-class SourceType(object):
+class SourceType:
     """Enum for originating source of a :py:class:`mlflow.entities.Run`."""
 
     NOTEBOOK, JOB, PROJECT, LOCAL, UNKNOWN = range(1, 6)

--- a/mlflow/entities/view_type.py
+++ b/mlflow/entities/view_type.py
@@ -1,7 +1,7 @@
 from mlflow.protos import service_pb2
 
 
-class ViewType(object):
+class ViewType:
     """Enum to filter requested experiment types."""
 
     ACTIVE_ONLY, DELETED_ONLY, ALL = range(1, 4)

--- a/mlflow/models/flavor_backend.py
+++ b/mlflow/models/flavor_backend.py
@@ -1,7 +1,7 @@
 from abc import ABCMeta, abstractmethod
 
 
-class FlavorBackend(object):
+class FlavorBackend:
     """
     Abstract class for Flavor Backend.
     This class defines the API interface for local model deployment of MLflow model flavors.

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -28,7 +28,7 @@ _LOG_MODEL_METADATA_WARNING_TEMPLATE = (
 )
 
 
-class Model(object):
+class Model:
     """
     An MLflow Model that can support multiple model flavors. Provides APIs for implementing
     new Model flavors.

--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
         MlflowInferableDataset = Union[pd.DataFrame, np.ndarray, Dict[str, np.ndarray]]
 
 
-class ModelSignature(object):
+class ModelSignature:
     """
     ModelSignature specifies schema of model's inputs and outputs.
 

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -14,7 +14,7 @@ from scipy.sparse import csr_matrix, csc_matrix
 ModelInputExample = Union[pd.DataFrame, np.ndarray, dict, list, csr_matrix, csc_matrix]
 
 
-class _Example(object):
+class _Example:
     """
     Represents an input example for MLflow model.
 

--- a/mlflow/paddle/__init__.py
+++ b/mlflow/paddle/__init__.py
@@ -419,7 +419,7 @@ def _load_pyfunc(path):
     return _PaddleWrapper(load_model(path))
 
 
-class _PaddleWrapper(object):
+class _PaddleWrapper:
     """
     Wrapper class that creates a predict function such that
     predict(data: pd.DataFrame) -> model's output as pd.DataFrame (pandas DataFrame)

--- a/mlflow/projects/_project_spec.py
+++ b/mlflow/projects/_project_spec.py
@@ -107,7 +107,7 @@ def load_project(directory):
     )
 
 
-class Project(object):
+class Project:
     """A project specification loaded from an MLproject file in the passed-in directory."""
 
     def __init__(self, conda_env_path, entry_points, docker_env, name):
@@ -136,7 +136,7 @@ class Project(object):
         )
 
 
-class EntryPoint(object):
+class EntryPoint:
     """An entry point in an MLproject specification."""
 
     def __init__(self, name, parameters, command):
@@ -199,7 +199,7 @@ class EntryPoint(object):
         return {str(key): quote(str(value)) for key, value in param_dict.items()}
 
 
-class Parameter(object):
+class Parameter:
     """A parameter in an MLproject entry point."""
 
     def __init__(self, name, yaml_obj):

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -69,7 +69,7 @@ def before_run_validations(tracking_uri, backend_config):
         )
 
 
-class DatabricksJobRunner(object):
+class DatabricksJobRunner:
     """
     Helper class for running an MLflow project as a Databricks Job.
     :param databricks_profile: Optional Databricks CLI profile to use to fetch hostname &

--- a/mlflow/projects/submitted_run.py
+++ b/mlflow/projects/submitted_run.py
@@ -9,7 +9,7 @@ from mlflow.entities import RunStatus
 _logger = logging.getLogger(__name__)
 
 
-class SubmittedRun(object):
+class SubmittedRun:
     """
     Wrapper around an MLflow project run (e.g. a subprocess running an entry point
     command or a Databricks job run) and exposing methods for waiting on and cancelling the run.

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -563,7 +563,7 @@ def _enforce_schema(pfInput: PyFuncInput, input_schema: Schema):
     )
 
 
-class PyFuncModel(object):
+class PyFuncModel:
     """
     MLflow 'python function' model.
 

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -57,7 +57,7 @@ def get_default_conda_env():
     return _mlflow_conda_env(additional_pip_deps=get_default_pip_requirements())
 
 
-class PythonModel(object):
+class PythonModel:
     """
     Represents a generic Python model that evaluates inputs and produces API-compatible outputs.
     By subclassing :class:`~PythonModel`, users can create customized MLflow models with the
@@ -94,7 +94,7 @@ class PythonModel(object):
         """
 
 
-class PythonModelContext(object):
+class PythonModelContext:
     """
     A collection of artifacts that a :class:`~PythonModel` can use when performing inference.
     :class:`~PythonModelContext` objects are created *implicitly* by the
@@ -281,7 +281,7 @@ def _load_pyfunc(model_path):
     return _PythonModelPyfuncWrapper(python_model=python_model, context=context)
 
 
-class _PythonModelPyfuncWrapper(object):
+class _PythonModelPyfuncWrapper:
     """
     Wrapper class that creates a predict function such that
     predict(model_input: pd.DataFrame) -> model's output as pd.DataFrame (pandas DataFrame)

--- a/mlflow/pyfunc/spark_model_cache.py
+++ b/mlflow/pyfunc/spark_model_cache.py
@@ -6,7 +6,7 @@ import zipfile
 from pyspark.files import SparkFiles
 
 
-class SparkModelCache(object):
+class SparkModelCache:
     """Caches models in memory on Spark Executors, to avoid continually reloading from disk.
 
     This class has to be part of a different module than the one that _uses_ it. This is

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -730,7 +730,7 @@ def _load_pyfunc(path, **kwargs):
     return _PyTorchWrapper(_load_model(path, **kwargs))
 
 
-class _PyTorchWrapper(object):
+class _PyTorchWrapper:
     """
     Wrapper class that creates a predict function such that
     predict(data: pd.DataFrame) -> model's output as pd.DataFrame (pandas DataFrame)

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -708,7 +708,7 @@ def _load_pyfunc(path):
     return _PyFuncModelWrapper(spark, _load_model(model_uri=path))
 
 
-class _PyFuncModelWrapper(object):
+class _PyFuncModelWrapper:
     """
     Wrapper around Spark MLlib PipelineModel providing interface for scoring pandas DataFrame.
     """

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -455,7 +455,7 @@ def _load_pyfunc(path):
     return _TF2Wrapper(model=loaded_model, infer=loaded_model.signatures[tf_signature_def_key])
 
 
-class _TF2Wrapper(object):
+class _TF2Wrapper:
     """
     Wrapper class that exposes a TensorFlow model for inference via a ``predict`` function such that
     ``predict(data: pandas.DataFrame) -> pandas.DataFrame``. For TensorFlow versions >= 2.0.0.

--- a/mlflow/tracking/_model_registry/client.py
+++ b/mlflow/tracking/_model_registry/client.py
@@ -19,7 +19,7 @@ _logger = logging.getLogger(__name__)
 AWAIT_MODEL_VERSION_CREATE_SLEEP_DURATION_SECONDS = 3
 
 
-class ModelRegistryClient(object):
+class ModelRegistryClient:
     """
     Client of an MLflow Model Registry Server that creates and manages registered
     models and model versions.

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -29,7 +29,7 @@ from mlflow.utils.uri import add_databricks_profile_info_to_artifact_uri
 from collections import OrderedDict
 
 
-class TrackingServiceClient(object):
+class TrackingServiceClient:
     """
     Client of an MLflow Tracking Server that creates and manages experiments and runs.
     """

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -47,7 +47,7 @@ if TYPE_CHECKING:
 _logger = logging.getLogger(__name__)
 
 
-class MlflowClient(object):
+class MlflowClient:
     """
     Client of an MLflow Tracking Server that creates and manages experiments and runs, and of an
     MLflow Registry Server that creates and manages registered models and model versions. It's a

--- a/mlflow/tracking/context/abstract_context.py
+++ b/mlflow/tracking/context/abstract_context.py
@@ -1,7 +1,7 @@
 from abc import ABCMeta, abstractmethod
 
 
-class RunContextProvider(object):
+class RunContextProvider:
     """
     Abstract base class for context provider objects specifying custom tags at run-creation time
     (e.g. tags specifying the git repo with which the run is associated).

--- a/mlflow/tracking/context/registry.py
+++ b/mlflow/tracking/context/registry.py
@@ -13,7 +13,7 @@ from mlflow.tracking.context.databricks_command_context import DatabricksCommand
 _logger = logging.getLogger(__name__)
 
 
-class RunContextProviderRegistry(object):
+class RunContextProviderRegistry:
     """Registry for run context provider implementations
 
     This class allows the registration of a run context provider which can be used to infer meta

--- a/mlflow/tracking/request_header/abstract_request_header_provider.py
+++ b/mlflow/tracking/request_header/abstract_request_header_provider.py
@@ -1,7 +1,7 @@
 from abc import ABCMeta, abstractmethod
 
 
-class RequestHeaderProvider(object):
+class RequestHeaderProvider:
     """
     Abstract base class for specifying custom request headers to add to outgoing requests
     (e.g. request headers specifying the environment from which mlflow is running).

--- a/mlflow/tracking/request_header/registry.py
+++ b/mlflow/tracking/request_header/registry.py
@@ -9,7 +9,7 @@ from mlflow.tracking.request_header.databricks_request_header_provider import (
 _logger = logging.getLogger(__name__)
 
 
-class RequestHeaderProviderRegistry(object):
+class RequestHeaderProviderRegistry:
     def __init__(self):
         self._registry = []
 

--- a/mlflow/types/schema.py
+++ b/mlflow/types/schema.py
@@ -68,7 +68,7 @@ class DataType(Enum):
         return getattr(pyspark.sql.types, self._spark_type)()
 
 
-class ColSpec(object):
+class ColSpec:
     """
     Specification of name and type of a single column in a dataset.
     """
@@ -119,7 +119,7 @@ class ColSpec(object):
             return "{name}: {type}".format(name=repr(self.name), type=repr(self.type))
 
 
-class TensorInfo(object):
+class TensorInfo:
     """
     Representation of the shape and type of a Tensor.
     """
@@ -181,7 +181,7 @@ class TensorInfo(object):
         return "Tensor({type}, {shape})".format(type=repr(self.dtype.name), shape=repr(self.shape))
 
 
-class TensorSpec(object):
+class TensorSpec:
     """
     Specification used to represent a dataset stored as a Tensor.
     """
@@ -249,7 +249,7 @@ class TensorSpec(object):
             return "{name}: {info}".format(name=repr(self.name), info=repr(self._tensorInfo))
 
 
-class Schema(object):
+class Schema:
     """
     Specification of a dataset.
 

--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -212,7 +212,7 @@ def _infer_pandas_column(col: pd.Series) -> DataType:
     if len(col.values.shape) > 1:
         raise MlflowException("Expected 1d array, got array with shape {}".format(col.shape))
 
-    class IsInstanceOrNone(object):
+    class IsInstanceOrNone:
         def __init__(self, *args):
             self.classes = args
             self.seen_instances = 0

--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -505,7 +505,7 @@ def _get_new_training_session_class():
     # 1. We don't currently have any use cases for allow_children=True.
     # 2. The list append & pop operations are thread-safe, so we will always clear the session stack
     #    once all _TrainingSessions exit.
-    class _TrainingSession(object):
+    class _TrainingSession:
         _session_stack = []
 
         def __init__(self, clazz, allow_children=True):

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -181,7 +181,7 @@ def read_yaml(root, file_name):
         raise e
 
 
-class TempDir(object):
+class TempDir:
     def __init__(self, chdr=False, remove_on_exit=True):
         self._dir = None
         self._path = None

--- a/mlflow/utils/gorilla.py
+++ b/mlflow/utils/gorilla.py
@@ -92,7 +92,7 @@ def default_filter(name, obj):
     return not (isinstance(obj, types.ModuleType) or name.startswith("_"))
 
 
-class DecoratorData(object):
+class DecoratorData:
 
     """Decorator data.
 
@@ -115,7 +115,7 @@ class DecoratorData(object):
         self.filter = None
 
 
-class Settings(object):
+class Settings:
 
     """Define the patching behaviour.
 
@@ -171,7 +171,7 @@ class Settings(object):
         self.__dict__.update(**kwargs)
 
 
-class Patch(object):
+class Patch:
 
     """Describe all the information required to apply a patch.
 

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -291,7 +291,7 @@ def cloud_storage_http_request(
         raise MlflowException("API request failed with exception %s" % e)
 
 
-class MlflowHostCreds(object):
+class MlflowHostCreds:
     """
     Provides a hostname and optional authentication for talking to an MLflow tracking server.
     :param host: Hostname (e.g., http://localhost:5000) to MLflow server. Required.

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -24,7 +24,7 @@ from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 import math
 
 
-class SearchUtils(object):
+class SearchUtils:
     LIKE_OPERATOR = "LIKE"
     ILIKE_OPERATOR = "ILIKE"
     ASC_OPERATOR = "asc"

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -304,7 +304,7 @@ def mock_s3_bucket():
         yield bucket_name
 
 
-class safe_edit_yaml(object):
+class safe_edit_yaml:
     def __init__(self, root, file_name, edit_func):
         self._root = root
         self._file_name = file_name

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -191,7 +191,7 @@ def keras_custom_env(tmpdir):
 
 @pytest.mark.allow_infer_pip_requirements_fallback
 def test_that_keras_module_arg_works(model_path):
-    class MyModel(object):
+    class MyModel:
         def __init__(self, x):
             self._x = x
 
@@ -203,7 +203,7 @@ def test_that_keras_module_arg_works(model_path):
             with h5py.File(path, "w") as f:
                 f.create_dataset(name="x", data=self._x)
 
-    class FakeKerasModule(object):
+    class FakeKerasModule:
         __name__ = "some.test.keras.module"
         __version__ = "42.42.42"
 

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -58,7 +58,7 @@ def test_model_save_load():
     assert m.to_yaml() == o.to_yaml()
 
 
-class TestFlavor(object):
+class TestFlavor:
     @classmethod
     def save_model(cls, path, mlflow_model, signature=None, input_example=None):
         mlflow_model.flavors["flavor1"] = {"a": 1, "b": 2}

--- a/tests/projects/test_projects.py
+++ b/tests/projects/test_projects.py
@@ -475,7 +475,7 @@ def test_parse_kubernetes_config_invalid_template_job_file():
 @pytest.mark.parametrize("synchronous", [True, False])
 @mock.patch("databricks_cli.configure.provider.get_config")
 def test_credential_propagation(get_config, synchronous):
-    class DummyProcess(object):
+    class DummyProcess:
         def wait(self):
             return 0
 

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -963,7 +963,7 @@ def test_repr_can_be_called_withtout_run_id_or_artifact_path():
         flavors={"python_function": {"loader_module": "someFlavour"}},
     )
 
-    class TestModel(object):
+    class TestModel:
         def predict(self, model_input):
             return model_input
 

--- a/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
+++ b/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
@@ -26,7 +26,7 @@ from mlflow.utils.model_utils import _get_flavor_configuration
 from tests.helper_functions import _assert_pip_requirements
 
 
-class TestModel(object):
+class TestModel:
     @staticmethod
     def predict(pdf):
         return pdf

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -31,7 +31,7 @@ def score_model_as_udf(model_uri, pandas_df, result_type="double"):
     return [x["prediction"] for x in new_df.collect()]
 
 
-class ConstantPyfuncWrapper(object):
+class ConstantPyfuncWrapper:
     @staticmethod
     def predict(model_input):
         m, _ = model_input.shape

--- a/tests/store/artifact/test_azure_blob_artifact_repo.py
+++ b/tests/store/artifact/test_azure_blob_artifact_repo.py
@@ -15,7 +15,7 @@ TEST_BLOB_CONTAINER_ROOT = "wasbs://container@account.blob.core.windows.net/"
 TEST_URI = os.path.join(TEST_BLOB_CONTAINER_ROOT, TEST_ROOT_PATH)
 
 
-class MockBlobList(object):
+class MockBlobList:
     def __init__(self, items, next_marker=None):
         self.items = items
         self.next_marker = next_marker

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -73,7 +73,7 @@ def test_dir(tmpdir):
     return tmpdir
 
 
-class TestDatabricksArtifactRepository(object):
+class TestDatabricksArtifactRepository:
     def test_init_validation_and_cleaning(self):
         with mock.patch(
             DATABRICKS_ARTIFACT_REPOSITORY + "._get_run_artifact_root"

--- a/tests/store/artifact/test_databricks_models_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_models_artifact_repo.py
@@ -30,7 +30,7 @@ def databricks_model_artifact_repo():
     return DatabricksModelsArtifactRepository(MOCK_MODEL_ROOT_URI_WITH_PROFILE)
 
 
-class TestDatabricksModelArtifactRepository(object):
+class TestDatabricksModelArtifactRepository:
     def test_init_with_version_uri_containing_profile(self):
         repo = DatabricksModelsArtifactRepository(MOCK_MODEL_ROOT_URI_WITH_PROFILE)
         assert repo.artifact_uri == MOCK_MODEL_ROOT_URI_WITH_PROFILE

--- a/tests/store/artifact/test_dbfs_fuse_artifact_repo.py
+++ b/tests/store/artifact/test_dbfs_fuse_artifact_repo.py
@@ -58,7 +58,7 @@ def test_dir(files_dir):
     return files_dir
 
 
-class TestDbfsFuseArtifactRepository(object):
+class TestDbfsFuseArtifactRepository:
     @pytest.mark.parametrize("artifact_path", [None, "output", ""])
     def test_log_artifact(self, dbfs_fuse_artifact_repo, test_file, artifact_path, artifact_dir):
         dbfs_fuse_artifact_repo.log_artifact(test_file.strpath, artifact_path)

--- a/tests/store/artifact/test_dbfs_rest_artifact_repo.py
+++ b/tests/store/artifact/test_dbfs_rest_artifact_repo.py
@@ -64,7 +64,7 @@ LIST_ARTIFACTS_SINGLE_FILE_RESPONSE = {
 }
 
 
-class TestDbfsArtifactRepository(object):
+class TestDbfsArtifactRepository:
     def test_init_validation_and_cleaning(self):
         with mock.patch(
             DBFS_ARTIFACT_REPOSITORY_PACKAGE + "._get_host_creds_from_default_store"

--- a/tests/store/tracking/__init__.py
+++ b/tests/store/tracking/__init__.py
@@ -5,7 +5,7 @@ from mlflow.models import Model
 from mlflow.utils.mlflow_tags import MLFLOW_LOGGED_MODELS
 
 
-class AbstractStoreTest(object):
+class AbstractStoreTest:
     def create_test_run(self):
         raise Exception("this should be overriden")
 

--- a/tests/store/tracking/test_rest_store.py
+++ b/tests/store/tracking/test_rest_store.py
@@ -66,7 +66,7 @@ def mock_http_request():
     )
 
 
-class TestRestStore(object):
+class TestRestStore:
     @mock.patch("requests.Session.request")
     def test_successful_http_request(self, request):
         def mock_request(*args, **kwargs):

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -11,7 +11,7 @@ from mlflow.protos.databricks_pb2 import (
 )
 
 
-class TestMlflowException(object):
+class TestMlflowException:
     def test_error_code_constructor(self):
         assert (
             MlflowException("test", error_code=INVALID_PARAMETER_VALUE).error_code

--- a/tests/tracking/context/test_registry.py
+++ b/tests/tracking/context/test_registry.py
@@ -74,7 +74,7 @@ def test_registry_instance_defaults():
 
 
 def test_registry_instance_loads_entrypoints():
-    class MockRunContext(object):
+    class MockRunContext:
         pass
 
     mock_entrypoint = mock.Mock()

--- a/tests/tracking/request_header/test_registry.py
+++ b/tests/tracking/request_header/test_registry.py
@@ -71,7 +71,7 @@ def test_registry_instance_defaults():
 
 
 def test_registry_instance_loads_entrypoints():
-    class MockRequestHeaderProvider(object):
+    class MockRequestHeaderProvider:
         pass
 
     mock_entrypoint = mock.Mock()


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

We can remove inheritance from `object` since we no longer support python 2.

## How is this patch tested?

Existing tests

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
