### PR TITLE
Add configuration warning for --artifacts-only server initialization

### DIFF
--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -21,7 +21,10 @@ from mlflow.utils import cli_args
 from mlflow.utils.annotations import experimental
 from mlflow.utils.logging_utils import eprint
 from mlflow.utils.process import ShellCommandException
-from mlflow.utils.uri import resolve_default_artifact_root
+from mlflow.utils.server_cli_utils import (
+    resolve_default_artifact_root,
+    artifacts_only_config_warning,
+)
 from mlflow.entities.lifecycle_stage import LifecycleStage
 from mlflow.exceptions import MlflowException
 
@@ -417,6 +420,7 @@ def server(
     default_artifact_root = resolve_default_artifact_root(
         serve_artifacts, default_artifact_root, backend_store_uri
     )
+    artifacts_only_config_warning(artifacts_only, backend_store_uri)
 
     try:
         initialize_backend_stores(backend_store_uri, default_artifact_root)

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -23,7 +23,7 @@ from mlflow.utils.logging_utils import eprint
 from mlflow.utils.process import ShellCommandException
 from mlflow.utils.server_cli_utils import (
     resolve_default_artifact_root,
-    artifacts_only_config_warning,
+    artifacts_only_config_validation,
 )
 from mlflow.entities.lifecycle_stage import LifecycleStage
 from mlflow.exceptions import MlflowException
@@ -272,7 +272,7 @@ def ui(
     Launch the MLflow tracking UI for local viewing of run results. To launch a production
     server, use the "mlflow server" command instead.
 
-    The UI will be visible at http://localhost:5000 by default, and only accept connections
+    The UI will be visible at http://localhost:5000 by default, and only accepts connections
     from the local machine. To let the UI server accept connections from other machines, you will
     need to pass ``--host 0.0.0.0`` to listen on all network interfaces (or a specific interface
     address).
@@ -403,7 +403,7 @@ def server(
     """
     Run the MLflow tracking server.
 
-    The server which listen on http://localhost:5000 by default, and only accept connections
+    The server listens on http://localhost:5000 by default and only accepts connections
     from the local machine. To let the server accept connections from other machines, you will need
     to pass ``--host 0.0.0.0`` to listen on all network interfaces
     (or a specific interface address).
@@ -420,7 +420,7 @@ def server(
     default_artifact_root = resolve_default_artifact_root(
         serve_artifacts, default_artifact_root, backend_store_uri
     )
-    artifacts_only_config_warning(artifacts_only, backend_store_uri)
+    artifacts_only_config_validation(artifacts_only, backend_store_uri)
 
     try:
         initialize_backend_stores(backend_store_uri, default_artifact_root)

--- a/mlflow/utils/server_cli_utils.py
+++ b/mlflow/utils/server_cli_utils.py
@@ -1,0 +1,47 @@
+"""
+Utilities for MLflow cli server config validation and resolving.
+NOTE: these functions are intended to be used as utilities for the cli click-based interface.
+Do not use for any other purpose as the potential Exceptions being raised will be misleading
+for users.
+"""
+
+import click
+
+from mlflow.store.tracking import DEFAULT_ARTIFACTS_URI, DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH
+from mlflow.utils.logging_utils import eprint
+from mlflow.utils.uri import is_local_uri
+
+
+def resolve_default_artifact_root(
+    serve_artifacts: bool,
+    default_artifact_root: str,
+    backend_store_uri: str,
+    resolve_to_local: bool = False,
+) -> str:
+    if serve_artifacts and not default_artifact_root:
+        default_artifact_root = DEFAULT_ARTIFACTS_URI
+    elif not serve_artifacts and not default_artifact_root:
+        if is_local_uri(backend_store_uri):
+            default_artifact_root = backend_store_uri
+        elif resolve_to_local:
+            default_artifact_root = DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH
+        else:
+            msg = (
+                "Option 'default-artifact-root' is required when backend store is not "
+                "local file based."
+            )
+            eprint(msg)
+            raise click.UsageError(message=msg)
+    return default_artifact_root
+
+
+def artifacts_only_config_warning(artifacts_only: bool, backend_store_uri: str) -> None:
+
+    if artifacts_only and not is_local_uri(backend_store_uri):
+        msg = (
+            "You are starting a tracking server in `--artifacts-only` mode with a non-default "
+            f"`--backend_store_uri`: '{backend_store_uri}'. To prevent errors in listing "
+            "artifacts, please ensure that any other tracking servers that are started do not "
+            "specify the argument `--backend_store_uri` at initialization."
+        )
+        click.echo(message=msg, nl=True, color=True)

--- a/mlflow/utils/server_cli_utils.py
+++ b/mlflow/utils/server_cli_utils.py
@@ -35,13 +35,27 @@ def resolve_default_artifact_root(
     return default_artifact_root
 
 
-def artifacts_only_config_warning(artifacts_only: bool, backend_store_uri: str) -> None:
+def _is_default_backend_store_uri(backend_store_uri: str) -> bool:
+    """
+    Utility function to validate if the configured backend store uri location is set as the
+    default value for MLflow server.
 
-    if artifacts_only and not is_local_uri(backend_store_uri):
+    :param backend_store_uri: The value set for the backend store uri for MLflow server artifact
+           handling.
+    :return: bool True if the default value is set.
+    """
+    return backend_store_uri == DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH
+
+
+def artifacts_only_config_validation(artifacts_only: bool, backend_store_uri: str) -> None:
+
+    if artifacts_only and not _is_default_backend_store_uri(backend_store_uri):
         msg = (
-            "You are starting a tracking server in `--artifacts-only` mode with a non-default "
-            f"`--backend_store_uri`: '{backend_store_uri}'. To prevent errors in listing "
-            "artifacts, please ensure that any other tracking servers that are started do not "
-            "specify the argument `--backend_store_uri` at initialization."
+            "You are starting a tracking server in `--artifacts-only` mode and have provided a "
+            f"value for `--backend_store_uri`: '{backend_store_uri}'. A tracking server in "
+            "`--artifacts-only` mode cannot have a custom value set for `--backend_store_uri` to "
+            "properly proxy access to the artifact storage location. Remove the "
+            "`--backend_store_uri` argument in your configuration arguments for this server and "
+            "any other tracking servers when operating in proxy artifact access mode."
         )
-        click.echo(message=msg, nl=True, color=True)
+        raise click.UsageError(message=msg)

--- a/mlflow/utils/server_cli_utils.py
+++ b/mlflow/utils/server_cli_utils.py
@@ -53,9 +53,7 @@ def artifacts_only_config_validation(artifacts_only: bool, backend_store_uri: st
         msg = (
             "You are starting a tracking server in `--artifacts-only` mode and have provided a "
             f"value for `--backend_store_uri`: '{backend_store_uri}'. A tracking server in "
-            "`--artifacts-only` mode cannot have a custom value set for `--backend_store_uri` to "
-            "properly proxy access to the artifact storage location. Remove the "
-            "`--backend_store_uri` argument in your configuration arguments for this server and "
-            "any other tracking servers when operating in proxy artifact access mode."
+            "`--artifacts-only` mode cannot have a value set for `--backend_store_uri` to "
+            "properly proxy access to the artifact storage location."
         )
         raise click.UsageError(message=msg)

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -1,13 +1,10 @@
-import sys
 import posixpath
 import urllib.parse
 
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.store.db.db_types import DATABASE_ENGINES
-from mlflow.store.tracking import DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH, DEFAULT_ARTIFACTS_URI
 from mlflow.utils.validation import _validate_db_type_string
-from mlflow.utils.logging_utils import eprint
 
 _INVALID_DB_URI_MSG = (
     "Please refer to https://mlflow.org/docs/latest/tracking.html#storage for "
@@ -297,22 +294,3 @@ def dbfs_hdfs_uri_to_fuse_path(dbfs_uri):
         )
 
     return _DBFS_FUSE_PREFIX + dbfs_uri[len(_DBFS_HDFS_URI_PREFIX) :]
-
-
-def resolve_default_artifact_root(
-    serve_artifacts, default_artifact_root, backend_store_uri, resolve_to_local=False
-):
-    if serve_artifacts and not default_artifact_root:
-        default_artifact_root = DEFAULT_ARTIFACTS_URI
-    elif not serve_artifacts and not default_artifact_root:
-        if is_local_uri(backend_store_uri):
-            default_artifact_root = backend_store_uri
-        elif resolve_to_local:
-            default_artifact_root = DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH
-        else:
-            eprint(
-                "Option 'default-artifact-root' is required, when backend store is not "
-                "local file based."
-            )
-            sys.exit(1)
-    return default_artifact_root

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -294,3 +294,21 @@ def test_mlflow_artifact_service_unavailable_without_config():
         )
     finally:
         process.kill()
+
+
+def test_mlflow_artifact_only_prints_warning_for_configs():
+
+    with mock.patch("mlflow.server._run_server") as run_server_mock, mock.patch(
+        "mlflow.store.tracking.sqlalchemy_store.SqlAlchemyStore"
+    ), mock.patch("mlflow.store.model_registry.sqlalchemy_store.SqlAlchemyStore"):
+        result = CliRunner(mix_stderr=False).invoke(
+            server,
+            ["--serve-artifacts", "--artifacts-only", "--backend-store-uri", "sqlite:///my.db"],
+            catch_exceptions=False,
+        )
+        assert result.stdout.startswith(
+            "You are starting a tracking server in `--artifacts-only` mode with a "
+            "non-default `--backend_store_uri`:"
+        )
+        assert result.exit_code == 0
+        run_server_mock.assert_called()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -306,9 +306,10 @@ def test_mlflow_artifact_only_prints_warning_for_configs():
             ["--serve-artifacts", "--artifacts-only", "--backend-store-uri", "sqlite:///my.db"],
             catch_exceptions=False,
         )
-        assert result.stdout.startswith(
-            "You are starting a tracking server in `--artifacts-only` mode with a "
-            "non-default `--backend_store_uri`:"
+        assert result.stderr.startswith(
+            "Usage: server [OPTIONS]\nTry 'server --help' for help.\n\nError: You are starting a "
+            "tracking server in `--artifacts-only` mode and have provided a value for "
+            "`--backend_store_uri`"
         )
-        assert result.exit_code == 0
-        run_server_mock.assert_called()
+        assert result.exit_code != 0
+        run_server_mock.assert_not_called()


### PR DESCRIPTION
Signed-off-by: Ben Wilson <benjamin.wilson@databricks.com>

## What changes are proposed in this pull request?

Adds a cli warning if an mlflow server is started in --artifacts-only mode and the default value of --backend-store-uri is not the default value. The warning will print to stdout that any other servers that are started should not define the --backend-store-uri to this external location to prevent issues with artifact listing (namely in the UI). 
This is a corrected change to the reverted PR #5571 which incorrectly raised an exception.
This PR also moves server cli utility functions into its own module since the function `resolve_default_artifact_root()` was the sole importer of several modules and didn't really belong in `mlflow.utils.uri`.  

## How is this patch tested?

Unit test added to validate stdout printing of the proper warning raised and to validate that the server is still capable of executing a start command.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
