### PR TITLE
Make `EnvManager` private

### DIFF
--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -22,7 +22,7 @@ from mlflow.utils.annotations import experimental
 from mlflow.utils.logging_utils import eprint
 from mlflow.utils.process import ShellCommandException
 from mlflow.utils.uri import resolve_default_artifact_root
-from mlflow.utils.environment import EnvManager
+from mlflow.utils.environment import _EnvManager
 from mlflow.entities.lifecycle_stage import LifecycleStage
 from mlflow.exceptions import MlflowException
 
@@ -186,7 +186,7 @@ def run(
             docker_args=args_dict,
             backend=backend,
             backend_config=backend_config,
-            use_conda=env_manager is EnvManager.CONDA,
+            use_conda=env_manager is _EnvManager.CONDA,
             storage_dir=storage_dir,
             synchronous=backend in ("local", "kubernetes") or backend is None,
             run_id=run_id,

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -14,7 +14,7 @@ from mlflow.pyfunc import ENV, scoring_server, mlserver
 from mlflow.utils.conda import get_or_create_conda_env, get_conda_bin_executable, get_conda_command
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.file_utils import path_to_local_file_uri
-from mlflow.utils.environment import EnvManager
+from mlflow.utils.environment import _EnvManager
 from mlflow.version import VERSION
 
 
@@ -27,7 +27,7 @@ class PyFuncBackend(FlavorBackend):
     """
 
     def __init__(
-        self, config, workers=1, env_manager=EnvManager.CONDA, install_mlflow=False, **kwargs
+        self, config, workers=1, env_manager=_EnvManager.CONDA, install_mlflow=False, **kwargs
     ):
         super().__init__(config=config, **kwargs)
         self._nworkers = workers or 1
@@ -37,7 +37,7 @@ class PyFuncBackend(FlavorBackend):
 
     def prepare_env(self, model_uri, capture_output=False):
         local_path = _download_artifact_from_uri(model_uri)
-        if self._env_manager is EnvManager.LOCAL or ENV not in self._config:
+        if self._env_manager is _EnvManager.LOCAL or ENV not in self._config:
             return 0
         conda_env_path = os.path.join(local_path, self._config[ENV])
 
@@ -57,7 +57,7 @@ class PyFuncBackend(FlavorBackend):
         # NB: Absolute windows paths do not work with mlflow apis, use file uri to ensure
         # platform compatibility.
         local_uri = path_to_local_file_uri(local_path)
-        if self._env_manager is EnvManager.CONDA and ENV in self._config:
+        if self._env_manager is _EnvManager.CONDA and ENV in self._config:
             conda_env_path = os.path.join(local_path, self._config[ENV])
 
             conda_env_name = get_or_create_conda_env(
@@ -135,7 +135,7 @@ class PyFuncBackend(FlavorBackend):
         else:
             setup_sigterm_on_parent_death = None
 
-        if self._env_manager is EnvManager.CONDA and ENV in self._config:
+        if self._env_manager is _EnvManager.CONDA and ENV in self._config:
             conda_env_path = os.path.join(local_path, self._config[ENV])
 
             conda_env_name = get_or_create_conda_env(
@@ -179,7 +179,7 @@ class PyFuncBackend(FlavorBackend):
             return child_proc
 
     def can_score_model(self):
-        if self._env_manager is EnvManager.LOCAL:
+        if self._env_manager is _EnvManager.LOCAL:
             # noconda => already in python and dependencies are assumed to be installed.
             return True
         conda_path = get_conda_bin_executable("conda")

--- a/mlflow/utils/cli_args.py
+++ b/mlflow/utils/cli_args.py
@@ -5,7 +5,7 @@ import click
 import warnings
 
 
-from mlflow.utils.environment import EnvManager
+from mlflow.utils.environment import _EnvManager
 
 MODEL_PATH = click.option(
     "--model-path",
@@ -75,14 +75,14 @@ def _resolve_env_manager(ctx, _, value):
             FutureWarning,
             stacklevel=2,
         )
-        return EnvManager.LOCAL
+        return _EnvManager.LOCAL
 
     # Only `--env-manager` is specified
     if value is not None:
-        return EnvManager.from_string(value)
+        return _EnvManager.from_string(value)
 
     # Neither `--no-conda` nor `--env-manager` is specified
-    return EnvManager.CONDA
+    return _EnvManager.CONDA
 
 
 ENV_MANAGER = click.option(

--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -20,7 +20,7 @@ _REQUIREMENTS_FILE_NAME = "requirements.txt"
 _CONSTRAINTS_FILE_NAME = "constraints.txt"
 
 
-class EnvManager(Enum):
+class _EnvManager(Enum):
     LOCAL = "local"
     CONDA = "conda"
 

--- a/tests/pyfunc/test_scoring_server.py
+++ b/tests/pyfunc/test_scoring_server.py
@@ -22,7 +22,7 @@ from mlflow.pyfunc.scoring_server import get_cmd
 from mlflow.types import Schema, ColSpec, DataType
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils.proto_json_utils import NumpyEncoder
-from mlflow.utils.environment import EnvManager
+from mlflow.utils.environment import _EnvManager
 
 from tests.helper_functions import pyfunc_serve_and_score_model, random_int, random_str
 
@@ -631,7 +631,7 @@ def test_scoring_server_client(sklearn_model, model_path):
     server_proc = None
     try:
         server_proc = _get_flavor_backend(
-            model_path, eng_manager=EnvManager.CONDA, workers=1, install_mlflow=False
+            model_path, eng_manager=_EnvManager.CONDA, workers=1, install_mlflow=False
         ).serve(
             model_uri=model_path,
             port=port,

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -20,7 +20,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.models import ModelSignature
 from mlflow.pyfunc import spark_udf, PythonModel, PyFuncModel
 from mlflow.pyfunc.spark_model_cache import SparkModelCache
-from mlflow.utils.environment import EnvManager
+from mlflow.utils.environment import _EnvManager
 
 import tests
 from mlflow.types import Schema, ColSpec
@@ -411,7 +411,7 @@ def test_spark_udf_embedded_model_server_killed_when_job_canceled(spark, sklearn
         from mlflow.models.cli import _get_flavor_backend
 
         _get_flavor_backend(
-            model_path, env_manager=EnvManager.CONDA, workers=1, install_mlflow=False
+            model_path, env_manager=_EnvManager.CONDA, workers=1, install_mlflow=False
         ).serve(
             model_uri=model_path,
             port=server_port,
@@ -429,9 +429,9 @@ def test_spark_udf_embedded_model_server_killed_when_job_canceled(spark, sklearn
         # and the udf task starts a mlflow model server process.
         spark.range(1).repartition(1).select(udf_with_model_server("id")).collect()
 
-    _get_flavor_backend(model_path, env_manager=EnvManager.CONDA, install_mlflow=False).prepare_env(
-        model_uri=model_path
-    )
+    _get_flavor_backend(
+        model_path, env_manager=_EnvManager.CONDA, install_mlflow=False
+    ).prepare_env(model_uri=model_path)
 
     job_thread = threading.Thread(target=run_job)
     job_thread.start()


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

Make the `EnvManger` enum private.

## How is this patch tested?

Existing tests

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
