### PR TITLE
Add a python script to log MLflow runs in Databricks

### DIFF
--- a/examples/databricks/log_runs.py
+++ b/examples/databricks/log_runs.py
@@ -28,7 +28,7 @@ def main():
     os.environ["DATABRICKS_TOKEN"] = args.token
 
     mlflow.set_tracking_uri("databricks")
-    experiment_name = f"/Users/harutaka.kawamura@databricks.com/{uuid.uuid4().hex}"
+    experiment_name = f"/Users/{args.user}/{uuid.uuid4().hex}"
     experiment_id = mlflow.create_experiment(experiment_name)
     mlflow.set_experiment(experiment_id=experiment_id)
 

--- a/examples/databricks/log_runs.py
+++ b/examples/databricks/log_runs.py
@@ -19,10 +19,14 @@ import mlflow
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--host")
-    parser.add_argument("--token")
-    parser.add_argument("--user")
-    parser.add_argument("--experiment-id", default=None)
+    parser.add_argument("--host", help="Databricks workspace URL")
+    parser.add_argument("--token", help="Databricks personal access token")
+    parser.add_argument("--user", help="Databricks username")
+    parser.add_argument(
+        "--experiment-id",
+        default=None,
+        help="ID of the experiment to log runs in. If unspecified, a new experiment will be created.",
+    )
     args = parser.parse_args()
 
     os.environ["DATABRICKS_HOST"] = args.host

--- a/examples/databricks/log_runs.py
+++ b/examples/databricks/log_runs.py
@@ -1,5 +1,5 @@
 """
-Logs MLflow runs in Databricks.
+Logs MLflow runs in Databricks from an external host.
 
 How to run:
 $ python examples/databricks/log_runs.py --host <host> --token <token> --user <user>

--- a/examples/databricks/log_runs.py
+++ b/examples/databricks/log_runs.py
@@ -2,7 +2,7 @@
 Logs MLflow runs in Databricks from an external host.
 
 How to run:
-$ python examples/databricks/log_runs.py --host <host> --token <token> --user <user>
+$ python examples/databricks/log_runs.py --host <host> --token <token> --user <user> [--experiment-id 123]
 
 See also:
 https://docs.databricks.com/dev-tools/api/latest/authentication.html#generate-a-personal-access-token
@@ -22,13 +22,17 @@ def main():
     parser.add_argument("--host")
     parser.add_argument("--token")
     parser.add_argument("--user")
+    parser.add_argument("--experiment-id", default=None)
     args = parser.parse_args()
 
     os.environ["DATABRICKS_HOST"] = args.host
     os.environ["DATABRICKS_TOKEN"] = args.token
 
     mlflow.set_tracking_uri("databricks")
-    experiment = mlflow.set_experiment(f"/Users/{args.user}/{uuid.uuid4().hex}")
+    if args.experiment_id:
+        experiment = mlflow.set_experiment(experiment_id=args.experiment_id)
+    else:
+        experiment = mlflow.set_experiment(f"/Users/{args.user}/{uuid.uuid4().hex}")
 
     mlflow.sklearn.autolog()
     num_runs = 5

--- a/examples/databricks/log_runs.py
+++ b/examples/databricks/log_runs.py
@@ -28,13 +28,11 @@ def main():
     os.environ["DATABRICKS_TOKEN"] = args.token
 
     mlflow.set_tracking_uri("databricks")
-    experiment_name = f"/Users/{args.user}/{uuid.uuid4().hex}"
-    experiment_id = mlflow.create_experiment(experiment_name)
-    mlflow.set_experiment(experiment_id=experiment_id)
+    experiment = mlflow.set_experiment(f"/Users/{args.user}/{uuid.uuid4().hex}")
 
     mlflow.sklearn.autolog()
     num_runs = 5
-    print(f"Logging {num_runs} runs in {args.host}#/mlflow/experiments/{experiment_id}")
+    print(f"Logging {num_runs} runs in {args.host}#/mlflow/experiments/{experiment.experiment_id}")
     for i in range(num_runs):
         with mlflow.start_run() as run:
             print(f"Logging run:", run.info.run_id, f"{i + 1} / {num_runs} ")

--- a/examples/databricks/log_runs.py
+++ b/examples/databricks/log_runs.py
@@ -32,9 +32,9 @@ def main():
     experiment_id = mlflow.create_experiment(experiment_name)
     mlflow.set_experiment(experiment_id=experiment_id)
 
-    print(f"Logging runs in {args.host}#/mlflow/experiments/{experiment_id}")
     mlflow.sklearn.autolog()
     num_runs = 5
+    print(f"Logging {num_runs} runs in {args.host}#/mlflow/experiments/{experiment_id}")
     for i in range(num_runs):
         with mlflow.start_run() as run:
             print(f"Logging run:", run.info.run_id, f"{i + 1} / {num_runs} ")

--- a/examples/databricks/log_runs.py
+++ b/examples/databricks/log_runs.py
@@ -1,0 +1,45 @@
+"""
+Logs MLflow runs in Databricks.
+
+How to run:
+$ python examples/databricks/log_runs.py --host <host> --token <token> --user <user>
+
+See also:
+https://docs.databricks.com/dev-tools/api/latest/authentication.html#generate-a-personal-access-token
+"""
+import os
+import uuid
+import argparse
+
+from sklearn.linear_model import LinearRegression
+from sklearn.datasets import load_iris
+
+import mlflow
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host")
+    parser.add_argument("--token")
+    parser.add_argument("--user")
+    args = parser.parse_args()
+
+    os.environ["DATABRICKS_HOST"] = args.host
+    os.environ["DATABRICKS_TOKEN"] = args.token
+
+    mlflow.set_tracking_uri("databricks")
+    experiment_name = f"/Users/harutaka.kawamura@databricks.com/{uuid.uuid4().hex}"
+    experiment_id = mlflow.create_experiment(experiment_name)
+    mlflow.set_experiment(experiment_id=experiment_id)
+
+    print(f"Logging runs in {args.host}#/mlflow/experiments/{experiment_id}")
+    mlflow.sklearn.autolog()
+    num_runs = 5
+    for i in range(num_runs):
+        with mlflow.start_run() as run:
+            print(f"Logging run:", run.info.run_id, f"{i + 1} / {num_runs} ")
+            LinearRegression().fit(*load_iris(as_frame=True, return_X_y=True))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Add a python script to log MLflow runs in Databricks.

## Motivation

To quickly log runs when we want to test MLflow UI on databricks in a test shard.

## How is this patch tested?

Manul test

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
