### PR TITLE
Remove attempted sqlalchemy import from mlflow skinny search path and add tests

### DIFF
--- a/dev/run-python-skinny-tests.sh
+++ b/dev/run-python-skinny-tests.sh
@@ -33,7 +33,7 @@ pytest tests/deployments/test_cli.py
 pytest tests/deployments/test_deployments.py
 pytest tests/projects/test_projects_cli.py
 pytest tests/utils/test_requirements_utils.py::test_infer_requirements_excludes_mlflow
+pytest tests/utils/test_search_utils.py
 pytest tests/store/tracking/test_file_store.py
-pytest tests/store/tracking/test_search_utils.py
 
 test $err = 0

--- a/dev/run-python-skinny-tests.sh
+++ b/dev/run-python-skinny-tests.sh
@@ -33,5 +33,7 @@ pytest tests/deployments/test_cli.py
 pytest tests/deployments/test_deployments.py
 pytest tests/projects/test_projects_cli.py
 pytest tests/utils/test_requirements_utils.py::test_infer_requirements_excludes_mlflow
+pytest tests/store/tracking/test_file_store.py
+pytest tests/store/tracking/test_search_utils.py
 
 test $err = 0

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -16,7 +16,6 @@ from sqlparse.sql import (
     IdentifierList,
 )
 from sqlparse.tokens import Token as TokenType
-import sqlalchemy as sa
 
 from mlflow.entities import RunInfo
 from mlflow.exceptions import MlflowException
@@ -92,6 +91,8 @@ class SearchUtils:
 
     @classmethod
     def get_sql_filter_ops(cls, column, operator, dialect):
+        import sqlalchemy as sa
+
         if dialect == MYSQL:
 
             def like_op(value):

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -19,18 +19,14 @@ import pandas as pd
 import pytest
 
 import mlflow
-import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
-import mlflow.pyfunc
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.file_utils import read_yaml, write_yaml
-from mlflow.utils.model_utils import _get_flavor_configuration, FLAVOR_CONFIG_CODE
 from mlflow.utils.environment import (
     _get_pip_deps,
     _CONDA_ENV_FILE_NAME,
     _REQUIREMENTS_FILE_NAME,
     _CONSTRAINTS_FILE_NAME,
 )
-from mlflow.utils.requirements_utils import _get_installed_version
 
 LOCALHOST = "127.0.0.1"
 
@@ -68,7 +64,7 @@ def score_model_in_sagemaker_docker_container(
     model_uri,
     data,
     content_type,
-    flavor=mlflow.pyfunc.FLAVOR_NAME,
+    flavor="python_function",
     activity_polling_timeout_seconds=500,
 ):
     """
@@ -253,6 +249,8 @@ class RestEndpoint:
                 self._proc.kill()
 
     def invoke(self, data, content_type):
+        import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
+
         if type(data) == pd.DataFrame:
             if content_type == pyfunc_scoring_server.CONTENT_TYPE_JSON_RECORDS_ORIENTED:
                 data = data.to_json(orient="records")
@@ -348,6 +346,9 @@ def _read_lines(path):
 
 
 def _compare_logged_code_paths(code_path, model_path, flavor_name):
+    import mlflow.pyfunc
+    from mlflow.utils.model_utils import _get_flavor_configuration, FLAVOR_CONFIG_CODE
+
     pyfunc_conf = _get_flavor_configuration(
         model_path=model_path, flavor_name=mlflow.pyfunc.FLAVOR_NAME
     )
@@ -401,6 +402,8 @@ def _is_available_on_pypi(package, version=None, module=None):
                    if `package` is 'scikit-learn', `module` should be 'sklearn'. If None, defaults
                    to `package`.
     """
+    from mlflow.utils.requirements_utils import _get_installed_version
+
     resp = requests.get("https://pypi.python.org/pypi/{}/json".format(package))
     if not resp.ok:
         return False

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -15,7 +15,6 @@ import uuid
 import sys
 import yaml
 
-import pandas as pd
 import pytest
 
 import mlflow
@@ -250,6 +249,7 @@ class RestEndpoint:
 
     def invoke(self, data, content_type):
         import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
+        import pandas as pd
 
         if type(data) == pd.DataFrame:
             if content_type == pyfunc_scoring_server.CONTENT_TYPE_JSON_RECORDS_ORIENTED:


### PR DESCRIPTION
Signed-off-by: dbczumar <corey.zumar@databricks.com>

## What changes are proposed in this pull request?

Remove attempted sqlalchemy import from mlflow skinny search path and add tests

## How is this patch tested?

Added test coverage

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
