### PR TITLE
Pin setuptools to fix pytorch example failures

### DIFF
--- a/examples/pytorch/BertNewsClassification/conda.yaml
+++ b/examples/pytorch/BertNewsClassification/conda.yaml
@@ -14,3 +14,10 @@ dependencies:
   - torch>=1.9.0
   - torchtext==0.10.0
   - pytorch-lightning==1.5.1
+  # torch <= 1.10.1 doesn't work with setuptools >= 59.6.0.
+  # See the following PRs for details:
+  # https://github.com/pytorch/pytorch/pull/69904
+  # https://github.com/pytorch/pytorch/pull/69947
+  #
+  # TODO: Remove this requirement once torch > 1.10.1 is released.
+  - setuptools<59.6.0

--- a/examples/pytorch/IterativePruning/conda.yaml
+++ b/examples/pytorch/IterativePruning/conda.yaml
@@ -11,3 +11,8 @@ dependencies:
   - ax-platform
   - prettytable
   - torch>=1.9.0
+  # torch <= 1.10.1 doesn't work with setuptools >= 59.6.0.
+  # See the following PRs for details:
+  # https://github.com/pytorch/pytorch/pull/69904
+  # https://github.com/pytorch/pytorch/pull/69947
+  - setuptools<59.6.0

--- a/examples/pytorch/IterativePruning/conda.yaml
+++ b/examples/pytorch/IterativePruning/conda.yaml
@@ -15,4 +15,6 @@ dependencies:
   # See the following PRs for details:
   # https://github.com/pytorch/pytorch/pull/69904
   # https://github.com/pytorch/pytorch/pull/69947
+  #
+  # TODO: Remove this requirement once torch > 1.10.1 is released.
   - setuptools<59.6.0

--- a/examples/pytorch/MNIST/conda.yaml
+++ b/examples/pytorch/MNIST/conda.yaml
@@ -8,3 +8,10 @@ dependencies:
   - torchvision>=0.9.1
   - torch>=1.9.0
   - pytorch-lightning==1.5.1
+  # torch <= 1.10.1 doesn't work with setuptools >= 59.6.0.
+  # See the following PRs for details:
+  # https://github.com/pytorch/pytorch/pull/69904
+  # https://github.com/pytorch/pytorch/pull/69947
+  #
+  # TODO: Remove this requirement once torch > 1.10.1 is released.
+  - setuptools<59.6.0


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Pin setuptools to fix pytorch example failures:

https://github.com/mlflow/mlflow/runs/4785850029?check_suite_focus=true#step:7:439

```
Traceback (most recent call last):
  File "mnist_autolog_example.py", line 11, in <module>
    import pytorch_lightning as pl
  File "/usr/share/miniconda/envs/mlflow-a97aa9219843239fed756e293a8f663e382f2da9/lib/python3.8/site-packages/pytorch_lightning/__init__.py", line 20, in <module>
    from pytorch_lightning.callbacks import Callback  # noqa: E402
  File "/usr/share/miniconda/envs/mlflow-a97aa9219843239fed756e293a8f663e382f2da9/lib/python3.8/site-packages/pytorch_lightning/callbacks/__init__.py", line 26, in <module>
    from pytorch_lightning.callbacks.pruning import ModelPruning
  File "/usr/share/miniconda/envs/mlflow-a97aa9219843239fed756e293a8f663e382f2da9/lib/python3.8/site-packages/pytorch_lightning/callbacks/pruning.py", line 31, in <module>
    from pytorch_lightning.core.lightning import LightningModule
  File "/usr/share/miniconda/envs/mlflow-a97aa9219843239fed756e293a8f663e382f2da9/lib/python3.8/site-packages/pytorch_lightning/core/__init__.py", line 16, in <module>
    from pytorch_lightning.core.lightning import LightningModule
  File "/usr/share/miniconda/envs/mlflow-a97aa9219843239fed756e293a8f663e382f2da9/lib/python3.8/site-packages/pytorch_lightning/core/lightning.py", line 39, in <module>
    from pytorch_lightning.trainer.connectors.logger_connector.fx_validator import _FxValidator
  File "/usr/share/miniconda/envs/mlflow-a97aa9219843239fed756e293a8f663e382f2da9/lib/python3.8/site-packages/pytorch_lightning/trainer/__init__.py", line 16, in <module>
    from pytorch_lightning.trainer.trainer import Trainer
  File "/usr/share/miniconda/envs/mlflow-a97aa9219843239fed756e293a8f663e382f2da9/lib/python3.8/site-packages/pytorch_lightning/trainer/trainer.py", line 35, in <module>
    from pytorch_lightning.loggers import LightningLoggerBase
  File "/usr/share/miniconda/envs/mlflow-a97aa9219843239fed756e293a8f663e382f2da9/lib/python3.8/site-packages/pytorch_lightning/loggers/__init__.py", line 18, in <module>
    from pytorch_lightning.loggers.tensorboard import TensorBoardLogger
  File "/usr/share/miniconda/envs/mlflow-a97aa9219843239fed756e293a8f663e382f2da9/lib/python3.8/site-packages/pytorch_lightning/loggers/tensorboard.py", line 26, in <module>
    from torch.utils.tensorboard import SummaryWriter
  File "/usr/share/miniconda/envs/mlflow-a97aa9219843239fed756e293a8f663e382f2da9/lib/python3.8/site-packages/torch/utils/tensorboard/__init__.py", line 4, in <module>
    LooseVersion = distutils.version.LooseVersion
AttributeError: module 'setuptools._distutils' has no attribute 'version'
```

## How is this patch tested?

Existing tests

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
