### PR TITLE
Add model registration argument for autolog

### DIFF
--- a/mlflow/fastai/__init__.py
+++ b/mlflow/fastai/__init__.py
@@ -380,6 +380,7 @@ def autolog(
     exclusive=False,
     disable_for_unsupported_versions=False,
     silent=False,
+    registered_model_name=None,
 ):  # pylint: disable=unused-argument
     """
     Enable automatic logging from Fastai to MLflow.
@@ -404,6 +405,8 @@ def autolog(
     :param silent: If ``True``, suppress all event logs and warnings from MLflow during Fastai
                    autologging. If ``False``, show all events and warnings during Fastai
                    autologging.
+    :param registered_model_name: If given, register the fitted model as the given name, or
+                                  create a new version model under the given name.
 
     .. code-block:: python
         :caption: Example

--- a/mlflow/fastai/__init__.py
+++ b/mlflow/fastai/__init__.py
@@ -405,8 +405,9 @@ def autolog(
     :param silent: If ``True``, suppress all event logs and warnings from MLflow during Fastai
                    autologging. If ``False``, show all events and warnings during Fastai
                    autologging.
-    :param registered_model_name: If given, register the fitted model as the given name, or
-                                  create a new version model under the given name.
+    :param registered_model_name: If given, each time a model is trained, it is registered as a
+                                  new model version of the registered model with this name.
+                                  The registered model is created if it does not already exist.
 
     .. code-block:: python
         :caption: Example

--- a/mlflow/fastai/callback.py
+++ b/mlflow/fastai/callback.py
@@ -141,7 +141,7 @@ class __MlflowFastaiCallback(Callback, metaclass=ExceptionSafeClass):
 
         if self.log_models:
             registered_model_name = get_autologging_config(
-                mlflow.paddle.FLAVOR_NAME, "registered_model_name", None
+                mlflow.fastai.FLAVOR_NAME, "registered_model_name", None
             )
             log_model(
                 self.learn, artifact_path="model", registered_model_name=registered_model_name

--- a/mlflow/fastai/callback.py
+++ b/mlflow/fastai/callback.py
@@ -7,7 +7,7 @@ import matplotlib.pyplot as plt
 import logging
 
 import mlflow.tracking
-from mlflow.utils.autologging_utils import ExceptionSafeClass
+from mlflow.utils.autologging_utils import ExceptionSafeClass, get_autologging_config
 from mlflow.fastai import log_model
 
 from fastai.callback.core import Callback
@@ -140,4 +140,9 @@ class __MlflowFastaiCallback(Callback, metaclass=ExceptionSafeClass):
                 cb("after_fit")
 
         if self.log_models:
-            log_model(self.learn, artifact_path="model")
+            registered_model_name = get_autologging_config(
+                mlflow.paddle.FLAVOR_NAME, "registered_model_name", None
+            )
+            log_model(
+                self.learn, artifact_path="model", registered_model_name=registered_model_name
+            )

--- a/mlflow/gluon/__init__.py
+++ b/mlflow/gluon/__init__.py
@@ -353,6 +353,7 @@ def autolog(
     exclusive=False,
     disable_for_unsupported_versions=False,
     silent=False,
+    registered_model_name=None,
 ):  # pylint: disable=unused-argument
     """
     Enables (or disables) and configures autologging from Gluon to MLflow.
@@ -373,6 +374,8 @@ def autolog(
     :param silent: If ``True``, suppress all event logs and warnings from MLflow during MXNet Gluon
                    autologging. If ``False``, show all events and warnings during MXNet Gluon
                    autologging.
+    :param registered_model_name: If given, register the fitted model as the given name, or
+                                  create a new version model under the given name.
     """
 
     from mxnet.gluon.contrib.estimator import Estimator

--- a/mlflow/gluon/__init__.py
+++ b/mlflow/gluon/__init__.py
@@ -374,8 +374,9 @@ def autolog(
     :param silent: If ``True``, suppress all event logs and warnings from MLflow during MXNet Gluon
                    autologging. If ``False``, show all events and warnings during MXNet Gluon
                    autologging.
-    :param registered_model_name: If given, register the fitted model as the given name, or
-                                  create a new version model under the given name.
+    :param registered_model_name: If given, each time a model is trained, it is registered as a
+                                  new model version of the registered model with this name.
+                                  The registered model is created if it does not already exist.
     """
 
     from mxnet.gluon.contrib.estimator import Estimator

--- a/mlflow/gluon/_autolog.py
+++ b/mlflow/gluon/_autolog.py
@@ -37,7 +37,7 @@ class __MLflowGluonCallback(EpochEnd, TrainEnd, TrainBegin, metaclass=ExceptionS
     def train_end(self, estimator, *args, **kwargs):
         if isinstance(estimator.net, HybridSequential) and self.log_models:
             registered_model_name = get_autologging_config(
-                mlflow.paddle.FLAVOR_NAME, "registered_model_name", None
+                mlflow.gluon.FLAVOR_NAME, "registered_model_name", None
             )
             mlflow.gluon.log_model(
                 estimator.net, artifact_path="model", registered_model_name=registered_model_name

--- a/mlflow/gluon/_autolog.py
+++ b/mlflow/gluon/_autolog.py
@@ -2,7 +2,7 @@ from mxnet.gluon.contrib.estimator import EpochEnd, TrainBegin, TrainEnd
 from mxnet.gluon.nn import HybridSequential
 
 import mlflow
-from mlflow.utils.autologging_utils import ExceptionSafeClass
+from mlflow.utils.autologging_utils import ExceptionSafeClass, get_autologging_config
 
 
 class __MLflowGluonCallback(EpochEnd, TrainEnd, TrainBegin, metaclass=ExceptionSafeClass):
@@ -36,4 +36,9 @@ class __MLflowGluonCallback(EpochEnd, TrainEnd, TrainBegin, metaclass=ExceptionS
 
     def train_end(self, estimator, *args, **kwargs):
         if isinstance(estimator.net, HybridSequential) and self.log_models:
-            mlflow.gluon.log_model(estimator.net, artifact_path="model")
+            registered_model_name = get_autologging_config(
+                mlflow.paddle.FLAVOR_NAME, "registered_model_name", None
+            )
+            mlflow.gluon.log_model(
+                estimator.net, artifact_path="model", registered_model_name=registered_model_name
+            )

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -45,6 +45,7 @@ from mlflow.utils.autologging_utils import (
     ExceptionSafeClass,
     log_fn_args_as_params,
     batch_metrics_logger,
+    get_autologging_config,
 )
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 
@@ -565,6 +566,7 @@ def autolog(
     exclusive=False,
     disable_for_unsupported_versions=False,
     silent=False,
+    registered_model_name=None,
 ):  # pylint: disable=unused-argument
     # pylint: disable=E0611
     """
@@ -627,6 +629,8 @@ def autolog(
     :param silent: If ``True``, suppress all event logs and warnings from MLflow during Keras
                    autologging. If ``False``, show all events and warnings during Keras
                    autologging.
+    :param registered_model_name: If given, register the fitted model as the given name, or
+                                  create a new version model under the given name.
     """
     import keras
 
@@ -685,7 +689,14 @@ def autolog(
 
             def on_train_end(self, logs=None):
                 if log_models:
-                    log_model(self.model, artifact_path="model")
+                    registered_model_name = get_autologging_config(
+                        mlflow.paddle.FLAVOR_NAME, "registered_model_name", None
+                    )
+                    log_model(
+                        self.model,
+                        artifact_path="model",
+                        registered_model_name=registered_model_name,
+                    )
 
             # As of Keras 2.4.0, Keras Callback implementations must define the following
             # methods indicating whether or not the callback overrides functions for

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -629,8 +629,9 @@ def autolog(
     :param silent: If ``True``, suppress all event logs and warnings from MLflow during Keras
                    autologging. If ``False``, show all events and warnings during Keras
                    autologging.
-    :param registered_model_name: If given, register the fitted model as the given name, or
-                                  create a new version model under the given name.
+    :param registered_model_name: If given, each time a model is trained, it is registered as a
+                                  new model version of the registered model with this name.
+                                  The registered model is created if it does not already exist.
     """
     import keras
 

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -690,7 +690,7 @@ def autolog(
             def on_train_end(self, logs=None):
                 if log_models:
                     registered_model_name = get_autologging_config(
-                        mlflow.paddle.FLAVOR_NAME, "registered_model_name", None
+                        FLAVOR_NAME, "registered_model_name", None
                     )
                     log_model(
                         self.model,

--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -61,6 +61,7 @@ from mlflow.utils.autologging_utils import (
     ENSURE_AUTOLOGGING_ENABLED_TEXT,
     batch_metrics_logger,
     MlflowAutologgingQueueingClient,
+    get_autologging_config,
 )
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 
@@ -369,6 +370,7 @@ def autolog(
     exclusive=False,
     disable_for_unsupported_versions=False,
     silent=False,
+    registered_model_name=None,
 ):  # pylint: disable=unused-argument
     """
     Enables (or disables) and configures autologging from LightGBM to MLflow. Logs the following:
@@ -411,6 +413,8 @@ def autolog(
     :param silent: If ``True``, suppress all event logs and warnings from MLflow during LightGBM
                    autologging. If ``False``, show all events and warnings during LightGBM
                    autologging.
+    :param registered_model_name: If given, register the fitted model as the given name, or
+                                  create a new version model under the given name.
     """
     import lightgbm
     import numpy as np
@@ -612,11 +616,15 @@ def autolog(
                 _logger,
             )
 
+            registered_model_name = get_autologging_config(
+                mlflow.paddle.FLAVOR_NAME, "registered_model_name", None
+            )
             log_model(
                 model,
                 artifact_path="model",
                 signature=signature,
                 input_example=input_example,
+                registered_model_name=registered_model_name,
             )
 
         param_logging_operations.await_completion()

--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -616,9 +616,6 @@ def autolog(
                 _logger,
             )
 
-            registered_model_name = get_autologging_config(
-                FLAVOR_NAME, "registered_model_name", None
-            )
             log_model(
                 model,
                 artifact_path="model",

--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -61,7 +61,6 @@ from mlflow.utils.autologging_utils import (
     ENSURE_AUTOLOGGING_ENABLED_TEXT,
     batch_metrics_logger,
     MlflowAutologgingQueueingClient,
-    get_autologging_config,
 )
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 

--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -413,8 +413,9 @@ def autolog(
     :param silent: If ``True``, suppress all event logs and warnings from MLflow during LightGBM
                    autologging. If ``False``, show all events and warnings during LightGBM
                    autologging.
-    :param registered_model_name: If given, register the fitted model as the given name, or
-                                  create a new version model under the given name.
+    :param registered_model_name: If given, each time a model is trained, it is registered as a
+                                  new model version of the registered model with this name.
+                                  The registered model is created if it does not already exist.
     """
     import lightgbm
     import numpy as np

--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -617,7 +617,7 @@ def autolog(
             )
 
             registered_model_name = get_autologging_config(
-                mlflow.paddle.FLAVOR_NAME, "registered_model_name", None
+                FLAVOR_NAME, "registered_model_name", None
             )
             log_model(
                 model,

--- a/mlflow/paddle/__init__.py
+++ b/mlflow/paddle/__init__.py
@@ -487,8 +487,9 @@ def autolog(
     :param silent: If ``True``, suppress all event logs and warnings from MLflow during PyTorch
                    Lightning autologging. If ``False``, show all events and warnings during
                    PaddlePaddle autologging.
-    :param registered_model_name: If given, register the fitted model as the given name, or
-                                  create a new version model under the given name.
+    :param registered_model_name: If given, each time a model is trained, it is registered as a
+                                  new model version of the registered model with this name.
+                                  The registered model is created if it does not already exist.
 
     .. code-block:: python
         :caption: Example

--- a/mlflow/paddle/__init__.py
+++ b/mlflow/paddle/__init__.py
@@ -465,6 +465,7 @@ def autolog(
     disable=False,
     exclusive=False,
     silent=False,
+    registered_model_name=None,
 ):  # pylint: disable=unused-argument
     """
     Enables (or disables) and configures autologging from PaddlePaddle to MLflow.
@@ -486,6 +487,8 @@ def autolog(
     :param silent: If ``True``, suppress all event logs and warnings from MLflow during PyTorch
                    Lightning autologging. If ``False``, show all events and warnings during
                    PaddlePaddle autologging.
+    :param registered_model_name: If given, register the fitted model as the given name, or
+                                  create a new version model under the given name.
 
     .. code-block:: python
         :caption: Example

--- a/mlflow/paddle/_paddle_autolog.py
+++ b/mlflow/paddle/_paddle_autolog.py
@@ -124,7 +124,12 @@ def patched_fit(original, self, *args, **kwargs):
     mlflow.log_text(str(self.summary()), "model_summary.txt")
 
     if log_models:
-        mlflow.paddle.log_model(pd_model=self, artifact_path="model")
+        registered_model_name = get_autologging_config(
+            mlflow.paddle.FLAVOR_NAME, "registered_model_name", None
+        )
+        mlflow.paddle.log_model(
+            pd_model=self, artifact_path="model", registered_model_name=registered_model_name
+        )
 
     client.flush(synchronous=True)
 

--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -18,7 +18,6 @@ from mlflow.utils.autologging_utils import (
     _get_new_training_session_class,
     autologging_integration,
     safe_patch,
-    get_autologging_config,
 )
 from mlflow.utils.autologging_utils import get_method_call_arg_value
 from mlflow.utils.file_utils import TempDir

--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -18,6 +18,7 @@ from mlflow.utils.autologging_utils import (
     _get_new_training_session_class,
     autologging_integration,
     safe_patch,
+    get_autologging_config,
 )
 from mlflow.utils.autologging_utils import get_method_call_arg_value
 from mlflow.utils.file_utils import TempDir
@@ -679,6 +680,7 @@ def autolog(
     disable_for_unsupported_versions=False,
     silent=False,
     log_post_training_metrics=True,
+    registered_model_name=None,
 ):  # pylint: disable=unused-argument
     """
     Enables (or disables) and configures autologging for pyspark ml estimators.
@@ -793,6 +795,8 @@ def autolog(
     :param log_post_training_metrics: If ``True``, post training metrics are logged. Defaults to
                                       ``True``. See the `post training metrics`_ section for more
                                       details.
+    :param registered_model_name: If given, register the fitted model as the given name, or
+                                  create a new version model under the given name.
 
     **The default log model allowlist in mlflow**
         .. literalinclude:: ../../../mlflow/pyspark/ml/log_model_allowlist.txt
@@ -894,10 +898,13 @@ def autolog(
 
         if log_models:
             if _should_log_model(spark_model):
+                registered_model_name = get_autologging_config(
+                    mlflow.paddle.FLAVOR_NAME, "registered_model_name", None
+                )
+
                 # TODO: support model signature
                 mlflow.spark.log_model(
-                    spark_model,
-                    artifact_path="model",
+                    spark_model, artifact_path="model", registered_model_name=registered_model_name
                 )
                 if _is_parameter_search_model(spark_model):
                     mlflow.spark.log_model(

--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -899,7 +899,7 @@ def autolog(
         if log_models:
             if _should_log_model(spark_model):
                 registered_model_name = get_autologging_config(
-                    mlflow.paddle.FLAVOR_NAME, "registered_model_name", None
+                    AUTOLOGGING_INTEGRATION_NAME, "registered_model_name", None
                 )
 
                 # TODO: support model signature

--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -898,10 +898,6 @@ def autolog(
 
         if log_models:
             if _should_log_model(spark_model):
-                registered_model_name = get_autologging_config(
-                    AUTOLOGGING_INTEGRATION_NAME, "registered_model_name", None
-                )
-
                 # TODO: support model signature
                 mlflow.spark.log_model(
                     spark_model, artifact_path="model", registered_model_name=registered_model_name

--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -795,8 +795,9 @@ def autolog(
     :param log_post_training_metrics: If ``True``, post training metrics are logged. Defaults to
                                       ``True``. See the `post training metrics`_ section for more
                                       details.
-    :param registered_model_name: If given, register the fitted model as the given name, or
-                                  create a new version model under the given name.
+    :param registered_model_name: If given, each time a model is trained, it is registered as a
+                                  new model version of the registered model with this name.
+                                  The registered model is created if it does not already exist.
 
     **The default log model allowlist in mlflow**
         .. literalinclude:: ../../../mlflow/pyspark/ml/log_model_allowlist.txt

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -891,6 +891,7 @@ def autolog(
     exclusive=False,
     disable_for_unsupported_versions=False,
     silent=False,
+    registered_model_name=None,
 ):  # pylint: disable=unused-argument
     """
     Enables (or disables) and configures autologging from `PyTorch Lightning
@@ -927,6 +928,8 @@ def autolog(
     :param silent: If ``True``, suppress all event logs and warnings from MLflow during PyTorch
                    Lightning autologging. If ``False``, show all events and warnings during
                    PyTorch Lightning autologging.
+    :param registered_model_name: If given, register the fitted model as the given name, or
+                                  create a new version model under the given name.
 
     .. code-block:: python
         :caption: Example

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -928,8 +928,9 @@ def autolog(
     :param silent: If ``True``, suppress all event logs and warnings from MLflow during PyTorch
                    Lightning autologging. If ``False``, show all events and warnings during
                    PyTorch Lightning autologging.
-    :param registered_model_name: If given, register the fitted model as the given name, or
-                                  create a new version model under the given name.
+    :param registered_model_name: If given, each time a model is trained, it is registered as a
+                                  new model version of the registered model with this name.
+                                  The registered model is created if it does not already exist.
 
     .. code-block:: python
         :caption: Example

--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -312,7 +312,7 @@ def patched_fit(original, self, *args, **kwargs):
 
     if log_models:
         registered_model_name = get_autologging_config(
-            mlflow.paddle.FLAVOR_NAME, "registered_model_name", None
+            mlflow.pytorch.FLAVOR_NAME, "registered_model_name", None
         )
         mlflow.pytorch.log_model(
             pytorch_model=self.model,

--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -311,7 +311,14 @@ def patched_fit(original, self, *args, **kwargs):
         shutil.rmtree(tempdir)
 
     if log_models:
-        mlflow.pytorch.log_model(pytorch_model=self.model, artifact_path="model")
+        registered_model_name = get_autologging_config(
+            mlflow.paddle.FLAVOR_NAME, "registered_model_name", None
+        )
+        mlflow.pytorch.log_model(
+            pytorch_model=self.model,
+            artifact_path="model",
+            registered_model_name=registered_model_name,
+        )
 
         if early_stop_callback is not None and self.checkpoint_callback.best_model_path:
             mlflow.log_artifact(

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -1159,8 +1159,9 @@ def autolog(
     :param serialization_format: The format in which to serialize the model. This should be one of
                                  the following: ``mlflow.sklearn.SERIALIZATION_FORMAT_PICKLE`` or
                                  ``mlflow.sklearn.SERIALIZATION_FORMAT_CLOUDPICKLE``.
-    :param registered_model_name: If given, register the fitted model as the given name, or
-                                  create a new version model under the given name.
+    :param registered_model_name: If given, each time a model is trained, it is registered as a
+                                  new model version of the registered model with this name.
+                                  The registered model is created if it does not already exist.
     """
     _autolog(
         flavor_name=FLAVOR_NAME,

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -1261,7 +1261,7 @@ def _autolog(
                 else mlflow.lightgbm.log_model
             )
             registered_model_name = get_autologging_config(
-                mlflow.paddle.FLAVOR_NAME, "registered_model_name", None
+                FLAVOR_NAME, "registered_model_name", None
             )
             log_model_func(
                 self,
@@ -1385,7 +1385,7 @@ def _autolog(
                 _logger,
             )
             registered_model_name = get_autologging_config(
-                mlflow.paddle.FLAVOR_NAME, "registered_model_name", None
+                FLAVOR_NAME, "registered_model_name", None
             )
             _log_model_with_except_handling(
                 estimator,

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -1261,7 +1261,7 @@ def _autolog(
                 else mlflow.lightgbm.log_model
             )
             registered_model_name = get_autologging_config(
-                FLAVOR_NAME, "registered_model_name", None
+                flavor_name, "registered_model_name", None
             )
             log_model_func(
                 self,

--- a/mlflow/statsmodels.py
+++ b/mlflow/statsmodels.py
@@ -512,7 +512,7 @@ def autolog(
                     global _save_model_called_from_autolog
                     _save_model_called_from_autolog = True
                     registered_model_name = get_autologging_config(
-                        mlflow.paddle.FLAVOR_NAME, "registered_model_name", None
+                        FLAVOR_NAME, "registered_model_name", None
                     )
                     try:
                         log_model(

--- a/mlflow/statsmodels.py
+++ b/mlflow/statsmodels.py
@@ -423,8 +423,9 @@ def autolog(
     :param silent: If ``True``, suppress all event logs and warnings from MLflow during statsmodels
                    autologging. If ``False``, show all events and warnings during statsmodels
                    autologging.
-    :param registered_model_name: If given, register the fitted model as the given name, or
-                                  create a new version model under the given name.
+    :param registered_model_name: If given, each time a model is trained, it is registered as a
+                                  new model version of the registered model with this name.
+                                  The registered model is created if it does not already exist.
     """
     import statsmodels
 

--- a/mlflow/statsmodels.py
+++ b/mlflow/statsmodels.py
@@ -396,6 +396,7 @@ def autolog(
     exclusive=False,
     disable_for_unsupported_versions=False,
     silent=False,
+    registered_model_name=None,
 ):  # pylint: disable=unused-argument
     """
     Enables (or disables) and configures automatic logging from statsmodels to MLflow.
@@ -422,6 +423,8 @@ def autolog(
     :param silent: If ``True``, suppress all event logs and warnings from MLflow during statsmodels
                    autologging. If ``False``, show all events and warnings during statsmodels
                    autologging.
+    :param registered_model_name: If given, register the fitted model as the given name, or
+                                  create a new version model under the given name.
     """
     import statsmodels
 
@@ -508,8 +511,15 @@ def autolog(
                 if get_autologging_config(FLAVOR_NAME, "log_models", True):
                     global _save_model_called_from_autolog
                     _save_model_called_from_autolog = True
+                    registered_model_name = get_autologging_config(
+                        mlflow.paddle.FLAVOR_NAME, "registered_model_name", None
+                    )
                     try:
-                        log_model(model, artifact_path="model")
+                        log_model(
+                            model,
+                            artifact_path="model",
+                            registered_model_name=registered_model_name,
+                        )
                     finally:
                         _save_model_called_from_autolog = False
 

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -626,6 +626,7 @@ def autolog(
     exclusive=False,
     disable_for_unsupported_versions=False,
     silent=False,
+    registered_model_name=None,
 ):  # pylint: disable=unused-argument
     # pylint: disable=E0611
     """
@@ -692,6 +693,8 @@ def autolog(
     :param silent: If ``True``, suppress all event logs and warnings from MLflow during TensorFlow
                    autologging. If ``False``, show all events and warnings during TensorFlow
                    autologging.
+    :param registered_model_name: If given, register the fitted model as the given name, or
+                                  create a new version model under the given name.
     """
     import tensorflow
 

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -693,8 +693,9 @@ def autolog(
     :param silent: If ``True``, suppress all event logs and warnings from MLflow during TensorFlow
                    autologging. If ``False``, show all events and warnings during TensorFlow
                    autologging.
-    :param registered_model_name: If given, register the fitted model as the given name, or
-                                  create a new version model under the given name.
+    :param registered_model_name: If given, each time a model is trained, it is registered as a
+                                  new model version of the registered model with this name.
+                                  The registered model is created if it does not already exist.
     """
     import tensorflow
 

--- a/mlflow/tensorflow/_autolog.py
+++ b/mlflow/tensorflow/_autolog.py
@@ -47,7 +47,7 @@ class __MLflowTfKeras2Callback(Callback, metaclass=ExceptionSafeClass):
     def on_train_end(self, logs=None):  # pylint: disable=unused-argument
         if self.log_models:
             registered_model_name = get_autologging_config(
-                mlflow.paddle.FLAVOR_NAME, "registered_model_name", None
+                mlflow.tensorflow.FLAVOR_NAME, "registered_model_name", None
             )
             mlflow.keras.log_model(
                 self.model, artifact_path="model", registered_model_name=registered_model_name

--- a/mlflow/tensorflow/_autolog.py
+++ b/mlflow/tensorflow/_autolog.py
@@ -1,7 +1,7 @@
 from tensorflow.keras.callbacks import Callback, TensorBoard
 
 import mlflow
-from mlflow.utils.autologging_utils import ExceptionSafeClass
+from mlflow.utils.autologging_utils import ExceptionSafeClass, get_autologging_config
 
 
 class _TensorBoard(TensorBoard, metaclass=ExceptionSafeClass):
@@ -46,4 +46,9 @@ class __MLflowTfKeras2Callback(Callback, metaclass=ExceptionSafeClass):
 
     def on_train_end(self, logs=None):  # pylint: disable=unused-argument
         if self.log_models:
-            mlflow.keras.log_model(self.model, artifact_path="model")
+            registered_model_name = get_autologging_config(
+                mlflow.paddle.FLAVOR_NAME, "registered_model_name", None
+            )
+            mlflow.keras.log_model(
+                self.model, artifact_path="model", registered_model_name=registered_model_name
+            )

--- a/mlflow/xgboost/__init__.py
+++ b/mlflow/xgboost/__init__.py
@@ -660,7 +660,7 @@ def autolog(
             )
 
             registered_model_name = get_autologging_config(
-                mlflow.paddle.FLAVOR_NAME, "registered_model_name", None
+                FLAVOR_NAME, "registered_model_name", None
             )
             log_model(
                 model,

--- a/mlflow/xgboost/__init__.py
+++ b/mlflow/xgboost/__init__.py
@@ -382,8 +382,9 @@ def autolog(
     :param silent: If ``True``, suppress all event logs and warnings from MLflow during XGBoost
                    autologging. If ``False``, show all events and warnings during XGBoost
                    autologging.
-    :param registered_model_name: If given, register the fitted model as the given name, or
-                                  create a new version model under the given name.
+    :param registered_model_name: If given, each time a model is trained, it is registered as a
+                                  new model version of the registered model with this name.
+                                  The registered model is created if it does not already exist.
     """
     import functools
     import xgboost

--- a/mlflow/xgboost/__init__.py
+++ b/mlflow/xgboost/__init__.py
@@ -59,6 +59,7 @@ from mlflow.utils.autologging_utils import (
     ENSURE_AUTOLOGGING_ENABLED_TEXT,
     batch_metrics_logger,
     MlflowAutologgingQueueingClient,
+    get_autologging_config,
 )
 
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
@@ -338,6 +339,7 @@ def autolog(
     exclusive=False,
     disable_for_unsupported_versions=False,
     silent=False,
+    registered_model_name=None,
 ):  # pylint: disable=W0102,unused-argument
     """
     Enables (or disables) and configures autologging from XGBoost to MLflow. Logs the following:
@@ -380,6 +382,8 @@ def autolog(
     :param silent: If ``True``, suppress all event logs and warnings from MLflow during XGBoost
                    autologging. If ``False``, show all events and warnings during XGBoost
                    autologging.
+    :param registered_model_name: If given, register the fitted model as the given name, or
+                                  create a new version model under the given name.
     """
     import functools
     import xgboost
@@ -655,11 +659,15 @@ def autolog(
                 _logger,
             )
 
+            registered_model_name = get_autologging_config(
+                mlflow.paddle.FLAVOR_NAME, "registered_model_name", None
+            )
             log_model(
                 model,
                 artifact_path="model",
                 signature=signature,
                 input_example=input_example,
+                registered_model_name=registered_model_name,
             )
 
         param_logging_operations.await_completion()

--- a/tests/gluon/test_gluon_autolog.py
+++ b/tests/gluon/test_gluon_autolog.py
@@ -223,9 +223,9 @@ def test_autolog_registering_model(registered_model_name):
     )
     est = get_estimator(model, trainer)
 
-    with patch("mlflow.register_model") as mock_register_model, \
-            mlflow.start_run(), \
-            warnings.catch_warnings():
+    with patch(
+        "mlflow.register_model"
+    ) as mock_register_model, mlflow.start_run(), warnings.catch_warnings():
         warnings.simplefilter("ignore")
         est.fit(data, epochs=3)
 

--- a/tests/gluon/test_gluon_autolog.py
+++ b/tests/gluon/test_gluon_autolog.py
@@ -15,7 +15,7 @@ import mlflow.gluon
 from mlflow.tracking.client import MlflowClient
 from mlflow.gluon._autolog import __MLflowGluonCallback
 from mlflow.utils.autologging_utils import BatchMetricsLogger
-from unittest.mock import patch, ANY
+from unittest.mock import patch
 from tests.gluon.utils import is_mxnet_older_than_1_6_0, get_estimator
 
 

--- a/tests/keras/test_keras_autolog.py
+++ b/tests/keras/test_keras_autolog.py
@@ -7,7 +7,7 @@ import mlflow
 import mlflow.keras
 from mlflow.tracking.client import MlflowClient
 from mlflow.utils.autologging_utils import BatchMetricsLogger
-from unittest.mock import patch, ANY
+from unittest.mock import patch
 
 import keras
 

--- a/tests/keras/test_keras_autolog.py
+++ b/tests/keras/test_keras_autolog.py
@@ -5,6 +5,7 @@ from packaging.version import Version
 
 import mlflow
 import mlflow.keras
+from mlflow.tracking.client import MlflowClient
 from mlflow.utils.autologging_utils import BatchMetricsLogger
 from unittest.mock import patch, ANY
 
@@ -407,20 +408,16 @@ def test_fit_generator(random_train_data, random_one_hot_labels):
 
 
 @pytest.mark.large
-@pytest.mark.parametrize("registered_model_name", [None, "model_abc"])
-def test_autolog_registering_model(registered_model_name, random_train_data, random_one_hot_labels):
+def test_autolog_registering_model(random_train_data, random_one_hot_labels):
+    registered_model_name = "test_autolog_registered_model"
     mlflow.keras.autolog(registered_model_name=registered_model_name)
 
     data = random_train_data
     labels = random_one_hot_labels
 
     model = create_model()
-    with patch("mlflow.register_model") as mock_register_model, mlflow.start_run():
+    with mlflow.start_run():
         model.fit(data, labels, epochs=10)
 
-        if registered_model_name is None:
-            mock_register_model.assert_not_called()
-        else:
-            mock_register_model.assert_called_once_with(
-                ANY, registered_model_name, await_registration_for=ANY
-            )
+        registered_model = MlflowClient().get_registered_model(registered_model_name)
+        assert registered_model.name == registered_model_name

--- a/tests/lightgbm/test_lightgbm_autolog.py
+++ b/tests/lightgbm/test_lightgbm_autolog.py
@@ -16,8 +16,9 @@ import mlflow.lightgbm
 from mlflow.lightgbm import _autolog_callback
 from mlflow.models import Model
 from mlflow.models.utils import _read_example
+from mlflow.tracking.client import MlflowClient
 from mlflow.utils.autologging_utils import picklable_exception_safe_function, BatchMetricsLogger
-from unittest.mock import patch, ANY
+from unittest.mock import patch
 
 mpl.use("Agg")
 
@@ -645,35 +646,28 @@ def test_callback_func_is_pickable():
 
 
 @pytest.mark.large
-@pytest.mark.parametrize("registered_model_name", [None, "model_abc"])
-def test_sklearn_api_autolog_registering_model(registered_model_name):
+def test_sklearn_api_autolog_registering_model():
+    registered_model_name = "test_autolog_registered_model"
     mlflow.lightgbm.autolog(registered_model_name=registered_model_name)
 
     X, y = datasets.load_iris(return_X_y=True)
     params = {"n_estimators": 10, "reg_lambda": 1}
     model = lgb.LGBMClassifier(**params)
 
-    with patch("mlflow.register_model") as mock_register_model, mlflow.start_run():
+    with mlflow.start_run():
         model.fit(X, y)
 
-        if registered_model_name is None:
-            mock_register_model.assert_not_called()
-        else:
-            mock_register_model.assert_called_once_with(
-                ANY, registered_model_name, await_registration_for=ANY
-            )
+        registered_model = MlflowClient().get_registered_model(registered_model_name)
+        assert registered_model.name == registered_model_name
 
 
 @pytest.mark.large
-@pytest.mark.parametrize("registered_model_name", [None, "model_abc"])
-def test_lgb_api_autolog_registering_model(registered_model_name, bst_params, train_set):
+def test_lgb_api_autolog_registering_model(bst_params, train_set):
+    registered_model_name = "test_autolog_registered_model"
     mlflow.lightgbm.autolog(registered_model_name=registered_model_name)
 
-    with patch("mlflow.register_model") as mock_register_model, mlflow.start_run():
+    with mlflow.start_run():
         lgb.train(bst_params, train_set, num_boost_round=1)
-        if registered_model_name is None:
-            mock_register_model.assert_not_called()
-        else:
-            mock_register_model.assert_called_once_with(
-                ANY, registered_model_name, await_registration_for=ANY
-            )
+
+        registered_model = MlflowClient().get_registered_model(registered_model_name)
+        assert registered_model.name == registered_model_name

--- a/tests/lightgbm/test_lightgbm_autolog.py
+++ b/tests/lightgbm/test_lightgbm_autolog.py
@@ -677,4 +677,3 @@ def test_lgb_api_autolog_registering_model(registered_model_name, bst_params, tr
             mock_register_model.assert_called_once_with(
                 ANY, registered_model_name, await_registration_for=ANY
             )
-

--- a/tests/lightgbm/test_lightgbm_autolog.py
+++ b/tests/lightgbm/test_lightgbm_autolog.py
@@ -17,7 +17,7 @@ from mlflow.lightgbm import _autolog_callback
 from mlflow.models import Model
 from mlflow.models.utils import _read_example
 from mlflow.utils.autologging_utils import picklable_exception_safe_function, BatchMetricsLogger
-from unittest.mock import patch
+from unittest.mock import patch, ANY
 
 mpl.use("Agg")
 
@@ -642,3 +642,39 @@ def test_callback_func_is_pickable():
         functools.partial(_autolog_callback, BatchMetricsLogger(run_id="1234"), eval_results={})
     )
     pickle.dumps(cb)
+
+
+@pytest.mark.large
+@pytest.mark.parametrize("registered_model_name", [None, "model_abc"])
+def test_sklearn_api_autolog_registering_model(registered_model_name):
+    mlflow.lightgbm.autolog(registered_model_name=registered_model_name)
+
+    X, y = datasets.load_iris(return_X_y=True)
+    params = {"n_estimators": 10, "reg_lambda": 1}
+    model = lgb.LGBMClassifier(**params)
+
+    with patch("mlflow.register_model") as mock_register_model, mlflow.start_run():
+        model.fit(X, y)
+
+        if registered_model_name is None:
+            mock_register_model.assert_not_called()
+        else:
+            mock_register_model.assert_called_once_with(
+                ANY, registered_model_name, await_registration_for=ANY
+            )
+
+
+@pytest.mark.large
+@pytest.mark.parametrize("registered_model_name", [None, "model_abc"])
+def test_lgb_api_autolog_registering_model(registered_model_name, bst_params, train_set):
+    mlflow.lightgbm.autolog(registered_model_name=registered_model_name)
+
+    with patch("mlflow.register_model") as mock_register_model, mlflow.start_run():
+        lgb.train(bst_params, train_set, num_boost_round=1)
+        if registered_model_name is None:
+            mock_register_model.assert_not_called()
+        else:
+            mock_register_model.assert_called_once_with(
+                ANY, registered_model_name, await_registration_for=ANY
+            )
+

--- a/tests/paddle/test_paddle_autolog.py
+++ b/tests/paddle/test_paddle_autolog.py
@@ -2,7 +2,6 @@ import pytest
 import paddle
 import mlflow
 from mlflow.tracking import MlflowClient
-from unittest.mock import patch, ANY
 
 pytestmark = pytest.mark.large
 
@@ -96,15 +95,12 @@ def test_autolog_log_models_configuration(log_models):
 
 
 @pytest.mark.large
-@pytest.mark.parametrize("registered_model_name", [None, "model_abc"])
-def test_autolog_registering_model(registered_model_name):
+def test_autolog_registering_model():
+    registered_model_name = "test_autolog_registered_model"
     mlflow.paddle.autolog(registered_model_name=registered_model_name)
 
-    with patch("mlflow.register_model") as mock_register_model, mlflow.start_run():
+    with mlflow.start_run():
         train_model()
-        if registered_model_name is None:
-            mock_register_model.assert_not_called()
-        else:
-            mock_register_model.assert_called_once_with(
-                ANY, registered_model_name, await_registration_for=ANY
-            )
+
+        registered_model = MlflowClient().get_registered_model(registered_model_name)
+        assert registered_model.name == registered_model_name

--- a/tests/pytorch/test_pytorch_autolog.py
+++ b/tests/pytorch/test_pytorch_autolog.py
@@ -10,6 +10,7 @@ from pytorch_lightning.callbacks import ModelCheckpoint
 from mlflow.utils.file_utils import TempDir
 from iris_data_module import IrisDataModule, IrisDataModuleWithoutValidation
 from mlflow.pytorch._pytorch_autolog import _get_optimizer_name
+from unittest.mock import patch, ANY
 
 NUM_EPOCHS = 20
 
@@ -304,3 +305,22 @@ def test_pytorch_autologging_supports_data_parallel_execution():
     artifacts = list(map(lambda x: x.path, artifacts))
     assert "model" in artifacts
     assert "model_summary.txt" in artifacts
+
+
+@pytest.mark.large
+@pytest.mark.parametrize("registered_model_name", [None, "model_abc"])
+def test_autolog_registering_model(registered_model_name):
+    mlflow.pytorch.autolog(registered_model_name=registered_model_name)
+    model = IrisClassification()
+    dm = IrisDataModule()
+    dm.setup(stage="fit")
+    trainer = pl.Trainer(max_epochs=NUM_EPOCHS)
+
+    with patch("mlflow.register_model") as mock_register_model, mlflow.start_run():
+        trainer.fit(model, dm)
+        if registered_model_name is None:
+            mock_register_model.assert_not_called()
+        else:
+            mock_register_model.assert_called_once_with(
+                ANY, registered_model_name, await_registration_for=ANY
+            )

--- a/tests/pytorch/test_pytorch_autolog.py
+++ b/tests/pytorch/test_pytorch_autolog.py
@@ -10,7 +10,6 @@ from pytorch_lightning.callbacks import ModelCheckpoint
 from mlflow.utils.file_utils import TempDir
 from iris_data_module import IrisDataModule, IrisDataModuleWithoutValidation
 from mlflow.pytorch._pytorch_autolog import _get_optimizer_name
-from unittest.mock import patch
 from mlflow.tracking.client import MlflowClient
 
 NUM_EPOCHS = 20

--- a/tests/spark/autologging/ml/test_pyspark_ml_autologging.py
+++ b/tests/spark/autologging/ml/test_pyspark_ml_autologging.py
@@ -7,7 +7,6 @@ import pytest
 from collections import namedtuple
 from packaging.version import Version
 from unittest import mock
-from unittest.mock import patch, ANY
 
 import mlflow
 from mlflow.entities import RunStatus
@@ -17,6 +16,7 @@ from mlflow.utils.validation import (
     MAX_PARAM_VAL_LENGTH,
     MAX_ENTITY_KEY_LENGTH,
 )
+from mlflow.tracking.client import MlflowClient
 
 import pyspark
 from pyspark.ml import Pipeline
@@ -808,15 +808,12 @@ def test_autologging_handle_wrong_tuning_params(dataset_regression):
 
 
 @pytest.mark.large
-@pytest.mark.parametrize("registered_model_name", [None, "model_abc"])
-def test_autolog_registering_model(registered_model_name, spark_session, dataset_binomial):
+def test_autolog_registering_model(spark_session, dataset_binomial):
+    registered_model_name = "test_autolog_registered_model"
     mlflow.pyspark.ml.autolog(registered_model_name=registered_model_name)
-    with patch("mlflow.register_model") as mock_register_model, mlflow.start_run():
+    with mlflow.start_run():
         lr = LinearRegression()
         lr.fit(dataset_binomial)
-        if registered_model_name is None:
-            mock_register_model.assert_not_called()
-        else:
-            mock_register_model.assert_called_once_with(
-                ANY, registered_model_name, await_registration_for=ANY
-            )
+
+        registered_model = MlflowClient().get_registered_model(registered_model_name)
+        assert registered_model.name == registered_model_name

--- a/tests/spark/autologging/ml/test_pyspark_ml_autologging.py
+++ b/tests/spark/autologging/ml/test_pyspark_ml_autologging.py
@@ -807,6 +807,7 @@ def test_autologging_handle_wrong_tuning_params(dataset_regression):
         pipeline.fit(dataset_regression)
 
 
+# pylint: disable=unused-argument
 @pytest.mark.large
 def test_autolog_registering_model(spark_session, dataset_binomial):
     registered_model_name = "test_autolog_registered_model"

--- a/tests/statsmodels/test_statsmodels_autolog.py
+++ b/tests/statsmodels/test_statsmodels_autolog.py
@@ -5,7 +5,6 @@ from statsmodels.tsa.base.tsa_model import TimeSeriesModel
 import mlflow
 import mlflow.statsmodels
 from mlflow.tracking.client import MlflowClient
-from unittest.mock import patch, ANY
 from tests.statsmodels.model_fixtures import (
     arma_model,
     ols_model,

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -910,6 +910,18 @@ def test_tf_keras_autolog_distributed_training(random_train_data, random_one_hot
 
 
 @pytest.mark.large
+def test_tf_keras_model_autolog_registering_model(random_train_data, random_one_hot_labels):
+    registered_model_name = "test_autolog_registered_model"
+    mlflow.tensorflow.autolog(registered_model_name=registered_model_name)
+    with mlflow.start_run():
+        model = create_tf_keras_model()
+        model.fit(random_train_data, random_one_hot_labels, epochs=10)
+
+        registered_model = MlflowClient().get_registered_model(registered_model_name)
+        assert registered_model.name == registered_model_name
+
+
+@pytest.mark.large
 @pytest.mark.skipif(
     Version(tf.__version__) < Version("2.6.0"),
     reason=("TensorFlow only has a hard dependency on Keras in version >= 2.6.0"),
@@ -975,15 +987,3 @@ def test_import_keras_with_fluent_autolog_enables_tensorflow_autologging():
 
     assert not autologging_is_disabled(mlflow.tensorflow.FLAVOR_NAME)
     assert autologging_is_disabled(mlflow.keras.FLAVOR_NAME)
-
-
-@pytest.mark.large
-def test_tf_keras_model_autolog_registering_model(random_train_data, random_one_hot_labels):
-    registered_model_name = "test_autolog_registered_model"
-    mlflow.tensorflow.autolog(registered_model_name=registered_model_name)
-    with mlflow.start_run():
-        model = create_tf_keras_model()
-        model.fit(random_train_data, random_one_hot_labels, epochs=10)
-
-        registered_model = MlflowClient().get_registered_model(registered_model_name)
-        assert registered_model.name == registered_model_name

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -978,7 +978,9 @@ def test_import_keras_with_fluent_autolog_enables_tensorflow_autologging():
 
 @pytest.mark.large
 @pytest.mark.parametrize("registered_model_name", [None, "model_abc"])
-def test_tf_keras_model_autolog_registering_model(registered_model_name, random_train_data, random_one_hot_labels):
+def test_tf_keras_model_autolog_registering_model(
+    registered_model_name, random_train_data, random_one_hot_labels
+):
     mlflow.tensorflow.autolog(registered_model_name=registered_model_name)
     with patch("mlflow.register_model") as mock_register_model, mlflow.start_run():
         model = create_tf_keras_model()

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -856,6 +856,18 @@ def test_fit_generator(random_train_data, random_one_hot_labels):
 
 
 @pytest.mark.large
+def test_tf_keras_model_autolog_registering_model(random_train_data, random_one_hot_labels):
+    registered_model_name = "test_autolog_registered_model"
+    mlflow.tensorflow.autolog(registered_model_name=registered_model_name)
+    with mlflow.start_run():
+        model = create_tf_keras_model()
+        model.fit(random_train_data, random_one_hot_labels, epochs=10)
+
+        registered_model = MlflowClient().get_registered_model(registered_model_name)
+        assert registered_model.name == registered_model_name
+
+
+@pytest.mark.large
 @pytest.mark.usefixtures("clear_tf_keras_imports")
 def test_fluent_autolog_with_tf_keras_logs_expected_content(
     random_train_data, random_one_hot_labels
@@ -907,18 +919,6 @@ def test_tf_keras_autolog_distributed_training(random_train_data, random_one_hot
         model.fit(random_train_data, random_one_hot_labels, **fit_params)
     client = mlflow.tracking.MlflowClient()
     assert client.get_run(run.info.run_id).data.params.keys() >= fit_params.keys()
-
-
-@pytest.mark.large
-def test_tf_keras_model_autolog_registering_model(random_train_data, random_one_hot_labels):
-    registered_model_name = "test_autolog_registered_model"
-    mlflow.tensorflow.autolog(registered_model_name=registered_model_name)
-    with mlflow.start_run():
-        model = create_tf_keras_model()
-        model.fit(random_train_data, random_one_hot_labels, epochs=10)
-
-        registered_model = MlflowClient().get_registered_model(registered_model_name)
-        assert registered_model.name == registered_model_name
 
 
 @pytest.mark.large

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -10,6 +10,7 @@ from sklearn import datasets
 import xgboost as xgb
 import matplotlib as mpl
 import yaml
+from unittest.mock import patch, ANY
 
 import mlflow
 import mlflow.xgboost
@@ -598,3 +599,39 @@ def test_callback_class_is_pickable():
 
     cb = AutologCallback(BatchMetricsLogger(run_id="1234"), eval_results={})
     pickle.dumps(cb)
+
+
+@pytest.mark.large
+@pytest.mark.parametrize("registered_model_name", [None, "model_abc"])
+def test_sklearn_api_autolog_registering_model(registered_model_name):
+    mlflow.xgboost.autolog(registered_model_name=registered_model_name)
+
+    X, y = datasets.load_iris(return_X_y=True)
+    params = {"n_estimators": 10, "reg_lambda": 1}
+    model = xgb.XGBRegressor(**params)
+
+    with patch("mlflow.register_model") as mock_register_model, mlflow.start_run():
+        model.fit(X, y)
+
+        if registered_model_name is None:
+            mock_register_model.assert_not_called()
+        else:
+            mock_register_model.assert_called_once_with(
+                ANY, registered_model_name, await_registration_for=ANY
+            )
+
+
+@pytest.mark.large
+@pytest.mark.parametrize("registered_model_name", [None, "model_abc"])
+def test_xgb_api_autolog_registering_model(registered_model_name, bst_params, dtrain):
+    mlflow.xgboost.autolog(registered_model_name=registered_model_name)
+
+    with patch("mlflow.register_model") as mock_register_model, mlflow.start_run():
+        xgb.train(bst_params, dtrain)
+        if registered_model_name is None:
+            mock_register_model.assert_not_called()
+        else:
+            mock_register_model.assert_called_once_with(
+                ANY, registered_model_name, await_registration_for=ANY
+            )
+

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -634,4 +634,3 @@ def test_xgb_api_autolog_registering_model(registered_model_name, bst_params, dt
             mock_register_model.assert_called_once_with(
                 ANY, registered_model_name, await_registration_for=ANY
             )
-


### PR DESCRIPTION
Signed-off-by: Weichen Xu <weichen.xu@databricks.com>

## What changes are proposed in this pull request?

Add model registration argument for autolog

## How is this patch tested?

Unit tests.

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add model registration argument for autolog

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
