### PR TITLE
Fix invalid Anaconda URLs

### DIFF
--- a/mlflow/R/mlflow/README.Rmd
+++ b/mlflow/R/mlflow/README.Rmd
@@ -29,7 +29,7 @@ devtools::install_github("mlflow/mlflow", subdir = "mlflow/R/mlflow")
 mlflow::install_mlflow()
 ```
 
-Notice also that [Anaconda](https://www.anaconda.com/products/individual) or [Miniconda](https://docs.conda.io/en/latest/miniconda.html) need to be manually installed.
+Notice also that [Anaconda](https://www.anaconda.com/products/distribution) or [Miniconda](https://docs.conda.io/en/latest/miniconda.html) need to be manually installed.
 
 ### Development
 

--- a/mlflow/R/mlflow/README.md
+++ b/mlflow/R/mlflow/README.md
@@ -19,7 +19,7 @@ devtools::install_github("mlflow/mlflow", subdir = "mlflow/R/mlflow")
 mlflow::install_mlflow()
 ```
 
-Notice also that [Anaconda](https://www.anaconda.com/products/individual) or
+Notice also that [Anaconda](https://www.anaconda.com/products/distribution) or
 [Miniconda](https://docs.conda.io/en/latest/miniconda.html) need to be manually
 installed.
 


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Fix the following error in the CRAN submission check:

https://github.com/mlflow/mlflow/runs/5728726598?check_suite_focus=true#step:9:1820

```
Status: 1 NOTE
See
  ‘/mlflow/mlflow/R/mlflow/mlflow.Rcheck/00check.log’
for details.
── R CMD check results ────────────────────────────────────── mlflow 1.24.1 ────
Duration: 1m 11s

❯ checking CRAN incoming feasibility ... NOTE
  Maintainer: ‘Matei Zaharia <matei@databricks.com>’
  
  Found the following (possibly) invalid URLs:
    URL: https://www.anaconda.com/products/individual (moved to https://www.anaconda.com/products/distribution)
      From: README.md
      Status: 200
      Message: OK

0 errors ✔ | 0 warnings ✔ | 1 note ✖
```

## How is this patch tested?

Make sure the CRAN submission check passes now.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
