### PR TITLE
Add `--env-manager` option for `mlflow models` commands and deprecate `--no-conda` flag

### DIFF
--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -21,6 +21,7 @@ from mlflow.utils.annotations import experimental
 from mlflow.utils.logging_utils import eprint
 from mlflow.utils.process import ShellCommandException
 from mlflow.utils.uri import resolve_default_artifact_root
+from mlflow.utils.environment import EnvManager
 from mlflow.entities.lifecycle_stage import LifecycleStage
 from mlflow.exceptions import MlflowException
 
@@ -107,6 +108,7 @@ def cli():
     "at https://www.mlflow.org/docs/latest/projects.html.",
 )
 @cli_args.NO_CONDA
+@cli_args.ENV_MANAGER
 @click.option(
     "--storage-dir",
     envvar="MLFLOW_TMP_DIR",
@@ -138,6 +140,7 @@ def run(
     backend,
     backend_config,
     no_conda,
+    env_manager,
     storage_dir,
     run_id,
     run_name,
@@ -154,6 +157,7 @@ def run(
     By default, Git projects run in a new working directory with the given parameters, while
     local projects run from the project's root directory.
     """
+    env_manager = cli_args._validate_env_manager(no_conda, env_manager)
     if experiment_id is not None and experiment_name is not None:
         eprint("Specify only one of 'experiment-name' or 'experiment-id' options.")
         sys.exit(1)
@@ -182,7 +186,7 @@ def run(
             docker_args=args_dict,
             backend=backend,
             backend_config=backend_config,
-            use_conda=(not no_conda),
+            use_conda=env_manager is EnvManager.CONDA,
             storage_dir=storage_dir,
             synchronous=backend in ("local", "kubernetes") or backend is None,
             run_id=run_id,

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -139,7 +139,7 @@ def run(
     experiment_id,
     backend,
     backend_config,
-    no_conda,
+    no_conda,  # pylint: disable=unused-argument
     env_manager,
     storage_dir,
     run_id,
@@ -157,7 +157,6 @@ def run(
     By default, Git projects run in a new working directory with the given parameters, while
     local projects run from the project's root directory.
     """
-    env_manager = cli_args._validate_env_manager(no_conda, env_manager)
     if experiment_id is not None and experiment_name is not None:
         eprint("Specify only one of 'experiment-name' or 'experiment-id' options.")
         sys.exit(1)

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -30,10 +30,18 @@ def commands():
 @cli_args.HOST
 @cli_args.WORKERS
 @cli_args.NO_CONDA
+@cli_args.ENV_MANAGER
 @cli_args.INSTALL_MLFLOW
 @cli_args.ENABLE_MLSERVER
 def serve(
-    model_uri, port, host, workers, no_conda=False, install_mlflow=False, enable_mlserver=False
+    model_uri,
+    port,
+    host,
+    workers,
+    no_conda=False,
+    env_manager=None,
+    install_mlflow=False,
+    enable_mlserver=False,
 ):
     """
     Serve a model saved with MLflow by launching a webserver on the specified host and port.
@@ -54,6 +62,7 @@ def serve(
             "data": [[1, 2, 3], [4, 5, 6]]
         }'
     """
+    env_manager = cli_args._validate_env_manager(no_conda, env_manager)
     return _get_flavor_backend(
         model_uri, no_conda=no_conda, workers=workers, install_mlflow=install_mlflow
     ).serve(model_uri=model_uri, port=port, host=host, enable_mlserver=enable_mlserver)
@@ -89,15 +98,24 @@ def serve(
     ".html",
 )
 @cli_args.NO_CONDA
+@cli_args.ENV_MANAGER
 @cli_args.INSTALL_MLFLOW
 def predict(
-    model_uri, input_path, output_path, content_type, json_format, no_conda, install_mlflow
+    model_uri,
+    input_path,
+    output_path,
+    content_type,
+    json_format,
+    no_conda,
+    env_manager,
+    install_mlflow,
 ):
     """
     Generate predictions in json format using a saved MLflow model. For information about the input
     data formats accepted by this function, see the following documentation:
     https://www.mlflow.org/docs/latest/models.html#built-in-deployment-tools.
     """
+    env_manager = cli_args._validate_env_manager(no_conda, env_manager)
     if content_type == "json" and json_format not in ("split", "records"):
         raise Exception("Unsupported json format '{}'.".format(json_format))
     return _get_flavor_backend(model_uri, no_conda=no_conda, install_mlflow=install_mlflow).predict(
@@ -112,13 +130,15 @@ def predict(
 @commands.command("prepare-env")
 @cli_args.MODEL_URI
 @cli_args.NO_CONDA
+@cli_args.ENV_MANAGER
 @cli_args.INSTALL_MLFLOW
-def prepare_env(model_uri, no_conda, install_mlflow):
+def prepare_env(model_uri, no_conda, env_manager, install_mlflow):
     """
     Performs any preparation necessary to predict or serve the model, for example
     downloading dependencies or initializing a conda environment. After preparation,
     calling predict or serve should be fast.
     """
+    env_manager = cli_args._validate_env_manager(no_conda, env_manager)
     return _get_flavor_backend(
         model_uri, no_conda=no_conda, install_mlflow=install_mlflow
     ).prepare_env(model_uri=model_uri)

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -38,7 +38,7 @@ def serve(
     port,
     host,
     workers,
-    no_conda=False,
+    no_conda,  # pylint: disable=unused-argument
     env_manager=None,
     install_mlflow=False,
     enable_mlserver=False,
@@ -62,7 +62,6 @@ def serve(
             "data": [[1, 2, 3], [4, 5, 6]]
         }'
     """
-    env_manager = cli_args._validate_env_manager(no_conda, env_manager)
     return _get_flavor_backend(
         model_uri, env_manager=env_manager, workers=workers, install_mlflow=install_mlflow
     ).serve(model_uri=model_uri, port=port, host=host, enable_mlserver=enable_mlserver)
@@ -106,7 +105,7 @@ def predict(
     output_path,
     content_type,
     json_format,
-    no_conda,
+    no_conda,  # pylint: disable=unused-argument
     env_manager,
     install_mlflow,
 ):
@@ -115,7 +114,6 @@ def predict(
     data formats accepted by this function, see the following documentation:
     https://www.mlflow.org/docs/latest/models.html#built-in-deployment-tools.
     """
-    env_manager = cli_args._validate_env_manager(no_conda, env_manager)
     if content_type == "json" and json_format not in ("split", "records"):
         raise Exception("Unsupported json format '{}'.".format(json_format))
     return _get_flavor_backend(
@@ -134,13 +132,17 @@ def predict(
 @cli_args.NO_CONDA
 @cli_args.ENV_MANAGER
 @cli_args.INSTALL_MLFLOW
-def prepare_env(model_uri, no_conda, env_manager, install_mlflow):
+def prepare_env(
+    model_uri,
+    no_conda,  # pylint: disable=unused-argument
+    env_manager,
+    install_mlflow,
+):
     """
     Performs any preparation necessary to predict or serve the model, for example
     downloading dependencies or initializing a conda environment. After preparation,
     calling predict or serve should be fast.
     """
-    env_manager = cli_args._validate_env_manager(no_conda, env_manager)
     return _get_flavor_backend(
         model_uri, env_manager=env_manager, install_mlflow=install_mlflow
     ).prepare_env(model_uri=model_uri)

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -64,7 +64,7 @@ def serve(
     """
     env_manager = cli_args._validate_env_manager(no_conda, env_manager)
     return _get_flavor_backend(
-        model_uri, no_conda=no_conda, workers=workers, install_mlflow=install_mlflow
+        model_uri, env_manager=env_manager, workers=workers, install_mlflow=install_mlflow
     ).serve(model_uri=model_uri, port=port, host=host, enable_mlserver=enable_mlserver)
 
 
@@ -118,7 +118,9 @@ def predict(
     env_manager = cli_args._validate_env_manager(no_conda, env_manager)
     if content_type == "json" and json_format not in ("split", "records"):
         raise Exception("Unsupported json format '{}'.".format(json_format))
-    return _get_flavor_backend(model_uri, no_conda=no_conda, install_mlflow=install_mlflow).predict(
+    return _get_flavor_backend(
+        model_uri, env_manager=env_manager, install_mlflow=install_mlflow
+    ).predict(
         model_uri=model_uri,
         input_path=input_path,
         output_path=output_path,
@@ -140,7 +142,7 @@ def prepare_env(model_uri, no_conda, env_manager, install_mlflow):
     """
     env_manager = cli_args._validate_env_manager(no_conda, env_manager)
     return _get_flavor_backend(
-        model_uri, no_conda=no_conda, install_mlflow=install_mlflow
+        model_uri, env_manager=env_manager, install_mlflow=install_mlflow
     ).prepare_env(model_uri=model_uri)
 
 

--- a/mlflow/projects/backend/local.py
+++ b/mlflow/projects/backend/local.py
@@ -149,7 +149,7 @@ def _build_mlflow_run_cmd(
     if storage_dir is not None:
         mlflow_run_arr.extend(["--storage-dir", storage_dir])
     if not use_conda:
-        mlflow_run_arr.append("--env-manager", "local")
+        mlflow_run_arr.extend(["--env-manager", "local"])
     for key, value in parameters.items():
         mlflow_run_arr.extend(["-P", "%s=%s" % (key, value)])
     return mlflow_run_arr

--- a/mlflow/projects/backend/local.py
+++ b/mlflow/projects/backend/local.py
@@ -149,7 +149,7 @@ def _build_mlflow_run_cmd(
     if storage_dir is not None:
         mlflow_run_arr.extend(["--storage-dir", storage_dir])
     if not use_conda:
-        mlflow_run_arr.append("--no-conda")
+        mlflow_run_arr.append("--env-manager", "local")
     for key, value in parameters.items():
         mlflow_run_arr.extend(["-P", "%s=%s" % (key, value)])
     return mlflow_run_arr

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1227,7 +1227,7 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
             def batch_predict_fn(pdf):
                 return client.invoke(pdf)
 
-        elif env_manager == "local":
+        elif env_manager is EnvManager.LOCAL:
             if should_use_spark_to_broadcast_file:
                 loaded_model, _ = SparkModelCache.get_or_load(archive_path)
             else:

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1019,7 +1019,7 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
         artifact_uri=model_uri, output_path=_get_or_create_model_cache_dir()
     )
 
-    if env_manager == EnvManager.LOCAL:
+    if env_manager is EnvManager.LOCAL:
         # Assume spark executor python environment is the same with spark driver side.
         _warn_dependency_requirement_mismatches(local_model_path)
         _logger.warning(
@@ -1049,7 +1049,7 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
         # Prepare restored environment in driver side if possible.
         if env_manager is EnvManager.CONDA:
             _get_flavor_backend(
-                local_model_path, env_manager=EnvManager.LOCAL, install_mlflow=False
+                local_model_path, env_manager=EnvManager.CONDA, install_mlflow=False
             ).prepare_env(model_uri=local_model_path, capture_output=False)
 
     # Broadcast local model directory to remote worker if needed.
@@ -1169,7 +1169,7 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
                 # this prevents spark UDF task failing fast if other exception raised when scoring
                 # server launching.
                 _get_flavor_backend(
-                    local_model_path_on_executor, env_manager=EnvManager.LOCAL, install_mlflow=False
+                    local_model_path_on_executor, env_manager=EnvManager.CONDA, install_mlflow=False
                 ).prepare_env(model_uri=local_model_path_on_executor, capture_output=True)
             else:
                 local_model_path_on_executor = local_model_path
@@ -1178,7 +1178,7 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
             # TODO: adjust timeout for server requests handler.
             scoring_server_proc = _get_flavor_backend(
                 local_model_path_on_executor,
-                env_manager=EnvManager.LOCAL,
+                env_manager=EnvManager.CONDA,
                 workers=1,
                 install_mlflow=False,
             ).serve(

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -248,6 +248,7 @@ from mlflow.utils.model_utils import (
 )
 from mlflow.utils.uri import append_to_uri_path
 from mlflow.utils.environment import (
+    EnvManager,
     _validate_env_arguments,
     _process_pip_requirements,
     _process_conda_env,
@@ -986,10 +987,7 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
     from pyspark.sql.types import DoubleType, IntegerType, FloatType, LongType, StringType
     from mlflow.models.cli import _get_flavor_backend
 
-    if env_manager not in ["local", "conda"]:
-        raise MlflowException(
-            f"Illegal env_manager value '{env_manager}'.", error_code=INVALID_PARAMETER_VALUE
-        )
+    env_manager = EnvManager.from_string(env_manager)
 
     # Check whether spark is in local or local-cluster mode
     # this case all executors and driver share the same filesystem
@@ -1021,7 +1019,7 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
         artifact_uri=model_uri, output_path=_get_or_create_model_cache_dir()
     )
 
-    if env_manager == "local":
+    if env_manager == EnvManager.LOCAL:
         # Assume spark executor python environment is the same with spark driver side.
         _warn_dependency_requirement_mismatches(local_model_path)
         _logger.warning(
@@ -1049,10 +1047,10 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
 
     if not should_use_spark_to_broadcast_file:
         # Prepare restored environment in driver side if possible.
-        if env_manager == "conda":
-            _get_flavor_backend(local_model_path, no_conda=False, install_mlflow=False).prepare_env(
-                model_uri=local_model_path, capture_output=False
-            )
+        if env_manager is EnvManager.CONDA:
+            _get_flavor_backend(
+                local_model_path, env_manager=EnvManager.LOCAL, install_mlflow=False
+            ).prepare_env(model_uri=local_model_path, capture_output=False)
 
     # Broadcast local model directory to remote worker if needed.
     if should_use_spark_to_broadcast_file:
@@ -1158,7 +1156,7 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
         #   For NFS available case, set conda env dir / virtualenv env dir in sub-directory under
         #   NFS directory, and in spark driver side prepare restored env once, and then all
         #   spark UDF tasks running on spark workers can skip re-creating the restored env.
-        if env_manager == "conda":
+        if env_manager is EnvManager.CONDA:
             server_port = find_free_port()
 
             if should_use_spark_to_broadcast_file:
@@ -1171,7 +1169,7 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
                 # this prevents spark UDF task failing fast if other exception raised when scoring
                 # server launching.
                 _get_flavor_backend(
-                    local_model_path_on_executor, no_conda=False, install_mlflow=False
+                    local_model_path_on_executor, env_manager=EnvManager.LOCAL, install_mlflow=False
                 ).prepare_env(model_uri=local_model_path_on_executor, capture_output=True)
             else:
                 local_model_path_on_executor = local_model_path
@@ -1179,7 +1177,10 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
 
             # TODO: adjust timeout for server requests handler.
             scoring_server_proc = _get_flavor_backend(
-                local_model_path_on_executor, no_conda=False, workers=1, install_mlflow=False
+                local_model_path_on_executor,
+                env_manager=EnvManager.LOCAL,
+                workers=1,
+                install_mlflow=False,
             ).serve(
                 model_uri=local_model_path_on_executor,
                 port=server_port,

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -26,7 +26,9 @@ class PyFuncBackend(FlavorBackend):
     Flavor backend implementation for the generic python models.
     """
 
-    def __init__(self, config, env_manager, workers=1, install_mlflow=False, **kwargs):
+    def __init__(
+        self, config, workers=1, env_manager=EnvManager.CONDA, install_mlflow=False, **kwargs
+    ):
         super().__init__(config=config, **kwargs)
         self._nworkers = workers or 1
         self._env_manager = env_manager

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -14,6 +14,7 @@ from mlflow.pyfunc import ENV, scoring_server, mlserver
 from mlflow.utils.conda import get_or_create_conda_env, get_conda_bin_executable, get_conda_command
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.file_utils import path_to_local_file_uri
+from mlflow.utils.environment import EnvManager
 from mlflow.version import VERSION
 
 
@@ -25,16 +26,16 @@ class PyFuncBackend(FlavorBackend):
     Flavor backend implementation for the generic python models.
     """
 
-    def __init__(self, config, workers=1, no_conda=False, install_mlflow=False, **kwargs):
+    def __init__(self, config, env_manager, workers=1, install_mlflow=False, **kwargs):
         super().__init__(config=config, **kwargs)
         self._nworkers = workers or 1
-        self._no_conda = no_conda
+        self._env_manager = env_manager
         self._install_mlflow = install_mlflow
         self._env_id = os.environ.get("MLFLOW_HOME", VERSION) if install_mlflow else None
 
     def prepare_env(self, model_uri, capture_output=False):
         local_path = _download_artifact_from_uri(model_uri)
-        if self._no_conda or ENV not in self._config:
+        if self._env_manager is EnvManager.LOCAL or ENV not in self._config:
             return 0
         conda_env_path = os.path.join(local_path, self._config[ENV])
 
@@ -54,7 +55,7 @@ class PyFuncBackend(FlavorBackend):
         # NB: Absolute windows paths do not work with mlflow apis, use file uri to ensure
         # platform compatibility.
         local_uri = path_to_local_file_uri(local_path)
-        if not self._no_conda and ENV in self._config:
+        if self._env_manager is EnvManager.CONDA and ENV in self._config:
             conda_env_path = os.path.join(local_path, self._config[ENV])
 
             conda_env_name = get_or_create_conda_env(
@@ -132,7 +133,7 @@ class PyFuncBackend(FlavorBackend):
         else:
             setup_sigterm_on_parent_death = None
 
-        if not self._no_conda and ENV in self._config:
+        if self._env_manager is EnvManager.CONDA and ENV in self._config:
             conda_env_path = os.path.join(local_path, self._config[ENV])
 
             conda_env_name = get_or_create_conda_env(
@@ -176,7 +177,7 @@ class PyFuncBackend(FlavorBackend):
             return child_proc
 
     def can_score_model(self):
-        if self._no_conda:
+        if self._env_manager is not EnvManager.LOCAL:
             # noconda => already in python and dependencies are assumed to be installed.
             return True
         conda_path = get_conda_bin_executable("conda")

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -177,7 +177,7 @@ class PyFuncBackend(FlavorBackend):
             return child_proc
 
     def can_score_model(self):
-        if self._env_manager is not EnvManager.LOCAL:
+        if self._env_manager is EnvManager.LOCAL:
             # noconda => already in python and dependencies are assumed to be installed.
             return True
         conda_path = get_conda_bin_executable("conda")

--- a/mlflow/utils/cli_args.py
+++ b/mlflow/utils/cli_args.py
@@ -61,7 +61,7 @@ def _resolve_env_manager(ctx, _, value):
     no_conda = ctx.params.get("no_conda", False)
     # Both `--no-conda` and `--env-manager` are specified
     if no_conda and value is not None:
-        raise Exception(
+        raise click.BadParameter(
             "`--no-conda` (deprecated) and `--env-manager` cannot be used at the same time."
         )
 

--- a/mlflow/utils/cli_args.py
+++ b/mlflow/utils/cli_args.py
@@ -56,27 +56,12 @@ NO_CONDA = click.option(
 )
 
 
-def _env_manager_callback(_, __, value):
-    """
-    Validates the value of `--env-manager` and converts it to the corresponding member of
-    `EnvManager`.
-    """
-    if value is None:
-        return value
-
-    allowed_values = [e.value for e in EnvManager]
-    if value not in allowed_values:
-        raise click.BadParameter(f"Expected one of {allowed_values} but got '{value}'")
-
-    return EnvManager[value.upper()]
-
-
 ENV_MANAGER = click.option(
     "--env-manager",
     default=None,
     required=False,
     type=click.UNPROCESSED,
-    callback=_env_manager_callback,
+    callback=lambda ctx, param, value: None if value is None else EnvManager.from_string(value),
     help="If specified, create an environment for MLmodel/MLproject using the specified "
     "environment manager. Valid values are ['local', 'conda']. If unspecified, default to "
     "'conda'.",

--- a/mlflow/utils/cli_args.py
+++ b/mlflow/utils/cli_args.py
@@ -83,11 +83,11 @@ ENV_MANAGER = click.option(
 )
 
 
-def _get_env_manager(no_conda, env_manager):
+def _validate_env_manager(no_conda, env_manager):
     # Both `--no-conda` and `--env-manager` are specified
     if no_conda and env_manager is not None:
         raise Exception(
-            "`--no-conda` (deprecated) and `--env-manager` cannot be specified at the same time."
+            "`--no-conda` (deprecated) and `--env-manager` cannot be used at the same time."
         )
     # Only `--no-conda` is specified
     elif no_conda:

--- a/mlflow/utils/cli_args.py
+++ b/mlflow/utils/cli_args.py
@@ -93,7 +93,7 @@ ENV_MANAGER = click.option(
     # '\b' prevents rewrapping text:
     # https://click.palletsprojects.com/en/8.1.x/documentation/#preventing-rewrapping
     help="""
-If specified, create an environment for MLmodel using the specified
+If specified, create an environment for MLmodel/MLproject using the specified
 environment manager. The following values are supported:
 
 \b

--- a/mlflow/utils/cli_args.py
+++ b/mlflow/utils/cli_args.py
@@ -2,6 +2,10 @@
 Definitions of click options shared by several CLI commands.
 """
 import click
+import warnings
+
+
+from mlflow.utils.environment import EnvManager
 
 MODEL_PATH = click.option(
     "--model-path",
@@ -45,11 +49,63 @@ RUN_ID = click.option(
 NO_CONDA = click.option(
     "--no-conda",
     is_flag=True,
-    help="If specified, will assume that MLmodel/MLproject is running within "
+    help="[Deprecated] If specified, will assume that MLmodel/MLproject is running within "
     "a Conda environment with the necessary dependencies for "
     "the current project instead of attempting to create a new "
     "conda environment.",
 )
+
+
+def _env_manager_callback(_, __, value):
+    """
+    Validates the value of `--env-manager` and converts it to the corresponding member of
+    `EnvManager`.
+    """
+    if value is None:
+        return value
+
+    allowed_values = [e.value for e in EnvManager]
+    if value not in allowed_values:
+        raise click.BadParameter(f"Expected one of {allowed_values} but got '{value}'")
+
+    return EnvManager[value.upper()]
+
+
+ENV_MANAGER = click.option(
+    "--env-manager",
+    default=None,
+    required=False,
+    type=click.UNPROCESSED,
+    callback=_env_manager_callback,
+    help="If specified, create an environment for MLmodel/MLproject using the specified "
+    "environment manager. Valid values are ['local', 'conda']. If unspecified, default to "
+    "'conda'.",
+)
+
+
+def _get_env_manager(no_conda, env_manager):
+    # Both `--no-conda` and `--env-manager` are specified
+    if no_conda and env_manager is not None:
+        raise Exception(
+            "`--no-conda` (deprecated) and `--env-manager` cannot be specified at the same time."
+        )
+    # Only `--no-conda` is specified
+    elif no_conda:
+        warnings.warn(
+            (
+                "`--no-conda` is deprecated and will be removed in a future MLflow release. "
+                "Use `--env-manager=local` instead."
+            ),
+            FutureWarning,
+            stacklevel=2,
+        )
+        return EnvManager.LOCAL
+    # Neither `--no-conda` nor `--env-manager` is specified
+    elif env_manager is None:
+        return EnvManager.CONDA
+
+    return env_manager
+
 
 INSTALL_MLFLOW = click.option(
     "--install-mlflow",

--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -1,7 +1,7 @@
 import yaml
 import os
 import logging
-
+from enum import Enum
 
 from mlflow.utils import PYTHON_VERSION
 from mlflow.utils.requirements_utils import _parse_requirements, _infer_requirements
@@ -18,6 +18,11 @@ channels:
 _CONDA_ENV_FILE_NAME = "conda.yaml"
 _REQUIREMENTS_FILE_NAME = "requirements.txt"
 _CONSTRAINTS_FILE_NAME = "constraints.txt"
+
+
+class EnvManager(Enum):
+    LOCAL = "local"
+    CONDA = "conda"
 
 
 def _mlflow_conda_env(

--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -31,6 +31,9 @@ class EnvManager(Enum):
             raise ValueError(f"Expected one of {allowed_values} but got '{value}'")
         return cls[value.upper()]
 
+    def __str__(self):
+        return self.name.lower()
+
 
 def _mlflow_conda_env(
     path=None,

--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -24,6 +24,13 @@ class EnvManager(Enum):
     LOCAL = "local"
     CONDA = "conda"
 
+    @classmethod
+    def from_string(cls, value):
+        allowed_values = [e.value for e in cls]
+        if value not in allowed_values:
+            raise ValueError(f"Expected one of {allowed_values} but got '{value}'")
+        return cls[value.upper()]
+
 
 def _mlflow_conda_env(
     path=None,

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 import sys
 
+from click.testing import CliRunner
 import numpy as np
 import pandas as pd
 import pytest
@@ -21,6 +22,7 @@ except ImportError:
 import mlflow
 from mlflow import pyfunc
 import mlflow.sklearn
+import mlflow.models.cli as models_cli
 
 from mlflow.utils.file_utils import TempDir, path_to_local_file_uri
 from mlflow.utils.environment import _mlflow_conda_env
@@ -496,3 +498,22 @@ def _validate_with_rest_endpoint(scoring_proc, host_port, df, x, sk_model, enabl
             assert scoring_response_dict["error_code"] == ErrorCode.Name(BAD_REQUEST)
             assert "message" in scoring_response_dict
             assert "stack_trace" in scoring_response_dict
+
+
+patch_get_flavor_backend = mock.patch("mlflow.models.cli._get_flavor_backend")
+
+
+@patch_get_flavor_backend
+def test_deprecation_warning_is_raised_when_no_conda_is_specified(mock_flavor_backend):
+    with pytest.warns(FutureWarning, match=r"--no-conda.+deprecated"):
+        CliRunner().invoke(models_cli.serve, ["--model-uri", "model", "--no-conda"])
+    mock_flavor_backend.assert_called_once()
+
+
+def test_exception_is_thrown_when_both_no_conda_and_env_manager_are_specified():
+    with pytest.raises(Exception, match="cannot be used at the same time"):
+        CliRunner().invoke(
+            models_cli.serve,
+            ["--model-uri", "model", "--no-conda", "--env-manager=local"],
+            catch_exceptions=False,
+        )

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -504,16 +504,25 @@ patch_get_flavor_backend = mock.patch("mlflow.models.cli._get_flavor_backend")
 
 
 @patch_get_flavor_backend
-def test_deprecation_warning_is_raised_when_no_conda_is_specified(mock_flavor_backend):
+def test_env_manager_deprecation_warning_is_raised_when_no_conda_is_specified(mock_flavor_backend):
     with pytest.warns(FutureWarning, match=r"--no-conda.+deprecated"):
         CliRunner().invoke(models_cli.serve, ["--model-uri", "model", "--no-conda"])
     mock_flavor_backend.assert_called_once()
 
 
-def test_exception_is_thrown_when_both_no_conda_and_env_manager_are_specified():
+def test_env_manager_exception_is_thrown_when_both_no_conda_and_env_manager_are_specified():
     with pytest.raises(Exception, match="cannot be used at the same time"):
         CliRunner().invoke(
             models_cli.serve,
             ["--model-uri", "model", "--no-conda", "--env-manager=local"],
+            catch_exceptions=False,
+        )
+
+
+def test_env_manager_invalid_value():
+    with pytest.raises(ValueError, match=r"Expected .+ but got 'abc'"):
+        CliRunner().invoke(
+            models_cli.serve,
+            ["--model-uri", "model", "--env-manager=abc"],
             catch_exceptions=False,
         )

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -508,7 +508,11 @@ patch_get_flavor_backend = mock.patch("mlflow.models.cli._get_flavor_backend")
 @patch_get_flavor_backend
 def test_env_manager_deprecation_warning_is_raised_when_no_conda_is_specified(mock_flavor_backend):
     with pytest.warns(FutureWarning, match=r"--no-conda.+deprecated"):
-        CliRunner().invoke(models_cli.serve, ["--model-uri", "model", "--no-conda"])
+        CliRunner().invoke(
+            models_cli.serve,
+            ["--model-uri", "model", "--no-conda"],
+            catch_exceptions=False,
+        )
     mock_flavor_backend.assert_called_once()
 
 
@@ -521,7 +525,7 @@ def test_env_manager_exception_is_thrown_when_both_no_conda_and_env_manager_are_
         )
 
 
-def test_env_manager_invalid_value():
+def test_env_manager_unsupported_value():
     with pytest.raises(ValueError, match=r"Expected .+ but got 'abc'"):
         CliRunner().invoke(
             models_cli.serve,

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -516,13 +516,17 @@ def test_env_manager_deprecation_warning_is_raised_when_no_conda_is_specified(mo
     mock_flavor_backend.assert_called_once()
 
 
-def test_env_manager_exception_is_thrown_when_both_no_conda_and_env_manager_are_specified():
-    with pytest.raises(Exception, match="cannot be used at the same time"):
-        CliRunner().invoke(
-            models_cli.serve,
-            ["--model-uri", "model", "--no-conda", "--env-manager=local"],
-            catch_exceptions=False,
-        )
+def test_env_manager_specifying_both_no_conda_and_env_manager_is_not_allowed():
+    res = CliRunner().invoke(
+        models_cli.serve,
+        ["--model-uri", "model", "--no-conda", "--env-manager=local"],
+        catch_exceptions=False,
+    )
+    assert res.exit_code != 0
+    assert (
+        "`--no-conda` (deprecated) and `--env-manager` cannot be used at the same time."
+        in res.stdout
+    )
 
 
 def test_env_manager_unsupported_value():

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -44,7 +44,7 @@ from mlflow.pyfunc.scoring_server import (
 )
 
 # NB: for now, windows tests do not have conda available.
-no_conda = ["--no-conda"] if sys.platform == "win32" else []
+no_conda = ["--env-manager", "local"] if sys.platform == "win32" else []
 
 # NB: need to install mlflow since the pip version does not have mlflow models cli.
 install_mlflow = ["--install-mlflow"] if not no_conda else []
@@ -377,7 +377,7 @@ def test_prepare_env_passes(sk_model):
 
         # Test with no conda
         p = subprocess.Popen(
-            ["mlflow", "models", "prepare-env", "-m", model_uri, "--no-conda"],
+            ["mlflow", "models", "prepare-env", "-m", model_uri, "--env-manager", "local"],
             stderr=subprocess.PIPE,
         )
         assert p.wait() == 0
@@ -408,7 +408,9 @@ def test_prepare_env_fails(sk_model):
             model_uri = "runs:/{run_id}/model".format(run_id=active_run.info.run_id)
 
         # Test with no conda
-        p = subprocess.Popen(["mlflow", "models", "prepare-env", "-m", model_uri, "--no-conda"])
+        p = subprocess.Popen(
+            ["mlflow", "models", "prepare-env", "-m", model_uri, "--env-manager", "local"]
+        )
         assert p.wait() == 0
 
         # With conda - should fail due to bad conda environment.

--- a/tests/pyfunc/test_scoring_server.py
+++ b/tests/pyfunc/test_scoring_server.py
@@ -22,6 +22,7 @@ from mlflow.pyfunc.scoring_server import get_cmd
 from mlflow.types import Schema, ColSpec, DataType
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils.proto_json_utils import NumpyEncoder
+from mlflow.utils.environment import EnvManager
 
 from tests.helper_functions import pyfunc_serve_and_score_model, random_int, random_str
 
@@ -630,7 +631,7 @@ def test_scoring_server_client(sklearn_model, model_path):
     server_proc = None
     try:
         server_proc = _get_flavor_backend(
-            model_path, no_conda=False, workers=1, install_mlflow=False
+            model_path, eng_manager=EnvManager.CONDA, workers=1, install_mlflow=False
         ).serve(
             model_uri=model_path,
             port=port,

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -20,6 +20,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.models import ModelSignature
 from mlflow.pyfunc import spark_udf, PythonModel, PyFuncModel
 from mlflow.pyfunc.spark_model_cache import SparkModelCache
+from mlflow.utils.environment import EnvManager
 
 import tests
 from mlflow.types import Schema, ColSpec
@@ -407,7 +408,9 @@ def test_spark_udf_embedded_model_server_killed_when_job_canceled(spark, sklearn
     def udf_with_model_server(it: Iterator[pd.Series]) -> Iterator[pd.Series]:
         from mlflow.models.cli import _get_flavor_backend
 
-        _get_flavor_backend(model_path, no_conda=False, workers=1, install_mlflow=False).serve(
+        _get_flavor_backend(
+            model_path, env_manager=EnvManager.CONDA, workers=1, install_mlflow=False
+        ).serve(
             model_uri=model_path,
             port=server_port,
             host="127.0.0.1",
@@ -424,7 +427,7 @@ def test_spark_udf_embedded_model_server_killed_when_job_canceled(spark, sklearn
         # and the udf task starts a mlflow model server process.
         spark.range(1).repartition(1).select(udf_with_model_server("id")).collect()
 
-    _get_flavor_backend(model_path, no_conda=False, install_mlflow=False).prepare_env(
+    _get_flavor_backend(model_path, env_manager=EnvManager.CONDA, install_mlflow=False).prepare_env(
         model_uri=model_path
     )
 


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

As a stepping stone for pyenv + virtualenv support in MLflow Models & Projects, introduce `--env-manager` option and deprecate `--no-conda`.

## How is this patch tested?

Unit tests

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
