### PR TITLE
[Test]

### DIFF
--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -516,7 +516,7 @@ def process_changed_files(changed_files, matrix_base):
         if (__file__ in changed_files)
         else get_changed_flavors(changed_files, flavors)
     )
-    return set(filter(lambda x: x["flavor"] in changed_flavors, matrix_base))
+    return set(filter(lambda x: x["flavor"] in flavors, matrix_base))
 
 
 def generate_matrix(args):

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -516,7 +516,7 @@ def process_changed_files(changed_files, matrix_base):
         if (__file__ in changed_files)
         else get_changed_flavors(changed_files, flavors)
     )
-    return set(filter(lambda x: x["flavor"] in flavors, matrix_base))
+    return set(filter(lambda x: x["flavor"] in changed_flavors, matrix_base))
 
 
 def generate_matrix(args):

--- a/mlflow/java/pom.xml
+++ b/mlflow/java/pom.xml
@@ -109,16 +109,6 @@
         <version>2.10.0</version>
       </dependency>
       <dependency>
-        <groupId>ml.combust.mleap</groupId>
-        <artifactId>mleap-spark_2.11</artifactId>
-        <version>0.10.3</version>
-      </dependency>
-      <dependency>
-        <groupId>ml.combust.mleap</groupId>
-        <artifactId>mleap-runtime_2.11</artifactId>
-        <version>0.10.3</version>
-      </dependency>
-      <dependency>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.22.0</version>

--- a/mlflow/mleap.py
+++ b/mlflow/mleap.py
@@ -22,6 +22,7 @@ from mlflow.models.utils import ModelInputExample, _save_example
 from mlflow.utils import reraise
 from mlflow.utils.annotations import keyword_only
 
+
 FLAVOR_NAME = "mleap"
 
 _logger = logging.getLogger(__name__)

--- a/requirements/doc-requirements.txt
+++ b/requirements/doc-requirements.txt
@@ -2,5 +2,6 @@
 # sphinx >= 4.0.0 is incompatible with our custom CSS styles and renders the documents improperly.
 # See https://github.com/mlflow/mlflow/pull/4480
 sphinx==3.5.4
+jinja2==3.0.3
 sphinx-autobuild
 sphinx-click


### PR DESCRIPTION
Signed-off-by: Weichen Xu <weichen.xu@databricks.com>

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

(Details)

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
