### PR TITLE
Fix pytorch test exception assert

### DIFF
--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -996,15 +996,13 @@ def test_requirements_file_save_model(create_requirements_file, sequential_model
 
 @pytest.mark.parametrize("scripted_model", [True, False])
 def test_log_model_invalid_requirement_file_path(sequential_model):
-    with mlflow.start_run(), pytest.raises(MlflowException) as exc:
+    with mlflow.start_run(),\
+            pytest.raises(MlflowException, match=r"FileNotFoundError.*non_existing_file\.txt"):
         mlflow.pytorch.log_model(
             pytorch_model=sequential_model,
             artifact_path="models",
             requirements_file="non_existing_file.txt",
         )
-
-    assert "non_existing_file.txt" in str(exc.value)
-    assert "FileNotFoundError" in str(exc.value)
 
 
 @pytest.mark.parametrize("scripted_model", [True, False])
@@ -1092,15 +1090,13 @@ def test_extra_files_save_model(create_extra_files, sequential_model):
 
 @pytest.mark.parametrize("scripted_model", [True, False])
 def test_log_model_invalid_extra_file_path(sequential_model):
-    with mlflow.start_run(), pytest.raises(MlflowException) as exc:
+    with mlflow.start_run(),\
+            pytest.raises(MlflowException, match=r"FileNotFoundError.*non_existing_file\.txt"):
         mlflow.pytorch.log_model(
             pytorch_model=sequential_model,
             artifact_path="models",
             extra_files=["non_existing_file.txt"],
         )
-
-    assert "non_existing_file.txt" in str(exc.value)
-    assert "FileNotFoundError" in str(exc.value)
 
 
 @pytest.mark.parametrize("scripted_model", [True, False])

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -996,12 +996,15 @@ def test_requirements_file_save_model(create_requirements_file, sequential_model
 
 @pytest.mark.parametrize("scripted_model", [True, False])
 def test_log_model_invalid_requirement_file_path(sequential_model):
-    with mlflow.start_run(), pytest.raises(FileNotFoundError, match="non_existing_file.txt"):
+    with mlflow.start_run(), pytest.raises(MlflowException) as exc:
         mlflow.pytorch.log_model(
             pytorch_model=sequential_model,
             artifact_path="models",
             requirements_file="non_existing_file.txt",
         )
+
+    assert "non_existing_file.txt" in str(exc.value)
+    assert "FileNotFoundError" in str(exc.value)
 
 
 @pytest.mark.parametrize("scripted_model", [True, False])
@@ -1089,12 +1092,15 @@ def test_extra_files_save_model(create_extra_files, sequential_model):
 
 @pytest.mark.parametrize("scripted_model", [True, False])
 def test_log_model_invalid_extra_file_path(sequential_model):
-    with mlflow.start_run(), pytest.raises(FileNotFoundError, match="non_existing_file.txt"):
+    with mlflow.start_run(), pytest.raises(MlflowException) as exc:
         mlflow.pytorch.log_model(
             pytorch_model=sequential_model,
             artifact_path="models",
             extra_files=["non_existing_file.txt"],
         )
+
+    assert "non_existing_file.txt" in str(exc.value)
+    assert "FileNotFoundError" in str(exc.value)
 
 
 @pytest.mark.parametrize("scripted_model", [True, False])

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -996,8 +996,7 @@ def test_requirements_file_save_model(create_requirements_file, sequential_model
 
 @pytest.mark.parametrize("scripted_model", [True, False])
 def test_log_model_invalid_requirement_file_path(sequential_model):
-    with mlflow.start_run(),\
-            pytest.raises(MlflowException, match=r"FileNotFoundError.*non_existing_file\.txt"):
+    with mlflow.start_run(), pytest.raises(MlflowException, match="FileNotFoundError"):
         mlflow.pytorch.log_model(
             pytorch_model=sequential_model,
             artifact_path="models",
@@ -1090,8 +1089,7 @@ def test_extra_files_save_model(create_extra_files, sequential_model):
 
 @pytest.mark.parametrize("scripted_model", [True, False])
 def test_log_model_invalid_extra_file_path(sequential_model):
-    with mlflow.start_run(),\
-            pytest.raises(MlflowException, match=r"FileNotFoundError.*non_existing_file\.txt"):
+    with mlflow.start_run(), pytest.raises(MlflowException, match="FileNotFoundError"):
         mlflow.pytorch.log_model(
             pytorch_model=sequential_model,
             artifact_path="models",


### PR DESCRIPTION
Signed-off-by: dbczumar <corey.zumar@databricks.com>

## What changes are proposed in this pull request?

#5359 updated artifact repositories to return `MlflowException`s consistently in the event of artifact download failures. PyTorch tests were not run against this PR because no PyTorch-related files were touched, but our cross-version tests indicate that the PyTorch tests assert on a the exception type being `FileNotFoundError`, which is no longer the case. This PR updates the expected exception in the tests.

## How is this patch tested?

- Cross version tests for PyTorch run on this PR

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [X] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
