### PR TITLE
Fix #5360

### DIFF
--- a/tests/db/run_checks.py
+++ b/tests/db/run_checks.py
@@ -33,10 +33,7 @@ def run_logging_operations():
             python_model=MockModel(),
             registered_model_name="mock",
         )
-    runs = mlflow.search_runs(
-      experiment_ids=["0"],
-      order_by=["param.start_time DESC"]
-    )
+    runs = mlflow.search_runs(experiment_ids=["0"], order_by=["param.start_time DESC"])
 
     run = mlflow.get_run(runs["run_id"][0])
 

--- a/tests/db/run_checks.py
+++ b/tests/db/run_checks.py
@@ -33,6 +33,12 @@ def run_logging_operations():
             python_model=MockModel(),
             registered_model_name="mock",
         )
+    runs = mlflow.search_runs(
+      experiment_ids=["0"],
+      order_by=["param.start_time DESC"]
+    )
+
+    run = mlflow.get_run(runs["run_id"][0])
 
     # Ensure the following migration scripts work correctly:
     # - cfd24bdc0731_update_run_status_constraint_with_killed.py

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -2005,11 +2005,11 @@ def test_get_orderby_clauses():
     store = SqlAlchemyStore("sqlite:///:memory:", ARTIFACT_URI)
     with store.ManagedSessionMaker() as session:
         # test that ['runs.start_time DESC', 'SqlRun.run_uuid'] is returned by default
-        parsed = [str(x) for x in _get_orderby_clauses([], session)[0]]
+        parsed = [str(x) for x in _get_orderby_clauses([], session)[1]]
         assert parsed == ["runs.start_time DESC", "SqlRun.run_uuid"]
 
         # test that the given 'start_time' replaces the default one ('runs.start_time DESC')
-        parsed = [str(x) for x in _get_orderby_clauses(["attribute.start_time ASC"], session)[0]]
+        parsed = [str(x) for x in _get_orderby_clauses(["attribute.start_time ASC"], session)[1]]
         assert "SqlRun.start_time" in parsed
         assert "SqlRun.start_time DESC" not in parsed
 
@@ -2030,7 +2030,11 @@ def test_get_orderby_clauses():
         # test that an exception is NOT raised when key types are different
         _get_orderby_clauses(["param.a", "metric.a", "tag.a"], session)
 
+        select_clause, parsed, _ = _get_orderby_clauses(["metric.a"], session)
+        select_clause = [str(x) for x in select_clause]
+        parsed = [str(x) for x in parsed]
         # test that "=" is used rather than "is" when comparing to True
-        parsed = [str(x) for x in _get_orderby_clauses(["metric.a"], session)[0]]
-        assert "is_nan = true" in parsed[0]
-        assert "value IS NULL" in parsed[0]
+        assert "is_nan = true" in select_clause[0]
+        assert "value IS NULL" in select_clause[0]
+        # test that clause name is in parsed
+        assert "clause_1" in parsed[0]


### PR DESCRIPTION
Signed-off-by: Diana Carvalho <diana@datarevenue.com>

## What changes are proposed in this pull request?
The query in search_runs doesn't work when there is an order_by in a MSSQL Server. This bug was initially reported [here](https://github.com/mlflow/mlflow/issues/5360). In the end, the issue is how sqlalchemy relates to the MSSQL server. I opened an [issue](https://github.com/sqlalchemy/sqlalchemy/issues/7696) in sqlalchemy and the community there guided me to this solution. 

The message "ORDER BY items must appear in the SELECT list when DISTINCT" means that we cannot ORDER BY a SQL expression directly, you can only ORDER BY a SQL label that itself is in the columns clause. This is what is achieved in this PR: add the labels in the columns clause and the labels name in the order by clause.

## How is this patch tested?
With existing unit tests. I used the default SQLite db and MSSQL DB to reproduce the problem.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [x] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
