### PR TITLE
enable cross version tests for diviner

### DIFF
--- a/dev/run-python-flavor-tests.sh
+++ b/dev/run-python-flavor-tests.sh
@@ -17,9 +17,6 @@ pytest tests/h2o --large
 pytest tests/shap --large
 pytest tests/paddle --large
 
-# TODO: When the Diviner repo is set to public status, move the tests to cross-version testing
-pytest tests/diviner --large
-
 pytest tests/tracking/fluent/test_fluent_autolog.py --large
 pytest tests/autologging --large
 find tests/spark/autologging/ml -name 'test*.py' | xargs -L 1 pytest --large

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -378,3 +378,18 @@ pmdarima:
     requirements: ["prophet"]
     run: |
       pytest tests/pmdarima/test_pmdarima_model_export.py --large
+
+diviner:
+  package_info:
+    pip_release: "diviner"
+    install_dev: |
+      if [ ! -d "$CACHE_DIR" ] || [ -z $(find $CACHE_DIR -type f -name "diviner-*.whl") ]; then
+        pip wheel --no-deps --wheel-dir $CACHE_DIR git+https://github.com/databricks/diviner.git
+      fi
+      pip install $CACHE_DIR/diviner-*.whl
+
+  models:
+    minimum: "0.1.0"
+    maximum: "0.1.0"
+    run: |
+      pytest tests/diviner/test_diviner_model_export.py --large

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -383,10 +383,7 @@ diviner:
   package_info:
     pip_release: "diviner"
     install_dev: |
-      if [ ! -d "$CACHE_DIR" ] || [ -z $(find $CACHE_DIR -type f -name "diviner-*.whl") ]; then
-        pip wheel --no-deps --wheel-dir $CACHE_DIR git+https://github.com/databricks/diviner.git
-      fi
-      pip install $CACHE_DIR/diviner-*.whl
+      pip install git+https://github.com/databricks/diviner.git
 
   models:
     minimum: "0.1.0"

--- a/tests/diviner/test_diviner_model_export.py
+++ b/tests/diviner/test_diviner_model_export.py
@@ -34,6 +34,7 @@ from tests.helper_functions import (
     _compare_logged_code_paths,
 )
 
+pytestmark = pytest.mark.large
 
 DS_FORMAT = "%Y-%m-%dT%H:%M:%S"
 EXTRA_PYFUNC_SERVING_TEST_ARGS = [] if _is_available_on_pypi("diviner") else ["--no-conda"]


### PR DESCRIPTION
Signed-off-by: Ben Wilson <benjamin.wilson@databricks.com>

## What changes are proposed in this pull request?

Enable cross version tests for diviner

## How is this patch tested?

cross version tests on Github Actions

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
