### PR TITLE
[WIP] Add `_PythonEnv` class to log vesions of python and build packages when logging a model

### DIFF
--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -39,7 +39,9 @@ from mlflow.utils.environment import (
     _validate_env_arguments,
     _process_pip_requirements,
     _process_conda_env,
+    _PythonEnv,
     _CONDA_ENV_FILE_NAME,
+    _PYTHON_ENV_FILE_NAME,
     _REQUIREMENTS_FILE_NAME,
     _CONSTRAINTS_FILE_NAME,
 )
@@ -292,6 +294,10 @@ def save_model(
 
     # Save `requirements.txt`
     write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME), "\n".join(pip_requirements))
+
+    _PythonEnv.from_current_environment().with_dependencies(
+        [f"-r {_REQUIREMENTS_FILE_NAME}"]
+    ).to_yaml(os.path.join(path, _PYTHON_ENV_FILE_NAME))
 
 
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name="scikit-learn"))

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -295,9 +295,13 @@ def save_model(
     # Save `requirements.txt`
     write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME), "\n".join(pip_requirements))
 
-    _PythonEnv.from_current_environment().with_dependencies(
-        [f"-r {_REQUIREMENTS_FILE_NAME}"]
-    ).to_yaml(os.path.join(path, _PYTHON_ENV_FILE_NAME))
+    (
+        _PythonEnv()
+        .with_current_python()
+        .with_default_build_dependencies()
+        .with_dependencies([f"-r {_REQUIREMENTS_FILE_NAME}"])
+        .to_yaml(os.path.join(path, _PYTHON_ENV_FILE_NAME))
+    )
 
 
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name="scikit-learn"))

--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -31,7 +31,7 @@ class _PythonEnv:
         return str(self.to_dict())
 
     @staticmethod
-    def _get_python_version():
+    def get_current_python():
         return ".".join(map(str, sys.version_info[:3]))
 
     @staticmethod
@@ -42,13 +42,13 @@ class _PythonEnv:
             return None
 
     @staticmethod
-    def _get_build_dependencies():
-        dependencies = []
+    def get_default_build_dependencies():
+        build_dependencies = []
         for package in ["pip", "setuptools", "wheel"]:
             version = _PythonEnv._get_package_version(package)
-            if version:
-                dependencies.append(package + "==" + version)
-        return dependencies
+            dep = (package + "==" + version) if version else package
+            build_dependencies.append(dep)
+        return build_dependencies
 
     def to_dict(self):
         return self.__dict__.copy()
@@ -57,16 +57,23 @@ class _PythonEnv:
     def from_dict(cls, dct):
         return cls(**dct)
 
+    def with_python(self, python):
+        kwargs = {**self.to_dict(), "python": python}
+        return _PythonEnv(**kwargs)
+
+    def with_current_python(self):
+        return self.with_python(_PythonEnv.get_current_python())
+
+    def with_build_dependencies(self, build_dependencies):
+        kwargs = {**self.to_dict(), "build_dependencies": build_dependencies}
+        return _PythonEnv(**kwargs)
+
+    def with_default_build_dependencies(self):
+        return self.with_build_dependencies(_PythonEnv.get_default_build_dependencies())
+
     def with_dependencies(self, dependencies):
         kwargs = {**self.to_dict(), "dependencies": dependencies}
         return _PythonEnv(**kwargs)
-
-    @classmethod
-    def from_current_environment(cls):
-        return cls(
-            python=_PythonEnv._get_python_version(),
-            build_dependencies=_PythonEnv._get_build_dependencies(),
-        )
 
     def to_yaml(self, path):
         with open(path, "w") as f:

--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -58,7 +58,7 @@ class _PythonEnv:
         return cls(**dct)
 
     def with_dependencies(self, dependencies):
-        kwargs = {**self.to_dict, "dependencies": dependencies}
+        kwargs = {**self.to_dict(), "dependencies": dependencies}
         return _PythonEnv(**kwargs)
 
     @classmethod


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Add `_PythonEnv` class to log vesions of python and build packages when logging a model.

## How is this patch tested?

- Unit tests
- Existing tests

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
