### PR TITLE
Add custom pylint rule to detect print functions

### DIFF
--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -486,8 +486,7 @@ def gc(backend_store_uri, run_ids):
         artifact_repo = get_artifact_repository(run.info.artifact_uri)
         artifact_repo.delete_artifacts()
         backend_store._hard_delete_run(run_id)
-        # pylint: disable=print-function
-        print("Run with ID %s has been permanently deleted." % str(run_id))
+        click.echo("Run with ID %s has been permanently deleted." % str(run_id))
 
 
 cli.add_command(mlflow.deployments.cli.commands)

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -486,6 +486,7 @@ def gc(backend_store_uri, run_ids):
         artifact_repo = get_artifact_repository(run.info.artifact_uri)
         artifact_repo.delete_artifacts()
         backend_store._hard_delete_run(run_id)
+        # pylint: disable=print-function
         print("Run with ID %s has been permanently deleted." % str(run_id))
 
 

--- a/mlflow/data.py
+++ b/mlflow/data.py
@@ -1,6 +1,7 @@
 import os
 import re
 import urllib.parse
+import logging
 
 from mlflow.utils import process
 
@@ -11,20 +12,26 @@ DBFS_REGEX = re.compile("^%s" % re.escape(DBFS_PREFIX))
 S3_REGEX = re.compile("^%s" % re.escape(S3_PREFIX))
 GS_REGEX = re.compile("^%s" % re.escape(GS_PREFIX))
 
+_logger = logging.getLogger(__name__)
+
 
 class DownloadException(Exception):
     pass
 
 
 def _fetch_dbfs(uri, local_path):
-    print("=== Downloading DBFS file %s to local path %s ===" % (uri, os.path.abspath(local_path)))
+    _logger.info(
+        "=== Downloading DBFS file %s to local path %s ===", uri, os.path.abspath(local_path)
+    )
     process.exec_cmd(cmd=["databricks", "fs", "cp", "-r", uri, local_path])
 
 
 def _fetch_s3(uri, local_path):
     import boto3
 
-    print("=== Downloading S3 object %s to local path %s ===" % (uri, os.path.abspath(local_path)))
+    _logger.info(
+        "=== Downloading S3 object %s to local path %s ===", uri, os.path.abspath(local_path)
+    )
 
     client_kwargs = {}
     endpoint_url = os.environ.get("MLFLOW_S3_ENDPOINT_URL")
@@ -43,7 +50,9 @@ def _fetch_s3(uri, local_path):
 def _fetch_gs(uri, local_path):
     from google.cloud import storage
 
-    print("=== Downloading GCS file %s to local path %s ===" % (uri, os.path.abspath(local_path)))
+    _logger.info(
+        "=== Downloading GCS file %s to local path %s ===", uri, os.path.abspath(local_path)
+    )
     (bucket, gs_path) = parse_gs_uri(uri)
     storage.Client().bucket(bucket).blob(gs_path).download_to_filename(local_path)
 

--- a/mlflow/experiments.py
+++ b/mlflow/experiments.py
@@ -44,8 +44,7 @@ def create(experiment_name, artifact_location):
     """
     store = _get_store()
     exp_id = store.create_experiment(experiment_name, artifact_location)
-    # pylint: disable=print-function
-    print("Created experiment '%s' with id %s" % (experiment_name, exp_id))
+    click.echo("Created experiment '%s' with id %s" % (experiment_name, exp_id))
 
 
 @commands.command("list")
@@ -72,8 +71,7 @@ def list_experiments(view):
         ]
         for exp in experiments
     ]
-    # pylint: disable=print-function
-    print(tabulate(sorted(table), headers=["Experiment Id", "Name", "Artifact Location"]))
+    click.echo(tabulate(sorted(table), headers=["Experiment Id", "Name", "Artifact Location"]))
 
 
 @commands.command("delete")
@@ -96,8 +94,7 @@ def delete_experiment(experiment_id):
     """
     store = _get_store()
     store.delete_experiment(experiment_id)
-    # pylint: disable=print-function
-    print("Experiment with ID %s has been deleted." % str(experiment_id))
+    click.echo("Experiment with ID %s has been deleted." % str(experiment_id))
 
 
 @commands.command("restore")
@@ -110,8 +107,7 @@ def restore_experiment(experiment_id):
     """
     store = _get_store()
     store.restore_experiment(experiment_id)
-    # pylint: disable=print-function
-    print("Experiment with id %s has been restored." % str(experiment_id))
+    click.echo("Experiment with id %s has been restored." % str(experiment_id))
 
 
 @commands.command("rename")
@@ -124,8 +120,7 @@ def rename_experiment(experiment_id, new_name):
     """
     store = _get_store()
     store.rename_experiment(experiment_id, new_name)
-    # pylint: disable=print-function
-    print("Experiment with id %s has been renamed to '%s'." % (experiment_id, new_name))
+    click.echo("Experiment with id %s has been renamed to '%s'." % (experiment_id, new_name))
 
 
 @commands.command("csv")
@@ -139,10 +134,9 @@ def generate_csv_with_runs(experiment_id, filename):
     runs = fluent.search_runs(experiment_ids=experiment_id)
     if filename:
         runs.to_csv(filename, index=False)
-        # pylint: disable=print-function
-        print(
+        click.echo(
             "Experiment with ID %s has been exported as a CSV to file: %s."
             % (experiment_id, filename)
         )
     else:
-        print(runs.to_csv(index=False))  # pylint: disable=print-function
+        click.echo(runs.to_csv(index=False))

--- a/mlflow/experiments.py
+++ b/mlflow/experiments.py
@@ -44,6 +44,7 @@ def create(experiment_name, artifact_location):
     """
     store = _get_store()
     exp_id = store.create_experiment(experiment_name, artifact_location)
+    # pylint: disable=print-function
     print("Created experiment '%s' with id %s" % (experiment_name, exp_id))
 
 
@@ -71,6 +72,7 @@ def list_experiments(view):
         ]
         for exp in experiments
     ]
+    # pylint: disable=print-function
     print(tabulate(sorted(table), headers=["Experiment Id", "Name", "Artifact Location"]))
 
 
@@ -94,6 +96,7 @@ def delete_experiment(experiment_id):
     """
     store = _get_store()
     store.delete_experiment(experiment_id)
+    # pylint: disable=print-function
     print("Experiment with ID %s has been deleted." % str(experiment_id))
 
 
@@ -107,6 +110,7 @@ def restore_experiment(experiment_id):
     """
     store = _get_store()
     store.restore_experiment(experiment_id)
+    # pylint: disable=print-function
     print("Experiment with id %s has been restored." % str(experiment_id))
 
 
@@ -120,6 +124,7 @@ def rename_experiment(experiment_id, new_name):
     """
     store = _get_store()
     store.rename_experiment(experiment_id, new_name)
+    # pylint: disable=print-function
     print("Experiment with id %s has been renamed to '%s'." % (experiment_id, new_name))
 
 
@@ -134,9 +139,10 @@ def generate_csv_with_runs(experiment_id, filename):
     runs = fluent.search_runs(experiment_ids=experiment_id)
     if filename:
         runs.to_csv(filename, index=False)
+        # pylint: disable=print-function
         print(
             "Experiment with ID %s has been exported as a CSV to file: %s."
             % (experiment_id, filename)
         )
     else:
-        print(runs.to_csv(index=False))
+        print(runs.to_csv(index=False))  # pylint: disable=print-function

--- a/mlflow/models/container/__init__.py
+++ b/mlflow/models/container/__init__.py
@@ -10,6 +10,7 @@ import signal
 import shutil
 from subprocess import check_call, Popen
 import sys
+import logging
 
 from pkg_resources import resource_filename
 
@@ -39,6 +40,9 @@ DISABLE_NGINX = "DISABLE_NGINX"
 ENABLE_MLSERVER = "ENABLE_MLSERVER"
 
 SERVING_ENVIRONMENT = "SERVING_ENVIRONMENT"
+
+
+_logger = logging.getLogger(__name__)
 
 
 def _init(cmd):
@@ -96,7 +100,7 @@ def _install_pyfunc_deps(model_path=None, install_mlflow=False, enable_mlserver=
             return
         conf = model.flavors[pyfunc.FLAVOR_NAME]
         if pyfunc.ENV in conf:
-            print("creating and activating custom environment")
+            _logger.info("creating and activating custom environment")
             env = conf[pyfunc.ENV]
             env_path_dst = os.path.join("/opt/mlflow/", env)
             env_path_dst_dir = os.path.dirname(env_path_dst)
@@ -225,7 +229,7 @@ def _sigterm_handler(pids):
     Attempt to kill all launched processes and exit.
 
     """
-    print("Got sigterm signal, exiting.")
+    _logger.info("Got sigterm signal, exiting.")
     for pid in pids:
         try:
             os.kill(pid, signal.SIGTERM)

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -57,7 +57,7 @@ def _resolve_experiment_id(experiment_name=None, experiment_id=None):
         if exp:
             return exp.experiment_id
         else:
-            print("INFO: '{}' does not exist. Creating a new experiment".format(experiment_name))
+            _logger("'{}' does not exist. Creating a new experiment".format(experiment_name))
             return client.create_experiment(experiment_name)
 
     return _get_experiment_id()

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -57,7 +57,7 @@ def _resolve_experiment_id(experiment_name=None, experiment_id=None):
         if exp:
             return exp.experiment_id
         else:
-            _logger("'{}' does not exist. Creating a new experiment".format(experiment_name))
+            _logger.info("'%s' does not exist. Creating a new experiment", experiment_name)
             return client.create_experiment(experiment_name)
 
     return _get_experiment_id()

--- a/mlflow/runs.py
+++ b/mlflow/runs.py
@@ -49,6 +49,7 @@ def list_run(experiment_id, view):
         tags = {k: v for k, v in run.data.tags.items()}
         run_name = tags.get(MLFLOW_RUN_NAME, "")
         table.append([conv_longdate_to_str(run.info.start_time), run_name, run.info.run_id])
+    # pylint: disable=print-function
     print(tabulate(sorted(table, reverse=True), headers=["Date", "Name", "ID"]))
 
 
@@ -62,7 +63,7 @@ def delete_run(run_id):
     """
     store = _get_store()
     store.delete_run(run_id)
-    print("Run with ID %s has been deleted." % str(run_id))
+    print("Run with ID %s has been deleted." % str(run_id))  # pylint: disable=print-function
 
 
 @commands.command("restore")
@@ -74,7 +75,7 @@ def restore_run(run_id):
     """
     store = _get_store()
     store.restore_run(run_id)
-    print("Run with id %s has been restored." % str(run_id))
+    print("Run with id %s has been restored." % str(run_id))  # pylint: disable=print-function
 
 
 @commands.command("describe")
@@ -86,4 +87,4 @@ def describe_run(run_id):
     store = _get_store()
     run = store.get_run(run_id)
     json_run = json.dumps(run.to_dictionary(), indent=4)
-    print(json_run)
+    print(json_run)  # pylint: disable=print-function

--- a/mlflow/runs.py
+++ b/mlflow/runs.py
@@ -49,8 +49,7 @@ def list_run(experiment_id, view):
         tags = {k: v for k, v in run.data.tags.items()}
         run_name = tags.get(MLFLOW_RUN_NAME, "")
         table.append([conv_longdate_to_str(run.info.start_time), run_name, run.info.run_id])
-    # pylint: disable=print-function
-    print(tabulate(sorted(table, reverse=True), headers=["Date", "Name", "ID"]))
+    click.echo(tabulate(sorted(table, reverse=True), headers=["Date", "Name", "ID"]))
 
 
 @commands.command("delete")
@@ -63,7 +62,7 @@ def delete_run(run_id):
     """
     store = _get_store()
     store.delete_run(run_id)
-    print("Run with ID %s has been deleted." % str(run_id))  # pylint: disable=print-function
+    click.echo("Run with ID %s has been deleted." % str(run_id))
 
 
 @commands.command("restore")
@@ -75,7 +74,7 @@ def restore_run(run_id):
     """
     store = _get_store()
     store.restore_run(run_id)
-    print("Run with id %s has been restored." % str(run_id))  # pylint: disable=print-function
+    click.echo("Run with id %s has been restored." % str(run_id))
 
 
 @commands.command("describe")
@@ -87,4 +86,4 @@ def describe_run(run_id):
     store = _get_store()
     run = store.get_run(run_id)
     json_run = json.dumps(run.to_dictionary(), indent=4)
-    print(json_run)  # pylint: disable=print-function
+    click.echo(json_run)

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -134,7 +134,7 @@ def push_image_to_ecr(image=DEFAULT_IMAGE_NAME):
         ecr_client.describe_repositories(repositoryNames=[image])["repositories"]
     except ecr_client.exceptions.RepositoryNotFoundException:
         ecr_client.create_repository(repositoryName=image)
-        print("Created new ECR repository: {repository_name}".format(repository_name=image))
+        _logger.info("Created new ECR repository: %s", image)
     # TODO: it would be nice to translate the docker login, tag and push to python api.
     # x = ecr_client.get_authorization_token()['authorizationData'][0]
     # docker_login_cmd = "docker login -u AWS -p {token} {url}".format(token=x['authorizationToken']
@@ -1031,7 +1031,7 @@ def run_local(model_uri, port=5000, image=DEFAULT_IMAGE_NAME, flavor=None):
         flavor = _get_preferred_deployment_flavor(model_config)
     else:
         _validate_deployment_flavor(model_config, flavor)
-    print("Using the {selected_flavor} flavor for local serving!".format(selected_flavor=flavor))
+    _logger.info("Using the %s flavor for local serving!", flavor)
 
     deployment_config = _get_deployment_config(flavor_name=flavor)
 

--- a/mlflow/sagemaker/cli.py
+++ b/mlflow/sagemaker/cli.py
@@ -577,7 +577,7 @@ def build_and_push_container(build, push, container, mlflow_home):
     The image is pushed to ECR under current active AWS account and to current active AWS region.
     """
     if not (build or push):
-        print("skipping both build and push, have nothing to do!")  # pylint: disable=print-function
+        click.echo("skipping both build and push, have nothing to do!")
     if build:
         sagemaker_image_entrypoint = """
         ENTRYPOINT ["python", "-c", "import sys; from mlflow.models import container as C; \

--- a/mlflow/sagemaker/cli.py
+++ b/mlflow/sagemaker/cli.py
@@ -577,7 +577,7 @@ def build_and_push_container(build, push, container, mlflow_home):
     The image is pushed to ECR under current active AWS account and to current active AWS region.
     """
     if not (build or push):
-        print("skipping both build and push, have nothing to do!")
+        print("skipping both build and push, have nothing to do!")  # pylint: disable=print-function
     if build:
         sagemaker_image_entrypoint = """
         ENTRYPOINT ["python", "-c", "import sys; from mlflow.models import container as C; \

--- a/mlflow/store/artifact/cli.py
+++ b/mlflow/store/artifact/cli.py
@@ -85,7 +85,7 @@ def list_artifacts(run_id, artifact_path):
     artifact_uri = store.get_run(run_id).info.artifact_uri
     artifact_repo = get_artifact_repository(artifact_uri)
     file_infos = artifact_repo.list_artifacts(artifact_path)
-    print(_file_infos_to_json(file_infos))
+    print(_file_infos_to_json(file_infos))  # pylint: disable=print-function
 
 
 def _file_infos_to_json(file_infos):
@@ -119,7 +119,7 @@ def download_artifacts(run_id, artifact_path, artifact_uri):
         sys.exit(1)
 
     if artifact_uri is not None:
-        print(_download_artifact_from_uri(artifact_uri))
+        print(_download_artifact_from_uri(artifact_uri))  # pylint: disable=print-function
         return
 
     artifact_path = artifact_path if artifact_path is not None else ""
@@ -127,7 +127,7 @@ def download_artifacts(run_id, artifact_path, artifact_uri):
     artifact_uri = store.get_run(run_id).info.artifact_uri
     artifact_repo = get_artifact_repository(artifact_uri)
     artifact_location = artifact_repo.download_artifacts(artifact_path)
-    print(artifact_location)
+    print(artifact_location)  # pylint: disable=print-function
 
 
 if __name__ == "__main__":

--- a/mlflow/store/artifact/cli.py
+++ b/mlflow/store/artifact/cli.py
@@ -85,7 +85,7 @@ def list_artifacts(run_id, artifact_path):
     artifact_uri = store.get_run(run_id).info.artifact_uri
     artifact_repo = get_artifact_repository(artifact_uri)
     file_infos = artifact_repo.list_artifacts(artifact_path)
-    print(_file_infos_to_json(file_infos))  # pylint: disable=print-function
+    click.echo(_file_infos_to_json(file_infos))
 
 
 def _file_infos_to_json(file_infos):
@@ -119,7 +119,7 @@ def download_artifacts(run_id, artifact_path, artifact_uri):
         sys.exit(1)
 
     if artifact_uri is not None:
-        print(_download_artifact_from_uri(artifact_uri))  # pylint: disable=print-function
+        click.echo(_download_artifact_from_uri(artifact_uri))
         return
 
     artifact_path = artifact_path if artifact_path is not None else ""
@@ -127,7 +127,7 @@ def download_artifacts(run_id, artifact_path, artifact_uri):
     artifact_uri = store.get_run(run_id).info.artifact_uri
     artifact_repo = get_artifact_repository(artifact_uri)
     artifact_location = artifact_repo.download_artifacts(artifact_path)
-    print(artifact_location)  # pylint: disable=print-function
+    click.echo(artifact_location)
 
 
 if __name__ == "__main__":

--- a/mlflow/tracking/_tracking_service/utils.py
+++ b/mlflow/tracking/_tracking_service/utils.py
@@ -1,6 +1,6 @@
 import os
-import sys
 from functools import partial
+import logging
 
 from mlflow.store.tracking import DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH
 from mlflow.store.db.db_types import DATABASE_ENGINES
@@ -28,6 +28,7 @@ _TRACKING_SERVER_CERT_PATH_ENV_VAR = "MLFLOW_TRACKING_SERVER_CERT_PATH"
 # see https://requests.readthedocs.io/en/master/api/
 _TRACKING_CLIENT_CERT_PATH_ENV_VAR = "MLFLOW_TRACKING_CLIENT_CERT_PATH"
 
+_logger = logging.getLogger(__name__)
 _tracking_uri = None
 
 
@@ -170,10 +171,10 @@ def _get_git_url_if_present(uri):
     try:
         from git import Repo, InvalidGitRepositoryError, GitCommandNotFound, NoSuchPathError
     except ImportError as e:
-        print(
-            "Notice: failed to import Git (the git executable is probably not on your PATH),"
-            " so Git SHA is not available. Error: %s" % e,
-            file=sys.stderr,
+        _logger.warning(
+            "Failed to import Git (the git executable is probably not on your PATH),"
+            " so Git SHA is not available. Error: %s",
+            e,
         )
         return uri
     try:

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -2265,7 +2265,7 @@ class MlflowClient:
             # Databricks Secret Manager with scope=<scope> and key=<prefix>-workspaceid.
             workspace_host, workspace_id = get_workspace_info_from_databricks_secrets(tracking_uri)
             if not workspace_id:
-                print(
+                _logger.info(
                     "No workspace ID specified; if your Databricks workspaces share the same"
                     " host URL, you may want to specify the workspace ID (along with the host"
                     " information in the secret manager) for run lineage tracking. For more"

--- a/mlflow/utils/logging_utils.py
+++ b/mlflow/utils/logging_utils.py
@@ -87,4 +87,4 @@ def _configure_mlflow_loggers(root_module_name):
 
 
 def eprint(*args, **kwargs):
-    print(*args, file=MLFLOW_LOGGING_STREAM, **kwargs)
+    print(*args, file=MLFLOW_LOGGING_STREAM, **kwargs)  # pylint: disable=print-function

--- a/pylint_plugins/__init__.py
+++ b/pylint_plugins/__init__.py
@@ -1,5 +1,7 @@
 from .pytest_raises_without_match import PytestRaisesWithoutMatch
+from .print_function import PrintFunction
 
 
 def register(linter):
     linter.register_checker(PytestRaisesWithoutMatch(linter))
+    linter.register_checker(PrintFunction(linter))

--- a/pylint_plugins/print_function.py
+++ b/pylint_plugins/print_function.py
@@ -10,7 +10,7 @@ IGNORE_DIRS = list(
         os.path.abspath,
         [
             "dev",
-            # TODO: Remove (or replace) print statements in tests
+            # TODO: Remove (or replace) print functions in tests
             "tests",
         ],
     )

--- a/pylint_plugins/print_function.py
+++ b/pylint_plugins/print_function.py
@@ -1,0 +1,44 @@
+import os
+
+import astroid
+from pylint.interfaces import IAstroidChecker
+from pylint.checkers import BaseChecker
+
+
+IGNORE_DIRS = list(
+    map(
+        os.path.abspath,
+        [
+            "dev",
+            # TODO: Remove (or replace) print statements in tests
+            "tests",
+        ],
+    )
+)
+
+
+def _is_print_function(node: astroid.Call):
+    return isinstance(node.func, astroid.Name) and node.func.name == "print"
+
+
+def _should_ignore(node: astroid.Call):
+    path = node.root().file
+    return any(path.startswith(d) for d in IGNORE_DIRS)
+
+
+class PrintFunction(BaseChecker):
+    __implements__ = IAstroidChecker
+
+    name = "print-function"
+    msgs = {
+        "W0002": (
+            "print function should not be used",
+            name,
+            "Use logging methods instead",
+        ),
+    }
+    priority = -1
+
+    def visit_call(self, node: astroid.Call):
+        if not _should_ignore(node) and _is_print_function(node):
+            self.add_message(self.name, node=node)

--- a/tests/pylint_plugins/test_print_function.py
+++ b/tests/pylint_plugins/test_print_function.py
@@ -1,0 +1,28 @@
+import pytest
+
+from tests.pylint_plugins.utils import create_message, extract_node, skip_if_pylint_unavailable
+
+pytestmark = skip_if_pylint_unavailable()
+
+
+@pytest.fixture(scope="module")
+def test_case():
+    import pylint.testutils
+    from pylint_plugins import PrintFunction
+
+    class TestPrintFunction(pylint.testutils.CheckerTestCase):
+        CHECKER_CLASS = PrintFunction
+
+    test_case = TestPrintFunction()
+    test_case.setup_method()
+    return test_case
+
+
+def test_print_function(test_case):
+    node = extract_node("print('hello')")
+    with test_case.assertAddsMessages(create_message(test_case.CHECKER_CLASS.name, node)):
+        test_case.walk(node)
+
+    node = extract_node("module.print('hello')")
+    with test_case.assertNoMessages():
+        test_case.walk(node)

--- a/tests/pylint_plugins/test_pytest_raises_without_match.py
+++ b/tests/pylint_plugins/test_pytest_raises_without_match.py
@@ -1,10 +1,8 @@
 import pytest
 
-from tests.helper_functions import _is_importable
+from tests.pylint_plugins.utils import create_message, extract_node, skip_if_pylint_unavailable
 
-pytestmark = pytest.mark.skipif(
-    not _is_importable("pylint"), reason="pylint is required to run tests in this module"
-)
+pytestmark = skip_if_pylint_unavailable()
 
 
 @pytest.fixture(scope="module")
@@ -19,18 +17,6 @@ def test_case():
     test_case = TestPytestRaisesWithoutMatch()
     test_case.setup_method()
     return test_case
-
-
-def create_message(msg_id, node):
-    import pylint.testutils
-
-    return pylint.testutils.Message(msg_id=msg_id, node=node)
-
-
-def extract_node(code):
-    import astroid
-
-    return astroid.extract_node(code)
 
 
 def iter_bad_cases():

--- a/tests/pylint_plugins/utils.py
+++ b/tests/pylint_plugins/utils.py
@@ -1,6 +1,15 @@
 import subprocess
 import re
 
+import pytest
+from tests.helper_functions import _is_importable
+
+
+def skip_if_pylint_unavailable():
+    return pytest.mark.skipif(
+        not _is_importable("pylint"), reason="pylint is required to run tests in this module"
+    )
+
 
 def get_pylint_msg_ids():
     from pylint.constants import MSG_TYPES
@@ -9,3 +18,15 @@ def get_pylint_msg_ids():
     stdout = res.stdout.decode("utf-8")
     letters = "".join(MSG_TYPES.keys())
     return set(re.findall(rf"\(([{letters}][0-9]{{4}})\)", stdout))
+
+
+def create_message(msg_id, node):
+    import pylint.testutils
+
+    return pylint.testutils.Message(msg_id=msg_id, node=node)
+
+
+def extract_node(code):
+    import astroid
+
+    return astroid.extract_node(code)


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Add a custom pylint rule to prevent us from merging changes containing `print` functions for debugging purposes.

## How is this patch tested?

Existing tests

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
