### PR TITLE
Avoid using the latest version of pip

### DIFF
--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -150,7 +150,9 @@ jobs:
       - name: Install mlflow & test dependencies
         run: |
           python --version
-          pip install --upgrade pip wheel
+          pip install --upgrade pip
+          latest_pip_version=$(pip --version | cut -d ' ' -f 2)
+          pip install --upgrade "pip<$latest_pip_version" wheel
           pip install -e .
           pip install -r requirements/small-requirements.txt
       - name: Install ${{ matrix.package }} ${{ matrix.version }}

--- a/dev/install-common-deps.sh
+++ b/dev/install-common-deps.sh
@@ -17,7 +17,13 @@ sudo apt clean
 df -h
 
 python --version
-pip install --upgrade pip wheel
+
+# When a new version of pip is released on PyPI, it takes a while until that version is
+# uploaded to conda-forge. This time lag causes `conda create` to fail with
+# a `ResolvePackageNotFound` error. As a workaround, use the second latest version of pip.
+pip install --upgrade pip
+latest_pip_version=$(pip --version | cut -d ' ' -f 2)
+pip install --upgrade "pip<$latest_pip_version" wheel
 pip --version
 
 if [[ "$MLFLOW_SKINNY" == "true" ]]; then


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Avoid using the latest version of pip as a fix for the following issue:

https://github.com/mlflow/mlflow/runs/5445309546?check_suite_focus=true#step:5:1919

```
Solving environment: ...working... failed

ResolvePackageNotFound: 
  - pip=22.0.4
```

When a new version of pip is released on PyPI, it takes a while until that version is uploaded to conda-forge. This time lag causes `conda create` to fail with a `ResolvePackageNotFound` error. pip 22.0.4 was released a few hours ago and is not uploaded to conda-forge yet.

## How is this patch tested?

Existing tests

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
