### PR TITLE
Test mleap ci2

### DIFF
--- a/mlflow/R/mlflow/DESCRIPTION
+++ b/mlflow/R/mlflow/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mlflow
 Title: Interface to 'MLflow'
-Version: 1.23.1
+Version: 1.24.0
 Authors@R: 
     c(person(given = "Matei",
              family = "Zaharia",

--- a/mlflow/R/mlflow/R/install.R
+++ b/mlflow/R/mlflow/R/install.R
@@ -79,7 +79,7 @@ mlflow_conda_bin <- function() {
   conda_home <- Sys.getenv("MLFLOW_CONDA_HOME", NA)
   conda <- if (!is.na(conda_home)) paste(conda_home, "bin", "conda", sep = "/") else "auto"
   conda_try <- try(conda_binary(conda = conda), silent = TRUE)
-  if (class(conda_try) == "try-error") {
+  if (inherits(conda_try, "try-error")) {
     msg <- paste(attributes(conda_try)$condition$message,
                  paste("  If you are not using conda, you can set the environment variable",
                  "MLFLOW_PYTHON_BIN to the path of your python executable."),

--- a/mlflow/R/mlflow/R/python.R
+++ b/mlflow/R/mlflow/R/python.R
@@ -41,7 +41,7 @@ python_mlflow_bin <- function() {
 #' @importFrom reticulate conda_binary
 python_conda_home <- function() {
   path <- try(dirname(dirname(mlflow_conda_bin())), silent = TRUE)
-  if (class(path) == "try-error") {
+  if (inherits(path, "try-error")) {
     return(NA)
   }
   path

--- a/mlflow/java/client/pom.xml
+++ b/mlflow/java/client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.mlflow</groupId>
     <artifactId>mlflow-parent</artifactId>
-    <version>1.23.1-SNAPSHOT</version>
+    <version>1.24.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/mlflow/java/pom.xml
+++ b/mlflow/java/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.mlflow</groupId>
   <artifactId>mlflow-parent</artifactId>
-  <version>1.23.1-SNAPSHOT</version>
+  <version>1.24.0</version>
   <packaging>pom</packaging>
   <name>MLflow Parent POM</name>
   <url>http://mlflow.org</url>
@@ -59,7 +59,7 @@
   </distributionManagement>
 
   <properties>
-    <mlflow-version>1.23.1-SNAPSHOT</mlflow-version>
+    <mlflow-version>1.24.0</mlflow-version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <scala.version>2.11.12</scala.version>

--- a/mlflow/java/scoring/pom.xml
+++ b/mlflow/java/scoring/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.mlflow</groupId>
     <artifactId>mlflow-parent</artifactId>
-    <version>1.23.1-SNAPSHOT</version>
+    <version>1.24.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/mlflow/java/spark/pom.xml
+++ b/mlflow/java/spark/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mlflow-spark</artifactId>
-  <version>1.23.1-SNAPSHOT</version>
+  <version>1.24.0</version>
   <name>${project.artifactId}</name>
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.mlflow</groupId>
     <artifactId>mlflow-parent</artifactId>
-    <version>1.23.1-SNAPSHOT</version>
+    <version>1.24.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -230,7 +230,7 @@ onnx:
 
   models:
     minimum: "1.5.0"
-    maximum: "1.10.2"
+    maximum: "1.11.0"
     requirements: ["onnxruntime", "torch", "scikit-learn"]
     run: |
       pytest tests/onnx/test_onnx_model_export.py --large

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -342,7 +342,7 @@ mleap:
         cat $SAGEMAKER_OUT;
         exit 1
       fi
-      pytest tests/mleap/test_mleap_model_export.py --large
+      pytest tests/mleap/test_mleap_model_export.py -k test_model_deployment --large -s
 
 prophet:
   package_info:

--- a/mlflow/mleap.py
+++ b/mlflow/mleap.py
@@ -24,6 +24,7 @@ from mlflow.utils.annotations import keyword_only
 
 FLAVOR_NAME = "mleap"
 
+
 _logger = logging.getLogger(__name__)
 
 

--- a/mlflow/version.py
+++ b/mlflow/version.py
@@ -2,7 +2,7 @@
 import re
 
 
-VERSION = "1.23.1.dev0"
+VERSION = "1.24.0"
 
 
 def is_release_version():


### PR DESCRIPTION
## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

(Details)

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
