### PR TITLE
[Test] mleap CI 

### DIFF
--- a/mlflow/java/pom.xml
+++ b/mlflow/java/pom.xml
@@ -109,6 +109,16 @@
         <version>2.10.0</version>
       </dependency>
       <dependency>
+        <groupId>ml.combust.mleap</groupId>
+        <artifactId>mleap-spark_2.11</artifactId>
+        <version>0.10.3</version>
+      </dependency>
+      <dependency>
+        <groupId>ml.combust.mleap</groupId>
+        <artifactId>mleap-runtime_2.11</artifactId>
+        <version>0.10.3</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.22.0</version>

--- a/mlflow/java/pom.xml
+++ b/mlflow/java/pom.xml
@@ -109,16 +109,6 @@
         <version>2.10.0</version>
       </dependency>
       <dependency>
-        <groupId>ml.combust.mleap</groupId>
-        <artifactId>mleap-spark_2.11</artifactId>
-        <version>0.10.3</version>
-      </dependency>
-      <dependency>
-        <groupId>ml.combust.mleap</groupId>
-        <artifactId>mleap-runtime_2.11</artifactId>
-        <version>0.10.3</version>
-      </dependency>
-      <dependency>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.22.0</version>

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -344,7 +344,7 @@ mleap:
         cat $SAGEMAKER_OUT;
         exit 1
       fi
-      pytest tests/mleap/test_mleap_model_export.py -k test_model_deployment --large -s
+      pytest tests/mleap/test_mleap_model_export.py --large -s
 
 prophet:
   package_info:

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -333,8 +333,8 @@ mleap:
     minimum: "0.15.0"
     maximum: "0.19.0"
     requirements:
-      "<= 0.17.0": ["pyspark==2.4.5"]
-      "> 0.17.0": ["pyspark==3.0.2"]
+      "<= 0.17.0": ["pyspark==2.4.8"]
+      "> 0.17.0": ["pyspark==3.0.3"]
     run: |
       SAGEMAKER_OUT=$(mktemp)
       if mlflow sagemaker build-and-push-container --no-push --mlflow-home . > $SAGEMAKER_OUT 2>&1; then

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -344,7 +344,7 @@ mleap:
         cat $SAGEMAKER_OUT;
         exit 1
       fi
-      pytest tests/mleap/test_mleap_model_export.py --large
+      pytest tests/mleap/test_mleap_model_export.py -k test_model_deployment --large -s
 
 prophet:
   package_info:

--- a/mlflow/mleap.py
+++ b/mlflow/mleap.py
@@ -22,6 +22,7 @@ from mlflow.models.utils import ModelInputExample, _save_example
 from mlflow.utils import reraise
 from mlflow.utils.annotations import keyword_only
 
+
 FLAVOR_NAME = "mleap"
 
 _logger = logging.getLogger(__name__)


### PR DESCRIPTION
Signed-off-by: Weichen Xu <weichen.xu@databricks.com>

## What changes are proposed in this pull request?

mleap CI

## How is this patch tested?

(Details)

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
