### PR TITLE
Drop support for python 3.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
 
   build_doc:
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.7
 
     steps:
       - checkout

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -2,7 +2,7 @@ name: "setup-python"
 description: "Ensures to install a python version that's available on Anaconda"
 inputs:
   python-version:
-    description: "The python version to install (e.g. 3.6)"
+    description: "The python version to install (e.g. 3.7)"
     required: true
 outputs:
   installed-python-version:
@@ -20,14 +20,12 @@ runs:
       # where we trigger more than 100 GitHub Actions runs.
       run: |
         python_version="${{ inputs.python-version }}"
-        if [[ "$python_version" == "3.6" ]]; then
-          python_version="3.6.13"
-        elif [[ "$python_version" == "3.7" ]]; then
+        if [[ "$python_version" == "3.7" ]]; then
           python_version="3.7.12"
         elif [[ "$python_version" == "3.8" ]]; then
           python_version="3.8.12"
         else
-          echo "Invalid python version: '$python_version'. Must be one of ['3.6', '3.7', '3.8']"
+          echo "Invalid python version: '$python_version'. Must be one of ['3.7', '3.8']"
           exit 1
         fi
         echo "::set-output name=version::$python_version"

--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.6'
+          python-version: "3.7"
       - run: |
           pip install requests
       - name: Check diff
@@ -77,7 +77,7 @@ jobs:
           ref: ${{ needs.check-comment.outputs.ref }}
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.6'
+          python-version: "3.7"
       - name: Install dependencies
         run: |
           pip install -r requirements/lint-requirements.txt

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -52,7 +52,7 @@ jobs:
           ref: ${{ github.event.inputs.ref }}
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.6"
+          python-version: "3.7"
       - name: Install dependencies
         run: |
           pip install packaging requests pyyaml pytest
@@ -123,15 +123,8 @@ jobs:
           if [[ "${{ matrix.package }}" = "statsmodels" && "${{ matrix.version }}" = "dev" ]]
           then
             python_version=3.8
-          elif [[ "${{ matrix.version }}" = "dev" ]] || \
-             [[ "${{ matrix.package }}" = "scikit-learn" && ! "${{ matrix.version }}" =~ ^0\.* ]] || \
-             [[ "${{ matrix.package }}" = "statsmodels" ]] || \
-             [[ "${{ matrix.package }}" = "tensorflow" && ! "${{ matrix.version }}" =~ ^2\.[0-6] ]] || \
-             [[ "${{ matrix.package }}" = "keras" && ! "${{ matrix.version }}" =~ ^2\.[0-6] ]]
-          then
-            python_version=3.7
           else
-            python_version=3.6
+            python_version=3.7
           fi
           echo "::set-output name=version::$python_version"
       - uses: ./.github/actions/setup-python

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -47,7 +47,7 @@ jobs:
 
     - uses: ./.github/actions/setup-python
       with:
-        python-version: 3.6
+        python-version: "3.7"
 
     - name: Install dependencies
       if: ${{ github.event_name == 'schedule' || steps.check-diff.outputs.examples_changed == 'true' }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -32,7 +32,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: ./.github/actions/setup-python
       with:
-        python-version: 3.6
+        python-version: "3.7"
     - uses: ./.github/actions/cache-pip
     - name: Install dependencies
       env:
@@ -103,7 +103,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: ./.github/actions/setup-python
       with:
-        python-version: 3.6
+        python-version: "3.7"
     - name: Install dependencies
       env:
         INSTALL_SKINNY_PYTHON_DEPS: true
@@ -120,7 +120,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: ./.github/actions/setup-python
       with:
-        python-version: 3.6
+        python-version: "3.7"
     - name: Install dependencies
       env:
         INSTALL_SMALL_PYTHON_DEPS: true
@@ -141,7 +141,7 @@ jobs:
         rm -rf "$AGENT_TOOLSDIRECTORY"
     - uses: ./.github/actions/setup-python
       with:
-        python-version: 3.6
+        python-version: "3.7"
     - uses: actions/setup-java@v2
       with:
         java-version: 11
@@ -196,7 +196,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: ./.github/actions/setup-python
       with:
-        python-version: 3.6
+        python-version: "3.7"
     - name: Set up Java
       uses: actions/setup-java@v2
       with:
@@ -266,7 +266,7 @@ jobs:
           rm -rf "$AGENT_TOOLSDIRECTORY"
       - uses: ./.github/actions/setup-python
         with:
-          python-version: 3.6
+          python-version: "3.7"
       - uses: actions/setup-java@v2
         with:
           java-version: 11
@@ -294,7 +294,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/setup-python
         with:
-          python-version: 3.6
+          python-version: "3.7"
       - uses: actions/setup-java@v2
         with:
           java-version: 11
@@ -319,7 +319,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.6'
+          python-version: "3.7"
       - name: Install mlflow
         run: |
           pip install -e .
@@ -339,7 +339,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/setup-python
         with:
-          python-version: 3.6
+          python-version: "3.7"
       - uses: actions/setup-java@v2
         with:
           java-version: 11
@@ -362,7 +362,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: "3.7"
       - name: Install python dependencies
         run: |
           pip install -r requirements/small-requirements.txt

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -139,7 +139,7 @@ by running the following from your checkout of MLflow:
 
 .. code-block:: bash
 
-    conda create --name mlflow-dev-env python=3.6
+    conda create --name mlflow-dev-env python=3.7
     conda activate mlflow-dev-env
     pip install -e .[extras] # installs mlflow from current checkout with some useful extra utilities
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && \
     apt-get install -y default-libmysqlclient-dev build-essential curl \
     # cmake and protobuf-compiler required for onnx install
     cmake protobuf-compiler &&  \
-    conda install python=3.6 && \
+    conda install python=3.7 && \
     # install required python packages
     pip install -r requirements/dev-requirements.txt --no-cache-dir && \
     # install mlflow in editable form

--- a/examples/h2o/conda.yaml
+++ b/examples/h2o/conda.yaml
@@ -2,10 +2,10 @@ name: h2o_example
 channels:
   - conda-forge
 dependencies:
-  - python=3.6
+  - python=3.7
   - pip
   - pip:
     - h2o
     - mlflow>=1.0
-    - numpy==1.14.2
+    - numpy
     - pandas

--- a/examples/hyperparam/conda.yaml
+++ b/examples/hyperparam/conda.yaml
@@ -2,16 +2,16 @@ name: hyperparam_example
 channels:
   - conda-forge
 dependencies:
-  - python=3.6
+  - python=3.7
   - pip
   - pip:
-    - numpy==1.19.5
+    - numpy
     - click
-    - pandas==0.22.0
-    - scipy==1.4.1
-    - scikit-learn==0.19.1
+    - pandas
+    - scipy
+    - scikit-learn
     - tensorflow==1.13.1
-    - matplotlib==2.2.2
+    - matplotlib
     - keras==2.3.1
     - mlflow>=1.6
-    - hyperopt==0.1
+    - hyperopt

--- a/examples/hyperparam/train.py
+++ b/examples/hyperparam/train.py
@@ -117,15 +117,14 @@ def run(training_data, epochs, batch_size, learning_rate, momentum, seed):
     train, test = train_test_split(data, random_state=seed)
     train, valid = train_test_split(train, random_state=seed)
     # The predicted column is "quality" which is a scalar from [3, 9]
-    train_x = train.drop(["quality"], axis=1).as_matrix()
-    train_x = (train_x).astype("float32")
-    train_y = train[["quality"]].as_matrix().astype("float32")
-    valid_x = (valid.drop(["quality"], axis=1).as_matrix()).astype("float32")
+    train_x = train.drop(["quality"], axis=1).astype("float32").values
+    train_y = train[["quality"]].astype("float32").values
+    valid_x = valid.drop(["quality"], axis=1).astype("float32").values
 
-    valid_y = valid[["quality"]].as_matrix().astype("float32")
+    valid_y = valid[["quality"]].astype("float32").values
 
-    test_x = (test.drop(["quality"], axis=1).as_matrix()).astype("float32")
-    test_y = test[["quality"]].as_matrix().astype("float32")
+    test_x = test.drop(["quality"], axis=1).astype("float32").values
+    test_y = test[["quality"]].astype("float32").values
 
     with mlflow.start_run():
         if epochs == 0:  # score null model

--- a/examples/lightgbm/lightgbm_native/conda.yaml
+++ b/examples/lightgbm/lightgbm_native/conda.yaml
@@ -2,7 +2,7 @@ name: lightgbm-example
 channels:
   - conda-forge
 dependencies:
-  - python=3.6
+  - python=3.7
   - pip
   - pip:
       - mlflow>=1.6.0

--- a/examples/lightgbm/lightgbm_sklearn/conda.yaml
+++ b/examples/lightgbm/lightgbm_sklearn/conda.yaml
@@ -2,7 +2,7 @@ name: lightgbm-example
 channels:
   - conda-forge
 dependencies:
-  - python=3.6
+  - python=3.7
   - pip
   - pip:
       - mlflow>=1.6.0

--- a/examples/mlflow_artifacts/Dockerfile
+++ b/examples/mlflow_artifacts/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.7
 
 WORKDIR /app
 

--- a/examples/mlflow_artifacts/Dockerfile.dev
+++ b/examples/mlflow_artifacts/Dockerfile.dev
@@ -1,11 +1,9 @@
-FROM python:3.6
+FROM python:3.7
 
 WORKDIR /app
 
 # Install packages requied to interact with PostgreSQL and MinIO
 RUN pip install psycopg2 boto3
-# Install mlflow to cache its dependencies to speed up image rebuild
-RUN pip install mlflow
 # Install the dev version of mlflow via wheel
 COPY dist ./dist
 RUN pip install dist/mlflow-*.whl

--- a/examples/multistep_workflow/conda.yaml
+++ b/examples/multistep_workflow/conda.yaml
@@ -2,7 +2,7 @@ name: multistep
 channels:
   - conda-forge
 dependencies:
-  - python=3.6
+  - python=3.7
   - pip
   - pip:
     - tensorflow==1.15.2

--- a/examples/paddle/conda.yaml
+++ b/examples/paddle/conda.yaml
@@ -3,7 +3,7 @@ channels:
 - defaults
 - conda-forge
 dependencies:
-- python=3.6.13
+- python=3.7
 - pip
 - pip:
   - mlflow

--- a/examples/pytorch/conda.yaml
+++ b/examples/pytorch/conda.yaml
@@ -2,7 +2,7 @@ name: pytorch_example
 channels:
   - conda-forge
 dependencies:
-  - python=3.6
+  - python=3.7
   - pip
   - pip:
     - torch==1.8.1

--- a/examples/sklearn_elasticnet_diabetes/linux/conda.yaml
+++ b/examples/sklearn_elasticnet_diabetes/linux/conda.yaml
@@ -2,13 +2,13 @@ name: tutorial
 channels:
   - conda-forge
 dependencies:
-  - python=3.6
+  - python=3.7
   - pip
   - pip:
     - mlflow
-    - numpy==1.14.3
-    - matplotlib==3.0.2
-    - pandas==0.22.0
+    - numpy
+    - matplotlib
+    - pandas
     - scipy
-    - scikit-learn==0.19.1
-    - cloudpickle==0.6.1
+    - scikit-learn
+    - cloudpickle

--- a/examples/sklearn_elasticnet_diabetes/linux/train_diabetes.py
+++ b/examples/sklearn_elasticnet_diabetes/linux/train_diabetes.py
@@ -95,7 +95,7 @@ if __name__ == "__main__":
     eps = 5e-3  # the smaller it is the longer is the path
 
     print("Computing regularization path using the elastic net.")
-    alphas_enet, coefs_enet, _ = enet_path(X, y, eps=eps, l1_ratio=l1_ratio, fit_intercept=False)
+    alphas_enet, coefs_enet, _ = enet_path(X, y, eps=eps, l1_ratio=l1_ratio)
 
     # Display results
     fig = plt.figure(1)

--- a/examples/sklearn_elasticnet_diabetes/osx/conda.yaml
+++ b/examples/sklearn_elasticnet_diabetes/osx/conda.yaml
@@ -3,13 +3,12 @@ channels:
   - anaconda
   - conda-forge
 dependencies:
-  - python=3.6
-  - python.app
+  - python=3.7
   - pip
   - pip:
     - mlflow>=1.0
-    - cloudpickle=0.6.1
-    - numpy==1.14.3
-    - matplotlib==3.0.2
-    - pandas==0.22.0
-    - scikit-learn==0.19.1
+    - cloudpickle
+    - numpy
+    - matplotlib
+    - pandas
+    - scikit-learn

--- a/examples/sklearn_elasticnet_diabetes/osx/train_diabetes.py
+++ b/examples/sklearn_elasticnet_diabetes/osx/train_diabetes.py
@@ -95,7 +95,7 @@ if __name__ == "__main__":
     eps = 5e-3  # the smaller it is the longer is the path
 
     print("Computing regularization path using the elastic net.")
-    alphas_enet, coefs_enet, _ = enet_path(X, y, eps=eps, l1_ratio=l1_ratio, fit_intercept=False)
+    alphas_enet, coefs_enet, _ = enet_path(X, y, eps=eps, l1_ratio=l1_ratio)
 
     # Display results
     fig = plt.figure(1)

--- a/examples/sklearn_logistic_regression/conda.yaml
+++ b/examples/sklearn_logistic_regression/conda.yaml
@@ -2,10 +2,9 @@ name: sklearn-example
 channels:
   - conda-forge
 dependencies:
-  - python=3.6
+  - python=3.7
   - pip
   - pip:
     - mlflow>=1.0
     - scipy
-    - scikit-learn==0.19.1
-
+    - scikit-learn

--- a/examples/spacy/conda.yaml
+++ b/examples/spacy/conda.yaml
@@ -2,7 +2,7 @@ name: spacy-example
 channels:
   - conda-forge
 dependencies:
-  - python=3.6
+  - python=3.7
   - pip
   - pip:
     - mlflow>=1.0

--- a/examples/statsmodels/conda.yaml
+++ b/examples/statsmodels/conda.yaml
@@ -2,7 +2,7 @@ name: statsmodels-example
 channels:
   - conda-forge
 dependencies:
-  - python=3.6
+  - python=3.7
   - pip
   - pip:
       - mlflow>=1.6.0

--- a/examples/tensorflow/tf2/conda.yaml
+++ b/examples/tensorflow/tf2/conda.yaml
@@ -2,7 +2,7 @@ name: tensorflow-example
 channels:
   - conda-forge
 dependencies:
-  - python=3.6
+  - python=3.7
   - pip
   - pip:
     - mlflow

--- a/examples/xgboost/xgboost_native/conda.yaml
+++ b/examples/xgboost/xgboost_native/conda.yaml
@@ -2,11 +2,11 @@ name: xgboost-example
 channels:
   - conda-forge
 dependencies:
-  - python=3.6
+  - python=3.7
   - pip
   - pip:
       - mlflow>=1.6.0
       - scipy
-      - scikit-learn==0.19.1
+      - scikit-learn
       - matplotlib
       - xgboost

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -27,8 +27,6 @@ implement mutual exclusion manually.
 
 For a lower level API, see the :py:mod:`mlflow.tracking` module.
 """
-import sys
-
 from mlflow.version import VERSION as __version__  # pylint: disable=unused-import
 from mlflow.utils.logging_utils import _configure_mlflow_loggers
 import mlflow.tracking._model_registry.fluent
@@ -100,24 +98,25 @@ except ImportError as e:
 
 _configure_mlflow_loggers(root_module_name=__name__)
 
-_major = 3
-_minor = 6
-_deprecated_version = (_major, _minor)
-_min_supported_version = (_major, _minor + 1)
+# TODO: Comment out this block when we deprecate support for python 3.7.
+# _major = 3
+# _minor = 7
+# _deprecated_version = (_major, _minor)
+# _min_supported_version = (_major, _minor + 1)
 
-if sys.version_info[:2] == _deprecated_version:
-    warnings.warn(
-        "MLflow support for Python {dep_ver} is deprecated and will be dropped in "
-        "an upcoming release. At that point, existing Python {dep_ver} workflows "
-        "that use MLflow will continue to work without modification, but Python {dep_ver} "
-        "users will no longer get access to the latest MLflow features and bugfixes. "
-        "We recommend that you upgrade to Python {min_ver} or newer.".format(
-            dep_ver=".".join(map(str, _deprecated_version)),
-            min_ver=".".join(map(str, _min_supported_version)),
-        ),
-        FutureWarning,
-        stacklevel=2,
-    )
+# if sys.version_info[:2] == _deprecated_version:
+#     warnings.warn(
+#         "MLflow support for Python {dep_ver} is deprecated and will be dropped in "
+#         "an upcoming release. At that point, existing Python {dep_ver} workflows "
+#         "that use MLflow will continue to work without modification, but Python {dep_ver} "
+#         "users will no longer get access to the latest MLflow features and bugfixes. "
+#         "We recommend that you upgrade to Python {min_ver} or newer.".format(
+#             dep_ver=".".join(map(str, _deprecated_version)),
+#             min_ver=".".join(map(str, _min_supported_version)),
+#         ),
+#         FutureWarning,
+#         stacklevel=2,
+#     )
 
 ActiveRun = mlflow.tracking.fluent.ActiveRun
 log_param = mlflow.tracking.fluent.log_param

--- a/setup.py
+++ b/setup.py
@@ -129,10 +129,10 @@ setup(
     else open("README_SKINNY.rst").read() + open("README.rst").read(),
     long_description_content_type="text/x-rst",
     license="Apache License 2.0",
-    classifiers=["Intended Audience :: Developers", "Programming Language :: Python :: 3.6"],
+    classifiers=["Intended Audience :: Developers", "Programming Language :: Python :: 3.7"],
     keywords="ml ai databricks",
     url="https://mlflow.org/",
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     project_urls={
         "Bug Tracker": "https://github.com/mlflow/mlflow/issues",
         "Documentation": "https://mlflow.org/docs/latest/index.html",

--- a/tests/db/Dockerfile
+++ b/tests/db/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.7
 
 WORKDIR /tmp/mlflow
 

--- a/tests/db/Dockerfile.mssql
+++ b/tests/db/Dockerfile.mssql
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.7
 
 WORKDIR /tmp/mlflow
 

--- a/tests/resources/example_docker_project/Dockerfile
+++ b/tests/resources/example_docker_project/Dockerfile
@@ -1,5 +1,5 @@
 FROM continuumio/miniconda3:4.6.14
 
 RUN apt-get update -y && apt-get install build-essential -y
-RUN conda install python=3.6
+RUN conda install python=3.7
 RUN pip install mlflow && pip install sqlalchemy

--- a/tests/resources/example_project/conda.yaml
+++ b/tests/resources/example_project/conda.yaml
@@ -4,7 +4,7 @@ name: tutorial
 channels:
   - defaults
 dependencies:
-  - python=3.6
+  - python=3.7
   - pip:
     - -e ../../../
     - psutil


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

Drop support for python 3.6.

## How is this patch tested?

Confirming all the existing checks pass.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Support for Python 3.6 has been dropped.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [x] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
