### PR TITLE
Implement the `predict()` function for SageMaker deployment plugin

### DIFF
--- a/tests/sagemaker/test_sagemaker_deployment_client.py
+++ b/tests/sagemaker/test_sagemaker_deployment_client.py
@@ -2,11 +2,13 @@ import os
 import pytest
 import time
 from collections import namedtuple
+from io import BytesIO
 from unittest import mock
 
 import boto3
 import botocore
 import numpy as np
+import pandas as pd
 from click.testing import CliRunner
 from sklearn.linear_model import LogisticRegression
 
@@ -1296,15 +1298,14 @@ def test_deploy_cli_list_sagemaker_deployments(pretrained_model, sagemaker_clien
 
 
 @mock_sagemaker_aws_services
-def test_predict(sagemaker_deployment_client):
-    import pandas as pd
-    from io import BytesIO
-
+def test_predict_with_dataframe_input_output(sagemaker_deployment_client):
+    output_df = pd.DataFrame({1: ["2", ".", "3"]})
     boto_caller = botocore.client.BaseClient._make_api_call
 
     def mock_invoke_endpoint(self, operation_name, operation_kwargs):
         if operation_name == "InvokeEndpoint":
-            result = dict(Body=BytesIO(b"[1.23]"))
+            output_json = output_df.to_json(orient="split")
+            result = dict(Body=BytesIO(bytes(output_json, encoding='utf-8')))
         else:
             result = boto_caller(self, operation_name, operation_kwargs)
         return result
@@ -1315,4 +1316,22 @@ def test_predict(sagemaker_deployment_client):
         result = sagemaker_deployment_client.predict("test", df)
 
         assert isinstance(result, pd.DataFrame)
-        assert list(result[0]) == [1.23]
+        assert result.equals(output_df)
+
+
+@mock_sagemaker_aws_services
+def test_predict_with_array_input_output(sagemaker_deployment_client):
+    boto_caller = botocore.client.BaseClient._make_api_call
+
+    def mock_invoke_endpoint(self, operation_name, operation_kwargs):
+        if operation_name == "InvokeEndpoint":
+            result = dict(Body=BytesIO(b'[1,2,3]'))
+        else:
+            result = boto_caller(self, operation_name, operation_kwargs)
+        return result
+
+    with mock.patch("botocore.client.BaseClient._make_api_call", new=mock_invoke_endpoint):
+        result = sagemaker_deployment_client.predict("test", np.array(range(10)))
+
+        assert isinstance(result, pd.DataFrame)
+        assert list(result[0]) == [1, 2, 3]

--- a/tests/sagemaker/test_sagemaker_deployment_client.py
+++ b/tests/sagemaker/test_sagemaker_deployment_client.py
@@ -1305,7 +1305,7 @@ def test_predict_with_dataframe_input_output(sagemaker_deployment_client):
     def mock_invoke_endpoint(self, operation_name, operation_kwargs):
         if operation_name == "InvokeEndpoint":
             output_json = output_df.to_json(orient="split")
-            result = dict(Body=BytesIO(bytes(output_json, encoding='utf-8')))
+            result = dict(Body=BytesIO(bytes(output_json, encoding="utf-8")))
         else:
             result = boto_caller(self, operation_name, operation_kwargs)
         return result
@@ -1325,7 +1325,7 @@ def test_predict_with_array_input_output(sagemaker_deployment_client):
 
     def mock_invoke_endpoint(self, operation_name, operation_kwargs):
         if operation_name == "InvokeEndpoint":
-            result = dict(Body=BytesIO(b'[1,2,3]'))
+            result = dict(Body=BytesIO(b"[1,2,3]"))
         else:
             result = boto_caller(self, operation_name, operation_kwargs)
         return result


### PR DESCRIPTION
Signed-off-by: James Tran <tran.james2001@gmail.com>

## What changes are proposed in this pull request?

Implement the `predict()` function for SageMaker deployment plugin. A prediction can be obtained through Python code or `mlflow deployments predict` command. For example:

```bash
cat > ./input.json <<- input
{"feat1": {"0": 1}, "feat2": {"0": 2}, "feat3": {"0": 3}}
input

mlflow deployments predict \\
    --target sagemaker:/us-east-1/arn:aws:1234:role/assumed_role \\
    --name my-deployment \\
    --input-path ./input.json
```

## How is this patch tested?

I have added a unit test and tested the CLI manually using a scikit-learn model.

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Implement the `predict()` function for SageMaker deployment plugin. A prediction can be obtained through Python code or `mlflow deployments predict` command.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [x] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
