### PR TITLE
Add `MlflowException.invalid_parameter_value`

### DIFF
--- a/mlflow/exceptions.py
+++ b/mlflow/exceptions.py
@@ -64,6 +64,14 @@ class MlflowException(Exception):
 
     @classmethod
     def invalid_parameter_value(cls, message, **kwargs):
+        """
+        Constructs an `MlflowException` object with the `INVALID_PARAMETER_VALUE` error code.
+
+        :param message: The message describing the error that occured. This will be included in the
+                        exception's serialized JSON representation.
+        :param kwargs: Additional key-value pairs to include in the serialized JSON representation
+                       of the MlflowException.
+        """
         return cls(message, error_code=INVALID_PARAMETER_VALUE, **kwargs)
 
 

--- a/mlflow/exceptions.py
+++ b/mlflow/exceptions.py
@@ -62,6 +62,10 @@ class MlflowException(Exception):
     def get_http_status_code(self):
         return ERROR_CODE_TO_HTTP_STATUS.get(self.error_code, 500)
 
+    @classmethod
+    def invalid_parameter_value(cls, message, **kwargs):
+        return cls(message, error_code=INVALID_PARAMETER_VALUE, **kwargs)
+
 
 class RestException(MlflowException):
     """Exception thrown on non 200-level responses from the REST API"""

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -44,9 +44,7 @@ class TestMlflowException:
 
     def test_invalid_parameter_value(self):
         mlflow_exception = MlflowException.invalid_parameter_value("test")
-        deserialized_exception = json.loads(mlflow_exception.serialize_as_json())
-        assert deserialized_exception["message"] == "test"
-        assert deserialized_exception["error_code"] == INVALID_PARAMETER_VALUE
+        assert mlflow_exception == INVALID_PARAMETER_VALUE
 
 
 def test_rest_exception():

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -42,6 +42,12 @@ class TestMlflowException:
             == 400
         )
 
+    def test_invalid_parameter_value(self):
+        mlflow_exception = MlflowException.invalid_parameter_value("test")
+        deserialized_exception = json.loads(mlflow_exception.serialize_as_json())
+        assert deserialized_exception["message"] == "test"
+        assert deserialized_exception["error_code"] == INVALID_PARAMETER_VALUE
+
 
 def test_rest_exception():
     mlflow_exception = MlflowException("test", error_code=RESOURCE_ALREADY_EXISTS)

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -44,7 +44,7 @@ class TestMlflowException:
 
     def test_invalid_parameter_value(self):
         mlflow_exception = MlflowException.invalid_parameter_value("test")
-        assert mlflow_exception == INVALID_PARAMETER_VALUE
+        assert mlflow_exception.error_code == "INVALID_PARAMETER_VALUE"
 
 
 def test_rest_exception():


### PR DESCRIPTION
Signed-off-by: Chris Terrell Jones <ctjones333@aol.com>

## What changes are proposed in this pull request?

Added a class method invalid_parameter_value to reduce imports

Fix #5598

## How is this patch tested?

Unit tests

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
