### PR TITLE
[WIP][ML-21119] Log SparkML model with disabled DBFS root

### DIFF
--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -34,7 +34,10 @@ from mlflow.models.model import MLMODEL_FILE_NAME
 from mlflow.models.signature import ModelSignature
 from mlflow.models.utils import ModelInputExample, _save_example
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
-from mlflow.tracking.artifact_utils import _download_artifact_from_uri
+from mlflow.tracking.artifact_utils import (
+    _download_artifact_from_uri,
+    _get_root_uri_and_artifact_path,
+)
 from mlflow.utils.environment import (
     _mlflow_conda_env,
     _validate_env_arguments,
@@ -46,6 +49,8 @@ from mlflow.utils.environment import (
 )
 from mlflow.utils.requirements_utils import _get_pinned_requirement
 from mlflow.utils.docstring_utils import format_docstring, LOG_MODEL_PARAM_DOCS
+from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
+from mlflow.store.artifact.databricks_artifact_repo import DatabricksArtifactRepository
 from mlflow.store.artifact.runs_artifact_repo import RunsArtifactRepository
 from mlflow.store.artifact.models_artifact_repo import ModelsArtifactRepository
 from mlflow.utils.file_utils import TempDir, write_to
@@ -656,6 +661,15 @@ def _load_model(model_uri, dfs_tmpdir_base=None):
     return PipelineModel.load(model_uri)
 
 
+def _load_model_from_mlflowdbfs(artifact_repo, artifact_path):
+    assert isinstance(artifact_repo, DatabricksArtifactRepository)
+
+    from pyspark.ml.pipeline import PipelineModel
+
+    mlflowdbfs_path = artifact_repo._get_mlflowdbfs_path(artifact_path)
+    return PipelineModel.load(mlflowdbfs_path)
+
+
 def load_model(model_uri, dfs_tmpdir=None):
     """
     Load the Spark MLlib model from the path.
@@ -701,10 +715,20 @@ def load_model(model_uri, dfs_tmpdir=None):
         _logger.info("'%s' resolved as '%s'", runs_uri, model_uri)
     flavor_conf = _get_flavor_configuration_from_uri(model_uri, FLAVOR_NAME)
     model_uri = append_to_uri_path(model_uri, flavor_conf["model_data"])
-    local_model_path = _download_artifact_from_uri(model_uri)
-    _add_code_from_conf_to_system_path(local_model_path, flavor_conf)
+    root_uri, artifact_path = _get_root_uri_and_artifact_path(model_uri)
+    artifact_repo = get_artifact_repository(artifact_uri=root_uri)
 
-    return _load_model(model_uri=model_uri, dfs_tmpdir_base=dfs_tmpdir)
+    if (
+        isinstance(artifact_repo, DatabricksArtifactRepository)
+        and databricks_utils.is_mlflowdbfs_available()
+    ):
+        return _load_model_from_mlflowdbfs(artifact_repo, artifact_path)
+    else:
+        local_model_path = artifact_repo.download_artifacts(
+            artifact_path=artifact_path, dst_path=None
+        )
+        _add_code_from_conf_to_system_path(local_model_path, flavor_conf)
+        return _load_model(model_uri=model_uri, dfs_tmpdir_base=dfs_tmpdir)
 
 
 def _load_pyfunc(path):

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -41,6 +41,7 @@ from mlflow.utils.rest_utils import (
 from mlflow.utils.uri import (
     extract_and_normalize_path,
     get_databricks_profile_uri_from_artifact_uri,
+    get_mlflowdbfs_uri,
     is_databricks_acled_artifacts_uri,
     is_valid_dbfs_uri,
     remove_databricks_profile_info_from_artifact_uri,
@@ -315,6 +316,18 @@ class DatabricksArtifactRepository(ArtifactRepository):
         else:
             run_relative_artifact_path = self.run_relative_artifact_repo_root_path
         return run_relative_artifact_path
+
+    def _get_mlflowdbfs_path(self, artifact_path):
+        db_creds = get_databricks_host_creds(self.databricks_profile_uri)
+        return get_mlflowdbfs_uri(
+            netloc=db_creds.host,
+            path=artifact_path,
+            run_id=self.run_id,
+            ignore_tls_verification=db_creds.ignore_tls_verification,
+            username=db_creds.username,
+            password=db_creds.password,
+            token=db_creds.token,
+        )
 
     def log_artifact(self, local_file, artifact_path=None):
         run_relative_artifact_path = self._get_run_relative_artifact_path_for_upload(

--- a/mlflow/tracking/artifact_utils.py
+++ b/mlflow/tracking/artifact_utils.py
@@ -55,11 +55,9 @@ def get_artifact_uri(run_id, artifact_path=None, tracking_uri=None):
 
 # TODO: This would be much simpler if artifact_repo.download_artifacts could take the absolute path
 # or no path.
-def _download_artifact_from_uri(artifact_uri, output_path=None):
+def _get_root_uri_and_artifact_path(artifact_uri):
     """
     :param artifact_uri: The *absolute* URI of the artifact to download.
-    :param output_path: The local filesystem path to which to download the artifact. If unspecified,
-                        a local output path will be created.
     """
     if os.path.exists(artifact_uri):
         if os.name != "nt":
@@ -69,9 +67,7 @@ def _download_artifact_from_uri(artifact_uri, output_path=None):
             # resolve them (i.e., spaces converted to %20 within a file name or path listing)
             root_uri = os.path.dirname(artifact_uri)
             artifact_path = os.path.basename(artifact_uri)
-            return get_artifact_repository(artifact_uri=root_uri).download_artifacts(
-                artifact_path=artifact_path, dst_path=output_path
-            )
+            return root_uri, artifact_path
         else:  # if we're dealing with nt-based systems, we need to utilize pathname2url to encode.
             artifact_uri = path_to_local_file_uri(artifact_uri)
 
@@ -92,6 +88,16 @@ def _download_artifact_from_uri(artifact_uri, output_path=None):
         parsed_uri = parsed_uri._replace(path=posixpath.dirname(parsed_uri.path))
         root_uri = prefix + urllib.parse.urlunparse(parsed_uri)
 
+    return root_uri, artifact_path
+
+
+def _download_artifact_from_uri(artifact_uri, output_path=None):
+    """
+    :param artifact_uri: The *absolute* URI of the artifact to download.
+    :param output_path: The local filesystem path to which to download the artifact. If unspecified,
+                        a local output path will be created.
+    """
+    root_uri, artifact_path = _get_root_uri_and_artifact_path(artifact_uri)
     return get_artifact_repository(artifact_uri=root_uri).download_artifacts(
         artifact_path=artifact_path, dst_path=output_path
     )

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -142,6 +142,18 @@ def is_dbfs_fuse_available():
             return False
 
 
+@_use_repl_context_if_available("isMlflowdbfsAvailable")  # todo: add repl context
+def is_mlflowdbfs_available():
+    try:
+        spark_session = _get_active_spark_session()
+        return (
+            spark_session is not None
+            and spark_session.conf.get("spark.databricks.io.mlflowdbfs.endpoint") is not None
+        )  # todo: add spark conf
+    except Exception:
+        return False
+
+
 @_use_repl_context_if_available("isInCluster")
 def is_in_cluster():
     try:

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -91,6 +91,22 @@ def get_db_info_from_uri(uri):
     return None, None
 
 
+def get_mlflowdbfs_uri(
+    netloc, path, run_id, ignore_tls_verification, username=None, password=None, token=None
+):
+    scheme = "mlflowdbfs"
+    query_list = [("run_id", run_id), ("ignore_tls_verification", ignore_tls_verification)]
+    if token is not None:
+        query_list.append(("token", token))
+    elif (username is not None) and (password is not None):
+        query_list.extend([("username", username), ("password", password)])
+    query = urllib.parse.urlencode(query_list)
+    parse_result = urllib.parse.ParseResult(
+        scheme=scheme, netloc=netloc, path=path, query=query, params="", fragment=""
+    )
+    return urllib.parse.urlunparse(parse_result)
+
+
 def get_databricks_profile_uri_from_artifact_uri(uri):
     """
     Retrieves the netloc portion of the URI as a ``databricks://`` URI,


### PR DESCRIPTION
Signed-off-by: Liang Zhang <liang.zhang@databricks.com>

## What changes are proposed in this pull request?

Make `mlflow.spark.log_model()` and `mlflow.spark.load_model()` work on databricks when DBFS root is disabled.
The model saving/loading to/from internal databricks artifact storage will be done through mlflowdbfs.

## How is this patch tested?

(Details)

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
