### PR TITLE
adding warnings for scenarios 5 and 6

### DIFF
--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -212,6 +212,13 @@ Enabling the Tracking Server to perform proxied artifact access in order to rout
   * Retrieving artifacts from the configured backend store for a user request is done with the same authorized authentication that was configured at server start
   * Artifacts are passed to the end user through the Tracking Server through the interface of the ``HttpArtifactRepository``
 
+.. note::
+    When an experiment is created, the artifact storage location from the configuration of the tracking server is logged in the experiment's metadata.
+    If enabling proxied artifact storage, any existing experiments that were created while operating a tracking server in non-proxy mode will not
+    be available for adding runs to them. This is due to the default artifact storage locations (``artifact_uri``) of the old experiments logged prior to
+    enabling a tracking server's proxied access while operating in  ``--serve-artifacts`` mode. It is highly advised to create new experiments when performing
+    a migration that enables proxied artifact access to prevent errors in logging run artifacts to an existing experiment from occurring at the client side.
+
 .. warning::
     The MLflow artifact proxied access service enables users to have an *assumed role of access to all artifacts* that are accessible to the Tracking Server.
     Administrators who are enabling this feature should ensure that the access level granted to the Tracking Server for artifact
@@ -243,6 +250,13 @@ Running an MLFlow server in ``--artifacts-only`` mode:
 
   * Listing of artifact responses will pass from the file store through the Tracking Server to the client
   * Loading of artifacts will utilize the access credentials of the MLflow Tracking Server to acquire the files which are then passed on to the client
+
+.. note::
+  - If migrating from Scenario 5 to Scenario 6 due to request volumes, it is important to perform two validations:
+
+    - Ensure that the new tracking server that is operating in ``--artifacts-only`` mode has access permissions to the
+      location set by ``--artifacts-destination`` that the former multi-role tracking server had.
+    - The former multi-role tracking server that was serving artifacts must have the ``-serve-artifacts`` argument disabled.
 
 .. warning::
     Operating the Tracking Server in proxied artifact access mode by setting the parameter ``--serve-artifacts`` during server start, even in ``--artifacts-only`` mode,


### PR DESCRIPTION
Signed-off-by: Ben Wilson <benjamin.wilson@databricks.com>

## What changes are proposed in this pull request?

Adding in warnings for serve-artifacts mode of the tracking server

## How is this patch tested?

Docs build and visual validation in browser

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
