### PR TITLE
store/artifact/mlflow: utilize netloc over host:port

### DIFF
--- a/mlflow/store/artifact/mlflow_artifacts_repo.py
+++ b/mlflow/store/artifact/mlflow_artifacts_repo.py
@@ -5,6 +5,7 @@ from mlflow.store.artifact.http_artifact_repo import HttpArtifactRepository
 from mlflow.tracking._tracking_service.utils import get_tracking_uri
 from mlflow.exceptions import MlflowException
 
+
 def _check_if_host_is_numeric(hostname):
     if hostname:
         try:
@@ -67,24 +68,21 @@ class MlflowArtifactsRepository(HttpArtifactRepository):
             resolved = f"{base_url}/{track_parse.path}{uri_parse.path}"
         resolved = re.sub("//+", "/", resolved)
 
-        resolved_artifacts_uri = urlunparse((
-            # scheme
-            track_parse.scheme,
-
-            # netloc
-            uri_parse.netloc if uri_parse.netloc else track_parse.netloc,
-
-            # path
-            resolved,
-
-            # params
-            '',
-
-            # query
-            '',
-
-            # fragment
-            ''
-        ))
+        resolved_artifacts_uri = urlunparse(
+            (
+                # scheme
+                track_parse.scheme,
+                # netloc
+                uri_parse.netloc if uri_parse.netloc else track_parse.netloc,
+                # path
+                resolved,
+                # params
+                "",
+                # query
+                "",
+                # fragment
+                "",
+            )
+        )
 
         return resolved_artifacts_uri.replace("///", "/").rstrip("/")

--- a/mlflow/store/artifact/mlflow_artifacts_repo.py
+++ b/mlflow/store/artifact/mlflow_artifacts_repo.py
@@ -1,17 +1,9 @@
-from urllib.parse import urlparse
-from collections import namedtuple
+from urllib.parse import urlparse, urlunparse
 import re
 
 from mlflow.store.artifact.http_artifact_repo import HttpArtifactRepository
 from mlflow.tracking._tracking_service.utils import get_tracking_uri
 from mlflow.exceptions import MlflowException
-
-
-def _parse_artifact_uri(artifact_uri):
-    ParsedURI = namedtuple("ParsedURI", "scheme host port path")
-    parsed_uri = urlparse(artifact_uri)
-    return ParsedURI(parsed_uri.scheme, parsed_uri.hostname, parsed_uri.port, parsed_uri.path)
-
 
 def _check_if_host_is_numeric(hostname):
     if hostname:
@@ -29,10 +21,10 @@ def _validate_port_mapped_to_hostname(uri_parse):
     # hostname specified. `urllib.parse.urlparse` will treat such a uri as a filesystem
     # definition, mapping the provided port as a hostname value if this condition is not
     # validated.
-    if uri_parse.host and _check_if_host_is_numeric(uri_parse.host) and not uri_parse.port:
+    if uri_parse.hostname and _check_if_host_is_numeric(uri_parse.hostname) and not uri_parse.port:
         raise MlflowException(
             "The mlflow-artifacts uri was supplied with a port number: "
-            f"{uri_parse.host}, but no host was defined."
+            f"{uri_parse.hostname}, but no host was defined."
         )
 
 
@@ -57,9 +49,9 @@ class MlflowArtifactsRepository(HttpArtifactRepository):
 
         base_url = "/api/2.0/mlflow-artifacts/artifacts"
 
-        track_parse = _parse_artifact_uri(tracking_uri)
+        track_parse = urlparse(tracking_uri)
 
-        uri_parse = _parse_artifact_uri(artifact_uri)
+        uri_parse = urlparse(artifact_uri)
 
         # Check to ensure that a port is present with no hostname
         _validate_port_mapped_to_hostname(uri_parse)
@@ -75,23 +67,24 @@ class MlflowArtifactsRepository(HttpArtifactRepository):
             resolved = f"{base_url}/{track_parse.path}{uri_parse.path}"
         resolved = re.sub("//+", "/", resolved)
 
-        if uri_parse.host and uri_parse.port:
-            resolved_artifacts_uri = (
-                f"{track_parse.scheme}://{uri_parse.host}:{uri_parse.port}{resolved}"
-            )
-        elif uri_parse.host and not uri_parse.port:
-            resolved_artifacts_uri = f"{track_parse.scheme}://{uri_parse.host}{resolved}"
-        elif not uri_parse.host and not uri_parse.port and uri_parse.path == track_parse.path:
-            resolved_artifacts_uri = (
-                f"{track_parse.scheme}://{track_parse.host}:{track_parse.port}{resolved}"
-            )
-        elif not uri_parse.host and not uri_parse.port:
-            resolved_artifacts_uri = (
-                f"{track_parse.scheme}://{track_parse.host}:" f"{track_parse.port}{resolved}"
-            )
-        else:
-            raise MlflowException(
-                f"The supplied artifact uri {artifact_uri} could not be resolved."
-            )
+        resolved_artifacts_uri = urlunparse((
+            # scheme
+            track_parse.scheme,
+
+            # netloc
+            uri_parse.netloc if uri_parse.netloc else track_parse.netloc,
+
+            # path
+            resolved,
+
+            # params
+            '',
+
+            # query
+            '',
+
+            # fragment
+            ''
+        ))
 
         return resolved_artifacts_uri.replace("///", "/").rstrip("/")


### PR DESCRIPTION
## What changes are proposed in this pull request?

According to the urllib module documentation[1] and
RFC 1808 Section 2.1[2], the general structure of a URL is:

    scheme://netloc/path;parameters?query#fragment

Utilizing netloc over hostname:port not only simplifies the
implementation but also allows authentication info to be
passed in the URL, i.e:

    https://username:password@trackingserver.ai/

[1] https://docs.python.org/3/library/urllib.parse.html
[2] https://datatracker.ietf.org/doc/html/rfc1808.html#section-2.1

Signed-off-by: Mert Kırpıcı <smertk@gmail.com>

## How is this patch tested?

Manually for now, but I am planning to add unit tests in a short while.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

URLs of the form http://*user:pass*@example.com/ used to work for the tracking server but not for artifact serving. This is fixed now. 

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
