### PR TITLE
Mark "Changing param values is not allowed" as User initiated failure exception type

### DIFF
--- a/mlflow/exceptions.py
+++ b/mlflow/exceptions.py
@@ -43,6 +43,7 @@ class MlflowException(Exception):
         :param error_code: An appropriate error code for the error that occured; it will be included
                            in the exception's serialized JSON representation. This should be one of
                            the codes listed in the `mlflow.protos.databricks_pb2` proto.
+        :param is_user_initiated: A boolean value represents whether the error is user initiated.
         :param kwargs: Additional key-value pairs to include in the serialized JSON representation
                        of the MlflowException.
         """
@@ -59,7 +60,7 @@ class MlflowException(Exception):
         exception_dict = {
             "error_code": self.error_code,
             "message": self.message,
-            "is_user_initiated": self.is_user_initiated
+            "is_user_initiated": self.is_user_initiated,
         }
         exception_dict.update(self.json_kwargs)
         return json.dumps(exception_dict)

--- a/mlflow/exceptions.py
+++ b/mlflow/exceptions.py
@@ -56,7 +56,11 @@ class MlflowException(Exception):
         super().__init__(message)
 
     def serialize_as_json(self):
-        exception_dict = {"error_code": self.error_code, "message": self.message}
+        exception_dict = {
+            "error_code": self.error_code,
+            "message": self.message,
+            "is_user_initiated": self.is_user_initiated
+        }
         exception_dict.update(self.json_kwargs)
         return json.dumps(exception_dict)
 

--- a/mlflow/exceptions.py
+++ b/mlflow/exceptions.py
@@ -36,7 +36,7 @@ class MlflowException(Exception):
     instead.
     """
 
-    def __init__(self, message, error_code=INTERNAL_ERROR, **kwargs):
+    def __init__(self, message, error_code=INTERNAL_ERROR, is_user_initiated=False, **kwargs):
         """
         :param message: The message describing the error that occured. This will be included in the
                         exception's serialized JSON representation.
@@ -51,6 +51,7 @@ class MlflowException(Exception):
         except (ValueError, TypeError):
             self.error_code = ErrorCode.Name(INTERNAL_ERROR)
         self.message = message
+        self.is_user_initiated = is_user_initiated
         self.json_kwargs = kwargs
         super().__init__(message)
 

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -826,6 +826,7 @@ class FileStore(AbstractStore):
                 " logged with value='{}' for run ID='{}'. Attempted logging new value"
                 " '{}'.".format(param_key, current_value, run_id, new_value),
                 databricks_pb2.INVALID_PARAMETER_VALUE,
+                is_user_initiated=True,
             )
 
     def set_experiment_tag(self, experiment_id, tag):

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -687,6 +687,7 @@ class SqlAlchemyStore(AbstractStore):
                         " logged with value='{}' for run ID='{}'. Attempted logging new value"
                         " '{}'.".format(param.key, old_value, run_id, param.value),
                         INVALID_PARAMETER_VALUE,
+                        is_user_initiated=True,
                     )
                 else:
                     raise

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -243,7 +243,9 @@ class TrackingServiceClient:
         except MlflowException as e:
             if e.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE):
                 msg = f"{e.message}{PARAM_VALIDATION_MSG}'"
-                raise MlflowException(msg, INVALID_PARAMETER_VALUE)
+                raise MlflowException(
+                    msg, INVALID_PARAMETER_VALUE, is_user_initiated=e.is_user_initiated
+                )
             else:
                 raise e
 

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -737,6 +737,7 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         ) as e:
             fs.log_param(run_id, Param(param_name, "value2"))
         assert e.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+        assert e.exception.is_user_initiated
         run = fs.get_run(run_id)
         assert run.data.params[param_name] == "value1"
 

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -758,6 +758,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase, AbstractStoreTest):
         with self.assertRaises(MlflowException) as e:
             self.store.log_param(run.info.run_id, param2)
         self.assertIn("Changing param values is not allowed. Param with key=", e.exception.message)
+        assert e.exception.is_user_initiated
 
     def test_log_empty_str(self):
         run = self._run_factory()
@@ -1610,6 +1611,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase, AbstractStoreTest):
             )
         self.assertIn("Changing param values is not allowed. Param with key=", e.exception.message)
         assert e.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+        assert e.exception.is_user_initiated
         self._verify_logged(self.store, run.info.run_id, metrics=[], params=[param], tags=[])
 
     def test_log_batch_param_overwrite_disallowed_single_req(self):
@@ -1626,6 +1628,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase, AbstractStoreTest):
             )
         self.assertIn("Changing param values is not allowed. Param with key=", e.exception.message)
         assert e.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+        assert e.exception.is_user_initiated
         self._verify_logged(self.store, run.info.run_id, metrics=[], params=[param0], tags=[])
 
     def test_log_batch_accepts_empty_payload(self):

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -489,6 +489,7 @@ def test_log_params_duplicate_keys_raises():
         ) as e:
             mlflow.log_param("a", "3")
         assert e.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+        assert e.value.is_user_initiated
     finished_run = tracking.MlflowClient().get_run(run_id)
     assert finished_run.data.params == params
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Mark "Changing param values is not allowed" as User initiated failure exception type

## How is this patch tested?

N/A

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
