### PR TITLE
Add switching logic for rest api handlers for list_artifacts

### DIFF
--- a/examples/mlflow_artifacts/Dockerfile
+++ b/examples/mlflow_artifacts/Dockerfile
@@ -3,4 +3,4 @@ FROM python:3.7
 WORKDIR /app
 
 # Install mlflow and packages requied to interact with PostgreSQL and MinIO
-RUN pip install mlflow psycopg2 boto3
+RUN pip install psycopg2 boto3 git+https://www.github.com/mlflow/mlflow@proxy-artifact-access-fix

--- a/examples/mlflow_artifacts/Dockerfile
+++ b/examples/mlflow_artifacts/Dockerfile
@@ -3,4 +3,4 @@ FROM python:3.7
 WORKDIR /app
 
 # Install mlflow and packages requied to interact with PostgreSQL and MinIO
-RUN pip install psycopg2 boto3 git+https://www.github.com/mlflow/mlflow@proxy-artifact-access-fix
+RUN pip install mlflow psycopg2 boto3

--- a/examples/mlflow_artifacts/example.py
+++ b/examples/mlflow_artifacts/example.py
@@ -21,7 +21,7 @@ def main():
     with mlflow.start_run() as run, tempfile.TemporaryDirectory() as tmp_dir:
         tmp_path_a = os.path.join(tmp_dir, "a.txt")
         save_text(tmp_path_a, "0")
-        tmp_sub_dir = tmp_path_b = os.path.join(tmp_dir, "dir")
+        tmp_sub_dir = os.path.join(tmp_dir, "dir")
         os.makedirs(tmp_sub_dir)
         tmp_path_b = os.path.join(tmp_sub_dir, "b.txt")
         save_text(tmp_path_b, "1")

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -1013,7 +1013,7 @@ def _list_artifacts_mlflow_artifacts():
     artifact_repo = _get_artifact_repo_mlflow_artifacts()
     _run_root_path = _get_run_root_path()
 
-    if isinstance(_run_root_path, str):
+    if _run_root_path and isinstance(_run_root_path, str):
         path = _insert_run_path_mlflow_artifacts_uri(_run_root_path, path)
     else:
         root_path = os.environ.get(ARTIFACTS_DESTINATION_ENV_VAR)
@@ -1081,7 +1081,7 @@ def _get_run_root_path():
             _, path = core_path.path.split("mlartifacts", 1)
     else:
         path = ""
-    return path.lstrip("/")
+    return path.lstrip("/").lstrip("\\").lstrip("\\\\")
 
 
 def _add_static_prefix(route):

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -147,8 +147,8 @@ def _get_artifact_repo_mlflow_artifacts():
 
 def _get_serve_artifacts_mode():
     """
-    Set whether the MLflow server is operating in ``--serve-artifacts`` mode for artifact listing
-    endpoint resolution.
+    Initializes ``_serve_artifacts_mode`` that indicates whether the MLflow server is operating in
+    ``-serve_artifacts`` mode for artifact listing and returns the value.
     """
     from mlflow.server import SERVE_ARTIFACTS_ENV_VAR
 
@@ -633,7 +633,6 @@ def _list_experiments():
 
 
 @catch_mlflow_exception
-@_disable_if_artifacts_only
 def _get_artifact_repo(run):
     return get_artifact_repository(run.info.artifact_uri)
 

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -1074,14 +1074,14 @@ def _get_run_root_path():
         artifact_uri = run.info.artifact_uri
         core_path = urllib.parse.urlparse(artifact_uri)
         if core_path.scheme.startswith("http"):
-            _, path = core_path.path.split("mlflow-artifacts/artifacts/", 1)
+            _, _, path = core_path.path.split("artifacts", 2)
         elif core_path.scheme.startswith("mlflow-artifacts"):
-            path = core_path.path.lstrip("/")
+            path = core_path.path
         else:
-            _, path = core_path.path.split("mlartifacts/", 1)
+            _, path = core_path.path.split("mlartifacts", 1)
     else:
-        path = None
-    return path
+        path = ""
+    return path.lstrip("/")
 
 
 def _add_static_prefix(route):

--- a/mlflow/store/artifact/artifact_repository_registry.py
+++ b/mlflow/store/artifact/artifact_repository_registry.py
@@ -54,9 +54,9 @@ class ArtifactRepositoryRegistry:
     def get_artifact_repository(self, artifact_uri):
         """Get an artifact repository from the registry based on the scheme of artifact_uri
 
-        :param store_uri: The store URI. This URI is used to select which artifact repository
-                          implementation to instantiate and is passed to the
-                          constructor of the implementation.
+        :param artifact_uri: The artifact store URI. This URI is used to select which artifact
+                             repository implementation to instantiate and is passed to the
+                             constructor of the implementation.
 
         :return: An instance of `mlflow.store.ArtifactRepository` that fulfills the artifact URI
                  requirements.
@@ -97,9 +97,9 @@ _artifact_repository_registry.register_entrypoints()
 def get_artifact_repository(artifact_uri):
     """Get an artifact repository from the registry based on the scheme of artifact_uri
 
-    :param store_uri: The store URI. This URI is used to select which artifact repository
-                      implementation to instantiate and is passed to the
-                      constructor of the implementation.
+    :param artifact_uri: The artifact store URI. This URI is used to select which artifact
+                         repository implementation to instantiate and is passed to the
+                         constructor of the implementation.
 
     :return: An instance of `mlflow.store.ArtifactRepository` that fulfills the artifact URI
              requirements.

--- a/tests/tracking/test_mlflow_artifacts.py
+++ b/tests/tracking/test_mlflow_artifacts.py
@@ -272,22 +272,32 @@ def test_mlflow_artifacts_rest_api_list_artifacts(artifacts_server, tmpdir):
 
     client = mlflow.tracking.MlflowClient()
     experiment = client.get_experiment_by_name(name)
-    exp_id = experiment.experiment_id
-    run_id = client.list_run_infos(experiment.experiment_id)[0].run_id
-    artifacts = get_artifacts_from_rest_api(api, run_id)
-    assert len(artifacts) >= 1
-    artifacts_base = get_artifacts_from_rest_api(api, run_id, exp_id)
-    artifacts_path = f"{exp_id}/{artifacts_base['files'][0]['path']}/artifacts"
+    run = client.list_run_infos(experiment.experiment_id)
+    run_id = run[0].run_id
 
-    artifacts_contents = get_artifacts_from_rest_api(api, run_id, f"{artifacts_path}")
+    print("DIRECT API ARTIFACTS: ")
+    print(client.list_artifacts(run_id))
+    print(client.list_artifacts(run_id, "dir"))
+    print("END OF DIRECT API ARTIFACTS")
+
+    print(f"\n\n RUN_INFO: \n{run}")
+    print(f"\n\n RUN_ID: \n{run_id}")
+    artifacts = get_artifacts_from_rest_api(api, run_id)
+    print(f"\nARTIFACTS: \n {artifacts}")
+
+    assert len(artifacts) >= 1
+
     expected_contents = {
         "files": [
             {"path": "a.txt", "is_dir": False, "file_size": 1},
             {"path": "dir", "is_dir": True},
         ]
     }
-    assert artifacts_contents == expected_contents
+    assert artifacts == expected_contents
 
-    nested_contents = get_artifacts_from_rest_api(api, run_id, f"{artifacts_path}/dir")
+    nested_contents = get_artifacts_from_rest_api(api, run_id, "dir")
+
+    print(f"\n\n NESTED_CONTENTS: {nested_contents}\n\n")
+
     expected_nested = {"files": [{"path": "b.txt", "is_dir": False, "file_size": 1}]}
     assert nested_contents == expected_nested

--- a/tests/tracking/test_mlflow_artifacts.py
+++ b/tests/tracking/test_mlflow_artifacts.py
@@ -5,7 +5,6 @@ import tempfile
 import requests
 import pathlib
 import pytest
-import json
 
 import mlflow
 from tests.helper_functions import LOCALHOST, get_safe_port
@@ -253,8 +252,8 @@ def get_artifacts_from_rest_api(url, run_id, path=None):
         resp = requests.get(url, params={"run_id": run_id, "path": path})
     else:
         resp = requests.get(url, params={"run_id": run_id})
-    assert resp.status_code == 200
-    return json.loads(resp.content.decode("utf-8"))
+    resp.raise_for_status()
+    return resp.json()
 
 
 def test_mlflow_artifacts_rest_api_list_artifacts(artifacts_server, tmpdir):

--- a/tests/tracking/test_mlflow_artifacts.py
+++ b/tests/tracking/test_mlflow_artifacts.py
@@ -274,19 +274,8 @@ def test_mlflow_artifacts_rest_api_list_artifacts(artifacts_server, tmpdir):
     experiment = client.get_experiment_by_name(name)
     run = client.list_run_infos(experiment.experiment_id)
     run_id = run[0].run_id
-
-    print("DIRECT API ARTIFACTS: ")
-    print(client.list_artifacts(run_id))
-    print(client.list_artifacts(run_id, "dir"))
-    print("END OF DIRECT API ARTIFACTS")
-
-    print(f"\n\n RUN_INFO: \n{run}")
-    print(f"\n\n RUN_ID: \n{run_id}")
     artifacts = get_artifacts_from_rest_api(api, run_id)
-    print(f"\nARTIFACTS: \n {artifacts}")
-
     assert len(artifacts) >= 1
-
     expected_contents = {
         "files": [
             {"path": "a.txt", "is_dir": False, "file_size": 1},
@@ -294,10 +283,6 @@ def test_mlflow_artifacts_rest_api_list_artifacts(artifacts_server, tmpdir):
         ]
     }
     assert artifacts == expected_contents
-
     nested_contents = get_artifacts_from_rest_api(api, run_id, "dir")
-
-    print(f"\n\n NESTED_CONTENTS: {nested_contents}\n\n")
-
     expected_nested = {"files": [{"path": "b.txt", "is_dir": False, "file_size": 1}]}
     assert nested_contents == expected_nested


### PR DESCRIPTION
Signed-off-by: Ben Wilson <benjamin.wilson@databricks.com>

## What changes are proposed in this pull request?

Fix REST API handler to support proxied artifact mode of mlflow server (server started with ``--serve-artifacts``) so that a REST get on ``artifacts/list`` returns the correct values from the ``_list_artifacts_mlflow_artifacts()`` handler instead of the standard ``_list_artifacts()`` handler. 

## How is this patch tested?

Unit tests

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
