### PR TITLE
Remove deprecated `mlflow.data.download_uri`

### DIFF
--- a/mlflow/data.py
+++ b/mlflow/data.py
@@ -74,18 +74,3 @@ def parse_gs_uri(uri):
 def is_uri(string):
     parsed_uri = urllib.parse.urlparse(string)
     return len(parsed_uri.scheme) > 0
-
-
-@deprecated(alternative="mlflow.tracking.MlflowClient.download_artifacts", since="1.9")
-def download_uri(uri, output_path):
-    if DBFS_REGEX.match(uri):
-        _fetch_dbfs(uri, output_path)
-    elif S3_REGEX.match(uri):
-        _fetch_s3(uri, output_path)
-    elif GS_REGEX.match(uri):
-        _fetch_gs(uri, output_path)
-    else:
-        raise DownloadException(
-            "`uri` must be a DBFS (%s), S3 (%s), or GCS (%s) URI, got "
-            "%s" % (DBFS_PREFIX, S3_PREFIX, GS_PREFIX, uri)
-        )

--- a/mlflow/data.py
+++ b/mlflow/data.py
@@ -3,7 +3,6 @@ import re
 import urllib.parse
 
 from mlflow.utils import process
-from mlflow.utils.annotations import deprecated
 
 DBFS_PREFIX = "dbfs:/"
 S3_PREFIX = "s3://"

--- a/tests/data/test_data.py
+++ b/tests/data/test_data.py
@@ -2,11 +2,8 @@ from contextlib import contextmanager
 import os
 import shutil
 import tempfile
-from unittest import mock
 
-import pytest
-
-from mlflow.data import is_uri, download_uri, DownloadException
+from mlflow.data import is_uri
 from mlflow.projects import _project_spec
 
 TEST_DIR = "tests"
@@ -32,25 +29,3 @@ def test_is_uri():
     assert is_uri("dbfs:/some/dbfs/path")
     assert is_uri("file://some/local/path")
     assert not is_uri("/tmp/some/local/path")
-
-
-def test_download_uri():
-    # Verify downloading from DBFS & S3 urls calls the corresponding helper functions
-    prefix_to_mock = {
-        "dbfs:/": "mlflow.data._fetch_dbfs",
-        "s3://": "mlflow.data._fetch_s3",
-        "gs://": "mlflow.data._fetch_gs",
-    }
-    for prefix, fn_name in prefix_to_mock.items():
-        with mock.patch(fn_name) as mocked_fn, temp_directory() as dst_dir:
-            download_uri(
-                uri=os.path.join(prefix, "some/path"), output_path=os.path.join(dst_dir, "tmp-file")
-            )
-            assert mocked_fn.call_count == 1
-    # Verify exceptions are thrown when downloading from unsupported/invalid URIs
-    invalid_prefixes = ["file://", "/tmp"]
-    for prefix in invalid_prefixes:
-        with temp_directory() as dst_dir, pytest.raises(DownloadException, match="`uri` must be"):
-            download_uri(
-                uri=os.path.join(prefix, "some/path"), output_path=os.path.join(dst_dir, "tmp-file")
-            )


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

Remove deprecated `mlflow.data.download_uri`.

## How is this patch tested?

Existing tests

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`mlflow.data.download_uri` has been removed.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [x] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
