### PR TITLE
Fix ListArtifacts and get-artifact compatibility errors with proxied artifacts

### DIFF
--- a/examples/mlflow_artifacts/Dockerfile
+++ b/examples/mlflow_artifacts/Dockerfile
@@ -3,4 +3,4 @@ FROM python:3.7
 WORKDIR /app
 
 # Install mlflow and packages requied to interact with PostgreSQL and MinIO
-RUN pip install mlflow psycopg2 boto3
+RUN pip install psycopg2 boto3 git+https://www.github.com/mlflow/mlflow@proxy-artifact-access-fix

--- a/examples/mlflow_artifacts/Dockerfile
+++ b/examples/mlflow_artifacts/Dockerfile
@@ -3,4 +3,4 @@ FROM python:3.7
 WORKDIR /app
 
 # Install mlflow and packages requied to interact with PostgreSQL and MinIO
-RUN pip install psycopg2 boto3 git+https://www.github.com/mlflow/mlflow@proxy-artifact-access-fix
+RUN pip install mlflow psycopg2 boto3

--- a/examples/mlflow_artifacts/example.py
+++ b/examples/mlflow_artifacts/example.py
@@ -21,7 +21,7 @@ def main():
     with mlflow.start_run() as run, tempfile.TemporaryDirectory() as tmp_dir:
         tmp_path_a = os.path.join(tmp_dir, "a.txt")
         save_text(tmp_path_a, "0")
-        tmp_sub_dir = tmp_path_b = os.path.join(tmp_dir, "dir")
+        tmp_sub_dir = os.path.join(tmp_dir, "dir")
         os.makedirs(tmp_sub_dir)
         tmp_path_b = os.path.join(tmp_sub_dir, "b.txt")
         save_text(tmp_path_b, "1")

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -193,8 +193,8 @@ def _is_servable_proxied_run_artifact_root(run_artifact_root):
     # location. Such failures can be remediated by granting the original MLflow server access to
     # Location B.
     return (
-        parsed_run_artifact_root.scheme in ["http", "https", "mlflow-artifacts"] and
-        _is_serving_artifacts()
+        parsed_run_artifact_root.scheme in ["http", "https", "mlflow-artifacts"]
+        and _is_serving_artifacts()
     )
 
 
@@ -399,7 +399,7 @@ def get_artifact_handler():
     else:
         artifact_repo = _get_artifact_repo(run)
         artifact_path = request_dict["path"]
-        
+
     return _send_artifact(artifact_repo, artifact_path)
 
 
@@ -698,7 +698,7 @@ def _list_artifacts_for_proxied_run_artifact_root(proxied_artifact_root, relativ
         relative_path=relative_path,
     )
 
-    artifact_entities  = []
+    artifact_entities = []
     for file_info in artifact_destination_repo.list_artifacts(artifact_destination_path):
         basename = posixpath.basename(file_info.path)
         artifact_path = posixpath.join(relative_path, basename) if relative_path else basename

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -1013,7 +1013,7 @@ def _list_artifacts_mlflow_artifacts():
     artifact_repo = _get_artifact_repo_mlflow_artifacts()
     _run_root_path = _get_run_root_path()
 
-    if isinstance(_run_root_path, str):
+    if _run_root_path and isinstance(_run_root_path, str):
         path = _insert_run_path_mlflow_artifacts_uri(_run_root_path, path)
     else:
         root_path = os.environ.get(ARTIFACTS_DESTINATION_ENV_VAR)
@@ -1081,7 +1081,7 @@ def _get_run_root_path():
             _, path = core_path.path.split("mlartifacts", 1)
     else:
         path = ""
-    return path.lstrip("/")
+    return path.lstrip("/").lstrip("\\").lstrip("\\\\")
 
 
 def _add_static_prefix(route):

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -147,8 +147,8 @@ def _get_artifact_repo_mlflow_artifacts():
 
 def _get_serve_artifacts_mode():
     """
-    Set whether the MLflow server is operating in ``--serve-artifacts`` mode for artifact listing
-    endpoint resolution.
+    Initializes ``_serve_artifacts_mode`` that indicates whether the MLflow server is operating in
+    ``-serve_artifacts`` mode for artifact listing and returns the value.
     """
     from mlflow.server import SERVE_ARTIFACTS_ENV_VAR
 
@@ -633,7 +633,6 @@ def _list_experiments():
 
 
 @catch_mlflow_exception
-@_disable_if_artifacts_only
 def _get_artifact_repo(run):
     return get_artifact_repository(run.info.artifact_uri)
 

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -146,10 +146,10 @@ def _get_artifact_repo_mlflow_artifacts():
     return _artifact_repo
 
 
-def _is_serving_artifacts():
+def _is_serving_proxied_artifacts():
     """
-    :return: ``True`` if the MLflow server is serving artifacts (i.e. acting as a proxy for artifact
-             upload / download / list operations), as would be enabled by specifying the
+    :return: ``True`` if the MLflow server is serving proxied artifacts (i.e. acting as a proxy for
+             artifact upload / download / list operations), as would be enabled by specifying the
              ``--serve-artifacts`` configuration option. ``False`` otherwise.
     """
     from mlflow.server import SERVE_ARTIFACTS_ENV_VAR
@@ -192,7 +192,7 @@ def _is_servable_proxied_run_artifact_root(run_artifact_root):
     # Location B.
     return (
         parsed_run_artifact_root.scheme in ["http", "https", "mlflow-artifacts"]
-        and _is_serving_artifacts()
+        and _is_serving_proxied_artifacts()
     )
 
 
@@ -357,7 +357,7 @@ _TEXT_EXTENSIONS = [
 def _disable_unless_serve_artifacts(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
-        if not _is_serving_artifacts():
+        if not _is_serving_proxied_artifacts():
             return Response(
                 (
                     f"Endpoint: {request.url_rule} disabled due to the mlflow server running "

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -74,9 +74,6 @@ from mlflow.protos.mlflow_artifacts_pb2 import (
 )
 from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST, INVALID_PARAMETER_VALUE
 from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
-from mlflow.store.artifact.http_artifact_repo import HttpArtifactRepository
-from mlflow.store.artifact.mlflow_artifacts_repo import MlflowArtifactsRepository
-from mlflow.store.artifact.local_artifact_repo import LocalArtifactRepository
 from mlflow.store.db.db_types import DATABASE_ENGINES
 from mlflow.tracking._model_registry.registry import ModelRegistryStoreRegistry
 from mlflow.tracking._tracking_service.registry import TrackingStoreRegistry

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -1074,14 +1074,14 @@ def _get_run_root_path():
         artifact_uri = run.info.artifact_uri
         core_path = urllib.parse.urlparse(artifact_uri)
         if core_path.scheme.startswith("http"):
-            _, path = core_path.path.split("mlflow-artifacts/artifacts/", 1)
+            _, _, path = core_path.path.split("artifacts", 2)
         elif core_path.scheme.startswith("mlflow-artifacts"):
-            path = core_path.path.lstrip("/")
+            path = core_path.path
         else:
-            _, path = core_path.path.split("mlartifacts/", 1)
+            _, path = core_path.path.split("mlartifacts", 1)
     else:
-        path = None
-    return path
+        path = ""
+    return path.lstrip("/")
 
 
 def _add_static_prefix(route):

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -708,9 +708,7 @@ def _list_artifacts_for_proxied_run_artifact_root(proxied_artifact_root, relativ
     for file_info in artifact_destination_repo.list_artifacts(artifact_destination_path):
         basename = posixpath.basename(file_info.path)
         run_relative_artifact_path = (
-            posixpath.join(relative_path, basename)
-            if relative_path
-            else basename
+            posixpath.join(relative_path, basename) if relative_path else basename
         )
         artifact_entities.append(
             FileInfo(run_relative_artifact_path, file_info.is_dir, file_info.file_size)

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -4,9 +4,7 @@ import os
 import re
 import tempfile
 import posixpath
-import pathlib
 import urllib
-import uuid
 
 import logging
 from functools import wraps

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -710,8 +710,14 @@ def _list_artifacts_for_proxied_run_artifact_root(proxied_artifact_root, relativ
     artifact_entities = []
     for file_info in artifact_destination_repo.list_artifacts(artifact_destination_path):
         basename = posixpath.basename(file_info.path)
-        artifact_path = posixpath.join(relative_path, basename) if relative_path else basename
-        artifact_entities.append(FileInfo(artifact_path, file_info.is_dir, file_info.file_size))
+        run_relative_artifact_path = (
+            posixpath.join(relative_path, basename)
+            if relative_path
+            else basename
+        )
+        artifact_entities.append(
+            FileInfo(run_relative_artifact_path, file_info.is_dir, file_info.file_size)
+        )
 
     return artifact_entities
 

--- a/mlflow/store/artifact/artifact_repository_registry.py
+++ b/mlflow/store/artifact/artifact_repository_registry.py
@@ -54,9 +54,9 @@ class ArtifactRepositoryRegistry:
     def get_artifact_repository(self, artifact_uri):
         """Get an artifact repository from the registry based on the scheme of artifact_uri
 
-        :param store_uri: The store URI. This URI is used to select which artifact repository
-                          implementation to instantiate and is passed to the
-                          constructor of the implementation.
+        :param artifact_uri: The artifact store URI. This URI is used to select which artifact
+                             repository implementation to instantiate and is passed to the
+                             constructor of the implementation.
 
         :return: An instance of `mlflow.store.ArtifactRepository` that fulfills the artifact URI
                  requirements.
@@ -97,9 +97,9 @@ _artifact_repository_registry.register_entrypoints()
 def get_artifact_repository(artifact_uri):
     """Get an artifact repository from the registry based on the scheme of artifact_uri
 
-    :param store_uri: The store URI. This URI is used to select which artifact repository
-                      implementation to instantiate and is passed to the
-                      constructor of the implementation.
+    :param artifact_uri: The artifact store URI. This URI is used to select which artifact
+                         repository implementation to instantiate and is passed to the
+                         constructor of the implementation.
 
     :return: An instance of `mlflow.store.ArtifactRepository` that fulfills the artifact URI
              requirements.

--- a/tests/tracking/test_mlflow_artifacts.py
+++ b/tests/tracking/test_mlflow_artifacts.py
@@ -272,22 +272,32 @@ def test_mlflow_artifacts_rest_api_list_artifacts(artifacts_server, tmpdir):
 
     client = mlflow.tracking.MlflowClient()
     experiment = client.get_experiment_by_name(name)
-    exp_id = experiment.experiment_id
-    run_id = client.list_run_infos(experiment.experiment_id)[0].run_id
-    artifacts = get_artifacts_from_rest_api(api, run_id)
-    assert len(artifacts) >= 1
-    artifacts_base = get_artifacts_from_rest_api(api, run_id, exp_id)
-    artifacts_path = f"{exp_id}/{artifacts_base['files'][0]['path']}/artifacts"
+    run = client.list_run_infos(experiment.experiment_id)
+    run_id = run[0].run_id
 
-    artifacts_contents = get_artifacts_from_rest_api(api, run_id, f"{artifacts_path}")
+    print("DIRECT API ARTIFACTS: ")
+    print(client.list_artifacts(run_id))
+    print(client.list_artifacts(run_id, "dir"))
+    print("END OF DIRECT API ARTIFACTS")
+
+    print(f"\n\n RUN_INFO: \n{run}")
+    print(f"\n\n RUN_ID: \n{run_id}")
+    artifacts = get_artifacts_from_rest_api(api, run_id)
+    print(f"\nARTIFACTS: \n {artifacts}")
+
+    assert len(artifacts) >= 1
+
     expected_contents = {
         "files": [
             {"path": "a.txt", "is_dir": False, "file_size": 1},
             {"path": "dir", "is_dir": True},
         ]
     }
-    assert artifacts_contents == expected_contents
+    assert artifacts == expected_contents
 
-    nested_contents = get_artifacts_from_rest_api(api, run_id, f"{artifacts_path}/dir")
+    nested_contents = get_artifacts_from_rest_api(api, run_id, "dir")
+
+    print(f"\n\n NESTED_CONTENTS: {nested_contents}\n\n")
+
     expected_nested = {"files": [{"path": "b.txt", "is_dir": False, "file_size": 1}]}
     assert nested_contents == expected_nested

--- a/tests/tracking/test_mlflow_artifacts.py
+++ b/tests/tracking/test_mlflow_artifacts.py
@@ -5,7 +5,6 @@ import tempfile
 import requests
 import pathlib
 import pytest
-import json
 
 import mlflow
 from tests.helper_functions import LOCALHOST, get_safe_port
@@ -253,8 +252,8 @@ def get_artifacts_from_rest_api(url, run_id, path=None):
         resp = requests.get(url, params={"run_id": run_id, "path": path})
     else:
         resp = requests.get(url, params={"run_id": run_id})
-    assert resp.status_code == 200
-    return json.loads(resp.content.decode("utf-8"))
+    resp.raise_for_status()
+    return resp.json()
 
 
 def test_mlflow_artifacts_rest_api_list_artifacts(artifacts_server, tmpdir):

--- a/tests/tracking/test_mlflow_artifacts.py
+++ b/tests/tracking/test_mlflow_artifacts.py
@@ -248,7 +248,6 @@ docker-compose down {rmi_option} --volumes --remove-orphans
 
 
 def test_rest_tracking_api_list_artifacts_with_proxied_artifacts(artifacts_server, tmpdir):
-
     def list_artifacts_via_rest_api(url, run_id, path=None):
         if path:
             resp = requests.get(url, params={"run_id": run_id, "path": path})
@@ -277,7 +276,9 @@ def test_rest_tracking_api_list_artifacts_with_proxied_artifacts(artifacts_serve
     ]
     assert list_artifacts_response.get("root_uri") == run.info.artifact_uri
 
-    nested_list_artifacts_response = list_artifacts_via_rest_api(url=api, run_id=run.info.run_id, path="dir")
+    nested_list_artifacts_response = list_artifacts_via_rest_api(
+        url=api, run_id=run.info.run_id, path="dir"
+    )
     assert nested_list_artifacts_response.get("files") == [
         {"path": "dir/b.txt", "is_dir": False, "file_size": 1},
     ]
@@ -294,6 +295,8 @@ def test_rest_get_artifact_api_proxied_with_artifacts(artifacts_server, tmpdir):
     with mlflow.start_run() as run:
         mlflow.log_artifact(tmp_path_a)
 
-    get_artifact_response = requests.get(url=f"{url}/get-artifact", params={"run_id": run.info.run_id, "path": "a.txt"})
+    get_artifact_response = requests.get(
+        url=f"{url}/get-artifact", params={"run_id": run.info.run_id, "path": "a.txt"}
+    )
     get_artifact_response.raise_for_status()
     assert get_artifact_response.text == "abcdefg"

--- a/tests/tracking/test_mlflow_artifacts.py
+++ b/tests/tracking/test_mlflow_artifacts.py
@@ -274,19 +274,8 @@ def test_mlflow_artifacts_rest_api_list_artifacts(artifacts_server, tmpdir):
     experiment = client.get_experiment_by_name(name)
     run = client.list_run_infos(experiment.experiment_id)
     run_id = run[0].run_id
-
-    print("DIRECT API ARTIFACTS: ")
-    print(client.list_artifacts(run_id))
-    print(client.list_artifacts(run_id, "dir"))
-    print("END OF DIRECT API ARTIFACTS")
-
-    print(f"\n\n RUN_INFO: \n{run}")
-    print(f"\n\n RUN_ID: \n{run_id}")
     artifacts = get_artifacts_from_rest_api(api, run_id)
-    print(f"\nARTIFACTS: \n {artifacts}")
-
     assert len(artifacts) >= 1
-
     expected_contents = {
         "files": [
             {"path": "a.txt", "is_dir": False, "file_size": 1},
@@ -294,10 +283,6 @@ def test_mlflow_artifacts_rest_api_list_artifacts(artifacts_server, tmpdir):
         ]
     }
     assert artifacts == expected_contents
-
     nested_contents = get_artifacts_from_rest_api(api, run_id, "dir")
-
-    print(f"\n\n NESTED_CONTENTS: {nested_contents}\n\n")
-
     expected_nested = {"files": [{"path": "b.txt", "is_dir": False, "file_size": 1}]}
     assert nested_contents == expected_nested


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix ListArtifacts and get-artifact compatibility errors with proxied artifacts. Addresses #5377.

## How is this patch tested?

- Unit tests
- Manual tests conducted via the MLflow UI (artifact listing and downloading from the artifact viewer for HTTP, `mlflow-artifacts`, and non-proxied - e.g. `/tmp/mylocaldirectory` routes)

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

Fix listing and downloading of artifacts from the MLflow UI when the MLflow server is operating in `--serve-artifacts` mode.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [X] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
