### PR TITLE
Implement issue-5501 - add mlflow_version info to logged model

### DIFF
--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -26,6 +26,7 @@ _LOG_MODEL_METADATA_WARNING_TEMPLATE = (
     "mlflow server via REST, consider upgrading the server version to MLflow "
     "1.7.0 or above."
 )
+_MLFLOW_VERSION_KEY = "mlflow_version"
 
 
 class ModelInfo(NamedTuple):
@@ -94,7 +95,7 @@ class Model:
         signature=None,  # ModelSignature
         saved_input_example_info: Dict[str, Any] = None,
         model_uuid: Union[str, Callable, None] = lambda: uuid.uuid4().hex,
-        mlflow_version: Union[str, Callable, None] = lambda: mlflow.version.VERSION,
+        mlflow_version: Union[str, None] = mlflow.version.VERSION,
         **kwargs,
     ):
         # store model id instead of run_id and path to avoid confusion when model gets exported
@@ -107,7 +108,7 @@ class Model:
         self.signature = signature
         self.saved_input_example_info = saved_input_example_info
         self.model_uuid = model_uuid() if callable(model_uuid) else model_uuid
-        self.mlflow_version = mlflow_version() if callable(mlflow_version) else mlflow_version
+        self.mlflow_version = mlflow_version
         self.__dict__.update(kwargs)
 
     def __eq__(self, other):
@@ -200,9 +201,8 @@ class Model:
 
         # Do not save mlflow_version attribute if it's not defined
         info = self.to_dict()
-        mlflow_version_key = "mlflow_version"
-        if not self.mlflow_version and mlflow_version_key in info:
-            info.pop(mlflow_version_key)
+        if not self.mlflow_version and _MLFLOW_VERSION_KEY in info:
+            info.pop(_MLFLOW_VERSION_KEY)
 
         return yaml.safe_dump(info, stream=stream, default_flow_style=False)
 
@@ -239,8 +239,8 @@ class Model:
         if "model_uuid" not in model_dict:
             model_dict["model_uuid"] = None
 
-        if "mlflow_version" not in model_dict:
-            model_dict["mlflow_version"] = None
+        if _MLFLOW_VERSION_KEY not in model_dict:
+            model_dict[_MLFLOW_VERSION_KEY] = None
 
         return cls(**model_dict)
 

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -194,17 +194,13 @@ class Model:
             res["signature"] = self.signature.to_dict()
         if self.saved_input_example_info is not None:
             res["saved_input_example_info"] = self.saved_input_example_info
+        if self.mlflow_version is None and _MLFLOW_VERSION_KEY in res:
+            res.pop(_MLFLOW_VERSION_KEY)
         return res
 
     def to_yaml(self, stream=None):
         """Write the model as yaml string."""
-
-        # Do not save mlflow_version attribute if it's not defined
-        info = self.to_dict()
-        if not self.mlflow_version and _MLFLOW_VERSION_KEY in info:
-            info.pop(_MLFLOW_VERSION_KEY)
-
-        return yaml.safe_dump(info, stream=stream, default_flow_style=False)
+        return yaml.safe_dump(self.to_dict(), stream=stream, default_flow_style=False)
 
     def __str__(self):
         return self.to_yaml()

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -94,7 +94,7 @@ class Model:
         signature=None,  # ModelSignature
         saved_input_example_info: Dict[str, Any] = None,
         model_uuid: Union[str, Callable, None] = lambda: uuid.uuid4().hex,
-        mlflow_version=None,
+        mlflow_version: Union[str, Callable, None] = lambda: mlflow.version.VERSION,
         **kwargs,
     ):
         # store model id instead of run_id and path to avoid confusion when model gets exported
@@ -107,7 +107,7 @@ class Model:
         self.signature = signature
         self.saved_input_example_info = saved_input_example_info
         self.model_uuid = model_uuid() if callable(model_uuid) else model_uuid
-        self.mlflow_version = mlflow_version
+        self.mlflow_version = mlflow_version() if callable(mlflow_version) else mlflow_version
         self.__dict__.update(kwargs)
 
     def __eq__(self, other):
@@ -208,6 +208,11 @@ class Model:
 
     def save(self, path):
         """Write the model as a local YAML file."""
+
+        # Saved model must have mlflow_version set
+        if self.mlflow_version is None:
+            self.mlflow_version = mlflow.version.VERSION
+
         with open(path, "w") as out:
             self.to_yaml(out)
 
@@ -231,6 +236,9 @@ class Model:
 
         if "model_uuid" not in model_dict:
             model_dict["model_uuid"] = None
+
+        if "mlflow_version" not in model_dict:
+            model_dict["mlflow_version"] = None
 
         return cls(**model_dict)
 
@@ -284,9 +292,7 @@ class Model:
         with TempDir() as tmp:
             local_path = tmp.path("model")
             run_id = mlflow.tracking.fluent._get_or_start_run().info.run_id
-            mlflow_model = cls(
-                artifact_path=artifact_path, run_id=run_id, mlflow_version=mlflow.version.VERSION
-            )
+            mlflow_model = cls(artifact_path=artifact_path, run_id=run_id)
             flavor.save_model(path=local_path, mlflow_model=mlflow_model, **kwargs)
             mlflow.tracking.fluent.log_artifacts(local_path, artifact_path)
             try:

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -197,7 +197,14 @@ class Model:
 
     def to_yaml(self, stream=None):
         """Write the model as yaml string."""
-        return yaml.safe_dump(self.to_dict(), stream=stream, default_flow_style=False)
+
+        # Do not save mlflow_version attribute if it's not defined
+        info = self.to_dict()
+        mlflow_version_key = "mlflow_version"
+        if not self.mlflow_version and mlflow_version_key in info:
+            info.pop(mlflow_version_key)
+
+        return yaml.safe_dump(info, stream=stream, default_flow_style=False)
 
     def __str__(self):
         return self.to_yaml()
@@ -208,11 +215,6 @@ class Model:
 
     def save(self, path):
         """Write the model as a local YAML file."""
-
-        # Saved model must have mlflow_version set
-        if self.mlflow_version is None:
-            self.mlflow_version = mlflow.version.VERSION
-
         with open(path, "w") as out:
             self.to_yaml(out)
 

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -110,7 +110,7 @@ def test_model_log():
         assert isinstance(loaded_example, pd.DataFrame)
         assert loaded_example.to_dict(orient="records")[0] == input_example
 
-        assert loaded_model.mlflow_version == mlflow.version.VERSION
+        assert Version(loaded_model.mlflow_version) == Version(mlflow.version.VERSION)
 
 
 def test_model_info():

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -16,6 +16,7 @@ from mlflow.utils.proto_json_utils import _dataframe_from_json
 
 from unittest import mock
 from scipy.sparse import csc_matrix
+from packaging.version import Version
 
 
 def test_model_save_load():
@@ -149,15 +150,13 @@ def test_model_info():
 
         assert model_info.signature_dict == sig.to_dict()
 
-        assert model_info.mlflow_version == loaded_model.mlflow_version
+        assert Version(model_info.mlflow_version) == Version(loaded_model.mlflow_version)
 
 
 def test_load_model_without_mlflow_version():
 
     with TempDir(chdr=True) as tmp:
-        model = Model(artifact_path="some/path", run_id="1234")
-        del model.mlflow_version
-
+        model = Model(artifact_path="some/path", run_id="1234", mlflow_version=None)
         path = tmp.path("model")
         with open(path, "w") as out:
             model.to_yaml(out)

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -155,27 +155,15 @@ def test_model_info():
 def test_load_model_without_mlflow_version():
 
     with TempDir(chdr=True) as tmp:
-        sig = ModelSignature(
-            inputs=Schema([ColSpec("integer", "x"), ColSpec("integer", "y")]),
-            outputs=Schema([ColSpec(name=None, type="double")]),
-        )
-        input_example = {"x": 1, "y": 2}
+        model = Model(artifact_path="some/path", run_id="1234")
+        del model.mlflow_version
 
-        experiment_id = mlflow.create_experiment("test")
-        with mlflow.start_run(experiment_id=experiment_id) as run:
-            Model.log("some/path", TestFlavor, signature=sig, input_example=input_example)
-        _download_artifact_from_uri(
-            "runs:/{}/some/path".format(run.info.run_id), output_path=tmp.path("")
-        )
+        path = tmp.path("model")
+        with open(path, "w") as out:
+            model.to_yaml(out)
+        loaded_model = Model.load(path)
 
-        loaded_model = Model.load(tmp.path("MLmodel"))
-        del loaded_model.mlflow_version
-
-        legacy_model_path = tmp.path("legacy_MLmodel")
-        loaded_model.save(legacy_model_path)
-        loaded_model_without_mlflow_version = Model.load(legacy_model_path)
-
-        assert loaded_model_without_mlflow_version.mlflow_version is None
+        assert loaded_model.mlflow_version is None
 
 
 def test_model_log_with_databricks_runtime():


### PR DESCRIPTION
Signed-off-by: Nikolay Ulmasov <ulmasov@hotmail.com>

## What changes are proposed in this pull request?

Implement issue #5501 - Add an mlflow_version field to the MLModel spec that is automatically populated with the current MLflow version when an MLflow Model is saved / logged.

Models logged with previous versions will have `mlflow_version=None` when loaded from a file.

## How is this patch tested?

Extended existing tests and added a test to load previously logged models without mlflow_version info

## Does this PR change the documentation?

- [ x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Users can check the version of MLFlow the model with logged with. 

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
