### PR TITLE
Replace `universal_newlines` with `text` in `subprocess.Popen`

### DIFF
--- a/mlflow/models/docker_utils.py
+++ b/mlflow/models/docker_utils.py
@@ -127,7 +127,7 @@ def _build_image_from_context(context_dir: str, image_name: str):
         *platform_option,
         ".",
     ]
-    proc = Popen(commands, cwd=context_dir, stdout=PIPE, stderr=STDOUT, universal_newlines=True)
+    proc = Popen(commands, cwd=context_dir, stdout=PIPE, stderr=STDOUT, text=True)
     for x in iter(proc.stdout.readline, ""):
         eprint(x, end="")
 

--- a/mlflow/projects/backend/local.py
+++ b/mlflow/projects/backend/local.py
@@ -168,13 +168,11 @@ def _run_mlflow_run_cmd(mlflow_run_arr, env_map):
         return subprocess.Popen(
             mlflow_run_arr,
             env=final_env,
-            universal_newlines=True,
+            text=True,
             creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,
         )
     else:
-        return subprocess.Popen(
-            mlflow_run_arr, env=final_env, universal_newlines=True, preexec_fn=os.setsid
-        )
+        return subprocess.Popen(mlflow_run_arr, env=final_env, text=True, preexec_fn=os.setsid)
 
 
 def _run_entry_point(command, work_dir, experiment_id, run_id):

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -1041,7 +1041,7 @@ def run_local(model_uri, port=5000, image=DEFAULT_IMAGE_NAME, flavor=None):
         cmd += ["-e", "{key}={value}".format(key=key, value=value)]
     cmd += ["--rm", image, "serve"]
     _logger.info("executing: %s", " ".join(cmd))
-    proc = Popen(cmd, stdout=sys.stdout, stderr=sys.stderr, universal_newlines=True)
+    proc = Popen(cmd, stdout=sys.stdout, stderr=sys.stderr, text=True)
 
     def _sigterm_handler(*_):
         _logger.info("received termination signal => killing docker process")

--- a/mlflow/utils/process.py
+++ b/mlflow/utils/process.py
@@ -32,7 +32,7 @@ def exec_cmd(
 
     if stream_output:
         child = subprocess.Popen(
-            cmd, env=cmd_env, cwd=cwd, universal_newlines=True, stdin=subprocess.PIPE, **kwargs
+            cmd, env=cmd_env, cwd=cwd, text=True, stdin=subprocess.PIPE, **kwargs
         )
         child.communicate(cmd_stdin)
         exit_code = child.wait()
@@ -47,7 +47,7 @@ def exec_cmd(
             stdin=subprocess.PIPE,
             stderr=subprocess.PIPE,
             cwd=cwd,
-            universal_newlines=True,
+            text=True,
             **kwargs,
         )
         (stdout, stderr) = child.communicate(cmd_stdin)

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -195,7 +195,7 @@ def _start_scoring_proc(cmd, env, stdout=sys.stdout, stderr=sys.stderr):
             cmd,
             stdout=stdout,
             stderr=stderr,
-            universal_newlines=True,
+            text=True,
             env=env,
             # Assign the scoring process to a process group. All child processes of the
             # scoring process will be assigned to this group as well. This allows child
@@ -207,7 +207,7 @@ def _start_scoring_proc(cmd, env, stdout=sys.stdout, stderr=sys.stderr):
             cmd,
             stdout=stdout,
             stderr=stderr,
-            universal_newlines=True,
+            text=True,
             env=env,
             # On Windows, `os.setsid` and `preexec_fn` are unavailable
             creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -321,7 +321,7 @@ def test_predict(iris_data, sk_model):
         p = subprocess.Popen(
             ["mlflow", "models", "predict", "-m", model_uri, "-t", "json", "--json-format", "split"]
             + extra_options,
-            universal_newlines=True,
+            text=True,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=sys.stderr,


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Replace `universal_newlines` with `text` in `subprocess.Popen`. `text` is a more readable alias for `universal_newlines` and was introduced in Python 3.7.

## How is this patch tested?

Existing tests

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
