### PR TITLE
Remove deprecated `mlflow.types.schema.columns`

### DIFF
--- a/mlflow/types/schema.py
+++ b/mlflow/types/schema.py
@@ -295,19 +295,6 @@ class Schema:
         """Representation of a dataset that defines this schema."""
         return self._inputs
 
-    @property
-    @deprecated(alternative="mlflow.types.Schema.inputs", since="1.14")
-    def columns(self) -> List[ColSpec]:
-        """
-        .. deprecated:: 1.14
-          Please use :func:`mlflow.types.Schema.inputs`
-          The list of columns that defines this schema.
-
-        """
-        if self.is_tensor_spec():
-            raise MlflowException("Not supported by TensorSpec, use `inputs` instead")
-        return self._inputs
-
     def is_tensor_spec(self) -> bool:
         """Return true iff this schema is specified using TensorSpec"""
         return self.inputs and isinstance(self.inputs[0], TensorSpec)

--- a/mlflow/types/schema.py
+++ b/mlflow/types/schema.py
@@ -345,7 +345,7 @@ class Schema:
         """
         if self.is_tensor_spec():
             raise MlflowException("TensorSpec only supports numpy types, use numpy_types() instead")
-        return [x.type for x in self.columns]
+        return [x.type for x in self.input_types]
 
     def numpy_types(self) -> List[np.dtype]:
         """Convenience shortcut to get the datatypes as numpy types."""

--- a/mlflow/types/schema.py
+++ b/mlflow/types/schema.py
@@ -345,7 +345,7 @@ class Schema:
         """
         if self.is_tensor_spec():
             raise MlflowException("TensorSpec only supports numpy types, use numpy_types() instead")
-        return [x.type for x in self.input_types]
+        return [x.type for x in self.inputs]
 
     def numpy_types(self) -> List[np.dtype]:
         """Convenience shortcut to get the datatypes as numpy types."""

--- a/tests/types/test_schema.py
+++ b/tests/types/test_schema.py
@@ -150,7 +150,7 @@ def test_schema_inference_on_dataframe(pandas_df_with_all_types):
         columns=["boolean_ext", "integer_ext", "string_ext"]
     )
     schema = _infer_schema(basic_types)
-    assert schema == Schema([ColSpec(x, x) for x in basic_types.columns])
+    assert schema == Schema([ColSpec(x, x) for x in basic_types.inputs])
 
     ext_types = pandas_df_with_all_types[["boolean_ext", "integer_ext", "string_ext"]].copy()
     expected_schema = Schema(
@@ -424,7 +424,7 @@ def test_spark_schema_inference(pandas_df_with_all_types):
         columns=["boolean_ext", "integer_ext", "string_ext"]
     )
     schema = _infer_schema(pandas_df_with_all_types)
-    assert schema == Schema([ColSpec(x, x) for x in pandas_df_with_all_types.columns])
+    assert schema == Schema([ColSpec(x, x) for x in pandas_df_with_all_types.inputs])
     spark_session = pyspark.sql.SparkSession(pyspark.SparkContext.getOrCreate())
 
     struct_fields = []
@@ -437,7 +437,7 @@ def test_spark_schema_inference(pandas_df_with_all_types):
     spark_schema = StructType(struct_fields)
     sparkdf = spark_session.createDataFrame(pandas_df_with_all_types, schema=spark_schema)
     schema = _infer_schema(sparkdf)
-    assert schema == Schema([ColSpec(x, x) for x in pandas_df_with_all_types.columns])
+    assert schema == Schema([ColSpec(x, x) for x in pandas_df_with_all_types.inputs])
 
 
 @pytest.mark.large

--- a/tests/types/test_schema.py
+++ b/tests/types/test_schema.py
@@ -150,7 +150,7 @@ def test_schema_inference_on_dataframe(pandas_df_with_all_types):
         columns=["boolean_ext", "integer_ext", "string_ext"]
     )
     schema = _infer_schema(basic_types)
-    assert schema == Schema([ColSpec(x, x) for x in basic_types.inputs])
+    assert schema == Schema([ColSpec(x, x) for x in basic_types.columns])
 
     ext_types = pandas_df_with_all_types[["boolean_ext", "integer_ext", "string_ext"]].copy()
     expected_schema = Schema(
@@ -424,7 +424,7 @@ def test_spark_schema_inference(pandas_df_with_all_types):
         columns=["boolean_ext", "integer_ext", "string_ext"]
     )
     schema = _infer_schema(pandas_df_with_all_types)
-    assert schema == Schema([ColSpec(x, x) for x in pandas_df_with_all_types.inputs])
+    assert schema == Schema([ColSpec(x, x) for x in pandas_df_with_all_types.columns])
     spark_session = pyspark.sql.SparkSession(pyspark.SparkContext.getOrCreate())
 
     struct_fields = []
@@ -437,7 +437,7 @@ def test_spark_schema_inference(pandas_df_with_all_types):
     spark_schema = StructType(struct_fields)
     sparkdf = spark_session.createDataFrame(pandas_df_with_all_types, schema=spark_schema)
     schema = _infer_schema(sparkdf)
-    assert schema == Schema([ColSpec(x, x) for x in pandas_df_with_all_types.inputs])
+    assert schema == Schema([ColSpec(x, x) for x in pandas_df_with_all_types.columns])
 
 
 @pytest.mark.large


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

Remove deprecated `mlflow.types.schema.columns`.

## How is this patch tested?

Existing tests

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`mlflow.types.schema.columns` has been removed.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [x] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
