### PR TITLE
Simplify `process.exec_cmd` using `subprocess.run`

### DIFF
--- a/mlflow/data.py
+++ b/mlflow/data.py
@@ -23,7 +23,7 @@ def _fetch_dbfs(uri, local_path):
     _logger.info(
         "=== Downloading DBFS file %s to local path %s ===", uri, os.path.abspath(local_path)
     )
-    process.exec_cmd(cmd=["databricks", "fs", "cp", "-r", uri, local_path])
+    process._exec_cmd(cmd=["databricks", "fs", "cp", "-r", uri, local_path])
 
 
 def _fetch_s3(uri, local_path):

--- a/mlflow/projects/docker.py
+++ b/mlflow/projects/docker.py
@@ -30,7 +30,7 @@ def validate_docker_installation():
     """
     try:
         docker_path = "docker"
-        process.exec_cmd([docker_path, "--help"], throw_on_error=False)
+        process._exec_cmd([docker_path, "--help"], throw_on_error=False)
     except EnvironmentError:
         raise ExecutionException(
             "Could not find Docker executable. "

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -12,7 +12,7 @@ from mlflow.server.handlers import (
     _add_static_prefix,
     get_model_version_artifact_handler,
 )
-from mlflow.utils.process import exec_cmd
+from mlflow.utils.process import _exec_cmd
 
 # NB: These are intenrnal environment variables used for communication between
 # the cli and the forked gunicorn processes.

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -147,4 +147,4 @@ def _run_server(
         full_command = _build_waitress_command(waitress_opts, host, port)
     else:
         full_command = _build_gunicorn_command(gunicorn_opts, host, port, workers or 4)
-    exec_cmd(full_command, extra_env=env_map, capture_output=False)
+    _exec_cmd(full_command, extra_env=env_map, capture_output=False)

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -147,4 +147,4 @@ def _run_server(
         full_command = _build_waitress_command(waitress_opts, host, port)
     else:
         full_command = _build_gunicorn_command(gunicorn_opts, host, port, workers or 4)
-    exec_cmd(full_command, env=env_map, capture_output=False)
+    exec_cmd(full_command, extra_env=env_map, capture_output=False)

--- a/mlflow/utils/conda.py
+++ b/mlflow/utils/conda.py
@@ -85,8 +85,8 @@ def _get_conda_executable_for_create_env():
 
 
 def _list_conda_environments():
-    (_, stdout, _) = process.exec_cmd([get_conda_bin_executable("conda"), "env", "list", "--json"])
-    return list(map(os.path.basename, json.loads(stdout).get("envs", [])))
+    prc = process.exec_cmd([get_conda_bin_executable("conda"), "env", "list", "--json"])
+    return list(map(os.path.basename, json.loads(prc.stdout).get("envs", [])))
 
 
 def get_or_create_conda_env(conda_env_path, env_id=None, capture_output=False):

--- a/mlflow/utils/conda.py
+++ b/mlflow/utils/conda.py
@@ -85,7 +85,7 @@ def _get_conda_executable_for_create_env():
 
 
 def _list_conda_environments():
-    prc = process.exec_cmd([get_conda_bin_executable("conda"), "env", "list", "--json"])
+    prc = process._exec_cmd([get_conda_bin_executable("conda"), "env", "list", "--json"])
     return list(map(os.path.basename, json.loads(prc.stdout).get("envs", [])))
 
 
@@ -107,7 +107,7 @@ def get_or_create_conda_env(conda_env_path, env_id=None, capture_output=False):
     conda_env_create_path = _get_conda_executable_for_create_env()
 
     try:
-        process.exec_cmd([conda_path, "--help"], throw_on_error=False)
+        process._exec_cmd([conda_path, "--help"], throw_on_error=False)
     except EnvironmentError:
         raise ExecutionException(
             "Could not find Conda executable at {0}. "
@@ -120,7 +120,7 @@ def get_or_create_conda_env(conda_env_path, env_id=None, capture_output=False):
         )
 
     try:
-        process.exec_cmd([conda_env_create_path, "--help"], throw_on_error=False)
+        process._exec_cmd([conda_env_create_path, "--help"], throw_on_error=False)
     except EnvironmentError:
         raise ExecutionException(
             "You have set the env variable {0}, but {1} does not exist or "
@@ -139,7 +139,7 @@ def get_or_create_conda_env(conda_env_path, env_id=None, capture_output=False):
         _logger.info("=== Creating conda environment %s ===", project_env_name)
         try:
             if conda_env_path:
-                process.exec_cmd(
+                process._exec_cmd(
                     [
                         conda_env_create_path,
                         "env",
@@ -152,7 +152,7 @@ def get_or_create_conda_env(conda_env_path, env_id=None, capture_output=False):
                     capture_output=capture_output,
                 )
             else:
-                process.exec_cmd(
+                process._exec_cmd(
                     [
                         conda_env_create_path,
                         "create",
@@ -174,7 +174,7 @@ def get_or_create_conda_env(conda_env_path, env_id=None, capture_output=False):
                         "Removing %s.",
                         project_env_name,
                     )
-                    process.exec_cmd(
+                    process._exec_cmd(
                         [
                             conda_path,
                             "remove",

--- a/mlflow/utils/process.py
+++ b/mlflow/utils/process.py
@@ -1,3 +1,4 @@
+from multiprocessing.sharedctypes import Value
 import os
 import subprocess
 
@@ -46,7 +47,10 @@ def _exec_cmd(
     """
     illegal_kwargs = set(kwargs.keys()).intersection(("check", "capture_output", "text"))
     if illegal_kwargs:
-        raise ShellCommandException(f"`kwargs` cannot contain {illegal_kwargs}")
+        raise ValueError(f"`kwargs` cannot contain {illegal_kwargs}")
+
+    if extra_env is not None and "env" in kwargs:
+        raise ValueError("`extra_env` and `env` cannot be used at the same time")
 
     env = None if extra_env is None else {**os.environ, **extra_env}
     prc = subprocess.run(

--- a/mlflow/utils/process.py
+++ b/mlflow/utils/process.py
@@ -41,18 +41,18 @@ def _exec_cmd(
                       If this argument is specified, `kwargs` cannot contain `env`.
     :param: capture_output: If True, stdout and stderr will be captured and included in an exception
                             message on failure; if False, these streams won't be captured.
-    :param kwargs: Keyword arguments (except `check`, `capture_output`, and `text`) passed to
-                   `subprocess.run`.
+    :param kwargs: Keyword arguments (except `check` and `text`) passed to `subprocess.run`.
     :return: A `subprocess.CompletedProcess` instance.
     """
-    illegal_kwargs = set(kwargs.keys()).intersection(("check", "capture_output", "text"))
+    illegal_kwargs = set(kwargs.keys()).intersection(("check", "text"))
     if illegal_kwargs:
-        raise ValueError(f"`kwargs` cannot contain {illegal_kwargs}")
+        raise ValueError(f"`kwargs` cannot contain {list(illegal_kwargs)}")
 
-    if extra_env is not None and "env" in kwargs:
+    env = kwargs.pop("env", None)
+    if extra_env is not None and env is not None:
         raise ValueError("`extra_env` and `env` cannot be used at the same time")
 
-    env = None if extra_env is None else {**os.environ, **extra_env}
+    env = env if extra_env is None else {**os.environ, **extra_env}
     prc = subprocess.run(
         # In Python < 3.8, `subprocess.Popen` doesn't accpet a command containing path-like
         # objects (e.g. `["ls", pathlib.Path("abc")]`) on Windows. To avoid this issue,

--- a/mlflow/utils/process.py
+++ b/mlflow/utils/process.py
@@ -1,4 +1,3 @@
-from multiprocessing.sharedctypes import Value
 import os
 import subprocess
 

--- a/mlflow/utils/process.py
+++ b/mlflow/utils/process.py
@@ -50,7 +50,7 @@ def _exec_cmd(
 
     env = None if extra_env is None else {**os.environ, **extra_env}
     prc = subprocess.run(
-        # In Python <= 3.7, `subprocess.Popen` doesn't accpet a command containing path-like
+        # In Python < 3.8, `subprocess.Popen` doesn't accpet a command containing path-like
         # objects (e.g. `["ls", pathlib.Path("mlflow")]`) on Windows. To avoid this issue,
         # stringify all elements in `cmd`. Note `str(pathlib.Path("mlflow"))` returns 'mlflow'.
         map(str, cmd),

--- a/mlflow/utils/process.py
+++ b/mlflow/utils/process.py
@@ -1,8 +1,6 @@
 import os
 import subprocess
 
-from mlflow.exceptions import MlflowException
-
 
 class ShellCommandException(Exception):
     @classmethod

--- a/mlflow/utils/process.py
+++ b/mlflow/utils/process.py
@@ -39,6 +39,7 @@ def _exec_cmd(
     :param cmd: The command to run, as a list of strings.
     :param throw_on_error: If True, raises an Exception if the exit code of the program is nonzero.
     :param extra_env: Extra environment variables to be defined when running the child process.
+                      If this argument is specified, `kwargs` cannot contain `env`.
     :param: capture_output: If True, stdout and stderr will be captured and included in an exception
                             message on failure; if False, these streams won't be captured.
     :param kwargs: Keyword arguments (except `check`, `capture_output`, and `text`) passed to
@@ -55,8 +56,8 @@ def _exec_cmd(
     env = None if extra_env is None else {**os.environ, **extra_env}
     prc = subprocess.run(
         # In Python < 3.8, `subprocess.Popen` doesn't accpet a command containing path-like
-        # objects (e.g. `["ls", pathlib.Path("mlflow")]`) on Windows. To avoid this issue,
-        # stringify all elements in `cmd`. Note `str(pathlib.Path("mlflow"))` returns 'mlflow'.
+        # objects (e.g. `["ls", pathlib.Path("abc")]`) on Windows. To avoid this issue,
+        # stringify all elements in `cmd`. Note `str(pathlib.Path("abc"))` returns 'abc'.
         map(str, cmd),
         env=env,
         check=False,

--- a/mlflow/utils/process.py
+++ b/mlflow/utils/process.py
@@ -50,7 +50,10 @@ def _exec_cmd(
 
     env = None if extra_env is None else {**os.environ, **extra_env}
     prc = subprocess.run(
-        cmd,
+        # In Python <= 3.7, `subprocess.Popen` doesn't accpet a command containing path-like
+        # objects (e.g. `["ls", pathlib.Path("mlflow")]`) on Windows. To avoid this issue,
+        # stringify all elements in `cmd`. Note `str(pathlib.Path("mlflow"))` returns 'mlflow'.
+        map(str, cmd),
         env=env,
         check=False,
         capture_output=capture_output,

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -20,7 +20,7 @@ def hash_conda_env(conda_env_path):
 
 
 def get_conda_envs():
-    stdout = process.exec_cmd(["conda", "env", "list", "--json"]).stdout
+    stdout = process._exec_cmd(["conda", "env", "list", "--json"]).stdout
     return [os.path.basename(env) for env in json.loads(stdout)["envs"]]
 
 
@@ -29,7 +29,7 @@ def is_mlflow_conda_env(env_name):
 
 
 def remove_conda_env(env_name):
-    process.exec_cmd(["conda", "remove", "--name", env_name, "--yes", "--all"])
+    process._exec_cmd(["conda", "remove", "--name", env_name, "--yes", "--all"])
 
 
 def get_free_disk_space():
@@ -61,7 +61,7 @@ def clean_envs_and_cache():
     yield
 
     if get_free_disk_space() < 7.0:  # unit: GiB
-        process.exec_cmd(["./dev/remove-conda-envs.sh"])
+        process._exec_cmd(["./dev/remove-conda-envs.sh"])
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -197,4 +197,4 @@ def test_mlflow_run_example(directory, params, tmpdir):
 )
 def test_command_example(directory, command):
     cwd_dir = os.path.join(EXAMPLES_DIR, directory)
-    process.exec_cmd(command, cwd=cwd_dir)
+    process._exec_cmd(command, cwd=cwd_dir)

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -20,7 +20,7 @@ def hash_conda_env(conda_env_path):
 
 
 def get_conda_envs():
-    stdout = process.exec_cmd(["conda", "env", "list", "--json"])[1]
+    stdout = process.exec_cmd(["conda", "env", "list", "--json"]).stdout
     return [os.path.basename(env) for env in json.loads(stdout)["envs"]]
 
 

--- a/tests/projects/test_projects.py
+++ b/tests/projects/test_projects.py
@@ -4,6 +4,7 @@ import git
 import shutil
 import yaml
 import uuid
+import subprocess
 
 import pytest
 from unittest import mock
@@ -339,11 +340,13 @@ def test_create_env_with_mamba():
 
         if cmd[-1] == "--json":
             # We are supposed to list environments in JSON format
-            return None, json.dumps({"envs": ["mlflow-mock-environment"]}), None
+            return subprocess.CompletedProcess(
+                cmd, 0, json.dumps({"envs": ["mlflow-mock-environment"]}), None
+            )
         else:
             # Here we are creating the environment, no need to return
             # anything
-            return None
+            return subprocess.CompletedProcess(cmd, 0)
 
     def exec_cmd_mock_raise(cmd, *args, **kwargs):  # pylint: disable=unused-argument
 

--- a/tests/projects/test_projects.py
+++ b/tests/projects/test_projects.py
@@ -93,7 +93,7 @@ def test_invalid_run_mode():
 def test_use_conda():
     """Verify that we correctly handle the `use_conda` argument."""
     # Verify we throw an exception when conda is unavailable
-    with mock.patch("mlflow.utils.process.exec_cmd", side_effect=EnvironmentError):
+    with mock.patch("mlflow.utils.process._exec_cmd", side_effect=EnvironmentError):
         with pytest.raises(ExecutionException, match="Could not find Conda executable"):
             mlflow.projects.run(TEST_PROJECT_DIR, use_conda=True)
 
@@ -355,11 +355,11 @@ def test_create_env_with_mamba():
     with mock.patch.dict("os.environ", {mlflow.utils.conda.MLFLOW_CONDA_CREATE_ENV_CMD: "mamba"}):
 
         # Simulate success
-        with mock.patch("mlflow.utils.process.exec_cmd", side_effect=exec_cmd_mock):
+        with mock.patch("mlflow.utils.process._exec_cmd", side_effect=exec_cmd_mock):
             mlflow.utils.conda.get_or_create_conda_env(conda_env_path)
 
         # Simulate a non-working or non-existent mamba
-        with mock.patch("mlflow.utils.process.exec_cmd", side_effect=exec_cmd_mock_raise):
+        with mock.patch("mlflow.utils.process._exec_cmd", side_effect=exec_cmd_mock_raise):
             with pytest.raises(
                 ExecutionException,
                 match="You have set the env variable MLFLOW_CONDA_CREATE_ENV_CMD",

--- a/tests/projects/test_projects_cli.py
+++ b/tests/projects/test_projects_cli.py
@@ -90,7 +90,7 @@ def test_run_local_conda_env():
         conda_env_contents = handle.read()
     expected_env_name = "mlflow-%s" % hashlib.sha1(conda_env_contents.encode("utf-8")).hexdigest()
     try:
-        process.exec_cmd(cmd=["conda", "env", "remove", "--name", expected_env_name])
+        process._exec_cmd(cmd=["conda", "env", "remove", "--name", expected_env_name])
     except process.ShellCommandException:
         _logger.error(
             "Unable to remove conda environment %s. The environment may not have been present, "


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

Simplify `process.exec_cmd` using `subprocess.run` and change the return value to an instance of `subprocess.CompletedProcess` to make it easier to use the execution result.

## How is this patch tested?

Existing tests

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
