### PR TITLE
Increase Docker API requests timeout on image push

### DIFF
--- a/mlflow/projects/kubernetes.py
+++ b/mlflow/projects/kubernetes.py
@@ -17,9 +17,11 @@ from shlex import quote
 
 _logger = logging.getLogger(__name__)
 
+_DOCKER_API_TIMEOUT = 300
+
 
 def push_image_to_registry(image_tag):
-    client = docker.from_env()
+    client = docker.from_env(timeout=_DOCKER_API_TIMEOUT)
     _logger.info("=== Pushing docker image %s ===", image_tag)
     for line in client.images.push(repository=image_tag, stream=True, decode=True):
         if "error" in line and line["error"]:


### PR DESCRIPTION
## What changes are proposed in this pull request?

Increase the timeout for Docker API requests from 60 seconds (default) to 300 seconds to avoid issues with very large images and/or slow docker registries. The following exception is thrown:

```

2022/02/08 13:31:32 INFO mlflow.projects.kubernetes: === Pushing docker image quay.io/nagra/ni_trainingmill_run_env:67a41d10-4d32-4d6f-8f73-4e38b49fa12a ===
Traceback (most recent call last):
[...]
  File "/usr/local/lib/python3.9/site-packages/mlflow/projects/__init__.py", line 294, in run
    submitted_run_obj = _run(
  File "/usr/local/lib/python3.9/site-packages/mlflow/projects/__init__.py", line 152, in _run
    image_digest = kb.push_image_to_registry(image.tags[0])
  File "/usr/local/lib/python3.9/site-packages/mlflow/projects/kubernetes.py", line 24, in push_image_to_registry
    for line in client.images.push(repository=image_tag, stream=True, decode=True):
  File "/usr/local/lib/python3.9/site-packages/docker/api/client.py", line 344, in _stream_helper
    yield from json_stream(self._stream_helper(response, False))
  File "/usr/local/lib/python3.9/site-packages/docker/utils/json_stream.py", line 61, in split_buffer
    for data in stream_as_text(stream):
  File "/usr/local/lib/python3.9/site-packages/docker/utils/json_stream.py", line 17, in stream_as_text
    for data in stream:
  File "/usr/local/lib/python3.9/site-packages/docker/api/client.py", line 349, in _stream_helper
    data = reader.read(1)
  File "/usr/local/lib/python3.9/site-packages/urllib3/response.py", line 540, in read
    raise IncompleteRead(self._fp_bytes_read, self.length_remaining)
  File "/usr/local/lib/python3.9/contextlib.py", line 135, in __exit__
    self.gen.throw(type, value, traceback)
  File "/usr/local/lib/python3.9/site-packages/urllib3/response.py", line 441, in _error_catcher
    raise ReadTimeoutError(self._pool, None, "Read timed out.")
urllib3.exceptions.ReadTimeoutError: UnixHTTPConnectionPool(host='localhost', port=None): Read timed out.

```

Similar issues has been reported to the docker-py repo: https://github.com/docker/docker-py/issues/2266

## How is this patch tested?

Manually with a 4.7Gb image trying to push it to a quay.io repository.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
