### PR TITLE
Fix debug logging

### DIFF
--- a/mlflow/utils/logging_utils.py
+++ b/mlflow/utils/logging_utils.py
@@ -70,7 +70,6 @@ def _configure_mlflow_loggers(root_module_name):
             },
             "handlers": {
                 "mlflow_handler": {
-                    "level": "INFO",
                     "formatter": "mlflow_formatter",
                     "class": "logging.StreamHandler",
                     "stream": MLFLOW_LOGGING_STREAM,

--- a/tests/utils/test_logging_utils.py
+++ b/tests/utils/test_logging_utils.py
@@ -24,6 +24,13 @@ def reset_logging_enablement():
     logging_utils.enable_logging()
 
 
+@pytest.fixture(autouse=True)
+def reset_logging_level():
+    level_before = logger.level
+    yield
+    logger.setLevel(level_before)
+
+
 class TestStream:
     def __init__(self):
         self.content = None
@@ -89,3 +96,12 @@ def test_event_logging_stream_flushes_properly():
     eprint("foo", flush=True)
     assert "foo" in stream.content
     assert stream.flush_count > 0
+
+
+def test_debug_logs_emitted_correctly_when_configured():
+    stream = TestStream()
+    sys.stderr = stream
+
+    logger.setLevel(logging.DEBUG)
+    logger.debug("test debug")
+    assert "test debug" in stream.content


### PR DESCRIPTION
Signed-off-by: dbczumar <corey.zumar@databricks.com>

## What changes are proposed in this pull request?

Currently, setting the MLflow logger level to `logging.DEBUG` doesn't print debug logs because the configured handler always discards anything below the level `logging.INFO` via dict configuration `level: INFO`. This PR removes this errant dict config.

## How is this patch tested?

Added a unit test

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

Fix a bug causing debug logs to be hidden even if MLflow logger was set to level `logging.DEBUG`

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [X] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
