### PR TITLE
Use prometheus-client != 0.14.0 for tests

### DIFF
--- a/requirements/small-requirements.txt
+++ b/requirements/small-requirements.txt
@@ -19,4 +19,5 @@ shap>=0.40
 # Explicitly install a version of prometheus-client other than 0.14.0, which is not compatible
 # with many versions of prometheus-flask-exporter (prometheus-flask-exporter is used to provide
 # MLflow server metrics)
+
 prometheus-client!=0.14.0

--- a/requirements/small-requirements.txt
+++ b/requirements/small-requirements.txt
@@ -16,7 +16,7 @@ databricks-cli@git+https://github.com/databricks/databricks-cli.git
 pillow
 matplotlib
 shap>=0.40
-# Explicitly install a version of prometheus client other than 0.14.0, which is not compatible
+# Explicitly install a version of prometheus-client other than 0.14.0, which is not compatible
 # with many versions of prometheus-flask-exporter (prometheus-flask-exporter is used to provide
 # MLflow server metrics)
 prometheus-client!=0.14.0

--- a/requirements/small-requirements.txt
+++ b/requirements/small-requirements.txt
@@ -16,3 +16,7 @@ databricks-cli@git+https://github.com/databricks/databricks-cli.git
 pillow
 matplotlib
 shap>=0.40
+# Explicitly install a version of prometheus client other than 0.14.0, which is not compatible
+# with many versions of prometheus-flask-exporter (prometheus-flask-exporter is used to provide
+# MLflow server metrics)
+prometheus-client!=0.14.0

--- a/requirements/small-requirements.txt
+++ b/requirements/small-requirements.txt
@@ -20,4 +20,4 @@ shap>=0.40
 # with many versions of prometheus-flask-exporter (prometheus-flask-exporter is used to provide
 # MLflow server metrics)
 
-prometheus-client!=0.14.0
+# prometheus-client!=0.14.0


### PR DESCRIPTION
Signed-off-by: dbczumar <corey.zumar@databricks.com>

## What changes are proposed in this pull request?

https://pypi.org/project/prometheus-client/ version 0.14.0 made a backwards-incompatible change (https://github.com/prometheus/client_python/pull/776) that renamed the `choose_encoder` method to `choose_formatter`, breaking prometheus-flask-exporter. Because prometheus-flask-exporter does not pin a particular version of prometheus-client (https://github.com/rycus86/prometheus_flask_exporter/blob/02b2ea3e2f3b0b20e6a6558b9186d043445555ff/setup.py#L32), new installations of prometheus-flask-exporter are pulling in prometheus-client version 0.14.0 and causing failures.

This PR addresses the issue for MLflow CI by specifically installing prometheus-client 0.14.0. By the time the next prometheus-client is released, we reason that either prometheus-flask-exporter will have fixed the compatibility issue in a new release or prometheus-client will have corrected the backwards-incompatible change.

We don't feel a need to make any further changes for users because this feature likely isn't heavily used, and users of the feature can take a look at https://github.com/rycus86/prometheus_flask_exporter/pull/126 to understand how the issue is being addressed and install a working version of `prometheus-client`.

## How is this patch tested?

Existing CI

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [X] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
