### PR TITLE
Pin pip in conda.yaml

### DIFF
--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -46,7 +46,7 @@ def _mlflow_conda_env(
     pip_deps = (["mlflow"] if install_mlflow else []) + (
         additional_pip_deps if additional_pip_deps else []
     )
-    conda_deps = (additional_conda_deps if additional_conda_deps else [])
+    conda_deps = additional_conda_deps if additional_conda_deps else []
     if pip_deps:
         pip_version = _get_pip_version()
         if pip_version is not None:

--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -46,22 +46,21 @@ def _mlflow_conda_env(
     pip_deps = (["mlflow"] if install_mlflow else []) + (
         additional_pip_deps if additional_pip_deps else []
     )
-    conda_deps = (additional_conda_deps if additional_conda_deps else []) + (
-        ["pip"] if pip_deps else []
-    )
+    conda_deps = (additional_conda_deps if additional_conda_deps else [])
+    if pip_deps:
+        pip_version = _get_pip_version()
+        if pip_version is not None:
+            conda_deps.append(f"pip={pip_version}")
+        else:
+            _logger.warning(
+                "Failed to resolve installed pip version. ``pip`` will be added to conda.yaml"
+                " environment spec without a version specifier."
+            )
+            conda_deps.append("pip")
 
     env = yaml.safe_load(_conda_header)
     env["dependencies"] = ["python={}".format(PYTHON_VERSION)]
-    try:
-        import pip
-
-        pip_version = getattr(pip, "__version__")
-        if pip_version:
-            env["dependencies"].append(f"pip={pip_version}")
-    except ImportError:
-        pass
-    if conda_deps is not None:
-        env["dependencies"] += conda_deps
+    env["dependencies"] += conda_deps
     env["dependencies"].append({"pip": pip_deps})
     if additional_conda_channels is not None:
         env["channels"] += additional_conda_channels
@@ -72,6 +71,20 @@ def _mlflow_conda_env(
         return None
     else:
         return env
+
+
+def _get_pip_version():
+    """
+    :return: The version of ``pip`` that is installed in the current environment,
+             or ``None`` if ``pip`` is not currently installed / does not have a
+             ``__version__`` attribute.
+    """
+    try:
+        import pip
+
+        return getattr(pip, "__version__")
+    except ImportError:
+        return None
 
 
 def _mlflow_additional_pip_env(pip_deps, path=None):

--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -52,6 +52,14 @@ def _mlflow_conda_env(
 
     env = yaml.safe_load(_conda_header)
     env["dependencies"] = ["python={}".format(PYTHON_VERSION)]
+    try:
+        import pip
+
+        pip_version = getattr(pip, "__version__")
+        if pip_version:
+            env["dependencies"].append(f"pip={pip_version}")
+    except ImportError:
+        pass
     if conda_deps is not None:
         env["dependencies"] += conda_deps
     env["dependencies"].append({"pip": pip_deps})

--- a/tests/utils/test_environment.py
+++ b/tests/utils/test_environment.py
@@ -64,7 +64,6 @@ def test_mlflow_conda_env_includes_pip_dependencies_and_pip_is_specified(pip_spe
     for conda_dep in conda_deps:
         assert conda_dep in env["dependencies"]
     assert pip_specification in env["dependencies"]
-    assert env["dependencies"].count("pip") == (2 if pip_specification == "pip" else 1)
 
 
 def test_is_pip_deps():

--- a/tests/utils/test_environment.py
+++ b/tests/utils/test_environment.py
@@ -42,6 +42,8 @@ def test_mlflow_conda_env_returns_expected_env_dict_when_output_path_is_not_spec
 
 @pytest.mark.parametrize("conda_deps", [["conda-dep-1=0.0.1", "conda-dep-2"], None])
 def test_mlflow_conda_env_includes_pip_dependencies_but_pip_is_not_specified(conda_deps):
+    import pip
+
     additional_pip_deps = ["pip-dep==0.0.1"]
     env = _mlflow_conda_env(
         path=None, additional_conda_deps=conda_deps, additional_pip_deps=additional_pip_deps
@@ -49,7 +51,7 @@ def test_mlflow_conda_env_includes_pip_dependencies_but_pip_is_not_specified(con
     if conda_deps is not None:
         for conda_dep in conda_deps:
             assert conda_dep in env["dependencies"]
-    assert "pip" in env["dependencies"]
+    assert f"pip={pip.__version__}" in env["dependencies"]
 
 
 @pytest.mark.parametrize("pip_specification", ["pip", "pip==20.0.02"])


### PR DESCRIPTION
Signed-off-by: dbczumar <corey.zumar@databricks.com>

## What changes are proposed in this pull request?

Pin pip in conda.yaml. Pip has been known to make backwards-incompatible changes to resolution logic, rendering certain environments unresolvable. This problem recently occurred when Python 3.6 reached EOL and recent versions of pip failed to resolve certain dependencies in Python 3.6 environments.

## How is this patch tested?

- Existing test coverage
- **Pending** new unit test cases

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

When saving an MLflow Model, the `conda.yaml` environment files now records the version of `pip` that is currently installed.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
