### PR TITLE
[Custom Metrics] Enabled support for logging of numerical metrics

### DIFF
--- a/examples/evaluation/evaluate_with_custom_metrics.py
+++ b/examples/evaluation/evaluate_with_custom_metrics.py
@@ -1,0 +1,40 @@
+from sklearn.linear_model import LinearRegression
+from sklearn.datasets import fetch_california_housing
+from sklearn.model_selection import train_test_split
+import numpy as np
+import mlflow
+
+cali_housing = fetch_california_housing(as_frame=True)
+
+X_train, X_test, y_train, y_test = train_test_split(
+    cali_housing.data, cali_housing.target, test_size=0.2, random_state=123
+)
+
+lin_reg = LinearRegression()
+lin_reg.fit(X_train, y_train)
+
+eval_data = X_test.copy()
+eval_data["target"] = y_test
+
+
+def example_custom_metric_fn(eval_df, builtin_metrics):
+    return {
+        "squared_diff_plus_one": np.sum(np.abs(eval_df["prediction"] - eval_df["target"] + 1) ** 2),
+        "sum_on_label_divided_by_two": builtin_metrics["sum_on_label"] / 2,
+    }
+
+
+with mlflow.start_run() as run:
+    mlflow.sklearn.log_model(lin_reg, "model")
+    model_uri = mlflow.get_artifact_uri("model")
+    result = mlflow.evaluate(
+        model=model_uri,
+        data=eval_data,
+        targets="target",
+        model_type="regressor",
+        dataset_name="cali_housing",
+        evaluators=["default"],
+        custom_metrics=[example_custom_metric_fn],
+    )
+
+print(f"metrics:\n{result.metrics}")

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -483,7 +483,7 @@ class ModelEvaluator(metaclass=ABCMeta):
         :param run_id: The ID of the MLflow Run to which to log results.
         :param evaluator_config: A dictionary of additional configurations for
                                  the evaluator.
-        :param custom_metrics: A list of callable custom metric functions
+        :param custom_metrics: A list of callable custom metric functions.
         :param kwargs: For forwards compatibility, a placeholder for additional arguments that
                        may be added to the evaluation interface in the future.
         :return: An :py:class:`mlflow.models.EvaluationResult` instance containing
@@ -837,8 +837,9 @@ def evaluate(
                                       metrics: Dict[AnyStr, Union[int, float, np.number]] = ???
                                       artifacts: Dict[AnyStr, Any] = ???
                                       ...
-                                      # If no artifacts, replace the below with `return metrics`
-                                      return metrics, artifacts
+                                      if artifacts is not None:
+                                          return metrics, artifacts
+                                      return metrics
                                   ``
 
                               Example Usage:
@@ -858,8 +859,8 @@ def evaluate(
 
                               with mlflow.start_run():
                                   mlflow.evaluate(
-                                      model, X, targets, custom_metrics=(
-                                      squared_diff_plus_one,scatter_plot)...)
+                                      model, X, targets, custom_metrics=[
+                                      squared_diff_plus_one,scatter_plot,...])
 
     :return: An :py:class:`mlflow.models.EvaluationResult` instance containing
              evaluation results.

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -469,7 +469,7 @@ class ModelEvaluator(metaclass=ABCMeta):
         dataset,
         run_id,
         evaluator_config,
-        custom_metric_fns=None,
+        custom_metrics=None,
         **kwargs,
     ):
         """
@@ -483,7 +483,7 @@ class ModelEvaluator(metaclass=ABCMeta):
         :param run_id: The ID of the MLflow Run to which to log results.
         :param evaluator_config: A dictionary of additional configurations for
                                  the evaluator.
-        :param custom_metric_fns: A list of callable custom metric functions
+        :param custom_metrics: A list of callable custom metric functions
         :param kwargs: For forwards compatibility, a placeholder for additional arguments that
                        may be added to the evaluation interface in the future.
         :return: An :py:class:`mlflow.models.EvaluationResult` instance containing
@@ -608,7 +608,7 @@ def _evaluate(
     run_id,
     evaluator_name_list,
     evaluator_name_to_conf_map,
-    custom_metric_fns,
+    custom_metrics,
 ):
     """
     The public API "evaluate" will verify argument first, and then pass normalized arguments
@@ -642,7 +642,7 @@ def _evaluate(
                 dataset=dataset,
                 run_id=run_id,
                 evaluator_config=config,
-                custom_metric_fns=custom_metric_fns,
+                custom_metrics=custom_metrics,
             )
             eval_results.append(result)
 
@@ -674,7 +674,7 @@ def evaluate(
     feature_names: list = None,
     evaluators=None,
     evaluator_config=None,
-    custom_metric_fns=None,
+    custom_metrics=None,
 ):
     """
     Evaluate a PyFunc model on the specified dataset using one or more specified ``evaluators``, and
@@ -798,7 +798,7 @@ def evaluate(
                              If multiple evaluators are specified, each configuration should be
                              supplied as a nested dictionary whose key is the evaluator name.
 
-    :param custom_metric_fns: (Optional) A list of custom metric functions. A custom metric
+    :param custom_metrics: (Optional) A list of custom metric functions. A custom metric
                               function is required to take in two parameters:
                               - Union[pandas.Dataframe, pyspark.sql.DataFrame]: The first being a
                                 Pandas or Spark DataFrame containing ``prediction`` and ``target``
@@ -897,5 +897,5 @@ def evaluate(
             run_id=run_id,
             evaluator_name_list=evaluator_name_list,
             evaluator_name_to_conf_map=evaluator_name_to_conf_map,
-            custom_metric_fns=custom_metric_fns,
+            custom_metrics=custom_metrics,
         )

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -815,52 +815,27 @@ def evaluate(
                               - Dict[AnyStr, Union[int, float, np.number]: a singular dictionary of
                                 custom metrics, where the keys are the names of the metrics, and the
                                 values are the scalar values of the metrics.
-                              - Tuple[Dict[AnyStr, Union[int,float,np.number]], Dict[AnyStr,Any]]:
-                                a tuple of a dict containing the custom metrics, and a dict of
-                                artifacts, where the keys are the names of the artifacts, and the
-                                values are objects representing the artifacts.
 
-                              Object types that artifacts be represented as:
-                              - A string uri representing the file path to the artifact. MLflow will
-                                infer the type of the artifact based on the file extension.
-                              - ``EvaluationArtifact`` type objects. i.e. CsvEvaluationArtifact,
-                                ImageEvaluationArtifact.
-                              - Pandas DataFrame. This will be resolved as a CSV artifact.
-                              - Numpy array. This will be saved as a .npy artifact.
-                              - Matplotlib Figure. This will be saved as an image artifact.
-                              - Any JSON serializable object. This will be saved as a JSON artifact.
-
-                              Custom Metric Function Boilerplate:
-                                  ``
+                              .. code-block:: python
+                                  :caption: Custom Metric Function Boilerplate:
                                   def custom_metrics_boilerplate(eval_df, builtin_metrics):
                                       ...
                                       metrics: Dict[AnyStr, Union[int, float, np.number]] = ???
-                                      artifacts: Dict[AnyStr, Any] = ???
                                       ...
-                                      if artifacts is not None:
-                                          return metrics, artifacts
                                       return metrics
-                                  ``
 
-                              Example Usage:
-                              def squared_diff_plus_one(eval_df, builtin_metrics):
-                                  return {
-                                      "sdiff_plus_one": (np.sum(np.abs(eval_df["prediction"]
-                                                        - eval_df["target"]+1)**2))
-                                  }
+                              .. code-block:: python
+                                  :caption: Example usage of custom metrics:
+                                  def squared_diff_plus_one(eval_df, builtin_metrics):
+                                      return {
+                                          "sdiff_plus_one": (np.sum(np.abs(eval_df["prediction"]
+                                                            - eval_df["target"]+1)**2))
+                                      }
 
-                              def scatter_plot(eval_df, builtin_metrics):
-                                  plt.scatter(eval_df['prediction'], eval_df['target'])
-                                  plt.xlabel('Targets')
-                                  plt.ylabel('Predictions')
-                                  plt.title("Targets vs. Predictions")
-                                  plt.savefig("some/path/example.png")
-                                  return {}, {“pred_target_scatter”: “some/path/example.png”}
-
-                              with mlflow.start_run():
-                                  mlflow.evaluate(
-                                      model, X, targets, custom_metrics=[
-                                      squared_diff_plus_one,scatter_plot,...])
+                                  with mlflow.start_run():
+                                      mlflow.evaluate(
+                                          model, X, targets, custom_metrics=[
+                                          squared_diff_plus_one,...])
 
     :return: An :py:class:`mlflow.models.EvaluationResult` instance containing
              evaluation results.

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -462,15 +462,7 @@ class ModelEvaluator(metaclass=ABCMeta):
 
     @abstractmethod
     def evaluate(
-        self,
-        *,
-        model,
-        model_type,
-        dataset,
-        run_id,
-        evaluator_config,
-        custom_metrics=None,
-        **kwargs,
+        self, *, model, model_type, dataset, run_id, evaluator_config, custom_metrics=None, **kwargs
     ):
         """
         The abstract API to log metrics and artifacts, and return evaluation results.
@@ -799,43 +791,55 @@ def evaluate(
                              supplied as a nested dictionary whose key is the evaluator name.
 
     :param custom_metrics: (Optional) A list of custom metric functions. A custom metric
-                              function is required to take in two parameters:
-                              - Union[pandas.Dataframe, pyspark.sql.DataFrame]: The first being a
-                                Pandas or Spark DataFrame containing ``prediction`` and ``target``
-                                column. The ``prediction`` column contains the predictions made by
-                                the model. The ``target`` column contains the corresponding labels
-                                to the predictions made on that row.
-                              - Dict: The second is a dictionary containing the metrics calculated
-                                by the default evaluator. The keys are the names of the metrics
-                                and the values are the scalar values of the metrics. Refer to the
-                                DefaultEvaluator behavior section for what metrics will be returned
-                                based on the type of model (i.e. classifier or regressor).
+                           function is required to take in two parameters:
 
-                              A custom metric function can return in two different formats:
-                              - Dict[AnyStr, Union[int, float, np.number]: a singular dictionary of
-                                custom metrics, where the keys are the names of the metrics, and the
-                                values are the scalar values of the metrics.
+                           - Union[pandas.Dataframe, pyspark.sql.DataFrame]: The first being a
+                             Pandas or Spark DataFrame containing ``prediction`` and ``target``
+                             column. The ``prediction`` column contains the predictions made by
+                             the model. The ``target`` column contains the corresponding labels
+                             to the predictions made on that row.
+                           - Dict: The second is a dictionary containing the metrics calculated
+                             by the default evaluator. The keys are the names of the metrics
+                             and the values are the scalar values of the metrics. Refer to the
+                             DefaultEvaluator behavior section for what metrics will be returned
+                             based on the type of model (i.e. classifier or regressor).
 
-                              .. code-block:: python
-                                  :caption: Custom Metric Function Boilerplate:
-                                  def custom_metrics_boilerplate(eval_df, builtin_metrics):
-                                      ...
-                                      metrics: Dict[AnyStr, Union[int, float, np.number]] = ???
-                                      ...
-                                      return metrics
+                           A custom metric function can return in the following format:
 
-                              .. code-block:: python
-                                  :caption: Example usage of custom metrics:
-                                  def squared_diff_plus_one(eval_df, builtin_metrics):
-                                      return {
-                                          "sdiff_plus_one": (np.sum(np.abs(eval_df["prediction"]
-                                                            - eval_df["target"]+1)**2))
-                                      }
+                           - Dict[AnyStr, Union[int, float, np.number]: a singular dictionary of
+                             custom metrics, where the keys are the names of the metrics, and the
+                             values are the scalar values of the metrics.
 
-                                  with mlflow.start_run():
-                                      mlflow.evaluate(
-                                          model, X, targets, custom_metrics=[
-                                          squared_diff_plus_one,...])
+                           .. code-block:: python
+                               :caption: Custom Metric Function Boilerplate
+
+                               def custom_metrics_boilerplate(eval_df, builtin_metrics):
+                                   # ...
+                                   metrics: Dict[AnyStr, Union[int, float, np.number]] = some_dict
+                                   # ...
+                                   return metrics
+
+                           .. code-block:: python
+                               :caption: Example usage of custom metrics
+
+                               def squared_diff_plus_one(eval_df, builtin_metrics):
+                                 return {
+                                     "squared_diff_plus_one": (
+                                         np.sum(
+                                             np.abs(
+                                                 eval_df["prediction"] - eval_df["target"] + 1
+                                             ) ** 2
+                                         )
+                                     )
+                                 }
+
+                               with mlflow.start_run():
+                                   mlflow.evaluate(
+                                       model,
+                                       X,
+                                       targets,
+                                       custom_metrics=[squared_diff_plus_one, ...],
+                                   )
 
     :return: An :py:class:`mlflow.models.EvaluationResult` instance containing
              evaluation results.

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -825,7 +825,7 @@ def evaluate(
                                 infer the type of the artifact based on the file extension.
                               - ``EvaluationArtifact`` type objects. i.e. CsvEvaluationArtifact,
                                 ImageEvaluationArtifact.
-                              - Pandas DataFrame. This will be resolved as a parquet artifact.
+                              - Pandas DataFrame. This will be resolved as a CSV artifact.
                               - Numpy array. This will be saved as a .npy artifact.
                               - Matplotlib Figure. This will be saved as an image artifact.
                               - Any JSON serializable object. This will be saved as a JSON artifact.

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -461,7 +461,9 @@ class ModelEvaluator(metaclass=ABCMeta):
         raise NotImplementedError()
 
     @abstractmethod
-    def evaluate(self, *, model, model_type, dataset, run_id, evaluator_config, **kwargs):
+    def evaluate(
+        self, *, model, model_type, dataset, run_id, evaluator_config, custom_metrics=None, **kwargs
+    ):
         """
         The abstract API to log metrics and artifacts, and return evaluation results.
 
@@ -473,6 +475,7 @@ class ModelEvaluator(metaclass=ABCMeta):
         :param run_id: The ID of the MLflow Run to which to log results.
         :param evaluator_config: A dictionary of additional configurations for
                                  the evaluator.
+        :param custom_metrics: A list of custom metric functions
         :param kwargs: For forwards compatibility, a placeholder for additional arguments that
                        may be added to the evaluation interface in the future.
         :return: An :py:class:`mlflow.models.EvaluationResult` instance containing
@@ -590,7 +593,14 @@ def _get_last_failed_evaluator():
 
 
 def _evaluate(
-    *, model, model_type, dataset, run_id, evaluator_name_list, evaluator_name_to_conf_map
+    *,
+    model,
+    model_type,
+    dataset,
+    run_id,
+    evaluator_name_list,
+    evaluator_name_to_conf_map,
+    custom_metrics,
 ):
     """
     The public API "evaluate" will verify argument first, and then pass normalized arguments
@@ -624,6 +634,7 @@ def _evaluate(
                 dataset=dataset,
                 run_id=run_id,
                 evaluator_config=config,
+                custom_metrics=custom_metrics,
             )
             eval_results.append(result)
 
@@ -655,6 +666,7 @@ def evaluate(
     feature_names: list = None,
     evaluators=None,
     evaluator_config=None,
+    custom_metrics=None,
 ):
     """
     Evaluate a PyFunc model on the specified dataset using one or more specified ``evaluators``, and
@@ -814,4 +826,5 @@ def evaluate(
             run_id=run_id,
             evaluator_name_list=evaluator_name_list,
             evaluator_name_to_conf_map=evaluator_name_to_conf_map,
+            custom_metrics=custom_metrics,
         )

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -590,6 +590,7 @@ class DefaultEvaluator(ModelEvaluator):
             if metric_results is None:
                 continue
             self.metrics.update(metric_results)
+            # TODO: artifact detection and logging.
 
     def _evaluate_classifier(self):
         from mlflow.models.evaluation.lift_curve import plot_lift_curve

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -263,7 +263,7 @@ def _evaluate_custom_metric(custom_metric, eval_df, builtin_metrics):
     result = custom_metric(eval_df, builtin_metrics)
     if result is None:
         _logger.warning(
-            f"Custom metric function '{custom_metric.__name__}' returned None. Logging ignored."
+            f"Custom metric function '{custom_metric.__name__}' returned None."
         )
         return None, None
 
@@ -290,11 +290,6 @@ def _evaluate_custom_metric(custom_metric, eval_df, builtin_metrics):
 
     raise MlflowException(
         f"Custom metric '{custom_metric.__name__}' did not return in an expected format."
-        f"The two acceptable return types are:"
-        f"1. Dict[AnyStr, Union[int, float, np.number]: a dictionary of metrics"
-        f"2. Tuple[Dict[AnyStr, Union[int, float, np.number]], Dict[AnyStr, Any]]: a"
-        f"   dictionary of metrics and a dictionary of artifacts."
-        f"For more, check out the docstring for mlflow.evaluate"
     )
 
 

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -617,15 +617,16 @@ class DefaultEvaluator(ModelEvaluator):
     def _evaluate_custom_metrics(self):
         if self.custom_metrics is None:
             return
-        copy_of_y_pred = copy.deepcopy(self.y_pred)
-        copy_of_y = copy.deepcopy(self.y)
-        copy_of_metrics = copy.deepcopy(self.metrics)
-        for i, custom_metric in enumerate(self.custom_metrics):
-            # recreating the dataframe for each custom metric function call,
-            # in case the user modifies the eval_df inside their custom function.
-            eval_df = pd.DataFrame({"prediction": copy_of_y_pred, "target": copy_of_y})
-            metric_results, _ = _evaluate_custom_metric(i, custom_metric, eval_df, copy_of_metrics)
-            # skip logging metric functions that doesn't return anything
+        builtin_metrics = copy.deepcopy(self.metrics)
+        eval_df = pd.DataFrame(
+            {"prediction": copy.deepcopy(self.y_pred), "target": copy.deepcopy(self.y)}
+        )
+        for index, custom_metric in enumerate(self.custom_metrics):
+            # deepcopying eval_df and builtin_metrics for each custom metric function call,
+            # in case the user modifies them inside their function(s).
+            metric_results, _ = _evaluate_custom_metric(
+                index, custom_metric, eval_df.copy(), copy.deepcopy(builtin_metrics)
+            )
             self.metrics.update(metric_results)
             # TODO: artifact detection and logging.
 

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -262,9 +262,7 @@ _matplotlib_config = {
 def _evaluate_custom_metric(custom_metric, eval_df, builtin_metrics):
     result = custom_metric(eval_df, builtin_metrics)
     if result is None:
-        _logger.warning(
-            f"Custom metric function '{custom_metric.__name__}' returned None."
-        )
+        _logger.warning(f"Custom metric function '{custom_metric.__name__}' returned None.")
         return None, None
 
     def __validate_metrics_dict(metrics):
@@ -582,9 +580,8 @@ class DefaultEvaluator(ModelEvaluator):
             eval_df = pd.DataFrame({"prediction": self.y_pred, "target": self.y})
             metric_results, _ = _evaluate_custom_metric(custom_metric, eval_df, self.metrics)
             # skip logging metric functions that doesn't return anything
-            if metric_results is None:
-                continue
-            self.metrics.update(metric_results)
+            if metric_results is not None:
+                self.metrics.update(metric_results)
             # TODO: artifact detection and logging.
 
     def _evaluate_classifier(self):

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -2,7 +2,6 @@ import numpy as np
 import json
 import pandas as pd
 import pytest
-import re
 
 from mlflow.exceptions import MlflowException
 from mlflow.models.evaluation import evaluate
@@ -512,7 +511,7 @@ def test_evaluate_custom_metric_handle_none_result():
     def dummy_fn(*_):
         pass
 
-    assert _evaluate_custom_metric(dummy_fn, eval_df, metrics) == (None, None)
+    assert _evaluate_custom_metric(0, dummy_fn, eval_df, metrics) == (None, None)
 
 
 def test_evaluate_custom_metric_incorrect_return_formats():
@@ -543,9 +542,9 @@ def test_evaluate_custom_metric_incorrect_return_formats():
     ):
         with pytest.raises(
             MlflowException,
-            match=(re.escape(f"'{test_fn.__name__}' did not return in an expected format")),
+            match=f"'{test_fn.__name__}' (.*) did not return in an expected format",
         ):
-            _evaluate_custom_metric(test_fn, eval_df, metrics)
+            _evaluate_custom_metric(0, test_fn, eval_df, metrics)
 
 
 def test_evaluate_custom_metric_success():
@@ -560,7 +559,7 @@ def test_evaluate_custom_metric_success():
             "example_np_metric_2": np.ulonglong(10000000),
         }
 
-    res_metrics, res_artifacts = _evaluate_custom_metric(example_custom_metric, eval_df, metrics)
+    res_metrics, res_artifacts = _evaluate_custom_metric(0, example_custom_metric, eval_df, metrics)
     assert res_metrics == {
         "example_count_times_1_point_5": metrics["example_count"] * 1.5,
         "sum_on_label_minus_5": metrics["sum_on_label"] - 5,
@@ -584,7 +583,7 @@ def test_evaluate_custom_metric_success():
         )
 
     res_metrics_2, res_artifacts_2 = _evaluate_custom_metric(
-        example_custom_metric_with_artifacts, eval_df, metrics
+        0, example_custom_metric_with_artifacts, eval_df, metrics
     )
     assert res_metrics_2 == {
         "example_count_times_1_point_5": metrics["example_count"] * 1.5,

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -1,7 +1,9 @@
 import numpy as np
 import json
+import pandas as pd
+import pytest
 
-
+from mlflow.exceptions import MlflowException
 from mlflow.models.evaluation import evaluate
 from mlflow.models.evaluation.default_evaluator import (
     _get_classifier_global_metrics,
@@ -11,6 +13,7 @@ from mlflow.models.evaluation.default_evaluator import (
     _get_binary_sum_up_label_pred_prob,
     _get_classifier_per_class_metrics,
     _gen_classifier_curve,
+    _evaluate_custom_metric,
 )
 import mlflow
 from sklearn.linear_model import LogisticRegression
@@ -499,3 +502,153 @@ def test_gen_multiclass_roc_curve():
 
     expected_auc = [0.75, 0.75, 0.3333]
     assert np.allclose(results.auc, expected_auc, rtol=1e-3)
+
+
+def test_evaluate_custom_metric_handle_none_result():
+    eval_df = pd.DataFrame({"prediction": [1.2, 1.9, 3.2], "target": [1, 2, 3]})
+    metrics = _get_regressor_metrics(eval_df["target"], eval_df["prediction"])
+
+    def dummy_fn(*_):
+        pass
+
+    assert _evaluate_custom_metric(dummy_fn, eval_df, metrics) == (None, None)
+
+
+def test_evaluate_custom_metric_incorrect_return_formats():
+    eval_df = pd.DataFrame({"prediction": [1.2, 1.9, 3.2], "target": [1, 2, 3]})
+    metrics = _get_regressor_metrics(eval_df["target"], eval_df["prediction"])
+
+    def incorrect_return_type_1(*_):
+        return 3
+
+    def incorrect_return_type_2(*_):
+        return "stuff", 3
+
+    def non_str_metric_name(*_):
+        return {123: 123, "a": 32.1, "b": 3}
+
+    def non_numerical_metric_value(*_):
+        return {"stuff": 12, "non_numerical_metric": "123"}
+
+    def non_str_artifact_name(*_):
+        return {"a": 32.1, "b": 3}, {1: [1, 2, 3]}
+
+    for test_fn in (
+        incorrect_return_type_1,
+        incorrect_return_type_2,
+        non_str_metric_name,
+        non_numerical_metric_value,
+        non_str_artifact_name,
+    ):
+        with pytest.raises(
+            MlflowException,
+            match=(
+                f"Custom metric '{test_fn.__name__}' did not return in an expected format."
+                f"The two acceptable return types are:"
+                f"1. Dict[AnyStr, Union[int, float, np.number]: a dictionary of metrics"
+                f"2. Tuple[Dict[AnyStr, Union[int, float, np.number]], Dict[AnyStr, Any]]: a"
+                f"   dictionary of metrics and a dictionary of artifacts."
+                f"For more, check out the docstring for mlflow.evaluate"
+            ),
+        ):
+            _evaluate_custom_metric(test_fn, eval_df, metrics)
+
+
+def test_evaluate_custom_metric_success():
+    eval_df = pd.DataFrame({"prediction": [1.2, 1.9, 3.2], "target": [1, 2, 3]})
+    metrics = _get_regressor_metrics(eval_df["target"], eval_df["prediction"])
+
+    def example_custom_metric(_, given_metrics):
+        return {
+            "example_count_times_1_point_5": given_metrics["example_count"] * 1.5,
+            "sum_on_label_minus_5": given_metrics["sum_on_label"] - 5,
+            "example_np_metric_1": np.float32(123.2),
+            "example_np_metric_2": np.ulonglong(10000000),
+        }
+
+    res_metrics, res_artifacts = _evaluate_custom_metric(example_custom_metric, eval_df, metrics)
+    assert res_metrics == {
+        "example_count_times_1_point_5": metrics["example_count"] * 1.5,
+        "sum_on_label_minus_5": metrics["sum_on_label"] - 5,
+        "example_np_metric_1": np.float32(123.2),
+        "example_np_metric_2": np.ulonglong(10000000),
+    }
+    assert res_artifacts is None
+
+    def example_custom_metric_with_artifacts(given_df, given_metrics):
+        return (
+            {
+                "example_count_times_1_point_5": given_metrics["example_count"] * 1.5,
+                "sum_on_label_minus_5": given_metrics["sum_on_label"] - 5,
+                "example_np_metric_1": np.float32(123.2),
+                "example_np_metric_2": np.ulonglong(10000000),
+            },
+            {
+                "pred_target_abs_diff": np.abs(given_df["prediction"] - given_df["target"]),
+                "example_dictionary_artifact": {"a": 1, "b": 2},
+            },
+        )
+
+    res_metrics_2, res_artifacts_2 = _evaluate_custom_metric(
+        example_custom_metric_with_artifacts, eval_df, metrics
+    )
+    assert res_metrics_2 == {
+        "example_count_times_1_point_5": metrics["example_count"] * 1.5,
+        "sum_on_label_minus_5": metrics["sum_on_label"] - 5,
+        "example_np_metric_1": np.float32(123.2),
+        "example_np_metric_2": np.ulonglong(10000000),
+    }
+    assert "pred_target_abs_diff" in res_artifacts_2 and res_artifacts_2[
+        "pred_target_abs_diff"
+    ].equals(np.abs(eval_df["prediction"] - eval_df["target"]))
+    assert "example_dictionary_artifact" in res_artifacts_2 and res_artifacts_2[
+        "example_dictionary_artifact"
+    ] == {"a": 1, "b": 2}
+
+
+def test_custom_metric(binary_logistic_regressor_model_uri, breast_cancer_dataset):
+    def example_custom_metric(eval_df, given_metrics):
+        return {
+            "true_count": given_metrics["true_negatives"] + given_metrics["true_positives"],
+            "positive_count": np.sum(eval_df["prediction"]),
+        }
+
+    with mlflow.start_run() as run:
+        result = evaluate(
+            binary_logistic_regressor_model_uri,
+            breast_cancer_dataset._constructor_args["data"],
+            model_type="classifier",
+            targets=breast_cancer_dataset._constructor_args["targets"],
+            dataset_name=breast_cancer_dataset.name,
+            evaluators="default",
+            custom_metrics=[example_custom_metric],
+        )
+
+    _, metrics, _, _ = get_run_data(run.info.run_id)
+
+    model = mlflow.pyfunc.load_model(binary_logistic_regressor_model_uri)
+    _, _, predict_fn, _ = _extract_raw_model_and_predict_fn(model)
+    y = breast_cancer_dataset.labels_data
+    y_pred = predict_fn(breast_cancer_dataset.features_data)
+
+    expected_metrics = _get_classifier_per_class_metrics(y, y_pred)
+
+    assert "true_count_on_data_breast_cancer_dataset" in metrics and np.isclose(
+        metrics["true_count_on_data_breast_cancer_dataset"],
+        expected_metrics["true_negatives"] + expected_metrics["true_positives"],
+        rtol=1e-3,
+    )
+
+    assert "true_count" in result.metrics and np.isclose(
+        result.metrics["true_count"],
+        expected_metrics["true_negatives"] + expected_metrics["true_positives"],
+        rtol=1e-3,
+    )
+
+    assert "positive_count_on_data_breast_cancer_dataset" in metrics and np.isclose(
+        metrics["positive_count_on_data_breast_cancer_dataset"], np.sum(y_pred), rtol=1e-3
+    )
+
+    assert "positive_count" in result.metrics and np.isclose(
+        result.metrics["positive_count"], np.sum(y_pred), rtol=1e-3
+    )

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -2,6 +2,7 @@ import numpy as np
 import json
 import pandas as pd
 import pytest
+import re
 
 from mlflow.exceptions import MlflowException
 from mlflow.models.evaluation import evaluate
@@ -13,7 +14,7 @@ from mlflow.models.evaluation.default_evaluator import (
     _get_binary_sum_up_label_pred_prob,
     _get_classifier_per_class_metrics,
     _gen_classifier_curve,
-    _evaluate_custom_metric,
+    _evaluate_custom_metric_fn,
 )
 import mlflow
 from sklearn.linear_model import LogisticRegression
@@ -504,17 +505,17 @@ def test_gen_multiclass_roc_curve():
     assert np.allclose(results.auc, expected_auc, rtol=1e-3)
 
 
-def test_evaluate_custom_metric_handle_none_result():
+def test_evaluate_custom_metric_fn_handle_none_result():
     eval_df = pd.DataFrame({"prediction": [1.2, 1.9, 3.2], "target": [1, 2, 3]})
     metrics = _get_regressor_metrics(eval_df["target"], eval_df["prediction"])
 
     def dummy_fn(*_):
         pass
 
-    assert _evaluate_custom_metric(dummy_fn, eval_df, metrics) == (None, None)
+    assert _evaluate_custom_metric_fn(dummy_fn, eval_df, metrics) == (None, None)
 
 
-def test_evaluate_custom_metric_incorrect_return_formats():
+def test_evaluate_custom_metric_fn_incorrect_return_formats():
     eval_df = pd.DataFrame({"prediction": [1.2, 1.9, 3.2], "target": [1, 2, 3]})
     metrics = _get_regressor_metrics(eval_df["target"], eval_df["prediction"])
 
@@ -543,18 +544,20 @@ def test_evaluate_custom_metric_incorrect_return_formats():
         with pytest.raises(
             MlflowException,
             match=(
-                f"Custom metric '{test_fn.__name__}' did not return in an expected format."
-                f"The two acceptable return types are:"
-                f"1. Dict[AnyStr, Union[int, float, np.number]: a dictionary of metrics"
-                f"2. Tuple[Dict[AnyStr, Union[int, float, np.number]], Dict[AnyStr, Any]]: a"
-                f"   dictionary of metrics and a dictionary of artifacts."
-                f"For more, check out the docstring for mlflow.evaluate"
+                re.escape(
+                    f"Custom metric '{test_fn.__name__}' did not return in an expected format."
+                    f"The two acceptable return types are:"
+                    f"1. Dict[AnyStr, Union[int, float, np.number]: a dictionary of metrics"
+                    f"2. Tuple[Dict[AnyStr, Union[int, float, np.number]], Dict[AnyStr, Any]]: a"
+                    f"   dictionary of metrics and a dictionary of artifacts."
+                    f"For more, check out the docstring for mlflow.evaluate"
+                )
             ),
         ):
-            _evaluate_custom_metric(test_fn, eval_df, metrics)
+            _evaluate_custom_metric_fn(test_fn, eval_df, metrics)
 
 
-def test_evaluate_custom_metric_success():
+def test_evaluate_custom_metric_fn_success():
     eval_df = pd.DataFrame({"prediction": [1.2, 1.9, 3.2], "target": [1, 2, 3]})
     metrics = _get_regressor_metrics(eval_df["target"], eval_df["prediction"])
 
@@ -566,7 +569,7 @@ def test_evaluate_custom_metric_success():
             "example_np_metric_2": np.ulonglong(10000000),
         }
 
-    res_metrics, res_artifacts = _evaluate_custom_metric(example_custom_metric, eval_df, metrics)
+    res_metrics, res_artifacts = _evaluate_custom_metric_fn(example_custom_metric, eval_df, metrics)
     assert res_metrics == {
         "example_count_times_1_point_5": metrics["example_count"] * 1.5,
         "sum_on_label_minus_5": metrics["sum_on_label"] - 5,
@@ -589,7 +592,7 @@ def test_evaluate_custom_metric_success():
             },
         )
 
-    res_metrics_2, res_artifacts_2 = _evaluate_custom_metric(
+    res_metrics_2, res_artifacts_2 = _evaluate_custom_metric_fn(
         example_custom_metric_with_artifacts, eval_df, metrics
     )
     assert res_metrics_2 == {
@@ -621,7 +624,7 @@ def test_custom_metric(binary_logistic_regressor_model_uri, breast_cancer_datase
             targets=breast_cancer_dataset._constructor_args["targets"],
             dataset_name=breast_cancer_dataset.name,
             evaluators="default",
-            custom_metrics=[example_custom_metric],
+            custom_metric_fns=[example_custom_metric],
         )
 
     _, metrics, _, _ = get_run_data(run.info.run_id)

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -543,16 +543,7 @@ def test_evaluate_custom_metric_incorrect_return_formats():
     ):
         with pytest.raises(
             MlflowException,
-            match=(
-                re.escape(
-                    f"Custom metric '{test_fn.__name__}' did not return in an expected format."
-                    f"The two acceptable return types are:"
-                    f"1. Dict[AnyStr, Union[int, float, np.number]: a dictionary of metrics"
-                    f"2. Tuple[Dict[AnyStr, Union[int, float, np.number]], Dict[AnyStr, Any]]: a"
-                    f"   dictionary of metrics and a dictionary of artifacts."
-                    f"For more, check out the docstring for mlflow.evaluate"
-                )
-            ),
+            match=(re.escape(f"'{test_fn.__name__}' did not return in an expected format")),
         ):
             _evaluate_custom_metric(test_fn, eval_df, metrics)
 

--- a/tests/models/test_evaluation.py
+++ b/tests/models/test_evaluation.py
@@ -558,6 +558,7 @@ def test_evaluator_interface(multiclass_logistic_regressor_model_uri, iris_datas
                     dataset_name=iris_dataset.name,
                     evaluators="test_evaluator1",
                     evaluator_config=evaluator1_config,
+                    custom_metric_fns=None,
                 )
                 assert eval1_result.metrics == evaluator1_return_value.metrics
                 assert eval1_result.artifacts == evaluator1_return_value.artifacts
@@ -571,6 +572,7 @@ def test_evaluator_interface(multiclass_logistic_regressor_model_uri, iris_datas
                     dataset=iris_dataset,
                     run_id=run.info.run_id,
                     evaluator_config=evaluator1_config,
+                    custom_metric_fns=None,
                 )
 
 
@@ -633,6 +635,7 @@ def test_evaluate_with_multi_evaluators(multiclass_logistic_regressor_model_uri,
                         dataset=iris_dataset,
                         run_id=run.info.run_id,
                         evaluator_config=evaluator1_config,
+                        custom_metric_fns=None,
                     )
                     mock_can_evaluate2.assert_called_once_with(
                         model_type="classifier",
@@ -644,6 +647,7 @@ def test_evaluate_with_multi_evaluators(multiclass_logistic_regressor_model_uri,
                         dataset=iris_dataset,
                         run_id=run.info.run_id,
                         evaluator_config=evaluator2_config,
+                        custom_metric_fns=None,
                     )
 
 

--- a/tests/models/test_evaluation.py
+++ b/tests/models/test_evaluation.py
@@ -558,7 +558,7 @@ def test_evaluator_interface(multiclass_logistic_regressor_model_uri, iris_datas
                     dataset_name=iris_dataset.name,
                     evaluators="test_evaluator1",
                     evaluator_config=evaluator1_config,
-                    custom_metric_fns=None,
+                    custom_metrics=None,
                 )
                 assert eval1_result.metrics == evaluator1_return_value.metrics
                 assert eval1_result.artifacts == evaluator1_return_value.artifacts
@@ -572,7 +572,7 @@ def test_evaluator_interface(multiclass_logistic_regressor_model_uri, iris_datas
                     dataset=iris_dataset,
                     run_id=run.info.run_id,
                     evaluator_config=evaluator1_config,
-                    custom_metric_fns=None,
+                    custom_metrics=None,
                 )
 
 
@@ -635,7 +635,7 @@ def test_evaluate_with_multi_evaluators(multiclass_logistic_regressor_model_uri,
                         dataset=iris_dataset,
                         run_id=run.info.run_id,
                         evaluator_config=evaluator1_config,
-                        custom_metric_fns=None,
+                        custom_metrics=None,
                     )
                     mock_can_evaluate2.assert_called_once_with(
                         model_type="classifier",
@@ -647,7 +647,7 @@ def test_evaluate_with_multi_evaluators(multiclass_logistic_regressor_model_uri,
                         dataset=iris_dataset,
                         run_id=run.info.run_id,
                         evaluator_config=evaluator2_config,
-                        custom_metric_fns=None,
+                        custom_metrics=None,
                     )
 
 


### PR DESCRIPTION
Signed-off-by: Mark Zhang <mark.zhang@databricks.com>

## What changes are proposed in this pull request?

Added support for users to pass in custom metric functions into mlflow.evaluate. This PR is a part of more PRs to come for custom metrics support. Specifically, this PR focuses on enabling logging of numerical metrics generated by user's custom metric functions into MLflow.

## How is this patch tested?

Wrote unit tests located in mlflow/tests/models/test_default_evaluator.py

## Does this PR change the documentation?

Updates to the documentation will be done once the entire feature of custom metrics is complete.

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Enables MLflow tracking of custom metrics produced by user-provided metric functions.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
