### PR TITLE
feat: Support spark transformers tracking with mlflow

### DIFF
--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -734,7 +734,12 @@ class _PyFuncModelWrapper:
         :param pandas_df: pandas DataFrame containing input data.
         :return: List with model predictions.
         """
+        from pyspark.ml import PipelineModel
+
         spark_df = self.spark.createDataFrame(pandas_df)
+        if isinstance(self.spark_model, PipelineModel):
+            # make sure predict work by default for Transformers
+            self.spark_model.stages[-1].setOutputCol("prediction")
         return [
             x.prediction
             for x in self.spark_model.transform(spark_df).select("prediction").collect()

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -737,9 +737,11 @@ class _PyFuncModelWrapper:
         from pyspark.ml import PipelineModel
 
         spark_df = self.spark.createDataFrame(pandas_df)
-        if isinstance(self.spark_model, PipelineModel) and self.spark_model.stages[-1].hasParam("outputCol"):
+        if isinstance(self.spark_model, PipelineModel) and self.spark_model.stages[-1].hasParam(
+            "outputCol"
+        ):
             # make sure predict work by default for Transformers
-                self.spark_model.stages[-1].setOutputCol("prediction")
+            self.spark_model.stages[-1].setOutputCol("prediction")
         return [
             x.prediction
             for x in self.spark_model.transform(spark_df).select("prediction").collect()

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -739,7 +739,8 @@ class _PyFuncModelWrapper:
         spark_df = self.spark.createDataFrame(pandas_df)
         if isinstance(self.spark_model, PipelineModel):
             # make sure predict work by default for Transformers
-            self.spark_model.stages[-1].setOutputCol("prediction")
+            if self.spark_model.stages[-1].hasParam("outputCol"):
+                self.spark_model.stages[-1].setOutputCol("prediction")
         return [
             x.prediction
             for x in self.spark_model.transform(spark_df).select("prediction").collect()

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -116,7 +116,8 @@ def log_model(
     Note: If no run is active, it will instantiate a run to obtain a run_id.
 
     :param spark_model: Spark model to be saved - MLflow can only save descendants of
-                        pyspark.ml.Model which implement MLReadable and MLWritable.
+                        pyspark.ml.Model or pyspark.ml.Transformer which implement
+                        MLReadable and MLWritable.
     :param artifact_path: Run relative artifact path.
     :param conda_env: Either a dictionary representation of a Conda environment or the path to a
                       Conda environment yaml file. If provided, this decsribes the environment
@@ -451,9 +452,13 @@ def _save_model_metadata(
 def _validate_model(spark_model):
     from pyspark.ml.util import MLReadable, MLWritable
     from pyspark.ml import Model as PySparkModel
+    from pyspark.ml import Transformer as PySparkTransformer
 
     if (
-        not isinstance(spark_model, PySparkModel)
+        (
+            not isinstance(spark_model, PySparkModel)
+            and not isinstance(spark_model, PySparkTransformer)
+        )
         or not isinstance(spark_model, MLReadable)
         or not isinstance(spark_model, MLWritable)
     ):
@@ -485,7 +490,8 @@ def save_model(
     is also serialized in MLeap format and the MLeap flavor is added.
 
     :param spark_model: Spark model to be saved - MLflow can only save descendants of
-                        pyspark.ml.Model which implement MLReadable and MLWritable.
+                        pyspark.ml.Model or pyspark.ml.Transformer which implement
+                        MLReadable and MLWritable.
     :param path: Local path where the model is to be saved.
     :param mlflow_model: MLflow model config this flavor is being added to.
     :param conda_env: Either a dictionary representation of a Conda environment or the path to a

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -737,9 +737,8 @@ class _PyFuncModelWrapper:
         from pyspark.ml import PipelineModel
 
         spark_df = self.spark.createDataFrame(pandas_df)
-        if isinstance(self.spark_model, PipelineModel):
+        if isinstance(self.spark_model, PipelineModel) and self.spark_model.stages[-1].hasParam("outputCol"):
             # make sure predict work by default for Transformers
-            if self.spark_model.stages[-1].hasParam("outputCol"):
                 self.spark_model.stages[-1].setOutputCol("prediction")
         return [
             x.prediction

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -21,7 +21,7 @@ import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 import mlflow.tracking
 from mlflow import pyfunc
 from mlflow import spark as sparkm
-from mlflow.exceptions import MlflowException
+from mlflow.exceptions import MlflowException  # pylint: disable=unused-import
 from mlflow.models import Model, infer_signature
 from mlflow.models.utils import _read_example
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
@@ -275,10 +275,12 @@ def test_estimator_model_export(spark_model_estimator, model_path, spark_custom_
 
 @pytest.mark.large
 def test_transformer_model_export(spark_model_transformer, model_path, spark_custom_env):
-    with pytest.raises(MlflowException, match="Cannot serialize this model"):
-        sparkm.save_model(
-            spark_model_transformer.model, path=model_path, conda_env=spark_custom_env
-        )
+    sparkm.save_model(spark_model_transformer.model, path=model_path, conda_env=spark_custom_env)
+    # score and compare the reloaded sparkml model
+    reloaded_model = sparkm.load_model(model_uri=model_path)
+    preds_df = reloaded_model.transform(spark_model_transformer.spark_df)
+    preds = [x.features for x in preds_df.select("features").collect()]
+    assert spark_model_transformer.predictions == preds
 
 
 @pytest.mark.large
@@ -391,10 +393,39 @@ def test_sparkml_estimator_model_log(
 
 
 @pytest.mark.large
-def test_sparkml_model_log_invalid_args(spark_model_transformer, model_path):
-    # pylint: disable=unused-argument
-    with pytest.raises(MlflowException, match="Cannot serialize this model"):
-        sparkm.log_model(spark_model=spark_model_transformer.model, artifact_path="model0")
+@pytest.mark.parametrize("should_start_run", [False, True])
+@pytest.mark.parametrize("use_dfs_tmpdir", [False, True])
+def test_sparkml_transformer_model_log(
+    tmpdir, spark_model_transformer, should_start_run, use_dfs_tmpdir
+):
+    old_tracking_uri = mlflow.get_tracking_uri()
+    if use_dfs_tmpdir:
+        dfs_tmpdir = None
+    else:
+        dfs_tmpdir = tmpdir.join("test").strpath
+
+    try:
+        tracking_dir = os.path.abspath(str(tmpdir.join("mlruns")))
+        mlflow.set_tracking_uri("file://%s" % tracking_dir)
+        if should_start_run:
+            mlflow.start_run()
+        artifact_path = "model"
+        sparkm.log_model(
+            artifact_path=artifact_path,
+            spark_model=spark_model_transformer.model,
+            dfs_tmpdir=dfs_tmpdir,
+        )
+        model_uri = "runs:/{run_id}/{artifact_path}".format(
+            run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path
+        )
+
+        reloaded_model = sparkm.load_model(model_uri=model_uri, dfs_tmpdir=dfs_tmpdir)
+        preds_df = reloaded_model.transform(spark_model_transformer.spark_df)
+        preds = [x.features for x in preds_df.select("features").collect()]
+        assert spark_model_transformer.predictions == preds
+    finally:
+        mlflow.end_run()
+        mlflow.set_tracking_uri(old_tracking_uri)
 
 
 @pytest.mark.large


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Closes https://github.com/mlflow/mlflow/issues/5216
- Add support of pyspark.ml.Transformer to enable model tracking.

## How is this patch tested?

Tested local pytests and pack wheel packge to test on databricks.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Support all pyspark ml Transformers with the ability to save, log and load with mlflow.spark. 
https://github.com/mlflow/mlflow/issues/5216

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
