### PR TITLE
Do not fail save_model if existing empty folder

### DIFF
--- a/mlflow/catboost.py
+++ b/mlflow/catboost.py
@@ -43,7 +43,7 @@ from mlflow.utils.model_utils import (
     _get_flavor_configuration,
     _validate_and_copy_code_paths,
     _add_code_from_conf_to_system_path,
-    _validate_and_prepare_target_save_path
+    _validate_and_prepare_target_save_path,
 )
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 

--- a/mlflow/catboost.py
+++ b/mlflow/catboost.py
@@ -45,7 +45,6 @@ from mlflow.utils.model_utils import (
     _add_code_from_conf_to_system_path,
     _validate_and_prepare_target_save_path
 )
-from mlflow.exceptions import MlflowException
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 
 FLAVOR_NAME = "catboost"

--- a/mlflow/catboost.py
+++ b/mlflow/catboost.py
@@ -43,6 +43,7 @@ from mlflow.utils.model_utils import (
     _get_flavor_configuration,
     _validate_and_copy_code_paths,
     _add_code_from_conf_to_system_path,
+    _validate_and_prepare_target_save_path
 )
 from mlflow.exceptions import MlflowException
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
@@ -123,9 +124,7 @@ def save_model(
     _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
 
     path = os.path.abspath(path)
-    if os.path.exists(path):
-        raise MlflowException("Path '{}' already exists".format(path))
-    os.makedirs(path)
+    _validate_and_prepare_target_save_path(path)
     code_dir_subpath = _validate_and_copy_code_paths(code_paths, path)
 
     if mlflow_model is None:

--- a/mlflow/fastai/__init__.py
+++ b/mlflow/fastai/__init__.py
@@ -41,7 +41,7 @@ from mlflow.utils.model_utils import (
     _get_flavor_configuration,
     _validate_and_copy_code_paths,
     _add_code_from_conf_to_system_path,
-    _validate_and_prepare_target_save_path
+    _validate_and_prepare_target_save_path,
 )
 from mlflow.utils.autologging_utils import (
     log_fn_args_as_params,
@@ -146,8 +146,7 @@ def save_model(
     from fastai.callback.all import ParamScheduler
     from pathlib import Path
 
-    _validate_env_arguments(conda_env, pip_requirements,
-                            extra_pip_requirements)
+    _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
 
     path = os.path.abspath(path)
     _validate_and_prepare_target_save_path(path)
@@ -204,20 +203,17 @@ def save_model(
             extra_pip_requirements,
         )
     else:
-        conda_env, pip_requirements, pip_constraints = _process_conda_env(
-            conda_env)
+        conda_env, pip_requirements, pip_constraints = _process_conda_env(conda_env)
 
     with open(os.path.join(path, _CONDA_ENV_FILE_NAME), "w") as f:
         yaml.safe_dump(conda_env, stream=f, default_flow_style=False)
 
     # Save `constraints.txt` if necessary
     if pip_constraints:
-        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME),
-                 "\n".join(pip_constraints))
+        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME), "\n".join(pip_constraints))
 
     # Save `requirements.txt`
-    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME),
-             "\n".join(pip_requirements))
+    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME), "\n".join(pip_requirements))
 
 
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
@@ -389,14 +385,11 @@ def load_model(model_uri, dst_path=None):
         loaded_model = mlflow.fastai.load_model(model_uri)
         results = loaded_model.predict(predict_data)
     """
-    local_model_path = _download_artifact_from_uri(
-        artifact_uri=model_uri, output_path=dst_path)
-    flavor_conf = _get_flavor_configuration(
-        model_path=local_model_path, flavor_name=FLAVOR_NAME)
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
+    flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     _add_code_from_conf_to_system_path(local_model_path, flavor_conf)
 
-    model_file_path = os.path.join(
-        local_model_path, flavor_conf.get("data", "model.fastai"))
+    model_file_path = os.path.join(local_model_path, flavor_conf.get("data", "model.fastai"))
     return _load_model(path=model_file_path)
 
 
@@ -537,8 +530,7 @@ def autolog(
     def _log_model_info(learner):
         # The process excuted here, are incompatible with TrackerCallback
         # Hence it is removed and add again after the execution
-        remove_cbs = [cb for cb in learner.cbs if isinstance(
-            cb, TrackerCallback)]
+        remove_cbs = [cb for cb in learner.cbs if isinstance(cb, TrackerCallback)]
         if remove_cbs:
             learner.remove_cbs(remove_cbs)
 
@@ -568,20 +560,17 @@ def autolog(
         # Check if is trying to fit while fine tuning or not
         mlflow_cbs = [cb for cb in self.cbs if cb.name == "___mlflow_fastai"]
         fit_in_fine_tune = (
-            original.__name__ == "fit" and len(
-                mlflow_cbs) > 0 and mlflow_cbs[0].is_fine_tune
+            original.__name__ == "fit" and len(mlflow_cbs) > 0 and mlflow_cbs[0].is_fine_tune
         )
 
         if not fit_in_fine_tune:
-            log_fn_args_as_params(original, list(
-                args), kwargs, unlogged_params)
+            log_fn_args_as_params(original, list(args), kwargs, unlogged_params)
 
         run_id = mlflow.active_run().info.run_id
         with batch_metrics_logger(run_id) as metrics_logger:
 
             if not fit_in_fine_tune:
-                early_stop_callback = _find_callback_of_type(
-                    EarlyStoppingCallback, self.cbs)
+                early_stop_callback = _find_callback_of_type(EarlyStoppingCallback, self.cbs)
                 _log_early_stop_callback_params(early_stop_callback)
 
                 # First try to remove if any already registered callback

--- a/mlflow/fastai/__init__.py
+++ b/mlflow/fastai/__init__.py
@@ -42,6 +42,7 @@ from mlflow.utils.model_utils import (
     _get_flavor_configuration,
     _validate_and_copy_code_paths,
     _add_code_from_conf_to_system_path,
+    _validate_and_prepare_target_save_path
 )
 from mlflow.utils.autologging_utils import (
     log_fn_args_as_params,
@@ -149,12 +150,10 @@ def save_model(
     _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
 
     path = os.path.abspath(path)
-    if os.path.exists(path):
-        raise MlflowException("Path '{}' already exists".format(path))
+    _validate_and_prepare_target_save_path(path)
     model_data_subpath = "model.fastai"
     model_data_path = os.path.join(path, model_data_subpath)
     model_data_path = Path(model_data_path)
-    os.makedirs(path)
     code_dir_subpath = _validate_and_copy_code_paths(code_paths, path)
 
     if mlflow_model is None:

--- a/mlflow/fastai/__init__.py
+++ b/mlflow/fastai/__init__.py
@@ -22,7 +22,6 @@ import numpy as np
 from mlflow import pyfunc
 from mlflow.models import Model, ModelSignature, ModelInputExample
 import mlflow.tracking
-from mlflow.exceptions import MlflowException
 from mlflow.models.utils import _save_example
 from mlflow.models.model import MLMODEL_FILE_NAME
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
@@ -147,7 +146,8 @@ def save_model(
     from fastai.callback.all import ParamScheduler
     from pathlib import Path
 
-    _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
+    _validate_env_arguments(conda_env, pip_requirements,
+                            extra_pip_requirements)
 
     path = os.path.abspath(path)
     _validate_and_prepare_target_save_path(path)
@@ -204,17 +204,20 @@ def save_model(
             extra_pip_requirements,
         )
     else:
-        conda_env, pip_requirements, pip_constraints = _process_conda_env(conda_env)
+        conda_env, pip_requirements, pip_constraints = _process_conda_env(
+            conda_env)
 
     with open(os.path.join(path, _CONDA_ENV_FILE_NAME), "w") as f:
         yaml.safe_dump(conda_env, stream=f, default_flow_style=False)
 
     # Save `constraints.txt` if necessary
     if pip_constraints:
-        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME), "\n".join(pip_constraints))
+        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME),
+                 "\n".join(pip_constraints))
 
     # Save `requirements.txt`
-    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME), "\n".join(pip_requirements))
+    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME),
+             "\n".join(pip_requirements))
 
 
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
@@ -386,11 +389,14 @@ def load_model(model_uri, dst_path=None):
         loaded_model = mlflow.fastai.load_model(model_uri)
         results = loaded_model.predict(predict_data)
     """
-    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
-    flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
+    local_model_path = _download_artifact_from_uri(
+        artifact_uri=model_uri, output_path=dst_path)
+    flavor_conf = _get_flavor_configuration(
+        model_path=local_model_path, flavor_name=FLAVOR_NAME)
     _add_code_from_conf_to_system_path(local_model_path, flavor_conf)
 
-    model_file_path = os.path.join(local_model_path, flavor_conf.get("data", "model.fastai"))
+    model_file_path = os.path.join(
+        local_model_path, flavor_conf.get("data", "model.fastai"))
     return _load_model(path=model_file_path)
 
 
@@ -531,7 +537,8 @@ def autolog(
     def _log_model_info(learner):
         # The process excuted here, are incompatible with TrackerCallback
         # Hence it is removed and add again after the execution
-        remove_cbs = [cb for cb in learner.cbs if isinstance(cb, TrackerCallback)]
+        remove_cbs = [cb for cb in learner.cbs if isinstance(
+            cb, TrackerCallback)]
         if remove_cbs:
             learner.remove_cbs(remove_cbs)
 
@@ -561,17 +568,20 @@ def autolog(
         # Check if is trying to fit while fine tuning or not
         mlflow_cbs = [cb for cb in self.cbs if cb.name == "___mlflow_fastai"]
         fit_in_fine_tune = (
-            original.__name__ == "fit" and len(mlflow_cbs) > 0 and mlflow_cbs[0].is_fine_tune
+            original.__name__ == "fit" and len(
+                mlflow_cbs) > 0 and mlflow_cbs[0].is_fine_tune
         )
 
         if not fit_in_fine_tune:
-            log_fn_args_as_params(original, list(args), kwargs, unlogged_params)
+            log_fn_args_as_params(original, list(
+                args), kwargs, unlogged_params)
 
         run_id = mlflow.active_run().info.run_id
         with batch_metrics_logger(run_id) as metrics_logger:
 
             if not fit_in_fine_tune:
-                early_stop_callback = _find_callback_of_type(EarlyStoppingCallback, self.cbs)
+                early_stop_callback = _find_callback_of_type(
+                    EarlyStoppingCallback, self.cbs)
                 _log_early_stop_callback_params(early_stop_callback)
 
                 # First try to remove if any already registered callback

--- a/mlflow/gluon/__init__.py
+++ b/mlflow/gluon/__init__.py
@@ -16,6 +16,7 @@ from mlflow.utils.model_utils import (
     _get_flavor_configuration,
     _validate_and_copy_code_paths,
     _add_code_from_conf_to_system_path,
+    _validate_and_prepare_target_save_path
 )
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.environment import (
@@ -209,8 +210,7 @@ def save_model(
 
     _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
     path = os.path.abspath(path)
-    if os.path.exists(path):
-        raise MlflowException("Path '{}' already exists".format(path))
+    _validate_and_prepare_target_save_path(path)
     data_subpath = "data"
     data_path = os.path.join(path, data_subpath)
     os.makedirs(data_path)

--- a/mlflow/gluon/__init__.py
+++ b/mlflow/gluon/__init__.py
@@ -15,7 +15,7 @@ from mlflow.utils.model_utils import (
     _get_flavor_configuration,
     _validate_and_copy_code_paths,
     _add_code_from_conf_to_system_path,
-    _validate_and_prepare_target_save_path
+    _validate_and_prepare_target_save_path,
 )
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.environment import (
@@ -74,16 +74,12 @@ def load_model(model_uri, ctx, dst_path=None):
     from mxnet import gluon
     from mxnet import sym
 
-    local_model_path = _download_artifact_from_uri(
-        artifact_uri=model_uri, output_path=dst_path)
-    flavor_conf = _get_flavor_configuration(
-        model_path=local_model_path, flavor_name=FLAVOR_NAME)
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
+    flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     _add_code_from_conf_to_system_path(local_model_path, flavor_conf)
 
-    model_arch_path = os.path.join(
-        local_model_path, "data", _MODEL_SAVE_PATH) + "-symbol.json"
-    model_params_path = os.path.join(
-        local_model_path, "data", _MODEL_SAVE_PATH) + "-0000.params"
+    model_arch_path = os.path.join(local_model_path, "data", _MODEL_SAVE_PATH) + "-symbol.json"
+    model_params_path = os.path.join(local_model_path, "data", _MODEL_SAVE_PATH) + "-0000.params"
 
     if Version(mx.__version__) >= Version("2.0.0"):
         return gluon.SymbolBlock.imports(
@@ -127,8 +123,7 @@ class _GluonModelWrapper:
                 preds = preds.asnumpy()
             return preds
         else:
-            raise TypeError(
-                "Input data should be pandas.DataFrame or numpy.ndarray")
+            raise TypeError("Input data should be pandas.DataFrame or numpy.ndarray")
 
 
 def _load_pyfunc(path):
@@ -212,8 +207,7 @@ def save_model(
     """
     import mxnet as mx
 
-    _validate_env_arguments(conda_env, pip_requirements,
-                            extra_pip_requirements)
+    _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
     path = os.path.abspath(path)
     _validate_and_prepare_target_save_path(path)
     data_subpath = "data"
@@ -234,8 +228,7 @@ def save_model(
     pyfunc.add_to_model(
         mlflow_model, loader_module="mlflow.gluon", env=_CONDA_ENV_FILE_NAME, code=code_dir_subpath
     )
-    mlflow_model.add_flavor(
-        FLAVOR_NAME, mxnet_version=mx.__version__, code=code_dir_subpath)
+    mlflow_model.add_flavor(FLAVOR_NAME, mxnet_version=mx.__version__, code=code_dir_subpath)
     mlflow_model.save(os.path.join(path, MLMODEL_FILE_NAME))
 
     if conda_env is None:
@@ -255,20 +248,17 @@ def save_model(
             extra_pip_requirements,
         )
     else:
-        conda_env, pip_requirements, pip_constraints = _process_conda_env(
-            conda_env)
+        conda_env, pip_requirements, pip_constraints = _process_conda_env(conda_env)
 
     with open(os.path.join(path, _CONDA_ENV_FILE_NAME), "w") as f:
         yaml.safe_dump(conda_env, stream=f, default_flow_style=False)
 
     # Save `constraints.txt` if necessary
     if pip_constraints:
-        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME),
-                 "\n".join(pip_constraints))
+        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME), "\n".join(pip_constraints))
 
     # Save `requirements.txt`
-    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME),
-             "\n".join(pip_requirements))
+    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME), "\n".join(pip_requirements))
 
 
 def get_default_pip_requirements():

--- a/mlflow/gluon/__init__.py
+++ b/mlflow/gluon/__init__.py
@@ -7,7 +7,6 @@ import yaml
 
 import mlflow
 from mlflow import pyfunc
-from mlflow.exceptions import MlflowException
 from mlflow.models import Model
 from mlflow.models.model import MLMODEL_FILE_NAME
 from mlflow.models.signature import ModelSignature
@@ -75,12 +74,16 @@ def load_model(model_uri, ctx, dst_path=None):
     from mxnet import gluon
     from mxnet import sym
 
-    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
-    flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
+    local_model_path = _download_artifact_from_uri(
+        artifact_uri=model_uri, output_path=dst_path)
+    flavor_conf = _get_flavor_configuration(
+        model_path=local_model_path, flavor_name=FLAVOR_NAME)
     _add_code_from_conf_to_system_path(local_model_path, flavor_conf)
 
-    model_arch_path = os.path.join(local_model_path, "data", _MODEL_SAVE_PATH) + "-symbol.json"
-    model_params_path = os.path.join(local_model_path, "data", _MODEL_SAVE_PATH) + "-0000.params"
+    model_arch_path = os.path.join(
+        local_model_path, "data", _MODEL_SAVE_PATH) + "-symbol.json"
+    model_params_path = os.path.join(
+        local_model_path, "data", _MODEL_SAVE_PATH) + "-0000.params"
 
     if Version(mx.__version__) >= Version("2.0.0"):
         return gluon.SymbolBlock.imports(
@@ -124,7 +127,8 @@ class _GluonModelWrapper:
                 preds = preds.asnumpy()
             return preds
         else:
-            raise TypeError("Input data should be pandas.DataFrame or numpy.ndarray")
+            raise TypeError(
+                "Input data should be pandas.DataFrame or numpy.ndarray")
 
 
 def _load_pyfunc(path):
@@ -208,7 +212,8 @@ def save_model(
     """
     import mxnet as mx
 
-    _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
+    _validate_env_arguments(conda_env, pip_requirements,
+                            extra_pip_requirements)
     path = os.path.abspath(path)
     _validate_and_prepare_target_save_path(path)
     data_subpath = "data"
@@ -229,7 +234,8 @@ def save_model(
     pyfunc.add_to_model(
         mlflow_model, loader_module="mlflow.gluon", env=_CONDA_ENV_FILE_NAME, code=code_dir_subpath
     )
-    mlflow_model.add_flavor(FLAVOR_NAME, mxnet_version=mx.__version__, code=code_dir_subpath)
+    mlflow_model.add_flavor(
+        FLAVOR_NAME, mxnet_version=mx.__version__, code=code_dir_subpath)
     mlflow_model.save(os.path.join(path, MLMODEL_FILE_NAME))
 
     if conda_env is None:
@@ -249,17 +255,20 @@ def save_model(
             extra_pip_requirements,
         )
     else:
-        conda_env, pip_requirements, pip_constraints = _process_conda_env(conda_env)
+        conda_env, pip_requirements, pip_constraints = _process_conda_env(
+            conda_env)
 
     with open(os.path.join(path, _CONDA_ENV_FILE_NAME), "w") as f:
         yaml.safe_dump(conda_env, stream=f, default_flow_style=False)
 
     # Save `constraints.txt` if necessary
     if pip_constraints:
-        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME), "\n".join(pip_constraints))
+        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME),
+                 "\n".join(pip_constraints))
 
     # Save `requirements.txt`
-    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME), "\n".join(pip_requirements))
+    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME),
+             "\n".join(pip_requirements))
 
 
 def get_default_pip_requirements():

--- a/mlflow/h2o.py
+++ b/mlflow/h2o.py
@@ -36,6 +36,7 @@ from mlflow.utils.model_utils import (
     _get_flavor_configuration,
     _validate_and_copy_code_paths,
     _add_code_from_conf_to_system_path,
+    _validate_and_prepare_target_save_path
 )
 
 FLAVOR_NAME = "h2o"
@@ -106,8 +107,7 @@ def save_model(
     _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
 
     path = os.path.abspath(path)
-    if os.path.exists(path):
-        raise Exception("Path '{}' already exists".format(path))
+    _validate_and_prepare_target_save_path(path)
     model_data_subpath = "model.h2o"
     model_data_path = os.path.join(path, model_data_subpath)
     os.makedirs(model_data_path)

--- a/mlflow/h2o.py
+++ b/mlflow/h2o.py
@@ -36,7 +36,7 @@ from mlflow.utils.model_utils import (
     _get_flavor_configuration,
     _validate_and_copy_code_paths,
     _add_code_from_conf_to_system_path,
-    _validate_and_prepare_target_save_path
+    _validate_and_prepare_target_save_path,
 )
 
 FLAVOR_NAME = "h2o"

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -42,7 +42,7 @@ from mlflow.utils.model_utils import (
     _get_flavor_configuration,
     _validate_and_copy_code_paths,
     _add_code_from_conf_to_system_path,
-    _validate_and_prepare_target_save_path
+    _validate_and_prepare_target_save_path,
 )
 from mlflow.utils.autologging_utils import (
     autologging_integration,

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -42,6 +42,7 @@ from mlflow.utils.model_utils import (
     _get_flavor_configuration,
     _validate_and_copy_code_paths,
     _add_code_from_conf_to_system_path,
+    _validate_and_prepare_target_save_path
 )
 from mlflow.utils.autologging_utils import (
     autologging_integration,
@@ -217,8 +218,7 @@ def save_model(
 
     # check if path exists
     path = os.path.abspath(path)
-    if os.path.exists(path):
-        raise MlflowException("Path '{}' already exists".format(path))
+    _validate_and_prepare_target_save_path(path)
 
     # construct new data folder in existing path
     data_subpath = "data"

--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -51,7 +51,7 @@ from mlflow.utils.model_utils import (
     _get_flavor_configuration,
     _validate_and_copy_code_paths,
     _add_code_from_conf_to_system_path,
-    _validate_and_prepare_target_save_path
+    _validate_and_prepare_target_save_path,
 )
 from mlflow.utils.arguments_utils import _get_arg_names
 from mlflow.utils.autologging_utils import (
@@ -140,13 +140,11 @@ def save_model(
     """
     import lightgbm as lgb
 
-    _validate_env_arguments(conda_env, pip_requirements,
-                            extra_pip_requirements)
+    _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
 
     path = os.path.abspath(path)
     _validate_and_prepare_target_save_path(path)
-    model_data_subpath = "model.lgb" if isinstance(
-        lgb_model, lgb.Booster) else "model.pkl"
+    model_data_subpath = "model.lgb" if isinstance(lgb_model, lgb.Booster) else "model.pkl"
     model_data_path = os.path.join(path, model_data_subpath)
     os.makedirs(path)
     code_dir_subpath = _validate_and_copy_code_paths(code_paths, path)
@@ -199,20 +197,17 @@ def save_model(
             extra_pip_requirements,
         )
     else:
-        conda_env, pip_requirements, pip_constraints = _process_conda_env(
-            conda_env)
+        conda_env, pip_requirements, pip_constraints = _process_conda_env(conda_env)
 
     with open(os.path.join(path, _CONDA_ENV_FILE_NAME), "w") as f:
         yaml.safe_dump(conda_env, stream=f, default_flow_style=False)
 
     # Save `constraints.txt` if necessary
     if pip_constraints:
-        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME),
-                 "\n".join(pip_constraints))
+        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME), "\n".join(pip_constraints))
 
     # Save `requirements.txt`
-    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME),
-             "\n".join(pip_requirements))
+    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME), "\n".join(pip_requirements))
 
 
 def _save_model(lgb_model, model_path):
@@ -311,8 +306,7 @@ def _load_model(path):
     """
 
     model_dir = os.path.dirname(path) if os.path.isfile(path) else path
-    flavor_conf = _get_flavor_configuration(
-        model_path=model_dir, flavor_name=FLAVOR_NAME)
+    flavor_conf = _get_flavor_configuration(model_path=model_dir, flavor_name=FLAVOR_NAME)
 
     model_class = flavor_conf.get("model_class", "lightgbm.basic.Booster")
     lgb_model_path = os.path.join(model_dir, flavor_conf.get("data"))
@@ -361,8 +355,7 @@ def load_model(model_uri, dst_path=None):
     :return: A LightGBM model (an instance of `lightgbm.Booster`_) or a LightGBM scikit-learn
              model, depending on the saved model class specification.
     """
-    local_model_path = _download_artifact_from_uri(
-        artifact_uri=model_uri, output_path=dst_path)
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
     flavor_conf = _get_flavor_configuration(local_model_path, FLAVOR_NAME)
     _add_code_from_conf_to_system_path(local_model_path, flavor_conf)
     return _load_model(path=local_model_path)
@@ -507,8 +500,7 @@ def autolog(
             tmpdir = tempfile.mkdtemp()
             try:
                 # pylint: disable=undefined-loop-variable
-                filepath = os.path.join(
-                    tmpdir, "feature_importance_{}.png".format(imp_type))
+                filepath = os.path.join(tmpdir, "feature_importance_{}.png".format(imp_type))
                 fig.savefig(filepath)
                 mlflow.log_artifact(filepath)
             finally:
@@ -520,8 +512,7 @@ def autolog(
         # logging booster params separately via mlflow.log_params to extract key/value pairs
         # and make it easier to compare them across runs.
         booster_params = args[0] if len(args) > 0 else kwargs["params"]
-        autologging_client.log_params(
-            run_id=mlflow.active_run().info.run_id, params=booster_params)
+        autologging_client.log_params(run_id=mlflow.active_run().info.run_id, params=booster_params)
 
         unlogged_params = [
             "params",
@@ -589,8 +580,7 @@ def autolog(
                     metrics=last_iter_results,
                     step=extra_step,
                 )
-                early_stopping_logging_operations = autologging_client.flush(
-                    synchronous=False)
+                early_stopping_logging_operations = autologging_client.flush(synchronous=False)
 
         # logging feature importance as artifacts.
         for imp_type in ["split", "gain"]:
@@ -607,8 +597,7 @@ def autolog(
             imp = {ft: imp for ft, imp in zip(features, importance.tolist())}
             tmpdir = tempfile.mkdtemp()
             try:
-                filepath = os.path.join(
-                    tmpdir, "feature_importance_{}.json".format(imp_type))
+                filepath = os.path.join(tmpdir, "feature_importance_{}.json".format(imp_type))
                 with open(filepath, "w") as f:
                     json.dump(imp, f, indent=2)
                 mlflow.log_artifact(filepath)

--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -146,7 +146,6 @@ def save_model(
     _validate_and_prepare_target_save_path(path)
     model_data_subpath = "model.lgb" if isinstance(lgb_model, lgb.Booster) else "model.pkl"
     model_data_path = os.path.join(path, model_data_subpath)
-    os.makedirs(path)
     code_dir_subpath = _validate_and_copy_code_paths(code_paths, path)
 
     if mlflow_model is None:

--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -51,6 +51,7 @@ from mlflow.utils.model_utils import (
     _get_flavor_configuration,
     _validate_and_copy_code_paths,
     _add_code_from_conf_to_system_path,
+    _validate_and_prepare_target_save_path
 )
 from mlflow.exceptions import MlflowException
 from mlflow.utils.arguments_utils import _get_arg_names
@@ -140,12 +141,13 @@ def save_model(
     """
     import lightgbm as lgb
 
-    _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
+    _validate_env_arguments(conda_env, pip_requirements,
+                            extra_pip_requirements)
 
     path = os.path.abspath(path)
-    if os.path.exists(path):
-        raise MlflowException("Path '{}' already exists".format(path))
-    model_data_subpath = "model.lgb" if isinstance(lgb_model, lgb.Booster) else "model.pkl"
+    _validate_and_prepare_target_save_path(path)
+    model_data_subpath = "model.lgb" if isinstance(
+        lgb_model, lgb.Booster) else "model.pkl"
     model_data_path = os.path.join(path, model_data_subpath)
     os.makedirs(path)
     code_dir_subpath = _validate_and_copy_code_paths(code_paths, path)
@@ -198,17 +200,20 @@ def save_model(
             extra_pip_requirements,
         )
     else:
-        conda_env, pip_requirements, pip_constraints = _process_conda_env(conda_env)
+        conda_env, pip_requirements, pip_constraints = _process_conda_env(
+            conda_env)
 
     with open(os.path.join(path, _CONDA_ENV_FILE_NAME), "w") as f:
         yaml.safe_dump(conda_env, stream=f, default_flow_style=False)
 
     # Save `constraints.txt` if necessary
     if pip_constraints:
-        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME), "\n".join(pip_constraints))
+        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME),
+                 "\n".join(pip_constraints))
 
     # Save `requirements.txt`
-    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME), "\n".join(pip_requirements))
+    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME),
+             "\n".join(pip_requirements))
 
 
 def _save_model(lgb_model, model_path):
@@ -307,7 +312,8 @@ def _load_model(path):
     """
 
     model_dir = os.path.dirname(path) if os.path.isfile(path) else path
-    flavor_conf = _get_flavor_configuration(model_path=model_dir, flavor_name=FLAVOR_NAME)
+    flavor_conf = _get_flavor_configuration(
+        model_path=model_dir, flavor_name=FLAVOR_NAME)
 
     model_class = flavor_conf.get("model_class", "lightgbm.basic.Booster")
     lgb_model_path = os.path.join(model_dir, flavor_conf.get("data"))
@@ -356,7 +362,8 @@ def load_model(model_uri, dst_path=None):
     :return: A LightGBM model (an instance of `lightgbm.Booster`_) or a LightGBM scikit-learn
              model, depending on the saved model class specification.
     """
-    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
+    local_model_path = _download_artifact_from_uri(
+        artifact_uri=model_uri, output_path=dst_path)
     flavor_conf = _get_flavor_configuration(local_model_path, FLAVOR_NAME)
     _add_code_from_conf_to_system_path(local_model_path, flavor_conf)
     return _load_model(path=local_model_path)
@@ -501,7 +508,8 @@ def autolog(
             tmpdir = tempfile.mkdtemp()
             try:
                 # pylint: disable=undefined-loop-variable
-                filepath = os.path.join(tmpdir, "feature_importance_{}.png".format(imp_type))
+                filepath = os.path.join(
+                    tmpdir, "feature_importance_{}.png".format(imp_type))
                 fig.savefig(filepath)
                 mlflow.log_artifact(filepath)
             finally:
@@ -513,7 +521,8 @@ def autolog(
         # logging booster params separately via mlflow.log_params to extract key/value pairs
         # and make it easier to compare them across runs.
         booster_params = args[0] if len(args) > 0 else kwargs["params"]
-        autologging_client.log_params(run_id=mlflow.active_run().info.run_id, params=booster_params)
+        autologging_client.log_params(
+            run_id=mlflow.active_run().info.run_id, params=booster_params)
 
         unlogged_params = [
             "params",
@@ -581,7 +590,8 @@ def autolog(
                     metrics=last_iter_results,
                     step=extra_step,
                 )
-                early_stopping_logging_operations = autologging_client.flush(synchronous=False)
+                early_stopping_logging_operations = autologging_client.flush(
+                    synchronous=False)
 
         # logging feature importance as artifacts.
         for imp_type in ["split", "gain"]:
@@ -598,7 +608,8 @@ def autolog(
             imp = {ft: imp for ft, imp in zip(features, importance.tolist())}
             tmpdir = tempfile.mkdtemp()
             try:
-                filepath = os.path.join(tmpdir, "feature_importance_{}.json".format(imp_type))
+                filepath = os.path.join(
+                    tmpdir, "feature_importance_{}.json".format(imp_type))
                 with open(filepath, "w") as f:
                     json.dump(imp, f, indent=2)
                 mlflow.log_artifact(filepath)

--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -53,7 +53,6 @@ from mlflow.utils.model_utils import (
     _add_code_from_conf_to_system_path,
     _validate_and_prepare_target_save_path
 )
-from mlflow.exceptions import MlflowException
 from mlflow.utils.arguments_utils import _get_arg_names
 from mlflow.utils.autologging_utils import (
     autologging_integration,

--- a/mlflow/onnx.py
+++ b/mlflow/onnx.py
@@ -40,6 +40,7 @@ from mlflow.utils.model_utils import (
     _get_flavor_configuration,
     _validate_and_copy_code_paths,
     _add_code_from_conf_to_system_path,
+    _validate_and_prepare_target_save_path
 )
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 
@@ -137,11 +138,7 @@ def save_model(
     _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
 
     path = os.path.abspath(path)
-    if os.path.exists(path):
-        raise MlflowException(
-            message="Path '{}' already exists".format(path), error_code=RESOURCE_ALREADY_EXISTS
-        )
-    os.makedirs(path)
+    _validate_and_prepare_target_save_path(path)
     code_dir_subpath = _validate_and_copy_code_paths(code_paths, path)
 
     if mlflow_model is None:

--- a/mlflow/onnx.py
+++ b/mlflow/onnx.py
@@ -39,7 +39,7 @@ from mlflow.utils.model_utils import (
     _get_flavor_configuration,
     _validate_and_copy_code_paths,
     _add_code_from_conf_to_system_path,
-    _validate_and_prepare_target_save_path
+    _validate_and_prepare_target_save_path,
 )
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 
@@ -134,8 +134,7 @@ def save_model(
     if onnx_execution_providers is None:
         onnx_execution_providers = ONNX_EXECUTION_PROVIDERS
 
-    _validate_env_arguments(conda_env, pip_requirements,
-                            extra_pip_requirements)
+    _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
 
     path = os.path.abspath(path)
     _validate_and_prepare_target_save_path(path)
@@ -188,20 +187,17 @@ def save_model(
             extra_pip_requirements,
         )
     else:
-        conda_env, pip_requirements, pip_constraints = _process_conda_env(
-            conda_env)
+        conda_env, pip_requirements, pip_constraints = _process_conda_env(conda_env)
 
     with open(os.path.join(path, _CONDA_ENV_FILE_NAME), "w") as f:
         yaml.safe_dump(conda_env, stream=f, default_flow_style=False)
 
     # Save `constraints.txt` if necessary
     if pip_constraints:
-        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME),
-                 "\n".join(pip_constraints))
+        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME), "\n".join(pip_constraints))
 
     # Save `requirements.txt`
-    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME),
-             "\n".join(pip_requirements))
+    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME), "\n".join(pip_requirements))
 
 
 def _load_model(model_file):
@@ -313,8 +309,7 @@ class _OnnxModelWrapper:
             feed_dict = {self.inputs[0][0]: data}
         elif isinstance(data, pd.DataFrame):
             if len(self.inputs) > 1:
-                feed_dict = {name: data[name].values for (
-                    name, _) in self.inputs}
+                feed_dict = {name: data[name].values for (name, _) in self.inputs}
             else:
                 feed_dict = {self.inputs[0][0]: data.values}
 
@@ -342,8 +337,7 @@ class _OnnxModelWrapper:
                 return data.reshape(-1)
 
             response = pd.DataFrame.from_dict(
-                {c: format_output(p) for (c, p) in zip(
-                    self.output_names, predicted)}
+                {c: format_output(p) for (c, p) in zip(self.output_names, predicted)}
             )
             return response
         else:
@@ -381,13 +375,10 @@ def load_model(model_uri, dst_path=None):
     :return: An ONNX model instance.
 
     """
-    local_model_path = _download_artifact_from_uri(
-        artifact_uri=model_uri, output_path=dst_path)
-    flavor_conf = _get_flavor_configuration(
-        model_path=local_model_path, flavor_name=FLAVOR_NAME)
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
+    flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     _add_code_from_conf_to_system_path(local_model_path, flavor_conf)
-    onnx_model_artifacts_path = os.path.join(
-        local_model_path, flavor_conf["data"])
+    onnx_model_artifacts_path = os.path.join(local_model_path, flavor_conf["data"])
     return _load_model(model_file=onnx_model_artifacts_path)
 
 

--- a/mlflow/onnx.py
+++ b/mlflow/onnx.py
@@ -21,7 +21,6 @@ import mlflow.tracking
 from mlflow.exceptions import MlflowException
 from mlflow.models.signature import ModelSignature
 from mlflow.models.utils import ModelInputExample, _save_example
-from mlflow.protos.databricks_pb2 import RESOURCE_ALREADY_EXISTS
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.annotations import experimental
 from mlflow.utils.environment import (
@@ -135,7 +134,8 @@ def save_model(
     if onnx_execution_providers is None:
         onnx_execution_providers = ONNX_EXECUTION_PROVIDERS
 
-    _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
+    _validate_env_arguments(conda_env, pip_requirements,
+                            extra_pip_requirements)
 
     path = os.path.abspath(path)
     _validate_and_prepare_target_save_path(path)
@@ -188,17 +188,20 @@ def save_model(
             extra_pip_requirements,
         )
     else:
-        conda_env, pip_requirements, pip_constraints = _process_conda_env(conda_env)
+        conda_env, pip_requirements, pip_constraints = _process_conda_env(
+            conda_env)
 
     with open(os.path.join(path, _CONDA_ENV_FILE_NAME), "w") as f:
         yaml.safe_dump(conda_env, stream=f, default_flow_style=False)
 
     # Save `constraints.txt` if necessary
     if pip_constraints:
-        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME), "\n".join(pip_constraints))
+        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME),
+                 "\n".join(pip_constraints))
 
     # Save `requirements.txt`
-    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME), "\n".join(pip_requirements))
+    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME),
+             "\n".join(pip_requirements))
 
 
 def _load_model(model_file):
@@ -310,7 +313,8 @@ class _OnnxModelWrapper:
             feed_dict = {self.inputs[0][0]: data}
         elif isinstance(data, pd.DataFrame):
             if len(self.inputs) > 1:
-                feed_dict = {name: data[name].values for (name, _) in self.inputs}
+                feed_dict = {name: data[name].values for (
+                    name, _) in self.inputs}
             else:
                 feed_dict = {self.inputs[0][0]: data.values}
 
@@ -338,7 +342,8 @@ class _OnnxModelWrapper:
                 return data.reshape(-1)
 
             response = pd.DataFrame.from_dict(
-                {c: format_output(p) for (c, p) in zip(self.output_names, predicted)}
+                {c: format_output(p) for (c, p) in zip(
+                    self.output_names, predicted)}
             )
             return response
         else:
@@ -376,10 +381,13 @@ def load_model(model_uri, dst_path=None):
     :return: An ONNX model instance.
 
     """
-    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
-    flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
+    local_model_path = _download_artifact_from_uri(
+        artifact_uri=model_uri, output_path=dst_path)
+    flavor_conf = _get_flavor_configuration(
+        model_path=local_model_path, flavor_name=FLAVOR_NAME)
     _add_code_from_conf_to_system_path(local_model_path, flavor_conf)
-    onnx_model_artifacts_path = os.path.join(local_model_path, flavor_conf["data"])
+    onnx_model_artifacts_path = os.path.join(
+        local_model_path, flavor_conf["data"])
     return _load_model(model_file=onnx_model_artifacts_path)
 
 

--- a/mlflow/paddle/__init__.py
+++ b/mlflow/paddle/__init__.py
@@ -17,12 +17,10 @@ import yaml
 
 import mlflow
 from mlflow import pyfunc
-from mlflow.exceptions import MlflowException
 from mlflow.models import Model
 from mlflow.models.model import MLMODEL_FILE_NAME
 from mlflow.models.signature import ModelSignature
 from mlflow.models.utils import ModelInputExample, _save_example
-from mlflow.protos.databricks_pb2 import RESOURCE_ALREADY_EXISTS
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.environment import (
     _mlflow_conda_env,
@@ -199,7 +197,8 @@ def save_model(
     """
     import paddle
 
-    _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
+    _validate_env_arguments(conda_env, pip_requirements,
+                            extra_pip_requirements)
 
     _validate_and_prepare_target_save_path(path)
     code_dir_subpath = _validate_and_copy_code_paths(code_paths, path)
@@ -254,17 +253,20 @@ def save_model(
             extra_pip_requirements,
         )
     else:
-        conda_env, pip_requirements, pip_constraints = _process_conda_env(conda_env)
+        conda_env, pip_requirements, pip_constraints = _process_conda_env(
+            conda_env)
 
     with open(os.path.join(path, _CONDA_ENV_FILE_NAME), "w") as f:
         yaml.safe_dump(conda_env, stream=f, default_flow_style=False)
 
     # Save `constraints.txt` if necessary
     if pip_constraints:
-        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME), "\n".join(pip_constraints))
+        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME),
+                 "\n".join(pip_constraints))
 
     # Save `requirements.txt`
-    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME), "\n".join(pip_requirements))
+    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME),
+             "\n".join(pip_requirements))
 
 
 def load_model(model_uri, model=None, dst_path=None, **kwargs):
@@ -303,15 +305,19 @@ def load_model(model_uri, model=None, dst_path=None, **kwargs):
     """
     import paddle
 
-    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
-    flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
+    local_model_path = _download_artifact_from_uri(
+        artifact_uri=model_uri, output_path=dst_path)
+    flavor_conf = _get_flavor_configuration(
+        model_path=local_model_path, flavor_name=FLAVOR_NAME)
     _add_code_from_conf_to_system_path(local_model_path, flavor_conf)
-    pd_model_artifacts_path = os.path.join(local_model_path, flavor_conf["pickled_model"])
+    pd_model_artifacts_path = os.path.join(
+        local_model_path, flavor_conf["pickled_model"])
     if model is None:
         return paddle.jit.load(pd_model_artifacts_path, **kwargs)
     elif not isinstance(model, paddle.Model):
         raise TypeError(
-            "Invalid object type `{}` for `model`, must be `paddle.Model`".format(type(model))
+            "Invalid object type `{}` for `model`, must be `paddle.Model`".format(
+                type(model))
         )
     else:
         contains_pdparams = _contains_pdparams(local_model_path)
@@ -340,7 +346,6 @@ def log_model(
     pip_requirements=None,
     extra_pip_requirements=None,
 ):
-
     """
     Log a paddle model as an MLflow artifact for the current run. Produces an MLflow Model
     containing the following flavors:
@@ -457,7 +462,8 @@ class _PaddleWrapper:
                 "Please use a pandas.DataFrame or a numpy.ndarray"
             )
         else:
-            raise TypeError("Input data should be pandas.DataFrame or numpy.ndarray")
+            raise TypeError(
+                "Input data should be pandas.DataFrame or numpy.ndarray")
         inp_data = np.squeeze(inp_data)
 
         self.pd_model.eval()

--- a/mlflow/paddle/__init__.py
+++ b/mlflow/paddle/__init__.py
@@ -40,6 +40,7 @@ from mlflow.utils.model_utils import (
     _get_flavor_configuration,
     _validate_and_copy_code_paths,
     _add_code_from_conf_to_system_path,
+    _validate_and_prepare_target_save_path
 )
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.utils.autologging_utils import autologging_integration, safe_patch
@@ -200,12 +201,7 @@ def save_model(
 
     _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
 
-    if os.path.exists(path):
-        raise MlflowException(
-            message="Path '{}' already exists".format(path), error_code=RESOURCE_ALREADY_EXISTS
-        )
-
-    os.makedirs(path)
+    _validate_and_prepare_target_save_path(path)
     code_dir_subpath = _validate_and_copy_code_paths(code_paths, path)
 
     if mlflow_model is None:

--- a/mlflow/paddle/__init__.py
+++ b/mlflow/paddle/__init__.py
@@ -38,7 +38,7 @@ from mlflow.utils.model_utils import (
     _get_flavor_configuration,
     _validate_and_copy_code_paths,
     _add_code_from_conf_to_system_path,
-    _validate_and_prepare_target_save_path
+    _validate_and_prepare_target_save_path,
 )
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.utils.autologging_utils import autologging_integration, safe_patch
@@ -197,8 +197,7 @@ def save_model(
     """
     import paddle
 
-    _validate_env_arguments(conda_env, pip_requirements,
-                            extra_pip_requirements)
+    _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
 
     _validate_and_prepare_target_save_path(path)
     code_dir_subpath = _validate_and_copy_code_paths(code_paths, path)
@@ -253,20 +252,17 @@ def save_model(
             extra_pip_requirements,
         )
     else:
-        conda_env, pip_requirements, pip_constraints = _process_conda_env(
-            conda_env)
+        conda_env, pip_requirements, pip_constraints = _process_conda_env(conda_env)
 
     with open(os.path.join(path, _CONDA_ENV_FILE_NAME), "w") as f:
         yaml.safe_dump(conda_env, stream=f, default_flow_style=False)
 
     # Save `constraints.txt` if necessary
     if pip_constraints:
-        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME),
-                 "\n".join(pip_constraints))
+        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME), "\n".join(pip_constraints))
 
     # Save `requirements.txt`
-    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME),
-             "\n".join(pip_requirements))
+    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME), "\n".join(pip_requirements))
 
 
 def load_model(model_uri, model=None, dst_path=None, **kwargs):
@@ -305,19 +301,15 @@ def load_model(model_uri, model=None, dst_path=None, **kwargs):
     """
     import paddle
 
-    local_model_path = _download_artifact_from_uri(
-        artifact_uri=model_uri, output_path=dst_path)
-    flavor_conf = _get_flavor_configuration(
-        model_path=local_model_path, flavor_name=FLAVOR_NAME)
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
+    flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     _add_code_from_conf_to_system_path(local_model_path, flavor_conf)
-    pd_model_artifacts_path = os.path.join(
-        local_model_path, flavor_conf["pickled_model"])
+    pd_model_artifacts_path = os.path.join(local_model_path, flavor_conf["pickled_model"])
     if model is None:
         return paddle.jit.load(pd_model_artifacts_path, **kwargs)
     elif not isinstance(model, paddle.Model):
         raise TypeError(
-            "Invalid object type `{}` for `model`, must be `paddle.Model`".format(
-                type(model))
+            "Invalid object type `{}` for `model`, must be `paddle.Model`".format(type(model))
         )
     else:
         contains_pdparams = _contains_pdparams(local_model_path)
@@ -462,8 +454,7 @@ class _PaddleWrapper:
                 "Please use a pandas.DataFrame or a numpy.ndarray"
             )
         else:
-            raise TypeError(
-                "Input data should be pandas.DataFrame or numpy.ndarray")
+            raise TypeError("Input data should be pandas.DataFrame or numpy.ndarray")
         inp_data = np.squeeze(inp_data)
 
         self.pd_model.eval()

--- a/mlflow/pmdarima.py
+++ b/mlflow/pmdarima.py
@@ -32,7 +32,7 @@ from mlflow.utils.model_utils import (
     _get_flavor_configuration,
     _validate_and_copy_code_paths,
     _add_code_from_conf_to_system_path,
-    _validate_and_prepare_target_save_path
+    _validate_and_prepare_target_save_path,
 )
 from mlflow.utils.file_utils import write_to
 from mlflow.utils.requirements_utils import _get_pinned_requirement
@@ -131,8 +131,7 @@ def save_model(
     """
     import pmdarima
 
-    _validate_env_arguments(conda_env, pip_requirements,
-                            extra_pip_requirements)
+    _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
 
     path = os.path.abspath(path)
     _validate_and_prepare_target_save_path(path)
@@ -178,18 +177,15 @@ def save_model(
             default_reqs, pip_requirements, extra_pip_requirements
         )
     else:
-        conda_env, pip_requirements, pip_constraints = _process_conda_env(
-            conda_env)
+        conda_env, pip_requirements, pip_constraints = _process_conda_env(conda_env)
 
     with open(os.path.join(path, _CONDA_ENV_FILE_NAME), "w") as f:
         yaml.safe_dump(conda_env, stream=f, default_flow_style=False)
 
     if pip_constraints:
-        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME),
-                 "\n".join(pip_constraints))
+        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME), "\n".join(pip_constraints))
 
-    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME),
-             "\n".join(pip_requirements))
+    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME), "\n".join(pip_requirements))
 
 
 @experimental
@@ -296,14 +292,11 @@ def load_model(model_uri, dst_path=None):
 
     :return: A ``pmdarima`` model instance
     """
-    local_model_path = _download_artifact_from_uri(
-        artifact_uri=model_uri, output_path=dst_path)
-    flavor_conf = _get_flavor_configuration(
-        model_path=local_model_path, flavor_name=FLAVOR_NAME)
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
+    flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     _add_code_from_conf_to_system_path(local_model_path, flavor_conf)
     pmdarima_model_file_path = os.path.join(
-        local_model_path, flavor_conf.get(
-            _MODEL_BINARY_KEY, _MODEL_BINARY_FILE_NAME)
+        local_model_path, flavor_conf.get(_MODEL_BINARY_KEY, _MODEL_BINARY_FILE_NAME)
     )
 
     return _load_model(pmdarima_model_file_path)
@@ -397,8 +390,7 @@ class _PmdarimaModelWrapper:
         if return_conf_int:
             ci_low, ci_high = list(zip(*raw_predictions[1]))
             predictions = pd.DataFrame.from_dict(
-                {"yhat": raw_predictions[0],
-                    "yhat_lower": ci_low, "yhat_upper": ci_high}
+                {"yhat": raw_predictions[0], "yhat_lower": ci_low, "yhat_upper": ci_high}
             )
         else:
             predictions = pd.DataFrame.from_dict({"yhat": raw_predictions})

--- a/mlflow/prophet.py
+++ b/mlflow/prophet.py
@@ -37,6 +37,7 @@ from mlflow.utils.model_utils import (
     _get_flavor_configuration,
     _validate_and_copy_code_paths,
     _add_code_from_conf_to_system_path,
+    _validate_and_prepare_target_save_path
 )
 from mlflow.models.model import MLMODEL_FILE_NAME
 from mlflow.exceptions import MlflowException
@@ -118,12 +119,11 @@ def save_model(
 
     import prophet
 
-    _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
+    _validate_env_arguments(conda_env, pip_requirements,
+                            extra_pip_requirements)
 
     path = os.path.abspath(path)
-    if os.path.exists(path):
-        raise MlflowException(f"Path '{path}' already exists")
-    os.makedirs(path)
+    _validate_and_prepare_target_save_path(path)
     code_dir_subpath = _validate_and_copy_code_paths(code_paths, path)
 
     if mlflow_model is None:
@@ -174,14 +174,17 @@ def save_model(
             extra_pip_requirements,
         )
     else:
-        conda_env, pip_requirements, pip_constraints = _process_conda_env(conda_env)
+        conda_env, pip_requirements, pip_constraints = _process_conda_env(
+            conda_env)
 
     with open(os.path.join(path, _CONDA_ENV_FILE_NAME), "w") as f:
         yaml.safe_dump(conda_env, stream=f, default_flow_style=False)
 
     if pip_constraints:
-        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME), "\n".join(pip_constraints))
-    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME), "\n".join(pip_requirements))
+        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME),
+                 "\n".join(pip_constraints))
+    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME),
+             "\n".join(pip_requirements))
 
 
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
@@ -305,11 +308,14 @@ def load_model(model_uri, dst_path=None):
 
     :return: A Prophet model instance
     """
-    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
-    flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
+    local_model_path = _download_artifact_from_uri(
+        artifact_uri=model_uri, output_path=dst_path)
+    flavor_conf = _get_flavor_configuration(
+        model_path=local_model_path, flavor_name=FLAVOR_NAME)
     _add_code_from_conf_to_system_path(local_model_path, flavor_conf)
     pr_model_path = os.path.join(
-        local_model_path, flavor_conf.get(_MODEL_BINARY_KEY, _MODEL_BINARY_FILE_NAME)
+        local_model_path, flavor_conf.get(
+            _MODEL_BINARY_KEY, _MODEL_BINARY_FILE_NAME)
     )
 
     return _load_model(pr_model_path)

--- a/mlflow/prophet.py
+++ b/mlflow/prophet.py
@@ -37,7 +37,7 @@ from mlflow.utils.model_utils import (
     _get_flavor_configuration,
     _validate_and_copy_code_paths,
     _add_code_from_conf_to_system_path,
-    _validate_and_prepare_target_save_path
+    _validate_and_prepare_target_save_path,
 )
 from mlflow.models.model import MLMODEL_FILE_NAME
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
@@ -118,8 +118,7 @@ def save_model(
 
     import prophet
 
-    _validate_env_arguments(conda_env, pip_requirements,
-                            extra_pip_requirements)
+    _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
 
     path = os.path.abspath(path)
     _validate_and_prepare_target_save_path(path)
@@ -173,17 +172,14 @@ def save_model(
             extra_pip_requirements,
         )
     else:
-        conda_env, pip_requirements, pip_constraints = _process_conda_env(
-            conda_env)
+        conda_env, pip_requirements, pip_constraints = _process_conda_env(conda_env)
 
     with open(os.path.join(path, _CONDA_ENV_FILE_NAME), "w") as f:
         yaml.safe_dump(conda_env, stream=f, default_flow_style=False)
 
     if pip_constraints:
-        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME),
-                 "\n".join(pip_constraints))
-    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME),
-             "\n".join(pip_requirements))
+        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME), "\n".join(pip_constraints))
+    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME), "\n".join(pip_requirements))
 
 
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
@@ -307,14 +303,11 @@ def load_model(model_uri, dst_path=None):
 
     :return: A Prophet model instance
     """
-    local_model_path = _download_artifact_from_uri(
-        artifact_uri=model_uri, output_path=dst_path)
-    flavor_conf = _get_flavor_configuration(
-        model_path=local_model_path, flavor_name=FLAVOR_NAME)
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
+    flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     _add_code_from_conf_to_system_path(local_model_path, flavor_conf)
     pr_model_path = os.path.join(
-        local_model_path, flavor_conf.get(
-            _MODEL_BINARY_KEY, _MODEL_BINARY_FILE_NAME)
+        local_model_path, flavor_conf.get(_MODEL_BINARY_KEY, _MODEL_BINARY_FILE_NAME)
     )
 
     return _load_model(pr_model_path)

--- a/mlflow/prophet.py
+++ b/mlflow/prophet.py
@@ -40,7 +40,6 @@ from mlflow.utils.model_utils import (
     _validate_and_prepare_target_save_path
 )
 from mlflow.models.model import MLMODEL_FILE_NAME
-from mlflow.exceptions import MlflowException
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 
 FLAVOR_NAME = "prophet"

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -245,7 +245,7 @@ from mlflow.utils.model_utils import (
     _validate_and_copy_code_paths,
     _add_code_from_conf_to_system_path,
     _get_flavor_configuration_from_uri,
-    _validate_and_prepare_target_save_path
+    _validate_and_prepare_target_save_path,
 )
 from mlflow.utils.uri import append_to_uri_path
 from mlflow.utils.environment import (
@@ -280,8 +280,7 @@ ENV = "env"
 PY_VERSION = "python_version"
 
 _logger = logging.getLogger(__name__)
-PyFuncInput = Union[pandas.DataFrame, np.ndarray,
-                    csc_matrix, csr_matrix, List[Any], Dict[str, Any]]
+PyFuncInput = Union[pandas.DataFrame, np.ndarray, csc_matrix, csr_matrix, List[Any], Dict[str, Any]]
 PyFuncOutput = Union[pandas.DataFrame, pandas.Series, np.ndarray, list]
 
 
@@ -378,8 +377,7 @@ def _enforce_mlflow_datatype(name, values: pandas.Series, t: DataType):
             return values.astype(np.datetime64, errors="raise")
         except ValueError:
             raise MlflowException(
-                "Failed to convert column {0} from type {1} to {2}.".format(
-                    name, values.dtype, t)
+                "Failed to convert column {0} from type {1} to {2}.".format(name, values.dtype, t)
             )
 
     numpy_type = t.to_numpy()
@@ -422,8 +420,7 @@ def _enforce_mlflow_datatype(name, values: pandas.Series, t: DataType):
 
         raise MlflowException(
             "Incompatible input types for column {0}. "
-            "Can not safely convert {1} to {2}.{3}".format(
-                name, values.dtype, numpy_type, hint)
+            "Can not safely convert {1} to {2}.{3}".format(name, values.dtype, numpy_type, hint)
         )
 
 
@@ -436,8 +433,7 @@ def _enforce_tensor_spec(
     expected_shape = tensor_spec.shape
     actual_shape = values.shape
 
-    actual_type = values.dtype if isinstance(
-        values, np.ndarray) else values.data.dtype
+    actual_type = values.dtype if isinstance(values, np.ndarray) else values.data.dtype
 
     if len(expected_shape) != len(actual_shape):
         raise MlflowException(
@@ -472,8 +468,7 @@ def _enforce_col_schema(pfInput: PyFuncInput, input_schema: Schema):
     input_types = input_schema.input_types()
     new_pfInput = pandas.DataFrame()
     for i, x in enumerate(input_names):
-        new_pfInput[x] = _enforce_mlflow_datatype(
-            x, pfInput[x], input_types[i])
+        new_pfInput[x] = _enforce_mlflow_datatype(x, pfInput[x], input_types[i])
     return new_pfInput
 
 
@@ -491,14 +486,12 @@ def _enforce_tensor_schema(pfInput: PyFuncInput, input_schema: Schema):
                             type(pfInput[col_name])
                         )
                     )
-                new_pfInput[col_name] = _enforce_tensor_spec(
-                    pfInput[col_name], tensor_spec)
+                new_pfInput[col_name] = _enforce_tensor_spec(pfInput[col_name], tensor_spec)
         elif isinstance(pfInput, pandas.DataFrame):
             new_pfInput = dict()
             for col_name, tensor_spec in zip(input_schema.input_names(), input_schema.inputs):
                 new_pfInput[col_name] = _enforce_tensor_spec(
-                    np.array(pfInput[col_name],
-                             dtype=tensor_spec.type), tensor_spec
+                    np.array(pfInput[col_name], dtype=tensor_spec.type), tensor_spec
                 )
         else:
             raise MlflowException(
@@ -508,8 +501,7 @@ def _enforce_tensor_schema(pfInput: PyFuncInput, input_schema: Schema):
             )
     else:
         if isinstance(pfInput, pandas.DataFrame):
-            new_pfInput = _enforce_tensor_spec(
-                pfInput.to_numpy(), input_schema.inputs[0])
+            new_pfInput = _enforce_tensor_spec(pfInput.to_numpy(), input_schema.inputs[0])
         elif isinstance(pfInput, (np.ndarray, csc_matrix, csr_matrix)):
             new_pfInput = _enforce_tensor_spec(pfInput, input_schema.inputs[0])
         else:
@@ -546,8 +538,7 @@ def _enforce_schema(pfInput: PyFuncInput, input_schema: Schema):
                 )
         if not isinstance(pfInput, pandas.DataFrame):
             raise MlflowException(
-                "Expected input to be DataFrame or list. Found: %s" % type(
-                    pfInput).__name__
+                "Expected input to be DataFrame or list. Found: %s" % type(pfInput).__name__
             )
 
     if input_schema.has_input_names():
@@ -572,8 +563,7 @@ def _enforce_schema(pfInput: PyFuncInput, input_schema: Schema):
         if missing_cols:
             raise MlflowException(
                 "Model is missing inputs {0}."
-                " Note that there were extra inputs: {1}".format(
-                    missing_cols, extra_cols)
+                " Note that there were extra inputs: {1}".format(missing_cols, extra_cols)
             )
     elif not input_schema.is_tensor_spec():
         # The model signature does not specify column names => we can only verify column count.
@@ -583,8 +573,7 @@ def _enforce_schema(pfInput: PyFuncInput, input_schema: Schema):
                 "Model inference is missing inputs. The model signature declares "
                 "{0} inputs  but the provided value only has "
                 "{1} inputs. Note: the inputs were not named in the signature so we can "
-                "only verify their count.".format(
-                    len(input_schema.inputs), num_actual_columns)
+                "only verify their count.".format(len(input_schema.inputs), num_actual_columns)
             )
 
     return (
@@ -611,8 +600,7 @@ class PyFuncModel:
 
     def __init__(self, model_meta: Model, model_impl: Any):
         if not hasattr(model_impl, "predict"):
-            raise MlflowException(
-                "Model implementation is missing required predict method.")
+            raise MlflowException("Model implementation is missing required predict method.")
         if not model_meta:
             raise MlflowException("Model is missing metadata.")
         self._model_meta = model_meta
@@ -720,8 +708,7 @@ def load_model(
                      This directory must already exist. If unspecified, a local output
                      path will be created.
     """
-    local_path = _download_artifact_from_uri(
-        artifact_uri=model_uri, output_path=dst_path)
+    local_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
 
     if not suppress_warnings:
         _warn_dependency_requirement_mismatches(local_path)
@@ -731,25 +718,21 @@ def load_model(
     conf = model_meta.flavors.get(FLAVOR_NAME)
     if conf is None:
         raise MlflowException(
-            'Model does not have the "{flavor_name}" flavor'.format(
-                flavor_name=FLAVOR_NAME),
+            'Model does not have the "{flavor_name}" flavor'.format(flavor_name=FLAVOR_NAME),
             RESOURCE_DOES_NOT_EXIST,
         )
     model_py_version = conf.get(PY_VERSION)
     if not suppress_warnings:
-        _warn_potentially_incompatible_py_version_if_necessary(
-            model_py_version=model_py_version)
+        _warn_potentially_incompatible_py_version_if_necessary(model_py_version=model_py_version)
 
     _add_code_from_conf_to_system_path(local_path, conf, code_key=CODE)
-    data_path = os.path.join(local_path, conf[DATA]) if (
-        DATA in conf) else local_path
+    data_path = os.path.join(local_path, conf[DATA]) if (DATA in conf) else local_path
     model_impl = importlib.import_module(conf[MAIN])._load_pyfunc(data_path)
     return PyFuncModel(model_meta=model_meta, model_impl=model_impl)
 
 
 def _download_model_conda_env(model_uri):
-    conda_yml_file_name = _get_flavor_configuration_from_uri(
-        model_uri, FLAVOR_NAME)[ENV]
+    conda_yml_file_name = _get_flavor_configuration_from_uri(model_uri, FLAVOR_NAME)[ENV]
     return _download_artifact_from_uri(append_to_uri_path(model_uri, conda_yml_file_name))
 
 
@@ -1016,8 +999,7 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
     #  when NFS optimization added.
     should_use_nfs = False
 
-    should_use_spark_to_broadcast_file = not (
-        is_spark_in_local_mode or should_use_nfs)
+    should_use_spark_to_broadcast_file = not (is_spark_in_local_mode or should_use_nfs)
 
     if not isinstance(result_type, SparkDataType):
         result_type = _parse_datatype_string(result_type)
@@ -1026,14 +1008,12 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
     if isinstance(elem_type, ArrayType):
         elem_type = elem_type.elementType
 
-    supported_types = [IntegerType, LongType,
-                       FloatType, DoubleType, StringType]
+    supported_types = [IntegerType, LongType, FloatType, DoubleType, StringType]
 
     if not any([isinstance(elem_type, x) for x in supported_types]):
         raise MlflowException(
             message="Invalid result_type '{}'. Result type can only be one of or an array of one "
-            "of the following types: {}".format(
-                str(elem_type), str(supported_types)),
+            "of the following types: {}".format(str(elem_type), str(supported_types)),
             error_code=INVALID_PARAMETER_VALUE,
         )
 
@@ -1078,8 +1058,7 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
     if should_use_spark_to_broadcast_file:
         archive_path = SparkModelCache.add_local_model(spark, local_model_path)
 
-    model_metadata = Model.load(os.path.join(
-        local_model_path, MLMODEL_FILE_NAME))
+    model_metadata = Model.load(os.path.join(local_model_path, MLMODEL_FILE_NAME))
 
     def _predict_row_batch(predict_fn, args):
         input_schema = model_metadata.get_input_schema()
@@ -1106,35 +1085,29 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
                         "Model input is missing columns. Expected {0} input columns {1},"
                         " but the model received only {2} unnamed input columns"
                         " (Since the columns were passed unnamed they are expected to be in"
-                        " the order specified by the schema).".format(
-                            len(names), names, len(args))
+                        " the order specified by the schema).".format(len(names), names, len(args))
                     )
-            pdf = pandas.DataFrame(
-                data={names[i]: x for i, x in enumerate(args)}, columns=names)
+            pdf = pandas.DataFrame(data={names[i]: x for i, x in enumerate(args)}, columns=names)
 
         result = predict_fn(pdf)
 
         if not isinstance(result, pandas.DataFrame):
             result = pandas.DataFrame(data=result)
 
-        elem_type = result_type.elementType if isinstance(
-            result_type, ArrayType) else result_type
+        elem_type = result_type.elementType if isinstance(result_type, ArrayType) else result_type
 
         if type(elem_type) == IntegerType:
             result = result.select_dtypes(
                 [np.byte, np.ubyte, np.short, np.ushort, np.int32]
             ).astype(np.int32)
         elif type(elem_type) == LongType:
-            result = result.select_dtypes(
-                [np.byte, np.ubyte, np.short, np.ushort, int])
+            result = result.select_dtypes([np.byte, np.ubyte, np.short, np.ushort, int])
 
         elif type(elem_type) == FloatType:
-            result = result.select_dtypes(
-                include=(np.number,)).astype(np.float32)
+            result = result.select_dtypes(include=(np.number,)).astype(np.float32)
 
         elif type(elem_type) == DoubleType:
-            result = result.select_dtypes(
-                include=(np.number,)).astype(np.float64)
+            result = result.select_dtypes(include=(np.number,)).astype(np.float64)
 
         if len(result.columns) == 0:
             raise MlflowException(
@@ -1153,8 +1126,7 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
             return result[result.columns[0]]
 
     result_type_hint = (
-        pandas.DataFrame if isinstance(
-            result_type, SparkStructType) else pandas.Series
+        pandas.DataFrame if isinstance(result_type, SparkStructType) else pandas.Series
     )
 
     @pandas_udf(result_type)
@@ -1218,8 +1190,7 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
                 stderr=subprocess.STDOUT,
             )
 
-            server_tail_logs = collections.deque(
-                maxlen=_MLFLOW_SERVER_OUTPUT_TAIL_LINES_TO_KEEP)
+            server_tail_logs = collections.deque(maxlen=_MLFLOW_SERVER_OUTPUT_TAIL_LINES_TO_KEEP)
 
             def server_redirect_log_thread_func(child_stdout):
                 for line in child_stdout:
@@ -1231,8 +1202,7 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
                     sys.stdout.write("[model server] " + decoded)
 
             server_redirect_log_thread = threading.Thread(
-                target=server_redirect_log_thread_func, args=(
-                    scoring_server_proc.stdout,)
+                target=server_redirect_log_thread_func, args=(scoring_server_proc.stdout,)
             )
             server_redirect_log_thread.setDaemon(True)
             server_redirect_log_thread.start()
@@ -1240,8 +1210,7 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
             client = ScoringServerClient("127.0.0.1", server_port)
 
             try:
-                client.wait_server_ready(
-                    timeout=90, scoring_server_proc=scoring_server_proc)
+                client.wait_server_ready(timeout=90, scoring_server_proc=scoring_server_proc)
             except Exception:
                 err_msg = "During spark UDF task execution, mlflow model server failed to launch. "
                 if len(server_tail_logs) == _MLFLOW_SERVER_OUTPUT_TAIL_LINES_TO_KEEP:
@@ -1417,17 +1386,14 @@ def save_model(
     :param pip_requirements: {{ pip_requirements }}
     :param extra_pip_requirements: {{ extra_pip_requirements }}
     """
-    _validate_env_arguments(conda_env, pip_requirements,
-                            extra_pip_requirements)
+    _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
 
     mlflow_model = kwargs.pop("model", mlflow_model)
     if len(kwargs) > 0:
-        raise TypeError(
-            "save_model() got unexpected keyword arguments: {}".format(kwargs))
+        raise TypeError("save_model() got unexpected keyword arguments: {}".format(kwargs))
     if code_path is not None:
         if not isinstance(code_path, list):
-            raise TypeError(
-                "Argument code_path should be a list, not {}".format(type(code_path)))
+            raise TypeError("Argument code_path should be a list, not {}".format(type(code_path)))
 
     first_argument_set = {
         "loader_module": loader_module,
@@ -1437,10 +1403,8 @@ def save_model(
         "artifacts": artifacts,
         "python_model": python_model,
     }
-    first_argument_set_specified = any(
-        [item is not None for item in first_argument_set.values()])
-    second_argument_set_specified = any(
-        [item is not None for item in second_argument_set.values()])
+    first_argument_set_specified = any([item is not None for item in first_argument_set.values()])
+    second_argument_set_specified = any([item is not None for item in second_argument_set.values()])
     if first_argument_set_specified and second_argument_set_specified:
         raise MlflowException(
             message=(
@@ -1644,8 +1608,7 @@ def _save_model_with_loader_module_and_data_path(
     data = None
 
     if data_path is not None:
-        model_file = _copy_file_or_tree(
-            src=data_path, dst=path, dst_dir="data")
+        model_file = _copy_file_or_tree(src=data_path, dst=path, dst_dir="data")
         data = model_file
 
     code_dir_subpath = _validate_and_copy_code_paths(code_paths, path)
@@ -1681,20 +1644,17 @@ def _save_model_with_loader_module_and_data_path(
             extra_pip_requirements,
         )
     else:
-        conda_env, pip_requirements, pip_constraints = _process_conda_env(
-            conda_env)
+        conda_env, pip_requirements, pip_constraints = _process_conda_env(conda_env)
 
     with open(os.path.join(path, _CONDA_ENV_FILE_NAME), "w") as f:
         yaml.safe_dump(conda_env, stream=f, default_flow_style=False)
 
     # Save `constraints.txt` if necessary
     if pip_constraints:
-        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME),
-                 "\n".join(pip_constraints))
+        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME), "\n".join(pip_constraints))
 
     # Save `requirements.txt`
-    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME),
-             "\n".join(pip_requirements))
+    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME), "\n".join(pip_requirements))
     return mlflow_model
 
 

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -262,7 +262,6 @@ from mlflow.exceptions import MlflowException
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.protos.databricks_pb2 import (
     INVALID_PARAMETER_VALUE,
-    RESOURCE_ALREADY_EXISTS,
     RESOURCE_DOES_NOT_EXIST,
 )
 from scipy.sparse import csc_matrix, csr_matrix
@@ -281,7 +280,8 @@ ENV = "env"
 PY_VERSION = "python_version"
 
 _logger = logging.getLogger(__name__)
-PyFuncInput = Union[pandas.DataFrame, np.ndarray, csc_matrix, csr_matrix, List[Any], Dict[str, Any]]
+PyFuncInput = Union[pandas.DataFrame, np.ndarray,
+                    csc_matrix, csr_matrix, List[Any], Dict[str, Any]]
 PyFuncOutput = Union[pandas.DataFrame, pandas.Series, np.ndarray, list]
 
 
@@ -378,7 +378,8 @@ def _enforce_mlflow_datatype(name, values: pandas.Series, t: DataType):
             return values.astype(np.datetime64, errors="raise")
         except ValueError:
             raise MlflowException(
-                "Failed to convert column {0} from type {1} to {2}.".format(name, values.dtype, t)
+                "Failed to convert column {0} from type {1} to {2}.".format(
+                    name, values.dtype, t)
             )
 
     numpy_type = t.to_numpy()
@@ -421,7 +422,8 @@ def _enforce_mlflow_datatype(name, values: pandas.Series, t: DataType):
 
         raise MlflowException(
             "Incompatible input types for column {0}. "
-            "Can not safely convert {1} to {2}.{3}".format(name, values.dtype, numpy_type, hint)
+            "Can not safely convert {1} to {2}.{3}".format(
+                name, values.dtype, numpy_type, hint)
         )
 
 
@@ -434,7 +436,8 @@ def _enforce_tensor_spec(
     expected_shape = tensor_spec.shape
     actual_shape = values.shape
 
-    actual_type = values.dtype if isinstance(values, np.ndarray) else values.data.dtype
+    actual_type = values.dtype if isinstance(
+        values, np.ndarray) else values.data.dtype
 
     if len(expected_shape) != len(actual_shape):
         raise MlflowException(
@@ -469,7 +472,8 @@ def _enforce_col_schema(pfInput: PyFuncInput, input_schema: Schema):
     input_types = input_schema.input_types()
     new_pfInput = pandas.DataFrame()
     for i, x in enumerate(input_names):
-        new_pfInput[x] = _enforce_mlflow_datatype(x, pfInput[x], input_types[i])
+        new_pfInput[x] = _enforce_mlflow_datatype(
+            x, pfInput[x], input_types[i])
     return new_pfInput
 
 
@@ -487,12 +491,14 @@ def _enforce_tensor_schema(pfInput: PyFuncInput, input_schema: Schema):
                             type(pfInput[col_name])
                         )
                     )
-                new_pfInput[col_name] = _enforce_tensor_spec(pfInput[col_name], tensor_spec)
+                new_pfInput[col_name] = _enforce_tensor_spec(
+                    pfInput[col_name], tensor_spec)
         elif isinstance(pfInput, pandas.DataFrame):
             new_pfInput = dict()
             for col_name, tensor_spec in zip(input_schema.input_names(), input_schema.inputs):
                 new_pfInput[col_name] = _enforce_tensor_spec(
-                    np.array(pfInput[col_name], dtype=tensor_spec.type), tensor_spec
+                    np.array(pfInput[col_name],
+                             dtype=tensor_spec.type), tensor_spec
                 )
         else:
             raise MlflowException(
@@ -502,7 +508,8 @@ def _enforce_tensor_schema(pfInput: PyFuncInput, input_schema: Schema):
             )
     else:
         if isinstance(pfInput, pandas.DataFrame):
-            new_pfInput = _enforce_tensor_spec(pfInput.to_numpy(), input_schema.inputs[0])
+            new_pfInput = _enforce_tensor_spec(
+                pfInput.to_numpy(), input_schema.inputs[0])
         elif isinstance(pfInput, (np.ndarray, csc_matrix, csr_matrix)):
             new_pfInput = _enforce_tensor_spec(pfInput, input_schema.inputs[0])
         else:
@@ -539,7 +546,8 @@ def _enforce_schema(pfInput: PyFuncInput, input_schema: Schema):
                 )
         if not isinstance(pfInput, pandas.DataFrame):
             raise MlflowException(
-                "Expected input to be DataFrame or list. Found: %s" % type(pfInput).__name__
+                "Expected input to be DataFrame or list. Found: %s" % type(
+                    pfInput).__name__
             )
 
     if input_schema.has_input_names():
@@ -564,7 +572,8 @@ def _enforce_schema(pfInput: PyFuncInput, input_schema: Schema):
         if missing_cols:
             raise MlflowException(
                 "Model is missing inputs {0}."
-                " Note that there were extra inputs: {1}".format(missing_cols, extra_cols)
+                " Note that there were extra inputs: {1}".format(
+                    missing_cols, extra_cols)
             )
     elif not input_schema.is_tensor_spec():
         # The model signature does not specify column names => we can only verify column count.
@@ -574,7 +583,8 @@ def _enforce_schema(pfInput: PyFuncInput, input_schema: Schema):
                 "Model inference is missing inputs. The model signature declares "
                 "{0} inputs  but the provided value only has "
                 "{1} inputs. Note: the inputs were not named in the signature so we can "
-                "only verify their count.".format(len(input_schema.inputs), num_actual_columns)
+                "only verify their count.".format(
+                    len(input_schema.inputs), num_actual_columns)
             )
 
     return (
@@ -601,7 +611,8 @@ class PyFuncModel:
 
     def __init__(self, model_meta: Model, model_impl: Any):
         if not hasattr(model_impl, "predict"):
-            raise MlflowException("Model implementation is missing required predict method.")
+            raise MlflowException(
+                "Model implementation is missing required predict method.")
         if not model_meta:
             raise MlflowException("Model is missing metadata.")
         self._model_meta = model_meta
@@ -709,7 +720,8 @@ def load_model(
                      This directory must already exist. If unspecified, a local output
                      path will be created.
     """
-    local_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
+    local_path = _download_artifact_from_uri(
+        artifact_uri=model_uri, output_path=dst_path)
 
     if not suppress_warnings:
         _warn_dependency_requirement_mismatches(local_path)
@@ -719,21 +731,25 @@ def load_model(
     conf = model_meta.flavors.get(FLAVOR_NAME)
     if conf is None:
         raise MlflowException(
-            'Model does not have the "{flavor_name}" flavor'.format(flavor_name=FLAVOR_NAME),
+            'Model does not have the "{flavor_name}" flavor'.format(
+                flavor_name=FLAVOR_NAME),
             RESOURCE_DOES_NOT_EXIST,
         )
     model_py_version = conf.get(PY_VERSION)
     if not suppress_warnings:
-        _warn_potentially_incompatible_py_version_if_necessary(model_py_version=model_py_version)
+        _warn_potentially_incompatible_py_version_if_necessary(
+            model_py_version=model_py_version)
 
     _add_code_from_conf_to_system_path(local_path, conf, code_key=CODE)
-    data_path = os.path.join(local_path, conf[DATA]) if (DATA in conf) else local_path
+    data_path = os.path.join(local_path, conf[DATA]) if (
+        DATA in conf) else local_path
     model_impl = importlib.import_module(conf[MAIN])._load_pyfunc(data_path)
     return PyFuncModel(model_meta=model_meta, model_impl=model_impl)
 
 
 def _download_model_conda_env(model_uri):
-    conda_yml_file_name = _get_flavor_configuration_from_uri(model_uri, FLAVOR_NAME)[ENV]
+    conda_yml_file_name = _get_flavor_configuration_from_uri(
+        model_uri, FLAVOR_NAME)[ENV]
     return _download_artifact_from_uri(append_to_uri_path(model_uri, conda_yml_file_name))
 
 
@@ -1000,7 +1016,8 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
     #  when NFS optimization added.
     should_use_nfs = False
 
-    should_use_spark_to_broadcast_file = not (is_spark_in_local_mode or should_use_nfs)
+    should_use_spark_to_broadcast_file = not (
+        is_spark_in_local_mode or should_use_nfs)
 
     if not isinstance(result_type, SparkDataType):
         result_type = _parse_datatype_string(result_type)
@@ -1009,12 +1026,14 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
     if isinstance(elem_type, ArrayType):
         elem_type = elem_type.elementType
 
-    supported_types = [IntegerType, LongType, FloatType, DoubleType, StringType]
+    supported_types = [IntegerType, LongType,
+                       FloatType, DoubleType, StringType]
 
     if not any([isinstance(elem_type, x) for x in supported_types]):
         raise MlflowException(
             message="Invalid result_type '{}'. Result type can only be one of or an array of one "
-            "of the following types: {}".format(str(elem_type), str(supported_types)),
+            "of the following types: {}".format(
+                str(elem_type), str(supported_types)),
             error_code=INVALID_PARAMETER_VALUE,
         )
 
@@ -1059,7 +1078,8 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
     if should_use_spark_to_broadcast_file:
         archive_path = SparkModelCache.add_local_model(spark, local_model_path)
 
-    model_metadata = Model.load(os.path.join(local_model_path, MLMODEL_FILE_NAME))
+    model_metadata = Model.load(os.path.join(
+        local_model_path, MLMODEL_FILE_NAME))
 
     def _predict_row_batch(predict_fn, args):
         input_schema = model_metadata.get_input_schema()
@@ -1086,29 +1106,35 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
                         "Model input is missing columns. Expected {0} input columns {1},"
                         " but the model received only {2} unnamed input columns"
                         " (Since the columns were passed unnamed they are expected to be in"
-                        " the order specified by the schema).".format(len(names), names, len(args))
+                        " the order specified by the schema).".format(
+                            len(names), names, len(args))
                     )
-            pdf = pandas.DataFrame(data={names[i]: x for i, x in enumerate(args)}, columns=names)
+            pdf = pandas.DataFrame(
+                data={names[i]: x for i, x in enumerate(args)}, columns=names)
 
         result = predict_fn(pdf)
 
         if not isinstance(result, pandas.DataFrame):
             result = pandas.DataFrame(data=result)
 
-        elem_type = result_type.elementType if isinstance(result_type, ArrayType) else result_type
+        elem_type = result_type.elementType if isinstance(
+            result_type, ArrayType) else result_type
 
         if type(elem_type) == IntegerType:
             result = result.select_dtypes(
                 [np.byte, np.ubyte, np.short, np.ushort, np.int32]
             ).astype(np.int32)
         elif type(elem_type) == LongType:
-            result = result.select_dtypes([np.byte, np.ubyte, np.short, np.ushort, int])
+            result = result.select_dtypes(
+                [np.byte, np.ubyte, np.short, np.ushort, int])
 
         elif type(elem_type) == FloatType:
-            result = result.select_dtypes(include=(np.number,)).astype(np.float32)
+            result = result.select_dtypes(
+                include=(np.number,)).astype(np.float32)
 
         elif type(elem_type) == DoubleType:
-            result = result.select_dtypes(include=(np.number,)).astype(np.float64)
+            result = result.select_dtypes(
+                include=(np.number,)).astype(np.float64)
 
         if len(result.columns) == 0:
             raise MlflowException(
@@ -1127,7 +1153,8 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
             return result[result.columns[0]]
 
     result_type_hint = (
-        pandas.DataFrame if isinstance(result_type, SparkStructType) else pandas.Series
+        pandas.DataFrame if isinstance(
+            result_type, SparkStructType) else pandas.Series
     )
 
     @pandas_udf(result_type)
@@ -1191,7 +1218,8 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
                 stderr=subprocess.STDOUT,
             )
 
-            server_tail_logs = collections.deque(maxlen=_MLFLOW_SERVER_OUTPUT_TAIL_LINES_TO_KEEP)
+            server_tail_logs = collections.deque(
+                maxlen=_MLFLOW_SERVER_OUTPUT_TAIL_LINES_TO_KEEP)
 
             def server_redirect_log_thread_func(child_stdout):
                 for line in child_stdout:
@@ -1203,7 +1231,8 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
                     sys.stdout.write("[model server] " + decoded)
 
             server_redirect_log_thread = threading.Thread(
-                target=server_redirect_log_thread_func, args=(scoring_server_proc.stdout,)
+                target=server_redirect_log_thread_func, args=(
+                    scoring_server_proc.stdout,)
             )
             server_redirect_log_thread.setDaemon(True)
             server_redirect_log_thread.start()
@@ -1211,7 +1240,8 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
             client = ScoringServerClient("127.0.0.1", server_port)
 
             try:
-                client.wait_server_ready(timeout=90, scoring_server_proc=scoring_server_proc)
+                client.wait_server_ready(
+                    timeout=90, scoring_server_proc=scoring_server_proc)
             except Exception:
                 err_msg = "During spark UDF task execution, mlflow model server failed to launch. "
                 if len(server_tail_logs) == _MLFLOW_SERVER_OUTPUT_TAIL_LINES_TO_KEEP:
@@ -1387,14 +1417,17 @@ def save_model(
     :param pip_requirements: {{ pip_requirements }}
     :param extra_pip_requirements: {{ extra_pip_requirements }}
     """
-    _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
+    _validate_env_arguments(conda_env, pip_requirements,
+                            extra_pip_requirements)
 
     mlflow_model = kwargs.pop("model", mlflow_model)
     if len(kwargs) > 0:
-        raise TypeError("save_model() got unexpected keyword arguments: {}".format(kwargs))
+        raise TypeError(
+            "save_model() got unexpected keyword arguments: {}".format(kwargs))
     if code_path is not None:
         if not isinstance(code_path, list):
-            raise TypeError("Argument code_path should be a list, not {}".format(type(code_path)))
+            raise TypeError(
+                "Argument code_path should be a list, not {}".format(type(code_path)))
 
     first_argument_set = {
         "loader_module": loader_module,
@@ -1404,8 +1437,10 @@ def save_model(
         "artifacts": artifacts,
         "python_model": python_model,
     }
-    first_argument_set_specified = any([item is not None for item in first_argument_set.values()])
-    second_argument_set_specified = any([item is not None for item in second_argument_set.values()])
+    first_argument_set_specified = any(
+        [item is not None for item in first_argument_set.values()])
+    second_argument_set_specified = any(
+        [item is not None for item in second_argument_set.values()])
     if first_argument_set_specified and second_argument_set_specified:
         raise MlflowException(
             message=(
@@ -1609,7 +1644,8 @@ def _save_model_with_loader_module_and_data_path(
     data = None
 
     if data_path is not None:
-        model_file = _copy_file_or_tree(src=data_path, dst=path, dst_dir="data")
+        model_file = _copy_file_or_tree(
+            src=data_path, dst=path, dst_dir="data")
         data = model_file
 
     code_dir_subpath = _validate_and_copy_code_paths(code_paths, path)
@@ -1645,17 +1681,20 @@ def _save_model_with_loader_module_and_data_path(
             extra_pip_requirements,
         )
     else:
-        conda_env, pip_requirements, pip_constraints = _process_conda_env(conda_env)
+        conda_env, pip_requirements, pip_constraints = _process_conda_env(
+            conda_env)
 
     with open(os.path.join(path, _CONDA_ENV_FILE_NAME), "w") as f:
         yaml.safe_dump(conda_env, stream=f, default_flow_style=False)
 
     # Save `constraints.txt` if necessary
     if pip_constraints:
-        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME), "\n".join(pip_constraints))
+        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME),
+                 "\n".join(pip_constraints))
 
     # Save `requirements.txt`
-    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME), "\n".join(pip_requirements))
+    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME),
+             "\n".join(pip_requirements))
     return mlflow_model
 
 

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -245,6 +245,7 @@ from mlflow.utils.model_utils import (
     _validate_and_copy_code_paths,
     _add_code_from_conf_to_system_path,
     _get_flavor_configuration_from_uri,
+    _validate_and_prepare_target_save_path
 )
 from mlflow.utils.uri import append_to_uri_path
 from mlflow.utils.environment import (
@@ -1426,11 +1427,7 @@ def save_model(
         )
         raise MlflowException(message=msg, error_code=INVALID_PARAMETER_VALUE)
 
-    if os.path.exists(path):
-        raise MlflowException(
-            message="Path '{}' already exists".format(path), error_code=RESOURCE_ALREADY_EXISTS
-        )
-    os.makedirs(path)
+    _validate_and_prepare_target_save_path(path)
     if mlflow_model is None:
         mlflow_model = Model()
     if signature is not None:

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -48,6 +48,7 @@ from mlflow.utils.model_utils import (
     _get_flavor_configuration,
     _validate_and_copy_code_paths,
     _add_code_from_conf_to_system_path,
+    _validate_and_prepare_target_save_path
 )
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.utils.autologging_utils import autologging_integration, safe_patch
@@ -468,20 +469,19 @@ def save_model(
     """
     import torch
 
-    _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
+    _validate_env_arguments(conda_env, pip_requirements,
+                            extra_pip_requirements)
 
     pickle_module = pickle_module or mlflow_pytorch_pickle_module
 
     if not isinstance(pytorch_model, torch.nn.Module):
         raise TypeError("Argument 'pytorch_model' should be a torch.nn.Module")
     path = os.path.abspath(path)
-    if os.path.exists(path):
-        raise RuntimeError("Path '{}' already exists".format(path))
+    _validate_and_prepare_target_save_path(path)
 
     if mlflow_model is None:
         mlflow_model = Model()
 
-    os.makedirs(path)
     if signature is not None:
         mlflow_model.signature = signature
     if input_example is not None:
@@ -500,15 +500,18 @@ def save_model(
     #
     # TODO: Stop persisting this information to the filesystem once we have a mechanism for
     # supplying the MLmodel configuration to `mlflow.pytorch._load_pyfunc`
-    pickle_module_path = os.path.join(model_data_path, _PICKLE_MODULE_INFO_FILE_NAME)
+    pickle_module_path = os.path.join(
+        model_data_path, _PICKLE_MODULE_INFO_FILE_NAME)
     with open(pickle_module_path, "w") as f:
         f.write(pickle_module.__name__)
     # Save pytorch model
-    model_path = os.path.join(model_data_path, _SERIALIZED_TORCH_MODEL_FILE_NAME)
+    model_path = os.path.join(
+        model_data_path, _SERIALIZED_TORCH_MODEL_FILE_NAME)
     if isinstance(pytorch_model, torch.jit.ScriptModule):
         torch.jit.ScriptModule.save(pytorch_model, model_path)
     else:
-        torch.save(pytorch_model, model_path, pickle_module=pickle_module, **kwargs)
+        torch.save(pytorch_model, model_path,
+                   pickle_module=pickle_module, **kwargs)
 
     torchserve_artifacts_config = {}
 
@@ -522,8 +525,10 @@ def save_model(
                 _download_artifact_from_uri(
                     artifact_uri=extra_file, output_path=tmp_extra_files_dir.path()
                 )
-                rel_path = posixpath.join(_EXTRA_FILES_KEY, os.path.basename(extra_file))
-                torchserve_artifacts_config[_EXTRA_FILES_KEY].append({"path": rel_path})
+                rel_path = posixpath.join(
+                    _EXTRA_FILES_KEY, os.path.basename(extra_file))
+                torchserve_artifacts_config[_EXTRA_FILES_KEY].append(
+                    {"path": rel_path})
             shutil.move(
                 tmp_extra_files_dir.path(),
                 posixpath.join(path, _EXTRA_FILES_KEY),
@@ -545,7 +550,8 @@ def save_model(
                 artifact_uri=requirements_file, output_path=tmp_requirements_dir.path()
             )
             rel_path = os.path.basename(requirements_file)
-            torchserve_artifacts_config[_REQUIREMENTS_FILE_KEY] = {"path": rel_path}
+            torchserve_artifacts_config[_REQUIREMENTS_FILE_KEY] = {
+                "path": rel_path}
             shutil.move(tmp_requirements_dir.path(rel_path), path)
 
     mlflow_model.add_flavor(
@@ -584,18 +590,21 @@ def save_model(
             extra_pip_requirements,
         )
     else:
-        conda_env, pip_requirements, pip_constraints = _process_conda_env(conda_env)
+        conda_env, pip_requirements, pip_constraints = _process_conda_env(
+            conda_env)
 
     with open(os.path.join(path, _CONDA_ENV_FILE_NAME), "w") as f:
         yaml.safe_dump(conda_env, stream=f, default_flow_style=False)
 
     # Save `constraints.txt` if necessary
     if pip_constraints:
-        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME), "\n".join(pip_constraints))
+        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME),
+                 "\n".join(pip_constraints))
 
     if not requirements_file:
         # Save `requirements.txt`
-        write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME), "\n".join(pip_requirements))
+        write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME),
+                 "\n".join(pip_requirements))
 
 
 def _load_model(path, **kwargs):
@@ -621,7 +630,8 @@ def _load_model(path, **kwargs):
             )
         else:
             try:
-                kwargs["pickle_module"] = importlib.import_module(pickle_module_name)
+                kwargs["pickle_module"] = importlib.import_module(
+                    pickle_module_name)
             except ImportError as exc:
                 raise MlflowException(
                     message=(
@@ -644,7 +654,8 @@ def _load_model(path, **kwargs):
             return torch.load(model_path, **kwargs)
         except Exception:
             # If fails, assume the model as a scripted model
-            kwargs.pop("pickle_module", None)  # `torch.jit.load` does not accept `pickle_module`.
+            # `torch.jit.load` does not accept `pickle_module`.
+            kwargs.pop("pickle_module", None)
             return torch.jit.load(model_path, **kwargs)
 
 
@@ -708,8 +719,10 @@ def load_model(model_uri, dst_path=None, **kwargs):
     """
     import torch
 
-    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
-    pytorch_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
+    local_model_path = _download_artifact_from_uri(
+        artifact_uri=model_uri, output_path=dst_path)
+    pytorch_conf = _get_flavor_configuration(
+        model_path=local_model_path, flavor_name=FLAVOR_NAME)
     _add_code_from_conf_to_system_path(local_model_path, pytorch_conf)
 
     if torch.__version__ != pytorch_conf["pytorch_version"]:
@@ -718,7 +731,8 @@ def load_model(model_uri, dst_path=None, **kwargs):
             pytorch_conf["pytorch_version"],
             torch.__version__,
         )
-    torch_model_artifacts_path = os.path.join(local_model_path, pytorch_conf["model_data"])
+    torch_model_artifacts_path = os.path.join(
+        local_model_path, pytorch_conf["model_data"])
     return _load_model(path=torch_model_artifacts_path, **kwargs)
 
 
@@ -753,7 +767,8 @@ class _PyTorchWrapper:
                 "Please use a pandas.DataFrame or a numpy.ndarray"
             )
         else:
-            raise TypeError("Input data should be pandas.DataFrame or numpy.ndarray")
+            raise TypeError(
+                "Input data should be pandas.DataFrame or numpy.ndarray")
 
         self.pytorch_model.to(device)
         self.pytorch_model.eval()

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -48,7 +48,7 @@ from mlflow.utils.model_utils import (
     _get_flavor_configuration,
     _validate_and_copy_code_paths,
     _add_code_from_conf_to_system_path,
-    _validate_and_prepare_target_save_path
+    _validate_and_prepare_target_save_path,
 )
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.utils.autologging_utils import autologging_integration, safe_patch
@@ -469,8 +469,7 @@ def save_model(
     """
     import torch
 
-    _validate_env_arguments(conda_env, pip_requirements,
-                            extra_pip_requirements)
+    _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
 
     pickle_module = pickle_module or mlflow_pytorch_pickle_module
 
@@ -500,18 +499,15 @@ def save_model(
     #
     # TODO: Stop persisting this information to the filesystem once we have a mechanism for
     # supplying the MLmodel configuration to `mlflow.pytorch._load_pyfunc`
-    pickle_module_path = os.path.join(
-        model_data_path, _PICKLE_MODULE_INFO_FILE_NAME)
+    pickle_module_path = os.path.join(model_data_path, _PICKLE_MODULE_INFO_FILE_NAME)
     with open(pickle_module_path, "w") as f:
         f.write(pickle_module.__name__)
     # Save pytorch model
-    model_path = os.path.join(
-        model_data_path, _SERIALIZED_TORCH_MODEL_FILE_NAME)
+    model_path = os.path.join(model_data_path, _SERIALIZED_TORCH_MODEL_FILE_NAME)
     if isinstance(pytorch_model, torch.jit.ScriptModule):
         torch.jit.ScriptModule.save(pytorch_model, model_path)
     else:
-        torch.save(pytorch_model, model_path,
-                   pickle_module=pickle_module, **kwargs)
+        torch.save(pytorch_model, model_path, pickle_module=pickle_module, **kwargs)
 
     torchserve_artifacts_config = {}
 
@@ -525,10 +521,8 @@ def save_model(
                 _download_artifact_from_uri(
                     artifact_uri=extra_file, output_path=tmp_extra_files_dir.path()
                 )
-                rel_path = posixpath.join(
-                    _EXTRA_FILES_KEY, os.path.basename(extra_file))
-                torchserve_artifacts_config[_EXTRA_FILES_KEY].append(
-                    {"path": rel_path})
+                rel_path = posixpath.join(_EXTRA_FILES_KEY, os.path.basename(extra_file))
+                torchserve_artifacts_config[_EXTRA_FILES_KEY].append({"path": rel_path})
             shutil.move(
                 tmp_extra_files_dir.path(),
                 posixpath.join(path, _EXTRA_FILES_KEY),
@@ -550,8 +544,7 @@ def save_model(
                 artifact_uri=requirements_file, output_path=tmp_requirements_dir.path()
             )
             rel_path = os.path.basename(requirements_file)
-            torchserve_artifacts_config[_REQUIREMENTS_FILE_KEY] = {
-                "path": rel_path}
+            torchserve_artifacts_config[_REQUIREMENTS_FILE_KEY] = {"path": rel_path}
             shutil.move(tmp_requirements_dir.path(rel_path), path)
 
     mlflow_model.add_flavor(
@@ -590,21 +583,18 @@ def save_model(
             extra_pip_requirements,
         )
     else:
-        conda_env, pip_requirements, pip_constraints = _process_conda_env(
-            conda_env)
+        conda_env, pip_requirements, pip_constraints = _process_conda_env(conda_env)
 
     with open(os.path.join(path, _CONDA_ENV_FILE_NAME), "w") as f:
         yaml.safe_dump(conda_env, stream=f, default_flow_style=False)
 
     # Save `constraints.txt` if necessary
     if pip_constraints:
-        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME),
-                 "\n".join(pip_constraints))
+        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME), "\n".join(pip_constraints))
 
     if not requirements_file:
         # Save `requirements.txt`
-        write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME),
-                 "\n".join(pip_requirements))
+        write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME), "\n".join(pip_requirements))
 
 
 def _load_model(path, **kwargs):
@@ -630,8 +620,7 @@ def _load_model(path, **kwargs):
             )
         else:
             try:
-                kwargs["pickle_module"] = importlib.import_module(
-                    pickle_module_name)
+                kwargs["pickle_module"] = importlib.import_module(pickle_module_name)
             except ImportError as exc:
                 raise MlflowException(
                     message=(
@@ -719,10 +708,8 @@ def load_model(model_uri, dst_path=None, **kwargs):
     """
     import torch
 
-    local_model_path = _download_artifact_from_uri(
-        artifact_uri=model_uri, output_path=dst_path)
-    pytorch_conf = _get_flavor_configuration(
-        model_path=local_model_path, flavor_name=FLAVOR_NAME)
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
+    pytorch_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     _add_code_from_conf_to_system_path(local_model_path, pytorch_conf)
 
     if torch.__version__ != pytorch_conf["pytorch_version"]:
@@ -731,8 +718,7 @@ def load_model(model_uri, dst_path=None, **kwargs):
             pytorch_conf["pytorch_version"],
             torch.__version__,
         )
-    torch_model_artifacts_path = os.path.join(
-        local_model_path, pytorch_conf["model_data"])
+    torch_model_artifacts_path = os.path.join(local_model_path, pytorch_conf["model_data"])
     return _load_model(path=torch_model_artifacts_path, **kwargs)
 
 
@@ -767,8 +753,7 @@ class _PyTorchWrapper:
                 "Please use a pandas.DataFrame or a numpy.ndarray"
             )
         else:
-            raise TypeError(
-                "Input data should be pandas.DataFrame or numpy.ndarray")
+            raise TypeError("Input data should be pandas.DataFrame or numpy.ndarray")
 
         self.pytorch_model.to(device)
         self.pytorch_model.eval()

--- a/mlflow/shap.py
+++ b/mlflow/shap.py
@@ -36,6 +36,7 @@ from mlflow.utils.model_utils import (
     _get_flavor_configuration,
     _validate_and_copy_code_paths,
     _add_code_from_conf_to_system_path,
+    _validate_and_prepare_target_save_path
 )
 from mlflow.protos.databricks_pb2 import RESOURCE_ALREADY_EXISTS
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
@@ -421,13 +422,7 @@ def save_explainer(
 
     _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
 
-    if os.path.exists(path):
-        raise MlflowException(
-            message="Path '{}' already exists".format(path),
-            error_code=RESOURCE_ALREADY_EXISTS,
-        )
-
-    os.makedirs(path)
+    _validate_and_prepare_target_save_path(path)
     code_dir_subpath = _validate_and_copy_code_paths(code_paths, path)
 
     if mlflow_model is None:

--- a/mlflow/shap.py
+++ b/mlflow/shap.py
@@ -10,7 +10,6 @@ import mlflow
 import types
 import mlflow.utils.autologging_utils
 from mlflow import pyfunc
-from mlflow.exceptions import MlflowException
 from mlflow.utils.annotations import experimental
 from mlflow.utils.uri import append_to_uri_path
 from mlflow.models import Model
@@ -38,7 +37,6 @@ from mlflow.utils.model_utils import (
     _add_code_from_conf_to_system_path,
     _validate_and_prepare_target_save_path
 )
-from mlflow.protos.databricks_pb2 import RESOURCE_ALREADY_EXISTS
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 
 FLAVOR_NAME = "shap"
@@ -144,7 +142,8 @@ def _log_matplotlib_figure(fig, out_file, artifact_path=None):
 
 
 def _get_conda_env_for_underlying_model(underlying_model_path):
-    underlying_model_conda_path = os.path.join(underlying_model_path, "conda.yaml")
+    underlying_model_conda_path = os.path.join(
+        underlying_model_path, "conda.yaml")
     with open(underlying_model_conda_path, "r") as underlying_model_conda_file:
         return yaml.safe_load(underlying_model_conda_file)
 
@@ -272,11 +271,13 @@ def log_explanation(predict_function, features, artifact_path=None):
 
     artifact_path = _DEFAULT_ARTIFACT_PATH if artifact_path is None else artifact_path
     with mlflow.utils.autologging_utils.disable_autologging():
-        background_data = shap.kmeans(features, min(_MAXIMUM_BACKGROUND_DATA_SIZE, len(features)))
+        background_data = shap.kmeans(features, min(
+            _MAXIMUM_BACKGROUND_DATA_SIZE, len(features)))
         explainer = shap.KernelExplainer(predict_function, background_data)
         shap_values = explainer.shap_values(features)
 
-        _log_numpy(explainer.expected_value, _BASE_VALUES_FILE_NAME, artifact_path)
+        _log_numpy(explainer.expected_value,
+                   _BASE_VALUES_FILE_NAME, artifact_path)
         _log_numpy(shap_values, _SHAP_VALUES_FILE_NAME, artifact_path)
 
         shap.summary_plot(shap_values, features, plot_type="bar", show=False)
@@ -420,7 +421,8 @@ def save_explainer(
     """
     import shap
 
-    _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
+    _validate_env_arguments(conda_env, pip_requirements,
+                            extra_pip_requirements)
 
     _validate_and_prepare_target_save_path(path)
     code_dir_subpath = _validate_and_copy_code_paths(code_paths, path)
@@ -442,16 +444,19 @@ def save_explainer(
 
         if underlying_model_flavor != _UNKNOWN_MODEL_FLAVOR:
             serializable_by_mlflow = True  # prevents SHAP from serializing the underlying model
-            underlying_model_path = os.path.join(path, _UNDERLYING_MODEL_SUBPATH)
+            underlying_model_path = os.path.join(
+                path, _UNDERLYING_MODEL_SUBPATH)
         else:
             warnings.warn(
                 "Unable to serialize underlying model using MLflow, will use SHAP serialization"
             )
 
         if underlying_model_flavor == mlflow.sklearn.FLAVOR_NAME:
-            mlflow.sklearn.save_model(explainer.model.inner_model.__self__, underlying_model_path)
+            mlflow.sklearn.save_model(
+                explainer.model.inner_model.__self__, underlying_model_path)
         elif underlying_model_flavor == mlflow.pytorch.FLAVOR_NAME:
-            mlflow.pytorch.save_model(explainer.model.inner_model, underlying_model_path)
+            mlflow.pytorch.save_model(
+                explainer.model.inner_model, underlying_model_path)
 
     # saving the explainer object
     explainer_data_subpath = "explainer.shap"
@@ -500,10 +505,12 @@ def save_explainer(
             extra_pip_requirements,
         )
     else:
-        conda_env, pip_requirements, pip_constraints = _process_conda_env(conda_env)
+        conda_env, pip_requirements, pip_constraints = _process_conda_env(
+            conda_env)
 
     if underlying_model_path is not None:
-        underlying_model_conda_env = _get_conda_env_for_underlying_model(underlying_model_path)
+        underlying_model_conda_env = _get_conda_env_for_underlying_model(
+            underlying_model_path)
         conda_env = _merge_environments(conda_env, underlying_model_conda_env)
         pip_requirements = _get_pip_deps(conda_env)
 
@@ -512,10 +519,12 @@ def save_explainer(
 
     # Save `constraints.txt` if necessary
     if pip_constraints:
-        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME), "\n".join(pip_constraints))
+        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME),
+                 "\n".join(pip_constraints))
 
     # Save `requirements.txt`
-    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME), "\n".join(pip_requirements))
+    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME),
+             "\n".join(pip_requirements))
 
 
 # Defining save_model (Required by Model.log) to refer to save_explainer
@@ -564,10 +573,13 @@ def _merge_environments(shap_environment, model_environment):
     merged_conda_channels = _union_lists(
         shap_environment["channels"], model_environment["channels"]
     )
-    merged_conda_channels = [x for x in merged_conda_channels if x != "conda-forge"]
+    merged_conda_channels = [
+        x for x in merged_conda_channels if x != "conda-forge"]
 
-    shap_conda_deps, shap_pip_deps = _get_conda_and_pip_dependencies(shap_environment)
-    model_conda_deps, model_pip_deps = _get_conda_and_pip_dependencies(model_environment)
+    shap_conda_deps, shap_pip_deps = _get_conda_and_pip_dependencies(
+        shap_environment)
+    model_conda_deps, model_pip_deps = _get_conda_and_pip_dependencies(
+        model_environment)
 
     merged_conda_deps = _union_lists(shap_conda_deps, model_conda_deps)
     merged_pip_deps = _union_lists(shap_pip_deps, model_pip_deps)
@@ -600,18 +612,22 @@ def load_explainer(model_uri):
     """
 
     explainer_path = _download_artifact_from_uri(artifact_uri=model_uri)
-    flavor_conf = _get_flavor_configuration(model_path=explainer_path, flavor_name=FLAVOR_NAME)
+    flavor_conf = _get_flavor_configuration(
+        model_path=explainer_path, flavor_name=FLAVOR_NAME)
     _add_code_from_conf_to_system_path(explainer_path, flavor_conf)
-    explainer_artifacts_path = os.path.join(explainer_path, flavor_conf["serialized_explainer"])
+    explainer_artifacts_path = os.path.join(
+        explainer_path, flavor_conf["serialized_explainer"])
     underlying_model_flavor = flavor_conf["underlying_model_flavor"]
     model = None
 
     if underlying_model_flavor != _UNKNOWN_MODEL_FLAVOR:
-        underlying_model_path = os.path.join(explainer_path, _UNDERLYING_MODEL_SUBPATH)
+        underlying_model_path = os.path.join(
+            explainer_path, _UNDERLYING_MODEL_SUBPATH)
         if underlying_model_flavor == mlflow.sklearn.FLAVOR_NAME:
             model = mlflow.sklearn._load_pyfunc(underlying_model_path).predict
         elif underlying_model_flavor == mlflow.pytorch.FLAVOR_NAME:
-            model = mlflow.pytorch._load_model(os.path.join(underlying_model_path, "data"))
+            model = mlflow.pytorch._load_model(
+                os.path.join(underlying_model_path, "data"))
 
     return _load_explainer(explainer_file=explainer_artifacts_path, model=model)
 
@@ -633,24 +649,31 @@ def _load_explainer(explainer_file, model=None):
         if model is None:
             explainer = shap.Explainer.load(explainer)
         else:
-            explainer = shap.Explainer.load(explainer, model_loader=inject_model_loader)
+            explainer = shap.Explainer.load(
+                explainer, model_loader=inject_model_loader)
         return explainer
 
 
 class _SHAPWrapper:
     def __init__(self, path):
-        flavor_conf = _get_flavor_configuration(model_path=path, flavor_name=FLAVOR_NAME)
-        shap_explainer_artifacts_path = os.path.join(path, flavor_conf["serialized_explainer"])
+        flavor_conf = _get_flavor_configuration(
+            model_path=path, flavor_name=FLAVOR_NAME)
+        shap_explainer_artifacts_path = os.path.join(
+            path, flavor_conf["serialized_explainer"])
         underlying_model_flavor = flavor_conf["underlying_model_flavor"]
         model = None
         if underlying_model_flavor != _UNKNOWN_MODEL_FLAVOR:
-            underlying_model_path = os.path.join(path, _UNDERLYING_MODEL_SUBPATH)
+            underlying_model_path = os.path.join(
+                path, _UNDERLYING_MODEL_SUBPATH)
             if underlying_model_flavor == mlflow.sklearn.FLAVOR_NAME:
-                model = mlflow.sklearn._load_pyfunc(underlying_model_path).predict
+                model = mlflow.sklearn._load_pyfunc(
+                    underlying_model_path).predict
             elif underlying_model_flavor == mlflow.pytorch.FLAVOR_NAME:
-                model = mlflow.pytorch._load_model(os.path.join(underlying_model_path, "data"))
+                model = mlflow.pytorch._load_model(
+                    os.path.join(underlying_model_path, "data"))
 
-        self.explainer = _load_explainer(explainer_file=shap_explainer_artifacts_path, model=model)
+        self.explainer = _load_explainer(
+            explainer_file=shap_explainer_artifacts_path, model=model)
 
     def predict(self, dataframe):
         return self.explainer(dataframe.values).values

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -51,7 +51,7 @@ from mlflow.utils.model_utils import (
     _get_flavor_configuration,
     _validate_and_copy_code_paths,
     _add_code_from_conf_to_system_path,
-    _validate_and_prepare_target_save_path
+    _validate_and_prepare_target_save_path,
 )
 from mlflow.utils.autologging_utils import (
     autologging_integration,
@@ -71,8 +71,7 @@ FLAVOR_NAME = "sklearn"
 SERIALIZATION_FORMAT_PICKLE = "pickle"
 SERIALIZATION_FORMAT_CLOUDPICKLE = "cloudpickle"
 
-SUPPORTED_SERIALIZATION_FORMATS = [
-    SERIALIZATION_FORMAT_PICKLE, SERIALIZATION_FORMAT_CLOUDPICKLE]
+SUPPORTED_SERIALIZATION_FORMATS = [SERIALIZATION_FORMAT_PICKLE, SERIALIZATION_FORMAT_CLOUDPICKLE]
 
 _logger = logging.getLogger(__name__)
 _SklearnTrainingSession = _get_new_training_session_class()
@@ -220,8 +219,7 @@ def save_model(
     """
     import sklearn
 
-    _validate_env_arguments(conda_env, pip_requirements,
-                            extra_pip_requirements)
+    _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
 
     if serialization_format not in SUPPORTED_SERIALIZATION_FORMATS:
         raise MlflowException(
@@ -291,20 +289,17 @@ def save_model(
             extra_pip_requirements,
         )
     else:
-        conda_env, pip_requirements, pip_constraints = _process_conda_env(
-            conda_env)
+        conda_env, pip_requirements, pip_constraints = _process_conda_env(conda_env)
 
     with open(os.path.join(path, _CONDA_ENV_FILE_NAME), "w") as f:
         yaml.safe_dump(conda_env, stream=f, default_flow_style=False)
 
     # Save `constraints.txt` if necessary
     if pip_constraints:
-        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME),
-                 "\n".join(pip_constraints))
+        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME), "\n".join(pip_constraints))
 
     # Save `requirements.txt`
-    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME),
-             "\n".join(pip_requirements))
+    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME), "\n".join(pip_requirements))
 
 
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name="scikit-learn"))
@@ -566,15 +561,11 @@ def load_model(model_uri, dst_path=None):
         pandas_df = ...
         predictions = sk_model.predict(pandas_df)
     """
-    local_model_path = _download_artifact_from_uri(
-        artifact_uri=model_uri, output_path=dst_path)
-    flavor_conf = _get_flavor_configuration(
-        model_path=local_model_path, flavor_name=FLAVOR_NAME)
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
+    flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     _add_code_from_conf_to_system_path(local_model_path, FLAVOR_NAME)
-    sklearn_model_artifacts_path = os.path.join(
-        local_model_path, flavor_conf["pickled_model"])
-    serialization_format = flavor_conf.get(
-        "serialization_format", SERIALIZATION_FORMAT_PICKLE)
+    sklearn_model_artifacts_path = os.path.join(local_model_path, flavor_conf["pickled_model"])
+    serialization_format = flavor_conf.get("serialization_format", SERIALIZATION_FORMAT_PICKLE)
     return _load_model_from_local_file(
         path=sklearn_model_artifacts_path, serialization_format=serialization_format
     )
@@ -740,8 +731,7 @@ class _AutologgingMetricsManager:
         self._pred_result_id_to_dataset_name_and_run_id[prediction_result_id] = value
 
         def clean_id(id_):
-            _AUTOLOGGING_METRICS_MANAGER._pred_result_id_to_dataset_name_and_run_id.pop(
-                id_, None)
+            _AUTOLOGGING_METRICS_MANAGER._pred_result_id_to_dataset_name_and_run_id.pop(id_, None)
 
         # When the `predict_result` object being GCed, its ID may be reused, so register a finalizer
         # to clear the ID from the dict for preventing wrong ID mapping.
@@ -841,8 +831,7 @@ class _AutologgingMetricsManager:
         #    https://scikit-learn.org/stable/modules/generated/sklearn.metrics.silhouette_score.html#sklearn.metrics.silhouette_score
         for arg in call_arg_list:
             if arg is not None and not np.isscalar(arg) and id(arg) in dataset_id_list:
-                dataset_name, run_id = self._pred_result_id_to_dataset_name_and_run_id[id(
-                    arg)]
+                dataset_name, run_id = self._pred_result_id_to_dataset_name_and_run_id[id(arg)]
                 break
         else:
             return None, None
@@ -865,8 +854,7 @@ class _AutologgingMetricsManager:
 
             call_commands_list.sort(key=lambda x: x[0])
             dict_to_log = OrderedDict(call_commands_list)
-            client.log_dict(run_id=run_id, dictionary=dict_to_log,
-                            artifact_file="metric_info.json")
+            client.log_dict(run_id=run_id, dictionary=dict_to_log, artifact_file="metric_info.json")
             self._metric_info_artifact_need_update[run_id] = False
 
 
@@ -912,12 +900,10 @@ def _patch_estimator_method_if_available(flavor_name, class_def, func_name, patc
     )
     if raw_original_obj == original and (callable(original) or isinstance(original, property)):
         # normal method or property decorated method
-        safe_patch(flavor_name, class_def, func_name,
-                   patched_fn, manage_run=manage_run)
+        safe_patch(flavor_name, class_def, func_name, patched_fn, manage_run=manage_run)
     elif hasattr(raw_original_obj, "delegate_names") or hasattr(raw_original_obj, "check"):
         # sklearn delegated method
-        safe_patch(flavor_name, raw_original_obj, "fn",
-                   patched_fn, manage_run=manage_run)
+        safe_patch(flavor_name, raw_original_obj, "fn", patched_fn, manage_run=manage_run)
     else:
         # unsupported method type. skip patching
         pass
@@ -1256,8 +1242,7 @@ def _autolog(
     if max_tuning_runs is not None and max_tuning_runs < 0:
         raise MlflowException(
             message=(
-                "`max_tuning_runs` must be non-negative, instead got {}.".format(
-                    max_tuning_runs)
+                "`max_tuning_runs` must be non-negative, instead got {}.".format(max_tuning_runs)
             ),
             error_code=INVALID_PARAMETER_VALUE,
         )
@@ -1283,8 +1268,7 @@ def _autolog(
         if log_models:
             input_example, signature = resolve_input_example_and_signature(
                 lambda: X[:INPUT_EXAMPLE_SAMPLE_ROWS],
-                lambda input_example: infer_signature(
-                    input_example, self.predict(input_example)),
+                lambda input_example: infer_signature(input_example, self.predict(input_example)),
                 log_input_examples,
                 log_model_signatures,
                 _logger,
@@ -1343,8 +1327,7 @@ def _autolog(
         # however, child estimators act as seeds for the parameter search
         # process; accordingly, we avoid logging initial, untuned parameters
         # for these seed estimators.
-        should_log_params_deeply = not _is_parameter_search_estimator(
-            estimator)
+        should_log_params_deeply = not _is_parameter_search_estimator(estimator)
         run_id = mlflow.active_run().info.run_id
         autologging_client.log_params(
             run_id=mlflow.active_run().info.run_id,
@@ -1379,8 +1362,7 @@ def _autolog(
 
             return infer_signature(input_example, estimator.predict(input_example))
 
-        (X, y_true, sample_weight) = _get_X_y_and_sample_weight(
-            estimator.fit, args, kwargs)
+        (X, y_true, sample_weight) = _get_X_y_and_sample_weight(estimator.fit, args, kwargs)
 
         # log common metrics and artifacts for estimators (classifier, regressor)
         logged_metrics = _log_estimator_content(
@@ -1475,14 +1457,12 @@ def _autolog(
 
                     msg = (
                         "Encountered exception during creation of child runs for parameter search."
-                        " Child runs may be missing. Exception: {}".format(
-                            str(e))
+                        " Child runs may be missing. Exception: {}".format(str(e))
                     )
                     _logger.warning(msg)
 
                 try:
-                    cv_results_df = pd.DataFrame.from_dict(
-                        estimator.cv_results_)
+                    cv_results_df = pd.DataFrame.from_dict(estimator.cv_results_)
                     _log_parameter_search_results_as_artifact(
                         cv_results_df, mlflow.active_run().info.run_id
                     )
@@ -1543,8 +1523,7 @@ def _autolog(
             # Avoid nested patch when nested inference calls happens.
             with _AUTOLOGGING_METRICS_MANAGER.disable_log_post_training_metrics():
                 predict_result = original(self, *args, **kwargs)
-            eval_dataset = get_instance_method_first_arg_value(
-                original, args, kwargs)
+            eval_dataset = get_instance_method_first_arg_value(original, args, kwargs)
             eval_dataset_name = _AUTOLOGGING_METRICS_MANAGER.register_prediction_input_dataset(
                 self, eval_dataset
             )
@@ -1604,8 +1583,7 @@ def _autolog(
                     self, original, *args, **kwargs
                 )
 
-                eval_dataset = get_instance_method_first_arg_value(
-                    original, args, kwargs)
+                eval_dataset = get_instance_method_first_arg_value(original, args, kwargs)
                 eval_dataset_name = _AUTOLOGGING_METRICS_MANAGER.register_prediction_input_dataset(
                     self, eval_dataset
                 )
@@ -1641,16 +1619,14 @@ def _autolog(
                     # this is to allow access to the docstrings.
                     for delegate_name in self.delegate_names:
                         try:
-                            delegate = sklearn.utils.metaestimators.attrgetter(
-                                delegate_name)(obj)
+                            delegate = sklearn.utils.metaestimators.attrgetter(delegate_name)(obj)
                         except AttributeError:
                             continue
                         else:
                             getattr(delegate, self.attribute_name)
                             break
                     else:
-                        sklearn.utils.metaestimators.attrgetter(
-                            self.delegate_names[-1])(obj)
+                        sklearn.utils.metaestimators.attrgetter(self.delegate_names[-1])(obj)
 
                     def out(*args, **kwargs):
                         return self.fn(obj, *args, **kwargs)
@@ -1723,8 +1699,7 @@ def _autolog(
             )
 
         for scorer in sklearn.metrics.SCORERS.values():
-            safe_patch(flavor_name, scorer, "_score_func",
-                       patched_metric_api, manage_run=False)
+            safe_patch(flavor_name, scorer, "_score_func", patched_metric_api, manage_run=False)
 
     def patched_fn_with_autolog_disabled(original, *args, **kwargs):
         with disable_autologging():

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -30,7 +30,6 @@ from mlflow.models.model import MLMODEL_FILE_NAME
 from mlflow.models.signature import ModelSignature
 from mlflow.models.utils import ModelInputExample, _save_example
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, INTERNAL_ERROR
-from mlflow.protos.databricks_pb2 import RESOURCE_ALREADY_EXISTS
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils import _inspect_original_var_name
 from mlflow.utils.autologging_utils import get_instance_method_first_arg_value
@@ -72,7 +71,8 @@ FLAVOR_NAME = "sklearn"
 SERIALIZATION_FORMAT_PICKLE = "pickle"
 SERIALIZATION_FORMAT_CLOUDPICKLE = "cloudpickle"
 
-SUPPORTED_SERIALIZATION_FORMATS = [SERIALIZATION_FORMAT_PICKLE, SERIALIZATION_FORMAT_CLOUDPICKLE]
+SUPPORTED_SERIALIZATION_FORMATS = [
+    SERIALIZATION_FORMAT_PICKLE, SERIALIZATION_FORMAT_CLOUDPICKLE]
 
 _logger = logging.getLogger(__name__)
 _SklearnTrainingSession = _get_new_training_session_class()
@@ -220,7 +220,8 @@ def save_model(
     """
     import sklearn
 
-    _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
+    _validate_env_arguments(conda_env, pip_requirements,
+                            extra_pip_requirements)
 
     if serialization_format not in SUPPORTED_SERIALIZATION_FORMATS:
         raise MlflowException(
@@ -290,17 +291,20 @@ def save_model(
             extra_pip_requirements,
         )
     else:
-        conda_env, pip_requirements, pip_constraints = _process_conda_env(conda_env)
+        conda_env, pip_requirements, pip_constraints = _process_conda_env(
+            conda_env)
 
     with open(os.path.join(path, _CONDA_ENV_FILE_NAME), "w") as f:
         yaml.safe_dump(conda_env, stream=f, default_flow_style=False)
 
     # Save `constraints.txt` if necessary
     if pip_constraints:
-        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME), "\n".join(pip_constraints))
+        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME),
+                 "\n".join(pip_constraints))
 
     # Save `requirements.txt`
-    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME), "\n".join(pip_requirements))
+    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME),
+             "\n".join(pip_requirements))
 
 
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name="scikit-learn"))
@@ -562,11 +566,15 @@ def load_model(model_uri, dst_path=None):
         pandas_df = ...
         predictions = sk_model.predict(pandas_df)
     """
-    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
-    flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
+    local_model_path = _download_artifact_from_uri(
+        artifact_uri=model_uri, output_path=dst_path)
+    flavor_conf = _get_flavor_configuration(
+        model_path=local_model_path, flavor_name=FLAVOR_NAME)
     _add_code_from_conf_to_system_path(local_model_path, FLAVOR_NAME)
-    sklearn_model_artifacts_path = os.path.join(local_model_path, flavor_conf["pickled_model"])
-    serialization_format = flavor_conf.get("serialization_format", SERIALIZATION_FORMAT_PICKLE)
+    sklearn_model_artifacts_path = os.path.join(
+        local_model_path, flavor_conf["pickled_model"])
+    serialization_format = flavor_conf.get(
+        "serialization_format", SERIALIZATION_FORMAT_PICKLE)
     return _load_model_from_local_file(
         path=sklearn_model_artifacts_path, serialization_format=serialization_format
     )
@@ -732,7 +740,8 @@ class _AutologgingMetricsManager:
         self._pred_result_id_to_dataset_name_and_run_id[prediction_result_id] = value
 
         def clean_id(id_):
-            _AUTOLOGGING_METRICS_MANAGER._pred_result_id_to_dataset_name_and_run_id.pop(id_, None)
+            _AUTOLOGGING_METRICS_MANAGER._pred_result_id_to_dataset_name_and_run_id.pop(
+                id_, None)
 
         # When the `predict_result` object being GCed, its ID may be reused, so register a finalizer
         # to clear the ID from the dict for preventing wrong ID mapping.
@@ -832,7 +841,8 @@ class _AutologgingMetricsManager:
         #    https://scikit-learn.org/stable/modules/generated/sklearn.metrics.silhouette_score.html#sklearn.metrics.silhouette_score
         for arg in call_arg_list:
             if arg is not None and not np.isscalar(arg) and id(arg) in dataset_id_list:
-                dataset_name, run_id = self._pred_result_id_to_dataset_name_and_run_id[id(arg)]
+                dataset_name, run_id = self._pred_result_id_to_dataset_name_and_run_id[id(
+                    arg)]
                 break
         else:
             return None, None
@@ -855,7 +865,8 @@ class _AutologgingMetricsManager:
 
             call_commands_list.sort(key=lambda x: x[0])
             dict_to_log = OrderedDict(call_commands_list)
-            client.log_dict(run_id=run_id, dictionary=dict_to_log, artifact_file="metric_info.json")
+            client.log_dict(run_id=run_id, dictionary=dict_to_log,
+                            artifact_file="metric_info.json")
             self._metric_info_artifact_need_update[run_id] = False
 
 
@@ -901,10 +912,12 @@ def _patch_estimator_method_if_available(flavor_name, class_def, func_name, patc
     )
     if raw_original_obj == original and (callable(original) or isinstance(original, property)):
         # normal method or property decorated method
-        safe_patch(flavor_name, class_def, func_name, patched_fn, manage_run=manage_run)
+        safe_patch(flavor_name, class_def, func_name,
+                   patched_fn, manage_run=manage_run)
     elif hasattr(raw_original_obj, "delegate_names") or hasattr(raw_original_obj, "check"):
         # sklearn delegated method
-        safe_patch(flavor_name, raw_original_obj, "fn", patched_fn, manage_run=manage_run)
+        safe_patch(flavor_name, raw_original_obj, "fn",
+                   patched_fn, manage_run=manage_run)
     else:
         # unsupported method type. skip patching
         pass
@@ -1243,7 +1256,8 @@ def _autolog(
     if max_tuning_runs is not None and max_tuning_runs < 0:
         raise MlflowException(
             message=(
-                "`max_tuning_runs` must be non-negative, instead got {}.".format(max_tuning_runs)
+                "`max_tuning_runs` must be non-negative, instead got {}.".format(
+                    max_tuning_runs)
             ),
             error_code=INVALID_PARAMETER_VALUE,
         )
@@ -1269,7 +1283,8 @@ def _autolog(
         if log_models:
             input_example, signature = resolve_input_example_and_signature(
                 lambda: X[:INPUT_EXAMPLE_SAMPLE_ROWS],
-                lambda input_example: infer_signature(input_example, self.predict(input_example)),
+                lambda input_example: infer_signature(
+                    input_example, self.predict(input_example)),
                 log_input_examples,
                 log_model_signatures,
                 _logger,
@@ -1328,7 +1343,8 @@ def _autolog(
         # however, child estimators act as seeds for the parameter search
         # process; accordingly, we avoid logging initial, untuned parameters
         # for these seed estimators.
-        should_log_params_deeply = not _is_parameter_search_estimator(estimator)
+        should_log_params_deeply = not _is_parameter_search_estimator(
+            estimator)
         run_id = mlflow.active_run().info.run_id
         autologging_client.log_params(
             run_id=mlflow.active_run().info.run_id,
@@ -1363,7 +1379,8 @@ def _autolog(
 
             return infer_signature(input_example, estimator.predict(input_example))
 
-        (X, y_true, sample_weight) = _get_X_y_and_sample_weight(estimator.fit, args, kwargs)
+        (X, y_true, sample_weight) = _get_X_y_and_sample_weight(
+            estimator.fit, args, kwargs)
 
         # log common metrics and artifacts for estimators (classifier, regressor)
         logged_metrics = _log_estimator_content(
@@ -1458,12 +1475,14 @@ def _autolog(
 
                     msg = (
                         "Encountered exception during creation of child runs for parameter search."
-                        " Child runs may be missing. Exception: {}".format(str(e))
+                        " Child runs may be missing. Exception: {}".format(
+                            str(e))
                     )
                     _logger.warning(msg)
 
                 try:
-                    cv_results_df = pd.DataFrame.from_dict(estimator.cv_results_)
+                    cv_results_df = pd.DataFrame.from_dict(
+                        estimator.cv_results_)
                     _log_parameter_search_results_as_artifact(
                         cv_results_df, mlflow.active_run().info.run_id
                     )
@@ -1524,7 +1543,8 @@ def _autolog(
             # Avoid nested patch when nested inference calls happens.
             with _AUTOLOGGING_METRICS_MANAGER.disable_log_post_training_metrics():
                 predict_result = original(self, *args, **kwargs)
-            eval_dataset = get_instance_method_first_arg_value(original, args, kwargs)
+            eval_dataset = get_instance_method_first_arg_value(
+                original, args, kwargs)
             eval_dataset_name = _AUTOLOGGING_METRICS_MANAGER.register_prediction_input_dataset(
                 self, eval_dataset
             )
@@ -1584,7 +1604,8 @@ def _autolog(
                     self, original, *args, **kwargs
                 )
 
-                eval_dataset = get_instance_method_first_arg_value(original, args, kwargs)
+                eval_dataset = get_instance_method_first_arg_value(
+                    original, args, kwargs)
                 eval_dataset_name = _AUTOLOGGING_METRICS_MANAGER.register_prediction_input_dataset(
                     self, eval_dataset
                 )
@@ -1620,14 +1641,16 @@ def _autolog(
                     # this is to allow access to the docstrings.
                     for delegate_name in self.delegate_names:
                         try:
-                            delegate = sklearn.utils.metaestimators.attrgetter(delegate_name)(obj)
+                            delegate = sklearn.utils.metaestimators.attrgetter(
+                                delegate_name)(obj)
                         except AttributeError:
                             continue
                         else:
                             getattr(delegate, self.attribute_name)
                             break
                     else:
-                        sklearn.utils.metaestimators.attrgetter(self.delegate_names[-1])(obj)
+                        sklearn.utils.metaestimators.attrgetter(
+                            self.delegate_names[-1])(obj)
 
                     def out(*args, **kwargs):
                         return self.fn(obj, *args, **kwargs)
@@ -1700,7 +1723,8 @@ def _autolog(
             )
 
         for scorer in sklearn.metrics.SCORERS.values():
-            safe_patch(flavor_name, scorer, "_score_func", patched_metric_api, manage_run=False)
+            safe_patch(flavor_name, scorer, "_score_func",
+                       patched_metric_api, manage_run=False)
 
     def patched_fn_with_autolog_disabled(original, *args, **kwargs):
         with disable_autologging():

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -52,6 +52,7 @@ from mlflow.utils.model_utils import (
     _get_flavor_configuration,
     _validate_and_copy_code_paths,
     _add_code_from_conf_to_system_path,
+    _validate_and_prepare_target_save_path
 )
 from mlflow.utils.autologging_utils import (
     autologging_integration,
@@ -233,11 +234,7 @@ def save_model(
             error_code=INVALID_PARAMETER_VALUE,
         )
 
-    if os.path.exists(path):
-        raise MlflowException(
-            message="Path '{}' already exists".format(path), error_code=RESOURCE_ALREADY_EXISTS
-        )
-    os.makedirs(path)
+    _validate_and_prepare_target_save_path(path)
     code_path_subdir = _validate_and_copy_code_paths(code_paths, path)
 
     if mlflow_model is None:

--- a/mlflow/spacy.py
+++ b/mlflow/spacy.py
@@ -38,6 +38,7 @@ from mlflow.utils.model_utils import (
     _get_flavor_configuration,
     _validate_and_copy_code_paths,
     _add_code_from_conf_to_system_path,
+    _validate_and_prepare_target_save_path
 )
 
 FLAVOR_NAME = "spacy"
@@ -111,11 +112,7 @@ def save_model(
     _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
 
     path = os.path.abspath(path)
-    if os.path.exists(path):
-        raise MlflowException(
-            "Unable to save MLflow model to {path} - path '{path}' "
-            "already exists".format(path=path)
-        )
+    _validate_and_prepare_target_save_path(path)
 
     model_data_subpath = "model.spacy"
     model_data_path = os.path.join(path, model_data_subpath)

--- a/mlflow/spacy.py
+++ b/mlflow/spacy.py
@@ -38,7 +38,7 @@ from mlflow.utils.model_utils import (
     _get_flavor_configuration,
     _validate_and_copy_code_paths,
     _add_code_from_conf_to_system_path,
-    _validate_and_prepare_target_save_path
+    _validate_and_prepare_target_save_path,
 )
 
 FLAVOR_NAME = "spacy"

--- a/mlflow/statsmodels.py
+++ b/mlflow/statsmodels.py
@@ -39,7 +39,7 @@ from mlflow.utils.model_utils import (
     _get_flavor_configuration,
     _validate_and_copy_code_paths,
     _add_code_from_conf_to_system_path,
-    _validate_and_prepare_target_save_path
+    _validate_and_prepare_target_save_path,
 )
 from mlflow.exceptions import MlflowException
 from mlflow.utils.autologging_utils import (
@@ -136,8 +136,7 @@ def save_model(
     """
     import statsmodels
 
-    _validate_env_arguments(conda_env, pip_requirements,
-                            extra_pip_requirements)
+    _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
 
     path = os.path.abspath(path)
     _validate_and_prepare_target_save_path(path)
@@ -199,20 +198,17 @@ def save_model(
             extra_pip_requirements,
         )
     else:
-        conda_env, pip_requirements, pip_constraints = _process_conda_env(
-            conda_env)
+        conda_env, pip_requirements, pip_constraints = _process_conda_env(conda_env)
 
     with open(os.path.join(path, _CONDA_ENV_FILE_NAME), "w") as f:
         yaml.safe_dump(conda_env, stream=f, default_flow_style=False)
 
     # Save `constraints.txt` if necessary
     if pip_constraints:
-        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME),
-                 "\n".join(pip_constraints))
+        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME), "\n".join(pip_constraints))
 
     # Save `requirements.txt`
-    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME),
-             "\n".join(pip_requirements))
+    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME), "\n".join(pip_requirements))
 
 
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
@@ -327,10 +323,8 @@ def load_model(model_uri, dst_path=None):
 
     :return: A statsmodels model (an instance of `statsmodels.base.model.Results`_).
     """
-    local_model_path = _download_artifact_from_uri(
-        artifact_uri=model_uri, output_path=dst_path)
-    flavor_conf = _get_flavor_configuration(
-        model_path=local_model_path, flavor_name=FLAVOR_NAME)
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
+    flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     _add_code_from_conf_to_system_path(local_model_path, flavor_conf)
     statsmodels_model_file_path = os.path.join(
         local_model_path, flavor_conf.get("data", STATSMODELS_DATA_SUBPATH)
@@ -484,8 +478,7 @@ def autolog(
         """
         try:
             superclass = inspect.getmro(klass)[1]
-            overriden = getattr(klass, function_name) is not getattr(
-                superclass, function_name)
+            overriden = getattr(klass, function_name) is not getattr(superclass, function_name)
             return overriden
         except (IndexError, AttributeError):
             return False
@@ -516,8 +509,7 @@ def autolog(
         ]
 
         for clazz, method_name, patch_impl in patches_list:
-            safe_patch(FLAVOR_NAME, clazz, method_name,
-                       patch_impl, manage_run=True)
+            safe_patch(FLAVOR_NAME, clazz, method_name, patch_impl, manage_run=True)
 
     def wrapper_fit(original, self, *args, **kwargs):
 

--- a/mlflow/statsmodels.py
+++ b/mlflow/statsmodels.py
@@ -39,6 +39,7 @@ from mlflow.utils.model_utils import (
     _get_flavor_configuration,
     _validate_and_copy_code_paths,
     _add_code_from_conf_to_system_path,
+    _validate_and_prepare_target_save_path
 )
 from mlflow.exceptions import MlflowException
 from mlflow.utils.autologging_utils import (
@@ -135,13 +136,12 @@ def save_model(
     """
     import statsmodels
 
-    _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
+    _validate_env_arguments(conda_env, pip_requirements,
+                            extra_pip_requirements)
 
     path = os.path.abspath(path)
-    if os.path.exists(path):
-        raise MlflowException("Path '{}' already exists".format(path))
+    _validate_and_prepare_target_save_path(path)
     model_data_path = os.path.join(path, STATSMODELS_DATA_SUBPATH)
-    os.makedirs(path)
     code_dir_subpath = _validate_and_copy_code_paths(code_paths, path)
 
     if mlflow_model is None:
@@ -199,17 +199,20 @@ def save_model(
             extra_pip_requirements,
         )
     else:
-        conda_env, pip_requirements, pip_constraints = _process_conda_env(conda_env)
+        conda_env, pip_requirements, pip_constraints = _process_conda_env(
+            conda_env)
 
     with open(os.path.join(path, _CONDA_ENV_FILE_NAME), "w") as f:
         yaml.safe_dump(conda_env, stream=f, default_flow_style=False)
 
     # Save `constraints.txt` if necessary
     if pip_constraints:
-        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME), "\n".join(pip_constraints))
+        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME),
+                 "\n".join(pip_constraints))
 
     # Save `requirements.txt`
-    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME), "\n".join(pip_requirements))
+    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME),
+             "\n".join(pip_requirements))
 
 
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
@@ -324,8 +327,10 @@ def load_model(model_uri, dst_path=None):
 
     :return: A statsmodels model (an instance of `statsmodels.base.model.Results`_).
     """
-    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
-    flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
+    local_model_path = _download_artifact_from_uri(
+        artifact_uri=model_uri, output_path=dst_path)
+    flavor_conf = _get_flavor_configuration(
+        model_path=local_model_path, flavor_name=FLAVOR_NAME)
     _add_code_from_conf_to_system_path(local_model_path, flavor_conf)
     statsmodels_model_file_path = os.path.join(
         local_model_path, flavor_conf.get("data", STATSMODELS_DATA_SUBPATH)
@@ -479,7 +484,8 @@ def autolog(
         """
         try:
             superclass = inspect.getmro(klass)[1]
-            overriden = getattr(klass, function_name) is not getattr(superclass, function_name)
+            overriden = getattr(klass, function_name) is not getattr(
+                superclass, function_name)
             return overriden
         except (IndexError, AttributeError):
             return False
@@ -510,7 +516,8 @@ def autolog(
         ]
 
         for clazz, method_name, patch_impl in patches_list:
-            safe_patch(FLAVOR_NAME, clazz, method_name, patch_impl, manage_run=True)
+            safe_patch(FLAVOR_NAME, clazz, method_name,
+                       patch_impl, manage_run=True)
 
     def wrapper_fit(original, self, *args, **kwargs):
 

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -49,7 +49,7 @@ from mlflow.utils.model_utils import (
     _get_flavor_configuration,
     _validate_and_copy_code_paths,
     _add_code_from_conf_to_system_path,
-    _validate_and_prepare_target_save_path
+    _validate_and_prepare_target_save_path,
 )
 from mlflow.utils.autologging_utils import (
     autologging_integration,
@@ -269,8 +269,7 @@ def save_model(
     :param pip_requirements: {{ pip_requirements }}
     :param extra_pip_requirements: {{ extra_pip_requirements }}
     """
-    _validate_env_arguments(conda_env, pip_requirements,
-                            extra_pip_requirements)
+    _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
 
     _logger.info(
         "Validating the specified TensorFlow model by attempting to load it in a new TensorFlow"
@@ -292,8 +291,7 @@ def save_model(
         mlflow_model.signature = signature
     if input_example is not None:
         _save_example(mlflow_model, input_example, path)
-    root_relative_path = _copy_file_or_tree(
-        src=tf_saved_model_dir, dst=path, dst_dir=None)
+    root_relative_path = _copy_file_or_tree(src=tf_saved_model_dir, dst=path, dst_dir=None)
     model_dir_subpath = "tfmodel"
     model_dir_path = os.path.join(path, model_dir_subpath)
     shutil.move(os.path.join(path, root_relative_path), model_dir_path)
@@ -332,20 +330,17 @@ def save_model(
             extra_pip_requirements,
         )
     else:
-        conda_env, pip_requirements, pip_constraints = _process_conda_env(
-            conda_env)
+        conda_env, pip_requirements, pip_constraints = _process_conda_env(conda_env)
 
     with open(os.path.join(path, _CONDA_ENV_FILE_NAME), "w") as f:
         yaml.safe_dump(conda_env, stream=f, default_flow_style=False)
 
     # Save `constraints.txt` if necessary
     if pip_constraints:
-        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME),
-                 "\n".join(pip_constraints))
+        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME), "\n".join(pip_constraints))
 
     # Save `requirements.txt`
-    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME),
-             "\n".join(pip_requirements))
+    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME), "\n".join(pip_requirements))
 
 
 def _validate_saved_model(tf_saved_model_dir, tf_meta_graph_tags, tf_signature_def_key):
@@ -397,8 +392,7 @@ def load_model(model_uri, dst_path=None):
             output_tensors = [tf_graph.get_tensor_by_name(output_signature.name)
                                 for _, output_signature in signature_definition.outputs.items()]
     """
-    local_model_path = _download_artifact_from_uri(
-        artifact_uri=model_uri, output_path=dst_path)
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
     flavor_conf = _get_flavor_configuration(local_model_path, FLAVOR_NAME)
     _add_code_from_conf_to_system_path(local_model_path, flavor_conf)
     (
@@ -458,8 +452,7 @@ def _parse_flavor_configuration(flavor_conf, model_path):
                                          with the model. This is a key within the serialized
                                          ``SavedModel``'s signature definition mapping.
     """
-    tf_saved_model_dir = os.path.join(
-        model_path, flavor_conf["saved_model_dir"])
+    tf_saved_model_dir = os.path.join(model_path, flavor_conf["saved_model_dir"])
     tf_meta_graph_tags = flavor_conf["meta_graph_tags"]
     tf_signature_def_key = flavor_conf["signature_def_key"]
     return tf_saved_model_dir, tf_meta_graph_tags, tf_signature_def_key
@@ -525,12 +518,10 @@ class _TF2Wrapper:
                     val = np.array(val.to_list())
                 feed_dict[df_col_name] = tensorflow.constant(val)
         else:
-            raise TypeError(
-                "Only dict and DataFrame input types are supported")
+            raise TypeError("Only dict and DataFrame input types are supported")
 
         raw_preds = self.infer(**feed_dict)
-        pred_dict = {col_name: raw_preds[col_name].numpy()
-                     for col_name in raw_preds.keys()}
+        pred_dict = {col_name: raw_preds[col_name].numpy() for col_name in raw_preds.keys()}
         for col in pred_dict.keys():
             if all(len(element) == 1 for element in pred_dict[col]):
                 pred_dict[col] = pred_dict[col].ravel()
@@ -649,8 +640,7 @@ def _setup_callbacks(lst, log_models, metrics_logger):
     else:
         log_dir = _TensorBoardLogDir(location=tb.log_dir, is_temp=False)
         out_list = lst
-    out_list += [__MLflowTfKeras2Callback(log_models,
-                                          metrics_logger, _LOG_EVERY_N_STEPS)]
+    out_list += [__MLflowTfKeras2Callback(log_models, metrics_logger, _LOG_EVERY_N_STEPS)]
     return out_list, log_dir
 
 
@@ -751,8 +741,7 @@ def autolog(
     atexit.register(_flush_queue)
 
     if Version(tensorflow.__version__) < Version("1.12"):
-        warnings.warn(
-            "Could not log to MLflow. TensorFlow versions below 1.12 are not supported.")
+        warnings.warn("Could not log to MLflow. TensorFlow versions below 1.12 are not supported.")
         return
 
     try:
@@ -761,8 +750,7 @@ def autolog(
         from tensorflow.python.saved_model import tag_constants
         from tensorflow.python.summary.writer.writer import FileWriter
     except ImportError:
-        warnings.warn(
-            "Could not log to MLflow. TensorFlow versions below 1.12 are not supported.")
+        warnings.warn("Could not log to MLflow. TensorFlow versions below 1.12 are not supported.")
         return
 
     def train(original, self, *args, **kwargs):
@@ -812,22 +800,18 @@ def autolog(
                 with TempDir() as tmp:
                     artifact_path = "model"
                     local_path = tmp.path("model")
-                    mlflow_model = Model(
-                        artifact_path=artifact_path, run_id=_AUTOLOG_RUN_ID)
+                    mlflow_model = Model(artifact_path=artifact_path, run_id=_AUTOLOG_RUN_ID)
                     save_model_kwargs = dict(
                         tf_saved_model_dir=serialized.decode("utf-8"),
                         tf_meta_graph_tags=[tag_constants.SERVING],
                         tf_signature_def_key="predict",
                     )
-                    save_model(path=local_path,
-                               mlflow_model=mlflow_model, **save_model_kwargs)
+                    save_model(path=local_path, mlflow_model=mlflow_model, **save_model_kwargs)
                     client = MlflowClient()
-                    client.log_artifacts(
-                        _AUTOLOG_RUN_ID, local_path, artifact_path)
+                    client.log_artifacts(_AUTOLOG_RUN_ID, local_path, artifact_path)
 
                     try:
-                        client._record_logged_model(
-                            _AUTOLOG_RUN_ID, mlflow_model)
+                        client._record_logged_model(_AUTOLOG_RUN_ID, mlflow_model)
                     except MlflowException:
                         # We need to swallow all mlflow exceptions to maintain backwards
                         # compatibility with older tracking servers. Only print out a warning
@@ -911,8 +895,7 @@ def autolog(
         def _patch_implementation(
             self, original, inst, *args, **kwargs
         ):  # pylint: disable=arguments-differ
-            unlogged_params = ["self", "x", "y",
-                               "callbacks", "validation_data", "verbose"]
+            unlogged_params = ["self", "x", "y", "callbacks", "validation_data", "verbose"]
 
             log_fn_args_as_params(original, args, kwargs, unlogged_params)
 
@@ -927,8 +910,7 @@ def autolog(
                     # modifying their contents for future training invocations. Introduce
                     # TensorBoard & tf.keras callbacks if necessary
                     callbacks = list(args[5])
-                    callbacks, self.log_dir = _setup_callbacks(
-                        callbacks, False, metrics_logger)
+                    callbacks, self.log_dir = _setup_callbacks(callbacks, False, metrics_logger)
                     # Replace the callbacks positional entry in the copied arguments and convert
                     # the arguments back to tuple form for usage in the training function
                     args[5] = callbacks
@@ -980,8 +962,7 @@ def autolog(
                             return _extract_n_steps(input_training_data)
                         elif isinstance(input_training_data, dict):
                             input_example_slice = {
-                                k: np.take(
-                                    v, range(0, INPUT_EXAMPLE_SAMPLE_ROWS))
+                                k: np.take(v, range(0, INPUT_EXAMPLE_SAMPLE_ROWS))
                                 for k, v in input_training_data.items()
                             }
                         elif isinstance(input_training_data, tensorflow.keras.utils.Sequence):
@@ -1002,12 +983,10 @@ def autolog(
                     def _infer_model_signature(input_data_slice):
                         try:
                             original_stop_training = history.model.stop_training
-                            model_output = history.model.predict(
-                                input_data_slice)
+                            model_output = history.model.predict(input_data_slice)
 
                             if (
-                                Version(tensorflow.__version__) <= Version(
-                                    "2.1.4")
+                                Version(tensorflow.__version__) <= Version("2.1.4")
                                 and original_stop_training
                             ):
                                 # For these versions, `stop_training` flag on Model is set to False
@@ -1019,8 +998,7 @@ def autolog(
                                 # those TF versions
                                 history.model.stop_training = True
 
-                            model_signature = infer_signature(
-                                input_data_slice, model_output)
+                            model_signature = infer_signature(input_data_slice, model_output)
                         except TypeError as te:
                             warnings.warn(str(te))
                             model_signature = None
@@ -1081,8 +1059,7 @@ def autolog(
         def _patch_implementation(
             self, original, inst, *args, **kwargs
         ):  # pylint: disable=arguments-differ
-            unlogged_params = ["self", "generator",
-                               "callbacks", "validation_data", "verbose"]
+            unlogged_params = ["self", "generator", "callbacks", "validation_data", "verbose"]
 
             log_fn_args_as_params(original, args, kwargs, unlogged_params)
 
@@ -1116,8 +1093,7 @@ def autolog(
                 result = original(inst, *args, **kwargs)
 
             _flush_queue()
-            mlflow.log_artifacts(
-                local_dir=self.log_dir.location, artifact_path="tensorboard_logs")
+            mlflow.log_artifacts(local_dir=self.log_dir.location, artifact_path="tensorboard_logs")
             if self.log_dir.is_temp:
                 shutil.rmtree(self.log_dir.location)
 
@@ -1150,8 +1126,7 @@ def autolog(
         # To avoid unintentional creation of nested MLflow runs caused by a patched
         # `fit_generator()` method calling a patched `fit()` method, we only patch
         # `fit_generator()` in TF < 2.1.0
-        managed.append(
-            (tensorflow.keras.Model, "fit_generator", FitGeneratorPatch))
+        managed.append((tensorflow.keras.Model, "fit_generator", FitGeneratorPatch))
 
     non_managed = [
         (EventFileWriter, "add_event", add_event),
@@ -1165,10 +1140,8 @@ def autolog(
     if Version(tensorflow.__version__) >= Version("2.0.0"):
         old_estimator_class = tensorflow.compat.v1.estimator.Estimator
         v1_train = (old_estimator_class, "train", train)
-        v1_export_saved_model = (
-            old_estimator_class, "export_saved_model", export_saved_model)
-        v1_export_savedmodel = (old_estimator_class,
-                                "export_savedmodel", export_saved_model)
+        v1_export_saved_model = (old_estimator_class, "export_saved_model", export_saved_model)
+        v1_export_savedmodel = (old_estimator_class, "export_savedmodel", export_saved_model)
 
         managed.append(v1_train)
         non_managed.append(v1_export_saved_model)

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -50,6 +50,7 @@ from mlflow.utils.model_utils import (
     _get_flavor_configuration,
     _validate_and_copy_code_paths,
     _add_code_from_conf_to_system_path,
+    _validate_and_prepare_target_save_path
 )
 from mlflow.utils.autologging_utils import (
     autologging_integration,
@@ -282,9 +283,7 @@ def save_model(
     )
     _logger.info("Validation succeeded!")
 
-    if os.path.exists(path):
-        raise MlflowException("Path '{}' already exists".format(path), DIRECTORY_NOT_EMPTY)
-    os.makedirs(path)
+    _validate_and_prepare_target_save_path(path)
     code_dir_subpath = _validate_and_copy_code_paths(code_paths, path)
 
     if mlflow_model is None:

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -35,8 +35,7 @@ def _get_flavor_configuration(model_path, flavor_name):
     model_conf = Model.load(model_configuration_path)
     if flavor_name not in model_conf.flavors:
         raise MlflowException(
-            'Model does not have the "{flavor_name}" flavor'.format(
-                flavor_name=flavor_name),
+            'Model does not have the "{flavor_name}" flavor'.format(flavor_name=flavor_name),
             RESOURCE_DOES_NOT_EXIST,
         )
     conf = model_conf.flavors[flavor_name]
@@ -68,8 +67,7 @@ def _get_flavor_configuration_from_uri(model_uri, flavor_name):
     model_conf = Model.load(ml_model_file)
     if flavor_name not in model_conf.flavors:
         raise MlflowException(
-            'Model does not have the "{flavor_name}" flavor'.format(
-                flavor_name=flavor_name),
+            'Model does not have the "{flavor_name}" flavor'.format(flavor_name=flavor_name),
             RESOURCE_DOES_NOT_EXIST,
         )
     return model_conf.flavors[flavor_name]
@@ -96,8 +94,7 @@ def _get_code_dirs(src_code_path, dst_code_path=None):
 def _validate_code_paths(code_paths):
     if code_paths is not None:
         if not isinstance(code_paths, list):
-            raise TypeError(
-                "Argument code_paths should be a list, not {}".format(type(code_paths)))
+            raise TypeError("Argument code_paths should be a list, not {}".format(type(code_paths)))
 
 
 def _validate_and_copy_code_paths(code_paths, path, default_subpath="code"):
@@ -114,8 +111,7 @@ def _validate_and_copy_code_paths(code_paths, path, default_subpath="code"):
     if code_paths is not None:
         code_dir_subpath = default_subpath
         for code_path in code_paths:
-            _copy_file_or_tree(src=code_path, dst=path,
-                               dst_dir=code_dir_subpath)
+            _copy_file_or_tree(src=code_path, dst=path, dst_dir=code_dir_subpath)
     else:
         code_dir_subpath = None
     return code_dir_subpath
@@ -129,7 +125,7 @@ def _validate_and_prepare_target_save_path(path):
     if os.path.exists(path) and any(os.scandir(path)):
         raise MlflowException(
             message="Path '{}' already exists and is not empty".format(path),
-            error_code=RESOURCE_ALREADY_EXISTS
+            error_code=RESOURCE_ALREADY_EXISTS,
         )
 
     os.makedirs(path, exist_ok=True)

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -4,7 +4,7 @@ import sys
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model
 from mlflow.models.model import MLMODEL_FILE_NAME
-from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST
+from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST, RESOURCE_ALREADY_EXISTS
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.uri import append_to_uri_path
 from mlflow.utils.file_utils import _copy_file_or_tree
@@ -35,7 +35,8 @@ def _get_flavor_configuration(model_path, flavor_name):
     model_conf = Model.load(model_configuration_path)
     if flavor_name not in model_conf.flavors:
         raise MlflowException(
-            'Model does not have the "{flavor_name}" flavor'.format(flavor_name=flavor_name),
+            'Model does not have the "{flavor_name}" flavor'.format(
+                flavor_name=flavor_name),
             RESOURCE_DOES_NOT_EXIST,
         )
     conf = model_conf.flavors[flavor_name]
@@ -67,7 +68,8 @@ def _get_flavor_configuration_from_uri(model_uri, flavor_name):
     model_conf = Model.load(ml_model_file)
     if flavor_name not in model_conf.flavors:
         raise MlflowException(
-            'Model does not have the "{flavor_name}" flavor'.format(flavor_name=flavor_name),
+            'Model does not have the "{flavor_name}" flavor'.format(
+                flavor_name=flavor_name),
             RESOURCE_DOES_NOT_EXIST,
         )
     return model_conf.flavors[flavor_name]
@@ -94,7 +96,8 @@ def _get_code_dirs(src_code_path, dst_code_path=None):
 def _validate_code_paths(code_paths):
     if code_paths is not None:
         if not isinstance(code_paths, list):
-            raise TypeError("Argument code_paths should be a list, not {}".format(type(code_paths)))
+            raise TypeError(
+                "Argument code_paths should be a list, not {}".format(type(code_paths)))
 
 
 def _validate_and_copy_code_paths(code_paths, path, default_subpath="code"):
@@ -111,7 +114,8 @@ def _validate_and_copy_code_paths(code_paths, path, default_subpath="code"):
     if code_paths is not None:
         code_dir_subpath = default_subpath
         for code_path in code_paths:
-            _copy_file_or_tree(src=code_path, dst=path, dst_dir=code_dir_subpath)
+            _copy_file_or_tree(src=code_path, dst=path,
+                               dst_dir=code_dir_subpath)
     else:
         code_dir_subpath = None
     return code_dir_subpath
@@ -119,6 +123,16 @@ def _validate_and_copy_code_paths(code_paths, path, default_subpath="code"):
 
 def _add_code_to_system_path(code_path):
     sys.path = [code_path] + _get_code_dirs(code_path) + sys.path
+
+
+def _validate_and_prepare_target_save_path(path):
+    if os.path.exists(path) and any(os.scandir(path)):
+        raise MlflowException(
+            message="Path '{}' already exists and is not empty".format(path),
+            error_code=RESOURCE_ALREADY_EXISTS
+        )
+
+    os.makedirs(path, exist_ok=True)
 
 
 def _add_code_from_conf_to_system_path(local_path, conf, code_key=FLAVOR_CONFIG_CODE):

--- a/mlflow/xgboost/__init__.py
+++ b/mlflow/xgboost/__init__.py
@@ -48,7 +48,7 @@ from mlflow.utils.model_utils import (
     _get_flavor_configuration,
     _validate_and_copy_code_paths,
     _add_code_from_conf_to_system_path,
-    _validate_and_prepare_target_save_path
+    _validate_and_prepare_target_save_path,
 )
 from mlflow.utils.docstring_utils import format_docstring, LOG_MODEL_PARAM_DOCS
 from mlflow.utils.arguments_utils import _get_arg_names
@@ -137,8 +137,7 @@ def save_model(
     """
     import xgboost as xgb
 
-    _validate_env_arguments(conda_env, pip_requirements,
-                            extra_pip_requirements)
+    _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
 
     path = os.path.abspath(path)
     _validate_and_prepare_target_save_path(path)
@@ -191,20 +190,17 @@ def save_model(
             extra_pip_requirements,
         )
     else:
-        conda_env, pip_requirements, pip_constraints = _process_conda_env(
-            conda_env)
+        conda_env, pip_requirements, pip_constraints = _process_conda_env(conda_env)
 
     with open(os.path.join(path, _CONDA_ENV_FILE_NAME), "w") as f:
         yaml.safe_dump(conda_env, stream=f, default_flow_style=False)
 
     # Save `constraints.txt` if necessary
     if pip_constraints:
-        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME),
-                 "\n".join(pip_constraints))
+        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME), "\n".join(pip_constraints))
 
     # Save `requirements.txt`
-    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME),
-             "\n".join(pip_requirements))
+    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME), "\n".join(pip_requirements))
 
 
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
@@ -287,8 +283,7 @@ def _load_model(path):
                     the top-level MLflow Model directory (MLflow >= 1.22.0).
     """
     model_dir = os.path.dirname(path) if os.path.isfile(path) else path
-    flavor_conf = _get_flavor_configuration(
-        model_path=model_dir, flavor_name=FLAVOR_NAME)
+    flavor_conf = _get_flavor_configuration(model_path=model_dir, flavor_name=FLAVOR_NAME)
 
     # XGBoost models saved in MLflow >=1.22.0 have `model_class`
     # in the XGBoost flavor configuration to specify its XGBoost model class.
@@ -332,8 +327,7 @@ def load_model(model_uri, dst_path=None):
     :return: An XGBoost model. An instance of either `xgboost.Booster`_ or XGBoost scikit-learn
              models, depending on the saved model class specification.
     """
-    local_model_path = _download_artifact_from_uri(
-        artifact_uri=model_uri, output_path=dst_path)
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
     flavor_conf = _get_flavor_configuration(local_model_path, FLAVOR_NAME)
     _add_code_from_conf_to_system_path(local_model_path, flavor_conf)
     return _load_model(path=local_model_path)
@@ -486,16 +480,14 @@ def autolog(
                 # `num_features`-by-`num_classes` matrix
                 features = features[indices]
                 importances_per_class_by_feature = np.array(
-                    [[importance]
-                        for importance in importances_per_class_by_feature[indices]]
+                    [[importance] for importance in importances_per_class_by_feature[indices]]
                 )
                 # In this case, do not include class labels on the feature importance plot because
                 # only one importance value has been provided per feature, rather than an
                 # one importance value for each class per feature
                 label_classes_on_plot = False
             else:
-                importance_value_magnitudes = np.abs(
-                    importances_per_class_by_feature).sum(axis=1)
+                importance_value_magnitudes = np.abs(importances_per_class_by_feature).sum(axis=1)
                 indices = np.argsort(importance_value_magnitudes)
                 features = features[indices]
                 importances_per_class_by_feature = importances_per_class_by_feature[indices]
@@ -512,8 +504,7 @@ def autolog(
             fig, ax = plt.subplots(figsize=(w, h))
             # When importance values are provided for each class per feature, we want to ensure
             # that the same color is used for all bars in the bar chart that have the same class
-            colors_to_cycle = plt.rcParams["axes.prop_cycle"].by_key()[
-                "color"][:num_classes]
+            colors_to_cycle = plt.rcParams["axes.prop_cycle"].by_key()["color"][:num_classes]
             color_cycler = cycler(color=colors_to_cycle)
             ax.set_prop_cycle(color_cycler)
 
@@ -523,8 +514,7 @@ def autolog(
             feature_ylocs = np.arange(num_features)
             # Define offsets on the y-axis that are used to evenly space the bars for each class
             # around the y-axis position of each feature
-            offsets_per_yloc = np.linspace(-0.5, 0.5,
-                                           num_classes) / 2 if num_classes > 1 else [0]
+            offsets_per_yloc = np.linspace(-0.5, 0.5, num_classes) / 2 if num_classes > 1 else [0]
             for feature_idx, (feature_yloc, importances_per_class) in enumerate(
                 zip(feature_ylocs, importances_per_class_by_feature)
             ):
@@ -557,8 +547,7 @@ def autolog(
             tmpdir = tempfile.mkdtemp()
             try:
                 # pylint: disable=undefined-loop-variable
-                filepath = os.path.join(
-                    tmpdir, "feature_importance_{}.png".format(imp_type))
+                filepath = os.path.join(tmpdir, "feature_importance_{}.png".format(imp_type))
                 fig.savefig(filepath)
                 mlflow.log_artifact(filepath)
             finally:
@@ -569,8 +558,7 @@ def autolog(
         # logging booster params separately to extract key/value pairs and make it easier to
         # compare them across runs.
         booster_params = args[0] if len(args) > 0 else kwargs["params"]
-        autologging_client.log_params(
-            run_id=mlflow.active_run().info.run_id, params=booster_params)
+        autologging_client.log_params(run_id=mlflow.active_run().info.run_id, params=booster_params)
 
         unlogged_params = [
             "params",
@@ -634,8 +622,7 @@ def autolog(
                     metrics=eval_results[model.best_iteration],
                     step=extra_step,
                 )
-                early_stopping_logging_operations = autologging_client.flush(
-                    synchronous=False)
+                early_stopping_logging_operations = autologging_client.flush(synchronous=False)
 
         # logging feature importance as artifacts.
         for imp_type in importance_types:
@@ -653,8 +640,7 @@ def autolog(
             if imp is not None:
                 tmpdir = tempfile.mkdtemp()
                 try:
-                    filepath = os.path.join(
-                        tmpdir, "feature_importance_{}.json".format(imp_type))
+                    filepath = os.path.join(tmpdir, "feature_importance_{}.json".format(imp_type))
                     with open(filepath, "w") as f:
                         json.dump(imp, f)
                     mlflow.log_artifact(filepath)
@@ -708,8 +694,7 @@ def autolog(
 
         return model
 
-    safe_patch(FLAVOR_NAME, xgboost, "train", functools.partial(
-        train, log_models), manage_run=True)
+    safe_patch(FLAVOR_NAME, xgboost, "train", functools.partial(train, log_models), manage_run=True)
     # The `train()` method logs XGBoost models as Booster objects. When using XGBoost
     # scikit-learn models, we want to save / log models as their model classes. So we turn
     # off the log_models functionality in the `train()` method patched to `xgboost.sklearn`.

--- a/mlflow/xgboost/__init__.py
+++ b/mlflow/xgboost/__init__.py
@@ -48,6 +48,7 @@ from mlflow.utils.model_utils import (
     _get_flavor_configuration,
     _validate_and_copy_code_paths,
     _add_code_from_conf_to_system_path,
+    _validate_and_prepare_target_save_path
 )
 from mlflow.exceptions import MlflowException
 from mlflow.utils.docstring_utils import format_docstring, LOG_MODEL_PARAM_DOCS
@@ -140,9 +141,7 @@ def save_model(
     _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
 
     path = os.path.abspath(path)
-    if os.path.exists(path):
-        raise MlflowException("Path '{}' already exists".format(path))
-    os.makedirs(path)
+    _validate_and_prepare_target_save_path(path)
     code_dir_subpath = _validate_and_copy_code_paths(code_paths, path)
 
     if mlflow_model is None:

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -78,7 +78,8 @@ def _log_model_with_signature_and_example(tmp_path, sig, input_example):
     experiment_id = mlflow.create_experiment("test")
 
     with mlflow.start_run(experiment_id=experiment_id) as run:
-        Model.log("some/path", TestFlavor, signature=sig, input_example=input_example)
+        Model.log("some/path", TestFlavor, signature=sig,
+                  input_example=input_example)
 
     local_path = _download_artifact_from_uri(
         "runs:/{}/some/path".format(run.info.run_id), output_path=tmp_path.path("")
@@ -94,7 +95,8 @@ def test_model_log():
             outputs=Schema([ColSpec(name=None, type="double")]),
         )
         input_example = {"x": 1, "y": 2}
-        local_path, r = _log_model_with_signature_and_example(tmp, sig, input_example)
+        local_path, r = _log_model_with_signature_and_example(
+            tmp, sig, input_example)
 
         loaded_model = Model.load(os.path.join(local_path, "MLmodel"))
         assert loaded_model.run_id == r.info.run_id
@@ -104,7 +106,8 @@ def test_model_log():
             "flavor2": {"x": 1, "y": 2},
         }
         assert loaded_model.signature == sig
-        path = os.path.join(local_path, loaded_model.saved_input_example_info["artifact_path"])
+        path = os.path.join(
+            local_path, loaded_model.saved_input_example_info["artifact_path"])
         x = _dataframe_from_json(path)
         assert x.to_dict(orient="records")[0] == input_example
         assert not hasattr(loaded_model, "databricks_runtime")
@@ -113,11 +116,12 @@ def test_model_log():
         assert isinstance(loaded_example, pd.DataFrame)
         assert loaded_example.to_dict(orient="records")[0] == input_example
 
-        assert Version(loaded_model.mlflow_version) == Version(mlflow.version.VERSION)
+        assert Version(loaded_model.mlflow_version) == Version(
+            mlflow.version.VERSION)
 
 
 def test_model_log_existing_full_directory_fails():
-    with TempDir(chdr=True) as tmp:
+    with TempDir(chdr=True):
         sig = ModelSignature(
             inputs=Schema([ColSpec("integer", "x"), ColSpec("integer", "y")]),
             outputs=Schema([ColSpec(name=None, type="double")]),
@@ -132,7 +136,8 @@ def test_model_log_existing_full_directory_fails():
             f.write("dummy content")
         with mlflow.start_run(experiment_id=experiment_id):
             with pytest.raises(MlflowException, match="already exists and is not empty"):
-                Model.log("some/path", TestFlavor, signature=sig, input_example=input_example)
+                Model.log("some/path", TestFlavor, signature=sig,
+                          input_example=input_example)
 
 
 def test_model_info():
@@ -154,7 +159,8 @@ def test_model_info():
 
         assert model_info.run_id == run.info.run_id
         assert model_info.artifact_path == "some/path"
-        assert model_info.model_uri == "runs:/{}/some/path".format(run.info.run_id)
+        assert model_info.model_uri == "runs:/{}/some/path".format(
+            run.info.run_id)
 
         loaded_model = Model.load(os.path.join(local_path, "MLmodel"))
         assert model_info.utc_time_created == loaded_model.utc_time_created
@@ -165,19 +171,22 @@ def test_model_info():
             "flavor2": {"x": 1, "y": 2},
         }
 
-        path = os.path.join(local_path, model_info.saved_input_example_info["artifact_path"])
+        path = os.path.join(
+            local_path, model_info.saved_input_example_info["artifact_path"])
         x = _dataframe_from_json(path)
         assert x.to_dict(orient="records")[0] == input_example
 
         assert model_info.signature_dict == sig.to_dict()
 
-        assert Version(model_info.mlflow_version) == Version(loaded_model.mlflow_version)
+        assert Version(model_info.mlflow_version) == Version(
+            loaded_model.mlflow_version)
 
 
 def test_load_model_without_mlflow_version():
 
     with TempDir(chdr=True) as tmp:
-        model = Model(artifact_path="some/path", run_id="1234", mlflow_version=None)
+        model = Model(artifact_path="some/path",
+                      run_id="1234", mlflow_version=None)
         path = tmp.path("model")
         with open(path, "w") as out:
             model.to_yaml(out)
@@ -196,7 +205,8 @@ def test_model_log_with_databricks_runtime():
             outputs=Schema([ColSpec(name=None, type="double")]),
         )
         input_example = {"x": 1, "y": 2}
-        local_path, r = _log_model_with_signature_and_example(tmp, sig, input_example)
+        local_path, r = _log_model_with_signature_and_example(
+            tmp, sig, input_example)
 
         loaded_model = Model.load(os.path.join(local_path, "MLmodel"))
         assert loaded_model.run_id == r.info.run_id
@@ -206,7 +216,8 @@ def test_model_log_with_databricks_runtime():
             "flavor2": {"x": 1, "y": 2},
         }
         assert loaded_model.signature == sig
-        path = os.path.join(local_path, loaded_model.saved_input_example_info["artifact_path"])
+        path = os.path.join(
+            local_path, loaded_model.saved_input_example_info["artifact_path"])
         x = _dataframe_from_json(path)
         assert x.to_dict(orient="records")[0] == input_example
         assert loaded_model.databricks_runtime == dbr
@@ -237,9 +248,11 @@ def test_model_log_with_input_example_succeeds():
             index=[0],
         )
 
-        local_path, _ = _log_model_with_signature_and_example(tmp, sig, input_example)
+        local_path, _ = _log_model_with_signature_and_example(
+            tmp, sig, input_example)
         loaded_model = Model.load(os.path.join(local_path, "MLmodel"))
-        path = os.path.join(local_path, loaded_model.saved_input_example_info["artifact_path"])
+        path = os.path.join(
+            local_path, loaded_model.saved_input_example_info["artifact_path"])
         x = _dataframe_from_json(path, schema=sig.inputs)
 
         # date column will get deserialized into string
@@ -255,11 +268,13 @@ def test_model_load_input_example_numpy():
     with TempDir(chdr=True) as tmp:
         input_example = np.array([[3, 4, 5]], dtype=np.int32)
         sig = ModelSignature(
-            inputs=Schema([TensorSpec(type=input_example.dtype, shape=input_example.shape)]),
+            inputs=Schema(
+                [TensorSpec(type=input_example.dtype, shape=input_example.shape)]),
             outputs=Schema([ColSpec(name=None, type="double")]),
         )
 
-        local_path, _ = _log_model_with_signature_and_example(tmp, sig, input_example)
+        local_path, _ = _log_model_with_signature_and_example(
+            tmp, sig, input_example)
         loaded_model = Model.load(os.path.join(local_path, "MLmodel"))
         loaded_example = loaded_model.load_input_example(local_path)
 
@@ -271,11 +286,13 @@ def test_model_load_input_example_scipy():
     with TempDir(chdr=True) as tmp:
         input_example = csc_matrix(np.arange(0, 12, 0.5).reshape(3, 8))
         sig = ModelSignature(
-            inputs=Schema([TensorSpec(type=input_example.data.dtype, shape=input_example.shape)]),
+            inputs=Schema(
+                [TensorSpec(type=input_example.data.dtype, shape=input_example.shape)]),
             outputs=Schema([ColSpec(name=None, type="double")]),
         )
 
-        local_path, _ = _log_model_with_signature_and_example(tmp, sig, input_example)
+        local_path, _ = _log_model_with_signature_and_example(
+            tmp, sig, input_example)
         loaded_model = Model.load(os.path.join(local_path, "MLmodel"))
         loaded_example = loaded_model.load_input_example(local_path)
 
@@ -287,19 +304,23 @@ def test_model_load_input_example_failures():
     with TempDir(chdr=True) as tmp:
         input_example = np.array([[3, 4, 5]], dtype=np.int32)
         sig = ModelSignature(
-            inputs=Schema([TensorSpec(type=input_example.dtype, shape=input_example.shape)]),
+            inputs=Schema(
+                [TensorSpec(type=input_example.dtype, shape=input_example.shape)]),
             outputs=Schema([ColSpec(name=None, type="double")]),
         )
 
-        local_path, _ = _log_model_with_signature_and_example(tmp, sig, input_example)
+        local_path, _ = _log_model_with_signature_and_example(
+            tmp, sig, input_example)
         loaded_model = Model.load(os.path.join(local_path, "MLmodel"))
         loaded_example = loaded_model.load_input_example(local_path)
         assert loaded_example is not None
 
         with pytest.raises(FileNotFoundError, match="No such file or directory"):
-            loaded_model.load_input_example(os.path.join(local_path, "folder_which_does_not_exist"))
+            loaded_model.load_input_example(os.path.join(
+                local_path, "folder_which_does_not_exist"))
 
-        path = os.path.join(local_path, loaded_model.saved_input_example_info["artifact_path"])
+        path = os.path.join(
+            local_path, loaded_model.saved_input_example_info["artifact_path"])
         os.remove(path)
         with pytest.raises(FileNotFoundError, match="No such file or directory"):
             loaded_model.load_input_example(local_path)
@@ -309,11 +330,13 @@ def test_model_load_input_example_no_signature():
     with TempDir(chdr=True) as tmp:
         input_example = np.array([[3, 4, 5]], dtype=np.int32)
         sig = ModelSignature(
-            inputs=Schema([TensorSpec(type=input_example.dtype, shape=input_example.shape)]),
+            inputs=Schema(
+                [TensorSpec(type=input_example.dtype, shape=input_example.shape)]),
             outputs=Schema([ColSpec(name=None, type="double")]),
         )
 
-        local_path, _ = _log_model_with_signature_and_example(tmp, sig, input_example=None)
+        local_path, _ = _log_model_with_signature_and_example(
+            tmp, sig, input_example=None)
         loaded_model = Model.load(os.path.join(local_path, "MLmodel"))
         loaded_example = loaded_model.load_input_example(local_path)
         assert loaded_example is None

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -6,7 +6,6 @@ import mlflow
 import pandas as pd
 import numpy as np
 
-from mlflow.exceptions import MlflowException
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.models import Model
 from mlflow.models.signature import ModelSignature
@@ -78,8 +77,7 @@ def _log_model_with_signature_and_example(tmp_path, sig, input_example):
     experiment_id = mlflow.create_experiment("test")
 
     with mlflow.start_run(experiment_id=experiment_id) as run:
-        Model.log("some/path", TestFlavor, signature=sig,
-                  input_example=input_example)
+        Model.log("some/path", TestFlavor, signature=sig, input_example=input_example)
 
     local_path = _download_artifact_from_uri(
         "runs:/{}/some/path".format(run.info.run_id), output_path=tmp_path.path("")
@@ -95,8 +93,7 @@ def test_model_log():
             outputs=Schema([ColSpec(name=None, type="double")]),
         )
         input_example = {"x": 1, "y": 2}
-        local_path, r = _log_model_with_signature_and_example(
-            tmp, sig, input_example)
+        local_path, r = _log_model_with_signature_and_example(tmp, sig, input_example)
 
         loaded_model = Model.load(os.path.join(local_path, "MLmodel"))
         assert loaded_model.run_id == r.info.run_id
@@ -106,8 +103,7 @@ def test_model_log():
             "flavor2": {"x": 1, "y": 2},
         }
         assert loaded_model.signature == sig
-        path = os.path.join(
-            local_path, loaded_model.saved_input_example_info["artifact_path"])
+        path = os.path.join(local_path, loaded_model.saved_input_example_info["artifact_path"])
         x = _dataframe_from_json(path)
         assert x.to_dict(orient="records")[0] == input_example
         assert not hasattr(loaded_model, "databricks_runtime")
@@ -116,28 +112,7 @@ def test_model_log():
         assert isinstance(loaded_example, pd.DataFrame)
         assert loaded_example.to_dict(orient="records")[0] == input_example
 
-        assert Version(loaded_model.mlflow_version) == Version(
-            mlflow.version.VERSION)
-
-
-def test_model_log_existing_full_directory_fails():
-    with TempDir(chdr=True):
-        sig = ModelSignature(
-            inputs=Schema([ColSpec("integer", "x"), ColSpec("integer", "y")]),
-            outputs=Schema([ColSpec(name=None, type="double")]),
-        )
-        input_example = {"x": 1, "y": 2}
-
-        experiment_id = mlflow.create_experiment("test")
-
-        model_dir = "some/path"
-        os.makedirs(model_dir)
-        with open(os.path.join(model_dir, "foo.txt"), "wt") as f:
-            f.write("dummy content")
-        with mlflow.start_run(experiment_id=experiment_id):
-            with pytest.raises(MlflowException, match="already exists and is not empty"):
-                Model.log("some/path", TestFlavor, signature=sig,
-                          input_example=input_example)
+        assert Version(loaded_model.mlflow_version) == Version(mlflow.version.VERSION)
 
 
 def test_model_info():
@@ -159,8 +134,7 @@ def test_model_info():
 
         assert model_info.run_id == run.info.run_id
         assert model_info.artifact_path == "some/path"
-        assert model_info.model_uri == "runs:/{}/some/path".format(
-            run.info.run_id)
+        assert model_info.model_uri == "runs:/{}/some/path".format(run.info.run_id)
 
         loaded_model = Model.load(os.path.join(local_path, "MLmodel"))
         assert model_info.utc_time_created == loaded_model.utc_time_created
@@ -171,22 +145,19 @@ def test_model_info():
             "flavor2": {"x": 1, "y": 2},
         }
 
-        path = os.path.join(
-            local_path, model_info.saved_input_example_info["artifact_path"])
+        path = os.path.join(local_path, model_info.saved_input_example_info["artifact_path"])
         x = _dataframe_from_json(path)
         assert x.to_dict(orient="records")[0] == input_example
 
         assert model_info.signature_dict == sig.to_dict()
 
-        assert Version(model_info.mlflow_version) == Version(
-            loaded_model.mlflow_version)
+        assert Version(model_info.mlflow_version) == Version(loaded_model.mlflow_version)
 
 
 def test_load_model_without_mlflow_version():
 
     with TempDir(chdr=True) as tmp:
-        model = Model(artifact_path="some/path",
-                      run_id="1234", mlflow_version=None)
+        model = Model(artifact_path="some/path", run_id="1234", mlflow_version=None)
         path = tmp.path("model")
         with open(path, "w") as out:
             model.to_yaml(out)
@@ -205,8 +176,7 @@ def test_model_log_with_databricks_runtime():
             outputs=Schema([ColSpec(name=None, type="double")]),
         )
         input_example = {"x": 1, "y": 2}
-        local_path, r = _log_model_with_signature_and_example(
-            tmp, sig, input_example)
+        local_path, r = _log_model_with_signature_and_example(tmp, sig, input_example)
 
         loaded_model = Model.load(os.path.join(local_path, "MLmodel"))
         assert loaded_model.run_id == r.info.run_id
@@ -216,8 +186,7 @@ def test_model_log_with_databricks_runtime():
             "flavor2": {"x": 1, "y": 2},
         }
         assert loaded_model.signature == sig
-        path = os.path.join(
-            local_path, loaded_model.saved_input_example_info["artifact_path"])
+        path = os.path.join(local_path, loaded_model.saved_input_example_info["artifact_path"])
         x = _dataframe_from_json(path)
         assert x.to_dict(orient="records")[0] == input_example
         assert loaded_model.databricks_runtime == dbr
@@ -248,11 +217,9 @@ def test_model_log_with_input_example_succeeds():
             index=[0],
         )
 
-        local_path, _ = _log_model_with_signature_and_example(
-            tmp, sig, input_example)
+        local_path, _ = _log_model_with_signature_and_example(tmp, sig, input_example)
         loaded_model = Model.load(os.path.join(local_path, "MLmodel"))
-        path = os.path.join(
-            local_path, loaded_model.saved_input_example_info["artifact_path"])
+        path = os.path.join(local_path, loaded_model.saved_input_example_info["artifact_path"])
         x = _dataframe_from_json(path, schema=sig.inputs)
 
         # date column will get deserialized into string
@@ -268,13 +235,11 @@ def test_model_load_input_example_numpy():
     with TempDir(chdr=True) as tmp:
         input_example = np.array([[3, 4, 5]], dtype=np.int32)
         sig = ModelSignature(
-            inputs=Schema(
-                [TensorSpec(type=input_example.dtype, shape=input_example.shape)]),
+            inputs=Schema([TensorSpec(type=input_example.dtype, shape=input_example.shape)]),
             outputs=Schema([ColSpec(name=None, type="double")]),
         )
 
-        local_path, _ = _log_model_with_signature_and_example(
-            tmp, sig, input_example)
+        local_path, _ = _log_model_with_signature_and_example(tmp, sig, input_example)
         loaded_model = Model.load(os.path.join(local_path, "MLmodel"))
         loaded_example = loaded_model.load_input_example(local_path)
 
@@ -286,13 +251,11 @@ def test_model_load_input_example_scipy():
     with TempDir(chdr=True) as tmp:
         input_example = csc_matrix(np.arange(0, 12, 0.5).reshape(3, 8))
         sig = ModelSignature(
-            inputs=Schema(
-                [TensorSpec(type=input_example.data.dtype, shape=input_example.shape)]),
+            inputs=Schema([TensorSpec(type=input_example.data.dtype, shape=input_example.shape)]),
             outputs=Schema([ColSpec(name=None, type="double")]),
         )
 
-        local_path, _ = _log_model_with_signature_and_example(
-            tmp, sig, input_example)
+        local_path, _ = _log_model_with_signature_and_example(tmp, sig, input_example)
         loaded_model = Model.load(os.path.join(local_path, "MLmodel"))
         loaded_example = loaded_model.load_input_example(local_path)
 
@@ -304,23 +267,19 @@ def test_model_load_input_example_failures():
     with TempDir(chdr=True) as tmp:
         input_example = np.array([[3, 4, 5]], dtype=np.int32)
         sig = ModelSignature(
-            inputs=Schema(
-                [TensorSpec(type=input_example.dtype, shape=input_example.shape)]),
+            inputs=Schema([TensorSpec(type=input_example.dtype, shape=input_example.shape)]),
             outputs=Schema([ColSpec(name=None, type="double")]),
         )
 
-        local_path, _ = _log_model_with_signature_and_example(
-            tmp, sig, input_example)
+        local_path, _ = _log_model_with_signature_and_example(tmp, sig, input_example)
         loaded_model = Model.load(os.path.join(local_path, "MLmodel"))
         loaded_example = loaded_model.load_input_example(local_path)
         assert loaded_example is not None
 
         with pytest.raises(FileNotFoundError, match="No such file or directory"):
-            loaded_model.load_input_example(os.path.join(
-                local_path, "folder_which_does_not_exist"))
+            loaded_model.load_input_example(os.path.join(local_path, "folder_which_does_not_exist"))
 
-        path = os.path.join(
-            local_path, loaded_model.saved_input_example_info["artifact_path"])
+        path = os.path.join(local_path, loaded_model.saved_input_example_info["artifact_path"])
         os.remove(path)
         with pytest.raises(FileNotFoundError, match="No such file or directory"):
             loaded_model.load_input_example(local_path)
@@ -330,13 +289,11 @@ def test_model_load_input_example_no_signature():
     with TempDir(chdr=True) as tmp:
         input_example = np.array([[3, 4, 5]], dtype=np.int32)
         sig = ModelSignature(
-            inputs=Schema(
-                [TensorSpec(type=input_example.dtype, shape=input_example.shape)]),
+            inputs=Schema([TensorSpec(type=input_example.dtype, shape=input_example.shape)]),
             outputs=Schema([ColSpec(name=None, type="double")]),
         )
 
-        local_path, _ = _log_model_with_signature_and_example(
-            tmp, sig, input_example=None)
+        local_path, _ = _log_model_with_signature_and_example(tmp, sig, input_example=None)
         loaded_model = Model.load(os.path.join(local_path, "MLmodel"))
         loaded_example = loaded_model.load_input_example(local_path)
         assert loaded_example is None

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -151,19 +151,6 @@ def test_model_save_load(sklearn_knn_model, main_scoped_model_class, iris_data, 
 
 
 @pytest.mark.large
-def test_model_save_behavior_with_preexisting_folders(sklearn_knn_model, tmp_path):
-    sklearn_model_path = tmp_path / "sklearn_model_empty_exists"
-    sklearn_model_path.mkdir()
-    mlflow.sklearn.save_model(sk_model=sklearn_knn_model, path=sklearn_model_path)
-
-    sklearn_model_path = tmp_path / "sklearn_model_filled_exists"
-    sklearn_model_path.mkdir()
-    (sklearn_model_path / "foo.txt").write_text("dummy content")
-    with pytest.raises(MlflowException, match="already exists and is not empty"):
-        mlflow.sklearn.save_model(sk_model=sklearn_knn_model, path=sklearn_model_path)
-
-
-@pytest.mark.large
 def test_pyfunc_model_log_load_no_active_run(sklearn_knn_model, main_scoped_model_class, iris_data):
     sklearn_artifact_path = "sk_model_no_run"
     with mlflow.start_run():

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -151,6 +151,20 @@ def test_model_save_load(sklearn_knn_model, main_scoped_model_class, iris_data, 
 
 
 @pytest.mark.large
+def test_model_save_behavior_with_preexisting_folders(sklearn_knn_model, tmpdir):
+    sklearn_model_path = os.path.join(str(tmpdir), "sklearn_model_empty_exists")
+    os.makedirs(sklearn_model_path)
+    mlflow.sklearn.save_model(sk_model=sklearn_knn_model, path=sklearn_model_path)
+
+    sklearn_model_path = os.path.join(str(tmpdir), "sklearn_model_filled_exists")
+    os.makedirs(sklearn_model_path)
+    with open(os.path.join(sklearn_model_path, "foo.txt"), "wt") as f:
+        f.write("dummy content")
+    with pytest.raises(MlflowException, match="already exists and is not empty"):
+        mlflow.sklearn.save_model(sk_model=sklearn_knn_model, path=sklearn_model_path)
+
+
+@pytest.mark.large
 def test_pyfunc_model_log_load_no_active_run(sklearn_knn_model, main_scoped_model_class, iris_data):
     sklearn_artifact_path = "sk_model_no_run"
     with mlflow.start_run():

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -151,15 +151,14 @@ def test_model_save_load(sklearn_knn_model, main_scoped_model_class, iris_data, 
 
 
 @pytest.mark.large
-def test_model_save_behavior_with_preexisting_folders(sklearn_knn_model, tmpdir):
-    sklearn_model_path = os.path.join(str(tmpdir), "sklearn_model_empty_exists")
-    os.makedirs(sklearn_model_path)
+def test_model_save_behavior_with_preexisting_folders(sklearn_knn_model, tmp_path):
+    sklearn_model_path = tmp_path / "sklearn_model_empty_exists"
+    sklearn_model_path.mkdir()
     mlflow.sklearn.save_model(sk_model=sklearn_knn_model, path=sklearn_model_path)
 
-    sklearn_model_path = os.path.join(str(tmpdir), "sklearn_model_filled_exists")
-    os.makedirs(sklearn_model_path)
-    with open(os.path.join(sklearn_model_path, "foo.txt"), "wt") as f:
-        f.write("dummy content")
+    sklearn_model_path = tmp_path / "sklearn_model_filled_exists"
+    sklearn_model_path.mkdir()
+    (sklearn_model_path / "foo.txt").write_text("dummy content")
     with pytest.raises(MlflowException, match="already exists and is not empty"):
         mlflow.sklearn.save_model(sk_model=sklearn_knn_model, path=sklearn_model_path)
 

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -275,7 +275,7 @@ def test_raise_exception(sequential_model):
             mlflow.pytorch.save_model([1, 2, 3], path)
 
         mlflow.pytorch.save_model(sequential_model, path)
-        with pytest.raises(RuntimeError, match=f"Path '{os.path.abspath(path)}' already exists"):
+        with pytest.raises(MlflowException, match=f"Path '{os.path.abspath(path)}' already exists"):
             mlflow.pytorch.save_model(sequential_model, path)
 
         from mlflow import sklearn

--- a/tests/sklearn/test_sklearn_model_export.py
+++ b/tests/sklearn/test_sklearn_model_export.py
@@ -107,6 +107,19 @@ def test_model_save_load(sklearn_knn_model, model_path):
 
 
 @pytest.mark.large
+def test_model_save_behavior_with_preexisting_folders(sklearn_knn_model, tmp_path):
+    sklearn_model_path = tmp_path / "sklearn_model_empty_exists"
+    sklearn_model_path.mkdir()
+    mlflow.sklearn.save_model(sk_model=sklearn_knn_model, path=sklearn_model_path)
+
+    sklearn_model_path = tmp_path / "sklearn_model_filled_exists"
+    sklearn_model_path.mkdir()
+    (sklearn_model_path / "foo.txt").write_text("dummy content")
+    with pytest.raises(MlflowException, match="already exists and is not empty"):
+        mlflow.sklearn.save_model(sk_model=sklearn_knn_model, path=sklearn_model_path)
+
+
+@pytest.mark.large
 def test_signature_and_examples_are_saved_correctly(sklearn_knn_model):
     data = sklearn_knn_model.inference_data
     model = sklearn_knn_model.model


### PR DESCRIPTION
## What changes are proposed in this pull request?

Do not automatically fail <flavor>.save_model if the target path exists and is empty. Useful for orchestrated scenarios when external system precreates paths.

This is unlikely to break existing workflows, though is technically a behavioral break if a user were relying on save_model for path checks. For this scenario, the user would need to add an explicit check for this behavior before invoking save_model.

## How is this patch tested?

Existing save_model functionality is covered and added test for new weaker check of existing folder + extra content.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
