### PR TITLE
Update logged workspace url

### DIFF
--- a/mlflow/tracking/context/databricks_job_context.py
+++ b/mlflow/tracking/context/databricks_job_context.py
@@ -22,7 +22,8 @@ class DatabricksJobRunContext(RunContextProvider):
         job_run_id = databricks_utils.get_job_run_id()
         job_type = databricks_utils.get_job_type()
         webapp_url = databricks_utils.get_webapp_url()
-        workspace_url, workspace_id = databricks_utils.get_workspace_info_from_dbutils()
+        workspace_url = databricks_utils.get_workspace_url_from_spark_conf()
+        workspace_url_fallback, workspace_id = databricks_utils.get_workspace_info_from_dbutils()
         tags = {
             MLFLOW_SOURCE_NAME: (
                 "jobs/{job_id}/run/{job_run_id}".format(job_id=job_id, job_run_id=job_run_id)
@@ -41,6 +42,8 @@ class DatabricksJobRunContext(RunContextProvider):
             tags[MLFLOW_DATABRICKS_WEBAPP_URL] = webapp_url
         if workspace_url is not None:
             tags[MLFLOW_DATABRICKS_WORKSPACE_URL] = workspace_url
+        elif workspace_url_fallback is not None:
+            tags[MLFLOW_DATABRICKS_WORKSPACE_URL] = workspace_url_fallback
         if workspace_id is not None:
             tags[MLFLOW_DATABRICKS_WORKSPACE_ID] = workspace_id
         return tags

--- a/mlflow/tracking/context/databricks_job_context.py
+++ b/mlflow/tracking/context/databricks_job_context.py
@@ -22,7 +22,7 @@ class DatabricksJobRunContext(RunContextProvider):
         job_run_id = databricks_utils.get_job_run_id()
         job_type = databricks_utils.get_job_type()
         webapp_url = databricks_utils.get_webapp_url()
-        workspace_url = databricks_utils.get_workspace_url_from_spark_conf()
+        workspace_url = databricks_utils.get_workspace_url()
         workspace_url_fallback, workspace_id = databricks_utils.get_workspace_info_from_dbutils()
         tags = {
             MLFLOW_SOURCE_NAME: (

--- a/mlflow/tracking/context/databricks_notebook_context.py
+++ b/mlflow/tracking/context/databricks_notebook_context.py
@@ -20,7 +20,8 @@ class DatabricksNotebookRunContext(RunContextProvider):
         notebook_id = databricks_utils.get_notebook_id()
         notebook_path = databricks_utils.get_notebook_path()
         webapp_url = databricks_utils.get_webapp_url()
-        workspace_url, workspace_id = databricks_utils.get_workspace_info_from_dbutils()
+        workspace_url = databricks_utils.get_workspace_url()
+        workspace_url_fallback, workspace_id = databricks_utils.get_workspace_info_from_dbutils()
         tags = {
             MLFLOW_SOURCE_NAME: notebook_path,
             MLFLOW_SOURCE_TYPE: SourceType.to_string(SourceType.NOTEBOOK),
@@ -33,6 +34,8 @@ class DatabricksNotebookRunContext(RunContextProvider):
             tags[MLFLOW_DATABRICKS_WEBAPP_URL] = webapp_url
         if workspace_url is not None:
             tags[MLFLOW_DATABRICKS_WORKSPACE_URL] = workspace_url
+        elif workspace_url_fallback is not None:
+            tags[MLFLOW_DATABRICKS_WORKSPACE_URL] = workspace_url_fallback
         if workspace_id is not None:
             tags[MLFLOW_DATABRICKS_WORKSPACE_ID] = workspace_id
         return tags

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -320,7 +320,8 @@ def get_workspace_info_from_dbutils():
     return None, None
 
 
-def get_workspace_url_from_spark_conf():
+@_use_repl_context_if_available("workspaceUrl")
+def get_workspace_url():
     try:
         spark_session = _get_active_spark_session()
         if spark_session is not None:

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -320,6 +320,15 @@ def get_workspace_info_from_dbutils():
     return None, None
 
 
+def get_workspace_url_from_spark_conf():
+    try:
+        spark_session = _get_active_spark_session()
+        if spark_session is not None:
+            return spark_session.conf.get("spark.databricks.workspaceUrl")
+    except Exception:
+        return None
+
+
 def get_workspace_info_from_databricks_secrets(tracking_uri):
     profile, key_prefix = get_db_info_from_uri(tracking_uri)
     if key_prefix:

--- a/tests/tracking/context/test_databricks_job_context.py
+++ b/tests/tracking/context/test_databricks_job_context.py
@@ -29,7 +29,9 @@ def test_databricks_job_run_context_tags():
         "mlflow.utils.databricks_utils.get_workspace_url",
         return_value="https://dev.databricks.com",
     )
-    patch_workspace_url_none = mock.patch("mlflow.utils.databricks_utils.get_workspace_url")
+    patch_workspace_url_none = mock.patch(
+        "mlflow.utils.databricks_utils.get_workspace_url", return_value=None
+    )
     patch_workspace_info = mock.patch(
         "mlflow.utils.databricks_utils.get_workspace_info_from_dbutils",
         return_value=("https://databricks.com", "123456"),

--- a/tests/tracking/context/test_databricks_job_context.py
+++ b/tests/tracking/context/test_databricks_job_context.py
@@ -25,18 +25,29 @@ def test_databricks_job_run_context_tags():
     patch_job_run_id = mock.patch("mlflow.utils.databricks_utils.get_job_run_id")
     patch_job_type = mock.patch("mlflow.utils.databricks_utils.get_job_type")
     patch_webapp_url = mock.patch("mlflow.utils.databricks_utils.get_webapp_url")
+    patch_workspace_url = mock.patch(
+        "mlflow.utils.databricks_utils.get_workspace_url",
+        return_value="https://dev.databricks.com",
+    )
+    patch_workspace_url_none = mock.patch("mlflow.utils.databricks_utils.get_workspace_url")
     patch_workspace_info = mock.patch(
         "mlflow.utils.databricks_utils.get_workspace_info_from_dbutils",
         return_value=("https://databricks.com", "123456"),
     )
 
     with multi_context(
-        patch_job_id, patch_job_run_id, patch_job_type, patch_webapp_url, patch_workspace_info
+        patch_job_id,
+        patch_job_run_id,
+        patch_job_type,
+        patch_webapp_url,
+        patch_workspace_url,
+        patch_workspace_info,
     ) as (
         job_id_mock,
         job_run_id_mock,
         job_type_mock,
         webapp_url_mock,
+        workspace_url_mock,
         workspace_info_mock,
     ):
         assert DatabricksJobRunContext().tags() == {
@@ -48,7 +59,35 @@ def test_databricks_job_run_context_tags():
             MLFLOW_DATABRICKS_JOB_RUN_ID: job_run_id_mock.return_value,
             MLFLOW_DATABRICKS_JOB_TYPE: job_type_mock.return_value,
             MLFLOW_DATABRICKS_WEBAPP_URL: webapp_url_mock.return_value,
-            MLFLOW_DATABRICKS_WORKSPACE_URL: workspace_info_mock.return_value[0],
+            MLFLOW_DATABRICKS_WORKSPACE_URL: workspace_url_mock.return_value,
+            MLFLOW_DATABRICKS_WORKSPACE_ID: workspace_info_mock.return_value[1],
+        }
+
+    with multi_context(
+        patch_job_id,
+        patch_job_run_id,
+        patch_job_type,
+        patch_webapp_url,
+        patch_workspace_url_none,
+        patch_workspace_info,
+    ) as (
+        job_id_mock,
+        job_run_id_mock,
+        job_type_mock,
+        webapp_url_mock,
+        workspace_url_mock,
+        workspace_info_mock,
+    ):
+        assert DatabricksJobRunContext().tags() == {
+            MLFLOW_SOURCE_NAME: "jobs/{job_id}/run/{job_run_id}".format(
+                job_id=job_id_mock.return_value, job_run_id=job_run_id_mock.return_value
+            ),
+            MLFLOW_SOURCE_TYPE: SourceType.to_string(SourceType.JOB),
+            MLFLOW_DATABRICKS_JOB_ID: job_id_mock.return_value,
+            MLFLOW_DATABRICKS_JOB_RUN_ID: job_run_id_mock.return_value,
+            MLFLOW_DATABRICKS_JOB_TYPE: job_type_mock.return_value,
+            MLFLOW_DATABRICKS_WEBAPP_URL: webapp_url_mock.return_value,
+            MLFLOW_DATABRICKS_WORKSPACE_URL: workspace_info_mock.return_value[0],  # fallback value
             MLFLOW_DATABRICKS_WORKSPACE_ID: workspace_info_mock.return_value[1],
         }
 

--- a/tests/tracking/context/test_databricks_notebook_context.py
+++ b/tests/tracking/context/test_databricks_notebook_context.py
@@ -27,7 +27,9 @@ def test_databricks_notebook_run_context_tags():
         "mlflow.utils.databricks_utils.get_workspace_url",
         return_value="https://dev.databricks.com",
     )
-    patch_workspace_url_none = mock.patch("mlflow.utils.databricks_utils.get_workspace_url")
+    patch_workspace_url_none = mock.patch(
+        "mlflow.utils.databricks_utils.get_workspace_url", return_value=None
+    )
     patch_workspace_info = mock.patch(
         "mlflow.utils.databricks_utils.get_workspace_info_from_dbutils",
         return_value=("https://databricks.com", "123456"),

--- a/tests/tracking/context/test_databricks_notebook_context.py
+++ b/tests/tracking/context/test_databricks_notebook_context.py
@@ -23,17 +23,27 @@ def test_databricks_notebook_run_context_tags():
     patch_notebook_id = mock.patch("mlflow.utils.databricks_utils.get_notebook_id")
     patch_notebook_path = mock.patch("mlflow.utils.databricks_utils.get_notebook_path")
     patch_webapp_url = mock.patch("mlflow.utils.databricks_utils.get_webapp_url")
+    patch_workspace_url = mock.patch(
+        "mlflow.utils.databricks_utils.get_workspace_url",
+        return_value="https://dev.databricks.com",
+    )
+    patch_workspace_url_none = mock.patch("mlflow.utils.databricks_utils.get_workspace_url")
     patch_workspace_info = mock.patch(
         "mlflow.utils.databricks_utils.get_workspace_info_from_dbutils",
         return_value=("https://databricks.com", "123456"),
     )
 
     with multi_context(
-        patch_notebook_id, patch_notebook_path, patch_webapp_url, patch_workspace_info
+        patch_notebook_id,
+        patch_notebook_path,
+        patch_webapp_url,
+        patch_workspace_url,
+        patch_workspace_info,
     ) as (
         notebook_id_mock,
         notebook_path_mock,
         webapp_url_mock,
+        workspace_url_mock,
         workspace_info_mock,
     ):
         assert DatabricksNotebookRunContext().tags() == {
@@ -42,7 +52,30 @@ def test_databricks_notebook_run_context_tags():
             MLFLOW_DATABRICKS_NOTEBOOK_ID: notebook_id_mock.return_value,
             MLFLOW_DATABRICKS_NOTEBOOK_PATH: notebook_path_mock.return_value,
             MLFLOW_DATABRICKS_WEBAPP_URL: webapp_url_mock.return_value,
-            MLFLOW_DATABRICKS_WORKSPACE_URL: workspace_info_mock.return_value[0],
+            MLFLOW_DATABRICKS_WORKSPACE_URL: workspace_url_mock.return_value,
+            MLFLOW_DATABRICKS_WORKSPACE_ID: workspace_info_mock.return_value[1],
+        }
+
+    with multi_context(
+        patch_notebook_id,
+        patch_notebook_path,
+        patch_webapp_url,
+        patch_workspace_url_none,
+        patch_workspace_info,
+    ) as (
+        notebook_id_mock,
+        notebook_path_mock,
+        webapp_url_mock,
+        workspace_url_mock,
+        workspace_info_mock,
+    ):
+        assert DatabricksNotebookRunContext().tags() == {
+            MLFLOW_SOURCE_NAME: notebook_path_mock.return_value,
+            MLFLOW_SOURCE_TYPE: SourceType.to_string(SourceType.NOTEBOOK),
+            MLFLOW_DATABRICKS_NOTEBOOK_ID: notebook_id_mock.return_value,
+            MLFLOW_DATABRICKS_NOTEBOOK_PATH: notebook_path_mock.return_value,
+            MLFLOW_DATABRICKS_WEBAPP_URL: webapp_url_mock.return_value,
+            MLFLOW_DATABRICKS_WORKSPACE_URL: workspace_info_mock.return_value[0],  # fallback value
             MLFLOW_DATABRICKS_WORKSPACE_ID: workspace_info_mock.return_value[1],
         }
 

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -416,9 +416,14 @@ def test_start_run_defaults_databricks_notebook(
     webapp_url_patch = mock.patch(
         "mlflow.utils.databricks_utils.get_webapp_url", return_value=mock_webapp_url
     )
+    mock_workspace_url = mock.Mock()
+    workspace_url_patch = mock.patch(
+        "mlflow.utils.databricks_utils.get_workspace_url", return_value=mock_workspace_url
+    )
+    mock_workspace_id = mock.Mock()
     workspace_info_patch = mock.patch(
         "mlflow.utils.databricks_utils.get_workspace_info_from_dbutils",
-        return_value=("https://databricks.com", "123456"),
+        return_value=(mock_webapp_url, mock_workspace_id),
     )
 
     expected_tags = {
@@ -429,8 +434,8 @@ def test_start_run_defaults_databricks_notebook(
         mlflow_tags.MLFLOW_DATABRICKS_NOTEBOOK_ID: mock_notebook_id,
         mlflow_tags.MLFLOW_DATABRICKS_NOTEBOOK_PATH: mock_notebook_path,
         mlflow_tags.MLFLOW_DATABRICKS_WEBAPP_URL: mock_webapp_url,
-        mlflow_tags.MLFLOW_DATABRICKS_WORKSPACE_URL: "https://databricks.com",
-        mlflow_tags.MLFLOW_DATABRICKS_WORKSPACE_ID: "123456",
+        mlflow_tags.MLFLOW_DATABRICKS_WORKSPACE_URL: mock_workspace_url,
+        mlflow_tags.MLFLOW_DATABRICKS_WORKSPACE_ID: mock_workspace_id,
     }
 
     create_run_patch = mock.patch.object(MlflowClient, "create_run")
@@ -443,6 +448,7 @@ def test_start_run_defaults_databricks_notebook(
         notebook_id_patch,
         notebook_path_patch,
         webapp_url_patch,
+        workspace_url_patch,
         workspace_info_patch,
         create_run_patch,
     ):


### PR DESCRIPTION
Signed-off-by: Liang Zhang <liang.zhang@databricks.com>

## What changes are proposed in this pull request?

The correct workspace URL is propagated to the spark conf "spark.databricks.workspaceUrl". We should use this in the cross-workspace notebook/job source link generation, unless this conf is None, in which case we should fallback to the current implementation.

## How is this patch tested?

Existing tests. The new function just reads the spark conf, so no need to add additional test for it.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [x] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
