### PR TITLE
Adds input example and model signature to autologging for tf.keras for certain x types on tf.keras.Model.fit

### DIFF
--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -944,7 +944,9 @@ def autolog(
                                 for k, v in input_training_data.items()
                             }
                         elif isinstance(input_training_data, tensorflow.keras.utils.Sequence):
-                            input_example_slice = input_training_data[:][0][:INPUT_EXAMPLE_SAMPLE_ROWS]
+                            input_example_slice = input_training_data[:][0][
+                                :INPUT_EXAMPLE_SAMPLE_ROWS
+                            ]
 
                         else:
                             warnings.warn(
@@ -966,7 +968,7 @@ def autolog(
                         return model_signature
 
                     input_example, signature = resolve_input_example_and_signature(
-                        lambda: _get_input_data_slice(),
+                        _get_input_data_slice,
                         _infer_model_signature,
                         log_input_examples,
                         log_model_signatures,

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -954,15 +954,14 @@ def autolog(
                                             ).as_numpy_iterator()
                                         ]
                                     )[0]
-                                else:
-                                    return np.array(
-                                        [
-                                            v[0]
-                                            for v in input_example_n_steps.take(
-                                                INPUT_EXAMPLE_SAMPLE_ROWS
-                                            ).as_numpy_iterator()
-                                        ]
-                                    )
+                                return np.array(
+                                    [
+                                        v[0]
+                                        for v in input_example_n_steps.take(
+                                            INPUT_EXAMPLE_SAMPLE_ROWS
+                                        ).as_numpy_iterator()
+                                    ]
+                                )
 
                             return _extract_n_steps(input_example)
                         elif isinstance(input_example, dict):

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -969,7 +969,7 @@ def autolog(
                             ):
                                 # For these versions, `stop_training` flag on Model is set to False
                                 # This flag is used by the callback
-                                # (inside `_log_early_stop_callback_metrics`)
+                                # (inside ``_log_early_stop_callback_metrics``)
                                 # for logging of early stop metrics. In order for
                                 # that to work, need to force that flag to be True again since doing
                                 # predict on that model sets `stop_training` to false for

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -961,6 +961,15 @@ def autolog(
                     def _infer_model_signature(input_data_slice):
                         try:
                             model_output = history.model.predict(input_data_slice)
+
+                            if Version(tensorflow.__version__) <= Version("2.1.4"):
+                                # For these versions, `stop_training` flag on Model is set to False
+                                # This flag is used by the callback
+                                # (inside `_log_early_stop_callback_metrics`)
+                                # for logging of early stop metrics. In order for
+                                # that to work, need to force that flag to be True
+                                history.model.stop_training = True
+
                             model_signature = infer_signature(input_data_slice, model_output)
                         except TypeError as te:
                             warnings.warn(str(te))

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -960,14 +960,20 @@ def autolog(
 
                     def _infer_model_signature(input_data_slice):
                         try:
+                            original_stop_training = history.model.stop_training
                             model_output = history.model.predict(input_data_slice)
 
-                            if Version(tensorflow.__version__) <= Version("2.1.4"):
+                            if (
+                                Version(tensorflow.__version__) <= Version("2.1.4")
+                                and original_stop_training
+                            ):
                                 # For these versions, `stop_training` flag on Model is set to False
                                 # This flag is used by the callback
                                 # (inside `_log_early_stop_callback_metrics`)
                                 # for logging of early stop metrics. In order for
-                                # that to work, need to force that flag to be True
+                                # that to work, need to force that flag to be True again since doing
+                                # predict on that model sets `stop_training` to false for
+                                # those TF versions
                                 history.model.stop_training = True
 
                             model_signature = infer_signature(input_data_slice, model_output)

--- a/mlflow/tensorflow/_autolog.py
+++ b/mlflow/tensorflow/_autolog.py
@@ -39,11 +39,7 @@ class __MLflowTfKeras2Callback(Callback, metaclass=ExceptionSafeClass):
             summary = "\n".join(sum_list)
             mlflow.log_text(summary, artifact_file="model_summary.txt")
         except ValueError as ex:
-            if (
-                "This model has not yet been built. "
-                "Build the model first by calling `build()` "
-                "or by calling the model on a batch of data." == str(ex)
-            ):
+            if "This model has not yet been built" in str(ex):
                 warnings.warn(str(ex))
             else:
                 raise ex

--- a/mlflow/tensorflow/_autolog.py
+++ b/mlflow/tensorflow/_autolog.py
@@ -1,3 +1,5 @@
+import warnings
+
 from tensorflow.keras.callbacks import Callback, TensorBoard
 
 import mlflow
@@ -32,9 +34,19 @@ class __MLflowTfKeras2Callback(Callback, metaclass=ExceptionSafeClass):
             mlflow.log_param("opt_" + attribute, config[attribute])
 
         sum_list = []
-        self.model.summary(print_fn=sum_list.append)
-        summary = "\n".join(sum_list)
-        mlflow.log_text(summary, artifact_file="model_summary.txt")
+        try:
+            self.model.summary(print_fn=sum_list.append)
+            summary = "\n".join(sum_list)
+            mlflow.log_text(summary, artifact_file="model_summary.txt")
+        except ValueError as ex:
+            if (
+                "This model has not yet been built. "
+                "Build the model first by calling `build()` "
+                "or by calling the model on a batch of data." == str(ex)
+            ):
+                warnings.warn("s")
+            else:
+                raise ex
 
     def on_epoch_end(self, epoch, logs=None):
         # NB: tf.Keras uses zero-indexing for epochs, while other TensorFlow Estimator

--- a/mlflow/tensorflow/_autolog.py
+++ b/mlflow/tensorflow/_autolog.py
@@ -44,7 +44,7 @@ class __MLflowTfKeras2Callback(Callback, metaclass=ExceptionSafeClass):
                 "Build the model first by calling `build()` "
                 "or by calling the model on a batch of data." == str(ex)
             ):
-                warnings.warn("s")
+                warnings.warn(str(ex))
             else:
                 raise ex
 

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -1098,7 +1098,7 @@ def _assert_keras_autolog_input_example_load_and_predict_with_nparray(run, rando
 @pytest.mark.skipif(
     Version(tf.__version__) < Version("2.6.0"),
     reason="TensorFlow autologging is not used for vanilla Keras models in Keras < 2.6.0",
-    )
+)
 def test_keras_autolog_input_example_load_and_predict_with_nparray(
     random_train_data, random_one_hot_labels
 ):
@@ -1113,7 +1113,7 @@ def test_keras_autolog_input_example_load_and_predict_with_nparray(
 @pytest.mark.skipif(
     Version(tf.__version__) < Version("2.6.0"),
     reason="TensorFlow autologging is not used for vanilla Keras models in Keras < 2.6.0",
-    )
+)
 def test_keras_autolog_infers_model_signature_correctly_with_nparray(
     random_train_data, random_one_hot_labels
 ):
@@ -1132,7 +1132,7 @@ def test_keras_autolog_infers_model_signature_correctly_with_nparray(
 @pytest.mark.skipif(
     Version(tf.__version__) < Version("2.6.0"),
     reason="TensorFlow autologging is not used for vanilla Keras models in Keras < 2.6.0",
-    )
+)
 def test_keras_autolog_input_example_load_and_predict_with_tf_dataset(fashion_mnist_tf_dataset):
     mlflow.tensorflow.autolog()
     fashion_mnist_model = _create_fashion_mnist_model()
@@ -1150,7 +1150,7 @@ def test_keras_autolog_input_example_load_and_predict_with_tf_dataset(fashion_mn
 @pytest.mark.skipif(
     Version(tf.__version__) < Version("2.6.0"),
     reason="TensorFlow autologging is not used for vanilla Keras models in Keras < 2.6.0",
-    )
+)
 def test_keras_autolog_infers_model_signature_correctly_with_tf_dataset(fashion_mnist_tf_dataset):
     mlflow.tensorflow.autolog()
     fashion_mnist_model = _create_fashion_mnist_model()
@@ -1167,7 +1167,7 @@ def test_keras_autolog_infers_model_signature_correctly_with_tf_dataset(fashion_
 @pytest.mark.skipif(
     Version(tf.__version__) < Version("2.6.0"),
     reason="TensorFlow autologging is not used for vanilla Keras models in Keras < 2.6.0",
-    )
+)
 def test_keras_autolog_input_example_load_and_predict_with_dict(
     random_train_dict_mapping, random_one_hot_labels
 ):
@@ -1189,7 +1189,7 @@ def test_keras_autolog_input_example_load_and_predict_with_dict(
 @pytest.mark.skipif(
     Version(tf.__version__) < Version("2.6.0"),
     reason="TensorFlow autologging is not used for vanilla Keras models in Keras < 2.6.0",
-    )
+)
 def test_keras_autolog_infers_model_signature_correctly_with_dict(
     random_train_dict_mapping, random_one_hot_labels
 ):
@@ -1213,7 +1213,7 @@ def test_keras_autolog_infers_model_signature_correctly_with_dict(
 @pytest.mark.skipif(
     Version(tf.__version__) < Version("2.6.0"),
     reason="TensorFlow autologging is not used for vanilla Keras models in Keras < 2.6.0",
-    )
+)
 def test_keras_autolog_input_example_load_and_predict_with_keras_sequence(keras_data_gen_sequence):
     mlflow.tensorflow.autolog()
     model = create_tf_keras_model()
@@ -1228,7 +1228,7 @@ def test_keras_autolog_input_example_load_and_predict_with_keras_sequence(keras_
 @pytest.mark.skipif(
     Version(tf.__version__) < Version("2.6.0"),
     reason="TensorFlow autologging is not used for vanilla Keras models in Keras < 2.6.0",
-    )
+)
 def test_keras_autolog_infers_model_signature_correctly_with_keras_sequence(
     keras_data_gen_sequence,
 ):

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -1,25 +1,28 @@
 # pep8: disable=E501
 
 import collections
-import pytest
-import sys
+import os
 import pickle
-from packaging.version import Version
+import sys
+from unittest.mock import patch
+import json
 
 import numpy as np
 import pandas as pd
+import pytest
 import tensorflow as tf
+from packaging.version import Version
 from tensorflow.keras import layers
+import yaml
 
 import mlflow
-import mlflow.tensorflow
-from mlflow.tensorflow._autolog import _TensorBoard, __MLflowTfKeras2Callback
 import mlflow.keras
+import mlflow.tensorflow
+from mlflow.models import Model
+from mlflow.models.utils import _read_example
+from mlflow.tensorflow._autolog import _TensorBoard, __MLflowTfKeras2Callback
 from mlflow.tracking.client import MlflowClient
 from mlflow.utils.autologging_utils import BatchMetricsLogger, autologging_is_disabled
-from unittest.mock import patch
-
-import os
 
 np.random.seed(1337)
 
@@ -50,6 +53,80 @@ def random_one_hot_labels():
 
 
 @pytest.fixture
+def random_train_dict_mapping(random_train_data):
+    def _generate_features(pos):
+        return [v[pos] for v in random_train_data]
+
+    features = {
+        "a": np.array(_generate_features(0)),
+        "b": np.array(_generate_features(1)),
+        "c": np.array(_generate_features(2)),
+        "d": np.array(_generate_features(3)),
+    }
+    return features
+
+
+def _create_model_for_dict_mapping():
+    model = tf.keras.Sequential()
+    model.add(
+        layers.DenseFeatures(
+            [
+                tf.feature_column.numeric_column("a"),
+                tf.feature_column.numeric_column("b"),
+                tf.feature_column.numeric_column("c"),
+                tf.feature_column.numeric_column("d"),
+            ]
+        )
+    )
+    model.add(layers.Dense(16, activation="relu", input_shape=(4,)))
+    model.add(layers.Dense(3, activation="softmax"))
+
+    model.compile(
+        optimizer=tf.keras.optimizers.Adam(), loss="categorical_crossentropy", metrics=["accuracy"]
+    )
+    return model
+
+
+@pytest.fixture
+def fashion_mnist_tf_dataset():
+    train, _ = tf.keras.datasets.fashion_mnist.load_data()
+    images, labels = train
+    images = images / 255.0
+    labels = labels.astype(np.int32)
+    fmnist_train_ds = tf.data.Dataset.from_tensor_slices((images, labels))
+    fmnist_train_ds = fmnist_train_ds.shuffle(5000).batch(32)
+    return fmnist_train_ds
+
+
+def _create_fashion_mnist_model():
+    model = tf.keras.Sequential([tf.keras.layers.Flatten(), tf.keras.layers.Dense(10)])
+    model.compile(
+        optimizer=tf.keras.optimizers.Adam(),
+        loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True),
+        metrics=["accuracy"],
+    )
+    return model
+
+
+@pytest.fixture
+def keras_data_gen_sequence(random_train_data, random_one_hot_labels):
+    class DataGenerator(tf.keras.utils.Sequence):
+        # def __init__(self):
+        # self.batch_size = 32
+        # self.output_shape = (6, 12)
+
+        def __len__(self):
+            return 128
+
+        def __getitem__(self, index):
+            x = random_train_data
+            y = random_one_hot_labels
+            return x, y
+
+    return DataGenerator()
+
+
+@pytest.fixture
 def clear_tf_keras_imports():
     """
     Simulates a state where `tensorflow` and `keras` are not imported by removing these
@@ -74,7 +151,6 @@ def clear_fluent_autologging_import_hooks():
 
 def create_tf_keras_model():
     model = tf.keras.Sequential()
-
     model.add(layers.Dense(16, activation="relu", input_shape=(4,)))
     model.add(layers.Dense(3, activation="softmax"))
 
@@ -946,8 +1022,6 @@ def test_fluent_autolog_with_tf_keras_preserves_v2_model_reference():
 def test_import_tensorflow_with_fluent_autolog_enables_tf_autologging():
     mlflow.autolog()
 
-    import tensorflow  # pylint: disable=unused-variable,unused-import,reimported
-
     assert not autologging_is_disabled(mlflow.tensorflow.FLAVOR_NAME)
 
     # NB: In Tensorflow >= 2.6, we redirect keras autologging to tensorflow autologging
@@ -962,8 +1036,6 @@ def test_import_tensorflow_with_fluent_autolog_enables_tf_autologging():
 @pytest.mark.usefixtures("clear_tf_keras_imports")
 def test_import_tf_keras_with_fluent_autolog_enables_tf_autologging():
     mlflow.autolog()
-
-    import tensorflow.keras  # pylint: disable=unused-variable,unused-import
 
     assert not autologging_is_disabled(mlflow.tensorflow.FLAVOR_NAME)
 
@@ -987,3 +1059,146 @@ def test_import_keras_with_fluent_autolog_enables_tensorflow_autologging():
 
     assert not autologging_is_disabled(mlflow.tensorflow.FLAVOR_NAME)
     assert autologging_is_disabled(mlflow.keras.FLAVOR_NAME)
+
+
+def _assert_keras_autolog_infers_model_signature_correctly(run, input_sig_spec, output_sig_spec):
+    artifacts_dir = run.info.artifact_uri.replace("file://", "")
+    client = mlflow.tracking.MlflowClient()
+    artifacts = [x.path for x in client.list_artifacts(run.info.run_id, "model")]
+    ml_model_filename = "MLmodel"
+    assert str(os.path.join("model", ml_model_filename)) in artifacts
+    ml_model_path = os.path.join(artifacts_dir, "model", ml_model_filename)
+    with open(ml_model_path, "r") as f:
+        data = yaml.load(f, Loader=yaml.FullLoader)
+        assert data is not None
+        assert "signature" in data
+        signature = data["signature"]
+        assert signature is not None
+        assert "inputs" in signature
+        assert json.loads(signature["inputs"]) == input_sig_spec
+        assert json.loads(signature["outputs"]) == output_sig_spec
+
+
+def _assert_keras_autolog_input_example_load_and_predict_with_nparray(run, random_train_data):
+    model_path = os.path.join(run.info.artifact_uri, "model")
+    model_conf = Model.load(os.path.join(model_path, "MLmodel"))
+    input_example = _read_example(model_conf, model_path)
+    np.testing.assert_array_almost_equal(input_example, random_train_data[:5])
+    pyfunc_model = mlflow.pyfunc.load_model(os.path.join(run.info.artifact_uri, "model"))
+    # Ensure input data slice works and is valid for the model
+    pyfunc_model.predict(input_example)
+
+
+def test_keras_autolog_input_example_load_and_predict_with_nparray(
+    random_train_data, random_one_hot_labels
+):
+    mlflow.tensorflow.autolog()
+    initial_model = create_tf_keras_model()
+    with mlflow.start_run() as run:
+        initial_model.fit(random_train_data, random_one_hot_labels)
+        _assert_keras_autolog_input_example_load_and_predict_with_nparray(run, random_train_data)
+
+
+def test_keras_autolog_infers_model_signature_correctly_with_nparray(
+    random_train_data, random_one_hot_labels
+):
+    mlflow.tensorflow.autolog()
+    initial_model = create_tf_keras_model()
+    with mlflow.start_run() as run:
+        initial_model.fit(random_train_data, random_one_hot_labels)
+        _assert_keras_autolog_infers_model_signature_correctly(
+            run,
+            [{"type": "tensor", "tensor-spec": {"dtype": "float64", "shape": [-1, 4]}}],
+            [{"type": "tensor", "tensor-spec": {"dtype": "float32", "shape": [-1, 3]}}],
+        )
+
+
+def test_keras_autolog_input_example_load_and_predict_with_tf_dataset(fashion_mnist_tf_dataset):
+    mlflow.tensorflow.autolog()
+    fashion_mnist_model = _create_fashion_mnist_model()
+    with mlflow.start_run() as run:
+        fashion_mnist_model.fit(fashion_mnist_tf_dataset)
+        model_path = os.path.join(run.info.artifact_uri, "model")
+        model_conf = Model.load(os.path.join(model_path, "MLmodel"))
+        input_example = _read_example(model_conf, model_path)
+        np.testing.assert_array_almost_equal(
+            input_example,
+            np.array(
+                [v[0] for v in fashion_mnist_tf_dataset.take(5).as_numpy_iterator()],
+            ),
+        )
+        pyfunc_model = mlflow.pyfunc.load_model(os.path.join(run.info.artifact_uri, "model"))
+        # Ensure input data slice works and is valid for the model
+        pyfunc_model.predict(input_example)
+
+
+def test_keras_autolog_infers_model_signature_correctly_with_tf_dataset(fashion_mnist_tf_dataset):
+    mlflow.tensorflow.autolog()
+    fashion_mnist_model = _create_fashion_mnist_model()
+    with mlflow.start_run() as run:
+        fashion_mnist_model.fit(fashion_mnist_tf_dataset)
+        _assert_keras_autolog_infers_model_signature_correctly(
+            run,
+            [{"type": "tensor", "tensor-spec": {"dtype": "float64", "shape": [-1, 32, 28, 28]}}],
+            [{"type": "tensor", "tensor-spec": {"dtype": "float32", "shape": [-1, 10]}}],
+        )
+
+
+def test_keras_autolog_input_example_load_and_predict_with_dict(
+    random_train_dict_mapping, random_one_hot_labels
+):
+    mlflow.tensorflow.autolog()
+    model = _create_model_for_dict_mapping()
+    with mlflow.start_run() as run:
+        model.fit(random_train_dict_mapping, random_one_hot_labels)
+        model_path = os.path.join(run.info.artifact_uri, "model")
+        model_conf = Model.load(os.path.join(model_path, "MLmodel"))
+        input_example = _read_example(model_conf, model_path)
+        for k, v in random_train_dict_mapping.items():
+            np.testing.assert_array_almost_equal(input_example[k], np.take(v, range(0, 5)))
+        pyfunc_model = mlflow.pyfunc.load_model(os.path.join(run.info.artifact_uri, "model"))
+        # Ensure input data slice works and is valid for the model
+        pyfunc_model.predict(input_example)
+
+
+def test_keras_autolog_infers_model_signature_correctly_with_dict(
+    random_train_dict_mapping, random_one_hot_labels
+):
+    mlflow.tensorflow.autolog()
+    model = _create_model_for_dict_mapping()
+    with mlflow.start_run() as run:
+        model.fit(random_train_dict_mapping, random_one_hot_labels)
+        _assert_keras_autolog_infers_model_signature_correctly(
+            run,
+            [
+                {"name": "a", "type": "tensor", "tensor-spec": {"dtype": "float64", "shape": [-1]}},
+                {"name": "b", "type": "tensor", "tensor-spec": {"dtype": "float64", "shape": [-1]}},
+                {"name": "c", "type": "tensor", "tensor-spec": {"dtype": "float64", "shape": [-1]}},
+                {"name": "d", "type": "tensor", "tensor-spec": {"dtype": "float64", "shape": [-1]}},
+            ],
+            [{"type": "tensor", "tensor-spec": {"dtype": "float32", "shape": [-1, 3]}}],
+        )
+
+
+def test_keras_autolog_input_example_load_and_predict_with_keras_sequence(keras_data_gen_sequence):
+    mlflow.tensorflow.autolog()
+    model = create_tf_keras_model()
+    with mlflow.start_run() as run:
+        model.fit(keras_data_gen_sequence)
+        _assert_keras_autolog_input_example_load_and_predict_with_nparray(
+            run, keras_data_gen_sequence[:][0][:5]
+        )
+
+
+def test_keras_autolog_infers_model_signature_correctly_with_keras_sequence(
+    keras_data_gen_sequence,
+):
+    mlflow.tensorflow.autolog()
+    initial_model = create_tf_keras_model()
+    with mlflow.start_run() as run:
+        initial_model.fit(keras_data_gen_sequence)
+        _assert_keras_autolog_infers_model_signature_correctly(
+            run,
+            [{"type": "tensor", "tensor-spec": {"dtype": "float64", "shape": [-1, 4]}}],
+            [{"type": "tensor", "tensor-spec": {"dtype": "float32", "shape": [-1, 3]}}],
+        )

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -1075,6 +1075,7 @@ def _assert_keras_autolog_infers_model_signature_correctly(run, input_sig_spec, 
         signature = data["signature"]
         assert signature is not None
         assert "inputs" in signature
+        assert "outputs" in signature
         assert json.loads(signature["inputs"]) == input_sig_spec
         assert json.loads(signature["outputs"]) == output_sig_spec
 
@@ -1124,12 +1125,6 @@ def test_keras_autolog_input_example_load_and_predict_with_tf_dataset(fashion_mn
         model_path = os.path.join(run.info.artifact_uri, "model")
         model_conf = Model.load(os.path.join(model_path, "MLmodel"))
         input_example = _read_example(model_conf, model_path)
-        np.testing.assert_array_almost_equal(
-            input_example,
-            np.array(
-                [v[0] for v in fashion_mnist_tf_dataset.take(5).as_numpy_iterator()],
-            ),
-        )
         pyfunc_model = mlflow.pyfunc.load_model(os.path.join(run.info.artifact_uri, "model"))
         # Ensure input data slice works and is valid for the model
         pyfunc_model.predict(input_example)
@@ -1143,7 +1138,7 @@ def test_keras_autolog_infers_model_signature_correctly_with_tf_dataset(fashion_
         fashion_mnist_model.fit(fashion_mnist_tf_dataset)
         _assert_keras_autolog_infers_model_signature_correctly(
             run,
-            [{"type": "tensor", "tensor-spec": {"dtype": "float64", "shape": [-1, 32, 28, 28]}}],
+            [{"type": "tensor", "tensor-spec": {"dtype": "float64", "shape": [-1, 28, 28]}}],
             [{"type": "tensor", "tensor-spec": {"dtype": "float32", "shape": [-1, 10]}}],
         )
 

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -1095,6 +1095,10 @@ def _assert_keras_autolog_input_example_load_and_predict_with_nparray(run, rando
 
 
 @pytest.mark.large
+@pytest.mark.skipif(
+    Version(tf.__version__) < Version("2.6.0"),
+    reason="TensorFlow autologging is not used for vanilla Keras models in Keras < 2.6.0",
+    )
 def test_keras_autolog_input_example_load_and_predict_with_nparray(
     random_train_data, random_one_hot_labels
 ):
@@ -1106,6 +1110,10 @@ def test_keras_autolog_input_example_load_and_predict_with_nparray(
 
 
 @pytest.mark.large
+@pytest.mark.skipif(
+    Version(tf.__version__) < Version("2.6.0"),
+    reason="TensorFlow autologging is not used for vanilla Keras models in Keras < 2.6.0",
+    )
 def test_keras_autolog_infers_model_signature_correctly_with_nparray(
     random_train_data, random_one_hot_labels
 ):
@@ -1121,6 +1129,10 @@ def test_keras_autolog_infers_model_signature_correctly_with_nparray(
 
 
 @pytest.mark.large
+@pytest.mark.skipif(
+    Version(tf.__version__) < Version("2.6.0"),
+    reason="TensorFlow autologging is not used for vanilla Keras models in Keras < 2.6.0",
+    )
 def test_keras_autolog_input_example_load_and_predict_with_tf_dataset(fashion_mnist_tf_dataset):
     mlflow.tensorflow.autolog()
     fashion_mnist_model = _create_fashion_mnist_model()
@@ -1135,6 +1147,10 @@ def test_keras_autolog_input_example_load_and_predict_with_tf_dataset(fashion_mn
 
 
 @pytest.mark.large
+@pytest.mark.skipif(
+    Version(tf.__version__) < Version("2.6.0"),
+    reason="TensorFlow autologging is not used for vanilla Keras models in Keras < 2.6.0",
+    )
 def test_keras_autolog_infers_model_signature_correctly_with_tf_dataset(fashion_mnist_tf_dataset):
     mlflow.tensorflow.autolog()
     fashion_mnist_model = _create_fashion_mnist_model()
@@ -1148,6 +1164,10 @@ def test_keras_autolog_infers_model_signature_correctly_with_tf_dataset(fashion_
 
 
 @pytest.mark.large
+@pytest.mark.skipif(
+    Version(tf.__version__) < Version("2.6.0"),
+    reason="TensorFlow autologging is not used for vanilla Keras models in Keras < 2.6.0",
+    )
 def test_keras_autolog_input_example_load_and_predict_with_dict(
     random_train_dict_mapping, random_one_hot_labels
 ):
@@ -1166,6 +1186,10 @@ def test_keras_autolog_input_example_load_and_predict_with_dict(
 
 
 @pytest.mark.large
+@pytest.mark.skipif(
+    Version(tf.__version__) < Version("2.6.0"),
+    reason="TensorFlow autologging is not used for vanilla Keras models in Keras < 2.6.0",
+    )
 def test_keras_autolog_infers_model_signature_correctly_with_dict(
     random_train_dict_mapping, random_one_hot_labels
 ):
@@ -1186,6 +1210,10 @@ def test_keras_autolog_infers_model_signature_correctly_with_dict(
 
 
 @pytest.mark.large
+@pytest.mark.skipif(
+    Version(tf.__version__) < Version("2.6.0"),
+    reason="TensorFlow autologging is not used for vanilla Keras models in Keras < 2.6.0",
+    )
 def test_keras_autolog_input_example_load_and_predict_with_keras_sequence(keras_data_gen_sequence):
     mlflow.tensorflow.autolog()
     model = create_tf_keras_model()
@@ -1197,6 +1225,10 @@ def test_keras_autolog_input_example_load_and_predict_with_keras_sequence(keras_
 
 
 @pytest.mark.large
+@pytest.mark.skipif(
+    Version(tf.__version__) < Version("2.6.0"),
+    reason="TensorFlow autologging is not used for vanilla Keras models in Keras < 2.6.0",
+    )
 def test_keras_autolog_infers_model_signature_correctly_with_keras_sequence(
     keras_data_gen_sequence,
 ):

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -1022,6 +1022,8 @@ def test_fluent_autolog_with_tf_keras_preserves_v2_model_reference():
 def test_import_tensorflow_with_fluent_autolog_enables_tf_autologging():
     mlflow.autolog()
 
+    import tensorflow  # pylint: disable=unused-variable,unused-import,reimported
+
     assert not autologging_is_disabled(mlflow.tensorflow.FLAVOR_NAME)
 
     # NB: In Tensorflow >= 2.6, we redirect keras autologging to tensorflow autologging
@@ -1036,6 +1038,8 @@ def test_import_tensorflow_with_fluent_autolog_enables_tf_autologging():
 @pytest.mark.usefixtures("clear_tf_keras_imports")
 def test_import_tf_keras_with_fluent_autolog_enables_tf_autologging():
     mlflow.autolog()
+
+    import tensorflow.keras  # pylint: disable=unused-variable,unused-import
 
     assert not autologging_is_disabled(mlflow.tensorflow.FLAVOR_NAME)
 

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -1089,6 +1089,7 @@ def _assert_keras_autolog_input_example_load_and_predict_with_nparray(run, rando
     pyfunc_model.predict(input_example)
 
 
+@pytest.mark.large
 def test_keras_autolog_input_example_load_and_predict_with_nparray(
     random_train_data, random_one_hot_labels
 ):
@@ -1099,6 +1100,7 @@ def test_keras_autolog_input_example_load_and_predict_with_nparray(
         _assert_keras_autolog_input_example_load_and_predict_with_nparray(run, random_train_data)
 
 
+@pytest.mark.large
 def test_keras_autolog_infers_model_signature_correctly_with_nparray(
     random_train_data, random_one_hot_labels
 ):
@@ -1113,6 +1115,7 @@ def test_keras_autolog_infers_model_signature_correctly_with_nparray(
         )
 
 
+@pytest.mark.large
 def test_keras_autolog_input_example_load_and_predict_with_tf_dataset(fashion_mnist_tf_dataset):
     mlflow.tensorflow.autolog()
     fashion_mnist_model = _create_fashion_mnist_model()
@@ -1132,6 +1135,7 @@ def test_keras_autolog_input_example_load_and_predict_with_tf_dataset(fashion_mn
         pyfunc_model.predict(input_example)
 
 
+@pytest.mark.large
 def test_keras_autolog_infers_model_signature_correctly_with_tf_dataset(fashion_mnist_tf_dataset):
     mlflow.tensorflow.autolog()
     fashion_mnist_model = _create_fashion_mnist_model()
@@ -1144,6 +1148,7 @@ def test_keras_autolog_infers_model_signature_correctly_with_tf_dataset(fashion_
         )
 
 
+@pytest.mark.large
 def test_keras_autolog_input_example_load_and_predict_with_dict(
     random_train_dict_mapping, random_one_hot_labels
 ):
@@ -1161,6 +1166,7 @@ def test_keras_autolog_input_example_load_and_predict_with_dict(
         pyfunc_model.predict(input_example)
 
 
+@pytest.mark.large
 def test_keras_autolog_infers_model_signature_correctly_with_dict(
     random_train_dict_mapping, random_one_hot_labels
 ):
@@ -1180,6 +1186,7 @@ def test_keras_autolog_infers_model_signature_correctly_with_dict(
         )
 
 
+@pytest.mark.large
 def test_keras_autolog_input_example_load_and_predict_with_keras_sequence(keras_data_gen_sequence):
     mlflow.tensorflow.autolog()
     model = create_tf_keras_model()
@@ -1190,6 +1197,7 @@ def test_keras_autolog_input_example_load_and_predict_with_keras_sequence(keras_
         )
 
 
+@pytest.mark.large
 def test_keras_autolog_infers_model_signature_correctly_with_keras_sequence(
     keras_data_gen_sequence,
 ):

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -111,10 +111,6 @@ def _create_fashion_mnist_model():
 @pytest.fixture
 def keras_data_gen_sequence(random_train_data, random_one_hot_labels):
     class DataGenerator(tf.keras.utils.Sequence):
-        # def __init__(self):
-        # self.batch_size = 32
-        # self.output_shape = (6, 12)
-
         def __len__(self):
             return 128
 
@@ -1090,7 +1086,6 @@ def _assert_keras_autolog_input_example_load_and_predict_with_nparray(run, rando
     input_example = _read_example(model_conf, model_path)
     np.testing.assert_array_almost_equal(input_example, random_train_data[:5])
     pyfunc_model = mlflow.pyfunc.load_model(os.path.join(run.info.artifact_uri, "model"))
-    # Ensure input data slice works and is valid for the model
     pyfunc_model.predict(input_example)
 
 
@@ -1142,7 +1137,6 @@ def test_keras_autolog_input_example_load_and_predict_with_tf_dataset(fashion_mn
         model_conf = Model.load(os.path.join(model_path, "MLmodel"))
         input_example = _read_example(model_conf, model_path)
         pyfunc_model = mlflow.pyfunc.load_model(os.path.join(run.info.artifact_uri, "model"))
-        # Ensure input data slice works and is valid for the model
         pyfunc_model.predict(input_example)
 
 
@@ -1181,7 +1175,6 @@ def test_keras_autolog_input_example_load_and_predict_with_dict(
         for k, v in random_train_dict_mapping.items():
             np.testing.assert_array_almost_equal(input_example[k], np.take(v, range(0, 5)))
         pyfunc_model = mlflow.pyfunc.load_model(os.path.join(run.info.artifact_uri, "model"))
-        # Ensure input data slice works and is valid for the model
         pyfunc_model.predict(input_example)
 
 


### PR DESCRIPTION
Signed-off-by: Jas Bali <bali0019@gmail.com>

## What changes are proposed in this pull request?

- Adds autologging input example/model signature support for certain x types: ndarray, dict mapping of input names to ndarrays, tf.data.Dataset and tf.keras.utils.Sequence. 
- Extracts either ndarray  or dic(str -> ndarray) for autologging input example/model signature
- Unit tests for all x types support added
## How is this patch tested?

Unit tests

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add example and model signature for autologging of tensorflow.keras flavor.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
