### PR TITLE
Add ENV variables to control GCS upload/download chunk size and timeouts

### DIFF
--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -949,6 +949,14 @@ in the `GCS documentation <https://google-cloud.readthedocs.io/en/latest/core/au
 Finally, you must run ``pip install google-cloud-storage`` (on both your client and the server)
 to access Google Cloud Storage; MLflow does not declare a dependency on this package by default.
 
+
+
+You may set some MLflow environment variables to troubleshoot GCS read-timeouts (eg. due to slow transfer speeds) using the following variables:
+
+- ``MLFLOW_GCS_DEFAULT_TIMEOUT`` - Set the standard timeout for transfer operations in seconds (Default: 60)
+- ``MLFLOW_GCS_UPLOAD_CHUNK_SIZE`` - Set the standard upload chunk size for bigger files in KB (GCP Default: 104857600 ≙ 100MB), must be multiple of 256 KB
+- ``MLFLOW_GCS_DOWNLOAD_CHUNK_SIZE`` - Set the standard download chunk size for bigger files in KB (GCP Default: 104857600 ≙ 100MB), must be multiple of 256 KB
+
 FTP server
 ^^^^^^^^^^^
 

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -953,9 +953,9 @@ to access Google Cloud Storage; MLflow does not declare a dependency on this pac
 
 You may set some MLflow environment variables to troubleshoot GCS read-timeouts (eg. due to slow transfer speeds) using the following variables:
 
-- ``MLFLOW_GCS_DEFAULT_TIMEOUT`` - Set the standard timeout for transfer operations in seconds (Default: 60)
-- ``MLFLOW_GCS_UPLOAD_CHUNK_SIZE`` - Set the standard upload chunk size for bigger files in KB (GCP Default: 104857600 ≙ 100MB), must be multiple of 256 KB
-- ``MLFLOW_GCS_DOWNLOAD_CHUNK_SIZE`` - Set the standard download chunk size for bigger files in KB (GCP Default: 104857600 ≙ 100MB), must be multiple of 256 KB
+- ``MLFLOW_GCS_DEFAULT_TIMEOUT`` - Sets the standard timeout for transfer operations in seconds (Default: 60)
+- ``MLFLOW_GCS_UPLOAD_CHUNK_SIZE`` - Sets the standard upload chunk size for bigger files in bytes (Default: 104857600 ≙ 100MiB), must be multiple of 256 KB
+- ``MLFLOW_GCS_DOWNLOAD_CHUNK_SIZE`` - Sets the standard download chunk size for bigger files in bytes (Default: 104857600 ≙ 100MiB), must be multiple of 256 KB
 
 FTP server
 ^^^^^^^^^^^

--- a/mlflow/store/artifact/gcs_artifact_repo.py
+++ b/mlflow/store/artifact/gcs_artifact_repo.py
@@ -27,12 +27,21 @@ class GCSArtifactRepository(ArtifactRepository):
 
         from google.cloud.storage.constants import _DEFAULT_TIMEOUT
 
-        self._GCS_DOWNLOAD_CHUNK_SIZE = int(os.environ.get("MLFLOW_GCS_DOWNLOAD_CHUNK_SIZE")) \
-            if os.environ.get("MLFLOW_GCS_DOWNLOAD_CHUNK_SIZE") else None
-        self._GCS_UPLOAD_CHUNK_SIZE = int(os.environ.get("MLFLOW_GCS_UPLOAD_CHUNK_SIZE")) \
-            if os.environ.get("MLFLOW_GCS_UPLOAD_CHUNK_SIZE") else None
-        self._GCS_DEFAULT_TIMEOUT = float(os.environ.get("MLFLOW_GCS_DEFAULT_TIMEOUT")) \
-            if os.environ.get("MLFLOW_GCS_DEFAULT_TIMEOUT") else _DEFAULT_TIMEOUT
+        self._GCS_DOWNLOAD_CHUNK_SIZE = (
+            int(os.environ.get("MLFLOW_GCS_DOWNLOAD_CHUNK_SIZE"))
+            if os.environ.get("MLFLOW_GCS_DOWNLOAD_CHUNK_SIZE")
+            else None
+        )
+        self._GCS_UPLOAD_CHUNK_SIZE = (
+            int(os.environ.get("MLFLOW_GCS_UPLOAD_CHUNK_SIZE"))
+            if os.environ.get("MLFLOW_GCS_UPLOAD_CHUNK_SIZE")
+            else None
+        )
+        self._GCS_DEFAULT_TIMEOUT = (
+            float(os.environ.get("MLFLOW_GCS_DEFAULT_TIMEOUT"))
+            if os.environ.get("MLFLOW_GCS_DEFAULT_TIMEOUT")
+            else _DEFAULT_TIMEOUT
+        )
         super().__init__(artifact_uri)
 
     @staticmethod
@@ -81,8 +90,8 @@ class GCSArtifactRepository(ArtifactRepository):
             for f in filenames:
                 path = posixpath.join(upload_path, f)
                 gcs_bucket.blob(path, chunk_size=self._GCS_UPLOAD_CHUNK_SIZE).upload_from_filename(
-                    os.path.join(root, f),
-                    timeout=self._GCS_DEFAULT_TIMEOUT)
+                    os.path.join(root, f), timeout=self._GCS_DEFAULT_TIMEOUT
+                )
 
     def list_artifacts(self, path=None):
         (bucket, artifact_path) = self.parse_gcs_uri(self.artifact_uri)
@@ -101,7 +110,7 @@ class GCSArtifactRepository(ArtifactRepository):
             # returns subdirectories as well
             if result.name == prefix:
                 continue
-            blob_path = result.name[len(artifact_path) + 1:]
+            blob_path = result.name[len(artifact_path) + 1 :]
             infos.append(FileInfo(blob_path, False, result.size))
 
         return sorted(infos, key=lambda f: f.path)
@@ -112,14 +121,15 @@ class GCSArtifactRepository(ArtifactRepository):
         for page in results.pages:
             dir_paths.update(page.prefixes)
 
-        return [FileInfo(path[len(artifact_path) + 1: -1], True, None) for path in dir_paths]
+        return [FileInfo(path[len(artifact_path) + 1 : -1], True, None) for path in dir_paths]
 
     def _download_file(self, remote_file_path, local_path):
         (bucket, remote_root_path) = self.parse_gcs_uri(self.artifact_uri)
         remote_full_path = posixpath.join(remote_root_path, remote_file_path)
         gcs_bucket = self._get_bucket(bucket)
-        gcs_bucket.blob(remote_full_path, chunk_size=self._GCS_DOWNLOAD_CHUNK_SIZE).download_to_filename(local_path,
-                                                                                                         timeout=self._GCS_DEFAULT_TIMEOUT)
+        gcs_bucket.blob(
+            remote_full_path, chunk_size=self._GCS_DOWNLOAD_CHUNK_SIZE
+        ).download_to_filename(local_path, timeout=self._GCS_DEFAULT_TIMEOUT)
 
     def delete_artifacts(self, artifact_path=None):
         raise MlflowException("Not implemented yet")

--- a/mlflow/store/artifact/gcs_artifact_repo.py
+++ b/mlflow/store/artifact/gcs_artifact_repo.py
@@ -24,6 +24,15 @@ class GCSArtifactRepository(ArtifactRepository):
             from google.cloud import storage as gcs_storage
 
             self.gcs = gcs_storage
+
+        from google.cloud.storage.constants import _DEFAULT_TIMEOUT
+
+        self._GCS_DOWNLOAD_CHUNK_SIZE = int(os.environ.get("MLFLOW_GCS_DOWNLOAD_CHUNK_SIZE")) \
+            if os.environ.get("MLFLOW_GCS_DOWNLOAD_CHUNK_SIZE") else None
+        self._GCS_UPLOAD_CHUNK_SIZE = int(os.environ.get("MLFLOW_GCS_UPLOAD_CHUNK_SIZE")) \
+            if os.environ.get("MLFLOW_GCS_UPLOAD_CHUNK_SIZE") else None
+        self._GCS_DEFAULT_TIMEOUT = float(os.environ.get("MLFLOW_GCS_DEFAULT_TIMEOUT")) \
+            if os.environ.get("MLFLOW_GCS_DEFAULT_TIMEOUT") else _DEFAULT_TIMEOUT
         super().__init__(artifact_uri)
 
     @staticmethod
@@ -53,8 +62,8 @@ class GCSArtifactRepository(ArtifactRepository):
         dest_path = posixpath.join(dest_path, os.path.basename(local_file))
 
         gcs_bucket = self._get_bucket(bucket)
-        blob = gcs_bucket.blob(dest_path)
-        blob.upload_from_filename(local_file)
+        blob = gcs_bucket.blob(dest_path, chunk_size=self._GCS_UPLOAD_CHUNK_SIZE)
+        blob.upload_from_filename(local_file, timeout=self._GCS_DEFAULT_TIMEOUT)
 
     def log_artifacts(self, local_dir, artifact_path=None):
         (bucket, dest_path) = self.parse_gcs_uri(self.artifact_uri)
@@ -71,7 +80,9 @@ class GCSArtifactRepository(ArtifactRepository):
                 upload_path = posixpath.join(dest_path, rel_path)
             for f in filenames:
                 path = posixpath.join(upload_path, f)
-                gcs_bucket.blob(path).upload_from_filename(os.path.join(root, f))
+                gcs_bucket.blob(path, chunk_size=self._GCS_UPLOAD_CHUNK_SIZE).upload_from_filename(
+                    os.path.join(root, f),
+                    timeout=self._GCS_DEFAULT_TIMEOUT)
 
     def list_artifacts(self, path=None):
         (bucket, artifact_path) = self.parse_gcs_uri(self.artifact_uri)
@@ -90,7 +101,7 @@ class GCSArtifactRepository(ArtifactRepository):
             # returns subdirectories as well
             if result.name == prefix:
                 continue
-            blob_path = result.name[len(artifact_path) + 1 :]
+            blob_path = result.name[len(artifact_path) + 1:]
             infos.append(FileInfo(blob_path, False, result.size))
 
         return sorted(infos, key=lambda f: f.path)
@@ -101,13 +112,14 @@ class GCSArtifactRepository(ArtifactRepository):
         for page in results.pages:
             dir_paths.update(page.prefixes)
 
-        return [FileInfo(path[len(artifact_path) + 1 : -1], True, None) for path in dir_paths]
+        return [FileInfo(path[len(artifact_path) + 1: -1], True, None) for path in dir_paths]
 
     def _download_file(self, remote_file_path, local_path):
         (bucket, remote_root_path) = self.parse_gcs_uri(self.artifact_uri)
         remote_full_path = posixpath.join(remote_root_path, remote_file_path)
         gcs_bucket = self._get_bucket(bucket)
-        gcs_bucket.blob(remote_full_path).download_to_filename(local_path)
+        gcs_bucket.blob(remote_full_path, chunk_size=self._GCS_DOWNLOAD_CHUNK_SIZE).download_to_filename(local_path,
+                                                                                                         timeout=self._GCS_DEFAULT_TIMEOUT)
 
     def delete_artifacts(self, artifact_path=None):
         raise MlflowException("Not implemented yet")

--- a/tests/store/artifact/test_gcs_artifact_repo.py
+++ b/tests/store/artifact/test_gcs_artifact_repo.py
@@ -144,8 +144,8 @@ def test_log_artifact(gcs_mock, tmpdir):
     gcs_mock.Client().bucket.assert_called_with("test_bucket")
     gcs_mock.Client().bucket().blob.assert_called_with("some/path/test.txt",
                                                        chunk_size=repo._GCS_UPLOAD_CHUNK_SIZE)
-    gcs_mock.Client().bucket().blob().upload_from_filename.assert_called_with(fpath,
-                                                                              timeout=repo._GCS_DEFAULT_TIMEOUT)
+    gcs_mock.Client().bucket().blob().upload_from_filename \
+        .assert_called_with(fpath, timeout=repo._GCS_DEFAULT_TIMEOUT)
 
 
 def test_log_artifacts(gcs_mock, tmpdir):
@@ -176,9 +176,12 @@ def test_log_artifacts(gcs_mock, tmpdir):
     gcs_mock.Client().bucket.assert_called_with("test_bucket")
     gcs_mock.Client().bucket().blob().upload_from_filename.assert_has_calls(
         [
-            mock.call(os.path.normpath("%s/a.txt" % subd.strpath), timeout=repo._GCS_DEFAULT_TIMEOUT),
-            mock.call(os.path.normpath("%s/b.txt" % subd.strpath), timeout=repo._GCS_DEFAULT_TIMEOUT),
-            mock.call(os.path.normpath("%s/c.txt" % subd.strpath), timeout=repo._GCS_DEFAULT_TIMEOUT),
+            mock.call(os.path.normpath("%s/a.txt" % subd.strpath),
+                      timeout=repo._GCS_DEFAULT_TIMEOUT),
+            mock.call(os.path.normpath("%s/b.txt" % subd.strpath),
+                      timeout=repo._GCS_DEFAULT_TIMEOUT),
+            mock.call(os.path.normpath("%s/c.txt" % subd.strpath),
+                      timeout=repo._GCS_DEFAULT_TIMEOUT),
         ],
         any_order=True,
     )
@@ -188,6 +191,7 @@ def test_download_artifacts_calls_expected_gcs_client_methods(gcs_mock, tmpdir):
     repo = GCSArtifactRepository("gs://test_bucket/some/path", gcs_mock)
 
     def mkfile(fname, **kwargs):
+        # pylint: disable=unused-argument
         fname = os.path.basename(fname)
         f = tmpdir.join(fname)
         f.write("hello world!")
@@ -206,7 +210,8 @@ def test_download_artifacts_calls_expected_gcs_client_methods(gcs_mock, tmpdir):
     repo.download_artifacts("test.txt")
     assert os.path.exists(os.path.join(tmpdir.strpath, "test.txt"))
     gcs_mock.Client().bucket.assert_called_with("test_bucket")
-    gcs_mock.Client().bucket().blob.assert_called_with("some/path/test.txt", chunk_size=repo._GCS_DOWNLOAD_CHUNK_SIZE)
+    gcs_mock.Client().bucket().blob.assert_called_with("some/path/test.txt",
+                                                       chunk_size=repo._GCS_DOWNLOAD_CHUNK_SIZE)
     download_calls = gcs_mock.Client().bucket().blob().download_to_filename.call_args_list
     assert len(download_calls) == 1
     download_path_arg = download_calls[0][0][0]
@@ -260,6 +265,7 @@ def test_download_artifacts_downloads_expected_content(gcs_mock, tmpdir):
             return mock_empty_results
 
     def mkfile(fname, **kwargs):
+        # pylint: disable=unused-argument
         fname = os.path.basename(fname)
         f = tmpdir.join(fname)
         f.write("hello world!")

--- a/tests/store/artifact/test_gcs_artifact_repo.py
+++ b/tests/store/artifact/test_gcs_artifact_repo.py
@@ -137,15 +137,17 @@ def test_log_artifact(gcs_mock, tmpdir):
             "blob",
             "upload_from_filename",
         ],
-        side_effect=custom_isfile
+        side_effect=custom_isfile,
     )
     repo.log_artifact(fpath)
 
     gcs_mock.Client().bucket.assert_called_with("test_bucket")
-    gcs_mock.Client().bucket().blob.assert_called_with("some/path/test.txt",
-                                                       chunk_size=repo._GCS_UPLOAD_CHUNK_SIZE)
-    gcs_mock.Client().bucket().blob().upload_from_filename \
-        .assert_called_with(fpath, timeout=repo._GCS_DEFAULT_TIMEOUT)
+    gcs_mock.Client().bucket().blob.assert_called_with(
+        "some/path/test.txt", chunk_size=repo._GCS_UPLOAD_CHUNK_SIZE
+    )
+    gcs_mock.Client().bucket().blob().upload_from_filename.assert_called_with(
+        fpath, timeout=repo._GCS_DEFAULT_TIMEOUT
+    )
 
 
 def test_log_artifacts(gcs_mock, tmpdir):
@@ -176,12 +178,15 @@ def test_log_artifacts(gcs_mock, tmpdir):
     gcs_mock.Client().bucket.assert_called_with("test_bucket")
     gcs_mock.Client().bucket().blob().upload_from_filename.assert_has_calls(
         [
-            mock.call(os.path.normpath("%s/a.txt" % subd.strpath),
-                      timeout=repo._GCS_DEFAULT_TIMEOUT),
-            mock.call(os.path.normpath("%s/b.txt" % subd.strpath),
-                      timeout=repo._GCS_DEFAULT_TIMEOUT),
-            mock.call(os.path.normpath("%s/c.txt" % subd.strpath),
-                      timeout=repo._GCS_DEFAULT_TIMEOUT),
+            mock.call(
+                os.path.normpath("%s/a.txt" % subd.strpath), timeout=repo._GCS_DEFAULT_TIMEOUT
+            ),
+            mock.call(
+                os.path.normpath("%s/b.txt" % subd.strpath), timeout=repo._GCS_DEFAULT_TIMEOUT
+            ),
+            mock.call(
+                os.path.normpath("%s/c.txt" % subd.strpath), timeout=repo._GCS_DEFAULT_TIMEOUT
+            ),
         ],
         any_order=True,
     )
@@ -210,8 +215,9 @@ def test_download_artifacts_calls_expected_gcs_client_methods(gcs_mock, tmpdir):
     repo.download_artifacts("test.txt")
     assert os.path.exists(os.path.join(tmpdir.strpath, "test.txt"))
     gcs_mock.Client().bucket.assert_called_with("test_bucket")
-    gcs_mock.Client().bucket().blob.assert_called_with("some/path/test.txt",
-                                                       chunk_size=repo._GCS_DOWNLOAD_CHUNK_SIZE)
+    gcs_mock.Client().bucket().blob.assert_called_with(
+        "some/path/test.txt", chunk_size=repo._GCS_DOWNLOAD_CHUNK_SIZE
+    )
     download_calls = gcs_mock.Client().bucket().blob().download_to_filename.call_args_list
     assert len(download_calls) == 1
     download_path_arg = download_calls[0][0][0]


### PR DESCRIPTION
Add ENV variables to control GCS upload/download chunk size and timeouts
(fixes GCS timeouts for uploads/downloads with slow transfer speeds -> more info #3478 )

Partial fix to https://github.com/mlflow/mlflow/issues/3478

## What changes are proposed in this pull request?

Add ENV variables to control GCS upload/download chunk size and timeouts. Implementation details are open for discussion.

## How is this patch tested?

Not yet. 

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Environment variables MLFLOW_GCS_DEFAULT_TIMEOUT, MLFLOW_GCS_UPLOAD_CHUNK_SIZE, MLFLOW_GCS_DOWNLOAD_CHUNK_SIZE added to control GCS artifact storage

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes