### PR TITLE
Fixed EvaluationResult not saving or loading artifacts with proper file names

### DIFF
--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -16,7 +16,7 @@ import struct
 import sys
 import math
 import urllib
-import posixpath
+import pathlib
 from collections import OrderedDict
 from abc import ABCMeta, abstractmethod
 
@@ -109,7 +109,7 @@ class EvaluationResult:
             uri = meta["uri"]
             ArtifactCls = _get_class_from_string(meta["class_name"])
             artifact = ArtifactCls(uri=uri)
-            filename = posixpath.basename(urllib.parse.urlparse(uri).path)
+            filename = pathlib.Path(urllib.parse.urlparse(uri).path).name
             artifact._load(os.path.join(artifacts_dir, filename))
             artifacts[artifact_name] = artifact
 
@@ -135,7 +135,7 @@ class EvaluationResult:
         os.mkdir(artifacts_dir)
 
         for artifact in self.artifacts.values():
-            filename = posixpath.basename(urllib.parse.urlparse(artifact.uri).path)
+            filename = pathlib.Path(urllib.parse.urlparse(artifact.uri).path).name
             artifact._save(os.path.join(artifacts_dir, filename))
 
     @property

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -15,6 +15,7 @@ import logging
 import struct
 import sys
 import math
+import pathlib
 from collections import OrderedDict
 from abc import ABCMeta, abstractmethod
 
@@ -107,7 +108,7 @@ class EvaluationResult:
             uri = meta["uri"]
             ArtifactCls = _get_class_from_string(meta["class_name"])
             artifact = ArtifactCls(uri=uri)
-            artifact._load(os.path.join(artifacts_dir, artifact_name))
+            artifact._load(os.path.join(artifacts_dir, pathlib.Path(uri).name))
             artifacts[artifact_name] = artifact
 
         return EvaluationResult(metrics=metrics, artifacts=artifacts)
@@ -131,8 +132,8 @@ class EvaluationResult:
         artifacts_dir = os.path.join(path, "artifacts")
         os.mkdir(artifacts_dir)
 
-        for artifact_name, artifact in self.artifacts.items():
-            artifact._save(os.path.join(artifacts_dir, artifact_name))
+        for artifact in self.artifacts.values():
+            artifact._save(os.path.join(artifacts_dir, pathlib.Path(artifact.uri).name))
 
     @property
     def metrics(self) -> Dict[str, Any]:

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -15,7 +15,8 @@ import logging
 import struct
 import sys
 import math
-import pathlib
+import urllib
+import posixpath
 from collections import OrderedDict
 from abc import ABCMeta, abstractmethod
 
@@ -108,7 +109,8 @@ class EvaluationResult:
             uri = meta["uri"]
             ArtifactCls = _get_class_from_string(meta["class_name"])
             artifact = ArtifactCls(uri=uri)
-            artifact._load(os.path.join(artifacts_dir, pathlib.Path(uri).name))
+            filename = posixpath.basename(urllib.parse.urlparse(uri).path)
+            artifact._load(os.path.join(artifacts_dir, filename))
             artifacts[artifact_name] = artifact
 
         return EvaluationResult(metrics=metrics, artifacts=artifacts)
@@ -133,7 +135,8 @@ class EvaluationResult:
         os.mkdir(artifacts_dir)
 
         for artifact in self.artifacts.values():
-            artifact._save(os.path.join(artifacts_dir, pathlib.Path(artifact.uri).name))
+            filename = posixpath.basename(urllib.parse.urlparse(artifact.uri).path)
+            artifact._save(os.path.join(artifacts_dir, filename))
 
     @property
     def metrics(self) -> Dict[str, Any]:

--- a/tests/models/test_evaluation.py
+++ b/tests/models/test_evaluation.py
@@ -7,6 +7,7 @@ from mlflow.models.evaluation import (
     ModelEvaluator,
     EvaluationArtifact,
 )
+from mlflow.models.evaluation.artifacts import ImageEvaluationArtifact
 from mlflow.models.evaluation.base import (
     EvaluationDataset,
     _normalize_evaluators_and_evaluator_config_args as _normalize_config,
@@ -21,6 +22,8 @@ import pytest
 import numpy as np
 import pandas as pd
 from unittest import mock
+from PIL import ImageChops, Image
+import io
 from mlflow.utils.file_utils import TempDir
 from mlflow_test_plugin.dummy_evaluator import Array2DEvaluationArtifact
 from mlflow.models.evaluation.evaluator_registry import _model_evaluation_registry
@@ -226,7 +229,12 @@ def test_classifier_evaluate(multiclass_logistic_regressor_model_uri, iris_datas
         "accuracy_score_on_iris_dataset": expected_accuracy_score,
     }
 
-    expected_artifact = confusion_matrix(y_true, y_pred)
+    expected_csv_artifact = confusion_matrix(y_true, y_pred)
+    cm_figure = sklearn.metrics.ConfusionMatrixDisplay.from_predictions(y_true, y_pred).figure_
+    img_buf = io.BytesIO()
+    cm_figure.savefig(img_buf)
+    img_buf.seek(0)
+    expected_image_artifact = Image.open(img_buf)
 
     with mlflow.start_run() as run:
         eval_result = evaluate(
@@ -238,18 +246,42 @@ def test_classifier_evaluate(multiclass_logistic_regressor_model_uri, iris_datas
             evaluators="dummy_evaluator",
         )
 
-    artifact_name = "confusion_matrix_on_iris_dataset.csv"
-    saved_artifact_path = get_local_artifact_path(run.info.run_id, artifact_name)
+    csv_artifact_name = "confusion_matrix_on_iris_dataset"
+    saved_csv_artifact_path = get_local_artifact_path(run.info.run_id, csv_artifact_name + ".csv")
+
+    png_artifact_name = "confusion_matrix_image_on_iris_dataset"
+    saved_png_artifact_path = get_local_artifact_path(run.info.run_id, png_artifact_name) + ".png"
 
     _, saved_metrics, _, saved_artifacts = get_run_data(run.info.run_id)
     assert saved_metrics == expected_saved_metrics
-    assert saved_artifacts == [artifact_name]
+    assert set(saved_artifacts) == {csv_artifact_name + ".csv", png_artifact_name + ".png"}
 
     assert eval_result.metrics == expected_metrics
-    confusion_matrix_artifact = eval_result.artifacts[artifact_name]
-    assert np.array_equal(confusion_matrix_artifact.content, expected_artifact)
-    assert confusion_matrix_artifact.uri == get_artifact_uri(run.info.run_id, artifact_name)
-    assert np.array_equal(confusion_matrix_artifact._load(saved_artifact_path), expected_artifact)
+    confusion_matrix_artifact = eval_result.artifacts[csv_artifact_name]
+    assert np.array_equal(confusion_matrix_artifact.content, expected_csv_artifact)
+    assert confusion_matrix_artifact.uri == get_artifact_uri(
+        run.info.run_id, csv_artifact_name + ".csv"
+    )
+    assert np.array_equal(
+        confusion_matrix_artifact._load(saved_csv_artifact_path), expected_csv_artifact
+    )
+    confusion_matrix_image_artifact = eval_result.artifacts[png_artifact_name]
+    assert (
+        ImageChops.difference(
+            confusion_matrix_image_artifact.content, expected_image_artifact
+        ).getbbox()
+        is None
+    )
+    assert confusion_matrix_image_artifact.uri == get_artifact_uri(
+        run.info.run_id, png_artifact_name + ".png"
+    )
+    assert (
+        ImageChops.difference(
+            confusion_matrix_image_artifact._load(saved_png_artifact_path),
+            expected_image_artifact,
+        ).getbbox()
+        is None
+    )
 
     with TempDir() as temp_dir:
         temp_dir_path = temp_dir.path()
@@ -259,22 +291,40 @@ def test_classifier_evaluate(multiclass_logistic_regressor_model_uri, iris_datas
             assert json.load(fp) == eval_result.metrics
 
         with open(temp_dir.path("artifacts_metadata.json"), "r") as fp:
-            assert json.load(fp) == {
-                "confusion_matrix_on_iris_dataset.csv": {
-                    "uri": confusion_matrix_artifact.uri,
-                    "class_name": "mlflow_test_plugin.dummy_evaluator.Array2DEvaluationArtifact",
-                }
+            json_dict = json.load(fp)
+            assert "confusion_matrix_on_iris_dataset" in json_dict
+            assert json_dict["confusion_matrix_on_iris_dataset"] == {
+                "uri": confusion_matrix_artifact.uri,
+                "class_name": "mlflow_test_plugin.dummy_evaluator.Array2DEvaluationArtifact",
             }
 
-        assert os.listdir(temp_dir.path("artifacts")) == ["confusion_matrix_on_iris_dataset.csv"]
+            assert "confusion_matrix_image_on_iris_dataset" in json_dict
+            assert json_dict["confusion_matrix_image_on_iris_dataset"] == {
+                "uri": confusion_matrix_image_artifact.uri,
+                "class_name": "mlflow.models.evaluation.artifacts.ImageEvaluationArtifact",
+            }
+
+        assert set(os.listdir(temp_dir.path("artifacts"))) == {
+            "confusion_matrix_on_iris_dataset.csv",
+            "confusion_matrix_image_on_iris_dataset.png",
+        }
 
         loaded_eval_result = EvaluationResult.load(temp_dir_path)
         assert loaded_eval_result.metrics == eval_result.metrics
-        loaded_confusion_matrix_artifact = loaded_eval_result.artifacts[artifact_name]
+        loaded_confusion_matrix_artifact = loaded_eval_result.artifacts[csv_artifact_name]
         assert confusion_matrix_artifact.uri == loaded_confusion_matrix_artifact.uri
         assert np.array_equal(
             confusion_matrix_artifact.content,
             loaded_confusion_matrix_artifact.content,
+        )
+        loaded_confusion_matrix_image_artifact = loaded_eval_result.artifacts[png_artifact_name]
+        assert confusion_matrix_image_artifact.uri == loaded_confusion_matrix_image_artifact.uri
+        assert (
+            ImageChops.difference(
+                confusion_matrix_image_artifact.content,
+                loaded_confusion_matrix_image_artifact.content,
+            ).getbbox()
+            is None
         )
 
         new_confusion_matrix_artifact = Array2DEvaluationArtifact(uri=confusion_matrix_artifact.uri)
@@ -282,6 +332,14 @@ def test_classifier_evaluate(multiclass_logistic_regressor_model_uri, iris_datas
         assert np.array_equal(
             confusion_matrix_artifact.content,
             new_confusion_matrix_artifact.content,
+        )
+        new_confusion_matrix_image_artifact = ImageEvaluationArtifact(
+            uri=confusion_matrix_image_artifact.uri
+        )
+        new_confusion_matrix_image_artifact._load()
+        assert np.array_equal(
+            confusion_matrix_image_artifact.content,
+            new_confusion_matrix_image_artifact.content,
         )
 
 

--- a/tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_evaluator.py
+++ b/tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_evaluator.py
@@ -4,12 +4,14 @@ from mlflow.models.evaluation import (
     EvaluationArtifact,
     EvaluationResult,
 )
+from mlflow.models.evaluation.artifacts import ImageEvaluationArtifact
 from mlflow.tracking.artifact_utils import get_artifact_uri
 from mlflow.entities import Metric
 from sklearn import metrics as sk_metrics
 import time
 import pandas as pd
 import io
+from PIL import Image
 
 
 class Array2DEvaluationArtifact(EvaluationArtifact):
@@ -54,17 +56,41 @@ class DummyEvaluator(ModelEvaluator):
             metrics = {"accuracy_score": accuracy_score}
             self._log_metrics(run_id, metrics, dataset.name)
             confusion_matrix = sk_metrics.confusion_matrix(y, y_pred)
-            confusion_matrix_artifact_name = f"confusion_matrix_on_{dataset.name}.csv"
+            confusion_matrix_artifact_name = f"confusion_matrix_on_{dataset.name}"
             confusion_matrix_artifact = Array2DEvaluationArtifact(
-                uri=get_artifact_uri(run_id, confusion_matrix_artifact_name),
+                uri=get_artifact_uri(run_id, confusion_matrix_artifact_name + ".csv"),
                 content=confusion_matrix,
             )
             confusion_matrix_csv_buff = io.StringIO()
             confusion_matrix_artifact._save(confusion_matrix_csv_buff)
             client.log_text(
-                run_id, confusion_matrix_csv_buff.getvalue(), confusion_matrix_artifact_name
+                run_id,
+                confusion_matrix_csv_buff.getvalue(),
+                confusion_matrix_artifact_name + ".csv",
             )
-            artifacts = {confusion_matrix_artifact_name: confusion_matrix_artifact}
+
+            confusion_matrix_figure = sk_metrics.ConfusionMatrixDisplay.from_predictions(
+                y, y_pred
+            ).figure_
+            img_buf = io.BytesIO()
+            confusion_matrix_figure.savefig(img_buf)
+            img_buf.seek(0)
+            confusion_matrix_image = Image.open(img_buf)
+
+            confusion_matrix_image_artifact_name = f"confusion_matrix_image_on_{dataset.name}"
+            confusion_matrix_image_artifact = ImageEvaluationArtifact(
+                uri=get_artifact_uri(run_id, confusion_matrix_image_artifact_name + ".png"),
+                content=confusion_matrix_image,
+            )
+            confusion_matrix_image_artifact._save(confusion_matrix_image_artifact_name + ".png")
+            client.log_image(
+                run_id, confusion_matrix_image, confusion_matrix_image_artifact_name + ".png"
+            )
+
+            artifacts = {
+                confusion_matrix_artifact_name: confusion_matrix_artifact,
+                confusion_matrix_image_artifact_name: confusion_matrix_image_artifact,
+            }
         elif model_type == "regressor":
             mean_absolute_error = sk_metrics.mean_absolute_error(y, y_pred)
             mean_squared_error = sk_metrics.mean_squared_error(y, y_pred)


### PR DESCRIPTION
Signed-off-by: Mark Zhang <markzhang.inbox@gmail.com>

Fixes https://github.com/mlflow/mlflow/issues/5475

## What changes are proposed in this pull request?
Updated `EvaluationResult` to now use artifacts' uri to extract the proper file name to be saved locally. Whereas, before it was using the name of the artifacts directly without file extensions.

Also added tests in `test_evaluation` to test the behavior reported in https://github.com/mlflow/mlflow/issues/5475 with an image artifact.

## How is this patch tested?

Updated unit tests to reflect the addition of file extensions

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations