### PR TITLE
Add version to header and use version specific documentation links

### DIFF
--- a/mlflow/server/js/src/common/constants.js
+++ b/mlflow/server/js/src/common/constants.js
@@ -8,9 +8,15 @@ export const ErrorCodes = {
   PERMISSION_DENIED: 'PERMISSION_DENIED',
 };
 
-export const HomePageDocsUrl = 'https://www.mlflow.org/docs/latest/index.html';
+export const Version = '1.24.1.dev0';
 
-export const ModelRegistryDocUrl = 'https://mlflow.org/docs/latest/model-registry.html';
+const DOCS_VERSION = 'latest';
+
+const DOCS_ROOT = `https://www.mlflow.org/docs/${DOCS_VERSION}`;
+
+export const HomePageDocsUrl = `${DOCS_ROOT}/index.html`;
+
+export const ModelRegistryDocUrl = `${DOCS_ROOT}/model-registry.html`;
 
 export const ModelRegistryOnboardingString = (
   <FormattedMessage
@@ -20,23 +26,25 @@ export const ModelRegistryOnboardingString = (
 );
 
 export const RegisteringModelDocUrl =
-  'https://mlflow.org/docs/latest/' +
-  'model-registry.html#adding-an-mlflow-model-to-the-model-registry';
+  DOCS_ROOT + '/model-registry.html#adding-an-mlflow-model-to-the-model-registry';
 
-export const ExperimentTrackingDocUrl = 'https://www.mlflow.org/docs/latest/tracking.html';
+export const ExperimentCliDocUrl = `${DOCS_ROOT}/cli.html#mlflow-experiments`;
 
-export const PyfuncDocUrl = 'https://www.mlflow.org/docs/latest/python_api/mlflow.pyfunc.html';
+export const ExperimentSearchSyntaxDocUrl = `${DOCS_ROOT}/search-syntax.html`;
+
+export const ExperimentTrackingDocUrl = `${DOCS_ROOT}/tracking.html`;
+
+export const PyfuncDocUrl = `${DOCS_ROOT}/python_api/mlflow.pyfunc.html`;
 export const CustomPyfuncModelsDocUrl =
-  'https://www.mlflow.org/docs/latest/python_api/mlflow.pyfunc.html#creating-custom-pyfunc-models';
+  DOCS_ROOT + '/python_api/mlflow.pyfunc.html#creating-custom-pyfunc-models';
 
-export const LoggingRunsDocUrl =
-  'https://www.mlflow.org/docs/latest/tracking.html#logging-data-to-runs';
+export const LoggingRunsDocUrl = `${DOCS_ROOT}/tracking.html#logging-data-to-runs`;
 
 export const onboarding = 'onboarding';
 
 export const SupportPageUrl = 'https://github.com/mlflow/mlflow/issues';
 
-export const ModelSignatureUrl = 'https://mlflow.org/docs/latest/models.html#model-signature';
+export const ModelSignatureUrl = `${DOCS_ROOT}/models.html#model-signature`;
 
 export const LogModelWithSignatureUrl =
-  'https://www.mlflow.org/docs/latest/models.html#how-to-log-models-with-signatures';
+  DOCS_ROOT + '/models.html#how-to-log-models-with-signatures';

--- a/mlflow/server/js/src/experiment-tracking/components/App.css
+++ b/mlflow/server/js/src/experiment-tracking/components/App.css
@@ -43,6 +43,7 @@ button:hover, .btn:hover {
 div.mlflow-logo {
   display: flex;
   float: left;
+  align-items: flex-end;
 }
 
 img.mlflow-logo {
@@ -50,6 +51,12 @@ img.mlflow-logo {
   margin-left: 64px;
   margin-top: 10px;
   margin-bottom: 10px;
+}
+
+span.mlflow-version {
+  font-size: 12px;
+  margin-left: 5px;
+  margin-bottom: 13px;
 }
 
 div.github {

--- a/mlflow/server/js/src/experiment-tracking/components/App.js
+++ b/mlflow/server/js/src/experiment-tracking/components/App.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import './App.css';
 import logo from '../../common/static/home-logo.png';
+import { Version, HomePageDocsUrl } from '../../common/constants';
 import { HashRouter as Router, Route, Link, NavLink } from 'react-router-dom';
 import { RunPage } from './RunPage';
 import Routes from '../routes';
@@ -46,6 +47,7 @@ class App extends Component {
                 <Link to={Routes.rootRoute} className='App-mlflow'>
                   <img className='mlflow-logo' alt='MLflow' src={logo} />
                 </Link>
+                <span className={'mlflow-version'}>{Version}</span>
               </div>
               <div className='header-route-links'>
                 <NavLink
@@ -76,7 +78,7 @@ class App extends Component {
                     <span>GitHub</span>
                   </div>
                 </a>
-                <a href={'https://mlflow.org/docs/latest/index.html'}>
+                <a href={HomePageDocsUrl}>
                   <div className='docs'>
                     <span>Docs</span>
                   </div>

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentView.js
@@ -39,7 +39,11 @@ import { CSSTransition } from 'react-transition-group';
 import { Spinner } from '../../common/components/Spinner';
 import { RunsTableColumnSelectionDropdown } from './RunsTableColumnSelectionDropdown';
 import { getUUID } from '../../common/utils/ActionUtils';
-import { ExperimentTrackingDocUrl, onboarding } from '../../common/constants';
+import {
+  ExperimentSearchSyntaxDocUrl,
+  ExperimentTrackingDocUrl,
+  onboarding,
+} from '../../common/constants';
 import filterIcon from '../../common/static/filter-icon.svg';
 import { StyledDropdown } from '../../common/components/StyledDropdown';
 import { ExperimentNoteSection, ArtifactLocation } from './ExperimentViewHelpers';
@@ -497,11 +501,7 @@ export class ExperimentView extends Component {
           description='Learn more tooltip link to learn more on how to search in an experiments run table'
           values={{
             link: (chunks) => (
-              <a
-                href='https://www.mlflow.org/docs/latest/search-syntax.html'
-                target='_blank'
-                rel='noopener noreferrer'
-              >
+              <a href={ExperimentSearchSyntaxDocUrl} target='_blank' rel='noopener noreferrer'>
                 {chunks}
               </a>
             ),

--- a/mlflow/server/js/src/experiment-tracking/components/NoExperimentView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/NoExperimentView.js
@@ -1,11 +1,11 @@
 import React, { Component } from 'react';
 import Colors from '../styles/Colors';
 import noExperiments from '../../common/static/no-experiments.svg';
+import { ExperimentCliDocUrl } from '../../common/constants';
 
-const MLFLOW_EXPERIMENT_DOC_URL = 'https://www.mlflow.org/docs/latest/cli.html#experiments';
 export class NoExperimentView extends Component {
   render() {
-    const mlflowExperimentLink = <a href={MLFLOW_EXPERIMENT_DOC_URL}>mlflow experiments</a>;
+    const mlflowExperimentLink = <a href={ExperimentCliDocUrl}>mlflow experiments</a>;
     return (
       <div>
         <img


### PR DESCRIPTION
Signed-off-by: Adam Reeve <adreeve@gmail.com>

## What changes are proposed in this pull request?

Adds the mlflow version to the header and makes documentation links version specific. Fixes #3044.

The version is hard-coded in the Javascript source code. It looks like there's some automation that runs in Databricks Jenkins and updates the versions in the Python code already (eg. see #5417) so someone from Databricks will probably need to help out and configure this to also update the Javascript version if you're happy with this approach (I couldn't find any script responsible for this in the repo so I'm guessing it's configured elsewhere).

Alternatively, the UI could get the version from the Python tracking service API, but this approach seemed simpler seeing as the version is already present in multiple places in the source code.

The way I'm thinking this should work is that for development versions, the `DOCS_VERSION` remains at `latest` and only `Version` is updated, but when making a release, both `Version` and `DOCS_VERSION` are updated to the new version.

For putting the version in the header, I've taken inspiration from the documentation header and put it next to the logo:

![header-with-version](https://user-images.githubusercontent.com/626438/158725410-b02bcd01-a9cd-4f87-b93a-08753d25446c.png)

## How is this patch tested?

Ran Javascript tests, verified links work manually.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Added the Mlflow version to the header in the UI and changed documentation links to be specific to the installed Mlflow version.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
