### PR TITLE
fix for MSSQL paginated list experiments on behalf of @HaraldVanWoerkom

### DIFF
--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -294,6 +294,7 @@ class SqlAlchemyStore(AbstractStore):
                 queried_experiments = (
                     session.query(SqlExperiment)
                     .options(*query_options)
+                    .order_by(SqlExperiment.experiment_id)
                     .filter(*conditions)
                     .offset(offset)
                     .limit(max_results_for_query)

--- a/tests/db/run_checks.py
+++ b/tests/db/run_checks.py
@@ -7,6 +7,7 @@ from sqlalchemy.schema import MetaData, CreateTable
 
 import mlflow
 from mlflow.tracking._tracking_service.utils import _TRACKING_URI_ENV_VAR
+from mlflow.entities import ViewType
 
 
 class MockModel(mlflow.pyfunc.PythonModel):
@@ -36,6 +37,9 @@ def run_logging_operations():
     runs = mlflow.search_runs(experiment_ids=["0"], order_by=["param.start_time DESC"])
 
     run = mlflow.get_run(runs["run_id"][0])
+
+    experiments = mlflow.list_experiments(view_type=ViewType.ALL, max_results=5)
+    assert len(experiments) > 0
 
     # Ensure the following migration scripts work correctly:
     # - cfd24bdc0731_update_run_status_constraint_with_killed.py

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -1754,18 +1754,22 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase, AbstractStoreTest):
         This JSON dump can be replicated by installing MLflow version 1.2.0 and executing the
         following code from the directory containing this test suite:
 
-        >>> import json
-        >>> import mlflow
-        >>> from mlflow.tracking.client import MlflowClient
-        >>> mlflow.set_tracking_uri(
-        ...     "sqlite:///../../resources/db/db_version_7ac759974ad8_with_metrics.sql")
-        >>> client = MlflowClient()
-        >>> summary_metrics = {
-        ...     run.info.run_id: run.data.metrics for run
-        ...     in client.search_runs(experiment_ids="0")
-        ... }
-        >>> with open("dump.json", "w") as dump_file:
-        >>>     json.dump(summary_metrics, dump_file, indent=4)
+        .. code-block:: python
+
+          import json
+          import mlflow
+          from mlflow.tracking.client import MlflowClient
+
+          mlflow.set_tracking_uri(
+              "sqlite:///../../resources/db/db_version_7ac759974ad8_with_metrics.sql")
+          client = MlflowClient()
+          summary_metrics = {
+              run.info.run_id: run.data.metrics for run
+              in client.search_runs(experiment_ids="0")
+          }
+          with open("dump.json", "w") as dump_file:
+              json.dump(summary_metrics, dump_file, indent=4)
+
         """
         current_dir = os.path.dirname(os.path.abspath(__file__))
         db_resources_path = os.path.normpath(


### PR DESCRIPTION
Signed-off-by: Ben Wilson <benjamin.wilson@databricks.com>

## What changes are proposed in this pull request?

Add explicit ordering clause in list experiments SqlAlchemy to support deterministic sorting for paginated responses.

## How is this patch tested?

Unit tests (existing)

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
