### PR TITLE
Append user agent added by request_header_provider to default user agent

### DIFF
--- a/mlflow/tracking/request_header/default_request_header_provider.py
+++ b/mlflow/tracking/request_header/default_request_header_provider.py
@@ -14,4 +14,4 @@ class DefaultRequestHeaderProvider(RequestHeaderProvider):
         return True
 
     def request_headers(self):
-        return _DEFAULT_HEADERS
+        return dict(**_DEFAULT_HEADERS)

--- a/mlflow/tracking/request_header/default_request_header_provider.py
+++ b/mlflow/tracking/request_header/default_request_header_provider.py
@@ -1,0 +1,17 @@
+from mlflow.tracking.request_header.abstract_request_header_provider import RequestHeaderProvider
+from mlflow import __version__
+
+_USER_AGENT = "User-Agent"
+_DEFAULT_HEADERS = {_USER_AGENT: "mlflow-python-client/%s" % __version__}
+
+
+class DefaultRequestHeaderProvider(RequestHeaderProvider):
+    """
+    Provides default request headers for outgoing request.
+    """
+
+    def in_context(self):
+        return True
+
+    def request_headers(self):
+        return _DEFAULT_HEADERS

--- a/mlflow/tracking/request_header/registry.py
+++ b/mlflow/tracking/request_header/registry.py
@@ -5,6 +5,9 @@ import logging
 from mlflow.tracking.request_header.databricks_request_header_provider import (
     DatabricksRequestHeaderProvider,
 )
+from mlflow.tracking.request_header.default_request_header_provider import (
+    DefaultRequestHeaderProvider,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -35,6 +38,7 @@ class RequestHeaderProviderRegistry:
 
 _request_header_provider_registry = RequestHeaderProviderRegistry()
 _request_header_provider_registry.register(DatabricksRequestHeaderProvider)
+_request_header_provider_registry.register(DefaultRequestHeaderProvider)
 
 _request_header_provider_registry.register_entrypoints()
 

--- a/mlflow/tracking/request_header/registry.py
+++ b/mlflow/tracking/request_header/registry.py
@@ -56,7 +56,13 @@ def resolve_request_headers(request_headers=None):
     for provider in _request_header_provider_registry:
         try:
             if provider.in_context():
-                all_request_headers.update(provider.request_headers())
+                # all_request_headers.update(provider.request_headers())
+                for header, value in provider.request_headers().items():
+                    all_request_headers[header] = (
+                        "{} {}".format(all_request_headers[header], value)
+                        if header in all_request_headers
+                        else value
+                    )
         except Exception as e:
             _logger.warning("Encountered unexpected error during resolving request headers: %s", e)
 

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -132,7 +132,7 @@ def http_request(
 
     from mlflow.tracking.request_header.registry import resolve_request_headers
 
-    headers = resolve_request_headers()
+    headers = dict(**resolve_request_headers())
 
     if auth_str:
         headers["Authorization"] = auth_str

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -140,7 +140,7 @@ def http_request(
             _DEFAULT_HEADERS[_USER_AGENT], request_headers.pop(_USER_AGENT)
         )
 
-    headers = dict({**_DEFAULT_HEADERS, **request_headers})
+    headers = dict(**_DEFAULT_HEADERS, **request_headers)
     if auth_str:
         headers["Authorization"] = auth_str
 

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -18,7 +18,8 @@ from mlflow.exceptions import MlflowException, RestException
 
 RESOURCE_DOES_NOT_EXIST = "RESOURCE_DOES_NOT_EXIST"
 _REST_API_PATH_PREFIX = "/api/2.0"
-_DEFAULT_HEADERS = {"User-Agent": "mlflow-python-client/%s" % __version__}
+_USER_AGENT = "User-Agent"
+_DEFAULT_HEADERS = {_USER_AGENT: "mlflow-python-client/%s" % __version__}
 # Response codes that generally indicate transient network failures and merit client retries,
 # based on guidance from cloud service providers
 # (https://docs.microsoft.com/en-us/azure/architecture/best-practices/retry-service-specific#general-rest-and-retry-guidelines)
@@ -133,7 +134,13 @@ def http_request(
 
     from mlflow.tracking.request_header.registry import resolve_request_headers
 
-    headers = dict({**_DEFAULT_HEADERS, **resolve_request_headers()})
+    request_headers = resolve_request_headers()
+    if _USER_AGENT in request_headers:
+        _DEFAULT_HEADERS[_USER_AGENT] = "{} {}".format(
+            _DEFAULT_HEADERS[_USER_AGENT], request_headers.pop(_USER_AGENT)
+        )
+
+    headers = dict({**_DEFAULT_HEADERS, **request_headers})
     if auth_str:
         headers["Authorization"] = auth_str
 

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -18,8 +18,6 @@ from mlflow.exceptions import MlflowException, RestException
 
 RESOURCE_DOES_NOT_EXIST = "RESOURCE_DOES_NOT_EXIST"
 _REST_API_PATH_PREFIX = "/api/2.0"
-_USER_AGENT = "User-Agent"
-_DEFAULT_HEADERS = {_USER_AGENT: "mlflow-python-client/%s" % __version__}
 # Response codes that generally indicate transient network failures and merit client retries,
 # based on guidance from cloud service providers
 # (https://docs.microsoft.com/en-us/azure/architecture/best-practices/retry-service-specific#general-rest-and-retry-guidelines)
@@ -134,13 +132,8 @@ def http_request(
 
     from mlflow.tracking.request_header.registry import resolve_request_headers
 
-    request_headers = resolve_request_headers()
-    if _USER_AGENT in request_headers:
-        _DEFAULT_HEADERS[_USER_AGENT] = "{} {}".format(
-            _DEFAULT_HEADERS[_USER_AGENT], request_headers.pop(_USER_AGENT)
-        )
+    headers = resolve_request_headers()
 
-    headers = dict(**_DEFAULT_HEADERS, **request_headers)
     if auth_str:
         headers["Authorization"] = auth_str
 

--- a/tests/projects/test_databricks.py
+++ b/tests/projects/test_databricks.py
@@ -23,7 +23,9 @@ from mlflow.utils.mlflow_tags import (
     MLFLOW_DATABRICKS_SHELL_JOB_RUN_ID,
     MLFLOW_DATABRICKS_WEBAPP_URL,
 )
-from mlflow.utils.rest_utils import _DEFAULT_HEADERS
+from mlflow.tracking.request_header.default_request_header_provider import (
+    DefaultRequestHeaderProvider,
+)
 from mlflow.utils.uri import construct_db_uri_from_profile
 from tests import helper_functions
 from tests.integration.utils import invoke_cli_runner
@@ -440,7 +442,7 @@ def test_databricks_http_request_integration(get_config, request):
     """Confirms that the databricks http request params can in fact be used as an HTTP request"""
 
     def confirm_request_params(*args, **kwargs):
-        headers = dict(_DEFAULT_HEADERS)
+        headers = DefaultRequestHeaderProvider.request_headers()
         headers["Authorization"] = "Basic dXNlcjpwYXNz"
         assert args == ("PUT", "host/clusters/list")
         assert kwargs == {

--- a/tests/projects/test_databricks.py
+++ b/tests/projects/test_databricks.py
@@ -442,7 +442,7 @@ def test_databricks_http_request_integration(get_config, request):
     """Confirms that the databricks http request params can in fact be used as an HTTP request"""
 
     def confirm_request_params(*args, **kwargs):
-        headers = DefaultRequestHeaderProvider.request_headers()
+        headers = DefaultRequestHeaderProvider().request_headers()
         headers["Authorization"] = "Basic dXNlcjpwYXNz"
         assert args == ("PUT", "host/clusters/list")
         assert kwargs == {

--- a/tests/store/tracking/test_rest_store.py
+++ b/tests/store/tracking/test_rest_store.py
@@ -47,7 +47,10 @@ from mlflow.store.tracking.rest_store import (
     DatabricksRestStore,
 )
 from mlflow.utils.proto_json_utils import message_to_json
-from mlflow.utils.rest_utils import MlflowHostCreds, _DEFAULT_HEADERS
+from mlflow.utils.rest_utils import MlflowHostCreds
+from mlflow.tracking.request_header.default_request_header_provider import (
+    DefaultRequestHeaderProvider,
+)
 
 
 class MyCoolException(Exception):
@@ -75,7 +78,7 @@ class TestRestStore:
             kwargs = dict((k, v) for k, v in kwargs.items() if v is not None)
             assert kwargs == {
                 "params": {"view_type": "ACTIVE_ONLY"},
-                "headers": _DEFAULT_HEADERS,
+                "headers": DefaultRequestHeaderProvider().request_headers(),
                 "verify": True,
                 "timeout": 120,
             }

--- a/tests/tracking/request_header/test_default_request_header_provider.py
+++ b/tests/tracking/request_header/test_default_request_header_provider.py
@@ -1,0 +1,13 @@
+from mlflow.tracking.request_header.default_request_header_provider import (
+    DefaultRequestHeaderProvider,
+    _DEFAULT_HEADERS,
+)
+
+
+def test_default_request_header_provider_in_context():
+    assert DefaultRequestHeaderProvider().in_context()
+
+
+def test_default_request_header_provider_request_headers():
+    request_headers = DefaultRequestHeaderProvider().request_headers()
+    assert request_headers == _DEFAULT_HEADERS

--- a/tests/tracking/request_header/test_registry.py
+++ b/tests/tracking/request_header/test_registry.py
@@ -144,7 +144,7 @@ def mock_request_header_providers():
 def test_resolve_request_headers(mock_request_header_providers):
     request_headers_arg = {"two": "arg-override", "arg": "arg-val"}
     assert resolve_request_headers(request_headers_arg) == {
-        "one": "override",
+        "one": "one-val override",
         "two": "arg-override",
         "three": "three-val",
         "new": "new-val",
@@ -154,7 +154,7 @@ def test_resolve_request_headers(mock_request_header_providers):
 
 def test_resolve_request_headers_no_arg(mock_request_header_providers):
     assert resolve_request_headers() == {
-        "one": "override",
+        "one": "one-val override",
         "two": "two-val",
         "three": "three-val",
         "new": "new-val",

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -250,6 +250,7 @@ def test_http_request_request_headers(request):
         )
 
 
+@pytest.mark.large
 @mock.patch("requests.Session.request")
 def test_http_request_request_headers_user_agent(request):
     """This test requires the package in tests/resources/mlflow-test-plugin to be installed"""
@@ -284,6 +285,7 @@ def test_http_request_request_headers_user_agent(request):
         )
 
 
+@pytest.mark.large
 @mock.patch("requests.Session.request")
 def test_http_request_request_headers_user_agent_and_extra_header(request):
     """This test requires the package in tests/resources/mlflow-test-plugin to be installed"""

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -10,10 +10,12 @@ from mlflow.utils.rest_utils import (
     http_request,
     http_request_safe,
     MlflowHostCreds,
-    _DEFAULT_HEADERS,
     call_endpoint,
     call_endpoints,
     _can_parse_as_json_object,
+)
+from mlflow.tracking.request_header.default_request_header_provider import (
+    DefaultRequestHeaderProvider,
     _USER_AGENT,
 )
 from mlflow.protos.service_pb2 import GetRun
@@ -117,7 +119,7 @@ def test_http_request_hostonly(request):
         "GET",
         "http://my-host/my/endpoint",
         verify=True,
-        headers=_DEFAULT_HEADERS,
+        headers=DefaultRequestHeaderProvider().request_headers(),
         timeout=120,
     )
 
@@ -134,7 +136,7 @@ def test_http_request_cleans_hostname(request):
         "GET",
         "http://my-host/my/endpoint",
         verify=True,
-        headers=_DEFAULT_HEADERS,
+        headers=DefaultRequestHeaderProvider().request_headers(),
         timeout=120,
     )
 
@@ -146,7 +148,7 @@ def test_http_request_with_basic_auth(request):
     response.status_code = 200
     request.return_value = response
     http_request(host_only, "/my/endpoint", "GET")
-    headers = dict(_DEFAULT_HEADERS)
+    headers = DefaultRequestHeaderProvider().request_headers()
     headers["Authorization"] = "Basic dXNlcjpwYXNz"
     request.assert_called_with(
         "GET",
@@ -164,7 +166,7 @@ def test_http_request_with_token(request):
     response.status_code = 200
     request.return_value = response
     http_request(host_only, "/my/endpoint", "GET")
-    headers = dict(_DEFAULT_HEADERS)
+    headers = DefaultRequestHeaderProvider().request_headers()
     headers["Authorization"] = "Bearer my-token"
     request.assert_called_with(
         "GET",
@@ -186,7 +188,7 @@ def test_http_request_with_insecure(request):
         "GET",
         "http://my-host/my/endpoint",
         verify=False,
-        headers=_DEFAULT_HEADERS,
+        headers=DefaultRequestHeaderProvider().request_headers(),
         timeout=120,
     )
 
@@ -203,7 +205,7 @@ def test_http_request_client_cert_path(request):
         "http://my-host/my/endpoint",
         verify=True,
         cert="/some/path",
-        headers=_DEFAULT_HEADERS,
+        headers=DefaultRequestHeaderProvider().request_headers(),
         timeout=120,
     )
 
@@ -219,7 +221,7 @@ def test_http_request_server_cert_path(request):
         "GET",
         "http://my-host/my/endpoint",
         verify="/some/path",
-        headers=_DEFAULT_HEADERS,
+        headers=DefaultRequestHeaderProvider().request_headers(),
         timeout=120,
     )
 
@@ -245,7 +247,7 @@ def test_http_request_request_headers(request):
             "GET",
             "http://my-host/my/endpoint",
             verify="/some/path",
-            headers={**_DEFAULT_HEADERS, "test": "header"},
+            headers={**DefaultRequestHeaderProvider().request_headers(), "test": "header"},
             timeout=120,
         )
 
@@ -269,7 +271,9 @@ def test_http_request_request_headers_user_agent(request):
     ):
         host_only = MlflowHostCreds("http://my-host", server_cert_path="/some/path")
         expected_headers = {
-            _USER_AGENT: "{} {}".format(_DEFAULT_HEADERS[_USER_AGENT], "test_user_agent")
+            _USER_AGENT: "{} {}".format(
+                DefaultRequestHeaderProvider().request_headers()[_USER_AGENT], "test_user_agent"
+            )
         }
 
         response = mock.MagicMock()
@@ -304,7 +308,9 @@ def test_http_request_request_headers_user_agent_and_extra_header(request):
     ):
         host_only = MlflowHostCreds("http://my-host", server_cert_path="/some/path")
         expected_headers = {
-            _USER_AGENT: "{} {}".format(_DEFAULT_HEADERS[_USER_AGENT], "test_user_agent"),
+            _USER_AGENT: "{} {}".format(
+                DefaultRequestHeaderProvider().request_headers()[_USER_AGENT], "test_user_agent"
+            ),
             "header": "value",
         }
 
@@ -345,7 +351,7 @@ def test_http_request_wrapper(request):
         "GET",
         "http://my-host/my/endpoint",
         verify=False,
-        headers=_DEFAULT_HEADERS,
+        headers=DefaultRequestHeaderProvider().request_headers(),
         timeout=120,
     )
     response.text = "non json"
@@ -355,7 +361,7 @@ def test_http_request_wrapper(request):
         "GET",
         "http://my-host/my/endpoint",
         verify=False,
-        headers=_DEFAULT_HEADERS,
+        headers=DefaultRequestHeaderProvider().request_headers(),
         timeout=120,
     )
     response.status_code = 400


### PR DESCRIPTION

## What changes are proposed in this pull request?

This PR append the user agent added by request_header_provider plugin to the default user agent added by rest_utils. It fixes [this ](https://github.com/mlflow/mlflow/issues/5498)issue

## How is this patch tested?

Ran the test locally

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
