### PR TITLE
Support logging PyTorch metrics on training batch steps with autolog

### DIFF
--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -876,6 +876,7 @@ def load_state_dict(state_dict_uri, **kwargs):
 @autologging_integration(FLAVOR_NAME)
 def autolog(
     log_every_n_epoch=1,
+    log_every_n_step=False,
     log_models=True,
     disable=False,
     exclusive=False,
@@ -905,6 +906,9 @@ def autolog(
 
     :param log_every_n_epoch: If specified, logs metrics once every `n` epochs. By default, metrics
                        are logged after every epoch.
+    :param log_every_n_step: If specified, logs batch metrics once every `n` global step. By default,
+                       metrics are not logged for steps. Note that setting this to 1 can cause
+                       performance issues and is not recommended.
     :param log_models: If ``True``, trained models are logged as MLflow model artifacts.
                        If ``False``, trained models are not logged.
     :param disable: If ``True``, disables the PyTorch Lightning autologging integration.

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -876,7 +876,7 @@ def load_state_dict(state_dict_uri, **kwargs):
 @autologging_integration(FLAVOR_NAME)
 def autolog(
     log_every_n_epoch=1,
-    log_every_n_step=False,
+    log_every_n_step=None,
     log_models=True,
     disable=False,
     exclusive=False,
@@ -906,9 +906,9 @@ def autolog(
 
     :param log_every_n_epoch: If specified, logs metrics once every `n` epochs. By default, metrics
                        are logged after every epoch.
-    :param log_every_n_step: If specified, logs batch metrics once every `n` global step. By default,
-                       metrics are not logged for steps. Note that setting this to 1 can cause
-                       performance issues and is not recommended.
+    :param log_every_n_step: If specified, logs batch metrics once every `n` global step.
+                       By default, metrics are not logged for steps. Note that setting this to 1 can
+                       cause performance issues and is not recommended.
     :param log_models: If ``True``, trained models are logged as MLflow model artifacts.
                        If ``False``, trained models are not logged.
     :param disable: If ``True``, disables the PyTorch Lightning autologging integration.

--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -321,7 +321,7 @@ def patched_fit(original, self, *args, **kwargs):
 
     log_models = get_autologging_config(mlflow.pytorch.FLAVOR_NAME, "log_models", True)
     log_every_n_epoch = get_autologging_config(mlflow.pytorch.FLAVOR_NAME, "log_every_n_epoch", 1)
-    log_every_n_step = get_autologging_config(mlflow.pytorch.FLAVOR_NAME, "log_every_n_step", False)
+    log_every_n_step = get_autologging_config(mlflow.pytorch.FLAVOR_NAME, "log_every_n_step", None)
 
     early_stop_callback = None
     for callback in self.callbacks:

--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -8,6 +8,7 @@ import pytorch_lightning as pl
 from pytorch_lightning.core.memory import ModelSummary
 from pytorch_lightning.utilities import rank_zero_only
 
+from mlflow.exceptions import MlflowException
 from mlflow.utils.autologging_utils import (
     ExceptionSafeAbstractClass,
     BatchMetricsLogger,
@@ -28,6 +29,9 @@ logging.basicConfig(level=logging.ERROR)
 # tracking uri, experiment_id and run_id which may lead to a race condition.
 # TODO: Replace __MlflowPLCallback with Pytorch Lightning's built-in MlflowLogger
 # once the above mentioned issues have been addressed
+
+
+_pl_version = Version(pl.__version__)
 
 
 def _get_optimizer_name(optimizer):
@@ -60,6 +64,10 @@ class __MLflowPLCallback(pl.Callback, metaclass=ExceptionSafeAbstractClass):
     def __init__(
         self, client, metrics_logger, run_id, log_models, log_every_n_epoch, log_every_n_step
     ):
+        if log_every_n_step and _pl_version < Version("1.1.0"):
+            raise MlflowException(
+                "log_every_n_step is only supported for PyTorch-Lightning >= 1.1.0"
+            )
         self.early_stopping = False
         self.client = client
         self.metrics_logger = metrics_logger
@@ -100,8 +108,6 @@ class __MLflowPLCallback(pl.Callback, metaclass=ExceptionSafeAbstractClass):
                 if item[0] not in self._step_metrics
             )
             self._log_metrics(trainer, pl_module.current_epoch, metric_items)
-
-    _pl_version = Version(pl.__version__)
 
     # In pytorch-lightning >= 1.4.0, validation is run inside the training epoch and
     # `trainer.callback_metrics` contains both training and validation metrics of the
@@ -180,14 +186,11 @@ class __MLflowPLCallback(pl.Callback, metaclass=ExceptionSafeAbstractClass):
         step = trainer.global_step
         if (step + 1) % self.log_every_n_step == 0:
             # When logging at the end of a batch step, we only want to log metrics that are logged
-            # on steps, so rather than using trainer.callback_metrics which will also contain epoch
-            # logged metrics after an epoch has completed, we access the on_step metrics using
-            # trainer.logger_connector.metrics. For forked metrics (metrics logged on both steps and
-            # epochs), we exclude the metric with the non-forked name (eg. "loss" when we have
-            # "loss", "loss_step" and "loss_epoch") so that this is only logged on epochs. We also
-            # record which metrics we've logged per step, so we can later exclude these from metrics
-            # logged on epochs.
-            metrics = trainer.logger_connector.metrics["callback"]
+            # on steps. For forked metrics (metrics logged on both steps and epochs), we exclude the
+            # metric with the non-forked name (eg. "loss" when we have "loss", "loss_step" and
+            # "loss_epoch") so that this is only logged on epochs. We also record which metrics
+            # we've logged per step, so we can later exclude these from metrics logged on epochs.
+            metrics = _get_step_metrics(trainer)
             metric_items = [
                 item
                 for item in metrics.items()
@@ -297,6 +300,24 @@ def _log_early_stop_metrics(early_stop_callback, client, run_id):
         metrics["wait_count"] = early_stop_callback.wait_count
 
     client.log_metrics(run_id, metrics)
+
+
+# PyTorch-Lightning refactored the LoggerConnector class in version 1.4.0 and changed how
+# metrics are accessed.
+if _pl_version >= Version("1.4.0"):
+
+    def _get_step_metrics(trainer):
+        # logger_connector.metrics provides only on_step or on_epoch metrics depending on whether
+        # we're at the end of an epoch, as opposed to logger_connector.callback_metrics which caches
+        # all seen metrics and so will also contain epoch logged metrics after an epoch has
+        # completed.
+        return trainer.logger_connector.metrics["callback"]
+
+
+else:
+
+    def _get_step_metrics(trainer):
+        return trainer.logger_connector.cached_results.get_latest_batch_log_metrics()
 
 
 def patched_fit(original, self, *args, **kwargs):

--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -57,15 +57,17 @@ class __MLflowPLCallback(pl.Callback, metaclass=ExceptionSafeAbstractClass):
     Callback for auto-logging metrics and parameters.
     """
 
-    def __init__(self, client, metrics_logger, run_id, log_models, log_every_n_epoch):
+    def __init__(self, client, metrics_logger, run_id, log_models, log_every_n_epoch, log_every_n_step):
         self.early_stopping = False
         self.client = client
         self.metrics_logger = metrics_logger
         self.run_id = run_id
         self.log_models = log_models
         self.log_every_n_epoch = log_every_n_epoch
+        self.log_every_n_step = log_every_n_step
+        self._step_metrics = set()
 
-    def _log_metrics(self, trainer, pl_module):
+    def _log_metrics(self, trainer, step, metric_items):
         # pytorch-lightning runs a few steps of validation in the beginning of training
         # as a sanity check to catch bugs without having to wait for the training routine
         # to complete. During this check, we should skip logging metrics.
@@ -80,13 +82,18 @@ class __MLflowPLCallback(pl.Callback, metaclass=ExceptionSafeAbstractClass):
         if sanity_checking:
             return
 
+        # Cast metric value as  float before passing into logger.
+        metrics = dict(map(lambda x: (x[0], float(x[1])), metric_items))
+        self.metrics_logger.record_metrics(metrics, step)
+
+    def _log_epoch_metrics(self, trainer, pl_module):
         if (pl_module.current_epoch + 1) % self.log_every_n_epoch == 0:
             # `trainer.callback_metrics` contains both training and validation metrics
-            cur_metrics = trainer.callback_metrics
-            # Cast metric value as  float before passing into logger.
-            metrics = dict(map(lambda x: (x[0], float(x[1])), cur_metrics.items()))
-
-            self.metrics_logger.record_metrics(metrics, pl_module.current_epoch)
+            # and includes metrics logged on steps and epochs.
+            # If we have logged any metrics on a step basis in mlflow, we exclude these from the
+            # epoch level metrics to prevent mixing epoch and step based values.
+            metric_items = (item for item in trainer.callback_metrics.items() if item[0] not in self._step_metrics)
+            self._log_metrics(trainer, pl_module.current_epoch, metric_items)
 
     _pl_version = Version(pl.__version__)
 
@@ -100,7 +107,7 @@ class __MLflowPLCallback(pl.Callback, metaclass=ExceptionSafeAbstractClass):
         def on_train_epoch_end(
             self, trainer, pl_module, *args
         ):  # pylint: disable=signature-differs,arguments-differ,unused-argument
-            self._log_metrics(trainer, pl_module)
+            self._log_epoch_metrics(trainer, pl_module)
 
     # In pytorch-lightning >= 1.2.0, logging metrics in `on_epoch_end` results in duplicate
     # metrics records because `on_epoch_end` is called after both train and validation
@@ -128,7 +135,7 @@ class __MLflowPLCallback(pl.Callback, metaclass=ExceptionSafeAbstractClass):
             # log metrics in `on_validaion_epoch_end` to avoid logging the same metrics
             # records twice
             if not trainer.enable_validation:
-                self._log_metrics(trainer, pl_module)
+                self._log_epoch_metrics(trainer, pl_module)
 
         @rank_zero_only
         def on_validation_epoch_end(self, trainer, pl_module):
@@ -138,7 +145,7 @@ class __MLflowPLCallback(pl.Callback, metaclass=ExceptionSafeAbstractClass):
             :param trainer: pytorch lightning trainer instance
             :param pl_module: pytorch lightning base module
             """
-            self._log_metrics(trainer, pl_module)
+            self._log_epoch_metrics(trainer, pl_module)
 
     else:
 
@@ -150,7 +157,36 @@ class __MLflowPLCallback(pl.Callback, metaclass=ExceptionSafeAbstractClass):
             :param trainer: pytorch lightning trainer instance
             :param pl_module: pytorch lightning base module
             """
-            self._log_metrics(trainer, pl_module)
+            self._log_epoch_metrics(trainer, pl_module)
+
+    @rank_zero_only
+    def on_train_batch_end(
+            self, trainer, pl_module, *args
+    ):  # pylint: disable=signature-differs,arguments-differ,unused-argument
+        """
+        Log metric values after each step
+
+        :param trainer: pytorch lightning trainer instance
+        :param pl_module: pytorch lightning base module
+        """
+        if not self.log_every_n_step:
+            return
+        step = trainer.global_step
+        if (step + 1) % self.log_every_n_step == 0:
+            # When logging at the end of a batch step, we only want to log metrics that are logged on steps,
+            # so rather than using trainer.callback_metrics which will also contain epoch logged metrics
+            # after an epoch has completed, we access the on_step metrics using trainer.logger_connector.metrics.
+            # For forked metrics (metrics logged on both steps and epochs), we exclude the metric with the non-forked
+            # name (eg. "loss" when we have "loss", "loss_step" and "loss_epoch") so that this is only logged on epochs.
+            # We also record which metrics we've logged per step, so we can later exclude these from metrics logged on
+            # epochs.
+            metrics = trainer.logger_connector.metrics["callback"]
+            metric_items = [
+                item for item in metrics.items() if
+                item[0].endswith("_step") or f"{item[0]}_step" not in metrics.keys()]
+            for item in metric_items:
+                self._step_metrics.add(item[0])
+            self._log_metrics(trainer, step, metric_items)
 
     @rank_zero_only
     def on_train_start(self, trainer, pl_module):
@@ -276,6 +312,7 @@ def patched_fit(original, self, *args, **kwargs):
 
     log_models = get_autologging_config(mlflow.pytorch.FLAVOR_NAME, "log_models", True)
     log_every_n_epoch = get_autologging_config(mlflow.pytorch.FLAVOR_NAME, "log_every_n_epoch", 1)
+    log_every_n_step = get_autologging_config(mlflow.pytorch.FLAVOR_NAME, "log_every_n_step", False)
 
     early_stop_callback = None
     for callback in self.callbacks:
@@ -285,7 +322,7 @@ def patched_fit(original, self, *args, **kwargs):
 
     if not any(isinstance(callbacks, __MLflowPLCallback) for callbacks in self.callbacks):
         self.callbacks += [
-            __MLflowPLCallback(client, metrics_logger, run_id, log_models, log_every_n_epoch)
+            __MLflowPLCallback(client, metrics_logger, run_id, log_models, log_every_n_epoch, log_every_n_step)
         ]
 
     client.flush(synchronous=False)

--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -57,7 +57,9 @@ class __MLflowPLCallback(pl.Callback, metaclass=ExceptionSafeAbstractClass):
     Callback for auto-logging metrics and parameters.
     """
 
-    def __init__(self, client, metrics_logger, run_id, log_models, log_every_n_epoch, log_every_n_step):
+    def __init__(
+        self, client, metrics_logger, run_id, log_models, log_every_n_epoch, log_every_n_step
+    ):
         self.early_stopping = False
         self.client = client
         self.metrics_logger = metrics_logger
@@ -92,7 +94,11 @@ class __MLflowPLCallback(pl.Callback, metaclass=ExceptionSafeAbstractClass):
             # and includes metrics logged on steps and epochs.
             # If we have logged any metrics on a step basis in mlflow, we exclude these from the
             # epoch level metrics to prevent mixing epoch and step based values.
-            metric_items = (item for item in trainer.callback_metrics.items() if item[0] not in self._step_metrics)
+            metric_items = (
+                item
+                for item in trainer.callback_metrics.items()
+                if item[0] not in self._step_metrics
+            )
             self._log_metrics(trainer, pl_module.current_epoch, metric_items)
 
     _pl_version = Version(pl.__version__)
@@ -161,7 +167,7 @@ class __MLflowPLCallback(pl.Callback, metaclass=ExceptionSafeAbstractClass):
 
     @rank_zero_only
     def on_train_batch_end(
-            self, trainer, pl_module, *args
+        self, trainer, pl_module, *args
     ):  # pylint: disable=signature-differs,arguments-differ,unused-argument
         """
         Log metric values after each step
@@ -182,8 +188,10 @@ class __MLflowPLCallback(pl.Callback, metaclass=ExceptionSafeAbstractClass):
             # epochs.
             metrics = trainer.logger_connector.metrics["callback"]
             metric_items = [
-                item for item in metrics.items() if
-                item[0].endswith("_step") or f"{item[0]}_step" not in metrics.keys()]
+                item
+                for item in metrics.items()
+                if item[0].endswith("_step") or f"{item[0]}_step" not in metrics.keys()
+            ]
             for item in metric_items:
                 self._step_metrics.add(item[0])
             self._log_metrics(trainer, step, metric_items)
@@ -322,7 +330,9 @@ def patched_fit(original, self, *args, **kwargs):
 
     if not any(isinstance(callbacks, __MLflowPLCallback) for callbacks in self.callbacks):
         self.callbacks += [
-            __MLflowPLCallback(client, metrics_logger, run_id, log_models, log_every_n_epoch, log_every_n_step)
+            __MLflowPLCallback(
+                client, metrics_logger, run_id, log_models, log_every_n_epoch, log_every_n_step
+            )
         ]
 
     client.flush(synchronous=False)

--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -179,13 +179,14 @@ class __MLflowPLCallback(pl.Callback, metaclass=ExceptionSafeAbstractClass):
             return
         step = trainer.global_step
         if (step + 1) % self.log_every_n_step == 0:
-            # When logging at the end of a batch step, we only want to log metrics that are logged on steps,
-            # so rather than using trainer.callback_metrics which will also contain epoch logged metrics
-            # after an epoch has completed, we access the on_step metrics using trainer.logger_connector.metrics.
-            # For forked metrics (metrics logged on both steps and epochs), we exclude the metric with the non-forked
-            # name (eg. "loss" when we have "loss", "loss_step" and "loss_epoch") so that this is only logged on epochs.
-            # We also record which metrics we've logged per step, so we can later exclude these from metrics logged on
-            # epochs.
+            # When logging at the end of a batch step, we only want to log metrics that are logged
+            # on steps, so rather than using trainer.callback_metrics which will also contain epoch
+            # logged metrics after an epoch has completed, we access the on_step metrics using
+            # trainer.logger_connector.metrics. For forked metrics (metrics logged on both steps and
+            # epochs), we exclude the metric with the non-forked name (eg. "loss" when we have
+            # "loss", "loss_step" and "loss_epoch") so that this is only logged on epochs. We also
+            # record which metrics we've logged per step, so we can later exclude these from metrics
+            # logged on epochs.
             metrics = trainer.logger_connector.metrics["callback"]
             metric_items = [
                 item

--- a/tests/pytorch/iris.py
+++ b/tests/pytorch/iris.py
@@ -48,6 +48,7 @@ class IrisClassification(IrisClassificationBase):
         self.train_acc(torch.argmax(logits, dim=1), y)
         self.log("train_acc", self.train_acc.compute(), on_step=False, on_epoch=True)
         self.log("loss", loss)
+        self.log("loss_forked", loss, on_epoch=True, on_step=True)
         return {"loss": loss}
 
     def validation_step(self, batch, batch_idx):

--- a/tests/pytorch/test_pytorch_autolog.py
+++ b/tests/pytorch/test_pytorch_autolog.py
@@ -9,6 +9,7 @@ from pytorch_lightning.callbacks.early_stopping import EarlyStopping
 from pytorch_lightning.callbacks import ModelCheckpoint
 from mlflow.utils.file_utils import TempDir
 from iris_data_module import IrisDataModule, IrisDataModuleWithoutValidation
+from mlflow.exceptions import MlflowException
 from mlflow.pytorch._pytorch_autolog import _get_optimizer_name
 from mlflow.tracking.client import MlflowClient
 
@@ -126,6 +127,11 @@ def test_pytorch_autolog_logs_expected_metrics_without_validation(pytorch_model_
         assert len(metric_history) == NUM_EPOCHS
 
 
+@pytest.mark.skipif(
+    Version(pl.__version__) < Version("1.1.0"),
+    reason="Access to metrics from the current step is only possible since PyTorch-lightning 1.1.0"
+    "when LoggerConnector.cached_results was added",
+)
 def test_pytorch_autolog_logging_forked_metrics_on_step_and_epoch(
     pytorch_model_with_steps_logged,
 ):
@@ -148,6 +154,21 @@ def test_pytorch_autolog_logging_forked_metrics_on_step_and_epoch(
         assert (
             len(metric_history) == expected_len
         ), f"Expected {expected_len} values for {metric_key}, got {len(metric_history)}"
+
+
+@pytest.mark.skipif(
+    Version(pl.__version__) >= Version("1.1.0"),
+    reason="Logging step metrics is supported since PyTorch-Lightning 1.1.0",
+)
+def test_pytorch_autolog_raises_error_when_step_logging_unsupported():
+    mlflow.pytorch.autolog(log_every_n_step=1)
+    model = IrisClassification()
+    dm = IrisDataModule()
+    trainer = pl.Trainer(max_epochs=NUM_EPOCHS)
+    with pytest.raises(
+        MlflowException, match="log_every_n_step is only supported for PyTorch-Lightning >= 1.1.0"
+    ):
+        trainer.fit(model, dm)
 
 
 # pylint: disable=unused-argument

--- a/tests/pytorch/test_pytorch_autolog.py
+++ b/tests/pytorch/test_pytorch_autolog.py
@@ -9,6 +9,7 @@ from pytorch_lightning.callbacks.early_stopping import EarlyStopping
 from pytorch_lightning.callbacks import ModelCheckpoint
 from mlflow.utils.file_utils import TempDir
 from iris_data_module import IrisDataModule, IrisDataModuleWithoutValidation
+from mlflow.exceptions import MlflowException
 from mlflow.pytorch._pytorch_autolog import _get_optimizer_name
 from mlflow.tracking.client import MlflowClient
 
@@ -125,6 +126,11 @@ def test_pytorch_autolog_logs_expected_metrics_without_validation(pytorch_model_
         assert len(metric_history) == NUM_EPOCHS
 
 
+@pytest.mark.skipif(
+    Version(pl.__version__) < Version("1.1.0"),
+    reason="Access to step specific metrics only possible since PyTorch-lightning 1.1.0 when"
+    "LoggerConnector.cached_results was added",
+)
 def test_pytorch_autolog_logging_forked_metrics_on_step_and_epoch(
     pytorch_model_with_every_step_logged,
 ):
@@ -146,6 +152,21 @@ def test_pytorch_autolog_logging_forked_metrics_on_step_and_epoch(
         assert (
             len(metric_history) == expected_len
         ), f"Expected {expected_len} values for {metric_key}, got {len(metric_history)}"
+
+
+@pytest.mark.skipif(
+    Version(pl.__version__) >= Version("1.1.0"),
+    reason="Logging step metrics is supported since PyTorch-Lightning 1.1.0",
+)
+def test_pytorch_autolog_raises_error_when_step_logging_unsupported():
+    mlflow.pytorch.autolog(log_every_n_step=1)
+    model = IrisClassification()
+    dm = IrisDataModule()
+    trainer = pl.Trainer(max_epochs=NUM_EPOCHS)
+    with pytest.raises(
+        MlflowException, match="log_every_n_step is only supported for PyTorch-Lightning >= 1.1.0"
+    ):
+        trainer.fit(model, dm)
 
 
 # pylint: disable=unused-argument

--- a/tests/pytorch/test_pytorch_autolog.py
+++ b/tests/pytorch/test_pytorch_autolog.py
@@ -90,8 +90,15 @@ def test_pytorch_autolog_logs_expected_data(pytorch_model):
     # When autolog is configured with the default configuration to not log on steps,
     # then all metrics are logged per epoch, including step based metrics.
     client = mlflow.tracking.MlflowClient()
-    for metric_key in ["loss", "train_acc", "val_loss", "val_acc",
-                       "loss_forked", "loss_forked_step", "loss_forked_epoch"]:
+    for metric_key in [
+        "loss",
+        "train_acc",
+        "val_loss",
+        "val_acc",
+        "loss_forked",
+        "loss_forked_step",
+        "loss_forked_epoch",
+    ]:
         assert metric_key in run.data.metrics
         metric_history = client.get_metric_history(run.info.run_id, metric_key)
         assert len(metric_history) == NUM_EPOCHS
@@ -118,7 +125,9 @@ def test_pytorch_autolog_logs_expected_metrics_without_validation(pytorch_model_
         assert len(metric_history) == NUM_EPOCHS
 
 
-def test_pytorch_autolog_logging_forked_metrics_on_step_and_epoch(pytorch_model_with_every_step_logged):
+def test_pytorch_autolog_logging_forked_metrics_on_step_and_epoch(
+    pytorch_model_with_every_step_logged,
+):
     # When autolog is configured to log on steps as well as epochs,
     # then we only log step based metrics per step and not on epochs.
     trainer, run = pytorch_model_with_every_step_logged
@@ -126,16 +135,17 @@ def test_pytorch_autolog_logging_forked_metrics_on_step_and_epoch(pytorch_model_
 
     client = mlflow.tracking.MlflowClient()
     for (metric_key, expected_len) in [
-            ("train_acc", NUM_EPOCHS),
-            ("loss", num_steps),
-            ("loss_forked", NUM_EPOCHS),
-            ("loss_forked_step", num_steps),
-            ("loss_forked_epoch", NUM_EPOCHS),
+        ("train_acc", NUM_EPOCHS),
+        ("loss", num_steps),
+        ("loss_forked", NUM_EPOCHS),
+        ("loss_forked_step", num_steps),
+        ("loss_forked_epoch", NUM_EPOCHS),
     ]:
         assert metric_key in run.data.metrics, f"Missing {metric_key} in metrics"
         metric_history = client.get_metric_history(run.info.run_id, metric_key)
-        assert len(metric_history) == expected_len, (
-            f"Expected {expected_len} values for {metric_key}, got {len(metric_history)}")
+        assert (
+            len(metric_history) == expected_len
+        ), f"Expected {expected_len} values for {metric_key}, got {len(metric_history)}"
 
 
 # pylint: disable=unused-argument


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add a new `log_every_n_step` parameter to `mlflow.pytorch.autolog` that enables logging step based metrics using the step count instead of epoch. By default, this parameter is `False` and these metrics will be logged using epoch numbers to keep backwards compatibility.

This fixes #4235.

This is a second attempt after #5497 was reverted as that PR accessed `trainer.logger_connector` which is being made private in the next PyTorch-Lightning version.

The new approach only uses `trainer.callback_metrics` for recent PyTorch-Lightning versions and additionally tracks which metrics have been logged on epochs so these aren't considered as step based metrics. Recording the metrics seen on epochs and steps is done outside the check for whether they should be logged in mlflow, so that eg. if `log_every_n_epoch` is greater than 1, we still know which metrics were logged on the epoch within PyTorch-Lightning and shouldn't be considered as step based metrics in the second epoch (and similarly for when steps are logged less frequently than epochs, but that seems quite unlikely).

I was a little concerned about the performance impact of retrieving and checking the metric keys on each step and epoch so did some benchmarking, and the impact was fairly negligible. I used a very simple PyTorch model with a single layer and random data and ran 100 epochs, with each epoch running 64 training batches. I'm logging to a local mlflow dev server with a sqlite tracking store. I also ran the same benchmarks after merging in the current changes from #5460 which enables batch SQL writing, and the extra time taken when logging on steps is greatly reduced:

| Test case | Time taken (s) | Time taken with batch writing (s) |
| ------------- | ------------- | ------------- |
| Logging epochs only | 26.6 | 18.8 |
| Logging every 10th step with #5497 | 62.7 | 19.0 |
| Logging every 10th step with this PR | 63.1 | 19.2 |

I had hoped that changing to this approach would mean that the code would be the same for all PyTorch-Lightning versions, but unfortunately versions prior to 1.4.0 had test failures and I found that `trainer.callback_metrics` accessed within a callback after a training batch didn't include the metrics from the current batch, as these are only updated after all callbacks have been run, so I had to revert back to using the `logger_connector` approach for older versions.

## How is this patch tested?

New unit test added.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`mlflow.pytorch.autolog` now accepts a `log_every_n_step` parameter that can be used to log step based metrics against the step number.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
