### PR TITLE
Show minimum and maximum metric values in the run view UI

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/reducers/MetricReducer.js
+++ b/mlflow/server/js/src/experiment-tracking/reducers/MetricReducer.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import { minBy, maxBy } from 'lodash';
 import {
   GET_METRIC_HISTORY_API,
   GET_RUN_API,
@@ -106,13 +106,13 @@ const reducedMetricsByRunUuid = (state = {}, action, reducer) => {
  * Return minimum metrics by run UUID (object of run UUID -> object of metric key -> Metric object)
  */
 export const minMetricsByRunUuid = (state = {}, action) =>
-  reducedMetricsByRunUuid(state, action, (metrics) => _.minBy(metrics, 'value'));
+  reducedMetricsByRunUuid(state, action, (metrics) => minBy(metrics, 'value'));
 
 /**
  * Return maximum metrics by run UUID (object of run UUID -> object of metric key -> Metric object)
  */
 export const maxMetricsByRunUuid = (state = {}, action) =>
-  reducedMetricsByRunUuid(state, action, (metrics) => _.maxBy(metrics, 'value'));
+  reducedMetricsByRunUuid(state, action, (metrics) => maxBy(metrics, 'value'));
 
 export const metricsByRunUuid = (state = {}, action) => {
   switch (action.type) {

--- a/mlflow/server/js/src/experiment-tracking/reducers/Reducers.js
+++ b/mlflow/server/js/src/experiment-tracking/reducers/Reducers.js
@@ -14,7 +14,12 @@ import {
 } from '../actions';
 import { Experiment, Param, RunInfo, RunTag, ExperimentTag } from '../sdk/MlflowMessages';
 import { ArtifactNode } from '../utils/ArtifactUtils';
-import { metricsByRunUuid, latestMetricsByRunUuid } from './MetricReducer';
+import {
+  metricsByRunUuid,
+  latestMetricsByRunUuid,
+  minMetricsByRunUuid,
+  maxMetricsByRunUuid,
+} from './MetricReducer';
 import modelRegistryReducers from '../../model-registry/reducers';
 import _ from 'lodash';
 import {
@@ -362,6 +367,8 @@ export const entities = combineReducers({
   runInfosByUuid,
   metricsByRunUuid,
   latestMetricsByRunUuid,
+  minMetricsByRunUuid,
+  maxMetricsByRunUuid,
   paramsByRunUuid,
   tagsByRunUuid,
   experimentTagsByExperimentId,

--- a/mlflow/server/js/src/i18n/default/en.json
+++ b/mlflow/server/js/src/i18n/default/en.json
@@ -155,6 +155,10 @@
     "defaultMessage": "Add",
     "description": "Add button text in editable tags table view in MLflow"
   },
+  "5K7cOi": {
+    "defaultMessage": "Latest",
+    "description": "Column title for latest value column for displaying the latest value of the metrics for the experiment run "
+  },
   "5Mzn2b": {
     "defaultMessage": "Creator",
     "description": "Label name for creator metadata in model version page"
@@ -299,10 +303,6 @@
     "defaultMessage": "This model is also registered to the <link>model registry</link>.",
     "description": "Sub text to tell the users where the registered models are located "
   },
-  "BwyYS1": {
-    "defaultMessage": "Value",
-    "description": "Column title for value column for displaying the value of the metrics for the experiment run "
-  },
   "CGVHLD": {
     "defaultMessage": "Parameters",
     "description": "Label for the collapsible area to display the parameters used during the experiment run"
@@ -423,6 +423,10 @@
     "defaultMessage": "Y-axis Log Scale:",
     "description": "Label for the radio button to toggle the Log scale on the Y-axis of the metric graph for the experiment"
   },
+  "HNDOs1": {
+    "defaultMessage": "Min",
+    "description": "Column title for minimum value column for displaying the minimum value of the metrics for the experiment run "
+  },
   "HNLDYl": {
     "defaultMessage": "Failed to set tag. Error: {userVisibleError}",
     "description": "Text for user visible error when setting tag in model version view"
@@ -514,6 +518,10 @@
   "O9r1RR": {
     "defaultMessage": "Start Time:",
     "description": "Row title for the start time of runs on the experiment compare runs page"
+  },
+  "OAvz3d": {
+    "defaultMessage": "Max",
+    "description": "Column title for maximum value column for displaying the maximum value of the metrics for the experiment run "
   },
   "OEGyWZ": {
     "defaultMessage": "Predict on a Spark DataFrame.",


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds "Min" and "Max" columns to the metrics table in the run view, and renames the "Value" column to "Latest". The minimum and maximum values are computed using the GetMetricHistory API, as discussed in #4750

![min-max-run](https://user-images.githubusercontent.com/626438/159990443-845790f0-6a13-49b5-bfce-621153499d92.png)

## How is this patch tested?

Unit tests added for the new reduce functions and for the new component behaviour.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The run view in the UI now displays the minimum and maximum metric values for a run.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
