### PR TITLE
Add mlflow_version to Java model spec to fix serving behavior

### DIFF
--- a/mlflow/java/scoring/src/main/java/org/mlflow/LoaderModule.java
+++ b/mlflow/java/scoring/src/main/java/org/mlflow/LoaderModule.java
@@ -51,7 +51,7 @@ public abstract class LoaderModule<T extends Flavor> {
     } catch (IOException e) {
       throw new PredictorLoadingException(
           "Failed to load the model configuration at the specified path. Please ensure that"
-              + " this is the path to the root directory of a valid MLflow model");
+              + " this is the path to the root directory of a valid MLflow model", e);
     }
   }
 

--- a/mlflow/java/scoring/src/main/java/org/mlflow/mleap/MLeapLoader.java
+++ b/mlflow/java/scoring/src/main/java/org/mlflow/mleap/MLeapLoader.java
@@ -18,7 +18,7 @@ public class MLeapLoader extends LoaderModule<MLeapFlavor> {
           String.format(
               "Failed to read model files from the supplied model root path: %s."
                   + "Please ensure that this is the path to a valid MLflow model.",
-              modelRootPath));
+              modelRootPath), e);
     }
   }
 

--- a/mlflow/java/scoring/src/main/java/org/mlflow/models/Model.java
+++ b/mlflow/java/scoring/src/main/java/org/mlflow/models/Model.java
@@ -45,6 +45,9 @@ public class Model {
   @JsonProperty("model_uuid")
   private String modelUuid;
 
+  @JsonProperty("mlflow_version")
+  private String mlflowVersion;
+
   private String rootPath;
 
   /**
@@ -89,6 +92,12 @@ public class Model {
     /** @return The MLflow model's uuid */
   public Optional<String> getModelUuid() {
     return Optional.ofNullable(this.modelUuid);
+  }
+
+
+  /** @return The version of MLflow with which the model was saved */
+  public Optional<String> getMlflowVersion() {
+    return Optional.ofNullable(this.mlflowVersion);
   }
 
   /** @return The path to the root directory of the MLflow model */

--- a/mlflow/java/scoring/src/main/java/org/mlflow/sagemaker/MLeapPredictor.java
+++ b/mlflow/java/scoring/src/main/java/org/mlflow/sagemaker/MLeapPredictor.java
@@ -52,7 +52,7 @@ public class MLeapPredictor implements Predictor {
       logger.error("Could not read the model input schema from the specified path", e);
       throw new PredictorLoadingException(
               String.format(
-                "Failed to load model input schema from specified path: %s", inputSchemaPath));
+                "Failed to load model input schema from specified path: %s", inputSchemaPath), e);
     }
   }
 

--- a/mlflow/java/scoring/src/main/java/org/mlflow/sagemaker/PredictorLoadingException.java
+++ b/mlflow/java/scoring/src/main/java/org/mlflow/sagemaker/PredictorLoadingException.java
@@ -13,4 +13,14 @@ public class PredictorLoadingException extends RuntimeException {
   public PredictorLoadingException(String message) {
     super(message);
   }
+
+  /**
+   * Constructs an exception with contents from a causal exception
+   *
+   * @param message The user-readable error message associated with this exception
+   * @param ex The causal exception to include in the PredictorLoadingException
+   */
+  public PredictorLoadingException(String message, Exception ex) {
+    super(message, ex);
+  }
 }

--- a/mlflow/java/scoring/src/main/java/org/mlflow/sagemaker/ScoringServer.java
+++ b/mlflow/java/scoring/src/main/java/org/mlflow/sagemaker/ScoringServer.java
@@ -73,8 +73,8 @@ public class ScoringServer {
   private static Predictor loadPredictorFromPath(String modelPath)
       throws PredictorLoadingException {
     try {
-        Model config = Model.fromRootPath(modelPath);
-        return (new MLeapLoader()).load(config);
+      Model config = Model.fromRootPath(modelPath);
+      return (new MLeapLoader()).load(config);
     } catch (IOException e) {
       throw new PredictorLoadingException(
           "Failed to load the configuration for the MLflow model at the specified path.", e);

--- a/mlflow/java/scoring/src/main/java/org/mlflow/sagemaker/ScoringServer.java
+++ b/mlflow/java/scoring/src/main/java/org/mlflow/sagemaker/ScoringServer.java
@@ -73,8 +73,8 @@ public class ScoringServer {
   private static Predictor loadPredictorFromPath(String modelPath)
       throws PredictorLoadingException {
     try {
-    Model config = Model.fromRootPath(modelPath);
-    return (new MLeapLoader()).load(config);
+        Model config = Model.fromRootPath(modelPath);
+        return (new MLeapLoader()).load(config);
     } catch (IOException e) {
       throw new PredictorLoadingException(
           "Failed to load the configuration for the MLflow model at the specified path.", e);

--- a/mlflow/java/scoring/src/main/java/org/mlflow/sagemaker/ScoringServer.java
+++ b/mlflow/java/scoring/src/main/java/org/mlflow/sagemaker/ScoringServer.java
@@ -76,9 +76,8 @@ public class ScoringServer {
     Model config = Model.fromRootPath(modelPath);
     return (new MLeapLoader()).load(config);
     } catch (IOException e) {
-      System.out.println(e);
       throw new PredictorLoadingException(
-          "Failed to load the configuration for the MLflow model at the specified path.");
+          "Failed to load the configuration for the MLflow model at the specified path.", e);
     }
   }
 

--- a/mlflow/java/scoring/src/main/java/org/mlflow/sagemaker/ScoringServer.java
+++ b/mlflow/java/scoring/src/main/java/org/mlflow/sagemaker/ScoringServer.java
@@ -73,9 +73,10 @@ public class ScoringServer {
   private static Predictor loadPredictorFromPath(String modelPath)
       throws PredictorLoadingException {
     try {
-      Model config = Model.fromRootPath(modelPath);
-      return (new MLeapLoader()).load(config);
+    Model config = Model.fromRootPath(modelPath);
+    return (new MLeapLoader()).load(config);
     } catch (IOException e) {
+      System.out.println(e);
       throw new PredictorLoadingException(
           "Failed to load the configuration for the MLflow model at the specified path.");
     }

--- a/mlflow/java/scoring/src/test/java/org/mlflow/ModelTest.java
+++ b/mlflow/java/scoring/src/test/java/org/mlflow/ModelTest.java
@@ -18,6 +18,7 @@ public class ModelTest {
       Assert.assertTrue(model.getFlavor(MLeapFlavor.FLAVOR_NAME, MLeapFlavor.class).isPresent());
       Assert.assertTrue(model.getUtcTimeCreated().isPresent());
       Assert.assertTrue(model.getModelUuid().isPresent());
+      Assert.assertTrue(model.getMlflowVersion().isPresent());
     } catch (IOException e) {
       e.printStackTrace();
       Assert.fail("Encountered an exception while reading the model from a configuration path!");
@@ -30,6 +31,18 @@ public class ModelTest {
     try {
       Model model = Model.fromConfigPath(configPath);
       Assert.assertFalse(model.getModelUuid().isPresent());
+    } catch (IOException e) {
+      e.printStackTrace();
+      Assert.fail("Encountered an exception while reading the model from a configuration path!");
+    }
+  }
+
+  @Test
+  public void testModelIsLoadedCorrectlyWhenMlflowVersionDoesNotExist() {
+    String configPath = getClass().getResource("sample_model_root/MLmodel.no.mlflow_version").getFile();
+    try {
+      Model model = Model.fromConfigPath(configPath);
+      Assert.assertFalse(model.getMlflowVersion().isPresent());
     } catch (IOException e) {
       e.printStackTrace();
       Assert.fail("Encountered an exception while reading the model from a configuration path!");

--- a/mlflow/java/scoring/src/test/resources/org/mlflow/models/sample_model_root/MLmodel.no.mlflow_version
+++ b/mlflow/java/scoring/src/test/resources/org/mlflow/models/sample_model_root/MLmodel.no.mlflow_version
@@ -6,7 +6,6 @@ utc_time_created: '2018-08-10 18:34:28.720095'
 run_id: c228016dea284522882b657d91eeffa6
 artifact_path: model
 model_uuid: 4ab08bf9d91e4535bc2719f9210840c3
-mlflow_version: 1.25.0
 signature:
   inputs: '[{"name": "fixed acidity", "type": "double"}, {"name": "volatile acidity",
     "type": "double"}, {"name": "citric acid", "type": "double"}, {"name": "residual


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add mlflow_version to Java model spec to fix serving behavior

## How is this patch tested?

Existing coverage + new coverage to make sure models are loaded properly even if they lack `mlflow_version`

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

Add `mlflow_version` field to Java model spec

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
