### PR TITLE
turn sphinx nitpicky mode on and force a failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,13 +62,8 @@ jobs:
           environment:
             JAVA_HOME: /usr/lib/jvm/default-java
           command: |
-            make rsthtml SPHINXOPTS="-b html -W --keep-going -n -T"
-            pydocs=$?
+            make rsthtml
             make javadocs
-            javadocs=$?
-            err=$((pydocs + javadocs))
-            echo "Build test result: $err"
-            test $err = 0
       - store_artifacts:
           path: docs/build/html
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,6 +67,7 @@ jobs:
             make javadocs
             javadocs=$?
             err=$((pydocs + javadocs))
+            echo 'Build test result: $err'
             test $err = 0
       - store_artifacts:
           path: docs/build/html

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
             make javadocs
             javadocs=$?
             err=$((pydocs + javadocs))
-            echo 'Build test result: $err'
+            echo "Build test result: $err"
             test $err = 0
       - store_artifacts:
           path: docs/build/html

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,8 +62,12 @@ jobs:
           environment:
             JAVA_HOME: /usr/lib/jvm/default-java
           command: |
-            make rsthtml
+            make rsthtml SPHINXOPTS="-b html -W --keep-going -n -T"
+            pydocs=$?
             make javadocs
+            javadocs=$?
+            err=$((pydocs + javadocs))
+            test $err = 0
       - store_artifacts:
           path: docs/build/html
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -W --keep-going
+SPHINXOPTS    = -b html -W --keep-going -n -T
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = build

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -b html -W --keep-going -n -T
+SPHINXOPTS    = -W --keep-going -n -T
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = build

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -339,6 +339,8 @@ nitpick_ignore = [
     ("py:class", "mlflow.models.model.Model"),
     ("py:class", "mlflow.models.signature.ModelSignature"),
     ("py:class", "MlflowInferableDataset"),
+    ("py:class", "scipy.sparse.csr.csr_matrix"),
+    ("py:class", "scipy.sparse.csc.csc_matrix"),
     ("py:class", "scipy.sparse._csr.csr_matrix"),
     ("py:class", "scipy.sparse._csc.csc_matrix"),
 ]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -339,7 +339,7 @@ nitpick_ignore = [
     ("py:class", "mlflow.models.model.Model"),
     ("py:class", "mlflow.models.signature.ModelSignature"),
     ("py:class", "MlflowInferableDataset"),
-    ("py:class", "scipy.sparse.csr.csr_matrix"),
+    ("py:class", "scipy.sparse._csr.csr_matrix"),
     ("py:class", "scipy.sparse.csc.csc_matrix"),
 ]
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -340,7 +340,7 @@ nitpick_ignore = [
     ("py:class", "mlflow.models.signature.ModelSignature"),
     ("py:class", "MlflowInferableDataset"),
     ("py:class", "scipy.sparse._csr.csr_matrix"),
-    ("py:class", "scipy.sparse.csc.csc_matrix"),
+    ("py:class", "scipy.sparse._csc.csc_matrix"),
 ]
 
 


### PR DESCRIPTION
Signed-off-by: Ben Wilson <benjamin.wilson@databricks.com>

## What changes are proposed in this pull request?

Force circleci sphinx build to be in nitpicky mode

## How is this patch tested?

forced failure and CI validation

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

Enforce strict formatting of docs build (warnings will convert to errors)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
