### PR TITLE
Remove deprecated methods/properties in `mlflow.types.schema`

### DIFF
--- a/mlflow/types/schema.py
+++ b/mlflow/types/schema.py
@@ -348,18 +348,6 @@ class Schema:
         """Get types of the represented dataset."""
         return [x.type for x in self.inputs]
 
-    @deprecated(alternative="mlflow.types.Schema.input_types", since="1.14")
-    def column_types(self) -> List[DataType]:
-        """
-        .. deprecated:: 1.14
-          Please use :func:`mlflow.types.Schema.input_types()`
-          Get types of the represented dataset. Unsupported by TensorSpec.
-
-        """
-        if self.is_tensor_spec():
-            raise MlflowException("TensorSpec only supports numpy types, use numpy_types() instead")
-        return [x.type for x in self.columns]
-
     def numpy_types(self) -> List[np.dtype]:
         """Convenience shortcut to get the datatypes as numpy types."""
         if self.is_tensor_spec():

--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -145,7 +145,7 @@ def _infer_schema(data: Any) -> Schema:
             "but got '{}'".format(type(data))
         )
     if not schema.is_tensor_spec() and any(
-        [t in (DataType.integer, DataType.long) for t in schema.column_types()]
+        [t in (DataType.integer, DataType.long) for t in schema.input_types()]
     ):
         warnings.warn(
             "Hint: Inferred schema contains integer column(s). Integer columns in "

--- a/tests/types/test_schema.py
+++ b/tests/types/test_schema.py
@@ -138,8 +138,6 @@ def test_get_schema_type(dict_of_ndarrays):
     schema = _infer_schema(dict_of_ndarrays)
     assert ["float64"] * 4 == schema.numpy_types()
     with pytest.raises(MlflowException, match="TensorSpec only supports numpy types"):
-        schema.input_types()
-    with pytest.raises(MlflowException, match="TensorSpec only supports numpy types"):
         schema.pandas_types()
     with pytest.raises(MlflowException, match="TensorSpec cannot be converted to spark dataframe"):
         schema.as_spark_schema()

--- a/tests/types/test_schema.py
+++ b/tests/types/test_schema.py
@@ -138,7 +138,7 @@ def test_get_schema_type(dict_of_ndarrays):
     schema = _infer_schema(dict_of_ndarrays)
     assert ["float64"] * 4 == schema.numpy_types()
     with pytest.raises(MlflowException, match="TensorSpec only supports numpy types"):
-        schema.column_types()
+        schema.input_types()
     with pytest.raises(MlflowException, match="TensorSpec only supports numpy types"):
         schema.pandas_types()
     with pytest.raises(MlflowException, match="TensorSpec cannot be converted to spark dataframe"):
@@ -428,7 +428,7 @@ def test_spark_schema_inference(pandas_df_with_all_types):
     spark_session = pyspark.sql.SparkSession(pyspark.SparkContext.getOrCreate())
 
     struct_fields = []
-    for t in schema.column_types():
+    for t in schema.input_types():
         # pyspark _parse_datatype_string() expects "timestamp" instead of "datetime"
         if t == DataType.datetime:
             struct_fields.append(StructField("datetime", _parse_datatype_string("timestamp"), True))
@@ -468,7 +468,7 @@ def test_spark_type_mapping(pandas_df_with_all_types):
     )
     schema = _infer_schema(pandas_df_with_all_types)
     expected_spark_schema = StructType(
-        [StructField(t.name, t.to_spark(), True) for t in schema.column_types()]
+        [StructField(t.name, t.to_spark(), True) for t in schema.input_types()]
     )
     actual_spark_schema = schema.as_spark_schema()
     assert expected_spark_schema.jsonValue() == actual_spark_schema.jsonValue()
@@ -480,7 +480,7 @@ def test_spark_type_mapping(pandas_df_with_all_types):
     # test unnamed columns
     schema = Schema([ColSpec(col.type) for col in schema.inputs])
     expected_spark_schema = StructType(
-        [StructField(str(i), t.to_spark(), True) for i, t in enumerate(schema.column_types())]
+        [StructField(str(i), t.to_spark(), True) for i, t in enumerate(schema.input_types())]
     )
     actual_spark_schema = schema.as_spark_schema()
     assert expected_spark_schema.jsonValue() == actual_spark_schema.jsonValue()


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

Remove deprecated methods/properties in `mlflow.types.schema`.

## How is this patch tested?

Existing tests

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`mlflow.types.schema.column_types` has been removed.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [x] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
