### PR TITLE
Enable basic auth in MlflowArtifactsRepository

### DIFF
--- a/mlflow/store/artifact/http_artifact_repo.py
+++ b/mlflow/store/artifact/http_artifact_repo.py
@@ -1,32 +1,28 @@
 import os
-import requests
 import posixpath
 
 from mlflow.entities import FileInfo
 from mlflow.store.artifact.artifact_repo import ArtifactRepository, verify_artifact_path
+from mlflow.tracking._tracking_service.utils import _get_default_host_creds
 from mlflow.utils.file_utils import relative_path_to_artifact_path
-from mlflow.utils.rest_utils import augmented_raise_for_status
+from mlflow.utils.rest_utils import augmented_raise_for_status, http_request
 
 
 class HttpArtifactRepository(ArtifactRepository):
     """Stores artifacts in a remote artifact storage using HTTP requests"""
 
-    def __init__(self, artifact_uri):
-        super().__init__(artifact_uri)
-        self._session = requests.Session()
-
-    def __del__(self):
-        if hasattr(self, "_session"):
-            self._session.close()
+    @property
+    def _host_creds(self):
+        return _get_default_host_creds(self.artifact_uri)
 
     def log_artifact(self, local_file, artifact_path=None):
         verify_artifact_path(artifact_path)
 
         file_name = os.path.basename(local_file)
         paths = (artifact_path, file_name) if artifact_path else (file_name,)
-        url = posixpath.join(self.artifact_uri, *paths)
+        endpoint = posixpath.join("/", *paths)
         with open(local_file, "rb") as f:
-            resp = self._session.put(url, data=f, timeout=600)
+            resp = http_request(self._host_creds, endpoint, "PUT", data=f, timeout=600)
             augmented_raise_for_status(resp)
 
     def log_artifacts(self, local_dir, artifact_path=None):
@@ -44,12 +40,12 @@ class HttpArtifactRepository(ArtifactRepository):
                 self.log_artifact(os.path.join(root, f), artifact_dir)
 
     def list_artifacts(self, path=None):
-        sep = "/mlflow-artifacts/artifacts"
-        head, tail = self.artifact_uri.split(sep, maxsplit=1)
-        url = head + sep
+        endpoint = "/mlflow-artifacts/artifacts"
+        url, tail = self.artifact_uri.split(endpoint, maxsplit=1)
         root = tail.lstrip("/")
         params = {"path": posixpath.join(root, path) if path else root}
-        resp = self._session.get(url, params=params, timeout=10)
+        host_creds = _get_default_host_creds(url)
+        resp = http_request(host_creds, endpoint, "GET", params=params, timeout=10)
         augmented_raise_for_status(resp)
         file_infos = []
         for f in resp.json().get("files", []):
@@ -63,10 +59,10 @@ class HttpArtifactRepository(ArtifactRepository):
         return sorted(file_infos, key=lambda f: f.path)
 
     def _download_file(self, remote_file_path, local_path):
-        url = posixpath.join(self.artifact_uri, remote_file_path)
-        with self._session.get(url, stream=True, timeout=10) as resp:
-            augmented_raise_for_status(resp)
-            with open(local_path, "wb") as f:
-                chunk_size = 1024 * 1024  # 1 MB
-                for chunk in resp.iter_content(chunk_size=chunk_size):
-                    f.write(chunk)
+        endpoint = posixpath.join("/", remote_file_path)
+        resp = http_request(self._host_creds, endpoint, "GET", stream=True, timeout=10)
+        augmented_raise_for_status(resp)
+        with open(local_path, "wb") as f:
+            chunk_size = 1024 * 1024  # 1 MB
+            for chunk in resp.iter_content(chunk_size=chunk_size):
+                f.write(chunk)

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -347,3 +347,8 @@ class MlflowHostCreds:
         self.ignore_tls_verification = ignore_tls_verification
         self.client_cert_path = client_cert_path
         self.server_cert_path = server_cert_path
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        return NotImplemented

--- a/tests/store/artifact/test_http_artifact_repo.py
+++ b/tests/store/artifact/test_http_artifact_repo.py
@@ -6,6 +6,16 @@ import pytest
 
 from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
 from mlflow.store.artifact.http_artifact_repo import HttpArtifactRepository
+from mlflow.tracking._tracking_service.utils import (
+    _TRACKING_CLIENT_CERT_PATH_ENV_VAR,
+    _TRACKING_INSECURE_TLS_ENV_VAR,
+    _TRACKING_PASSWORD_ENV_VAR,
+    _TRACKING_SERVER_CERT_PATH_ENV_VAR,
+    _TRACKING_TOKEN_ENV_VAR,
+    _TRACKING_USERNAME_ENV_VAR,
+    _get_default_host_creds,
+)
+from mlflow.utils.rest_utils import MlflowHostCreds
 
 
 @pytest.mark.parametrize("scheme", ["http", "https"])
@@ -57,15 +67,24 @@ def http_artifact_repo():
 def test_log_artifact(http_artifact_repo, tmpdir, artifact_path):
     tmp_path = tmpdir.join("a.txt")
     tmp_path.write("0")
-    with mock.patch("requests.Session.put", return_value=MockResponse({}, 200)) as mock_put:
+    with mock.patch(
+        "mlflow.store.artifact.http_artifact_repo.http_request",
+        return_value=MockResponse({}, 200),
+    ) as mock_put:
         http_artifact_repo.log_artifact(tmp_path, artifact_path)
-        paths = (artifact_path,) if artifact_path else ()
-        expected_url = posixpath.join(http_artifact_repo.artifact_uri, *paths, tmp_path.basename)
+        paths = (artifact_path, tmp_path.basename) if artifact_path else (tmp_path.basename,)
         mock_put.assert_called_once_with(
-            expected_url, data=FileObjectMatcher(tmp_path, "rb"), timeout=mock.ANY
+            http_artifact_repo._host_creds,
+            posixpath.join("/", *paths),
+            "PUT",
+            data=FileObjectMatcher(tmp_path, "rb"),
+            timeout=mock.ANY,
         )
 
-    with mock.patch("requests.Session.put", return_value=MockResponse({}, 400)) as mock_put:
+    with mock.patch(
+        "mlflow.store.artifact.http_artifact_repo.http_request",
+        return_value=MockResponse({}, 400),
+    ):
         with pytest.raises(Exception, match="request failed"):
             http_artifact_repo.log_artifact(tmp_path, artifact_path)
 
@@ -77,35 +96,44 @@ def test_log_artifacts(http_artifact_repo, tmpdir, artifact_path):
     tmp_path_a.write("0")
     tmp_path_b.write("1")
 
-    with mock.patch("requests.Session.put", return_value=MockResponse({}, 200)) as mock_put:
+    with mock.patch.object(http_artifact_repo, "log_artifact") as mock_log_artifact:
         http_artifact_repo.log_artifacts(tmpdir, artifact_path)
-        paths = (artifact_path,) if artifact_path else ()
-        expected_url_1 = posixpath.join(
-            http_artifact_repo.artifact_uri, *paths, tmp_path_a.basename
+        mock_log_artifact.assert_has_calls(
+            [
+                mock.call(tmp_path_a.strpath, artifact_path),
+                mock.call(
+                    tmp_path_b.strpath,
+                    posixpath.join(artifact_path, "dir") if artifact_path else "dir",
+                ),
+            ],
         )
-        expected_url_2 = posixpath.join(
-            http_artifact_repo.artifact_uri, *paths, "dir", tmp_path_b.basename
-        )
-        calls = [(args[0], kwargs["data"]) for args, kwargs in mock_put.call_args_list]
-        assert calls == [
-            (expected_url_1, FileObjectMatcher(tmp_path_a, "rb")),
-            (expected_url_2, FileObjectMatcher(tmp_path_b, "rb")),
-        ]
 
-    with mock.patch("requests.Session.put", return_value=MockResponse({}, 400)) as mock_put:
+    with mock.patch(
+        "mlflow.store.artifact.http_artifact_repo.http_request",
+        return_value=MockResponse({}, 400),
+    ):
         with pytest.raises(Exception, match="request failed"):
             http_artifact_repo.log_artifacts(tmpdir, artifact_path)
 
 
 def test_list_artifacts(http_artifact_repo):
-    with mock.patch("requests.Session.get", return_value=MockResponse({}, 200)) as mock_get:
+    with mock.patch(
+        "mlflow.store.artifact.http_artifact_repo.http_request",
+        return_value=MockResponse({}, 200),
+    ) as mock_get:
         assert http_artifact_repo.list_artifacts() == []
+        endpoint = "/mlflow-artifacts/artifacts"
+        url, _ = http_artifact_repo.artifact_uri.split(endpoint, maxsplit=1)
         mock_get.assert_called_once_with(
-            http_artifact_repo.artifact_uri, params={"path": ""}, timeout=mock.ANY
+            _get_default_host_creds(url),
+            endpoint,
+            "GET",
+            params={"path": ""},
+            timeout=mock.ANY,
         )
 
     with mock.patch(
-        "requests.Session.get",
+        "mlflow.store.artifact.http_artifact_repo.http_request",
         return_value=MockResponse(
             {
                 "files": [
@@ -115,11 +143,11 @@ def test_list_artifacts(http_artifact_repo):
             },
             200,
         ),
-    ) as mock_get:
+    ):
         assert [a.path for a in http_artifact_repo.list_artifacts()] == ["1.txt", "dir"]
 
     with mock.patch(
-        "requests.Session.get",
+        "mlflow.store.artifact.http_artifact_repo.http_request",
         return_value=MockResponse(
             {
                 "files": [
@@ -129,13 +157,16 @@ def test_list_artifacts(http_artifact_repo):
             },
             200,
         ),
-    ) as mock_get:
+    ):
         assert [a.path for a in http_artifact_repo.list_artifacts(path="path")] == [
             "path/1.txt",
             "path/dir",
         ]
 
-    with mock.patch("requests.Session.get", return_value=MockResponse({}, 400)) as mock_get:
+    with mock.patch(
+        "mlflow.store.artifact.http_artifact_repo.http_request",
+        return_value=MockResponse({}, 400),
+    ):
         with pytest.raises(Exception, match="request failed"):
             http_artifact_repo.list_artifacts()
 
@@ -148,18 +179,25 @@ def read_file(path):
 @pytest.mark.parametrize("remote_file_path", ["a.txt", "dir/b.xtx"])
 def test_download_file(http_artifact_repo, tmpdir, remote_file_path):
     with mock.patch(
-        "requests.Session.get", return_value=MockStreamResponse("data", 200)
+        "mlflow.store.artifact.http_artifact_repo.http_request",
+        return_value=MockStreamResponse("data", 200),
     ) as mock_get:
         tmp_path = tmpdir.join(posixpath.basename(remote_file_path))
         http_artifact_repo._download_file(remote_file_path, tmp_path)
-        expected_url = posixpath.join(http_artifact_repo.artifact_uri, remote_file_path)
-        mock_get.assert_called_once_with(expected_url, stream=True, timeout=mock.ANY)
+        mock_get.assert_called_once_with(
+            http_artifact_repo._host_creds,
+            posixpath.join("/", remote_file_path),
+            "GET",
+            stream=True,
+            timeout=mock.ANY,
+        )
         with open(tmp_path) as f:
             assert f.read() == "data"
 
     with mock.patch(
-        "requests.Session.get", return_value=MockStreamResponse("data", 400)
-    ) as mock_get:
+        "mlflow.store.artifact.http_artifact_repo.http_request",
+        return_value=MockStreamResponse("data", 400),
+    ):
         with pytest.raises(Exception, match="request failed"):
             http_artifact_repo._download_file(remote_file_path, tmp_path)
 
@@ -199,7 +237,10 @@ def test_download_artifacts(http_artifact_repo, tmpdir):
         # Response for `_download_file("dir/b.txt")`
         MockStreamResponse("data_b", 200),
     ]
-    with mock.patch("requests.Session.get", side_effect=side_effect):
+    with mock.patch(
+        "mlflow.store.artifact.http_artifact_repo.http_request",
+        side_effect=side_effect,
+    ):
         http_artifact_repo.download_artifacts("", tmpdir)
         paths = [os.path.join(root, f) for root, _, files in os.walk(tmpdir) for f in files]
         assert [os.path.relpath(p, tmpdir) for p in paths] == [
@@ -208,3 +249,39 @@ def test_download_artifacts(http_artifact_repo, tmpdir):
         ]
         assert read_file(paths[0]) == "data_a"
         assert read_file(paths[1]) == "data_b"
+
+
+def test_default_host_creds():
+
+    artifact_uri = "https://test.com"
+    username = "user"
+    password = "pass"
+    token = "token"
+    ignore_tls_verification = False
+    client_cert_path = "client_cert_path"
+    server_cert_path = "server_cert_path"
+
+    expected_host_creds = MlflowHostCreds(
+        host=artifact_uri,
+        username=username,
+        password=password,
+        token=token,
+        ignore_tls_verification=ignore_tls_verification,
+        client_cert_path=client_cert_path,
+        server_cert_path=server_cert_path,
+    )
+
+    repo = HttpArtifactRepository(artifact_uri)
+
+    with mock.patch.dict(
+        "mlflow.tracking._tracking_service.utils.os.environ",
+        {
+            _TRACKING_USERNAME_ENV_VAR: username,
+            _TRACKING_PASSWORD_ENV_VAR: password,
+            _TRACKING_TOKEN_ENV_VAR: token,
+            _TRACKING_INSECURE_TLS_ENV_VAR: str(ignore_tls_verification),
+            _TRACKING_CLIENT_CERT_PATH_ENV_VAR: client_cert_path,
+            _TRACKING_SERVER_CERT_PATH_ENV_VAR: server_cert_path,
+        },
+    ):
+        assert repo._host_creds == expected_host_creds


### PR DESCRIPTION
## What changes are proposed in this pull request?

Replace uses of `requests` in `HttpArtifactRepository` (and by extension `MlflowArtifactsRepository`) with functionality from `mlflow.utils.rest_utils`. This enables basic auth for the `MlflowArtifactsRepository` through `_get_default_host_creds`. Credentials are read from the `MLFLOW_TRACKING_USERNAME` and `MLFLOW_TRACKING_PASSWORD` environment variables.

Some things that might be worth pointing out:
1. The `HttpArtifactsRepo` now creates an instance of `MlflowHostCreds` to use in calls to `mlflow.utils.rest_utils.http_request`, but the name "MlflowHostCreds" is a bit misleading, since the credentials (most likely) do not reference the tracking server, but some other endpoint.
1. A lot of tests in `test_mlflow_artifact_repo.py` are duplicates of `test_http_artifact_repo.py` and test the same functionality. I kept it as-is.

Closes https://github.com/mlflow/mlflow/issues/5358

## How is this patch tested?

Existing tests have been updated.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The MlflowArtifactsRepo now propagates basic auth headers from `MLFLOW_TRACKING_USERNAME` and `MLFLOW_TRACKING_PASSWORD`.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
