### PR TITLE
Improve evaluation api

### DIFF
--- a/docs/source/python_api/mlflow.models.evaluation.base.rst
+++ b/docs/source/python_api/mlflow.models.evaluation.base.rst
@@ -1,7 +1,0 @@
-mlflow.models.evaluation.base
-=============================
-
-.. automodule:: mlflow.models.evaluation.base
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/source/python_api/mlflow.models.evaluation.rst
+++ b/docs/source/python_api/mlflow.models.evaluation.rst
@@ -1,8 +1,0 @@
-mlflow.models.evaluation
-========================
-
-.. automodule:: mlflow.models.evaluation
-    :members:
-    :undoc-members:
-    :show-inheritance:
-

--- a/mlflow/models/__init__.py
+++ b/mlflow/models/__init__.py
@@ -24,14 +24,14 @@ For details, see `MLflow Models <../models.html>`_.
 from .model import Model
 from .flavor_backend import FlavorBackend
 from ..utils.environment import infer_pip_requirements
-from .evaluation import evaluate, EvaluationDataset
+from .evaluation import evaluate, _EvaluationDataset
 
 __all__ = [
     "Model",
     "FlavorBackend",
     "infer_pip_requirements",
     "evaluate",
-    "EvaluationDataset",
+    "_EvaluationDataset",
 ]
 
 

--- a/mlflow/models/__init__.py
+++ b/mlflow/models/__init__.py
@@ -24,14 +24,13 @@ For details, see `MLflow Models <../models.html>`_.
 from .model import Model
 from .flavor_backend import FlavorBackend
 from ..utils.environment import infer_pip_requirements
-from .evaluation import evaluate, _EvaluationDataset
+from .evaluation import evaluate
 
 __all__ = [
     "Model",
     "FlavorBackend",
     "infer_pip_requirements",
     "evaluate",
-    "_EvaluationDataset",
 ]
 
 

--- a/mlflow/models/__init__.py
+++ b/mlflow/models/__init__.py
@@ -24,13 +24,16 @@ For details, see `MLflow Models <../models.html>`_.
 from .model import Model
 from .flavor_backend import FlavorBackend
 from ..utils.environment import infer_pip_requirements
-from .evaluation import evaluate
+from .evaluation import evaluate, EvaluationArtifact, EvaluationResult, list_evaluators
 
 __all__ = [
     "Model",
     "FlavorBackend",
     "infer_pip_requirements",
     "evaluate",
+    "EvaluationArtifact",
+    "EvaluationResult",
+    "list_evaluators",
 ]
 
 

--- a/mlflow/models/evaluation/__init__.py
+++ b/mlflow/models/evaluation/__init__.py
@@ -4,7 +4,6 @@ from mlflow.models.evaluation.base import (
     EvaluationArtifact,
     evaluate,
     list_evaluators,
-    _get_last_failed_evaluator,
 )
 
 __all__ = [

--- a/mlflow/models/evaluation/__init__.py
+++ b/mlflow/models/evaluation/__init__.py
@@ -1,5 +1,6 @@
 from mlflow.models.evaluation.base import (
     ModelEvaluator,
+    EvaluationDataset,
     EvaluationResult,
     EvaluationArtifact,
     evaluate,
@@ -8,6 +9,7 @@ from mlflow.models.evaluation.base import (
 
 __all__ = [
     "ModelEvaluator",
+    "EvaluationDataset",
     "EvaluationResult",
     "EvaluationArtifact",
     "evaluate",

--- a/mlflow/models/evaluation/__init__.py
+++ b/mlflow/models/evaluation/__init__.py
@@ -1,19 +1,21 @@
 from mlflow.models.evaluation.base import (
     ModelEvaluator,
-    EvaluationDataset,
+    _EvaluationDataset,
     EvaluationResult,
     EvaluationMetrics,
     EvaluationArtifact,
     evaluate,
     list_evaluators,
+    get_last_failed_evaluator,
 )
 
 __all__ = [
     "ModelEvaluator",
-    "EvaluationDataset",
+    "_EvaluationDataset",
     "EvaluationResult",
     "EvaluationMetrics",
     "EvaluationArtifact",
     "evaluate",
     "list_evaluators",
+    "get_last_failed_evaluator",
 ]

--- a/mlflow/models/evaluation/__init__.py
+++ b/mlflow/models/evaluation/__init__.py
@@ -1,8 +1,6 @@
 from mlflow.models.evaluation.base import (
     ModelEvaluator,
-    _EvaluationDataset,
     EvaluationResult,
-    EvaluationMetrics,
     EvaluationArtifact,
     evaluate,
     list_evaluators,
@@ -11,9 +9,7 @@ from mlflow.models.evaluation.base import (
 
 __all__ = [
     "ModelEvaluator",
-    "_EvaluationDataset",
     "EvaluationResult",
-    "EvaluationMetrics",
     "EvaluationArtifact",
     "evaluate",
     "list_evaluators",

--- a/mlflow/models/evaluation/__init__.py
+++ b/mlflow/models/evaluation/__init__.py
@@ -4,7 +4,7 @@ from mlflow.models.evaluation.base import (
     EvaluationArtifact,
     evaluate,
     list_evaluators,
-    get_last_failed_evaluator,
+    _get_last_failed_evaluator,
 )
 
 __all__ = [
@@ -13,5 +13,4 @@ __all__ = [
     "EvaluationArtifact",
     "evaluate",
     "list_evaluators",
-    "get_last_failed_evaluator",
 ]

--- a/mlflow/models/evaluation/artifacts.py
+++ b/mlflow/models/evaluation/artifacts.py
@@ -4,7 +4,7 @@ from mlflow.models.evaluation.base import EvaluationArtifact
 
 
 class ImageEvaluationArtifact(EvaluationArtifact):
-    def save(self, output_artifact_path):
+    def _save(self, output_artifact_path):
         self._content.save(output_artifact_path)
 
     def _load_content_from_file(self, local_artifact_path):
@@ -15,7 +15,7 @@ class ImageEvaluationArtifact(EvaluationArtifact):
 
 
 class CsvEvaluationArtifact(EvaluationArtifact):
-    def save(self, output_artifact_path):
+    def _save(self, output_artifact_path):
         self._content.to_csv(output_artifact_path, index=False)
 
     def _load_content_from_file(self, local_artifact_path):

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -670,10 +670,9 @@ def evaluate(
     :param data: One of the following:
      - A numpy array or list of evaluation features, excluding labels.
      - A Pandas DataFrame, or a spark DataFrame,
-       containing evaluation features and labels. All columns will be regarded as feature
-       columns except the "labels" column.
-     Note: If the mlflow model to be evaluated is a pyspark ML model, then the input data must
-       be a spark DataFrame contains a feature column of "Vector" type, and a label column.
+       containing evaluation features and labels. If `feature_names` argument not specified,
+       all columns will be regarded as feature columns, otherwise column names which match
+       `feature_names` will be regarded as feature columns.
 
     :param model_type: A string describing the model type. The default evaluator
                        supports "regressor" and "classifier" as model types.

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -728,10 +728,11 @@ def evaluate(
        false_positives/false_negatives/true_positives/recall/precision/roc_auc,
        precision_recall_auc), precision-recall merged curves plot, ROC merged curves plot.
 
-    The logged mlflow metric keys are constructed using the format: "{metric_name}_on_{dataset_name}".
+    The logged mlflow metric keys are constructed using the format: `{metric_name}_on_{dataset_name}`.
+    Any preexisting metrics with the same name are overwritten.
 
-    The metrics/artifacts listed above will be logged into the current active mlflow run,
-    if no active run exists, a new mlflow run will be created for logging these metrics/artifacts.
+    The metrics/artifacts listed above are logged to the active MLflow run.
+    If no active run exists, a new MLflow run is created for logging these metrics and artifacts.
 
     Additionally, information about the specified dataset - hash, name (if specified), path
     (if specified), and the UUID of the model that evaluated it - is logged to the

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -648,8 +648,8 @@ def evaluate(
     model: Union[str, "mlflow.pyfunc.PyFuncModel"],
     data,
     *,
-    model_type: str,
     targets,
+    model_type: str,
     dataset_name=None,
     dataset_path=None,
     feature_names: list = None,
@@ -753,14 +753,14 @@ def evaluate(
        ROC curve and Precision-Recall curve.
 
     Limitations of evaluation dataset:
-     - If the input dataset is pandas dataframe, the feature columns in pandas dataframe must be
-       scalar value columns, other object types (nd.array/list/etc.) are not supported yet.
      - For classifier, evaluation dataset labels must contains all distinct values, the dataset
-       labels data will be used to infer the number of classes. For binary classifier, the
+       labels data will be used to infer the number of classes.
+     - For binary classifier, the
        negative label value must be 0 or -1 or False, and the positive label value must be
        1 or True.
-       For multiclass classifier, if logging explainability insights enabled, the label values
-       must be number type.
+     - If logging explainability insights enabled, the label values
+       must be number type, and all feature values must be number type and each feature column
+       must only contain scaler values.
 
     Limitations of metrics/artifacts computation:
      - For classifier, some metrics and plot computation require model provides

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -676,8 +676,8 @@ def evaluate(
                        supports "regressor" and "classifier" as model types.
 
     :param dataset_name: (Optional) The name of the dataset, must not contain double quotes (“).
-                         the name is logged to the `mlflow.datasets` tag. If not specified, the
-                         dataset hash is used as the dataset name.
+                         The name is logged to the `mlflow.datasets` tag for lineage tracking
+                         purposes. If not specified, the dataset hash is used as the dataset name.
 
     :param dataset_path: (Optional) The path where the data is stored. Must not contain double
                          quotes (“). If specified, the path is logged to the `mlflow.datasets`

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -745,14 +745,15 @@ def evaluate(
           Explainer based on the model.
         - **explainability_nsamples**: The number of sample rows to use for computing model
           explainability insights. Default value is 2000.
-        - **max_num_classes_threshold_logging_roc_pr_curve_for_multiclass_classifier**:
-          For multiclass classifier, specify the max number of classes which allow logging
-          per-class ROC curve and Precision-Recall curve.
+        - **max_classes_for_multiclass_roc_pr**:
+          For multiclass classification tasks, the maximum number of classes for which to log
+          the per-class ROC curve and Precision-Recall curve. If the number of classes is
+          larger than the configured maximum, these curves are not logged.
 
      - Limitations of evaluation dataset:
         - For classification tasks, dataset labels are used to infer the total number of classes.
         - For binary classification tasks, the negative label value must be 0 or -1 or False, and
-        - the positive label value must be 1 or True.
+          the positive label value must be 1 or True.
 
      - Limitations of metrics/artifacts computation:
         - For classification tasks, some metric and artifact computations require the model to

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -232,9 +232,7 @@ class _EvaluationDataset:
     NUM_SAMPLE_ROWS_FOR_HASH = 5
     SPARK_DATAFRAME_LIMIT = 10000
 
-    def __init__(
-        self, data, *, targets, name=None, path=None, feature_names=None
-    ):
+    def __init__(self, data, *, targets, name=None, path=None, feature_names=None):
         """
         The values of the constructor arguments comes from the `evaluate` call.
         """

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -236,31 +236,7 @@ class _EvaluationDataset:
         self, data, *, targets=None, label_col=None, name=None, path=None, feature_names=None
     ):
         """
-        :param data: One of the following:
-         - A numpy array or list of evaluation features, excluding labels.
-         - A Pandas DataFrame, or a spark DataFrame,
-           containing evaluation features and labels. All columns will be regarded as feature
-           columns except the "labels" column.
-         Note: If the mlflow model to be evaluated is a pyspark ML model, then the input data must
-           be a spark DataFrame contains a feature column of "Vector" type, and a label column.
-
-        :param targets: (Optional) A numpy array or list of evaluation labels, if `data` is also a
-          numpy array or list.
-
-        :param label_col: (Optional) The string name of a column from `data` that contains
-          evaluation labels, if `data` is a DataFrame.
-
-        :param name: (Optional) The name of the dataset (must not contain ").
-
-        :param path: (Optional) the path to a serialized DataFrame (must not contain ").
-          (e.g. a delta table, parquet file)
-
-        :param feature_names: (Optional) If `data` argument is a feature data numpy array or list,
-          `feature_names` argument is a list of the feature names for each feature. If None, then
-          the `feature_names` will be generated using the format "feature_{feature_index}".
-          if `data` argument is a pandas dataframe or a spark dataframe, `feature_names` argument
-          is a list of the column names of the feature columns in the dataframe. If None, then
-          all columns except the label column will be regarded as feature columns.
+        The values of the constructor arguments comes from the `evaluate` call.
         """
         import numpy as np
         import pandas as pd
@@ -691,14 +667,35 @@ def evaluate(
 
     :param model: A pyfunc model instance, or a URI referring to such a model.
 
+    :param data: One of the following:
+     - A numpy array or list of evaluation features, excluding labels.
+     - A Pandas DataFrame, or a spark DataFrame,
+       containing evaluation features and labels. All columns will be regarded as feature
+       columns except the "labels" column.
+     Note: If the mlflow model to be evaluated is a pyspark ML model, then the input data must
+       be a spark DataFrame contains a feature column of "Vector" type, and a label column.
+
     :param model_type: A string describing the model type. The default evaluator
                        supports "regressor" and "classifier" as model types.
-    :param data:
-    :param run_id: The ID of the MLflow Run to which to log results. If
-                   unspecified, behavior depends on the specified `evaluator`.
-                   When `run_id` is unspecified, the default evaluator logs
-                   results to the current active run, creating a new active run if
-                   one does not exist.
+
+    :param targets: (Optional) A numpy array or list of evaluation labels, if `data` is also a
+      numpy array or list.
+
+    :param label_col: (Optional) The string name of a column from `data` that contains
+      evaluation labels, if `data` is a DataFrame.
+
+    :param dataset_name: (Optional) The name of the dataset, must not contain double quotes (“).
+.
+    :param dataset_path: (Optional) the path to a serialized DataFrame
+      (e.g. a delta table, parquet file), must not contain double quotes (“).
+
+    :param feature_names: (Optional) If `data` argument is a feature data numpy array or list,
+      `feature_names` argument is a list of the feature names for each feature. If None, then
+      the `feature_names` will be generated using the format "feature_{feature_index}".
+      if `data` argument is a pandas dataframe or a spark dataframe, `feature_names` argument
+      is a list of the column names of the feature columns in the dataframe. If None, then
+      all columns except the label column will be regarded as feature columns.
+
     :param evaluators: The name of the evaluator to use for model evaluations, or
                        a list of evaluator names. If unspecified, all evaluators
                        capable of evaluating the specified model on the specified

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -1,4 +1,4 @@
-from typing import Dict, Union
+from typing import Dict, Union, Any
 import mlflow
 import hashlib
 import json
@@ -20,14 +20,6 @@ from abc import ABCMeta, abstractmethod
 
 
 _logger = logging.getLogger(__name__)
-
-
-class EvaluationMetrics(dict):
-    """
-    A dictionary of model evaluation metrics.
-    """
-
-    pass
 
 
 class EvaluationArtifact(metaclass=ABCMeta):
@@ -99,7 +91,7 @@ class EvaluationResult:
     def load(cls, path):
         """Load the evaluation results from the specified local filesystem path"""
         with open(os.path.join(path, "metrics.json"), "r") as fp:
-            metrics = EvaluationMetrics(json.load(fp))
+            metrics = json.load(fp)
 
         with open(os.path.join(path, "artifacts_metadata.json"), "r") as fp:
             artifacts_metadata = json.load(fp)
@@ -140,7 +132,7 @@ class EvaluationResult:
             artifact.save(os.path.join(artifacts_dir, artifact_name))
 
     @property
-    def metrics(self) -> "mlflow.models.evaluation.EvaluationMetrics":
+    def metrics(self) -> Dict[str, Any]:
         """
         A dictionary mapping scalar metric names to scalar metric values
         """
@@ -671,7 +663,7 @@ def _evaluate(
             "verify that the model type and other configs are set correctly."
         )
 
-    merged_eval_result = EvaluationResult(EvaluationMetrics(), dict())
+    merged_eval_result = EvaluationResult(dict(), dict())
     for eval_result in eval_results:
         merged_eval_result.metrics.update(eval_result.metrics)
         merged_eval_result.artifacts.update(eval_result.artifacts)

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -225,7 +225,7 @@ def _gen_md5_for_arraylike_obj(md5_gen, data):
         md5_gen.update(_hash_array_like_obj_as_bytes(data))
     else:
         head_rows = data[: _EvaluationDataset.NUM_SAMPLE_ROWS_FOR_HASH]
-        tail_rows = data[-_EvaluationDataset.NUM_SAMPLE_ROWS_FOR_HASH:]
+        tail_rows = data[-_EvaluationDataset.NUM_SAMPLE_ROWS_FOR_HASH :]
         md5_gen.update(_hash_array_like_obj_as_bytes(head_rows))
         md5_gen.update(_hash_array_like_obj_as_bytes(tail_rows))
 
@@ -240,7 +240,9 @@ class _EvaluationDataset:
     NUM_SAMPLE_ROWS_FOR_HASH = 5
     SPARK_DATAFRAME_LIMIT = 10000
 
-    def __init__(self, data, *, targets=None, label_col=None, name=None, path=None, feature_names=None):
+    def __init__(
+        self, data, *, targets=None, label_col=None, name=None, path=None, feature_names=None
+    ):
         """
         :param data: One of the following:
          - A numpy array or list of evaluation features, excluding labels.
@@ -295,8 +297,9 @@ class _EvaluationDataset:
             supported_dataframe_types = (pd.DataFrame,)
 
         if feature_names is not None and len(set(feature_names)) < len(list(feature_names)):
-            raise ValueError('`feature_names` argument must be a list containing unique feature '
-                             'names.')
+            raise ValueError(
+                "`feature_names` argument must be a list containing unique feature " "names."
+            )
 
         if isinstance(data, (np.ndarray, list)):
             if not isinstance(targets, (np.ndarray, list)):
@@ -467,11 +470,13 @@ class _EvaluationDataset:
         else:
             is_features_data_equal = self._features_data.equals(other._features_data)
 
-        return is_features_data_equal and \
-            np.array_equal(self._labels_data, other._labels_data) and \
-            self.name == other.name and \
-            self.path == other.path and \
-            self._feature_names == other._feature_names
+        return (
+            is_features_data_equal
+            and np.array_equal(self._labels_data, other._labels_data)
+            and self.name == other.name
+            and self.path == other.path
+            and self._feature_names == other._feature_names
+        )
 
 
 class ModelEvaluator(metaclass=ABCMeta):
@@ -684,7 +689,7 @@ def evaluate(
     label_col=None,
     dataset_name=None,
     dataset_path=None,
-    feature_names: list=None,
+    feature_names: list = None,
     evaluators=None,
     evaluator_config=None,
 ) -> "mlflow.models.evaluation.EvaluationResult":
@@ -806,8 +811,12 @@ def evaluate(
     ) = _normalize_evaluators_and_evaluator_config_args(evaluators, evaluator_config)
 
     dataset = _EvaluationDataset(
-        data, targets=targets, label_col=label_col, name=dataset_name,
-        path=dataset_path, feature_names=feature_names
+        data,
+        targets=targets,
+        label_col=label_col,
+        name=dataset_name,
+        path=dataset_path,
+        feature_names=feature_names,
     )
 
     with _start_run_or_reuse_active_run() as run_id:

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -665,12 +665,12 @@ def evaluate(
                  regarded as feature columns, otherwise column names which match `feature_names`
                  are regarded as feature columns.
 
-    :param model_type: A string describing the model type. The default evaluator
-                       supports "regressor" and "classifier" as model types.
-
     :param targets: If `data` is also a numpy array or list, A numpy array or list of evaluation
                     labels. If `data` is a DataFrame, the string name of a column from `data`
                     that contains evaluation labels.
+
+    :param model_type: A string describing the model type. The default evaluator
+                       supports "regressor" and "classifier" as model types.
 
     :param dataset_name: (Optional) The name of the dataset, must not contain double quotes (“).
                          the name is logged to the `mlflow.datasets` tag. If not specified, the

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -301,7 +301,7 @@ class DefaultEvaluator(ModelEvaluator):
 
         mlflow.log_artifact(artifact_file_local_path)
         artifact = ImageEvaluationArtifact(uri=mlflow.get_artifact_uri(artifact_file_name))
-        artifact.load(artifact_file_local_path)
+        artifact._load(artifact_file_local_path)
         self.artifacts[artifact_name] = artifact
 
     def _log_pandas_df_artifact(self, pandas_df, artifact_name):
@@ -313,7 +313,7 @@ class DefaultEvaluator(ModelEvaluator):
             uri=mlflow.get_artifact_uri(artifact_file_name),
             content=pandas_df,
         )
-        artifact.load(artifact_file_local_path)
+        artifact._load(artifact_file_local_path)
         self.artifacts[artifact_name] = artifact
 
     def _log_model_explainability(self):
@@ -336,7 +336,7 @@ class DefaultEvaluator(ModelEvaluator):
             # Note: python bool type inherits number type but np.bool_ does not inherit np.number.
             _logger.warning(
                 "Skip logging model explainability insights because it requires all label "
-                "values to be number type or bool type."
+                "values to be numeric or boolean."
             )
             return
 
@@ -345,7 +345,7 @@ class DefaultEvaluator(ModelEvaluator):
             if not np.issubdtype(feature_dtype, np.number):
                 _logger.warning(
                     "Skip logging model explainability insights because it requires all feature "
-                    "values to be number type, and each feature column must only contain scalar "
+                    "values to be numeric, and each feature column must only contain scalar "
                     "values."
                 )
                 return

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -497,17 +497,16 @@ class DefaultEvaluator(ModelEvaluator):
 
         log_roc_pr_curve = False
         if self.y_probs is not None:
-            max_num_classes_for_logging_curve = self.evaluator_config.get(
-                "max_num_classes_threshold_logging_roc_pr_curve_for_multiclass_classifier", 10
+            max_classes_for_multiclass_roc_pr = self.evaluator_config.get(
+                "max_classes_for_multiclass_roc_pr", 10
             )
-            if self.num_classes <= max_num_classes_for_logging_curve:
+            if self.num_classes <= max_classes_for_multiclass_roc_pr:
                 log_roc_pr_curve = True
             else:
                 _logger.warning(
-                    f"The classifier num_classes > {max_num_classes_for_logging_curve}, skip "
+                    f"The classifier num_classes > {max_classes_for_multiclass_roc_pr}, skip "
                     f"logging ROC curve and Precision-Recall curve. You can add evaluator config "
-                    f"'max_num_classes_threshold_logging_roc_pr_curve_for_multiclass_classifier' "
-                    f"to increase the threshold."
+                    f"'max_classes_for_multiclass_roc_pr' to increase the threshold."
                 )
 
         if log_roc_pr_curve:

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -325,7 +325,7 @@ class DefaultEvaluator(ModelEvaluator):
             #  but spark model input dataframe contains Vector type feature column
             #  which shap explainer does not support.
             #  To support this, we need expand the Vector type feature column into
-            #  multiple scaler feature columns and pass it to shap explainer.
+            #  multiple scalar feature columns and pass it to shap explainer.
             _logger.warning(
                 "Logging model explainability insights is not currently supported for PySpark "
                 "models."
@@ -345,7 +345,7 @@ class DefaultEvaluator(ModelEvaluator):
             if not np.issubdtype(feature_dtype, np.number):
                 _logger.warning(
                     "Skip logging model explainability insights because it requires all feature "
-                    "values to be number type, and each feature column must only contain scaler "
+                    "values to be number type, and each feature column must only contain scalar "
                     "values."
                 )
                 return

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1,7 +1,6 @@
 import mlflow
 from mlflow.models.evaluation.base import (
     ModelEvaluator,
-    EvaluationMetrics,
     EvaluationResult,
 )
 from mlflow.entities.metric import Metric
@@ -652,7 +651,7 @@ class DefaultEvaluator(ModelEvaluator):
 
             self.X = dataset.features_data
             self.y = dataset.labels_data
-            self.metrics = EvaluationMetrics()
+            self.metrics = dict()
             self.artifacts = {}
 
             infered_model_type = _infer_model_type_by_labels(self.y)

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -40,9 +40,11 @@ def assert_dict_equal(d1, d2, rtol):
 def test_regressor_evaluation(linear_regressor_model_uri, diabetes_dataset):
     with mlflow.start_run() as run:
         result = evaluate(
-            model=linear_regressor_model_uri,
+            linear_regressor_model_uri,
+            diabetes_dataset._constructor_args["data"],
             model_type="regressor",
-            dataset=diabetes_dataset,
+            targets=diabetes_dataset._constructor_args["targets"],
+            dataset_name=diabetes_dataset.name,
             evaluators="default",
         )
 
@@ -81,9 +83,11 @@ def test_regressor_evaluation(linear_regressor_model_uri, diabetes_dataset):
 def test_multi_classifier_evaluation(multiclass_logistic_regressor_model_uri, iris_dataset):
     with mlflow.start_run() as run:
         result = evaluate(
-            model=multiclass_logistic_regressor_model_uri,
+            multiclass_logistic_regressor_model_uri,
+            iris_dataset._constructor_args["data"],
             model_type="classifier",
-            dataset=iris_dataset,
+            targets=iris_dataset._constructor_args["targets"],
+            dataset_name=iris_dataset.name,
             evaluators="default",
         )
 
@@ -132,9 +136,11 @@ def test_multi_classifier_evaluation(multiclass_logistic_regressor_model_uri, ir
 def test_bin_classifier_evaluation(binary_logistic_regressor_model_uri, breast_cancer_dataset):
     with mlflow.start_run() as run:
         result = evaluate(
-            model=binary_logistic_regressor_model_uri,
+            binary_logistic_regressor_model_uri,
+            breast_cancer_dataset._constructor_args["data"],
             model_type="classifier",
-            dataset=breast_cancer_dataset,
+            targets=breast_cancer_dataset._constructor_args["targets"],
+            dataset_name=breast_cancer_dataset.name,
             evaluators="default",
         )
 
@@ -184,9 +190,11 @@ def test_bin_classifier_evaluation(binary_logistic_regressor_model_uri, breast_c
 def test_spark_regressor_model_evaluation(spark_linear_regressor_model_uri, diabetes_spark_dataset):
     with mlflow.start_run() as run:
         result = evaluate(
-            model=spark_linear_regressor_model_uri,
+            spark_linear_regressor_model_uri,
+            diabetes_spark_dataset._constructor_args["data"],
             model_type="regressor",
-            dataset=diabetes_spark_dataset,
+            label_col=diabetes_spark_dataset._constructor_args["label_col"],
+            dataset_name=diabetes_spark_dataset.name,
             evaluators="default",
             evaluator_config={"log_model_explainability": True},
         )
@@ -222,9 +230,11 @@ def test_spark_regressor_model_evaluation(spark_linear_regressor_model_uri, diab
 def test_svm_classifier_evaluation(svm_model_uri, breast_cancer_dataset):
     with mlflow.start_run() as run:
         result = evaluate(
-            model=svm_model_uri,
+            svm_model_uri,
+            breast_cancer_dataset._constructor_args["data"],
             model_type="classifier",
-            dataset=breast_cancer_dataset,
+            targets=breast_cancer_dataset._constructor_args["targets"],
+            dataset_name=breast_cancer_dataset.name,
             evaluators="default",
         )
 

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -193,7 +193,7 @@ def test_spark_regressor_model_evaluation(spark_linear_regressor_model_uri, diab
             spark_linear_regressor_model_uri,
             diabetes_spark_dataset._constructor_args["data"],
             model_type="regressor",
-            label_col=diabetes_spark_dataset._constructor_args["label_col"],
+            targets=diabetes_spark_dataset._constructor_args["targets"],
             dataset_name=diabetes_spark_dataset.name,
             evaluators="default",
             evaluator_config={"log_model_explainability": True},

--- a/tests/models/test_evaluation.py
+++ b/tests/models/test_evaluation.py
@@ -117,7 +117,7 @@ def diabetes_dataset():
 @pytest.fixture(scope="module")
 def diabetes_spark_dataset():
     spark_df = get_diabetes_spark_dataset().sample(fraction=0.3, seed=1)
-    constructor_args = {"data": spark_df, "label_col": "label", "name": "diabetes_spark_dataset"}
+    constructor_args = {"data": spark_df, "targets": "label", "name": "diabetes_spark_dataset"}
     ds = _EvaluationDataset(**constructor_args)
     ds._constructor_args = constructor_args
     return ds
@@ -211,7 +211,7 @@ def iris_pandas_df_dataset():
             "y": eval_y,
         }
     )
-    return _EvaluationDataset(data=data, label_col="y", name="iris_pandas_df_dataset")
+    return _EvaluationDataset(data=data, targets="y", name="iris_pandas_df_dataset")
 
 
 def test_classifier_evaluate(multiclass_logistic_regressor_model_uri, iris_dataset):
@@ -358,7 +358,7 @@ def test_dataset_hash(iris_dataset, iris_pandas_df_dataset, diabetes_spark_datas
 
 def test_dataset_with_pandas_dataframe():
     data = pd.DataFrame({"f1": [1, 2], "f2": [3, 4], "f3": [5, 6], "label": [0, 1]})
-    eval_dataset = _EvaluationDataset(data=data, label_col="label")
+    eval_dataset = _EvaluationDataset(data=data, targets="label")
 
     assert list(eval_dataset.features_data.columns) == ["f1", "f2", "f3"]
     assert np.array_equal(eval_dataset.features_data.f1.to_numpy(), [1, 2])
@@ -366,7 +366,7 @@ def test_dataset_with_pandas_dataframe():
     assert np.array_equal(eval_dataset.features_data.f3.to_numpy(), [5, 6])
     assert np.array_equal(eval_dataset.labels_data, [0, 1])
 
-    eval_dataset2 = _EvaluationDataset(data=data, label_col="label", feature_names=["f3", "f2"])
+    eval_dataset2 = _EvaluationDataset(data=data, targets="label", feature_names=["f3", "f2"])
     assert list(eval_dataset2.features_data.columns) == ["f3", "f2"]
     assert np.array_equal(eval_dataset2.features_data.f2.to_numpy(), [3, 4])
     assert np.array_equal(eval_dataset2.features_data.f3.to_numpy(), [5, 6])
@@ -413,7 +413,7 @@ def test_dataset_autogen_feature_names():
 def test_dataset_from_spark_df(spark_session):
     spark_df = spark_session.createDataFrame([(1.0, 2.0, 3.0)] * 10, ["f1", "f2", "y"])
     with mock.patch.object(_EvaluationDataset, "SPARK_DATAFRAME_LIMIT", 5):
-        dataset = _EvaluationDataset(spark_df, label_col="y")
+        dataset = _EvaluationDataset(spark_df, targets="y")
         assert list(dataset.features_data.columns) == ["f1", "f2"]
         assert list(dataset.features_data["f1"]) == [1.0] * 5
         assert list(dataset.features_data["f2"]) == [2.0] * 5

--- a/tests/models/test_evaluation.py
+++ b/tests/models/test_evaluation.py
@@ -99,9 +99,7 @@ def spark_session():
 def iris_dataset():
     X, y = get_iris()
     eval_X, eval_y = X[0::3], y[0::3]
-    constructor_args = {
-        'data': eval_X, 'targets': eval_y, 'name': "iris_dataset"
-    }
+    constructor_args = {"data": eval_X, "targets": eval_y, "name": "iris_dataset"}
     ds = _EvaluationDataset(**constructor_args)
     ds._constructor_args = constructor_args
     return ds
@@ -111,7 +109,7 @@ def iris_dataset():
 def diabetes_dataset():
     X, y = get_diabetes_dataset()
     eval_X, eval_y = X[0::3], y[0::3]
-    constructor_args = {'data': eval_X, 'targets': eval_y, 'name': "diabetes_dataset"}
+    constructor_args = {"data": eval_X, "targets": eval_y, "name": "diabetes_dataset"}
     ds = _EvaluationDataset(**constructor_args)
     ds._constructor_args = constructor_args
     return ds
@@ -120,7 +118,7 @@ def diabetes_dataset():
 @pytest.fixture(scope="module")
 def diabetes_spark_dataset():
     spark_df = get_diabetes_spark_dataset().sample(fraction=0.3, seed=1)
-    constructor_args = {'data': spark_df, 'label_col': "label", 'name': "diabetes_spark_dataset"}
+    constructor_args = {"data": spark_df, "label_col": "label", "name": "diabetes_spark_dataset"}
     ds = _EvaluationDataset(**constructor_args)
     ds._constructor_args = constructor_args
     return ds
@@ -130,7 +128,7 @@ def diabetes_spark_dataset():
 def breast_cancer_dataset():
     X, y = get_breast_cancer_dataset()
     eval_X, eval_y = X[0::3], y[0::3]
-    constructor_args = {'data': eval_X, 'targets': eval_y, 'name': "breast_cancer_dataset"}
+    constructor_args = {"data": eval_X, "targets": eval_y, "name": "breast_cancer_dataset"}
     ds = _EvaluationDataset(**constructor_args)
     ds._constructor_args = constructor_args
     return ds
@@ -234,9 +232,9 @@ def test_classifier_evaluate(multiclass_logistic_regressor_model_uri, iris_datas
     with mlflow.start_run() as run:
         eval_result = evaluate(
             classifier_model,
-            iris_dataset._constructor_args['data'],
+            iris_dataset._constructor_args["data"],
             model_type="classifier",
-            targets=iris_dataset._constructor_args['targets'],
+            targets=iris_dataset._constructor_args["targets"],
             dataset_name=iris_dataset.name,
             evaluators="dummy_evaluator",
         )
@@ -307,9 +305,9 @@ def test_regressor_evaluate(linear_regressor_model_uri, diabetes_dataset):
         with mlflow.start_run() as run:
             eval_result = evaluate(
                 model,
-                diabetes_dataset._constructor_args['data'],
+                diabetes_dataset._constructor_args["data"],
                 model_type="regressor",
-                targets=diabetes_dataset._constructor_args['targets'],
+                targets=diabetes_dataset._constructor_args["targets"],
                 dataset_name=diabetes_dataset.name,
                 evaluators="dummy_evaluator",
             )
@@ -330,9 +328,9 @@ def test_dataset_metadata():
     X, y = get_iris()
     d1 = _EvaluationDataset(data=X, targets=y, name="a1", path="/path/to/a1")
     assert d1._metadata == {
-        'hash': '6bdf4e119bf1a37e7907dfd9f0e68733',
-        'name': 'a1',
-        'path': '/path/to/a1'
+        "hash": "6bdf4e119bf1a37e7907dfd9f0e68733",
+        "name": "a1",
+        "path": "/path/to/a1",
     }
 
 
@@ -385,8 +383,9 @@ def test_dataset_with_array_data():
         assert np.array_equal(eval_dataset1.labels_data, labels)
         assert list(eval_dataset1.feature_names) == ["feature_1", "feature_2"]
 
-    assert _EvaluationDataset(data=input_data, targets=labels, feature_names=['a', 'b']) \
-        .feature_names == ['a', 'b']
+    assert _EvaluationDataset(
+        data=input_data, targets=labels, feature_names=["a", "b"]
+    ).feature_names == ["a", "b"]
 
     with pytest.raises(ValueError, match="all element must has the same length"):
         _EvaluationDataset(data=[[1, 2], [3, 4, 5]], targets=labels)
@@ -507,9 +506,9 @@ def test_evaluator_interface(multiclass_logistic_regressor_model_uri, iris_datas
                 ):
                     evaluate(
                         multiclass_logistic_regressor_model_uri,
-                        data=iris_dataset._constructor_args['data'],
+                        data=iris_dataset._constructor_args["data"],
                         model_type="classifier",
-                        targets=iris_dataset._constructor_args['targets'],
+                        targets=iris_dataset._constructor_args["targets"],
                         dataset_name=iris_dataset.name,
                         evaluators="test_evaluator1",
                         evaluator_config=evaluator1_config,
@@ -527,9 +526,9 @@ def test_evaluator_interface(multiclass_logistic_regressor_model_uri, iris_datas
             with mlflow.start_run() as run:
                 eval1_result = evaluate(
                     classifier_model,
-                    iris_dataset._constructor_args['data'],
+                    iris_dataset._constructor_args["data"],
                     model_type="classifier",
-                    targets=iris_dataset._constructor_args['targets'],
+                    targets=iris_dataset._constructor_args["targets"],
                     dataset_name=iris_dataset.name,
                     evaluators="test_evaluator1",
                     evaluator_config=evaluator1_config,
@@ -581,9 +580,9 @@ def test_evaluate_with_multi_evaluators(multiclass_logistic_regressor_model_uri,
                 with mlflow.start_run() as run:
                     eval_result = evaluate(
                         classifier_model,
-                        iris_dataset._constructor_args['data'],
+                        iris_dataset._constructor_args["data"],
                         model_type="classifier",
-                        targets=iris_dataset._constructor_args['targets'],
+                        targets=iris_dataset._constructor_args["targets"],
                         dataset_name=iris_dataset.name,
                         evaluators=evaluators,
                         evaluator_config={

--- a/tests/models/test_evaluation.py
+++ b/tests/models/test_evaluation.py
@@ -3,13 +3,12 @@ from collections import namedtuple
 
 from mlflow.models.evaluation import (
     evaluate,
-    _EvaluationDataset,
     EvaluationResult,
     ModelEvaluator,
     EvaluationArtifact,
-    EvaluationMetrics,
 )
 from mlflow.models.evaluation.base import (
+    _EvaluationDataset,
     _normalize_evaluators_and_evaluator_config_args as _normalize_config,
 )
 import hashlib
@@ -491,7 +490,7 @@ def test_evaluator_interface(multiclass_logistic_regressor_model_uri, iris_datas
     ):
         evaluator1_config = {"eval1_confg_a": 3, "eval1_confg_b": 4}
         evaluator1_return_value = EvaluationResult(
-            metrics=EvaluationMetrics({"m1": 5, "m2": 6}),
+            metrics={"m1": 5, "m2": 6},
             artifacts={"a1": FakeArtifact1(uri="uri1"), "a2": FakeArtifact2(uri="uri2")},
         )
         with mock.patch.object(
@@ -557,10 +556,10 @@ def test_evaluate_with_multi_evaluators(multiclass_logistic_regressor_model_uri,
         evaluator1_config = {"eval1_confg": 3}
         evaluator2_config = {"eval2_confg": 4}
         evaluator1_return_value = EvaluationResult(
-            metrics=EvaluationMetrics({"m1": 5}), artifacts={"a1": FakeArtifact1(uri="uri1")}
+            metrics={"m1": 5}, artifacts={"a1": FakeArtifact1(uri="uri1")}
         )
         evaluator2_return_value = EvaluationResult(
-            metrics=EvaluationMetrics({"m2": 6}), artifacts={"a2": FakeArtifact2(uri="uri2")}
+            metrics={"m2": 6}, artifacts={"a2": FakeArtifact2(uri="uri2")}
         )
 
         # evaluators = None is the case evaluators unspecified, it should fetch all registered

--- a/tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_evaluator.py
+++ b/tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_evaluator.py
@@ -1,7 +1,6 @@
 import mlflow
 from mlflow.models.evaluation import (
     ModelEvaluator,
-    EvaluationMetrics,
     EvaluationArtifact,
     EvaluationResult,
 )
@@ -52,7 +51,7 @@ class DummyEvaluator(ModelEvaluator):
         if model_type == "classifier":
             accuracy_score = sk_metrics.accuracy_score(y, y_pred)
 
-            metrics = EvaluationMetrics(accuracy_score=accuracy_score)
+            metrics = {'accuracy_score': accuracy_score}
             self._log_metrics(run_id, metrics, dataset.name)
             confusion_matrix = sk_metrics.confusion_matrix(y, y_pred)
             confusion_matrix_artifact_name = f"confusion_matrix_on_{dataset.name}.csv"
@@ -69,9 +68,10 @@ class DummyEvaluator(ModelEvaluator):
         elif model_type == "regressor":
             mean_absolute_error = sk_metrics.mean_absolute_error(y, y_pred)
             mean_squared_error = sk_metrics.mean_squared_error(y, y_pred)
-            metrics = EvaluationMetrics(
-                mean_absolute_error=mean_absolute_error, mean_squared_error=mean_squared_error
-            )
+            metrics = {
+                'mean_absolute_error': mean_absolute_error,
+                'mean_squared_error': mean_squared_error,
+            }
             self._log_metrics(run_id, metrics, dataset.name)
             artifacts = {}
         else:

--- a/tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_evaluator.py
+++ b/tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_evaluator.py
@@ -51,7 +51,7 @@ class DummyEvaluator(ModelEvaluator):
         if model_type == "classifier":
             accuracy_score = sk_metrics.accuracy_score(y, y_pred)
 
-            metrics = {'accuracy_score': accuracy_score}
+            metrics = {"accuracy_score": accuracy_score}
             self._log_metrics(run_id, metrics, dataset.name)
             confusion_matrix = sk_metrics.confusion_matrix(y, y_pred)
             confusion_matrix_artifact_name = f"confusion_matrix_on_{dataset.name}.csv"
@@ -69,8 +69,8 @@ class DummyEvaluator(ModelEvaluator):
             mean_absolute_error = sk_metrics.mean_absolute_error(y, y_pred)
             mean_squared_error = sk_metrics.mean_squared_error(y, y_pred)
             metrics = {
-                'mean_absolute_error': mean_absolute_error,
-                'mean_squared_error': mean_squared_error,
+                "mean_absolute_error": mean_absolute_error,
+                "mean_squared_error": mean_squared_error,
             }
             self._log_metrics(run_id, metrics, dataset.name)
             artifacts = {}

--- a/tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_evaluator.py
+++ b/tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_evaluator.py
@@ -13,7 +13,7 @@ import io
 
 
 class Array2DEvaluationArtifact(EvaluationArtifact):
-    def save(self, output_artifact_path):
+    def _save(self, output_artifact_path):
         pd.DataFrame(self._content).to_csv(output_artifact_path, index=False)
 
     def _load_content_from_file(self, local_artifact_path):
@@ -60,7 +60,7 @@ class DummyEvaluator(ModelEvaluator):
                 content=confusion_matrix,
             )
             confusion_matrix_csv_buff = io.StringIO()
-            confusion_matrix_artifact.save(confusion_matrix_csv_buff)
+            confusion_matrix_artifact._save(confusion_matrix_csv_buff)
             client.log_text(
                 run_id, confusion_matrix_csv_buff.getvalue(), confusion_matrix_artifact_name
             )


### PR DESCRIPTION
## What changes are proposed in this pull request?

Improve evaluation api

## How is this patch tested?

Unit tests.

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Change evaluation API to be:
```
def evaluate(
    model: Union[str, "mlflow.pyfunc.PyFuncModel"],
    data,
    *,
    model_type: str,
    targets=None,
    label_col=None,
    dataset_name=None,
    dataset_path=None,
    feature_names: list = None,
    evaluators=None,
    evaluator_config=None,
) -> "mlflow.models.evaluation.EvaluationResult"
```

Remove `EvaluationMetrics` class.


### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [x] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
