### PR TITLE
Refactor fastai example

### DIFF
--- a/examples/fastai/README.md
+++ b/examples/fastai/README.md
@@ -1,10 +1,8 @@
 ### MLflow Fastai Example
 
 This simple example illustrates how you can use the `mlflow.fastai.autolog()` API
-to track parameters, metrics, and artifacts while training a simple MNIST model. Derived from fastai's GitHub Repository 
-of [examples](https://github.com/fastai/fastai/blob/master/nbs/examples/mnist_blocks.py), this code is modified to run 
-as an MLflow project, with either default or supplied arguments. The default arguments are learning rate(`lr=0.01`) 
-and number of epochs (`epochs=5`).
+to track parameters, metrics, and artifacts while training a simple MLP model.
+The default arguments are learning rate(`lr=0.01`)  and number of epochs (`epochs=5`).
 
 You can use this example as a template and attempt advanced examples in
 [Fastai tutorials](https://docs.fast.ai/tutorial.html), using the `mlflow.fastai` model flavor and MLflow tracking API to

--- a/examples/fastai/train.py
+++ b/examples/fastai/train.py
@@ -62,7 +62,7 @@ def main():
     # Enable auto logging
     mlflow.fastai.autolog()
 
-    # Create a model
+    # Create Learner model
     learn = Learner(get_data_loaders(), Model(), loss_func=nn.MSELoss(), splitter=splitter)
 
     # Start MLflow session

--- a/examples/fastai/train.py
+++ b/examples/fastai/train.py
@@ -1,19 +1,12 @@
-#
-# This short example is based on the fastai GitHub Repository of vision examples
-# https://github.com/fastai/fastai/blob/master/nbs/examples/mnist_blocks.py
-# Modified here to show mlflow.fastai.autolog() capabilities
-#
 import argparse
-import mlflow.fastai
-from fastai.vision.all import (
-    CategoryBlock,
-    DataBlock,
-    GrandparentSplitter,
-    ImageBlock,
-    PILImage,
-    URLs,
-)
-from fastai.vision.all import cnn_learner, get_image_files, parent_label, resnet18, untar_data
+
+from fastai.learner import Learner
+from fastai.tabular.all import TabularDataLoaders
+import numpy as np
+from sklearn.datasets import load_iris
+from torch import nn
+
+import mlflow
 
 
 def parse_args():
@@ -33,29 +26,44 @@ def parse_args():
     return parser.parse_args()
 
 
+def get_data_loaders():
+    X, y = load_iris(return_X_y=True, as_frame=True)
+    y = y.astype(np.float32)
+    return TabularDataLoaders.from_df(
+        X.assign(target=y), cont_names=list(X.columns), y_names=y.name
+    )
+
+
+class Model(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear1 = nn.Linear(4, 3)
+        self.linear2 = nn.Linear(3, 1)
+
+    def forward(self, _, x_cont):
+        x = self.linear1(x_cont)
+        return self.linear2(x)
+
+
+def splitter(model):
+    params = list(model.parameters())
+    return [
+        # weights and biases of the first linear layer
+        params[:2],
+        # weights and biases of the second linear layer
+        params[2:],
+    ]
+
+
 def main():
     # Parse command-line arguments
     args = parse_args()
 
-    # Split data between training and testing
-    splitter = GrandparentSplitter(train_name="training", valid_name="testing")
-
-    # Prepare DataBlock which is a generic container to quickly build Datasets and DataLoaders
-    mnist = DataBlock(
-        blocks=(ImageBlock(PILImage), CategoryBlock),
-        get_items=get_image_files,
-        splitter=splitter,
-        get_y=parent_label,
-    )
-
-    # Download, untar the MNIST data set and create DataLoader from DataBlock
-    data = mnist.dataloaders(untar_data(URLs.MNIST), bs=256, num_workers=0)
-
     # Enable auto logging
     mlflow.fastai.autolog()
 
-    # Create Learner model
-    learn = cnn_learner(data, resnet18)
+    # Create a model
+    learn = Learner(get_data_loaders(), Model(), loss_func=nn.MSELoss(), splitter=splitter)
 
     # Start MLflow session
     with mlflow.start_run():


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

The fastai example currently trains ResNet18 with MNIST and takes a really long time to complete on GitHub Actions. This PR replaces the model and dataset with a simple MLP model and the iris dataset to run the example faster.

https://github.com/mlflow/mlflow/runs/5418608163?check_suite_focus=true#step:7:73

<img width="1062" alt="image" src="https://user-images.githubusercontent.com/17039389/156759498-591a6700-16f9-48b5-8775-9cb7e899c567.png">

916 + 839 sec = 1755 sec ≒ 30 minutes!

## How is this patch tested?

The updated example.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
