### PR TITLE
Add developer guide for building model evaluation plugins

### DIFF
--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -206,7 +206,7 @@ plugin:
        2) The ``run_local`` and ``target_help`` functions, with the ``target`` parameter excluded, as shown
        `here <https://github.com/mlflow/mlflow/blob/master/mlflow/deployments/base.py>`_
      - `PluginDeploymentClient <https://github.com/mlflow/mlflow/blob/master/tests/resources/mlflow-test-plugin/mlflow_test_plugin/fake_deployment_plugin.py>`_.
-   * - Plugins for custom mlflow evaluator.
+   * - Plugins for :ref:`MLflow Model Evaluation <model-evaluation>`
      - mlflow.model_evaluator
      - The entry point name (e.g. ``dummy_evaluator``) is the evaluator name which is used in the ``evaluators`` argument of the ``mlflow.evaluate`` API.
        The entry point value (e.g. ``dummy_evaluator:DummyEvaluator``) must refer to a subclass of ``mlflow.models.evaluation.ModelEvaluator``;

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -116,6 +116,8 @@ The example package contains a ``setup.py`` that declares a number of
                 "dummy-backend=mlflow_test_plugin.dummy_backend:PluginDummyProjectBackend",
             # Define a MLflow model deployment plugin for target 'faketarget'
             "mlflow.deployments": "faketarget=mlflow_test_plugin.fake_deployment_plugin",
+            # Define a Mlflow model evaluator with name "dummy_evaluator"
+            "mlflow.model_evaluator": "dummy_evaluator=mlflow_test_plugin.dummy_evaluator:DummyEvaluator",
         },
     )
 
@@ -203,6 +205,18 @@ plugin:
        2) The ``run_local`` and ``target_help`` functions, with the ``target`` parameter excluded, as shown
        `here <https://github.com/mlflow/mlflow/blob/master/mlflow/deployments/base.py>`_
      - `PluginDeploymentClient <https://github.com/mlflow/mlflow/blob/master/tests/resources/mlflow-test-plugin/mlflow_test_plugin/fake_deployment_plugin.py>`_.
+   * - Plugins for custom mlflow evaluator.
+     - mlflow.model_evaluator
+     - The entry point name (e.g. ``dummy_evaluator``) is the evaluator name which is used in the ``evaluators`` argument of the ``mlflow.evaluate`` API.
+       The entry point value (e.g. ``dummy_evaluator:DummyEvaluator``) specify a class which is subclass of ``mlflow.models.evaluation.ModelEvaluator``,
+       the subclass must implement 2 methods:
+       1) Implement ``can_evaluate`` method: The method accept keyword-only arguments of ``model_type`` and ``evaluator_config``,
+       return True if the evaluator can evaluate the specified model type with specified evaluator config. False otherwise.
+       2) Implement ``evaluate`` method: In the method implementation, it should log metrics and artifacts, and return evaluation results as an instance
+       of ``mlflow.models.EvaluationResult``. It accepts arguments of ``model`` (a pyfunc model instance.),
+       ``model_type`` (the same with ``model_type`` argument in ``mlflow.evaluate`` API),
+       ``dataset`` (an instance of `mlflow.models.evaluation.base._EvaluationDataset` containing features and labels (optional) for model evaluation,
+       ``run_id`` (the ID of the MLflow Run to which to log results), ``evaluator_config`` (a dictionary of additional configurations for the evaluator).
 
 
 Testing Your Plugin
@@ -217,6 +231,7 @@ reference implementations as an example:
 * `Example ArtifactRepository tests <https://github.com/mlflow/mlflow/blob/branch-1.5/tests/store/artifact/test_local_artifact_repo.py>`_
 * `Example RunContextProvider tests <https://github.com/mlflow/mlflow/blob/branch-1.5/tests/tracking/context/test_git_context.py>`_
 * `Example Model Registry Store tests <https://github.com/mlflow/mlflow/blob/branch-1.5/tests/store/model_registry/test_sqlalchemy_store.py>`_
+* `Example Custom Mlflow Evaluator tests <https://github.com/mlflow/mlflow/blob/a1faae7c4ae9141c4bb441cb69273f9c12fbc454/tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_evaluator.py>`
 
 
 Distributing Your Plugin

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -217,6 +217,7 @@ plugin:
        ``model_type`` (the same with ``model_type`` argument in ``mlflow.evaluate`` API),
        ``dataset`` (an instance of `mlflow.models.evaluation.base._EvaluationDataset` containing features and labels (optional) for model evaluation,
        ``run_id`` (the ID of the MLflow Run to which to log results), ``evaluator_config`` (a dictionary of additional configurations for the evaluator).
+     - `DummyEvaluator <https://github.com/mlflow/mlflow/blob/branch-1.23/tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_evaluator.py>`_.
 
 
 Testing Your Plugin
@@ -231,7 +232,7 @@ reference implementations as an example:
 * `Example ArtifactRepository tests <https://github.com/mlflow/mlflow/blob/branch-1.5/tests/store/artifact/test_local_artifact_repo.py>`_
 * `Example RunContextProvider tests <https://github.com/mlflow/mlflow/blob/branch-1.5/tests/tracking/context/test_git_context.py>`_
 * `Example Model Registry Store tests <https://github.com/mlflow/mlflow/blob/branch-1.5/tests/store/model_registry/test_sqlalchemy_store.py>`_
-* `Example Custom Mlflow Evaluator tests <https://github.com/mlflow/mlflow/blob/a1faae7c4ae9141c4bb441cb69273f9c12fbc454/tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_evaluator.py>`
+* `Example Custom Mlflow Evaluator tests <https://github.com/mlflow/mlflow/blob/branch-1.23/tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_evaluator.py>`_
 
 
 Distributing Your Plugin

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -26,6 +26,7 @@ The MLflow Python API supports several types of plugins:
   :py:func:`mlflow.start_run` fluent API.
 * **Model Registry Store**: override model registry backend logic, e.g. to log to a third-party storage solution
 * **MLFlow Project backend**: override the local execution backend to execute a project on your own cluster (Databricks, kubernetes, etc.)
+* **MLFlow ModelEvaluator**: Define custom model evaluator, which can be used in :py:func:`mlflow.evaluate` API.
 
 .. contents:: Table of Contents
   :local:
@@ -208,15 +209,15 @@ plugin:
    * - Plugins for custom mlflow evaluator.
      - mlflow.model_evaluator
      - The entry point name (e.g. ``dummy_evaluator``) is the evaluator name which is used in the ``evaluators`` argument of the ``mlflow.evaluate`` API.
-       The entry point value (e.g. ``dummy_evaluator:DummyEvaluator``) specify a class which is subclass of ``mlflow.models.evaluation.ModelEvaluator``,
+       The entry point value (e.g. ``dummy_evaluator:DummyEvaluator``) must refer to a subclass of ``mlflow.models.evaluation.ModelEvaluator``;
        the subclass must implement 2 methods:
-       1) Implement ``can_evaluate`` method: The method accept keyword-only arguments of ``model_type`` and ``evaluator_config``,
-       return True if the evaluator can evaluate the specified model type with specified evaluator config. False otherwise.
-       2) Implement ``evaluate`` method: In the method implementation, it should log metrics and artifacts, and return evaluation results as an instance
-       of ``mlflow.models.EvaluationResult``. It accepts arguments of ``model`` (a pyfunc model instance.),
-       ``model_type`` (the same with ``model_type`` argument in ``mlflow.evaluate`` API),
-       ``dataset`` (an instance of `mlflow.models.evaluation.base._EvaluationDataset` containing features and labels (optional) for model evaluation,
-       ``run_id`` (the ID of the MLflow Run to which to log results), ``evaluator_config`` (a dictionary of additional configurations for the evaluator).
+       1) ``can_evaluate``: Accepts the keyword-only arguments ``model_type`` and ``evaluator_config``.
+       Returns ``True`` if the evaluator can evaluate the specified model type with the specified evaluator config. Returns ``False`` otherwise.
+       2) ``evaluate``: Computes and logs metrics and artifacts, returning evaluation results as an instance
+       of ``mlflow.models.EvaluationResult``. Accepts the following arguments: ``model`` (a pyfunc model instance),
+       ``model_type`` (identical to the ``model_type`` argument from :py:func:`mlflow.evaluate()`),
+       ``dataset`` (an instance of ``mlflow.models.evaluation.base._EvaluationDataset`` containing features and labels (optional) for model evaluation),
+       ``run_id`` (the ID of the MLflow Run to which to log results), and ``evaluator_config`` (a dictionary of additional configurations for the evaluator).
      - `DummyEvaluator <https://github.com/mlflow/mlflow/blob/branch-1.23/tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_evaluator.py>`_.
 
 

--- a/tests/resources/mlflow-test-plugin/setup.py
+++ b/tests/resources/mlflow-test-plugin/setup.py
@@ -26,6 +26,7 @@ setup(
         "mlflow.project_backend": "dummy-backend=mlflow_test_plugin.dummy_backend:PluginDummyProjectBackend",  # pylint: disable=line-too-long
         # Define a MLflow model deployment plugin for target 'faketarget'
         "mlflow.deployments": "faketarget=mlflow_test_plugin.fake_deployment_plugin",
+        # Define a Mlflow model evaluator with name "dummy_evaluator"
         "mlflow.model_evaluator": "dummy_evaluator=mlflow_test_plugin.dummy_evaluator:DummyEvaluator",  # pylint: disable=line-too-long
     },
 )


### PR DESCRIPTION
Signed-off-by: Weichen Xu <weichen.xu@databricks.com>

## What changes are proposed in this pull request?

Add developer guide for building model evaluation plugins

## How is this patch tested?

N/A

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
