### PR TITLE
Remove unnecessary `set_tracking_uri` calls in tests

### DIFF
--- a/tests/diviner/test_diviner_model_export.py
+++ b/tests/diviner/test_diviner_model_export.py
@@ -237,11 +237,8 @@ def test_diviner_load_from_remote_uri_succeeds(grouped_pmdarima, model_path, moc
 
 
 def test_diviner_log_model(grouped_prophet, tmpdir):
-
-    old_uri = mlflow.get_tracking_uri()
     for should_start_run in [False, True]:
         try:
-            mlflow.set_tracking_uri("mlruns")
             if should_start_run:
                 mlflow.start_run()
             artifact_path = "diviner"
@@ -267,7 +264,6 @@ def test_diviner_log_model(grouped_prophet, tmpdir):
             assert model_path.joinpath(env_path).exists()
         finally:
             mlflow.end_run()
-            mlflow.set_tracking_uri(old_uri)
 
 
 def test_diviner_log_model_calls_register_model(grouped_pmdarima, tmp_path):

--- a/tests/fastai/test_fastai_model_export.py
+++ b/tests/fastai/test_fastai_model_export.py
@@ -137,12 +137,10 @@ def test_model_load_from_remote_uri_succeeds(fastai_model, model_path, mock_s3_b
 
 @pytest.mark.large
 def test_model_log(fastai_model, model_path):
-    old_uri = mlflow.get_tracking_uri()
     model = fastai_model.model
     with TempDir(chdr=True, remove_on_exit=True) as tmp:
         for should_start_run in [False, True]:
             try:
-                mlflow.set_tracking_uri("test")
                 if should_start_run:
                     mlflow.start_run()
 
@@ -178,7 +176,6 @@ def test_model_log(fastai_model, model_path):
 
             finally:
                 mlflow.end_run()
-                mlflow.set_tracking_uri(old_uri)
 
 
 def test_log_model_calls_register_model(fastai_model):

--- a/tests/lightgbm/test_lightgbm_model_export.py
+++ b/tests/lightgbm/test_lightgbm_model_export.py
@@ -151,12 +151,10 @@ def test_model_load_from_remote_uri_succeeds(lgb_model, model_path, mock_s3_buck
 
 @pytest.mark.large
 def test_model_log(lgb_model, model_path):
-    old_uri = mlflow.get_tracking_uri()
     model = lgb_model.model
     with TempDir(chdr=True, remove_on_exit=True) as tmp:
         for should_start_run in [False, True]:
             try:
-                mlflow.set_tracking_uri("test")
                 if should_start_run:
                     mlflow.start_run()
 
@@ -186,7 +184,6 @@ def test_model_log(lgb_model, model_path):
 
             finally:
                 mlflow.end_run()
-                mlflow.set_tracking_uri(old_uri)
 
 
 def test_log_model_calls_register_model(lgb_model):

--- a/tests/pmdarima/test_pmdarima_model_export.py
+++ b/tests/pmdarima/test_pmdarima_model_export.py
@@ -182,12 +182,9 @@ def test_pmdarima_load_from_remote_uri_succeeds(
 
 
 def test_pmdarima_log_model(auto_arima_model):
-
-    old_uri = mlflow.get_tracking_uri()
     with TempDir(chdr=True, remove_on_exit=True) as tmp:
         for should_start_run in [False, True]:
             try:
-                mlflow.set_tracking_uri("test")
                 if should_start_run:
                     mlflow.start_run()
                 artifact_path = "pmdarima"
@@ -213,7 +210,6 @@ def test_pmdarima_log_model(auto_arima_model):
                 assert os.path.exists(os.path.join(model_path, env_path))
             finally:
                 mlflow.end_run()
-                mlflow.set_tracking_uri(old_uri)
 
 
 def test_pmdarima_log_model_calls_register_model(auto_arima_object_model):

--- a/tests/prophet/test_prophet_model_export.py
+++ b/tests/prophet/test_prophet_model_export.py
@@ -203,11 +203,9 @@ def test_model_load_from_remote_uri_succeeds(prophet_model, model_path, mock_s3_
 
 
 def test_model_log(prophet_model):
-    old_uri = mlflow.get_tracking_uri()
     with TempDir(chdr=True, remove_on_exit=True) as tmp:
         for should_start_run in [False, True]:
             try:
-                mlflow.set_tracking_uri("test")
                 if should_start_run:
                     mlflow.start_run()
                 artifact_path = "prophet"
@@ -235,7 +233,6 @@ def test_model_log(prophet_model):
 
             finally:
                 mlflow.end_run()
-                mlflow.set_tracking_uri(old_uri)
 
 
 def test_log_model_calls_register_model(prophet_model):

--- a/tests/sklearn/test_sklearn_model_export.py
+++ b/tests/sklearn/test_sklearn_model_export.py
@@ -160,11 +160,9 @@ def test_model_load_from_remote_uri_succeeds(sklearn_knn_model, model_path, mock
 
 @pytest.mark.large
 def test_model_log(sklearn_logreg_model, model_path):
-    old_uri = mlflow.get_tracking_uri()
     with TempDir(chdr=True, remove_on_exit=True) as tmp:
         for should_start_run in [False, True]:
             try:
-                mlflow.set_tracking_uri("test")
                 if should_start_run:
                     mlflow.start_run()
 
@@ -197,7 +195,6 @@ def test_model_log(sklearn_logreg_model, model_path):
 
             finally:
                 mlflow.end_run()
-                mlflow.set_tracking_uri(old_uri)
 
 
 def test_log_model_calls_register_model(sklearn_logreg_model):

--- a/tests/xgboost/test_xgboost_model_export.py
+++ b/tests/xgboost/test_xgboost_model_export.py
@@ -146,12 +146,10 @@ def test_model_load_from_remote_uri_succeeds(xgb_model, model_path, mock_s3_buck
 
 @pytest.mark.large
 def test_model_log(xgb_model, model_path):
-    old_uri = mlflow.get_tracking_uri()
     model = xgb_model.model
     with TempDir(chdr=True, remove_on_exit=True) as tmp:
         for should_start_run in [False, True]:
             try:
-                mlflow.set_tracking_uri("test")
                 if should_start_run:
                     mlflow.start_run()
 
@@ -182,7 +180,6 @@ def test_model_log(xgb_model, model_path):
 
             finally:
                 mlflow.end_run()
-                mlflow.set_tracking_uri(old_uri)
 
 
 def test_log_model_calls_register_model(xgb_model):


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Remove unnecessary `set_tracking_uri` calls in tests. The `tracking_uri_mock` fixture sets the MLflow tracking URI to a unique SQLite database in each test. We usually don't need to call `set_tracking_uri` thanks to this fixture. This PR also prevents issues such as https://github.com/mlflow/mlflow/pull/5553#discussion_r841800024.

## How is this patch tested?

Existing tests

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
