### PR TITLE
Replace all(list comprehension) with all(generator) to lazily evaluate elements

### DIFF
--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -95,7 +95,7 @@ class _Example:
 
         def _handle_dataframe_input(input_ex):
             if isinstance(input_ex, dict):
-                if all([_is_scalar(x) for x in input_ex.values()]):
+                if all(_is_scalar(x) for x in input_ex.values()):
                     input_ex = pd.DataFrame([input_ex])
                 else:
                     raise TypeError(
@@ -107,7 +107,7 @@ class _Example:
                         raise TensorsNotSupportedException(
                             "Row '{0}' has shape {1}".format(i, x.shape)
                         )
-                if all([_is_scalar(x) for x in input_ex]):
+                if all(_is_scalar(x) for x in input_ex):
                     input_ex = pd.DataFrame([input_ex], columns=range(len(input_ex)))
                 else:
                     input_ex = pd.DataFrame(input_ex)

--- a/mlflow/projects/_project_spec.py
+++ b/mlflow/projects/_project_spec.py
@@ -52,7 +52,7 @@ def load_project(directory):
         if docker_env.get("volumes"):
             if not (
                 isinstance(docker_env["volumes"], list)
-                and all([isinstance(i, str) for i in docker_env["volumes"]])
+                and all(isinstance(i, str) for i in docker_env["volumes"])
             ):
                 raise ExecutionException(
                     "Project configuration (MLproject file) was invalid: "
@@ -63,7 +63,7 @@ def load_project(directory):
             if not (
                 isinstance(docker_env["environment"], list)
                 and all(
-                    [isinstance(i, list) or isinstance(i, str) for i in docker_env["environment"]]
+                    isinstance(i, list) or isinstance(i, str) for i in docker_env["environment"]
                 )
             ):
                 raise ExecutionException(

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -401,7 +401,7 @@ def _enforce_mlflow_datatype(name, values: pandas.Series, t: DataType):
         # double -> float) are not allowed. While supported by pandas and numpy,
         # these conversions alter the values significantly.
         def all_ints(xs):
-            return all([pandas.isnull(x) or int(x) == x for x in xs])
+            return all(pandas.isnull(x) or int(x) == x for x in xs)
 
         hint = ""
         if (
@@ -1015,7 +1015,7 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
 
     supported_types = [IntegerType, LongType, FloatType, DoubleType, StringType]
 
-    if not any([isinstance(elem_type, x) for x in supported_types]):
+    if not any(isinstance(elem_type, x) for x in supported_types):
         raise MlflowException(
             message="Invalid result_type '{}'. Result type can only be one of or an array of one "
             "of the following types: {}".format(str(elem_type), str(supported_types)),
@@ -1416,8 +1416,8 @@ def save_model(
         "artifacts": artifacts,
         "python_model": python_model,
     }
-    first_argument_set_specified = any([item is not None for item in first_argument_set.values()])
-    second_argument_set_specified = any([item is not None for item in second_argument_set.values()])
+    first_argument_set_specified = any(item is not None for item in first_argument_set.values())
+    second_argument_set_specified = any(item is not None for item in second_argument_set.values())
     if first_argument_set_specified and second_argument_set_specified:
         raise MlflowException(
             message=(

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -597,10 +597,8 @@ def _is_parameter_search_estimator(estimator):
     ]
 
     return any(
-        [
-            isinstance(estimator, param_search_estimator)
-            for param_search_estimator in parameter_search_estimators
-        ]
+        isinstance(estimator, param_search_estimator)
+        for param_search_estimator in parameter_search_estimators
     )
 
 
@@ -735,7 +733,7 @@ def _create_child_runs_for_parameter_search(
         metrics_to_log = {
             key: value
             for key, value in result_row.iteritems()
-            if not any([key.startswith(prefix) for prefix in excluded_metric_prefixes])
+            if not any(key.startswith(prefix) for prefix in excluded_metric_prefixes)
             and isinstance(value, Number)
         }
         autologging_client.log_metrics(

--- a/mlflow/spacy.py
+++ b/mlflow/spacy.py
@@ -130,10 +130,8 @@ def save_model(
     spacy_model.to_disk(path=model_data_path)
     # Save the pyfunc flavor if at least one text categorizer in spaCy pipeline
     if any(
-        [
-            isinstance(pipe_component[1], spacy.pipeline.TextCategorizer)
-            for pipe_component in spacy_model.pipeline
-        ]
+        isinstance(pipe_component[1], spacy.pipeline.TextCategorizer)
+        for pipe_component in spacy_model.pipeline
     ):
         pyfunc.add_to_model(
             mlflow_model,

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -110,7 +110,7 @@ class SqlAlchemyStore(AbstractStore):
             SqlRegisteredModel.__tablename__,
             SqlModelVersion.__tablename__,
         ]
-        if any([table not in inspected_tables for table in expected_tables]):
+        if any(table not in inspected_tables for table in expected_tables):
             # TODO: Replace the MlflowException with the following line once it's possible to run
             # the registry against a different DB than the tracking server:
             # mlflow.store.db.utils._initialize_tables(self.engine)

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -715,10 +715,8 @@ class FileStore(AbstractStore):
         run_dirs = list_all(
             experiment_dir,
             filter_func=lambda x: all(
-                [
-                    os.path.basename(os.path.normpath(x)) != reservedFolderName
-                    for reservedFolderName in FileStore.RESERVED_EXPERIMENT_FOLDERS
-                ]
+                os.path.basename(os.path.normpath(x)) != reservedFolderName
+                for reservedFolderName in FileStore.RESERVED_EXPERIMENT_FOLDERS
             )
             and os.path.isdir(x),
             full_path=True,

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -133,7 +133,7 @@ class SqlAlchemyStore(AbstractStore):
             SqlLatestMetric.__tablename__,
         ]
         inspected_tables = set(sqlalchemy.inspect(self.engine).get_table_names())
-        if any([table not in inspected_tables for table in expected_tables]):
+        if any(table not in inspected_tables for table in expected_tables):
             mlflow.store.db.utils._initialize_tables(self.engine)
         Base.metadata.bind = self.engine
         SessionMaker = sqlalchemy.orm.sessionmaker(bind=self.engine)

--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -145,7 +145,7 @@ def _infer_schema(data: Any) -> Schema:
             "but got '{}'".format(type(data))
         )
     if not schema.is_tensor_spec() and any(
-        [t in (DataType.integer, DataType.long) for t in schema.input_types()]
+        t in (DataType.integer, DataType.long) for t in schema.input_types()
     ):
         warnings.warn(
             "Hint: Inferred schema contains integer column(s). Integer columns in "

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -435,7 +435,7 @@ class SearchUtils:
         parsed = cls.parse_search_filter(filter_string)
 
         def run_matches(run):
-            return all([cls._does_run_match_clause(run, s) for s in parsed])
+            return all(cls._does_run_match_clause(run, s) for s in parsed)
 
         return [run for run in runs if run_matches(run)]
 
@@ -462,7 +462,7 @@ class SearchUtils:
             token_value = cls.ORDER_BY_KEY_TIMESTAMP
         elif (
             statement.tokens[0].match(ttype=TokenType.Keyword, values=[cls.ORDER_BY_KEY_TIMESTAMP])
-            and all([token.is_whitespace for token in statement.tokens[1:-1]])
+            and all(token.is_whitespace for token in statement.tokens[1:-1])
             and statement.tokens[-1].ttype == TokenType.Keyword.Order
         ):
             token_value = cls.ORDER_BY_KEY_TIMESTAMP + " " + statement.tokens[-1].value

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -164,7 +164,7 @@ def extract_db_type_from_uri(db_uri):
 
 def get_uri_scheme(uri_or_path):
     scheme = urllib.parse.urlparse(uri_or_path).scheme
-    if any([scheme.lower().startswith(db) for db in DATABASE_ENGINES]):
+    if any(scheme.lower().startswith(db) for db in DATABASE_ENGINES):
         return extract_db_type_from_uri(uri_or_path)
     else:
         return scheme

--- a/tests/autologging/test_autologging_behaviors_integration.py
+++ b/tests/autologging/test_autologging_behaviors_integration.py
@@ -281,7 +281,7 @@ def test_autolog_respects_silent_mode(tmpdir):
             e = executor.submit(train_model)
             executions.append(e)
 
-    assert all([e.result() is True for e in executions])
+    assert all(e.result() is True for e in executions)
     assert not stream.getvalue()
     # Verify that `warnings.showwarning` was restored to its original value after training
     # and that MLflow event logs are enabled
@@ -299,7 +299,7 @@ def test_autolog_respects_silent_mode(tmpdir):
             e = executor.submit(train_model)
             executions.append(e)
 
-    assert all([e.result() is True for e in executions])
+    assert all(e.result() is True for e in executions)
     assert stream.getvalue()
     # Verify that `warnings.showwarning` was restored to its original value after training
     # and that MLflow event logs are enabled

--- a/tests/autologging/test_autologging_behaviors_unit.py
+++ b/tests/autologging/test_autologging_behaviors_unit.py
@@ -181,13 +181,13 @@ def test_silent_mode_is_respected_in_multithreaded_environments(
             for _ in range(100):
                 executions.append(executor.submit(parallel_fn))
 
-    assert all([e.result() is True for e in executions])
+    assert all(e.result() is True for e in executions)
 
     # Verify that all warnings and log events from MLflow autologging code were silenced
     # and that all warnings from the original / underlying routine were emitted as normal
     assert not stream.getvalue()
     assert len(warnings_record) == 100
-    assert all(["Test warning from OG function" in str(w.message) for w in warnings_record])
+    assert all("Test warning from OG function" in str(w.message) for w in warnings_record)
 
     # Verify that `warnings.showwarning` was restored to its original value after training
     # and that MLflow event logs are enabled

--- a/tests/autologging/test_autologging_safety_unit.py
+++ b/tests/autologging/test_autologging_safety_unit.py
@@ -632,9 +632,9 @@ def test_safe_patch_makes_expected_event_logging_calls_for_successful_patch_invo
     patch_destination.fn("a", 1, b=2)
     expected_order = ["patch_start", "original_start", "original_success", "patch_success"]
     assert [call.method for call in mock_event_logger.calls] == expected_order
-    assert all([call.session == patch_session for call in mock_event_logger.calls])
-    assert all([call.patch_obj == patch_destination for call in mock_event_logger.calls])
-    assert all([call.function_name == "fn" for call in mock_event_logger.calls])
+    assert all(call.session == patch_session for call in mock_event_logger.calls)
+    assert all(call.patch_obj == patch_destination for call in mock_event_logger.calls)
+    assert all(call.function_name == "fn" for call in mock_event_logger.calls)
     patch_start, original_start, original_success, patch_success = mock_event_logger.calls
     assert patch_start.call_args == patch_success.call_args == ("a", 1)
     assert patch_start.call_kwargs == patch_success.call_kwargs == {"b": 2}

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -360,7 +360,7 @@ def test_add_to_model_adds_specified_kwargs_to_mlmodel_configuration():
     )
 
     assert mlflow.pyfunc.FLAVOR_NAME in model_config.flavors
-    assert all([item in model_config.flavors[mlflow.pyfunc.FLAVOR_NAME] for item in custom_kwargs])
+    assert all(item in model_config.flavors[mlflow.pyfunc.FLAVOR_NAME] for item in custom_kwargs)
 
 
 @pytest.mark.large
@@ -1005,12 +1005,10 @@ def test_load_model_with_differing_cloudpickle_version_at_micro_granularity_logs
         mlflow.pyfunc.load_model(model_uri=model_path)
 
     assert any(
-        [
-            "differs from the version of CloudPickle that is currently running" in log_message
-            and saver_cloudpickle_version in log_message
-            and loader_cloudpickle_version in log_message
-            for log_message in log_messages
-        ]
+        "differs from the version of CloudPickle that is currently running" in log_message
+        and saver_cloudpickle_version in log_message
+        and loader_cloudpickle_version in log_message
+        for log_message in log_messages
     )
 
 
@@ -1038,14 +1036,12 @@ def test_load_model_with_missing_cloudpickle_version_logs_warning(model_path):
         mlflow.pyfunc.load_model(model_uri=model_path)
 
     assert any(
-        [
-            (
-                "The version of CloudPickle used to save the model could not be found"
-                " in the MLmodel configuration"
-            )
-            in log_message
-            for log_message in log_messages
-        ]
+        (
+            "The version of CloudPickle used to save the model could not be found"
+            " in the MLmodel configuration"
+        )
+        in log_message
+        for log_message in log_messages
     )
 
 

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -562,12 +562,10 @@ def test_load_model_with_differing_pytorch_version_logs_warning(sequential_model
         mlflow.pytorch.load_model(model_uri=model_path)
 
     assert any(
-        [
-            "does not match installed PyTorch version" in log_message
-            and saver_pytorch_version in log_message
-            and loader_pytorch_version in log_message
-            for log_message in log_messages
-        ]
+        "does not match installed PyTorch version" in log_message
+        and saver_pytorch_version in log_message
+        and loader_pytorch_version in log_message
+        for log_message in log_messages
     )
 
 

--- a/tests/sagemaker/mock/test_sagemaker_service_mock.py
+++ b/tests/sagemaker/mock/test_sagemaker_service_mock.py
@@ -43,7 +43,7 @@ def test_created_model_is_listed_by_list_models_function(sagemaker_client):
     models_response = sagemaker_client.list_models()
     assert "Models" in models_response
     models = models_response["Models"]
-    assert all(["ModelName" in model for model in models])
+    assert all("ModelName" in model for model in models)
     assert model_name in [model["ModelName"] for model in models]
 
 
@@ -142,7 +142,7 @@ def test_created_endpoint_config_is_listed_by_list_endpoints_function(sagemaker_
     endpoint_configs_response = sagemaker_client.list_endpoint_configs()
     assert "EndpointConfigs" in endpoint_configs_response
     endpoint_configs = endpoint_configs_response["EndpointConfigs"]
-    assert all(["EndpointConfigName" in endpoint_config for endpoint_config in endpoint_configs])
+    assert all("EndpointConfigName" in endpoint_config for endpoint_config in endpoint_configs)
     assert endpoint_config_name in [
         endpoint_config["EndpointConfigName"] for endpoint_config in endpoint_configs
     ]
@@ -289,7 +289,7 @@ def test_created_endpoint_is_listed_by_list_endpoints_function(sagemaker_client)
     endpoints_response = sagemaker_client.list_endpoints()
     assert "Endpoints" in endpoints_response
     endpoints = endpoints_response["Endpoints"]
-    assert all(["EndpointName" in endpoint for endpoint in endpoints])
+    assert all("EndpointName" in endpoint for endpoint in endpoints)
     assert endpoint_name in [endpoint["EndpointName"] for endpoint in endpoints]
 
 
@@ -531,7 +531,7 @@ def test_created_transform_job_is_listed_by_list_transform_jobs_function(sagemak
     transform_jobs_response = sagemaker_client.list_transform_jobs()
     assert "TransformJobSummaries" in transform_jobs_response
     transform_jobs = transform_jobs_response["TransformJobSummaries"]
-    assert all(["TransformJobName" in transform_job for transform_job in transform_jobs])
+    assert all("TransformJobName" in transform_job for transform_job in transform_jobs)
     assert job_name in [transform_job["TransformJobName"] for transform_job in transform_jobs]
 
 

--- a/tests/sagemaker/test_batch_deployment.py
+++ b/tests/sagemaker/test_batch_deployment.py
@@ -196,7 +196,7 @@ def test_deploy_creates_sagemaker_transform_job_and_s3_resources_with_expected_n
     object_names = [
         entry["Key"] for entry in s3_client.list_objects(Bucket=default_bucket)["Contents"]
     ]
-    assert any([model_name in object_name for object_name in object_names])
+    assert any(model_name in object_name for object_name in object_names)
     assert job_name in [
         transform_job["TransformJobName"]
         for transform_job in sagemaker_client.list_transform_jobs()["TransformJobSummaries"]
@@ -239,7 +239,7 @@ def test_deploy_cli_creates_sagemaker_transform_job_and_s3_resources_with_expect
     object_names = [
         entry["Key"] for entry in s3_client.list_objects(Bucket=default_bucket)["Contents"]
     ]
-    assert any([model_name in object_name for object_name in object_names])
+    assert any(model_name in object_name for object_name in object_names)
     assert job_name in [
         transform_job["TransformJobName"]
         for transform_job in sagemaker_client.list_transform_jobs()["TransformJobSummaries"]
@@ -280,7 +280,7 @@ def test_deploy_creates_sagemaker_transform_job_and_s3_resources_with_expected_n
     object_names = [
         entry["Key"] for entry in s3_client.list_objects(Bucket=default_bucket)["Contents"]
     ]
-    assert any([model_name in object_name for object_name in object_names])
+    assert any(model_name in object_name for object_name in object_names)
     assert job_name in [
         transform_job["TransformJobName"]
         for transform_job in sagemaker_client.list_transform_jobs()["TransformJobSummaries"]
@@ -333,7 +333,7 @@ def test_deploy_cli_creates_sagemaker_transform_job_and_s3_resources_with_expect
     object_names = [
         entry["Key"] for entry in s3_client.list_objects(Bucket=default_bucket)["Contents"]
     ]
-    assert any([model_name in object_name for object_name in object_names])
+    assert any(model_name in object_name for object_name in object_names)
     assert job_name in [
         transform_job["TransformJobName"]
         for transform_job in sagemaker_client.list_transform_jobs()["TransformJobSummaries"]

--- a/tests/sagemaker/test_deployment.py
+++ b/tests/sagemaker/test_deployment.py
@@ -244,12 +244,10 @@ def test_deploy_creates_sagemaker_and_s3_resources_with_expected_names_and_env_f
     object_names = [
         entry["Key"] for entry in s3_client.list_objects(Bucket=default_bucket)["Contents"]
     ]
-    assert any([model_name in object_name for object_name in object_names])
+    assert any(model_name in object_name for object_name in object_names)
     assert any(
-        [
-            app_name in config["EndpointConfigName"]
-            for config in sagemaker_client.list_endpoint_configs()["EndpointConfigs"]
-        ]
+        app_name in config["EndpointConfigName"]
+        for config in sagemaker_client.list_endpoint_configs()["EndpointConfigs"]
     )
     assert app_name in [
         endpoint["EndpointName"] for endpoint in sagemaker_client.list_endpoints()["Endpoints"]
@@ -294,12 +292,10 @@ def test_deploy_cli_creates_sagemaker_and_s3_resources_with_expected_names_and_e
     object_names = [
         entry["Key"] for entry in s3_client.list_objects(Bucket=default_bucket)["Contents"]
     ]
-    assert any([model_name in object_name for object_name in object_names])
+    assert any(model_name in object_name for object_name in object_names)
     assert any(
-        [
-            app_name in config["EndpointConfigName"]
-            for config in sagemaker_client.list_endpoint_configs()["EndpointConfigs"]
-        ]
+        app_name in config["EndpointConfigName"]
+        for config in sagemaker_client.list_endpoint_configs()["EndpointConfigs"]
     )
     assert app_name in [
         endpoint["EndpointName"] for endpoint in sagemaker_client.list_endpoints()["Endpoints"]
@@ -341,12 +337,10 @@ def test_deploy_creates_sagemaker_and_s3_resources_with_expected_names_and_env_f
     object_names = [
         entry["Key"] for entry in s3_client.list_objects(Bucket=default_bucket)["Contents"]
     ]
-    assert any([model_name in object_name for object_name in object_names])
+    assert any(model_name in object_name for object_name in object_names)
     assert any(
-        [
-            app_name in config["EndpointConfigName"]
-            for config in sagemaker_client.list_endpoint_configs()["EndpointConfigs"]
-        ]
+        app_name in config["EndpointConfigName"]
+        for config in sagemaker_client.list_endpoint_configs()["EndpointConfigs"]
     )
     assert app_name in [
         endpoint["EndpointName"] for endpoint in sagemaker_client.list_endpoints()["Endpoints"]
@@ -393,12 +387,10 @@ def test_deploy_cli_creates_sagemaker_and_s3_resources_with_expected_names_and_e
     object_names = [
         entry["Key"] for entry in s3_client.list_objects(Bucket=default_bucket)["Contents"]
     ]
-    assert any([model_name in object_name for object_name in object_names])
+    assert any(model_name in object_name for object_name in object_names)
     assert any(
-        [
-            app_name in config["EndpointConfigName"]
-            for config in sagemaker_client.list_endpoint_configs()["EndpointConfigs"]
-        ]
+        app_name in config["EndpointConfigName"]
+        for config in sagemaker_client.list_endpoint_configs()["EndpointConfigs"]
     )
     assert app_name in [
         endpoint["EndpointName"] for endpoint in sagemaker_client.list_endpoints()["Endpoints"]
@@ -640,10 +632,8 @@ def test_deploy_in_replace_model_removes_preexisting_models_from_endpoint(
     ]
     assert len(deployed_models_after_replacement) == 1
     assert all(
-        [
-            model_name not in deployed_models_after_replacement
-            for model_name in deployed_models_before_replacement
-        ]
+        model_name not in deployed_models_after_replacement
+        for model_name in deployed_models_before_replacement
     )
 
 
@@ -794,15 +784,11 @@ def test_deploy_in_replace_mode_with_archiving_does_not_delete_resources(
         model["ModelName"] for model in sagemaker_client.list_models()["Models"]
     ]
     assert all(
-        [
-            object_name in object_names_after_replacement
-            for object_name in object_names_before_replacement
-        ]
+        object_name in object_names_after_replacement
+        for object_name in object_names_before_replacement
     )
     assert all(
-        [
-            endpoint_config in endpoint_configs_after_replacement
-            for endpoint_config in endpoint_configs_before_replacement
-        ]
+        endpoint_config in endpoint_configs_after_replacement
+        for endpoint_config in endpoint_configs_before_replacement
     )
-    assert all([model in models_after_replacement for model in models_before_replacement])
+    assert all(model in models_after_replacement for model in models_before_replacement)

--- a/tests/sagemaker/test_sagemaker_deployment_client.py
+++ b/tests/sagemaker/test_sagemaker_deployment_client.py
@@ -331,12 +331,10 @@ def test_create_deployment_create_sagemaker_and_s3_resources_with_expected_names
     object_names = [
         entry["Key"] for entry in s3_client.list_objects(Bucket=default_bucket)["Contents"]
     ]
-    assert any([model_name in object_name for object_name in object_names])
+    assert any(model_name in object_name for object_name in object_names)
     assert any(
-        [
-            name in config["EndpointConfigName"]
-            for config in sagemaker_client.list_endpoint_configs()["EndpointConfigs"]
-        ]
+        name in config["EndpointConfigName"]
+        for config in sagemaker_client.list_endpoint_configs()["EndpointConfigs"]
     )
     assert name in [
         endpoint["EndpointName"] for endpoint in sagemaker_client.list_endpoints()["Endpoints"]
@@ -369,12 +367,10 @@ def test_deploy_cli_creates_sagemaker_and_s3_resources_with_expected_names_and_e
     object_names = [
         entry["Key"] for entry in s3_client.list_objects(Bucket=default_bucket)["Contents"]
     ]
-    assert any([model_name in object_name for object_name in object_names])
+    assert any(model_name in object_name for object_name in object_names)
     assert any(
-        [
-            app_name in config["EndpointConfigName"]
-            for config in sagemaker_client.list_endpoint_configs()["EndpointConfigs"]
-        ]
+        app_name in config["EndpointConfigName"]
+        for config in sagemaker_client.list_endpoint_configs()["EndpointConfigs"]
     )
     assert app_name in [
         endpoint["EndpointName"] for endpoint in sagemaker_client.list_endpoints()["Endpoints"]
@@ -419,12 +415,10 @@ def test_create_deployment_creates_sagemaker_and_s3_resources_with_expected_name
     object_names = [
         entry["Key"] for entry in s3_client.list_objects(Bucket=default_bucket)["Contents"]
     ]
-    assert any([model_name in object_name for object_name in object_names])
+    assert any(model_name in object_name for object_name in object_names)
     assert any(
-        [
-            name in config["EndpointConfigName"]
-            for config in sagemaker_client.list_endpoint_configs()["EndpointConfigs"]
-        ]
+        name in config["EndpointConfigName"]
+        for config in sagemaker_client.list_endpoint_configs()["EndpointConfigs"]
     )
     assert name in [
         endpoint["EndpointName"] for endpoint in sagemaker_client.list_endpoints()["Endpoints"]
@@ -467,12 +461,10 @@ def test_deploy_cli_creates_sagemaker_and_s3_resources_with_expected_names_and_e
     object_names = [
         entry["Key"] for entry in s3_client.list_objects(Bucket=default_bucket)["Contents"]
     ]
-    assert any([model_name in object_name for object_name in object_names])
+    assert any(model_name in object_name for object_name in object_names)
     assert any(
-        [
-            app_name in config["EndpointConfigName"]
-            for config in sagemaker_client.list_endpoint_configs()["EndpointConfigs"]
-        ]
+        app_name in config["EndpointConfigName"]
+        for config in sagemaker_client.list_endpoint_configs()["EndpointConfigs"]
     )
     assert app_name in [
         endpoint["EndpointName"] for endpoint in sagemaker_client.list_endpoints()["Endpoints"]
@@ -688,10 +680,8 @@ def test_create_deployment_in_replace_mode_removes_preexisting_models_from_endpo
     ]
     assert len(deployed_models_after_replacement) == 1
     assert all(
-        [
-            model_name not in deployed_models_after_replacement
-            for model_name in deployed_models_before_replacement
-        ]
+        model_name not in deployed_models_after_replacement
+        for model_name in deployed_models_before_replacement
     )
 
 
@@ -832,10 +822,8 @@ def test_update_deployment_in_replace_mode_removes_preexisting_models_from_endpo
     ]
     assert len(deployed_models_after_replacement) == 1
     assert all(
-        [
-            model_name not in deployed_models_after_replacement
-            for model_name in deployed_models_before_replacement
-        ]
+        model_name not in deployed_models_after_replacement
+        for model_name in deployed_models_before_replacement
     )
 
 
@@ -986,18 +974,14 @@ def test_update_deployment_in_replace_mode_with_archiving_does_not_delete_resour
         model["ModelName"] for model in sagemaker_client.list_models()["Models"]
     ]
     assert all(
-        [
-            object_name in object_names_after_replacement
-            for object_name in object_names_before_replacement
-        ]
+        object_name in object_names_after_replacement
+        for object_name in object_names_before_replacement
     )
     assert all(
-        [
-            endpoint_config in endpoint_configs_after_replacement
-            for endpoint_config in endpoint_configs_before_replacement
-        ]
+        endpoint_config in endpoint_configs_after_replacement
+        for endpoint_config in endpoint_configs_before_replacement
     )
-    assert all([model in models_after_replacement for model in models_before_replacement])
+    assert all(model in models_after_replacement for model in models_before_replacement)
 
 
 @pytest.mark.large
@@ -1033,12 +1017,10 @@ def test_deploy_cli_updates_sagemaker_and_s3_resources_in_replace_mode(
     object_names = [
         entry["Key"] for entry in s3_client.list_objects(Bucket=default_bucket)["Contents"]
     ]
-    assert any([model_name in object_name for object_name in object_names])
+    assert any(model_name in object_name for object_name in object_names)
     assert any(
-        [
-            app_name in config["EndpointConfigName"]
-            for config in sagemaker_client.list_endpoint_configs()["EndpointConfigs"]
-        ]
+        app_name in config["EndpointConfigName"]
+        for config in sagemaker_client.list_endpoint_configs()["EndpointConfigs"]
     )
     assert app_name in [
         endpoint["EndpointName"] for endpoint in sagemaker_client.list_endpoints()["Endpoints"]

--- a/tests/sklearn/test_sklearn_model_export.py
+++ b/tests/sklearn/test_sklearn_model_export.py
@@ -529,7 +529,7 @@ def test_model_save_with_cloudpickle_format_adds_cloudpickle_to_conda_environmen
         if type(dependency) == dict and "pip" in dependency
     ]
     assert len(pip_deps) == 1
-    assert any(["cloudpickle" in pip_dep for pip_dep in pip_deps[0]["pip"]])
+    assert any("cloudpickle" in pip_dep for pip_dep in pip_deps[0]["pip"])
 
 
 @pytest.mark.large
@@ -560,10 +560,7 @@ def test_model_save_without_cloudpickle_format_does_not_add_cloudpickle_to_conda
         with open(saved_conda_env_path, "r") as f:
             saved_conda_env_parsed = yaml.safe_load(f)
         assert all(
-            [
-                "cloudpickle" not in dependency
-                for dependency in saved_conda_env_parsed["dependencies"]
-            ]
+            "cloudpickle" not in dependency for dependency in saved_conda_env_parsed["dependencies"]
         )
 
 

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -761,7 +761,7 @@ def test_tf_estimator_v1_autolog_can_load_from_artifact(tmpdir, export):
 def test_tf_estimator_autolog_logs_tensorboard_logs(tf_estimator_random_data_run):
     client = mlflow.tracking.MlflowClient()
     artifacts = client.list_artifacts(tf_estimator_random_data_run.info.run_id)
-    assert any(["tensorboard_logs" in a.path and a.is_dir for a in artifacts])
+    assert any("tensorboard_logs" in a.path and a.is_dir for a in artifacts)
 
 
 @pytest.mark.large

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -282,11 +282,8 @@ def test_metric_timestamp():
     finished_run = client.get_run(run_id)
     assert len(history) == 2
     assert all(
-        [
-            m.timestamp >= finished_run.info.start_time
-            and m.timestamp <= finished_run.info.end_time
-            for m in history
-        ]
+        m.timestamp >= finished_run.info.start_time and m.timestamp <= finished_run.info.end_time
+        for m in history
     )
 
 

--- a/tests/types/test_schema.py
+++ b/tests/types/test_schema.py
@@ -228,7 +228,7 @@ def test_schema_inference_on_pandas_series():
 
 
 def test_get_tensor_shape(dict_of_ndarrays):
-    assert all([-1 == _get_tensor_shape(tensor)[0] for tensor in dict_of_ndarrays.values()])
+    assert all(-1 == _get_tensor_shape(tensor)[0] for tensor in dict_of_ndarrays.values())
 
     data = dict_of_ndarrays["4D"]
     # Specify variable dimension


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes #5617.  Replaces all instances where list comprehension is used with generator comprehension syntax.

## How is this patch tested?

Ran the existing unit tests and linter.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
