### PR TITLE
Remove client name validation from metrics params and tags

### DIFF
--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -39,6 +39,7 @@ from mlflow.utils.validation import (
     _validate_batch_log_data,
     _validate_list_experiments_max_results,
     _validate_param_keys_unique,
+    _validate_experiment_name as validate_experiment_name,
 )
 from mlflow.utils.env import get_env
 from mlflow.utils.file_utils import (
@@ -295,11 +296,8 @@ class FileStore(AbstractStore):
         return experiment_id
 
     def _validate_experiment_name(self, name):
-        """Check the validity of an experiment name."""
-        if name is None or name == "":
-            raise MlflowException(
-                "Invalid experiment name '%s'" % name, databricks_pb2.INVALID_PARAMETER_VALUE
-            )
+
+        validate_experiment_name(name)
         experiment = self.get_experiment_by_name(name)
         if experiment is not None:
             if experiment.lifecycle_stage == LifecycleStage.DELETED:
@@ -395,7 +393,7 @@ class FileStore(AbstractStore):
         conflict_experiment = self._get_experiment_path(experiment_id, ViewType.ACTIVE_ONLY)
         if conflict_experiment is not None:
             raise MlflowException(
-                "Cannot restore eperiment with ID %d. "
+                "Cannot restore experiment with ID %d. "
                 "An experiment with same ID already exists." % experiment_id,
                 databricks_pb2.RESOURCE_ALREADY_EXISTS,
             )

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -47,6 +47,8 @@ from mlflow.utils.validation import (
     _validate_experiment_tag,
     _validate_tag,
     _validate_list_experiments_max_results,
+    _validate_param_keys_unique,
+    _validate_experiment_name,
 )
 from mlflow.utils.mlflow_tags import MLFLOW_LOGGED_MODELS
 
@@ -229,8 +231,7 @@ class SqlAlchemyStore(AbstractStore):
         return append_to_uri_path(self.artifact_root_uri, str(experiment_id))
 
     def create_experiment(self, name, artifact_location=None, tags=None):
-        if name is None or name == "":
-            raise MlflowException("Invalid experiment name", INVALID_PARAMETER_VALUE)
+        _validate_experiment_name(name)
 
         with self.ManagedSessionMaker() as session:
             try:
@@ -812,6 +813,7 @@ class SqlAlchemyStore(AbstractStore):
         _validate_run_id(run_id)
         _validate_batch_log_data(metrics, params, tags)
         _validate_batch_log_limits(metrics, params, tags)
+        _validate_param_keys_unique(params)
         with self.ManagedSessionMaker() as session:
             run = self._get_run(run_uuid=run_id, session=session)
             self._check_run_is_active(run)

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -10,12 +10,9 @@ import os
 from mlflow.store.tracking import SEARCH_MAX_RESULTS_DEFAULT
 from mlflow.tracking._tracking_service import utils
 from mlflow.utils.validation import (
-    _validate_param_name,
-    _validate_tag_name,
     _validate_run_id,
     _validate_experiment_artifact_location,
     _validate_experiment_name,
-    _validate_metric,
     _validate_param_keys_unique,
     PARAM_VALIDATION_MSG,
 )
@@ -228,7 +225,6 @@ class TrackingServiceClient:
         """
         timestamp = timestamp if timestamp is not None else int(time.time() * 1000)
         step = step if step is not None else 0
-        _validate_metric(key, value, timestamp, step)
         metric = Metric(key, value, timestamp, step)
         self.store.log_metric(run_id, metric)
 
@@ -236,7 +232,6 @@ class TrackingServiceClient:
         """
         Log a parameter against the run ID. Value is converted to a string.
         """
-        _validate_param_name(key)
         param = Param(key, str(value))
         try:
             self.store.log_param(run_id, param)
@@ -255,7 +250,6 @@ class TrackingServiceClient:
         :param key: Name of the tag.
         :param value: Tag value (converted to a string).
         """
-        _validate_tag_name(key)
         tag = ExperimentTag(key, str(value))
         self.store.set_experiment_tag(experiment_id, tag)
 
@@ -272,7 +266,6 @@ class TrackingServiceClient:
                       All backend stores will support values up to length 5000, but some
                       may support larger values.
         """
-        _validate_tag_name(key)
         tag = RunTag(key, str(value))
         self.store.set_tag(run_id, tag)
 
@@ -301,12 +294,6 @@ class TrackingServiceClient:
             return
         if len(params) > 1:
             _validate_param_keys_unique(params)
-        for metric in metrics:
-            _validate_metric(metric.key, metric.value, metric.timestamp, metric.step)
-        for param in params:
-            _validate_param_name(param.key)
-        for tag in tags:
-            _validate_tag_name(tag.key)
         self.store.log_batch(run_id=run_id, metrics=metrics, params=params, tags=tags)
 
     def _record_logged_model(self, run_id, mlflow_model):

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -12,8 +12,6 @@ from mlflow.tracking._tracking_service import utils
 from mlflow.utils.validation import (
     _validate_run_id,
     _validate_experiment_artifact_location,
-    _validate_experiment_name,
-    _validate_param_keys_unique,
     PARAM_VALIDATION_MSG,
 )
 from mlflow.entities import Param, Metric, RunStatus, RunTag, ViewType, ExperimentTag
@@ -173,7 +171,6 @@ class TrackingServiceClient:
                                   :py:class:`mlflow.entities.ExperimentTag` objects.
         :return: Integer ID of the created experiment.
         """
-        _validate_experiment_name(name)
         _validate_experiment_artifact_location(artifact_location)
 
         return self.store.create_experiment(
@@ -292,8 +289,6 @@ class TrackingServiceClient:
         """
         if len(metrics) == 0 and len(params) == 0 and len(tags) == 0:
             return
-        if len(params) > 1:
-            _validate_param_keys_unique(params)
         self.store.log_batch(run_id=run_id, metrics=metrics, params=params, tags=tags)
 
     def _record_logged_model(self, run_id, mlflow_model):

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -84,7 +84,7 @@ def _validate_metric_name(name):
     """Check that `name` is a valid metric name and raise an exception if it isn't."""
     if name is None:
         raise MlflowException(
-            f"Invalid metric name: '{name}'. {_MISSING_KEY_NAME_MESSAGE}",
+            f"Metric name cannot be None. {_MISSING_KEY_NAME_MESSAGE}",
             error_code=INVALID_PARAMETER_VALUE,
         )
     if not _VALID_PARAM_AND_METRIC_NAMES.match(name):
@@ -230,7 +230,7 @@ def _validate_param_name(name):
     """Check that `name` is a valid parameter name and raise an exception if it isn't."""
     if name is None:
         raise MlflowException(
-            f"Invalid parameter name: '{name}'. {_MISSING_KEY_NAME_MESSAGE}",
+            f"Parameter name cannot be None. {_MISSING_KEY_NAME_MESSAGE}",
             error_code=INVALID_PARAMETER_VALUE,
         )
     if not _VALID_PARAM_AND_METRIC_NAMES.match(name):
@@ -250,7 +250,7 @@ def _validate_tag_name(name):
     # Reuse param & metric check.
     if name is None:
         raise MlflowException(
-            f"Invalid tag name: '{name}'. {_MISSING_KEY_NAME_MESSAGE}",
+            f"Tag name cannot be None. {_MISSING_KEY_NAME_MESSAGE}",
             error_code=INVALID_PARAMETER_VALUE,
         )
     if not _VALID_PARAM_AND_METRIC_NAMES.match(name):

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -10,8 +10,6 @@ from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.store.db.db_types import DATABASE_ENGINES
 from mlflow.utils.string_utils import is_string_type
 
-_VALID_PARAM_AND_METRIC_NAMES = re.compile(r"^[/\w.\- ]*$")
-
 # Regex for valid run IDs: must be an alphanumeric string of length 1 to 256.
 _RUN_ID_REGEX = re.compile(r"^[a-zA-Z0-9][\w\-]{0,255}$")
 
@@ -79,12 +77,7 @@ def path_not_unique(name):
 
 
 def _validate_metric_name(name):
-    """Check that `name` is a valid metric name and raise an exception if it isn't."""
-    if name is None or not _VALID_PARAM_AND_METRIC_NAMES.match(name):
-        raise MlflowException(
-            "Invalid metric name: '%s'. %s" % (name, _BAD_CHARACTERS_MESSAGE),
-            INVALID_PARAMETER_VALUE,
-        )
+    """Check that path-referenced keys are valid and will not collide"""
     if path_not_unique(name):
         raise MlflowException(
             "Invalid metric name: '%s'. %s" % (name, bad_path_message(name)),
@@ -220,12 +213,7 @@ def _validate_param_keys_unique(params):
 
 
 def _validate_param_name(name):
-    """Check that `name` is a valid parameter name and raise an exception if it isn't."""
-    if name is None or not _VALID_PARAM_AND_METRIC_NAMES.match(name):
-        raise MlflowException(
-            "Invalid parameter name: '%s'. %s" % (name, _BAD_CHARACTERS_MESSAGE),
-            INVALID_PARAMETER_VALUE,
-        )
+    """Check that `name` is a valid parameter name if paths are involved to prevent collisions."""
     if path_not_unique(name):
         raise MlflowException(
             "Invalid parameter name: '%s'. %s" % (name, bad_path_message(name)),
@@ -234,12 +222,7 @@ def _validate_param_name(name):
 
 
 def _validate_tag_name(name):
-    """Check that `name` is a valid tag name and raise an exception if it isn't."""
-    # Reuse param & metric check.
-    if name is None or not _VALID_PARAM_AND_METRIC_NAMES.match(name):
-        raise MlflowException(
-            "Invalid tag name: '%s'. %s" % (name, _BAD_CHARACTERS_MESSAGE), INVALID_PARAMETER_VALUE
-        )
+    """Check that `name` is a valid tag name if paths are involved to prevent collisions."""
     if path_not_unique(name):
         raise MlflowException(
             "Invalid tag name: '%s'. %s" % (name, bad_path_message(name)), INVALID_PARAMETER_VALUE

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -76,8 +76,17 @@ def path_not_unique(name):
     return norm != name or norm == "." or norm.startswith("..") or norm.startswith("/")
 
 
+def _validate_key_name(name: str, log_type: str):
+    if name is None:
+        raise MlflowException(
+            f"Invalid {log_type} name. A key name must be provided.",
+            error_code=INVALID_PARAMETER_VALUE,
+        )
+
+
 def _validate_metric_name(name):
     """Check that path-referenced keys are valid and will not collide"""
+    _validate_key_name(name, "metric")
     if path_not_unique(name):
         raise MlflowException(
             "Invalid metric name: '%s'. %s" % (name, bad_path_message(name)),
@@ -214,6 +223,7 @@ def _validate_param_keys_unique(params):
 
 def _validate_param_name(name):
     """Check that `name` is a valid parameter name if paths are involved to prevent collisions."""
+    _validate_key_name(name, "param")
     if path_not_unique(name):
         raise MlflowException(
             "Invalid parameter name: '%s'. %s" % (name, bad_path_message(name)),
@@ -223,6 +233,7 @@ def _validate_param_name(name):
 
 def _validate_tag_name(name):
     """Check that `name` is a valid tag name if paths are involved to prevent collisions."""
+    _validate_key_name(name, "tag")
     if path_not_unique(name):
         raise MlflowException(
             "Invalid tag name: '%s'. %s" % (name, bad_path_message(name)), INVALID_PARAMETER_VALUE

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -1681,7 +1681,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
             self.store.log_batch(
                 run.info.run_id, metrics=[metric], params=[param0, param1], tags=[tag]
             )
-        self.assertIn("Changing param values is not allowed. Param with key=", e.exception.message)
+        self.assertIn("Duplicate parameter keys have been submitted:", e.exception.message)
         assert e.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
         self._verify_logged(self.store, run.info.run_id, metrics=[], params=[param0], tags=[])
 

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -1683,7 +1683,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
             )
         self.assertIn("Duplicate parameter keys have been submitted:", e.exception.message)
         assert e.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
-        self._verify_logged(self.store, run.info.run_id, metrics=[], params=[param0], tags=[])
+        self._verify_logged(self.store, run.info.run_id, metrics=[], params=[], tags=[])
 
     def test_log_batch_accepts_empty_payload(self):
         run = self._run_factory()

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -177,7 +177,7 @@ def test_list_experiments_paginated():
         returned_experiments.extend(result)
     assert result.token is None
     returned_exp_id_set = set([exp.experiment_id for exp in returned_experiments])
-    assert set(experiments) - returned_exp_id_set == {}
+    assert set(experiments) - returned_exp_id_set == set()
 
 
 def test_list_experiments_paginated_returns_in_correct_order():
@@ -318,9 +318,9 @@ def test_log_batch():
     for key, value in finished_run.data.metrics.items():
         assert expected_metrics[key] == value
     metric_history0 = client.get_metric_history(run_id, "metric-key0")
-    assert [(m.value, m.timestamp, m.step) for m in metric_history0] == [(1.0, t, 0)]
+    assert {(m.value, m.timestamp, m.step) for m in metric_history0} == {(1.0, t, 0)}
     metric_history1 = client.get_metric_history(run_id, "metric-key1")
-    assert [(m.value, m.timestamp, m.step) for m in metric_history1] == [(4.0, t, 1)]
+    assert {(m.value, m.timestamp, m.step) for m in metric_history1} == {(4.0, t, 1)}
 
     # Validate tags (for automatically-set tags)
     assert len(finished_run.data.tags) == len(exact_expected_tags) + len(approx_expected_tags)
@@ -360,13 +360,13 @@ def test_log_metric():
         assert expected_pairs[key] == value
     client = tracking.MlflowClient()
     metric_history_name1 = client.get_metric_history(run_id, "name_1")
-    assert [(m.value, m.timestamp, m.step) for m in metric_history_name1] == [
+    assert {(m.value, m.timestamp, m.step) for m in metric_history_name1} == {
         (25, 123 * 1000, 0),
         (30, 123 * 1000, 5),
         (40, 123 * 1000, -2),
-    ]
+    }
     metric_history_name2 = client.get_metric_history(run_id, "name_2")
-    assert [(m.value, m.timestamp, m.step) for m in metric_history_name2] == [(-3, 123 * 1000, 0)]
+    assert {(m.value, m.timestamp, m.step) for m in metric_history_name2} == {(-3, 123 * 1000, 0)}
 
 
 def test_log_metrics_uses_millisecond_timestamp_resolution_fluent():
@@ -379,13 +379,13 @@ def test_log_metrics_uses_millisecond_timestamp_resolution_fluent():
 
     client = tracking.MlflowClient()
     metric_history_name1 = client.get_metric_history(run_id, "name_1")
-    assert [(m.value, m.timestamp) for m in metric_history_name1] == [
+    assert {(m.value, m.timestamp) for m in metric_history_name1} == {
         (25, 123 * 1000),
         (30, 123 * 1000),
         (40, 123 * 1000),
-    ]
+    }
     metric_history_name2 = client.get_metric_history(run_id, "name_2")
-    assert set([(m.value, m.timestamp) for m in metric_history_name2]) == {(-3, 123 * 1000)}
+    assert {(m.value, m.timestamp) for m in metric_history_name2} == {(-3, 123 * 1000)}
 
 
 def test_log_metrics_uses_millisecond_timestamp_resolution_client():
@@ -400,14 +400,14 @@ def test_log_metrics_uses_millisecond_timestamp_resolution_client():
         mlflow_client.log_metric(run_id=run_id, key="name_1", value=40)
 
     metric_history_name1 = mlflow_client.get_metric_history(run_id, "name_1")
-    assert [(m.value, m.timestamp) for m in metric_history_name1] == [
+    assert {(m.value, m.timestamp) for m in metric_history_name1} == {
         (25, 123 * 1000),
         (30, 123 * 1000),
         (40, 123 * 1000),
-    ]
+    }
 
     metric_history_name2 = mlflow_client.get_metric_history(run_id, "name_2")
-    assert set([(m.value, m.timestamp) for m in metric_history_name2]) == {(-3, 123 * 1000)}
+    assert {(m.value, m.timestamp) for m in metric_history_name2} == {(-3, 123 * 1000)}
 
 
 @pytest.mark.parametrize("step_kwarg", [None, -10, 5])
@@ -560,7 +560,7 @@ def test_log_artifact_with_dirs(tmpdir):
         mlflow.log_artifact(str(art_dir))
         base = os.path.basename(str(art_dir))
         assert os.listdir(run_artifact_dir) == [base]
-        assert os.listdir(os.path.join(run_artifact_dir, base)) == ["child", "file0", "file1"]
+        assert set(os.listdir(os.path.join(run_artifact_dir, base))) == {"child", "file0", "file1"}
         with open(os.path.join(run_artifact_dir, base, "file0")) as f:
             assert f.read() == "something"
     # Test log artifact with directory and specified parent folder
@@ -581,9 +581,13 @@ def test_log_artifact_with_dirs(tmpdir):
         assert os.listdir(os.path.join(run_artifact_dir, "parent", "and_child")) == [
             os.path.basename(str(art_dir))
         ]
-        assert os.listdir(
-            os.path.join(run_artifact_dir, "parent", "and_child", os.path.basename(str(art_dir)))
-        ) == [os.path.basename(str(sub_dir))]
+        assert set(
+            os.listdir(
+                os.path.join(
+                    run_artifact_dir, "parent", "and_child", os.path.basename(str(art_dir))
+                )
+            )
+        ) == {os.path.basename(str(sub_dir))}
 
 
 def test_log_artifact():

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -559,6 +559,13 @@ def test_log_batch_validates_entity_names_and_values():
             tracking.MlflowClient().log_batch(run_id, tags=tags)
         assert e.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
+        metrics = [Metric(key=None, value=42.0, timestamp=4, step=1)]
+        with pytest.raises(
+            MlflowException, match="Invalid metric name. A key name must be provided."
+        ) as e:
+            tracking.MlflowClient().log_batch(run_id, metrics=metrics)
+        assert e.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+
 
 def test_log_artifact_with_dirs(tmpdir):
     # Test log artifact with a directory

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -512,24 +512,6 @@ def test_log_batch_duplicate_entries_raises():
         assert e.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
 
-def test_run_key_names_non_restrictive():
-    with start_run() as active_run:
-        run_id = active_run.info.run_id
-
-        quote_embed_key = '"\u5e78\u904b\u3092"'
-        metric_value = 42
-        param_value = 'hyphenated-parameter"'
-        tag_value = '"quote-wrapped_tag"'
-        tracking.MlflowClient().log_metric(run_id=run_id, key=quote_embed_key, value=metric_value)
-        tracking.MlflowClient().log_param(run_id=run_id, key=quote_embed_key, value=param_value)
-        tracking.MlflowClient().set_tag(run_id=run_id, key=quote_embed_key, value=tag_value)
-
-    finished_run = tracking.MlflowClient().get_run(run_id=run_id)
-    assert finished_run.data.metrics.get(quote_embed_key) == metric_value
-    assert finished_run.data.params.get(quote_embed_key) == param_value
-    assert finished_run.data.tags.get(quote_embed_key) == tag_value
-
-
 def test_log_batch_validates_entity_names_and_values():
     with start_run() as active_run:
         run_id = active_run.info.run_id
@@ -561,7 +543,7 @@ def test_log_batch_validates_entity_names_and_values():
 
         metrics = [Metric(key=None, value=42.0, timestamp=4, step=1)]
         with pytest.raises(
-            MlflowException, match="Invalid metric name. A key name must be provided."
+            MlflowException, match="Invalid metric name: 'None'. A key name must be provided."
         ) as e:
             tracking.MlflowClient().log_batch(run_id, metrics=metrics)
         assert e.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -147,7 +147,7 @@ def test_list_experiments():
             for exp in client.list_experiments(view_type=view_type_arg)
         ]
 
-        assert result == [(exp_id, stage) for exp_id, stage in ids_to_lifecycle_stage.items()]
+        assert result == list(ids_to_lifecycle_stage.items())
 
     experiment_id = mlflow.create_experiment("exp_1")
     assert experiment_id == "1"


### PR DESCRIPTION
Signed-off-by: Ben Wilson <benjamin.wilson@databricks.com>

## What changes are proposed in this pull request?

Remove the client validation checks for params, metrics, and tags key names. 

## How is this patch tested?

Unit test with previously illegal characters and utf extended set names.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The Mlflow client will no longer perform name validation checking on parameter names, metric names, or tag names. The underlying tracking backend's restrictions will instead be used to validate names. This does not change pathing validations, however, since the existence of pathing collision detection is distinct from prior valid name checking.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
