### PR TITLE
Prototype restoring model dependencies for `pyfunc.load_model` and `pyfunc.spark_udf`

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1103,7 +1103,7 @@ def _create_symlink(src, dst):
         pass
 
 
-def spark_udf(spark, model_uri, result_type="double", restore_env=False):
+def spark_udf(spark, model_uri, result_type="double"):
     """
     A Spark UDF that can be used to invoke the Python function formatted model.
 

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -853,7 +853,7 @@ class PyFuncModelWithRestoredPythonEnv(PyFuncModel):
         if isinstance(received_data[0], (np.ndarray, list)):
             result = np.concatenate(received_data)
         elif isinstance(received_data[0], (pd.DataFrame, pd.Series)):
-            result = pd.concat(received_data, axis=0)
+            result = pd.concat(received_data, axis=0, ignore_index=True)
         else:
             raise RuntimeError('Unknown result data type.')
 

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1119,11 +1119,11 @@ def spark_udf(spark, model_uri, result_type="double"):
         )
         # Assume spark executor python environment is the same with spark driver side.
         _warn_dependency_requirement_mismatches(local_model_path)
-        archive_path = SparkModelCache.add_local_model(spark, local_model_path)
+        model_cache_key = SparkModelCache.add_local_model(local_model_path)
         model_metadata = Model.load(os.path.join(local_model_path, MLMODEL_FILE_NAME))
 
     def predict(*args):
-        model = SparkModelCache.get_or_load(archive_path)
+        model = SparkModelCache.get_or_load(model_cache_key)
         input_schema = model.metadata.get_input_schema()
         pdf = None
 

--- a/mlflow/pyfunc/restored_python_env_model_infer_subproc.py
+++ b/mlflow/pyfunc/restored_python_env_model_infer_subproc.py
@@ -1,10 +1,10 @@
 import socket
 import sys
 import importlib
-from mlflow.pyfunc import _PICKLE_PROTOCOL_FOR_RESTORE_PY_ENV
 import argparse
 import pickle
 
+_PICKLE_PROTOCOL_FOR_RESTORE_PY_ENV = 3
 
 if __name__ == "__main__":
     sys.stdin.close()  # for safety, close it.

--- a/mlflow/pyfunc/restored_python_env_model_infer_subproc.py
+++ b/mlflow/pyfunc/restored_python_env_model_infer_subproc.py
@@ -1,0 +1,42 @@
+import socket
+import sys
+import importlib
+from mlflow.pyfunc import _PICKLE_PROTOCOL_FOR_RESTORE_PY_ENV
+import argparse
+import pickle
+
+
+if __name__ == "__main__":
+    sys.stdin.close()  # for safety, close it.
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--server_port', type=int)
+    parser.add_argument('--loader_module', type=str)
+    parser.add_argument('--model_path', type=str)
+
+    args = parser.parse_args()
+
+    model_impl = importlib.import_module(args.loader_module)._load_pyfunc(args.model_path)
+
+    sock = socket.socket()
+    try:
+        sock.connect(('127.0.0.1', args.server_port))
+        comm_stream = sock.makefile('rwb')
+
+        while True:
+            batch = pickle.load(comm_stream)
+            if batch is None:
+                break
+
+            # TODO: pipeline IO and inference computation
+            infer_result_batch = model_impl.predict(batch)
+            print('subproc predict batch done.')
+            pickle.dump(infer_result_batch, comm_stream, protocol=_PICKLE_PROTOCOL_FOR_RESTORE_PY_ENV)
+            comm_stream.flush()
+
+        # write a None object as the data end signal.
+        pickle.dump(None, comm_stream, protocol=_PICKLE_PROTOCOL_FOR_RESTORE_PY_ENV)
+        comm_stream.flush()
+    finally:
+        comm_stream.close()
+        sock.shutdown(socket.SHUT_RDWR)
+        sock.close()

--- a/mlflow/pyfunc/spark_model_cache.py
+++ b/mlflow/pyfunc/spark_model_cache.py
@@ -4,7 +4,6 @@ import tempfile
 import zipfile
 
 from mlflow.utils._spark_utils import _SparkBroadcastFileCache
-from pyspark.files import SparkFiles
 
 
 # TODO: For databricks runtime, use NFS instead of spark files for distributing model to remote workers.
@@ -32,6 +31,7 @@ class SparkModelCache:
         """Given a model_path which refers to a pyfunc directory locally,
         we will zip the directory up, enable it to be distributed to executors.
         This method must be called from spark driver side.
+        return a cache key for the model_path
         """
         model_path = os.path.normpath(model_path)
         _, archive_basepath = tempfile.mkstemp()
@@ -40,8 +40,8 @@ class SparkModelCache:
     @staticmethod
     def get_or_load(cache_key):
         """
-        Given a model_path used in `add_local_model`, this method will return the loaded model.
-        This method can be called from spark UDF routine.
+        Given a cache key returned by `add_local_model`, this method will return the loaded model.
+        This method can be called from either spark UDF routine or driver side.
         """
         if cache_key in SparkModelCache._models:
             SparkModelCache._cache_hits += 1

--- a/mlflow/pyfunc/spark_model_cache.py
+++ b/mlflow/pyfunc/spark_model_cache.py
@@ -3,7 +3,7 @@ import shutil
 import tempfile
 import zipfile
 
-from mlflow.utils._spark_utils import _add_spark_cache_file
+from mlflow.utils._spark_utils import _SparkBroadcastFileCache
 from pyspark.files import SparkFiles
 
 
@@ -28,36 +28,30 @@ class SparkModelCache:
         pass
 
     @staticmethod
-    def add_local_model(spark, model_path):
-        """Given a SparkSession and a model_path which refers to a pyfunc directory locally,
-        we will zip the directory up, enable it to be distributed to executors, and return
-        the "archive_path", which should be used as the path in get_or_load().
+    def add_local_model(model_path):
+        """Given a model_path which refers to a pyfunc directory locally,
+        we will zip the directory up, enable it to be distributed to executors.
+        This method must be called from spark driver side.
         """
+        model_path = os.path.normpath(model_path)
         _, archive_basepath = tempfile.mkstemp()
-        # NB: We must archive the directory as Spark.addFile does not support non-DFS
-        # directories when recursive=True.
-        archive_path = shutil.make_archive(archive_basepath, "zip", model_path)
-        _add_spark_cache_file(spark, archive_path)
-        return archive_path
+        return _SparkBroadcastFileCache.add_file(model_path)
 
     @staticmethod
-    def get_or_load(archive_path):
-        """Given a path returned by add_local_model(), this method will return the loaded model.
-        If this Python process ever loaded the model before, we will reuse that copy.
+    def get_or_load(cache_key):
         """
-        if archive_path in SparkModelCache._models:
+        Given a model_path used in `add_local_model`, this method will return the loaded model.
+        This method can be called from spark UDF routine.
+        """
+        if cache_key in SparkModelCache._models:
             SparkModelCache._cache_hits += 1
-            return SparkModelCache._models[archive_path]
+            return SparkModelCache._models[cache_key]
 
-        # BUG: Despite the documentation of SparkContext.addFile() and SparkFiles.get() in Scala
-        # and Python, it turns out that we actually need to use the basename as the input to
-        # SparkFiles.get(), as opposed to the (absolute) path.
-        archive_path_basename = os.path.basename(archive_path)
-        local_path = SparkFiles.get(archive_path_basename)
+        local_path = _SparkBroadcastFileCache.get_file(cache_key)
 
         # We must rely on a supposed cyclic import here because we want this behavior
         # on the Spark Executors (i.e., don't try to pickle the load_model function).
         from mlflow.pyfunc import load_pyfunc  # pylint: disable=cyclic-import
 
-        SparkModelCache._models[archive_path] = load_pyfunc(local_path)
-        return SparkModelCache._models[archive_path]
+        SparkModelCache._models[cache_key] = load_pyfunc(local_path)
+        return SparkModelCache._models[cache_key]

--- a/mlflow/utils/__init__.py
+++ b/mlflow/utils/__init__.py
@@ -1,6 +1,8 @@
 import logging
 from itertools import islice
 from sys import version_info
+import struct
+import hashlib
 
 
 _logger = logging.getLogger(__name__)
@@ -172,3 +174,31 @@ def _inspect_original_var_name(var, fallback_name):
 
     except Exception:
         return fallback_name
+
+
+def read_long_from_stream(stream):
+    length = stream.read(8)
+    if not length:
+        raise EOFError
+    return struct.unpack("!q", length)[0]
+
+
+def write_long_to_stream(value, stream):
+    stream.write(struct.pack("!q", value))
+
+
+def read_data_from_stream(stream):
+    data_len = read_long_from_stream(stream)
+    return stream.read(data_len)
+
+
+def write_data_to_stream(data_in_bytes, stream):
+    write_long_to_stream(len(data_in_bytes), stream)
+    stream.write(data_in_bytes)
+
+
+def get_file_sha_hexdigest(file_path):
+    with open(file_path, 'rb') as f:
+        file_data = f.read()
+
+    return hashlib.sha1(file_data).hexdigest()

--- a/mlflow/utils/_spark_utils.py
+++ b/mlflow/utils/_spark_utils.py
@@ -1,3 +1,11 @@
+import os.path
+import tempfile
+import uuid
+import atexit
+import shutil
+from pyspark.files import SparkFiles
+
+
 def _get_active_spark_session():
     try:
         from pyspark.sql import SparkSession
@@ -12,5 +20,79 @@ def _get_active_spark_session():
         return SparkSession._instantiatedSession
 
 
-def _add_spark_cache_file(spark, file_path):
+def _spark_context_add_archive(spark, file_path):
     spark.sparkContext._jsc.sc().addArchive(file_path)
+
+
+class _SparkBroadcastFileCache:
+    """
+    This class provide helper method for broadcasting driver side file/directory to
+    any spark executors.
+    The file/directory is archived before broadcasting to executor side.
+
+    Note:
+        For databricks runtime, don't use this class but use NFS instead.
+    """
+
+    _file_path_to_cache_key_map = {}
+
+    _archive_tmp_dir = None
+
+    @staticmethod
+    def _get_or_create_archive_tmp_dir():
+        if _SparkBroadcastFileCache._archive_tmp_dir is None:
+            _SparkBroadcastFileCache._archive_tmp_dir = \
+                _SparkBroadcastFileCache._archive_tmp_dir = tempfile.mkdtemp()
+
+            # TODO:
+            #  in atexit handler, also remove these cache files in spark executor side.
+            #  this require spark add corresponding removal API first.
+            #  otherwise these cache file will exist until spark application shutdown.
+            #  Note in databricks runtime spark application keep running until
+            #  spark cluster shutdown.
+            atexit.register(
+                shutil.rmtree, _SparkBroadcastFileCache._archive_tmp_dir, ignore_errors=True
+            )
+        return _SparkBroadcastFileCache._archive_tmp_dir
+
+    @staticmethod
+    def add_file(file_path):
+        """
+        This method is only allowed called from spark application driver side.
+        The file path can be a normal file or a directory path.
+        return cache_key as a string.
+        """
+        if file_path in _SparkBroadcastFileCache._file_path_to_cache_key_map:
+            return _SparkBroadcastFileCache._file_path_to_cache_key_map[file_path]
+        file_path = os.path.normpath(file_path)
+        archive_dir = _SparkBroadcastFileCache._get_or_create_archive_tmp_dir()
+        archive_basename = uuid.uuid4().hex
+        # NB: We must archive the directory as `Spark.addFile` does not support non-DFS
+        # directories when recursive=True.
+        archive_path = shutil.make_archive(os.path.join(archive_dir, archive_basename), "zip", file_path)
+        # Use `sparkContext.addArchive` API instead of `sparkContext.addFile` API because:
+        #  addArchive will auto extract archive and return unarchived path when get file from executor side
+        #  as opposed, using `sparkContext.addFile` API we need write extracting archive logic code by
+        #  ourselves, this causes several issues:
+        #   1. If we cache the extracted files within python process scope,
+        #   If `spark.python.worker.reuse` is False (the case databricks MLR by default),
+        #   then every spark task will extract the file again and save it to a new temporary directory,
+        #   it wastes both cpu and disk a lot.
+        #   2. If we cache the extracted files globally and allow it being shared with multiple
+        #   python processes (udf tasks), then we are hard to handle race condition. Each udf task run
+        #   within an individual python process and they are hard to coordinate with all others.
+        _spark_context_add_archive(_get_active_spark_session(), archive_path)
+        # Note: the cache key is in the format "{uuid}.zip", we must ensure the cache key is unique
+        # for each file_path
+        cache_key = os.path.basename(archive_path)
+        _SparkBroadcastFileCache._file_path_to_cache_key_map[file_path] = cache_key
+        return cache_key
+
+    @staticmethod
+    def get_file(cache_key):
+        """
+        This method can be called from spark task routine.
+        The file_path must be the same value with the path you called `add_file` from driver side.
+        Return the unarchived file/directory.
+        """
+        return SparkFiles.get(cache_key)

--- a/mlflow/utils/_spark_utils.py
+++ b/mlflow/utils/_spark_utils.py
@@ -10,3 +10,7 @@ def _get_active_spark_session():
     except Exception:
         # Fall back to this internal field for Spark 2.x and below.
         return SparkSession._instantiatedSession
+
+
+def _add_spark_cache_file(spark, file_path):
+    spark.sparkContext._jsc.sc().addArchive(file_path)

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -244,11 +244,9 @@ def test_model_cache(spark, model_path):
         code_path=[os.path.dirname(tests.__file__)],
     )
 
-    archive_path = SparkModelCache.add_local_model(spark, model_path)
-    assert archive_path != model_path
-
+    cache_key = SparkModelCache.add_local_model(model_path)
     # Ensure we can use the model locally.
-    local_model = SparkModelCache.get_or_load(archive_path)
+    local_model = SparkModelCache.get_or_load(cache_key)
     assert isinstance(local_model, PyFuncModel)
     assert isinstance(local_model._model_impl, ConstantPyfuncWrapper)
 
@@ -258,7 +256,7 @@ def test_model_cache(spark, model_path):
 
     # Request the model on all executors, and see how many times we got cache hits.
     def get_model(_):
-        model = SparkModelCache.get_or_load(archive_path)
+        model = SparkModelCache.get_or_load(cache_key)
         assert isinstance(model, PyFuncModel)
         # NB: Can not use instanceof test as remote does not know about ConstantPyfuncWrapper class.
         assert type(model._model_impl).__name__ == constant_model_name


### PR DESCRIPTION
Signed-off-by: Weichen Xu <weichen.xu@databricks.com>

## What changes are proposed in this pull request?

Prototype restoring model dependencies for `pyfunc.load_model` and `pyfunc.spark_udf`

## How is this patch tested?

Manually.

(1) Log a model first:
```
import mlflow
from sklearn.linear_model import LogisticRegression
from sklearn.datasets import make_classification
import sklearn.metrics

X, y = make_classification(n_samples=100, n_classes=3, n_informative=3, random_state=1)

"""
mlflow.sklearn.autolog()

with mlflow.start_run() as run:
    model = LogisticRegression(
        solver='liblinear',
        max_iter=1,
        C=0.5,
    ).fit(X, y)

print(run.info.run_id)
```

(2): load model with `restore_python_env` set to be `True`

```
import mlflow
from sklearn.linear_model import LogisticRegression
from sklearn.datasets import make_classification
import sklearn.metrics

X, y = make_classification(n_samples=100, n_classes=3, n_informative=3, random_state=1)

m = mlflow.pyfunc.load_model(
    'runs:/{run_id}/model',  # sklearn model, sklearn version 1.0.2
    restore_python_env=True,
)
print(type(m))

y_pred = m.predict(X)

print(f"precision={sklearn.metrics.precision_score(y, y_pred, average='micro')}")
```

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
