### PR TITLE
Improve confusion matrix plot

### DIFF
--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -600,10 +600,13 @@ class DefaultEvaluator(ModelEvaluator):
 
         def plot_confusion_matrix():
             import matplotlib
-            with matplotlib.rc_context({
-                'font.size': min(10, 50.0 / self.num_classes),
-                'axes.labelsize': 10,
-            }):
+
+            with matplotlib.rc_context(
+                {
+                    "font.size": min(10, 50.0 / self.num_classes),
+                    "axes.labelsize": 10,
+                }
+            ):
                 sk_metrics.ConfusionMatrixDisplay(
                     confusion_matrix=confusion_matrix,
                     display_labels=self.label_list,

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -599,10 +599,15 @@ class DefaultEvaluator(ModelEvaluator):
         )
 
         def plot_confusion_matrix():
-            sk_metrics.ConfusionMatrixDisplay(
-                confusion_matrix=confusion_matrix,
-                display_labels=self.label_list,
-            ).plot(cmap="Blues")
+            import matplotlib
+            with matplotlib.rc_context({
+                'font.size': min(10, 50.0 / self.num_classes),
+                'axes.labelsize': 10,
+            }):
+                sk_metrics.ConfusionMatrixDisplay(
+                    confusion_matrix=confusion_matrix,
+                    display_labels=self.label_list,
+                ).plot(cmap="Blues")
 
         if hasattr(sk_metrics, "ConfusionMatrixDisplay"):
             self._log_image_artifact(

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -290,11 +290,14 @@ def _get_classifier_artifacts(fitted_estimator, prefix, X, y_true, sample_weight
 
     def plot_confusion_matrix(*args, **kwargs):
         import matplotlib
+
         num_classes = len(set(y_true))
-        with matplotlib.rc_context({
-            'font.size': min(10.0, 50.0 / num_classes),
-            'axes.labelsize': 10.0,
-        }):
+        with matplotlib.rc_context(
+            {
+                "font.size": min(10.0, 50.0 / num_classes),
+                "axes.labelsize": 10.0,
+            }
+        ):
             return sklearn.metrics.plot_confusion_matrix(*args, **kwargs)
 
     classifier_artifacts = [

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -295,7 +295,7 @@ def _get_classifier_artifacts(fitted_estimator, prefix, X, y_true, sample_weight
             'font.size': min(10.0, 50.0 / num_classes),
             'axes.labelsize': 10.0,
         }):
-            sklearn.metrics.plot_confusion_matrix(*args, **kwargs)
+            return sklearn.metrics.plot_confusion_matrix(*args, **kwargs)
 
     classifier_artifacts = [
         _SklearnArtifact(

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -288,10 +288,19 @@ def _get_classifier_artifacts(fitted_estimator, prefix, X, y_true, sample_weight
     if not _is_plotting_supported():
         return []
 
+    def plot_confusion_matrix(*args, **kwargs):
+        import matplotlib
+        num_classes = len(set(y_true))
+        with matplotlib.rc_context({
+            'font.size': min(10.0, 50.0 / num_classes),
+            'axes.labelsize': 10.0,
+        }):
+            sklearn.metrics.plot_confusion_matrix(*args, **kwargs)
+
     classifier_artifacts = [
         _SklearnArtifact(
             name=prefix + "confusion_matrix",
-            function=sklearn.metrics.plot_confusion_matrix,
+            function=plot_confusion_matrix,
             arguments=dict(
                 estimator=fitted_estimator,
                 X=X,


### PR DESCRIPTION
Signed-off-by: Weichen Xu <weichen.xu@databricks.com>

## What changes are proposed in this pull request?
Improve confusion matrix plot.

TODO:
* limit the max classes to display confusion matrix plot. When classes > 20, the plot text will be too small to read. Another approach is inscrease plot dpi with classes increasing, but this might generate very huge size plot.

## How is this patch tested?

Manual

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
