### PR TITLE
Add an info log when xgboost autologging metric names are sanitized

### DIFF
--- a/mlflow/xgboost/_autolog.py
+++ b/mlflow/xgboost/_autolog.py
@@ -14,11 +14,15 @@ def _patch_metric_names(metric_dict):
     patched_metrics = {
         metric_name.replace("@", "_at_"): value for metric_name, value in metric_dict.items()
     }
-    if patched_metrics != metric_dict:
-        _logger.warning(
+    changed_keys = set(patched_metrics.keys()) - set(metric_dict.keys())
+    if changed_keys:
+        _logger.info(
             "Identified one or more metrics with names containing the invalid character `@`."
-            " These metric names have been sanitized by replacing `@` with `_at_`."
+            " These metric names have been sanitized by replacing `@` with `_at_`, as follows: %s",
+            ", ".join(changed_keys)
         )
+
+    return patched_metrics
 
 
 def autolog_callback(env, metrics_logger, eval_results):

--- a/mlflow/xgboost/_autolog.py
+++ b/mlflow/xgboost/_autolog.py
@@ -19,7 +19,7 @@ def _patch_metric_names(metric_dict):
         _logger.info(
             "Identified one or more metrics with names containing the invalid character `@`."
             " These metric names have been sanitized by replacing `@` with `_at_`, as follows: %s",
-            ", ".join(changed_keys)
+            ", ".join(changed_keys),
         )
 
     return patched_metrics

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -168,7 +168,10 @@ def test_xgb_autolog_atsign_metrics_info_log(xgb_metric):
 
     if "@" in xgb_metric:
         mock_info_log.assert_called_once()
-        first_pos_arg, second_pos_arg, = mock_info_log.call_args[0]
+        (
+            first_pos_arg,
+            second_pos_arg,
+        ) = mock_info_log.call_args[0]
         assert "metric names have been sanitized" in first_pos_arg
         assert xgb_metric.replace("@", "_at_") in second_pos_arg
         assert "map" not in second_pos_arg

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -168,7 +168,10 @@ def test_xgb_autolog_atsign_metrics_info_log(xgb_metric):
 
     if "@" in xgb_metric:
         mock_info_log.assert_called_once()
-        (first_pos_arg, second_pos_arg,) = mock_info_log.call_args[0]
+        (
+            first_pos_arg,
+            second_pos_arg,
+        ) = mock_info_log.call_args[0]
         assert "metric names have been sanitized" in first_pos_arg
         assert xgb_metric.replace("@", "_at_") in second_pos_arg
         assert "map" not in second_pos_arg

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -162,7 +162,7 @@ def test_xgb_autolog_atsign_metrics_info_log(xgb_metric):
     mlflow.xgboost.autolog()
 
     with mock.patch("mlflow.xgboost._autolog._logger.info") as mock_info_log:
-        params = {"objective": "rank:pairwise", "eval_metric": [xgb_metric]}
+        params = {"objective": "rank:pairwise", "eval_metric": [xgb_metric, "map"]}
         dtrain = xgb.DMatrix(np.array([[0], [1]]), label=[1, 0])
         xgb.train(params, dtrain, evals=[(dtrain, "train")], num_boost_round=1)
 
@@ -171,6 +171,7 @@ def test_xgb_autolog_atsign_metrics_info_log(xgb_metric):
         (first_pos_arg, second_pos_arg,) = mock_info_log.call_args[0]
         assert "metric names have been sanitized" in first_pos_arg
         assert xgb_metric.replace("@", "_at_") in second_pos_arg
+        assert "map" not in second_pos_arg
     else:
         mock_info_log.assert_not_called()
 

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -2,6 +2,7 @@ from packaging.version import Version
 import os
 import json
 import functools
+import mock
 import pickle
 import pytest
 import numpy as np
@@ -153,6 +154,25 @@ def test_xgb_autolog_atsign_metrics():
     xgb.train(params, dtrain, evals=[(dtrain, "train")], num_boost_round=1)
     run = get_latest_run()
     assert set(run.data.metrics) == expected_metrics
+
+
+@pytest.mark.large
+@pytest.mark.parametrize("xgb_metric", ["ndcg@2", "error"])
+def test_xgb_autolog_atsign_metrics_info_log(xgb_metric):
+    mlflow.xgboost.autolog()
+
+    with mock.patch("mlflow.xgboost._autolog._logger.info") as mock_info_log:
+        params = {"objective": "rank:pairwise", "eval_metric": [xgb_metric]}
+        dtrain = xgb.DMatrix(np.array([[0], [1]]), label=[1, 0])
+        xgb.train(params, dtrain, evals=[(dtrain, "train")], num_boost_round=1)
+
+    if "@" in xgb_metric:
+        mock_info_log.assert_called_once()
+        (first_pos_arg, second_pos_arg,) = mock_info_log.call_args[0]
+        assert "metric names have been sanitized" in first_pos_arg
+        assert xgb_metric.replace("@", "_at_") in second_pos_arg
+    else:
+        mock_info_log.assert_not_called()
 
 
 @pytest.mark.large

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -168,7 +168,7 @@ def test_xgb_autolog_atsign_metrics_info_log(xgb_metric):
 
     if "@" in xgb_metric:
         mock_info_log.assert_called_once()
-        (first_pos_arg, second_pos_arg,) = mock_info_log.call_args[0]
+        first_pos_arg, second_pos_arg, = mock_info_log.call_args[0]
         assert "metric names have been sanitized" in first_pos_arg
         assert xgb_metric.replace("@", "_at_") in second_pos_arg
         assert "map" not in second_pos_arg

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -2,7 +2,6 @@ from packaging.version import Version
 import os
 import json
 import functools
-import mock
 import pickle
 import pytest
 import numpy as np
@@ -11,6 +10,7 @@ from sklearn import datasets
 import xgboost as xgb
 import matplotlib as mpl
 import yaml
+from unittest import mock
 
 import mlflow
 import mlflow.xgboost


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add an info log when xgboost autologging metric names are sanitized

## How is this patch tested?

Unit tests

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

Add an info log when xgboost autologging metric names are sanitized

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
