### PR TITLE
Introduce mlflow.last_active_run fluent API

### DIFF
--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -413,7 +413,28 @@ The following libraries support autologging:
 
 For flavors that automatically save models as an artifact, `additional files <https://mlflow.org/docs/latest/models.html#storage-format>`_ for dependency management are logged.
 
-You can access the most recent autolog run through the :py:func:`mlflow.last_active_run` function.
+You can access the most recent autolog run through the :py:func:`mlflow.last_active_run` function. Here's a short sklearn autolog example that makes use of this function:
+
+.. code-block:: python
+
+    import mlflow
+
+    from sklearn.model_selection import train_test_split
+    from sklearn.datasets import load_diabetes
+    from sklearn.ensemble import RandomForestRegressor
+
+    mlflow.autolog()
+
+    db = load_diabetes()
+    X_train, X_test, y_train, y_test = train_test_split(db.data, db.target)
+
+    # Create and train models.
+    rf = RandomForestRegressor(n_estimators = 100, max_depth = 6, max_features = 3)
+    rf.fit(X_train, y_train)
+
+    # Use the model to make predictions on the test dataset.
+    predictions = rf.predict(X_test)
+    autolog_run = mlflow.last_active_run()
 
 Scikit-learn
 ------------

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -296,6 +296,9 @@ such attributes, use the :py:class:`mlflow.tracking.MlflowClient` as follows:
     client = mlflow.tracking.MlflowClient()
     data = client.get_run(mlflow.active_run().info.run_id).data
 
+:py:func:`mlflow.last_active_run` retuns a :py:class:`mlflow.entities.Run` object corresponding to the
+currently active run, if any. Otherwise, it returns a :py:class:`mlflow.entities.Run` object corresponding 
+the last run started from the current Python process that reached a terminal status (i.e. FINISHED, FAILED, or KILLED).
 
 :py:func:`mlflow.log_param` logs a single key-value param in the currently active run. The key and
 value are both strings. Use :py:func:`mlflow.log_params` to log multiple params at once.
@@ -410,6 +413,7 @@ The following libraries support autologging:
 
 For flavors that automatically save models as an artifact, `additional files <https://mlflow.org/docs/latest/models.html#storage-format>`_ for dependency management are logged.
 
+You can access the most recent autolog run through the :py:func:`mlflow.last_active_run` function.
 
 Scikit-learn
 ------------

--- a/examples/evaluation/evaluate_on_multiclass_classifier.py
+++ b/examples/evaluation/evaluate_on_multiclass_classifier.py
@@ -9,18 +9,19 @@ X, y = make_classification(n_samples=10000, n_classes=10, n_informative=5, rando
 
 X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.33, random_state=42)
 
-model = LogisticRegression(solver="liblinear").fit(X_train, y_train)
-model_uri = mlflow.get_artifact_uri("model")
-result = mlflow.evaluate(
-    model_uri,
-    X_test,
-    targets=y_test,
-    model_type="classifier",
-    dataset_name="multiclass-classification-dataset",
-    evaluators="default",
-    evaluator_config={"log_model_explainability": True, "explainability_nsamples": 1000},
-)
+with mlflow.start_run() as run:
+    model = LogisticRegression(solver="liblinear").fit(X_train, y_train)
+    model_uri = mlflow.get_artifact_uri("model")
+    result = mlflow.evaluate(
+        model_uri,
+        X_test,
+        targets=y_test,
+        model_type="classifier",
+        dataset_name="multiclass-classification-dataset",
+        evaluators="default",
+        evaluator_config={"log_model_explainability": True, "explainability_nsamples": 1000},
+    )
 
-print(f"run_id={mlflow.last_active_run().info.run_id}")
+print(f"run_id={run.info.run_id}")
 print(f"metrics:\n{result.metrics}")
 print(f"artifacts:\n{result.artifacts}")

--- a/examples/evaluation/evaluate_on_multiclass_classifier.py
+++ b/examples/evaluation/evaluate_on_multiclass_classifier.py
@@ -9,19 +9,18 @@ X, y = make_classification(n_samples=10000, n_classes=10, n_informative=5, rando
 
 X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.33, random_state=42)
 
-with mlflow.start_run() as run:
-    model = LogisticRegression(solver="liblinear").fit(X_train, y_train)
-    model_uri = mlflow.get_artifact_uri("model")
-    result = mlflow.evaluate(
-        model_uri,
-        X_test,
-        targets=y_test,
-        model_type="classifier",
-        dataset_name="multiclass-classification-dataset",
-        evaluators="default",
-        evaluator_config={"log_model_explainability": True, "explainability_nsamples": 1000},
-    )
+model = LogisticRegression(solver="liblinear").fit(X_train, y_train)
+model_uri = mlflow.get_artifact_uri("model")
+result = mlflow.evaluate(
+    model_uri,
+    X_test,
+    targets=y_test,
+    model_type="classifier",
+    dataset_name="multiclass-classification-dataset",
+    evaluators="default",
+    evaluator_config={"log_model_explainability": True, "explainability_nsamples": 1000},
+)
 
-print(f"run_id={run.info.run_id}")
+print(f"run_id={mlflow.last_active_run().info.run_id}")
 print(f"metrics:\n{result.metrics}")
 print(f"artifacts:\n{result.artifacts}")

--- a/examples/lightgbm/lightgbm_sklearn/train.py
+++ b/examples/lightgbm/lightgbm_sklearn/train.py
@@ -20,17 +20,15 @@ def main():
     # this includes lightgbm.sklearn estimators
     mlflow.lightgbm.autolog()
 
-    with mlflow.start_run() as run:
-
-        regressor = lgb.LGBMClassifier(n_estimators=20, reg_lambda=1.0)
-        regressor.fit(X_train, y_train, eval_set=[(X_test, y_test)])
-        y_pred = regressor.predict(X_test)
-        f1 = f1_score(y_test, y_pred, average="micro")
-        run_id = run.info.run_id
-        print("Logged data and model in run {}".format(run_id))
+    regressor = lgb.LGBMClassifier(n_estimators=20, reg_lambda=1.0)
+    regressor.fit(X_train, y_train, eval_set=[(X_test, y_test)])
+    y_pred = regressor.predict(X_test)
+    f1 = f1_score(y_test, y_pred, average="micro")
+    run_id = mlflow.last_active_run().info.run_id
+    print("Logged data and model in run {}".format(run_id))
 
     # show logged data
-    for key, data in fetch_logged_data(run.info.run_id).items():
+    for key, data in fetch_logged_data(run_id).items():
         print("\n---------- logged {} ----------".format(key))
         pprint(data)
 

--- a/examples/ray_serve/train_model.py
+++ b/examples/ray_serve/train_model.py
@@ -28,14 +28,14 @@ if __name__ == "__main__":
     val_x, val_y = data[100:], target[100:]
 
     # Train and evaluate model
-    with mlflow.start_run() as run:
-        model.fit(train_x, train_y)
+    model.fit(train_x, train_y)
+    run_id = mlflow.last_active_run().info.run_id
     print("MSE:", mean_squared_error(model.predict(val_x), val_y))
     print("Target names: ", target_names)
-    print("run_id: {}".format(run.info.run_id))
+    print("run_id: {}".format(run_id))
 
     # Register the auto-logged model
-    model_uri = "runs:/{}/model".format(run.info.run_id)
+    model_uri = "runs:/{}/model".format(run_id)
     registered_model_name = "RayMLflowIntegration"
     mv = mlflow.register_model(model_uri, registered_model_name)
     print("Name: {}".format(mv.name))

--- a/examples/sklearn_autolog/grid_search_cv.py
+++ b/examples/sklearn_autolog/grid_search_cv.py
@@ -16,17 +16,17 @@ def main():
     svc = svm.SVC()
     clf = GridSearchCV(svc, parameters)
 
-    with mlflow.start_run() as run:
-        clf.fit(iris.data, iris.target)
+    clf.fit(iris.data, iris.target)
+    run_id = mlflow.last_active_run().info.run_id
 
     # show data logged in the parent run
     print("========== parent run ==========")
-    for key, data in fetch_logged_data(run.info.run_id).items():
+    for key, data in fetch_logged_data(run_id).items():
         print("\n---------- logged {} ----------".format(key))
         pprint(data)
 
     # show data logged in the child runs
-    filter_child_runs = "tags.mlflow.parentRunId = '{}'".format(run.info.run_id)
+    filter_child_runs = "tags.mlflow.parentRunId = '{}'".format(run_id)
     runs = mlflow.search_runs(filter_string=filter_child_runs)
     param_cols = ["params.{}".format(p) for p in parameters.keys()]
     metric_cols = ["metrics.mean_test_score"]

--- a/examples/sklearn_autolog/linear_regression.py
+++ b/examples/sklearn_autolog/linear_regression.py
@@ -18,10 +18,11 @@ def main():
     # train a model
     model = LinearRegression()
     model.fit(X, y)
-    print("Logged data and model in run {}".format(mlflow.last_active_run().info.run_id))
+    run_id = mlflow.last_active_run().info.run_id
+    print("Logged data and model in run {}".format(run_id))
 
     # show logged data
-    for key, data in fetch_logged_data(run.info.run_id).items():
+    for key, data in fetch_logged_data(run_id).items():
         print("\n---------- logged {} ----------".format(key))
         pprint(data)
 

--- a/examples/sklearn_autolog/linear_regression.py
+++ b/examples/sklearn_autolog/linear_regression.py
@@ -17,9 +17,8 @@ def main():
 
     # train a model
     model = LinearRegression()
-    with mlflow.start_run() as run:
-        model.fit(X, y)
-        print("Logged data and model in run {}".format(run.info.run_id))
+    model.fit(X, y)
+    print("Logged data and model in run {}".format(mlflow.last_active_run().info.run_id))
 
     # show logged data
     for key, data in fetch_logged_data(run.info.run_id).items():

--- a/examples/sklearn_autolog/pipeline.py
+++ b/examples/sklearn_autolog/pipeline.py
@@ -20,10 +20,11 @@ def main():
     # train a model
     pipe = Pipeline([("scaler", StandardScaler()), ("lr", LinearRegression())])
     pipe.fit(X, y)
-    print("Logged data and model in run: {}".format(mlflow.last_active_run().info.run_id))
+    run_id = mlflow.last_active_run().info.run_id
+    print("Logged data and model in run: {}".format(run_id))
 
     # show logged data
-    for key, data in fetch_logged_data(run.info.run_id).items():
+    for key, data in fetch_logged_data(run_id).items():
         print("\n---------- logged {} ----------".format(key))
         pprint(data)
 

--- a/examples/sklearn_autolog/pipeline.py
+++ b/examples/sklearn_autolog/pipeline.py
@@ -19,9 +19,8 @@ def main():
 
     # train a model
     pipe = Pipeline([("scaler", StandardScaler()), ("lr", LinearRegression())])
-    with mlflow.start_run() as run:
-        pipe.fit(X, y)
-        print("Logged data and model in run: {}".format(run.info.run_id))
+    pipe.fit(X, y)
+    print("Logged data and model in run: {}".format(mlflow.last_active_run().info.run_id))
 
     # show logged data
     for key, data in fetch_logged_data(run.info.run_id).items():

--- a/examples/xgboost/xgboost_sklearn/train.py
+++ b/examples/xgboost/xgboost_sklearn/train.py
@@ -20,17 +20,15 @@ def main():
     # this includes xgboost.sklearn estimators
     mlflow.xgboost.autolog()
 
-    with mlflow.start_run() as run:
-
-        regressor = xgb.XGBRegressor(n_estimators=20, reg_lambda=1, gamma=0, max_depth=3)
-        regressor.fit(X_train, y_train, eval_set=[(X_test, y_test)])
-        y_pred = regressor.predict(X_test)
-        mse = mean_squared_error(y_test, y_pred)
-        run_id = run.info.run_id
-        print("Logged data and model in run {}".format(run_id))
+    regressor = xgb.XGBRegressor(n_estimators=20, reg_lambda=1, gamma=0, max_depth=3)
+    regressor.fit(X_train, y_train, eval_set=[(X_test, y_test)])
+    y_pred = regressor.predict(X_test)
+    mse = mean_squared_error(y_test, y_pred)
+    run_id = mlflow.last_active_run().info.run_id
+    print("Logged data and model in run {}".format(run_id))
 
     # show logged data
-    for key, data in fetch_logged_data(run.info.run_id).items():
+    for key, data in fetch_logged_data(run_id).items():
         print("\n---------- logged {} ----------".format(key))
         pprint(data)
 

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -155,6 +155,7 @@ delete_run = mlflow.tracking.fluent.delete_run
 register_model = mlflow.tracking._model_registry.fluent.register_model
 autolog = mlflow.tracking.fluent.autolog
 evaluate = mlflow.models.evaluate
+last_active_run = mlflow.tracking.fluent.last_active_run
 
 run = projects.run
 
@@ -195,4 +196,5 @@ __all__ = [
     "list_run_infos",
     "autolog",
     "evaluate",
+    "last_active_run",
 ] + _model_flavors_supported

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -390,14 +390,51 @@ def active_run() -> Optional[ActiveRun]:
 
 def last_active_run() -> Optional[Run]:
     """
-    Returns mlflow.active_run() if it is not None. Otherwise, return the
-    last run started from the current Python process that reached a
-    terminal status (i.e. FINISHED, FAILED, or KILLED).
+    Gets the most recent active run.
 
-    This is useful for retrieving the most recent autologged run.
+    Examples:
 
-    :return: A mlflow.entities.Run object if one exists. Otherwise it
-             returns None.
+    .. code-block:: python
+        :caption: To retrieve the most recent autologged run.
+
+        import mlflow
+
+        from sklearn.model_selection import train_test_split
+        from sklearn.datasets import load_diabetes
+        from sklearn.ensemble import RandomForestRegressor
+
+        db = load_diabetes()
+        X_train, X_test, y_train, y_test = train_test_split(db.data, db.target)
+
+        # Create and train models.
+        rf = RandomForestRegressor(n_estimators = 100, max_depth = 6, max_features = 3)
+        rf.fit(X_train, y_train)
+
+        # Use the model to make predictions on the test dataset.
+        predictions = rf.predict(X_test)
+        auto_autologged_run = mlflow.last_active_run()
+
+    .. code-block:: python
+        :caption: To get the most recently active run that ended
+
+        import mlflow
+
+        mlflow.start_run()
+        mlflow.end_run()
+        run = mlflow.last_active_run()
+
+    .. code-block:: python
+        :caption: To retrieve the currently active run
+
+        import mlflow
+
+        mlflow.start_run()
+        run = mlflow.last_active_run()
+        mlflow.end_run()
+
+    :return: Returns mlflow.active_run() if it is not None. Otherwise, return
+             last run started from the current Python process that reached a
+             terminal status (i.e. FINISHED, FAILED, or KILLED).
     """
     _active_run = active_run()
     if _active_run is not None:

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -432,7 +432,7 @@ def last_active_run() -> Optional[Run]:
         run = mlflow.last_active_run()
         mlflow.end_run()
 
-    :return: The active run, if a run is currently active (this is equivalent to ``mlflow.active_run()``). Otherwise, there is no currently active run,
+    :return: The active run, if a run is currently active (this is equivalent to ``mlflow.active_run()``). Otherwise, if no run is currently active, the
              last run started from the current Python process that reached a
              terminal status (i.e. FINISHED, FAILED, or KILLED).
     """

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -432,7 +432,7 @@ def last_active_run() -> Optional[Run]:
         run = mlflow.last_active_run()
         mlflow.end_run()
 
-    :return: Returns mlflow.active_run() if it is not None. Otherwise, return
+    :return: The active run, if a run is currently active (this is equivalent to ``mlflow.active_run()``). Otherwise, there is no currently active run,
              last run started from the current Python process that reached a
              terminal status (i.e. FINISHED, FAILED, or KILLED).
     """

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -395,13 +395,15 @@ def last_active_run() -> Optional[Run]:
     Examples:
 
     .. code-block:: python
-        :caption: To retrieve the most recent autologged run.
+        :caption: To retrieve the most recent autologged run:
 
         import mlflow
 
         from sklearn.model_selection import train_test_split
         from sklearn.datasets import load_diabetes
         from sklearn.ensemble import RandomForestRegressor
+
+        mlflow.autolog()
 
         db = load_diabetes()
         X_train, X_test, y_train, y_test = train_test_split(db.data, db.target)
@@ -415,7 +417,7 @@ def last_active_run() -> Optional[Run]:
         autolog_run = mlflow.last_active_run()
 
     .. code-block:: python
-        :caption: To get the most recently active run that ended
+        :caption: To get the most recently active run that ended:
 
         import mlflow
 
@@ -424,7 +426,7 @@ def last_active_run() -> Optional[Run]:
         run = mlflow.last_active_run()
 
     .. code-block:: python
-        :caption: To retrieve the currently active run
+        :caption: To retrieve the currently active run:
 
         import mlflow
 
@@ -434,7 +436,7 @@ def last_active_run() -> Optional[Run]:
 
     :return: The active run (this is equivalent to ``mlflow.active_run()``) if one exists.
              Otherwise, the last run started from the current Python process that reached
-              a terminal status (i.e. FINISHED, FAILED, or KILLED).
+             a terminal status (i.e. FINISHED, FAILED, or KILLED).
     """
     _active_run = active_run()
     if _active_run is not None:

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -412,7 +412,7 @@ def last_active_run() -> Optional[Run]:
 
         # Use the model to make predictions on the test dataset.
         predictions = rf.predict(X_test)
-        auto_autologged_run = mlflow.last_active_run()
+        autolog_run = mlflow.last_active_run()
 
     .. code-block:: python
         :caption: To get the most recently active run that ended
@@ -432,9 +432,9 @@ def last_active_run() -> Optional[Run]:
         run = mlflow.last_active_run()
         mlflow.end_run()
 
-    :return: The active run, if a run is currently active (this is equivalent to ``mlflow.active_run()``). Otherwise, if no run is currently active, the
-             last run started from the current Python process that reached a
-             terminal status (i.e. FINISHED, FAILED, or KILLED).
+    :return: The active run (this is equivalent to ``mlflow.active_run()``) if one exists.
+             Otherwise, the last run started from the current Python process that reached
+              a terminal status (i.e. FINISHED, FAILED, or KILLED).
     """
     _active_run = active_run()
     if _active_run is not None:

--- a/tests/autologging/test_autologging_behaviors_integration.py
+++ b/tests/autologging/test_autologging_behaviors_integration.py
@@ -101,6 +101,9 @@ def test_autologging_integrations_use_safe_patch_for_monkey_patching(integration
                 safe_patch_call_count = (
                     safe_patch_mock.call_count + sklearn_safe_patch_mock.call_count
                 )
+
+                # Assert autolog integrations use the fluent API for run management. This is to
+                # ensure certain fluent API methods like mlflow.last_active_run behaves as expected.
                 assert any(
                     kwargs["manage_run"]
                     for _, kwargs in sklearn_safe_patch_mock.call_args_list
@@ -111,6 +114,8 @@ def test_autologging_integrations_use_safe_patch_for_monkey_patching(integration
             safe_patch_call_count = safe_patch_mock.call_count
 
         if integration.__name__ != "mlflow.spark":
+            # Assert autolog integrations use the fluent API for run management. This is to
+            # ensure certain fluent API methods like mlflow.last_active_run behaves as expected.
             assert any(
                 kwargs["manage_run"]
                 for _, kwargs in safe_patch_mock.call_args_list

--- a/tests/autologging/test_autologging_behaviors_integration.py
+++ b/tests/autologging/test_autologging_behaviors_integration.py
@@ -37,6 +37,7 @@ AUTOLOGGING_INTEGRATIONS_TO_TEST = {
     mlflow.statsmodels: "statsmodels",
     mlflow.spark: "pyspark",
     mlflow.pyspark.ml: "pyspark",
+    mlflow.tensorflow: "tensorflow",
 }
 
 
@@ -84,36 +85,44 @@ def test_autologging_integrations_expose_configs_and_support_disablement(integra
 
 @pytest.mark.parametrize("integration", AUTOLOGGING_INTEGRATIONS_TO_TEST.keys())
 def test_autologging_integrations_use_safe_patch_for_monkey_patching(integration):
-    for integration in AUTOLOGGING_INTEGRATIONS_TO_TEST:
-        with mock.patch(
-            "mlflow.utils.gorilla.apply", wraps=gorilla.apply
-        ) as gorilla_mock, mock.patch(
-            integration.__name__ + ".safe_patch", wraps=safe_patch
-        ) as safe_patch_mock:
-            # In `mlflow.xgboost.autolog()` and `mlflow.lightgbm.autolog()`,
-            # we enable autologging for XGBoost and LightGBM sklearn models
-            # using `mlflow.sklearn._autolog()`. So besides `safe_patch` calls in
-            # `autolog()`, we need to count additional `safe_patch` calls
-            # in sklearn autologging routine as well.
-            if integration.__name__ in ["mlflow.xgboost", "mlflow.lightgbm"]:
-                with mock.patch(
-                    "mlflow.sklearn.safe_patch", wraps=safe_patch
-                ) as sklearn_safe_patch_mock:
-                    integration.autolog(disable=False)
-                    safe_patch_call_count = (
-                        safe_patch_mock.call_count + sklearn_safe_patch_mock.call_count
-                    )
-            else:
+    with mock.patch("mlflow.utils.gorilla.apply", wraps=gorilla.apply) as gorilla_mock, mock.patch(
+        integration.__name__ + ".safe_patch", wraps=safe_patch
+    ) as safe_patch_mock:
+        # In `mlflow.xgboost.autolog()` and `mlflow.lightgbm.autolog()`,
+        # we enable autologging for XGBoost and LightGBM sklearn models
+        # using `mlflow.sklearn._autolog()`. So besides `safe_patch` calls in
+        # `autolog()`, we need to count additional `safe_patch` calls
+        # in sklearn autologging routine as well.
+        if integration.__name__ in ["mlflow.xgboost", "mlflow.lightgbm"]:
+            with mock.patch(
+                "mlflow.sklearn.safe_patch", wraps=safe_patch
+            ) as sklearn_safe_patch_mock:
                 integration.autolog(disable=False)
-                safe_patch_call_count = safe_patch_mock.call_count
+                safe_patch_call_count = (
+                    safe_patch_mock.call_count + sklearn_safe_patch_mock.call_count
+                )
+                assert any(
+                    kwargs["manage_run"]
+                    for _, kwargs in sklearn_safe_patch_mock.call_args_list
+                    if "manage_run" in kwargs
+                )
+        else:
+            integration.autolog(disable=False)
+            safe_patch_call_count = safe_patch_mock.call_count
 
-            assert safe_patch_call_count > 0
-            # `safe_patch` leverages `gorilla.apply` in its implementation. Accordingly, we expect
-            # that the total number of `gorilla.apply` calls to be equivalent to the number of
-            # `safe_patch` calls. This verifies that autologging integrations are leveraging
-            # `safe_patch`, rather than calling `gorilla.apply` directly (which does not provide
-            # exception safety properties)
-            assert safe_patch_call_count == gorilla_mock.call_count
+        if integration.__name__ != "mlflow.spark":
+            assert any(
+                kwargs["manage_run"]
+                for _, kwargs in safe_patch_mock.call_args_list
+                if "manage_run" in kwargs
+            )
+        assert safe_patch_call_count > 0
+        # `safe_patch` leverages `gorilla.apply` in its implementation. Accordingly, we expect
+        # that the total number of `gorilla.apply` calls to be equivalent to the number of
+        # `safe_patch` calls. This verifies that autologging integrations are leveraging
+        # `safe_patch`, rather than calling `gorilla.apply` directly (which does not provide
+        # exception safety properties)
+        assert safe_patch_call_count == gorilla_mock.call_count
 
 
 def test_autolog_respects_exclusive_flag(setup_sklearn_model):

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -1016,7 +1016,6 @@ def test_last_active_run_returns_most_recently_ended_active_run():
     mlflow.log_param("b", 2)
     mlflow.end_run()
     last_active_run = mlflow.last_active_run()
-    print(last_active_run.data)
     assert last_active_run.info.run_id == run_id
     assert last_active_run.data.metrics == {"a": 1.0}
     assert last_active_run.data.params == {"b": "2"}

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -1012,7 +1012,7 @@ def test_last_active_run_returns_currently_active_run():
 
 def test_last_active_run_returns_most_recently_ended_active_run():
     run_id = mlflow.start_run().info.run_id
-    mlflow.log_metric("a", 1)
+    mlflow.log_metric("a", 1.0)
     mlflow.log_param("b", 2)
     mlflow.end_run()
     last_active_run = mlflow.last_active_run()

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -1001,3 +1001,22 @@ def test_delete_tag():
     with pytest.raises(MlflowException, match="No tag with name"):
         mlflow.delete_tag("b")
     mlflow.end_run()
+
+
+def test_last_active_run_returns_currently_active_run():
+    run_id = mlflow.start_run().info.run_id
+    last_active_run_id = mlflow.last_active_run().info.run_id
+    mlflow.end_run()
+    assert run_id == last_active_run_id
+
+
+def test_last_active_run_returns_most_recently_ended_active_run():
+    run_id = mlflow.start_run().info.run_id
+    mlflow.log_metric("a", 1)
+    mlflow.log_param("b", 2)
+    mlflow.end_run()
+    last_active_run = mlflow.last_active_run()
+    print(last_active_run.data)
+    assert last_active_run.info.run_id == run_id
+    assert last_active_run.data.metrics == {"a": 1.0}
+    assert last_active_run.data.params == {"b": "2"}

--- a/tests/tracking/fluent/test_fluent_autolog.py
+++ b/tests/tracking/fluent/test_fluent_autolog.py
@@ -347,6 +347,6 @@ def test_last_active_run_retrieves_autologged_run():
     rf.fit([[1, 2]], [[3]])
     rf.predict([[2, 1]])
 
-    auto_autologged_run = mlflow.last_active_run()
-    assert auto_autologged_run is not None
-    assert auto_autologged_run.info.run_id is not None
+    autolog_run = mlflow.last_active_run()
+    assert autolog_run is not None
+    assert autolog_run.info.run_id is not None

--- a/tests/tracking/fluent/test_fluent_autolog.py
+++ b/tests/tracking/fluent/test_fluent_autolog.py
@@ -89,9 +89,12 @@ def only_register(callback_fn, module, overwrite):  # pylint: disable=unused-arg
 
 
 @pytest.fixture(autouse=True)
-def disable_new_import_hook_firing_if_module_already_exists():
-    with mock.patch("mlflow.tracking.fluent.register_post_import_hook", wraps=only_register):
+def disable_new_import_hook_firing_if_module_already_exists(request):
+    if "do_not_disable_new_import_hook_firing_if_module_already_exists" in request.keywords:
         yield
+    else:
+        with mock.patch("mlflow.tracking.fluent.register_post_import_hook", wraps=only_register):
+            yield
 
 
 @pytest.mark.large
@@ -332,3 +335,18 @@ def test_autolog_obeys_silent_mode(
     mlflow.utils.import_hooks.notify_module_loaded(library)
 
     assert not stream.getvalue()
+
+
+@pytest.mark.do_not_disable_new_import_hook_firing_if_module_already_exists
+def test_last_active_run_retrieves_autologged_run():
+    from sklearn.ensemble import RandomForestRegressor
+
+    mlflow.autolog()
+
+    rf = RandomForestRegressor(n_estimators=1, max_depth=1, max_features=1)
+    rf.fit([[1, 2]], [[3]])
+    rf.predict([[2, 1]])
+
+    auto_autologged_run = mlflow.last_active_run()
+    assert auto_autologged_run is not None
+    assert auto_autologged_run.info.run_id is not None


### PR DESCRIPTION
Signed-off-by: Mark Zhang <mark.zhang@databricks.com>

## What changes are proposed in this pull request?

Introduces a new fluent API `mlflow.last_active_run`. It returns `mlflow.active_run()` if it is not None. Otherwise, return the last run started from the current Python process that reached a terminal status (i.e. FINISHED, FAILED, or KILLED).

This is particularly useful for retrieving the most recently autologged run. Currently, there is no way of accessing the `mlflow.entities.Run` object of the most recent autolog run. This API resolves this inconvenience.

## How is this patch tested?

* Added tests in `tests/tracking/fluent/test_fluent.py` and `tests/tracking/fluent/test_fluent_autolog.py`
* Manually tested:
   * Retrieving the most recently autologged run without explicit `mlflow.start_run`
   * Retrieving the currently active run in between `mlflow.start_run` and `mlflow.end_run`
 

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

Introduces `mlflow.last_active_run()`: It returns the active run if one exists. Otherwise, it returns the last run started from the current Python process that reached a terminal status (i.e. FINISHED, FAILED, or KILLED). This is particularly useful for retrieving the most recent autolog run.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
