### PR TITLE
Fix contour plot

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunContour.js
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunContour.js
@@ -152,10 +152,10 @@ export class CompareRunContour extends Component {
 
     const maybeRenderPlot = () => {
       const invalidAxes = [];
-      if (xs.length < 2) {
+      if ([...new Set(xs)].length < 2) {
         invalidAxes.push('X');
       }
-      if (ys.length < 2) {
+      if ([...new Set(ys)].length < 2) {
         invalidAxes.push('Y');
       }
       if (invalidAxes.length > 0) {

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunContour.js
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunContour.js
@@ -152,10 +152,10 @@ export class CompareRunContour extends Component {
 
     const maybeRenderPlot = () => {
       const invalidAxes = [];
-      if ([...new Set(xs)].length < 2) {
+      if (new Set(xs).size < 2) {
         invalidAxes.push('X');
       }
-      if ([...new Set(ys)].length < 2) {
+      if (new Set(ys).size < 2) {
         invalidAxes.push('Y');
       }
       if (invalidAxes.length > 0) {

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunContour.js
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunContour.js
@@ -150,23 +150,12 @@ export class CompareRunContour extends Component {
       tooltips.push(this.getPlotlyTooltip(index));
     });
 
-    // array.sort() doesn't sort negative values correctly.
-    const xsSorted = [...new Set(xs)].sort((a, b) => a - b);
-    const ysSorted = [...new Set(ys)].sort((a, b) => a - b);
-    const z = ysSorted.map(() => xsSorted.map(() => null));
-
-    xs.forEach((_, index) => {
-      const xi = xsSorted.indexOf(xs[index]);
-      const yi = ysSorted.indexOf(ys[index]);
-      z[yi][xi] = zs[index];
-    });
-
     const maybeRenderPlot = () => {
       const invalidAxes = [];
-      if (xsSorted.length < 2) {
+      if (xs.length < 2) {
         invalidAxes.push('X');
       }
-      if (ysSorted.length < 2) {
+      if (ys.length < 2) {
         invalidAxes.push('Y');
       }
       if (invalidAxes.length > 0) {
@@ -182,9 +171,9 @@ export class CompareRunContour extends Component {
           data={[
             // contour plot
             {
-              z,
-              x: xsSorted,
-              y: ysSorted,
+              z: zs,
+              x: xs,
+              y: ys,
               type: 'contour',
               hoverinfo: 'none',
               colorscale: this.getColorscale(),
@@ -195,8 +184,8 @@ export class CompareRunContour extends Component {
             },
             // scatter plot
             {
-              x: xsSorted,
-              y: ysSorted,
+              x: xs,
+              y: ys,
               text: tooltips,
               hoverinfo: 'text',
               type: 'scattergl',


### PR DESCRIPTION
Signed-off-by: Liang Zhang <liang.zhang@databricks.com>

## What changes are proposed in this pull request?

The contour plot is incorrect, the x, y, z, and tooltips don't make sense.
The data passed into the contour plot is mis-sorted. They don't really need to be sorted. This PR removed the sorting code and the plot shows correct values.

## How is this patch tested?

Manually tests.
Before:
<img width="1586" alt="Screen Shot 2022-01-27 at 4 12 51 PM" src="https://user-images.githubusercontent.com/7851093/151464695-76e9a1dd-0dfc-4acf-ae99-07faadf8091e.png">

After:
<img width="1586" alt="Screen Shot 2022-01-27 at 4 15 56 PM" src="https://user-images.githubusercontent.com/7851093/151464705-cac40b19-33b2-4dba-83f8-3418e72a4e58.png">

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
