### PR TITLE
Fix for issue 2945.  Detection of notebook source and version

### DIFF
--- a/mlflow/tracking/context/default_context.py
+++ b/mlflow/tracking/context/default_context.py
@@ -23,7 +23,18 @@ def _get_user():
 
 def _get_main_file():
     if len(sys.argv) > 0:
-        return sys.argv[0]
+        if 'ipykernel_launcher.py' in sys.argv[0]:
+            # Do something different if it looks like sys.argv[0] returned 
+            # a wrong path (because it's being called from inside a notebook).
+            # 
+            # It seems getting the current notebook path is non-trivial so
+            # I've used a PyPI package for convenience.
+            # - pip install ipynbname
+            # - https://github.com/msm1089/ipynbname
+            import ipynbname
+            return str(ipynbname.path())
+        else:
+            return sys.argv[0]
     return None
 
 

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,8 @@ SKINNY_REQUIREMENTS = [
     # (e.g. 'sklearn' -> 'scikit-learn'). importlib_metadata 3.7.0 or newer supports this function:
     # https://github.com/python/importlib_metadata/blob/main/CHANGES.rst#v370
     "importlib_metadata>=3.7.0,!=4.7.0",
+    # ipynbname for: https://github.com/mlflow/mlflow/issues/2945
+    "ipynbname>=2021.3.2",
 ]
 
 """


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix for https://github.com/mlflow/mlflow/issues/2945. Wrong detection of "source" when mlflow tracking is used from inside a Jupyter-lab notebook.  This was due to the use of `sys.argv[0]` which doesn't give the correct path when executed from inside a notebook.

It turns out getting the current notebook name turns out to be non-trivial, so I used a small pip installable package `ipynbname` which solves that problem. https://github.com/msm1089/ipynbname.  Added the dependency to `setup.py`.  Maybe better to be hard coded in rather than another dependency?

## How is this patch tested?

Cloned the repo, installed from source into to a new conda environment (`python=3.8.12`).
Ran the following from inside a jupyter notebook `.ipynb` file.
```python
import python

mlflow.set_tracking_uri('<tracking_uri>')
mlflow.set_experiment('mlflow-dev')
mlflow.start_run()
mlflow.log_param("my", "param")
mlflow.log_metric("score", 100)
mlflow.end_run()
```
Then I browsed to the new experiment and run on the tracking server.  Columns `Source` and `Version` now correctly reflect the notebook file name and git commit id.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

Fixed the detection of "source" and git "commit" for tracking sessions inside Jupyter notebooks.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
