### PR TITLE
Fix mlflow-R for passing CRAN checks

### DIFF
--- a/mlflow/R/mlflow/R/install.R
+++ b/mlflow/R/mlflow/R/install.R
@@ -79,7 +79,7 @@ mlflow_conda_bin <- function() {
   conda_home <- Sys.getenv("MLFLOW_CONDA_HOME", NA)
   conda <- if (!is.na(conda_home)) paste(conda_home, "bin", "conda", sep = "/") else "auto"
   conda_try <- try(conda_binary(conda = conda), silent = TRUE)
-  if (class(conda_try) == "try-error") {
+  if (inherits(conda_try, "try-error")) {
     msg <- paste(attributes(conda_try)$condition$message,
                  paste("  If you are not using conda, you can set the environment variable",
                  "MLFLOW_PYTHON_BIN to the path of your python executable."),

--- a/mlflow/R/mlflow/R/python.R
+++ b/mlflow/R/mlflow/R/python.R
@@ -41,7 +41,7 @@ python_mlflow_bin <- function() {
 #' @importFrom reticulate conda_binary
 python_conda_home <- function() {
   path <- try(dirname(dirname(mlflow_conda_bin())), silent = TRUE)
-  if (class(path) == "try-error") {
+  if (inherits(path, "try-error")) {
     return(NA)
   }
   path


### PR DESCRIPTION
Signed-off-by: Weichen Xu <weichen.xu@databricks.com>

## What changes are proposed in this pull request?

After mlflow-R 1.24.0 released, we found the CRAN checks failed:
https://win-builder.r-project.org/incoming_pretest/mlflow_1.24.0_20220307_064019/Windows/00check.log

This PR is for fixing this.

## How is this patch tested?

N/A

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [x] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
