### PR TITLE
Clean up conda environment when `pip install` fails during `conda create`

### DIFF
--- a/mlflow/utils/conda.py
+++ b/mlflow/utils/conda.py
@@ -84,6 +84,11 @@ def _get_conda_executable_for_create_env():
     return conda_env_create_path
 
 
+def _list_conda_environments():
+    (_, stdout, _) = process.exec_cmd([get_conda_bin_executable("conda"), "env", "list", "--json"])
+    return [os.path.basename(env) for env in json.loads(stdout)["envs"]]
+
+
 def get_or_create_conda_env(conda_env_path, env_id=None):
     """
     Given a `Project`, creates a conda environment containing the project's dependencies if such a
@@ -126,36 +131,55 @@ def get_or_create_conda_env(conda_env_path, env_id=None):
             )
         )
 
-    (_, stdout, _) = process.exec_cmd([conda_path, "env", "list", "--json"])
-    env_names = [os.path.basename(env) for env in json.loads(stdout)["envs"]]
+    env_names = _list_conda_environments()
     project_env_name = _get_conda_env_name(conda_env_path, env_id)
     if project_env_name not in env_names:
         _logger.info("=== Creating conda environment %s ===", project_env_name)
-        if conda_env_path:
-            process.exec_cmd(
-                [
-                    conda_env_create_path,
-                    "env",
-                    "create",
-                    "-n",
+        try:
+            if conda_env_path:
+                process.exec_cmd(
+                    [
+                        conda_env_create_path,
+                        "env",
+                        "create",
+                        "-n",
+                        project_env_name,
+                        "--file",
+                        conda_env_path,
+                    ],
+                    stream_output=True,
+                )
+            else:
+                process.exec_cmd(
+                    [
+                        conda_env_create_path,
+                        "create",
+                        "--channel",
+                        "conda-forge",
+                        "--override-channels",
+                        "-n",
+                        project_env_name,
+                        "python",
+                    ],
+                    stream_output=True,
+                )
+        except Exception:
+            if project_env_name in _list_conda_environments():
+                _logger.warning(
+                    "Encountered unexpected error while creating conda environment. Removing %s",
                     project_env_name,
-                    "--file",
-                    conda_env_path,
-                ],
-                stream_output=True,
-            )
-        else:
-            process.exec_cmd(
-                [
-                    conda_env_create_path,
-                    "create",
-                    "--channel",
-                    "conda-forge",
-                    "--override-channels",
-                    "-n",
-                    project_env_name,
-                    "python",
-                ],
-                stream_output=True,
-            )
+                )
+                process.exec_cmd(
+                    [
+                        conda_path,
+                        "remove",
+                        "--yes",
+                        "--name",
+                        project_env_name,
+                        "--all",
+                    ],
+                    stream_output=True,
+                )
+            raise
+
     return project_env_name

--- a/mlflow/utils/conda.py
+++ b/mlflow/utils/conda.py
@@ -156,6 +156,7 @@ def get_or_create_conda_env(conda_env_path, env_id=None):
                         "create",
                         "--channel",
                         "conda-forge",
+                        "--yes",
                         "--override-channels",
                         "-n",
                         project_env_name,

--- a/mlflow/utils/conda.py
+++ b/mlflow/utils/conda.py
@@ -86,7 +86,7 @@ def _get_conda_executable_for_create_env():
 
 def _list_conda_environments():
     (_, stdout, _) = process.exec_cmd([get_conda_bin_executable("conda"), "env", "list", "--json"])
-    return [os.path.basename(env) for env in json.loads(stdout)["envs"]]
+    return list(map(os.path.basename, json.loads(stdout).get("envs", [])))
 
 
 def get_or_create_conda_env(conda_env_path, env_id=None):

--- a/tests/projects/test_projects.py
+++ b/tests/projects/test_projects.py
@@ -384,7 +384,7 @@ dependencies:
     conda_yaml.write_text(content)
     envs_before = mlflow.utils.conda._list_conda_environments()
 
-    # `conda create` should fail because mlflow==999.999.999 doesn't exist
+    # `conda create` should fail because mlflow 999.999.999 doesn't exist
     with pytest.raises(ShellCommandException, match=r".*"):
         mlflow.utils.conda.get_or_create_conda_env(conda_yaml)
 

--- a/tests/projects/test_projects.py
+++ b/tests/projects/test_projects.py
@@ -3,6 +3,7 @@ import os
 import git
 import shutil
 import yaml
+import uuid
 
 import pytest
 from unittest import mock
@@ -29,6 +30,7 @@ from mlflow.utils.mlflow_tags import (
     MLFLOW_PROJECT_BACKEND,
     MLFLOW_PROJECT_ENV,
 )
+from mlflow.utils.process import ShellCommandException
 
 from tests.projects.utils import TEST_PROJECT_DIR, TEST_PROJECT_NAME, validate_exit_status
 
@@ -362,6 +364,38 @@ def test_create_env_with_mamba():
                 match="You have set the env variable MLFLOW_CONDA_CREATE_ENV_CMD",
             ):
                 mlflow.utils.conda.get_or_create_conda_env(conda_env_path)
+
+
+def test_conda_environment_cleaned_up_when_pip_fails(tmp_path, capfd):
+    conda_yaml = tmp_path / "conda.yaml"
+    content = """
+name: {name}
+channels:
+  - conda-forge
+dependencies:
+  - python=3.7.12
+  - pip
+  - pip:
+      - mlflow==999.999.999
+""".format(
+        # Enforce creating a new environment
+        name=uuid.uuid4().hex
+    )
+    conda_yaml.write_text(content)
+    envs_before = mlflow.utils.conda._list_conda_environments()
+
+    # `conda create` should fail because mlflow==999.999.999 doesn't exist
+    with pytest.raises(ShellCommandException, match=r".*"):
+        mlflow.utils.conda.get_or_create_conda_env(conda_yaml)
+
+    # Ensure `conda create` failed because of pip failure
+    captured = capfd.readouterr()
+    assert "ERROR: No matching distribution found for mlflow==999.999.999" in captured.err
+    assert "CondaEnvException: Pip failed" in captured.err
+
+    # Ensure the environment is cleaned up
+    envs_after = mlflow.utils.conda._list_conda_environments()
+    assert envs_before == envs_after
 
 
 def test_cancel_run():


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

conda doesn't clean up an environment when `pip install` fails during `conda create`. This behavior results in creating an incomplete conda environment and causes the following issue:

```bash
mlflow models serve ...
# fails a temporary network issue and leaves an incomplete conda environment

mlflow models serve ...
# serves the model in the incomplete environment created in the first attempt
```

## How is this patch tested?

Unit test

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
