### PR TITLE
Fix XGBoost autologging for metrics with @

### DIFF
--- a/mlflow/xgboost/_autolog.py
+++ b/mlflow/xgboost/_autolog.py
@@ -6,9 +6,15 @@ import xgboost
 from mlflow.utils.autologging_utils import ExceptionSafeAbstractClass
 
 
+def _patch_metric_names(metric_dict):
+    # XGBoost provides some metrics with "@", e.g. "ndcg@3" that are not valid MLflow metric names
+    return {metric_name.replace("@", "_at_"): value for metric_name, value in metric_dict.items()}
+
+
 def autolog_callback(env, metrics_logger, eval_results):
-    metrics_logger.record_metrics(dict(env.evaluation_result_list), env.iteration)
-    eval_results.append(dict(env.evaluation_result_list))
+    metric_dict = _patch_metric_names(dict(env.evaluation_result_list))
+    metrics_logger.record_metrics(metric_dict, env.iteration)
+    eval_results.append(metric_dict)
 
 
 IS_TRAINING_CALLBACK_SUPPORTED = Version(xgboost.__version__.replace("SNAPSHOT", "dev")) >= Version(
@@ -41,9 +47,8 @@ if IS_TRAINING_CALLBACK_SUPPORTED:
             # }
             evaluation_result_dict = {}
             for data_name, metric_dict in evals_log.items():
+                metric_dict = _patch_metric_names(metric_dict)
                 for metric_name, metric_values_on_each_iter in metric_dict.items():
-                    # XGBoost provides some metrics with "@", e.g. "ndcg@3"
-                    metric_name = metric_name.replace("@", "_at_")
                     key = "{}-{}".format(data_name, metric_name)
                     # The last element in `metric_values_on_each_iter` corresponds to
                     # the metric on the current iteration

--- a/mlflow/xgboost/_autolog.py
+++ b/mlflow/xgboost/_autolog.py
@@ -42,9 +42,11 @@ if IS_TRAINING_CALLBACK_SUPPORTED:
             evaluation_result_dict = {}
             for data_name, metric_dict in evals_log.items():
                 for metric_name, metric_values_on_each_iter in metric_dict.items():
+                    # XGBoost provides some metrics with "@", e.g. "ndcg@3"
+                    metric_name = metric_name.replace("@", "_at_")
                     key = "{}-{}".format(data_name, metric_name)
                     # The last element in `metric_values_on_each_iter` corresponds to
-                    # the meric on the current iteration
+                    # the metric on the current iteration
                     evaluation_result_dict[key] = metric_values_on_each_iter[-1]
 
             self.metrics_logger.record_metrics(evaluation_result_dict, epoch)

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -142,6 +142,19 @@ def test_xgb_autolog_logs_specified_params(bst_params, dtrain):
 
 
 @pytest.mark.large
+def test_xgb_autolog_atsign_metrics():
+    mlflow.xgboost.autolog()
+    xgb_metrics = ["ndcg@2", "map@3-", "error@0.4"]
+    expected_metrics = {"train-ndcg_at_2", "train-map_at_3-", "train-error_at_0.4"}
+
+    params = {"objective": "rank:pairwise", "eval_metric": xgb_metrics}
+    dtrain = xgb.DMatrix(np.array([[0], [1]]), label=[1, 0])
+    xgb.train(params, dtrain, evals=[(dtrain, "train")], num_boost_round=1)
+    run = get_latest_run()
+    assert set(run.data.metrics) == expected_metrics
+
+
+@pytest.mark.large
 def test_xgb_autolog_sklearn():
 
     mlflow.xgboost.autolog()


### PR DESCRIPTION
Signed-off-by: Max Friedrich <max.friedrich@new-work.se>

## What changes are proposed in this pull request?

Fix #5391: replace `"@"` with `"_at_"` in XGBoost metric names to support all XGBoost metrics

## How is this patch tested?

Added my example from #5391 as a test case

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Not sure if this is worth mentioning in the release notes, feel free to edit this PR description and remove the section!)

XGBoost autologging: Support XGBoost metrics with "@" in the name like `"ndcg@2"` by renaming to `"ndcg_at_2"`

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
