### PR TITLE
Adding support for multiclass models or models returning multiple probabilities in fastai and the pyfunc flavor

### DIFF
--- a/mlflow/fastai/__init__.py
+++ b/mlflow/fastai/__init__.py
@@ -317,7 +317,7 @@ class _FastaiModelWrapper:
     def predict(self, dataframe):
         dl = self.learner.dls.test_dl(dataframe)
         preds, _ = self.learner.get_preds(dl=dl)
-        return pd.DataFrame(map(np.array, preds.numpy()), columns=["predictions"])
+        return pd.Series(map(np.array, preds.numpy())).to_frame("predictions")
 
 
 def _load_pyfunc(path):
@@ -380,7 +380,6 @@ def autolog(
     exclusive=False,
     disable_for_unsupported_versions=False,
     silent=False,
-    registered_model_name=None,
 ):  # pylint: disable=unused-argument
     """
     Enable automatic logging from Fastai to MLflow.
@@ -405,9 +404,6 @@ def autolog(
     :param silent: If ``True``, suppress all event logs and warnings from MLflow during Fastai
                    autologging. If ``False``, show all events and warnings during Fastai
                    autologging.
-    :param registered_model_name: If given, each time a model is trained, it is registered as a
-                                  new model version of the registered model with this name.
-                                  The registered model is created if it does not already exist.
 
     .. code-block:: python
         :caption: Example

--- a/mlflow/fastai/__init__.py
+++ b/mlflow/fastai/__init__.py
@@ -380,6 +380,7 @@ def autolog(
     exclusive=False,
     disable_for_unsupported_versions=False,
     silent=False,
+    registered_model_name=None,
 ):  # pylint: disable=unused-argument
     """
     Enable automatic logging from Fastai to MLflow.
@@ -404,6 +405,9 @@ def autolog(
     :param silent: If ``True``, suppress all event logs and warnings from MLflow during Fastai
                    autologging. If ``False``, show all events and warnings during Fastai
                    autologging.
+    :param registered_model_name: If given, each time a model is trained, it is registered as a
+                                  new model version of the registered model with this name.
+                                  The registered model is created if it does not already exist.
 
     .. code-block:: python
         :caption: Example


### PR DESCRIPTION
Adding support for multiclass models or models returning multiple probabilities in `fastai` and the `pyfunc` flavor.

## What changes are proposed in this pull request?

- In a model created with `fastai` and loaded using the `pyfunc`, the `predict` implementation returns a single column called "predictions". However, if the model returns multiple classes probabilities, then an exception is raise because the implementation tries to build a `pd.DataFrame` that has multiple columns but indicating only one column index ("predictions"). The change proposed will comply with existing implementation of returning 1 single column, named `predictions`, but if multiple values are returned by the model then they will be packed in an array.

![image](https://user-images.githubusercontent.com/32112894/155761980-4a8724da-0139-45ed-a686-3ed9c6575d9d.png)

## How is this patch tested?

The implementation of `class _FastaiModelWrapper` has been changed. Concretely the method `predict` to use a `pd.Series` instead of a `pd.DataFrame` which will try to parse all the structure of the passed data. `pd.Series`, on the other hand, will try to keep all the passed data in a single column.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
