### PR TITLE
Improve infer model type method for default evaluator

### DIFF
--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -37,7 +37,9 @@ def _infer_model_type_by_labels(labels):
             return "regressor"
     if len(distinct_labels) > 1000 and len(distinct_labels) / len(labels) > 0.7:
         return "regressor"
-    return "classifier"
+    if len(distinct_labels) < 20:
+        return "classifier"
+    return None  # unknown
 
 
 def _extract_raw_model_and_predict_fn(model):
@@ -766,7 +768,7 @@ class DefaultEvaluator(ModelEvaluator):
 
             infered_model_type = _infer_model_type_by_labels(self.y)
 
-            if model_type != infered_model_type:
+            if infered_model_type is not None and model_type != infered_model_type:
                 _logger.warning(
                     f"According to the evaluation dataset label values, the model type looks like "
                     f"{infered_model_type}, but you specified model type {model_type}. Please "

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -37,7 +37,7 @@ def _infer_model_type_by_labels(labels):
             return "regressor"
     if len(distinct_labels) > 1000 and len(distinct_labels) / len(labels) > 0.7:
         return "regressor"
-    if len(distinct_labels) < 20:
+    if len(distinct_labels) < 10:
         return "classifier"
     return None  # unknown
 

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -37,7 +37,7 @@ def _infer_model_type_by_labels(labels):
             return "regressor"
     if len(distinct_labels) > 1000 and len(distinct_labels) / len(labels) > 0.7:
         return "regressor"
-    if len(distinct_labels) < 10:
+    if len(distinct_labels) < 20:
         return "classifier"
     return None  # unknown
 

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -37,7 +37,7 @@ def _infer_model_type_by_labels(labels):
             return "regressor"
     if len(distinct_labels) > 1000 and len(distinct_labels) / len(labels) > 0.7:
         return "regressor"
-    if len(distinct_labels) < 20:
+    if len(distinct_labels) <= 20:
         return "classifier"
     return None  # unknown
 

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -283,7 +283,7 @@ def test_infer_model_type_by_labels():
     assert _infer_model_type_by_labels([1, 2.5]) == "regressor"
     assert _infer_model_type_by_labels(list(range(2000))) == "regressor"
     assert _infer_model_type_by_labels([1, 2, 3]) == "classifier"
-    assert _infer_model_type_by_labels(list(range(20))) is None
+    assert _infer_model_type_by_labels(list(range(30))) is None
 
 
 def test_extract_raw_model_and_predict_fn(binary_logistic_regressor_model_uri):

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -283,6 +283,7 @@ def test_infer_model_type_by_labels():
     assert _infer_model_type_by_labels([1, 2.5]) == "regressor"
     assert _infer_model_type_by_labels(list(range(2000))) == "regressor"
     assert _infer_model_type_by_labels([1, 2, 3]) == "classifier"
+    assert _infer_model_type_by_labels(list(range(20))) is None
 
 
 def test_extract_raw_model_and_predict_fn(binary_logistic_regressor_model_uri):


### PR DESCRIPTION
Signed-off-by: Weichen Xu <weichen.xu@databricks.com>

## What changes are proposed in this pull request?

Improve infer model type method for default evaluator.

## How is this patch tested?

UT.

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
