### PR TITLE
docs(tracking): add warning regarding stacking artifact location when…

### DIFF
--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -920,7 +920,7 @@ Additionally, if MinIO server is configured with non-default region, you should 
 .. warning::
 
         The MLflow tracking server utilizes specific reserved keywords to generate a qualified path. These environment configurations, if present in the client environment, can create path resolution issues.
-        For example, if you provide ``--default-artifact-root $MLFLOW_S3_ENDPOINT_URL`` on the server side **and** ``MLFLOW_S3_ENDPOINT_URL`` on the client side.
+        For example, providing ``--default-artifact-root $MLFLOW_S3_ENDPOINT_URL`` on the server side **and** ``MLFLOW_S3_ENDPOINT_URL`` on the client side will create a client path resolution issue for the artifact storage location.
         MLflow queries the value provided by ``--default-artifact-root`` and suffixes the location with the values provided in ``MLFLOW_S3_ENDPOINT_URL``.
         Thus, for AWS S3, we end up with ``https://<bucketname>.s3.<region>.amazonaws.com/<key>/<bucketname>/<key>`` or similarly ``s3://<bucketname>/<key>/<bucketname>/<key>``.
         So make sure to set either option but not both if you run into the aforementioned issues.

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -921,7 +921,7 @@ Additionally, if MinIO server is configured with non-default region, you should 
 
         The MLflow tracking server utilizes specific reserved keywords to generate a qualified path. These environment configurations, if present in the client environment, can create path resolution issues.
         For example, providing ``--default-artifact-root $MLFLOW_S3_ENDPOINT_URL`` on the server side **and** ``MLFLOW_S3_ENDPOINT_URL`` on the client side will create a client path resolution issue for the artifact storage location.
-        MLflow queries the value provided by ``--default-artifact-root`` and suffixes the location with the values provided in ``MLFLOW_S3_ENDPOINT_URL``.
+        Upon resolving the artifact storage location, the MLflow client will use the value provided by ``--default-artifact-root`` and suffixes the location with the values provided in the environment variable  ``MLFLOW_S3_ENDPOINT_URL``.
         Depending on the value set for the environment variable ``MLFLOW_S3_ENDPOINT_URL``, the resulting artifact storage path for this scenario would be one of the following invalid object store paths:  ``https://<bucketname>.s3.<region>.amazonaws.com/<key>/<bucketname>/<key>`` or  ``s3://<bucketname>/<key>/<bucketname>/<key>``.
         To prevent path parsing issues, ensure that reserved environment variables are removed (``unset``) from client environments.
 

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -923,7 +923,7 @@ Additionally, if MinIO server is configured with non-default region, you should 
         For example, providing ``--default-artifact-root $MLFLOW_S3_ENDPOINT_URL`` on the server side **and** ``MLFLOW_S3_ENDPOINT_URL`` on the client side will create a client path resolution issue for the artifact storage location.
         MLflow queries the value provided by ``--default-artifact-root`` and suffixes the location with the values provided in ``MLFLOW_S3_ENDPOINT_URL``.
         Depending on the value set for the environment variable ``MLFLOW_S3_ENDPOINT_URL``, the resulting artifact storage path for this scenario would be one of the following invalid object store paths:  ``https://<bucketname>.s3.<region>.amazonaws.com/<key>/<bucketname>/<key>`` or  ``s3://<bucketname>/<key>/<bucketname>/<key>``.
-        So make sure to set either option but not both if you run into the aforementioned issues.
+        To prevent path parsing issues, ensure that reserved environment variables are removed (``unset``) from client environments.
 
 Complete list of configurable values for an S3 client is available in `boto3 documentation <https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#configuration>`_.
 

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -917,6 +917,11 @@ Additionally, if MinIO server is configured with non-default region, you should 
 
   export AWS_DEFAULT_REGION=my_region
 
+.. warning::
+
+        Do not provide ``--default-artifact-root $MLFLOW_S3_ENDPOINT_URL`` on the server side **and** ``MLFLOW_S3_ENDPOINT_URL`` on the client side.
+        MLflow queries the value provided by ``--default-artifact-root`` and suffixes the location with the values provided in ``MLFLOW_S3_ENDPOINT_URL``.
+        Thus, for AWS S3, we end up with ``https://<bucketname>.s3.<region>.amazonaws.com/<key>/<bucketname>/<key>`` or similarly ``s3://<bucketname>/<key>/<bucketname>/<key>``.
 
 Complete list of configurable values for an S3 client is available in `boto3 documentation <https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#configuration>`_.
 

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -922,7 +922,7 @@ Additionally, if MinIO server is configured with non-default region, you should 
         The MLflow tracking server utilizes specific reserved keywords to generate a qualified path. These environment configurations, if present in the client environment, can create path resolution issues.
         For example, providing ``--default-artifact-root $MLFLOW_S3_ENDPOINT_URL`` on the server side **and** ``MLFLOW_S3_ENDPOINT_URL`` on the client side will create a client path resolution issue for the artifact storage location.
         MLflow queries the value provided by ``--default-artifact-root`` and suffixes the location with the values provided in ``MLFLOW_S3_ENDPOINT_URL``.
-        Thus, for AWS S3, we end up with ``https://<bucketname>.s3.<region>.amazonaws.com/<key>/<bucketname>/<key>`` or similarly ``s3://<bucketname>/<key>/<bucketname>/<key>``.
+        Depending on the value set for the environment variable ``MLFLOW_S3_ENDPOINT_URL``, the resulting artifact storage path for this scenario would be one of the following invalid object store paths:  ``https://<bucketname>.s3.<region>.amazonaws.com/<key>/<bucketname>/<key>`` or  ``s3://<bucketname>/<key>/<bucketname>/<key>``.
         So make sure to set either option but not both if you run into the aforementioned issues.
 
 Complete list of configurable values for an S3 client is available in `boto3 documentation <https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#configuration>`_.

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -919,9 +919,11 @@ Additionally, if MinIO server is configured with non-default region, you should 
 
 .. warning::
 
-        Do not provide ``--default-artifact-root $MLFLOW_S3_ENDPOINT_URL`` on the server side **and** ``MLFLOW_S3_ENDPOINT_URL`` on the client side.
+        The MLflow tracking server utilizes specific reserved keywords to generate a qualified path. These environment configurations, if present in the client environment, can create path resolution issues.
+        For example, if you provide ``--default-artifact-root $MLFLOW_S3_ENDPOINT_URL`` on the server side **and** ``MLFLOW_S3_ENDPOINT_URL`` on the client side.
         MLflow queries the value provided by ``--default-artifact-root`` and suffixes the location with the values provided in ``MLFLOW_S3_ENDPOINT_URL``.
         Thus, for AWS S3, we end up with ``https://<bucketname>.s3.<region>.amazonaws.com/<key>/<bucketname>/<key>`` or similarly ``s3://<bucketname>/<key>/<bucketname>/<key>``.
+        So make sure to set either option but not both if you run into the aforementioned issues.
 
 Complete list of configurable values for an S3 client is available in `boto3 documentation <https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#configuration>`_.
 


### PR DESCRIPTION
… supplied in multiple locations

## What changes are proposed in this pull request?

This PR adds a warning about configuration of the artifact storage for mlflow tracking.
See https://github.com/mlflow/mlflow/issues/5519 for more information.

## How is this patch tested?

Just documentation, renders on my side in the IDE.

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
