### PR TITLE
Pin `torch` to `< 1.11.0` when testing older versions of `pytorch-lightning`

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -42,7 +42,9 @@ pytorch-lightning:
   autologging:
     minimum: "1.0.5"
     maximum: "1.5.10"
-    requirements: ["torchvision", "scikit-learn"]
+    requirements:
+      "< 1.2.0": ["torch<1.11.0", "torchvision", "scikit-learn"]
+      ">= 1.2.0": ["torchvision", "scikit-learn"]
     run: |
       pytest tests/pytorch/test_pytorch_autolog.py --large
 


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Fix the following error ([link](https://github.com/mlflow/mlflow/runs/5526315925?check_suite_focus=true#step:12:329)):

```python
>       raise ProcessRaisedException(msg, error_index, failed_process.pid)
E       torch.multiprocessing.spawn.ProcessRaisedException: 
E       
E       -- Process 0 terminated with the following error:
E       Traceback (most recent call last):
E         File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/torch/multiprocessing/spawn.py", line 69, in _wrap
E           fn(i, *args)
E         File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/pytorch_lightning/accelerators/ddp_cpu_spawn_accelerator.py", line 162, in ddp_train
E           results = self.train_or_test()
E         File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/pytorch_lightning/accelerators/accelerator.py", line 74, in train_or_test
E           results = self.trainer.train()
E         File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/pytorch_lightning/trainer/trainer.py", line 532, in train
E           self.run_sanity_check(self.get_model())
E         File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/pytorch_lightning/trainer/trainer.py", line 731, in run_sanity_check
E           _, eval_results = self.run_evaluation(max_batches=self.num_sanity_val_batches)
E         File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/pytorch_lightning/trainer/trainer.py", line 643, in run_evaluation
E           output = self.evaluation_loop.evaluation_step(batch, batch_idx, dataloader_idx)
E         File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/pytorch_lightning/trainer/evaluation_loop.py", line 171, in evaluation_step
E           output = self.trainer.accelerator_backend.validation_step(args)
E         File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/pytorch_lightning/accelerators/ddp_cpu_spawn_accelerator.py", line 177, in validation_step
E           return self._step(args)
E         File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/pytorch_lightning/accelerators/ddp_cpu_spawn_accelerator.py", line 188, in _step
E           output = self.trainer.model(*args)
E         File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/torch/nn/modules/module.py", line 1110, in _call_impl
E           return forward_call(*input, **kwargs)
E         File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/pytorch_lightning/overrides/data_parallel.py", line 177, in forward
E           self._sync_params()
E         File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/torch/nn/modules/module.py", line 1186, in __getattr__
E           type(self).__name__, name))
E       AttributeError: 'LightningDistributedDataParallel' object has no attribute '_sync_params'
```

## How is this patch tested?

Existing tests

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
