### PR TITLE
Use `<=` instead of `==` when logging pip requirement on conda.yaml

### DIFF
--- a/mlflow/shap.py
+++ b/mlflow/shap.py
@@ -29,6 +29,7 @@ from mlflow.utils.environment import (
     _CONDA_ENV_FILE_NAME,
     _REQUIREMENTS_FILE_NAME,
 )
+from mlflow.utils.requirements_utils import _get_package_name
 from mlflow.utils.file_utils import write_to
 from mlflow.utils.docstring_utils import format_docstring, LOG_MODEL_PARAM_DOCS
 from mlflow.utils.model_utils import _get_flavor_configuration
@@ -525,7 +526,8 @@ def _get_conda_and_pip_dependencies(conda_env):
                 if pip_dependency != "mlflow":
                     pip_deps.append(pip_dependency)
         else:
-            if dependency.split("=")[0] != "python" and dependency.split("=")[0] != "pip":
+            package_name = _get_package_name(dependency)
+            if package_name is not None and package_name not in ["python", "pip"]:
                 conda_deps.append(dependency)
 
     return conda_deps, pip_deps

--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -50,7 +50,11 @@ def _mlflow_conda_env(
     if pip_deps:
         pip_version = _get_pip_version()
         if pip_version is not None:
-            conda_deps.append(f"pip={pip_version}")
+            # When a new version of pip is released on PyPI, it takes a while until that version is
+            # uploaded to conda-forge. This time lag causes `conda create` to fail with
+            # a `ResolvePackageNotFound` error. As a workaround for this issue, use `<=` instead
+            # of `==` so conda installs `pip_version - 1` when `pip_version` is unavailable.
+            conda_deps.append(f"pip<={pip_version}")
         else:
             _logger.warning(
                 "Failed to resolve installed pip version. ``pip`` will be added to conda.yaml"

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -130,6 +130,15 @@ def _flatten(iterable):
     return chain.from_iterable(iterable)
 
 
+# https://www.python.org/dev/peps/pep-0508/#names
+_PACKAGE_NAME_REGEX = re.compile(r"^(\w+|\w+[\w._-]*\w+)")
+
+
+def _get_package_name(requirement):
+    m = _PACKAGE_NAME_REGEX.match(requirement)
+    return m and m.group(1)
+
+
 _NORMALIZE_REGEX = re.compile(r"[-_.]+")
 
 

--- a/tests/utils/test_environment.py
+++ b/tests/utils/test_environment.py
@@ -51,7 +51,7 @@ def test_mlflow_conda_env_includes_pip_dependencies_but_pip_is_not_specified(con
     if conda_deps is not None:
         for conda_dep in conda_deps:
             assert conda_dep in env["dependencies"]
-    assert f"pip={pip.__version__}" in env["dependencies"]
+    assert f"pip<={pip.__version__}" in env["dependencies"]
 
 
 @pytest.mark.parametrize("pip_specification", ["pip", "pip==20.0.02"])


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Use `<=` instead of `==` when logging pip requirement on conda.yaml to fix the issue reported in https://github.com/mlflow/mlflow/pull/5467.

## How is this patch tested?

Existing checks

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
