### PR TITLE
fix: func _parse_mlflow_gcs_vars

### DIFF
--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -953,8 +953,8 @@ to access Google Cloud Storage; MLflow does not declare a dependency on this pac
 
 You may set some MLflow environment variables to troubleshoot GCS read-timeouts (eg. due to slow transfer speeds) using the following variables:
 
-- ``MLFLOW_GCS_DEFAULT_TIMEOUT`` - Sets the standard timeout for transfer operations in seconds (Default: 60)
-- ``MLFLOW_GCS_UPLOAD_CHUNK_SIZE`` - Sets the standard upload chunk size for bigger files in bytes (Default: 104857600 ≙ 100MiB), must be multiple of 256 KB
+- ``MLFLOW_GCS_DEFAULT_TIMEOUT`` - Sets the standard timeout for transfer operations in seconds (Default: 60). Use -1 for indefinite timeout.
+- ``MLFLOW_GCS_UPLOAD_CHUNK_SIZE`` - Sets the standard upload chunk size for bigger files in bytes (Default: 104857600 ≙ 100MiB), must be multiple of 256 KB.
 - ``MLFLOW_GCS_DOWNLOAD_CHUNK_SIZE`` - Sets the standard download chunk size for bigger files in bytes (Default: 104857600 ≙ 100MiB), must be multiple of 256 KB
 
 FTP server

--- a/mlflow/store/artifact/gcs_artifact_repo.py
+++ b/mlflow/store/artifact/gcs_artifact_repo.py
@@ -43,7 +43,7 @@ class GCSArtifactRepository(ArtifactRepository):
             else _DEFAULT_TIMEOUT
         )
 
-        # If the user-supplied timeout environment variable value is -1, 
+        # If the user-supplied timeout environment variable value is -1,
         # use `None` for `self._GCS_DEFAULT_TIMEOUT`
         # to use indefinite timeout
         self._GCS_DEFAULT_TIMEOUT = (

--- a/mlflow/store/artifact/gcs_artifact_repo.py
+++ b/mlflow/store/artifact/gcs_artifact_repo.py
@@ -25,22 +25,16 @@ class GCSArtifactRepository(ArtifactRepository):
 
             self.gcs = gcs_storage
 
-        from google.cloud.storage.constants import _DEFAULT_TIMEOUT
+        self._GCS_DOWNLOAD_CHUNK_SIZE = self._parse_mlflow_gcs_vars(
+            os.environ.get("MLFLOW_GCS_DOWNLOAD_CHUNK_SIZE"), "chunk_size"
+        )
 
-        self._GCS_DOWNLOAD_CHUNK_SIZE = (
-            int(os.environ.get("MLFLOW_GCS_DOWNLOAD_CHUNK_SIZE"))
-            if os.environ.get("MLFLOW_GCS_DOWNLOAD_CHUNK_SIZE")
-            else None
+        self._GCS_UPLOAD_CHUNK_SIZE = self._parse_mlflow_gcs_vars(
+            os.environ.get("MLFLOW_GCS_UPLOAD_CHUNK_SIZE"), "chunk_size"
         )
-        self._GCS_UPLOAD_CHUNK_SIZE = (
-            int(os.environ.get("MLFLOW_GCS_UPLOAD_CHUNK_SIZE"))
-            if os.environ.get("MLFLOW_GCS_UPLOAD_CHUNK_SIZE")
-            else None
-        )
-        self._GCS_DEFAULT_TIMEOUT = (
-            float(os.environ.get("MLFLOW_GCS_DEFAULT_TIMEOUT"))
-            if os.environ.get("MLFLOW_GCS_DEFAULT_TIMEOUT")
-            else _DEFAULT_TIMEOUT
+
+        self._GCS_DEFAULT_TIMEOUT = self._parse_mlflow_gcs_vars(
+            os.environ.get("MLFLOW_GCS_DEFAULT_TIMEOUT"), "timeout"
         )
         super().__init__(artifact_uri)
 
@@ -130,6 +124,24 @@ class GCSArtifactRepository(ArtifactRepository):
         gcs_bucket.blob(
             remote_full_path, chunk_size=self._GCS_DOWNLOAD_CHUNK_SIZE
         ).download_to_filename(local_path, timeout=self._GCS_DEFAULT_TIMEOUT)
+
+    def _parse_mlflow_gcs_vars(self, environment_variable, var_type):
+        if var_type == "timeout":
+            if environment_variable:
+                if environment_variable == -1:
+                    return None
+                else:
+                    return float(environment_variable)
+            else:
+                from google.cloud.storage.constants import _DEFAULT_TIMEOUT
+
+                return _DEFAULT_TIMEOUT
+
+        elif var_type == "chunk_size":
+            if environment_variable:
+                return int(environment_variable)
+            else:
+                return None
 
     def delete_artifacts(self, artifact_path=None):
         raise MlflowException("Not implemented yet")

--- a/tests/store/artifact/test_gcs_artifact_repo.py
+++ b/tests/store/artifact/test_gcs_artifact_repo.py
@@ -6,7 +6,6 @@ from unittest import mock
 
 from google.cloud.storage import client as gcs_client
 from google.auth.exceptions import DefaultCredentialsError
-from google.cloud.storage.constants import _DEFAULT_TIMEOUT
 
 from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
 from mlflow.store.artifact.gcs_artifact_repo import GCSArtifactRepository
@@ -303,19 +302,3 @@ def test_download_artifacts_downloads_expected_content(gcs_mock, tmpdir):
     dir_contents = os.listdir(tmpdir.strpath)
     assert file_path_1 in dir_contents
     assert file_path_2 in dir_contents
-
-
-@pytest.mark.parametrize(
-    "env_var,var_type,expected",
-    [
-        (None, "timeout", _DEFAULT_TIMEOUT),
-        (5, "timeout", 5),
-        (-1, "timeout", None),
-        (None, "chunk_size", None),
-        (5, "chunk_size", 5),
-    ],
-)
-def test_env_var_parse(gcs_mock, env_var, var_type, expected):
-    repo = GCSArtifactRepository("gs://test_bucket/some/path", gcs_mock)
-    gcs_mock.Client.return_value.bucket.return_value.list_blobs.return_value = mock.MagicMock()
-    assert expected == repo._parse_mlflow_gcs_vars(env_var, var_type)


### PR DESCRIPTION
Signed-off-by: sebsatian-montero <smonteroparis@icloud.com>

## What changes are proposed in this pull request?
I am adding the function `_parse_mlflow_gcs_vars` that will better parse the new GCS MLFlow ENV variables. This will allow the engineer to use `-1` as an input in order to set indefinite timeouts when using the underlying GS client to log artifacts.

This PR is associated with this [Issue](https://github.com/mlflow/mlflow/issues/5482)

## How is this patch tested?

Added parametrised tests to run every env var case.

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [X] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
