### PR TITLE
Use `len(classes_)` instead of  `len(set(y_true))`

### DIFF
--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -291,9 +291,18 @@ def _get_classifier_artifacts(fitted_estimator, prefix, X, y_true, sample_weight
     def plot_confusion_matrix(*args, **kwargs):
         import matplotlib
 
+        if hasattr(fitted_estimator, "classes_"):
+            classes = fitted_estimator.classes_
+        elif hasattr(fitted_estimator, "estimator") and hasattr(
+            fitted_estimator.estimator, "classes_"
+        ):
+            classes = fitted_estimator.estimator.classes_
+        else:
+            classes = set(y_true)
+
         with matplotlib.rc_context(
             {
-                "font.size": min(10.0, 50.0 / len(fitted_estimator.classes_)),
+                "font.size": min(10.0, 50.0 / len(classes)),
                 "axes.labelsize": 10.0,
             }
         ):

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -293,7 +293,7 @@ def _get_classifier_artifacts(fitted_estimator, prefix, X, y_true, sample_weight
 
         with matplotlib.rc_context(
             {
-                "font.size": min(10.0, 50.0 / fitted_estimator.n_classes_),
+                "font.size": min(10.0, 50.0 / len(fitted_estimator.classes_)),
                 "axes.labelsize": 10.0,
             }
         ):

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -298,10 +298,14 @@ def _get_classifier_artifacts(fitted_estimator, prefix, X, y_true, sample_weight
     def plot_confusion_matrix(*args, **kwargs):
         import matplotlib
 
-        class_labels = _get_class_labels_from_estimator(fitted_estimator) or set(y_true)
+        class_labels = _get_class_labels_from_estimator(fitted_estimator)
+        if class_labels is None:
+            class_labels = set(y_true)
 
         with matplotlib.rc_context(
             {
+                "figure.dpi": 288,
+                "figure.figsize": [6.0, 4.0],
                 "font.size": min(10.0, 50.0 / len(class_labels)),
                 "axes.labelsize": 10.0,
             }

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -293,7 +293,7 @@ def _get_classifier_artifacts(fitted_estimator, prefix, X, y_true, sample_weight
 
         with matplotlib.rc_context(
             {
-                "font.size": min(10.0, 50.0 / fitted_estimator.n_classes),
+                "font.size": min(10.0, 50.0 / fitted_estimator.n_classes_),
                 "axes.labelsize": 10.0,
             }
         ):

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -257,6 +257,13 @@ def _get_classifier_metrics(fitted_estimator, prefix, X, y_true, sample_weight):
     return _get_metrics_value_dict(classifier_metrics)
 
 
+def _get_class_labels_from_estimator(estimator):
+    """
+    Extracts class labels from `estimator` if `estimator.classes` is available.
+    """
+    return estimator.classes_ if hasattr(estimator, "classes_") else None
+
+
 def _get_classifier_artifacts(fitted_estimator, prefix, X, y_true, sample_weight):
     """
     Draw and record various common artifacts for classifier
@@ -291,18 +298,11 @@ def _get_classifier_artifacts(fitted_estimator, prefix, X, y_true, sample_weight
     def plot_confusion_matrix(*args, **kwargs):
         import matplotlib
 
-        if hasattr(fitted_estimator, "classes_"):
-            classes = fitted_estimator.classes_
-        elif hasattr(fitted_estimator, "estimator") and hasattr(
-            fitted_estimator.estimator, "classes_"
-        ):
-            classes = fitted_estimator.estimator.classes_
-        else:
-            classes = set(y_true)
+        class_labels = _get_class_labels_from_estimator(fitted_estimator) or set(y_true)
 
         with matplotlib.rc_context(
             {
-                "font.size": min(10.0, 50.0 / len(classes)),
+                "font.size": min(10.0, 50.0 / len(class_labels)),
                 "axes.labelsize": 10.0,
             }
         ):

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -291,10 +291,9 @@ def _get_classifier_artifacts(fitted_estimator, prefix, X, y_true, sample_weight
     def plot_confusion_matrix(*args, **kwargs):
         import matplotlib
 
-        num_classes = len(set(y_true))
         with matplotlib.rc_context(
             {
-                "font.size": min(10.0, 50.0 / num_classes),
+                "font.size": min(10.0, 50.0 / fitted_estimator.n_classes),
                 "axes.labelsize": 10.0,
             }
         ):


### PR DESCRIPTION
## What changes are proposed in this pull request?

Use `len(classes_)` instead of  `len(set(y_true))` when computing the number of classes.

## How is this patch tested?

Existing tests

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
