### PR TITLE
Use fork in test test_cache_return_value_per_process

### DIFF
--- a/tests/utils/test_process_utils.py
+++ b/tests/utils/test_process_utils.py
@@ -50,7 +50,7 @@ def test_cache_return_value_per_process():
         # Test child process invalidates the cache.
         # We don't create child process by `multiprocessing.Process` because
         # `multiprocessing.Process` creates child process by pickling the target function
-        # and start a new process to run the pickled function. But the global variable
+        # and starts a new process to run the pickled function. But the global variable
         # `_per_process_value_cache_map` dict content is not pickled, this makes child process
         # automatically clear the `_per_process_value_cache_map` dict content.
         pid = os.fork()

--- a/tests/utils/test_process_utils.py
+++ b/tests/utils/test_process_utils.py
@@ -46,7 +46,7 @@ def test_cache_return_value_per_process():
 
     assert len({path1, path3, f2_path1, f2_path2}) == 4
 
-    # Following testing code relying on "os.fork" which windows system does not support.
+    # Skip the following block for Windows which doesn't support `os.fork`
     if os.name != "nt":
         # Test child process invalidates the cache.
         # We don't create child process by `multiprocessing.Process` because

--- a/tests/utils/test_process_utils.py
+++ b/tests/utils/test_process_utils.py
@@ -51,7 +51,7 @@ def test_cache_return_value_per_process():
         # We don't create child process by `multiprocessing.Process` because
         # `multiprocessing.Process` creates child process by pickling the target function
         # and start a new process to run the pickled function. But the global variable
-        # `_per_process_value_cache_map` dict content is not pickled, this make child process
+        # `_per_process_value_cache_map` dict content is not pickled, this makes child process
         # automatically clear the `_per_process_value_cache_map` dict content.
         pid = os.fork()
         if pid > 0:

--- a/tests/utils/test_process_utils.py
+++ b/tests/utils/test_process_utils.py
@@ -46,7 +46,7 @@ def test_cache_return_value_per_process():
 
     assert len({path1, path3, f2_path1, f2_path2}) == 4
 
-    # Skip the following block for Windows which doesn't support `os.fork`
+    # Skip the following block on Windows which doesn't support `os.fork`
     if os.name != "nt":
         # Test child process invalidates the cache.
         # We don't create child process by `multiprocessing.Process` because

--- a/tests/utils/test_process_utils.py
+++ b/tests/utils/test_process_utils.py
@@ -53,7 +53,7 @@ def test_cache_return_value_per_process():
         # `multiprocessing.Process` creates child process by pickling the target function
         # and starts a new process to run the pickled function. But the global variable
         # `_per_process_value_cache_map` dict content is not pickled, this makes child
-#         # and parent don't share the same global variables.
+        #         # and parent don't share the same global variables.
         pid = os.fork()
         if pid > 0:
             # in parent process

--- a/tests/utils/test_process_utils.py
+++ b/tests/utils/test_process_utils.py
@@ -48,12 +48,8 @@ def test_cache_return_value_per_process():
 
     # Skip the following block on Windows which doesn't support `os.fork`
     if os.name != "nt":
-        # Test child process invalidates the cache.
-        # We don't create child process by `multiprocessing.Process` because
-        # `multiprocessing.Process` creates child process by pickling the target function
-        # and starts a new process to run the pickled function. But the global variable
-        # `_per_process_value_cache_map` dict content is not pickled, this makes child
-        #         # and parent don't share the same global variables.
+        # Use `os.fork()` to make parent and child processes share the same global variable
+        # `_per_process_value_cache_map`.
         pid = os.fork()
         if pid > 0:
             # in parent process

--- a/tests/utils/test_process_utils.py
+++ b/tests/utils/test_process_utils.py
@@ -46,13 +46,14 @@ def test_cache_return_value_per_process():
 
     assert len({path1, path3, f2_path1, f2_path2}) == 4
 
+    # Following testing code relying on "os.fork" which windows system does not support.
     if os.name != "nt":
         # Test child process invalidates the cache.
         # We don't create child process by `multiprocessing.Process` because
         # `multiprocessing.Process` creates child process by pickling the target function
         # and start a new process to run the pickled function. But the global variable
-        # `_per_process_value_cache_map` dict content is not pickled, this make child process
-        # automatically clear the `_per_process_value_cache_map` dict content.
+        # `_per_process_value_cache_map` dict content is not pickled, this makes child
+        # and parent don't share the same global variables.
         pid = os.fork()
         if pid > 0:
             # in parent process

--- a/tests/utils/test_process_utils.py
+++ b/tests/utils/test_process_utils.py
@@ -20,22 +20,6 @@ def _gen_random_no_arg():
     return uuid.uuid4().hex
 
 
-_v1 = {}
-
-
-def _f1():
-    print(f"DBG child: {str(_v1)}")
-
-
-def _test_cache_return_value_per_process_child_proc_target(path1, path3, queue):
-    # in forked out child process
-    _f1()
-    child_path1 = _gen_random_str1(True)
-    child_path2 = _gen_random_str1(False)
-    result = len({path1, path3, child_path1, child_path2}) == 4
-    queue.put(result)
-
-
 def test_cache_return_value_per_process():
 
     path1 = _gen_random_str1(True)
@@ -62,7 +46,7 @@ def test_cache_return_value_per_process():
 
     assert len({path1, path3, f2_path1, f2_path2}) == 4
 
-    if os.name != 'nt':
+    if os.name != "nt":
         # Test child process invalidates the cache.
         # We don't create child process by `multiprocessing.Process` because
         # `multiprocessing.Process` creates child process by pickling the target function


### PR DESCRIPTION
Signed-off-by: Weichen Xu <weichen.xu@databricks.com>

## What changes are proposed in this pull request?

Use fork in test test_cache_return_value_per_process.
Reason:
Use fork to create child process instead of using `multiprocessing.Process` because
`multiprocessing.Process` creates child process by pickling the target function
and start a new process to run the pickled function. But the global variable
`_per_process_value_cache_map` dict content is not pickled, this make child process
automatically clear the `_per_process_value_cache_map` dict content.

## How is this patch tested?

Unit tests.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
