### PR TITLE
Run `test_sqlalchemy_store.py` against PostgreSQL, MySQL, and MSSQL

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -168,11 +168,12 @@ jobs:
         ./tests/db/compose.sh build --build-arg DEPENDENCIES="$(python setup.py -q dependencies)"
     - name: Database tests - run
       run: |
+        set +e
         for service in $(./tests/db/compose.sh config --services | grep '^mlflow-')
         do
           # Set `--no-TTY` to show container logs on GitHub Actions:
           # https://github.com/actions/virtual-environments/issues/5022
-          ./tests/db/compose.sh run --rm --no-TTY $service
+          ./tests/db/compose.sh run --rm --no-TTY $service pytest tests/store/tracking/test_sqlalchemy_store.py tests/db
         done
     - name: Database tests - clean up
       run: |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -168,7 +168,6 @@ jobs:
         ./tests/db/compose.sh build --build-arg DEPENDENCIES="$(python setup.py -q dependencies)"
     - name: Database tests - run
       run: |
-        set +e
         for service in $(./tests/db/compose.sh config --services | grep '^mlflow-')
         do
           # Set `--no-TTY` to show container logs on GitHub Actions:

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -987,9 +987,9 @@ def _get_orderby_clauses(order_by_list, session):
             observed_order_by_clauses.add((key_type, key))
 
             if ascending:
-                clauses.append(order_value)
+                clauses.append(sqlalchemy.nulls_last(order_value))
             else:
-                clauses.append(order_value.desc())
+                clauses.append(sqlalchemy.nulls_last(order_value.desc()))
 
     if (SearchUtils._ATTRIBUTE_IDENTIFIER, SqlRun.start_time.key) not in observed_order_by_clauses:
         clauses.append(SqlRun.start_time.desc())

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -147,6 +147,9 @@ class SqlAlchemyStore(AbstractStore):
             with self.ManagedSessionMaker() as session:
                 self._create_default_experiment(session)
 
+    def _get_dialect(self):
+        return self.engine.dialect.name
+
     def _set_zero_value_insertion_for_autoincrement_column(self, session):
         if self.db_type == MYSQL:
             # config letting MySQL override default
@@ -777,7 +780,7 @@ class SqlAlchemyStore(AbstractStore):
             cases_orderby, parsed_orderby, sorting_joins = _get_orderby_clauses(order_by, session)
 
             stmt = select(SqlRun, *cases_orderby)
-            for j in _get_sqlalchemy_filter_clauses(parsed_filters, session):
+            for j in _get_sqlalchemy_filter_clauses(parsed_filters, session, self._get_dialect()):
                 stmt = stmt.join(j)
             # using an outer join is necessary here because we want to be able to sort
             # on a column (tag, metric or param) without removing the lines that
@@ -792,7 +795,7 @@ class SqlAlchemyStore(AbstractStore):
                 .filter(
                     SqlRun.experiment_id.in_(experiment_ids),
                     SqlRun.lifecycle_stage.in_(stages),
-                    *_get_attributes_filtering_clauses(parsed_filters),
+                    *_get_attributes_filtering_clauses(parsed_filters, self._get_dialect()),
                 )
                 .order_by(*parsed_orderby)
                 .offset(offset)
@@ -846,7 +849,7 @@ class SqlAlchemyStore(AbstractStore):
             session.merge(SqlTag(key=MLFLOW_LOGGED_MODELS, value=value, run_uuid=run_id))
 
 
-def _get_attributes_filtering_clauses(parsed):
+def _get_attributes_filtering_clauses(parsed, dialect):
     clauses = []
     for sql_statement in parsed:
         key_type = sql_statement.get("type")
@@ -860,7 +863,7 @@ def _get_attributes_filtering_clauses(parsed):
             # by the call to parse_search_filter
             attribute = getattr(SqlRun, SqlRun.get_attribute_name(key_name))
             if comparator in SearchUtils.CASE_INSENSITIVE_STRING_COMPARISON_OPERATORS:
-                op = SearchUtils.get_sql_filter_ops(attribute, comparator)
+                op = SearchUtils.get_sql_filter_ops(attribute, comparator, dialect)
                 clauses.append(op(value))
             elif comparator in SearchUtils.filter_ops:
                 op = SearchUtils.filter_ops.get(comparator)
@@ -868,7 +871,7 @@ def _get_attributes_filtering_clauses(parsed):
     return clauses
 
 
-def _to_sqlalchemy_filtering_statement(sql_statement, session):
+def _to_sqlalchemy_filtering_statement(sql_statement, session, dialect):
     key_type = sql_statement.get("type")
     key_name = sql_statement.get("key")
     value = sql_statement.get("value")
@@ -891,7 +894,7 @@ def _to_sqlalchemy_filtering_statement(sql_statement, session):
         )
 
     if comparator in SearchUtils.CASE_INSENSITIVE_STRING_COMPARISON_OPERATORS:
-        op = SearchUtils.get_sql_filter_ops(entity.value, comparator)
+        op = SearchUtils.get_sql_filter_ops(entity.value, comparator, dialect)
         return session.query(entity).filter(entity.key == key_name, op(value)).subquery()
     elif comparator in SearchUtils.filter_ops:
         op = SearchUtils.filter_ops.get(comparator)
@@ -902,12 +905,12 @@ def _to_sqlalchemy_filtering_statement(sql_statement, session):
         return None
 
 
-def _get_sqlalchemy_filter_clauses(parsed, session):
+def _get_sqlalchemy_filter_clauses(parsed, session, dialect):
     """creates SqlAlchemy subqueries
     that will be inner-joined to SQLRun to act as multi-clause filters."""
     filters = []
     for sql_statement in parsed:
-        filter_query = _to_sqlalchemy_filtering_statement(sql_statement, session)
+        filter_query = _to_sqlalchemy_filtering_statement(sql_statement, session, dialect)
         if filter_query is not None:
             filters.append(filter_query)
     return filters
@@ -967,7 +970,7 @@ def _get_orderby_clauses(order_by_list, session):
                         # the column (is_nan) is not nullable. However it could become an issue
                         # if this precondition changes in the future.
                         (subquery.c.is_nan == sqlalchemy.true(), 1),
-                        (order_value.is_(None), 1),
+                        (order_value.is_(None), 2),
                     ],
                     else_=0,
                 ).label("clause_%s" % clause_id)
@@ -978,8 +981,6 @@ def _get_orderby_clauses(order_by_list, session):
                 )
             clauses.append(case.name)
             select_clauses.append(case)
-            # Sort NULLs last
-            select_clauses.append(order_value.is_(None))
             select_clauses.append(order_value)
 
             if (key_type, key) in observed_order_by_clauses:
@@ -988,7 +989,6 @@ def _get_orderby_clauses(order_by_list, session):
                 )
             observed_order_by_clauses.add((key_type, key))
 
-            clauses.append(order_value.is_(None))
             if ascending:
                 clauses.append(order_value)
             else:

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -978,6 +978,8 @@ def _get_orderby_clauses(order_by_list, session):
                 )
             clauses.append(case.name)
             select_clauses.append(case)
+            # Sort NULLs last
+            select_clauses.append(order_value.is_(None))
             select_clauses.append(order_value)
 
             if (key_type, key) in observed_order_by_clauses:
@@ -986,10 +988,11 @@ def _get_orderby_clauses(order_by_list, session):
                 )
             observed_order_by_clauses.add((key_type, key))
 
+            clauses.append(order_value.is_(None))
             if ascending:
-                clauses.append(sqlalchemy.nulls_last(order_value))
+                clauses.append(order_value)
             else:
-                clauses.append(sqlalchemy.nulls_last(order_value.desc()))
+                clauses.append(order_value.desc())
 
     if (SearchUtils._ATTRIBUTE_IDENTIFIER, SqlRun.start_time.key) not in observed_order_by_clauses:
         clauses.append(SqlRun.start_time.desc())

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -101,7 +101,7 @@ class SearchUtils:
                 )
 
         elif dialect == MSSQL:
-            like_op = column.collate("SQL_Latin1_General_CP1_CS_AS").like
+            like_op = column.collate("Japanese_Bushu_Kakusu_100_CS_AS_KS_WS_UTF8").like
         else:
             like_op = column.like
         sql_filter_ops = {"LIKE": like_op, "ILIKE": column.ilike}

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -16,6 +16,7 @@ from sqlparse.sql import (
     IdentifierList,
 )
 from sqlparse.tokens import Token as TokenType
+import sqlalchemy as sa
 
 from mlflow.entities import RunInfo
 from mlflow.exceptions import MlflowException
@@ -89,8 +90,14 @@ class SearchUtils:
     }
 
     @classmethod
-    def get_sql_filter_ops(cls, column, operator):
-        sql_filter_ops = {"LIKE": column.like, "ILIKE": column.ilike}
+    def get_sql_filter_ops(cls, column, operator, dialect):
+        if dialect == "mysql":
+            like_op = column.op("LIKE BINARY")
+        elif dialect == "mssql":
+            like_op = sa.collate(column, "SQL_Latin1_General_CP1_CS_AS").like
+        else:
+            like_op = column.like
+        sql_filter_ops = {"LIKE": like_op, "ILIKE": column.ilike}
         return sql_filter_ops[operator]
 
     @classmethod

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -20,6 +20,7 @@ from sqlparse.tokens import Token as TokenType
 from mlflow.entities import RunInfo
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
+from mlflow.store.db.db_types import MYSQL, MSSQL
 
 import math
 
@@ -90,9 +91,9 @@ class SearchUtils:
 
     @classmethod
     def get_sql_filter_ops(cls, column, operator, dialect):
-        if dialect == "mysql":
+        if dialect == MYSQL:
             like_op = column.op("LIKE BINARY")
-        elif dialect == "mssql":
+        elif dialect == MSSQL:
             like_op = column.collate("SQL_Latin1_General_CP1_CS_AS").like
         else:
             like_op = column.like

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -16,7 +16,6 @@ from sqlparse.sql import (
     IdentifierList,
 )
 from sqlparse.tokens import Token as TokenType
-import sqlalchemy as sa
 
 from mlflow.entities import RunInfo
 from mlflow.exceptions import MlflowException
@@ -94,7 +93,7 @@ class SearchUtils:
         if dialect == "mysql":
             like_op = column.op("LIKE BINARY")
         elif dialect == "mssql":
-            like_op = sa.collate(column, "SQL_Latin1_General_CP1_CS_AS").like
+            like_op = column.collate("SQL_Latin1_General_CP1_CS_AS").like
         else:
             like_op = column.like
         sql_filter_ops = {"LIKE": like_op, "ILIKE": column.ilike}

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -101,7 +101,7 @@ class SearchUtils:
                 )
 
         elif dialect == MSSQL:
-            like_op = column.collate("Japanese_Bushu_Kakusu_100_CS_AS_KS_WS_UTF8").like
+            like_op = column.collate("Japanese_Bushu_Kakusu_100_CS_AS_KS_WS").like
         else:
             like_op = column.like
         sql_filter_ops = {"LIKE": like_op, "ILIKE": column.ilike}

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -126,7 +126,7 @@ class TestParseDbUri(unittest.TestCase):
         )
 
 
-class TestSqlAlchemyStoreSqlite(unittest.TestCase, AbstractStoreTest):
+class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
     def _get_store(self, db_uri=""):
         return SqlAlchemyStore(db_uri, ARTIFACT_URI)
 
@@ -1971,7 +1971,7 @@ def test_sqlalchemy_store_can_be_initialized_when_default_experiment_has_been_de
     SqlAlchemyStore(db_uri, ARTIFACT_URI)
 
 
-class TestSqlAlchemyStoreSqliteMigratedDB(TestSqlAlchemyStoreSqlite):
+class TestSqlAlchemyStoreMigratedDB(TestSqlAlchemyStore):
     """
     Test case where user has an existing DB with schema generated before MLflow 1.0,
     then migrates their DB.

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -1548,7 +1548,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
 
         assert runs[:1000] == self._search(exp)
         for n in [0, 1, 2, 4, 8, 10, 20, 50, 100, 500, 1000, 1200, 2000]:
-            if n == 0 and self.store._get_dialect() == "mssql":
+            if n == 0 and self.store._get_dialect() == MSSQL:
                 # In SQL server, `max_results = 0` results in the following error:
                 # The number of rows provided for a FETCH clause must be greater then zero.
                 continue
@@ -1569,7 +1569,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
             ]
         )
         for n in [0, 1, 2, 4, 8, 10, 20]:
-            if n == 0 and self.store._get_dialect() == "mssql":
+            if n == 0 and self.store._get_dialect() == MSSQL:
                 # In SQL server, `max_results = 0` results in the following error:
                 # The number of rows provided for a FETCH clause must be greater then zero.
                 continue


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Run `test_sqlalchemy_store.py` against PostgreSQL, MySQL, and MSSQL to ensure MLflow tracking operations work in different databases and prevent issues / regressions.

## How is this patch tested?

Fixed tests

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [x] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
