### PR TITLE
Make tensorflow model prediction support array type input

### DIFF
--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -273,7 +273,6 @@ if _pl_version >= Version("1.4.0"):
     def _get_step_metrics(trainer):
         return trainer.callback_metrics
 
-
 else:
 
     def _get_step_metrics(trainer):

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -524,6 +524,7 @@ class _TF2Wrapper:
 
         raw_preds = self.infer(**feed_dict)
         pred_dict = {col_name: raw_preds[col_name].numpy() for col_name in raw_preds.keys()}
+        print(f"DBG: pred_dict={pred_dict}")
         for col in pred_dict.keys():
             if all(len(element) == 1 for element in pred_dict[col]):
                 pred_dict[col] = pred_dict[col].ravel()

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -524,7 +524,6 @@ class _TF2Wrapper:
 
         raw_preds = self.infer(**feed_dict)
         pred_dict = {col_name: raw_preds[col_name].numpy() for col_name in raw_preds.keys()}
-        print(f"DBG: pred_dict={pred_dict}")
         for col in pred_dict.keys():
             if all(len(element) == 1 for element in pred_dict[col]):
                 pred_dict[col] = pred_dict[col].ravel()
@@ -932,7 +931,6 @@ def autolog(
                 history = original(inst, *args, **kwargs)
 
                 if log_models:
-                    import numpy as np
 
                     def _get_input_data_slice():
                         input_training_data = args[0]

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -20,6 +20,7 @@ from collections import namedtuple
 import pandas
 from packaging.version import Version
 from threading import RLock
+import numpy as np
 
 import mlflow
 import mlflow.keras
@@ -512,9 +513,13 @@ class _TF2Wrapper:
                 # from the DataFrame will result in another DataFrame containing the columns
                 # with the shared name. TensorFlow cannot make eager tensors out of pandas
                 # DataFrames, so we convert the DataFrame to a numpy array here.
-                val = data[df_col_name].to_numpy()
+                val = data[df_col_name]
                 if isinstance(val, pandas.DataFrame):
                     val = val.values
+
+                val = val.to_list()
+                if isinstance(val[0], (list, np.ndarray)):
+                    val = np.array(val)
                 feed_dict[df_col_name] = tensorflow.constant(val)
         else:
             raise TypeError("Only dict and DataFrame input types are supported")

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -521,6 +521,7 @@ class _TF2Wrapper:
                 if isinstance(val[0], (list, np.ndarray)):
                     val = np.array(val)
                 feed_dict[df_col_name] = tensorflow.constant(val)
+                print(f'DBG: feed_dict={feed_dict}')
         else:
             raise TypeError("Only dict and DataFrame input types are supported")
 

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -516,12 +516,9 @@ class _TF2Wrapper:
                 val = data[df_col_name]
                 if isinstance(val, pandas.DataFrame):
                     val = val.values
-
-                val = val.to_list()
-                if isinstance(val[0], (list, np.ndarray)):
-                    val = np.array(val)
+                else:
+                    val = np.array(val.to_list())
                 feed_dict[df_col_name] = tensorflow.constant(val)
-                print(f'DBG: feed_dict={feed_dict}')
         else:
             raise TypeError("Only dict and DataFrame input types are supported")
 

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -512,7 +512,7 @@ class _TF2Wrapper:
                 # from the DataFrame will result in another DataFrame containing the columns
                 # with the shared name. TensorFlow cannot make eager tensors out of pandas
                 # DataFrames, so we convert the DataFrame to a numpy array here.
-                val = data[df_col_name]
+                val = data[df_col_name].to_numpy()
                 if isinstance(val, pandas.DataFrame):
                     val = val.values
                 feed_dict[df_col_name] = tensorflow.constant(val)

--- a/tests/tensorflow/test_tensorflow2_model_export.py
+++ b/tests/tensorflow/test_tensorflow2_model_export.py
@@ -827,4 +827,4 @@ def test_saved_model_support_array_type_input():
 
     result = model.predict(infer_df)
 
-    np.testing.assert_allclose(result["prediction"], [10.0, 26.0])
+    np.testing.assert_allclose(result["prediction"], infer_df.applymap(sum).values[:, 0])


### PR DESCRIPTION
## What changes are proposed in this pull request?

Make tensorflow model prediction support array type input.
This PR addresses https://github.com/mlflow/mlflow/issues/5494

## How is this patch tested?

Unit test "test_saved_model_support_array_type_input" added.

Integration test (Test on original user code):
https://e2-dogfood.staging.cloud.databricks.com/?o=6051921418418893#notebook/2674920562615402/command/2674920562615403


## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Make tensorflow model prediction support array type input.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
