### PR TITLE
refactor: Import tensorflow.estimator explicitly

### DIFF
--- a/examples/tensorflow/tf2/train_predict_2.py
+++ b/examples/tensorflow/tf2/train_predict_2.py
@@ -7,6 +7,7 @@ import pandas as pd
 import shutil
 import tempfile
 import tensorflow as tf
+from tensorflow import estimator as tf_estimator
 import mlflow.tensorflow
 
 TRAIN_URL = "http://download.tensorflow.org/data/iris_training.csv"
@@ -86,7 +87,7 @@ def main(argv):
         hidden_units = [10, 10]
 
         # Build 2 hidden layer DNN with 10, 10 units respectively.
-        classifier = tf.estimator.DNNClassifier(
+        classifier = tf_estimator.DNNClassifier(
             feature_columns=my_feature_columns,
             hidden_units=hidden_units,
             # The model must choose between 3 classes.
@@ -138,7 +139,7 @@ def main(argv):
             "PetalWidth": tf.Variable([], dtype=tf.float64, name="PetalWidth"),
         }
 
-        receiver_fn = tf.estimator.export.build_raw_serving_input_receiver_fn(feat_specifications)
+        receiver_fn = tf_estimator.export.build_raw_serving_input_receiver_fn(feat_specifications)
         temp = tempfile.mkdtemp()
         try:
             # The model is automatically logged when export_saved_model() is called.

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -11,6 +11,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import tensorflow as tf
+from tensorflow import estimator as tf_estimator
 from packaging.version import Version
 from tensorflow.keras import layers
 import yaml
@@ -654,9 +655,9 @@ def create_tf_estimator_model(directory, export, training_steps=100, use_v1_esti
     for feature in CSV_COLUMN_NAMES:
         feature_spec[feature] = tf.Variable([], dtype=tf.float64, name=feature)
 
-    receiver_fn = tf.estimator.export.build_raw_serving_input_receiver_fn(feature_spec)
+    receiver_fn = tf_estimator.export.build_raw_serving_input_receiver_fn(feature_spec)
 
-    run_config = tf.estimator.RunConfig(
+    run_config = tf_estimator.RunConfig(
         # Emit loss metrics to TensorBoard every step
         save_summary_steps=1,
     )
@@ -674,7 +675,7 @@ def create_tf_estimator_model(directory, export, training_steps=100, use_v1_esti
             config=run_config,
         )
     else:
-        classifier = tf.estimator.DNNClassifier(
+        classifier = tf_estimator.DNNClassifier(
             feature_columns=my_feature_columns,
             # Two hidden layers of 10 nodes each.
             hidden_units=[30, 10],

--- a/tests/tensorflow/test_tensorflow2_model_export.py
+++ b/tests/tensorflow/test_tensorflow2_model_export.py
@@ -14,6 +14,7 @@ import numpy as np
 import pandas as pd
 import pandas.testing
 import tensorflow as tf
+from tensorflow import estimator as tf_estimator
 import iris_data_utils
 
 import mlflow
@@ -68,7 +69,7 @@ def saved_tf_iris_model(tmpdir):
         my_feature_columns.append(tf.feature_column.numeric_column(key=key))
 
     # Build 2 hidden layer DNN with 10, 10 units respectively.
-    estimator = tf.estimator.DNNClassifier(
+    estimator = tf_estimator.DNNClassifier(
         feature_columns=my_feature_columns,
         # Two hidden layers of 10 nodes each.
         hidden_units=[10, 10],
@@ -125,7 +126,7 @@ def saved_tf_iris_model(tmpdir):
     for name in my_feature_columns:
         feature_spec[name.key] = tf.Variable([], dtype=tf.float64, name=name.key)
 
-    receiver_fn = tf.estimator.export.build_raw_serving_input_receiver_fn(feature_spec)
+    receiver_fn = tf_estimator.export.build_raw_serving_input_receiver_fn(feature_spec)
 
     # Save the estimator and its inference function
     saved_estimator_path = str(tmpdir.mkdir("saved_model"))
@@ -179,7 +180,7 @@ def saved_tf_categorical_model(tmpdir):
 
     # Build a DNNRegressor, with 20x20-unit hidden layers, with the feature columns
     # defined above as input
-    estimator = tf.estimator.DNNRegressor(hidden_units=[20, 20], feature_columns=feature_columns)
+    estimator = tf_estimator.DNNRegressor(hidden_units=[20, 20], feature_columns=feature_columns)
 
     # Train the estimator and obtain expected predictions on the training dataset
     estimator.train(
@@ -201,7 +202,7 @@ def saved_tf_categorical_model(tmpdir):
         "curb-weight": tf.Variable([], dtype=tf.float64, name="curb-weight"),
         "highway-mpg": tf.Variable([], dtype=tf.float64, name="highway-mpg"),
     }
-    receiver_fn = tf.estimator.export.build_raw_serving_input_receiver_fn(feature_spec)
+    receiver_fn = tf_estimator.export.build_raw_serving_input_receiver_fn(feature_spec)
 
     # Save the estimator and its inference function
     saved_estimator_path = str(tmpdir.mkdir("saved_model"))


### PR DESCRIPTION
Preparing for the future tensorflow.estimator migration. https://www.tensorflow.org/guide/migrate/migrating_estimator

Signed-off-by: Alexey Volkov <alexey.volkov@ark-kun.com>

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

(Details)

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [x] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
