### PR TITLE
ignore micro-version mismatch for databricks pyspark

### DIFF
--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -442,14 +442,14 @@ def _check_requirement_satisfied(requirement_str):
     Otherwise, returns an instance of `_MismatchedPackageInfo`.
     """
     _init_packages_to_modules_map()
-    req = pkg_resources.Requirement.parse(requirement_str)
-    pkg_name = req.name
 
-    if pkg_name == "pyspark" and is_in_databricks_runtime():
+    if re.match(r"pyspark[^\w-]", requirement_str) and is_in_databricks_runtime():
         # for databricks runtime pyspark, ignore micro-version mismatch.
         # replace == specifier to be ~= specifier, but keep === specifier unchanged.
         requirement_str = re.sub("([^=])==([^=])", r"\1~=\2", requirement_str)
-        req = pkg_resources.Requirement.parse(requirement_str)
+
+    req = pkg_resources.Requirement.parse(requirement_str)
+    pkg_name = req.name
 
     try:
         installed_version = _get_installed_version(pkg_name, _PACKAGES_TO_MODULES.get(pkg_name))

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -445,7 +445,7 @@ def _check_requirement_satisfied(requirement_str):
 
     if re.match(r"pyspark[^\w-]", requirement_str) and is_in_databricks_runtime():
         # for databricks runtime pyspark, ignore micro-version mismatch.
-        # replace == specifier to be ~= specifier, but keep === specifier unchanged.
+        # replace == operator with ~= operator, but keep === operator unchanged.
         requirement_str = re.sub("([^=])==([^=])", r"\1~=\2", requirement_str)
 
     req = pkg_resources.Requirement.parse(requirement_str)

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -445,7 +445,7 @@ def _check_requirement_satisfied(requirement_str):
     req = pkg_resources.Requirement.parse(requirement_str)
     pkg_name = req.name
 
-    if is_in_databricks_runtime() and pkg_name == 'pyspark':
+    if pkg_name == 'pyspark' and is_in_databricks_runtime():
         # for databricks runtime pyspark, ignore micro-version mismatch.
         # replace == specifier to be ~= specifier, but keep === specifier unchanged.
         requirement_str = re.sub('([^=])==([^=])', r'\1~=\2', requirement_str)

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -445,6 +445,12 @@ def _check_requirement_satisfied(requirement_str):
     req = pkg_resources.Requirement.parse(requirement_str)
     pkg_name = req.name
 
+    if is_in_databricks_runtime() and pkg_name == 'pyspark':
+        # for databricks runtime pyspark, ignore micro-version mismatch.
+        # replace == specifier to be ~= specifier, but keep === specifier unchanged.
+        requirement_str = re.sub('([^=])==([^=])', r'\1~=\2', requirement_str)
+        req = pkg_resources.Requirement.parse(requirement_str)
+
     try:
         installed_version = _get_installed_version(pkg_name, _PACKAGES_TO_MODULES.get(pkg_name))
     except ModuleNotFoundError:

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -445,10 +445,10 @@ def _check_requirement_satisfied(requirement_str):
     req = pkg_resources.Requirement.parse(requirement_str)
     pkg_name = req.name
 
-    if pkg_name == 'pyspark' and is_in_databricks_runtime():
+    if pkg_name == "pyspark" and is_in_databricks_runtime():
         # for databricks runtime pyspark, ignore micro-version mismatch.
         # replace == specifier to be ~= specifier, but keep === specifier unchanged.
-        requirement_str = re.sub('([^=])==([^=])', r'\1~=\2', requirement_str)
+        requirement_str = re.sub("([^=])==([^=])", r"\1~=\2", requirement_str)
         req = pkg_resources.Requirement.parse(requirement_str)
 
     try:

--- a/tests/pyfunc/test_warn_dependency_requirement_mismatches.py
+++ b/tests/pyfunc/test_warn_dependency_requirement_mismatches.py
@@ -113,6 +113,7 @@ def test_warn_dependency_requirement_mismatches_ignore_databricks_runtime_micro_
     req_file.write("pyspark==3.2.1")
 
     with mock.patch("mlflow.pyfunc._logger.warning") as mock_warning:
+        # Test for databricks pyspark
         with mock.patch(
             "mlflow.utils.requirements_utils.is_in_databricks_runtime", return_value=True
         ):
@@ -122,6 +123,7 @@ def test_warn_dependency_requirement_mismatches_ignore_databricks_runtime_micro_
                     mock_warning.assert_not_called()
                     mock_warning.reset_mock()
 
+        # Test for non-databricks pyspark
         with mock_get_installed_version({"pyspark": "3.2.2"}):
             _warn_dependency_requirement_mismatches(model_path=tmpdir)
             mock_warning.assert_called_once_with(


### PR DESCRIPTION
Signed-off-by: Weichen Xu <weichen.xu@databricks.com>

## What changes are proposed in this pull request?

ignore micro-version mismatch for databricks pyspark

## How is this patch tested?



## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

ignore micro-version mismatch for databricks pyspark

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
