### PR TITLE
Pin `click` to fix spacy tests

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -246,7 +246,7 @@ spacy:
   models:
     minimum: "2.2.4"
     maximum: "3.2.2"
-    requirements: ["scikit-learn"]
+    requirements: ["scikit-learn", "click<8.1.0"]
     run: |
       pytest tests/spacy/test_spacy_model_export.py --large
 

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -246,7 +246,9 @@ spacy:
   models:
     minimum: "2.2.4"
     maximum: "3.2.2"
-    requirements: ["scikit-learn", "click<8.1.0"]
+    requirements:
+      "<= 3.0.8": ["scikit-learn", "click<8.1.0", "flask<2.1.0"]
+      "> 3.0.8": ["scikit-learn", "click<8.1.0"]
     run: |
       pytest tests/spacy/test_spacy_model_export.py --large
 

--- a/tests/spacy/test_spacy_model_export.py
+++ b/tests/spacy/test_spacy_model_export.py
@@ -408,7 +408,12 @@ def test_pyfunc_serve_and_score(spacy_model_with_data):
     model, inference_dataframe = spacy_model_with_data
     artifact_path = "model"
     with mlflow.start_run():
-        extra_pip_requirements = ["click<8.1.0"] if spacy_version < Version("3.2.4") else None
+        if spacy_version <= Version("3.0.8"):
+            extra_pip_requirements = ["click<8.1.0", "flask<2.1.0"]
+        elif spacy_version < Version("3.2.4"):
+            extra_pip_requirements = ["click<8.1.0"]
+        else:
+            extra_pip_requirements = None
         mlflow.spacy.log_model(model, artifact_path, extra_pip_requirements=extra_pip_requirements)
         model_uri = mlflow.get_artifact_uri(artifact_path)
 

--- a/tests/spacy/test_spacy_model_export.py
+++ b/tests/spacy/test_spacy_model_export.py
@@ -36,8 +36,8 @@ EXTRA_PYFUNC_SERVING_TEST_ARGS = [] if _is_available_on_pypi("spacy") else ["--n
 
 ModelWithData = namedtuple("ModelWithData", ["model", "inference_data"])
 
-
-IS_SPACY_VERSION_NEWER_THAN_OR_EQUAL_TO_3_0_0 = Version(spacy.__version__) >= Version("3.0.0")
+spacy_version = Version(spacy.__version__)
+IS_SPACY_VERSION_NEWER_THAN_OR_EQUAL_TO_3_0_0 = spacy_version >= Version("3.0.0")
 
 
 @pytest.fixture(scope="module")
@@ -408,7 +408,8 @@ def test_pyfunc_serve_and_score(spacy_model_with_data):
     model, inference_dataframe = spacy_model_with_data
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.spacy.log_model(model, artifact_path)
+        extra_pip_requirements = ["click<8.1.0"] if spacy_version < Version("3.2.4") else None
+        mlflow.spacy.log_model(model, artifact_path, extra_pip_requirements=extra_pip_requirements)
         model_uri = mlflow.get_artifact_uri(artifact_path)
 
     resp = pyfunc_serve_and_score_model(


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Pin `click` to fix spacy tests:

https://github.com/mlflow/mlflow/runs/5749869140?check_suite_focus=true#step:12:479

```python
Traceback (most recent call last):
  File "/usr/share/miniconda/envs/mlflow-df01497c89f5687828726637e0517fa5e92912e7/lib/python3.7/site-packages/gunicorn/arbiter.py", line 589, in spawn_worker
    worker.init_process()
  File "/usr/share/miniconda/envs/mlflow-df01497c89f5687828726637e0517fa5e92912e7/lib/python3.7/site-packages/gunicorn/workers/base.py", line 134, in init_process
    self.load_wsgi()
  File "/usr/share/miniconda/envs/mlflow-df01497c89f5687828726637e0517fa5e92912e7/lib/python3.7/site-packages/gunicorn/workers/base.py", line 146, in load_wsgi
    self.wsgi = self.app.wsgi()
  File "/usr/share/miniconda/envs/mlflow-df01497c89f5687828726637e0517fa5e92912e7/lib/python3.7/site-packages/gunicorn/app/base.py", line 67, in wsgi
    self.callable = self.load()
  File "/usr/share/miniconda/envs/mlflow-df01497c89f5687828726637e0517fa5e92912e7/lib/python3.7/site-packages/gunicorn/app/wsgiapp.py", line 58, in load
    return self.load_wsgiapp()
  File "/usr/share/miniconda/envs/mlflow-df01497c89f5687828726637e0517fa5e92912e7/lib/python3.7/site-packages/gunicorn/app/wsgiapp.py", line 48, in load_wsgiapp
    return util.import_app(self.app_uri)
  File "/usr/share/miniconda/envs/mlflow-df01497c89f5687828726637e0517fa5e92912e7/lib/python3.7/site-packages/gunicorn/util.py", line 359, in import_app
    mod = importlib.import_module(module)
  File "/usr/share/miniconda/envs/mlflow-df01497c89f5687828726637e0517fa5e92912e7/lib/python3.7/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/home/runner/work/mlflow/mlflow/mlflow/pyfunc/scoring_server/wsgi.py", line 6, in <module>
    app = scoring_server.init(load_model(os.environ[scoring_server._SERVER_MODEL_PATH]))
  File "/home/runner/work/mlflow/mlflow/mlflow/pyfunc/__init__.py", line 723, in load_model
    model_impl = importlib.import_module(conf[MAIN])._load_pyfunc(data_path)
  File "/home/runner/work/mlflow/mlflow/mlflow/spacy.py", line 292, in _load_pyfunc
    return _SpacyModelWrapper(_load_model(path))
  File "/home/runner/work/mlflow/mlflow/mlflow/spacy.py", line 260, in _load_model
    import spacy
  File "/usr/share/miniconda/envs/mlflow-df01497c89f5687828726637e0517fa5e92912e7/lib/python3.7/site-packages/spacy/__init__.py", line 15, in <module>
    from .cli.info import info  # noqa: F401
  File "/usr/share/miniconda/envs/mlflow-df01497c89f5687828726637e0517fa5e92912e7/lib/python3.7/site-packages/spacy/cli/__init__.py", line 3, in <module>
    from ._util import app, setup_cli  # noqa: F401
  File "/usr/share/miniconda/envs/mlflow-df01497c89f5687828726637e0517fa5e92912e7/lib/python3.7/site-packages/spacy/cli/_util.py", line 9, in <module>
    import typer
  File "/usr/share/miniconda/envs/mlflow-df01497c89f5687828726637e0517fa5e92912e7/lib/python3.7/site-packages/typer/__init__.py", line 12, in <module>
    from click.termui import get_terminal_size as get_terminal_size
ImportError: cannot import name 'get_terminal_size' from 'click.termui' (/usr/share/miniconda/envs/mlflow-df01497c89f5687828726637e0517fa5e92912e7/lib/python3.7/site-packages/click/termui.py)
```

https://github.com/explosion/spaCy/issues/10564 reports the same issue

## How is this patch tested?

Existing tests

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
