### PR TITLE
Set `log_model_signatures=False` by default for `mlflow.tensorflow.autolog()`

### DIFF
--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -998,8 +998,8 @@ def autolog(
                         return input_example_slice
 
                     def _infer_model_signature(input_data_slice):
-                        # In certain TensorFlow versions, calling `predict()` on model  may modify the
-                        # `stop_training` attribute, so we save and restore it accordingly
+                        # In certain TensorFlow versions, calling `predict()` on model  may modify
+                        # the `stop_training` attribute, so we save and restore it accordingly
                         original_stop_training = history.model.stop_training
                         model_output = history.model.predict(input_data_slice)
                         history.model.stop_training = original_stop_training

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -733,7 +733,13 @@ def autolog(
                                  :py:class:`ModelSignatures <mlflow.models.ModelSignature>`
                                  describing model inputs and outputs are collected and logged along
                                  with tf/keras model artifacts during training. If ``False``,
-                                 signatures are not logged.
+                                 signatures are not logged. ``False`` by default because
+                                 logging TensorFlow models with signatures changes their pyfunc
+                                 inference behavior when Pandas DataFrames are passed to
+                                 ``predict()``: when a signature is present, an ``np.ndarray``
+                                 (for single-output models) or a mapping from
+                                 ``str`` -> ``np.ndarray`` (for multi-output models) is returned;
+                                 when a signature is not present, a Pandas DataFrame is returned.
     """
     import tensorflow
 

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -30,6 +30,7 @@ from mlflow.models import Model
 from mlflow.models.model import MLMODEL_FILE_NAME, _LOG_MODEL_METADATA_WARNING_TEMPLATE
 from mlflow.models.signature import ModelSignature
 from mlflow.models.utils import ModelInputExample, _save_example
+from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.tracking import MlflowClient
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri, get_artifact_uri
 from mlflow.utils.annotations import keyword_only
@@ -983,7 +984,8 @@ def autolog(
                                 " only log input examples and model signatures for the following"
                                 " input types: numpy.ndarray, dict[string -> numpy.ndarray],"
                                 " tensorflow.keras.utils.Sequence, and"
-                                " tensorflow.data.Dataset (TensorFlow >= 2.1.0 required)"
+                                " tensorflow.data.Dataset (TensorFlow >= 2.1.0 required)",
+                                INVALID_PARAMETER_VALUE,
                             )
 
                         return input_example_slice

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -1010,7 +1010,8 @@ def autolog(
                         _infer_model_signature,
                         log_input_examples,
                         (
-                            log_model_signatures and
+                            log_model_signatures
+                            and
                             # `log_model_signatures` is `False` by default for
                             # `mlflow.tensorflow.autolog()` in order to to preserve
                             # backwards-compatible inference behavior with older versions of MLflow
@@ -1024,9 +1025,7 @@ def autolog(
                             # we only enable signature logging if `mlflow.tensorflow.autolog()` is
                             # called explicitly with `log_model_signatures=True`
                             not get_autologging_config(
-                                FLAVOR_NAME,
-                                AUTOLOGGING_CONF_KEY_IS_GLOBALLY_CONFIGURED,
-                                False
+                                FLAVOR_NAME, AUTOLOGGING_CONF_KEY_IS_GLOBALLY_CONFIGURED, False
                             )
                         ),
                         _logger,

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -938,10 +938,11 @@ def autolog(
                         if isinstance(input_training_data, np.ndarray):
                             input_example_slice = input_training_data[:INPUT_EXAMPLE_SAMPLE_ROWS]
                         elif (
-                            isinstance(input_training_data, tensorflow.data.Dataset) and
+                            isinstance(input_training_data, tensorflow.data.Dataset)
+                            and
                             # TensorFlow < 2.1.0 does not include methods for converting
                             # a tf.data.Dataset to a numpy array, such as `as_numpy_iterator()`
-                            Version(tensorflow.__version__) >=  Version("2.1.0")
+                            Version(tensorflow.__version__) >= Version("2.1.0")
                         ):
                             steps = 1
                             if history.params is not None and "steps" in history.params:

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -30,6 +30,7 @@ from mlflow.utils.autologging_utils import (
     autologging_integration,
     AUTOLOGGING_INTEGRATIONS,
     autologging_is_disabled,
+    AUTOLOGGING_CONF_KEY_IS_GLOBALLY_CONFIGURED,
 )
 from mlflow.utils.import_hooks import register_post_import_hook
 from mlflow.utils.mlflow_tags import (
@@ -1604,8 +1605,6 @@ def autolog(
         "pytorch_lightning": pytorch.autolog,
     }
 
-    CONF_KEY_IS_GLOBALLY_CONFIGURED = "globally_configured"
-
     def get_autologging_params(autolog_fn):
         try:
             needed_params = list(inspect.signature(autolog_fn).parameters.keys())
@@ -1622,20 +1621,22 @@ def autolog(
             # Logic is as follows:
             # - if a previous_config exists, that means either `mlflow.autolog` or
             #   `mlflow.integration.autolog` was called.
-            # - if the config contains `CONF_KEY_IS_GLOBALLY_CONFIGURED`, the configuration
-            #   was set by `mlflow.autolog`, and so we can safely call `autolog_fn` with
-            #   `autologging_params`.
+            # - if the config contains `AUTOLOGGING_CONF_KEY_IS_GLOBALLY_CONFIGURED`, the
+            #   configuration was set by `mlflow.autolog`, and so we can safely call `autolog_fn`
+            #   with `autologging_params`.
             # - if the config doesn't contain this key, the configuration was set by an
             #   `mlflow.integration.autolog` call, so we should not call `autolog_fn` with
             #   new configs.
             prev_config = AUTOLOGGING_INTEGRATIONS.get(autolog_fn.integration_name)
-            if prev_config and not prev_config.get(CONF_KEY_IS_GLOBALLY_CONFIGURED, False):
+            if prev_config and not prev_config.get(
+                AUTOLOGGING_CONF_KEY_IS_GLOBALLY_CONFIGURED, False
+            ):
                 return
 
             autologging_params = get_autologging_params(autolog_fn)
             autolog_fn(**autologging_params)
             AUTOLOGGING_INTEGRATIONS[autolog_fn.integration_name][
-                CONF_KEY_IS_GLOBALLY_CONFIGURED
+               AUTOLOGGING_CONF_KEY_IS_GLOBALLY_CONFIGURED 
             ] = True
             if not autologging_is_disabled(
                 autolog_fn.integration_name

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1636,7 +1636,7 @@ def autolog(
             autologging_params = get_autologging_params(autolog_fn)
             autolog_fn(**autologging_params)
             AUTOLOGGING_INTEGRATIONS[autolog_fn.integration_name][
-               AUTOLOGGING_CONF_KEY_IS_GLOBALLY_CONFIGURED 
+                AUTOLOGGING_CONF_KEY_IS_GLOBALLY_CONFIGURED
             ] = True
             if not autologging_is_disabled(
                 autolog_fn.integration_name

--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -47,6 +47,12 @@ _AUTOLOGGING_TEST_MODE_ENV_VAR = "MLFLOW_AUTOLOGGING_TESTING"
 # Flag indicating whether autologging is globally disabled for all integrations.
 _AUTOLOGGING_GLOBALLY_DISABLED = False
 
+# Autologging config key indicating whether or not a particular autologging integration
+# was configured (i.e. its various `log_models`, `disable`, etc. configuration options
+# were set) via a call to `mlflow.autolog()`, rather than via a call to the integration-specific
+# autologging method (e.g., `mlflow.tensorflow.autolog()`, ...)
+AUTOLOGGING_CONF_KEY_IS_GLOBALLY_CONFIGURED = "globally_configured"
+
 # Dict mapping integration name to its config.
 AUTOLOGGING_INTEGRATIONS = {}
 

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -3,7 +3,6 @@
 import collections
 import os
 import pickle
-import sys
 from unittest.mock import patch
 import json
 

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -1091,10 +1091,6 @@ def _assert_keras_autolog_input_example_load_and_predict_with_nparray(run, rando
 
 
 @pytest.mark.large
-@pytest.mark.skipif(
-    Version(tf.__version__) < Version("2.6.0"),
-    reason="TensorFlow autologging is not used for vanilla Keras models in Keras < 2.6.0",
-)
 def test_keras_autolog_input_example_load_and_predict_with_nparray(
     random_train_data, random_one_hot_labels
 ):
@@ -1106,10 +1102,6 @@ def test_keras_autolog_input_example_load_and_predict_with_nparray(
 
 
 @pytest.mark.large
-@pytest.mark.skipif(
-    Version(tf.__version__) < Version("2.6.0"),
-    reason="TensorFlow autologging is not used for vanilla Keras models in Keras < 2.6.0",
-)
 def test_keras_autolog_infers_model_signature_correctly_with_nparray(
     random_train_data, random_one_hot_labels
 ):
@@ -1125,10 +1117,6 @@ def test_keras_autolog_infers_model_signature_correctly_with_nparray(
 
 
 @pytest.mark.large
-@pytest.mark.skipif(
-    Version(tf.__version__) < Version("2.6.0"),
-    reason="TensorFlow autologging is not used for vanilla Keras models in Keras < 2.6.0",
-)
 def test_keras_autolog_input_example_load_and_predict_with_tf_dataset(fashion_mnist_tf_dataset):
     mlflow.tensorflow.autolog(log_input_examples=True)
     fashion_mnist_model = _create_fashion_mnist_model()
@@ -1142,10 +1130,6 @@ def test_keras_autolog_input_example_load_and_predict_with_tf_dataset(fashion_mn
 
 
 @pytest.mark.large
-@pytest.mark.skipif(
-    Version(tf.__version__) < Version("2.6.0"),
-    reason="TensorFlow autologging is not used for vanilla Keras models in Keras < 2.6.0",
-)
 def test_keras_autolog_infers_model_signature_correctly_with_tf_dataset(fashion_mnist_tf_dataset):
     mlflow.tensorflow.autolog(log_model_signatures=True)
     fashion_mnist_model = _create_fashion_mnist_model()
@@ -1159,10 +1143,6 @@ def test_keras_autolog_infers_model_signature_correctly_with_tf_dataset(fashion_
 
 
 @pytest.mark.large
-@pytest.mark.skipif(
-    Version(tf.__version__) < Version("2.6.0"),
-    reason="TensorFlow autologging is not used for vanilla Keras models in Keras < 2.6.0",
-)
 def test_keras_autolog_input_example_load_and_predict_with_dict(
     random_train_dict_mapping, random_one_hot_labels
 ):
@@ -1180,10 +1160,6 @@ def test_keras_autolog_input_example_load_and_predict_with_dict(
 
 
 @pytest.mark.large
-@pytest.mark.skipif(
-    Version(tf.__version__) < Version("2.6.0"),
-    reason="TensorFlow autologging is not used for vanilla Keras models in Keras < 2.6.0",
-)
 def test_keras_autolog_infers_model_signature_correctly_with_dict(
     random_train_dict_mapping, random_one_hot_labels
 ):
@@ -1204,10 +1180,6 @@ def test_keras_autolog_infers_model_signature_correctly_with_dict(
 
 
 @pytest.mark.large
-@pytest.mark.skipif(
-    Version(tf.__version__) < Version("2.6.0"),
-    reason="TensorFlow autologging is not used for vanilla Keras models in Keras < 2.6.0",
-)
 def test_keras_autolog_input_example_load_and_predict_with_keras_sequence(keras_data_gen_sequence):
     mlflow.tensorflow.autolog(log_input_examples=True)
     model = create_tf_keras_model()
@@ -1219,10 +1191,6 @@ def test_keras_autolog_input_example_load_and_predict_with_keras_sequence(keras_
 
 
 @pytest.mark.large
-@pytest.mark.skipif(
-    Version(tf.__version__) < Version("2.6.0"),
-    reason="TensorFlow autologging is not used for vanilla Keras models in Keras < 2.6.0",
-)
 def test_keras_autolog_infers_model_signature_correctly_with_keras_sequence(
     keras_data_gen_sequence,
 ):
@@ -1241,7 +1209,7 @@ def test_keras_autolog_infers_model_signature_correctly_with_keras_sequence(
 def test_keras_autolog_does_not_log_model_signature_when_mlflow_autolog_called(
     keras_data_gen_sequence,
 ):
-    mlflow.tensorflow.autolog()
+    mlflow.autolog()
     initial_model = create_tf_keras_model()
     initial_model.fit(keras_data_gen_sequence)
 

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -156,7 +156,7 @@ def clear_autologging_config():
     Clears TensorFlow autologging config, simulating a fresh state where autologging has not
     been previously enabled with any particular configuration
     """
-    del AUTOLOGGING_INTEGRATIONS[mlflow.tensorflow.FLAVOR_NAME]
+    AUTOLOGGING_INTEGRATIONS.pop(mlflow.tensorflow.FLAVOR_NAME, None)
 
 
 def create_tf_keras_model():
@@ -1212,7 +1212,6 @@ def test_keras_autolog_input_example_load_and_predict_with_keras_sequence(keras_
 
 
 @pytest.mark.large
-@pytest.mark.bungus
 def test_keras_autolog_infers_model_signature_correctly_with_keras_sequence(
     keras_data_gen_sequence,
 ):
@@ -1228,7 +1227,6 @@ def test_keras_autolog_infers_model_signature_correctly_with_keras_sequence(
 
 
 @pytest.mark.large
-@pytest.mark.bungus
 def test_keras_autolog_does_not_log_model_signature_when_mlflow_autolog_called(
     keras_data_gen_sequence,
 ):

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -1235,3 +1235,14 @@ def test_keras_autolog_infers_model_signature_correctly_with_keras_sequence(
             [{"type": "tensor", "tensor-spec": {"dtype": "float64", "shape": [-1, 4]}}],
             [{"type": "tensor", "tensor-spec": {"dtype": "float32", "shape": [-1, 3]}}],
         )
+
+
+@pytest.mark.large
+def test_keras_autolog_does_not_log_model_signature_when_mlflow_autolog_called():
+    mlflow.autolog() 
+    initial_model = create_tf_keras_model()
+    initial_model.fit(keras_data_gen_sequence)
+   
+    mlmodel_path = f"runs:/{mlflow.last_active_run().info.run_id}/model/MLmodel"
+    mlmodel_contents = yaml.safe_load(open(mlmodel_path, "r"))
+    assert "signature" not in mlmodel_contents

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -127,18 +127,6 @@ def keras_data_gen_sequence(random_train_data, random_one_hot_labels):
     return DataGenerator()
 
 
-@pytest.fixture
-def clear_tf_keras_imports():
-    """
-    Simulates a state where `tensorflow` and `keras` are not imported by removing these
-    libraries from the `sys.modules` dictionary. This is useful for testing the interaction
-    between TensorFlow / Keras and the fluent `mlflow.autolog()` API because it will cause import
-    hooks to be re-triggered upon re-import after `mlflow.autolog()` is enabled.
-    """
-    sys.modules.pop("tensorflow", None)
-    sys.modules.pop("keras", None)
-
-
 @pytest.fixture(autouse=True)
 def clear_fluent_autologging_import_hooks():
     """
@@ -954,7 +942,6 @@ def test_tf_keras_model_autolog_registering_model(random_train_data, random_one_
 
 
 @pytest.mark.large
-@pytest.mark.usefixtures("clear_tf_keras_imports")
 def test_fluent_autolog_with_tf_keras_logs_expected_content(
     random_train_data, random_one_hot_labels
 ):
@@ -1012,7 +999,6 @@ def test_tf_keras_autolog_distributed_training(random_train_data, random_one_hot
     Version(tf.__version__) < Version("2.6.0"),
     reason=("TensorFlow only has a hard dependency on Keras in version >= 2.6.0"),
 )
-@pytest.mark.usefixtures("clear_tf_keras_imports")
 def test_fluent_autolog_with_tf_keras_preserves_v2_model_reference():
     """
     Verifies that, in TensorFlow >= 2.6.0, `tensorflow.keras.Model` refers to the correct class in
@@ -1028,7 +1014,6 @@ def test_fluent_autolog_with_tf_keras_preserves_v2_model_reference():
     assert tensorflow.keras.Model is ModelV2
 
 
-@pytest.mark.usefixtures("clear_tf_keras_imports")
 def test_import_tensorflow_with_fluent_autolog_enables_tf_autologging():
     mlflow.autolog()
 
@@ -1045,7 +1030,6 @@ def test_import_tensorflow_with_fluent_autolog_enables_tf_autologging():
 
 
 @pytest.mark.large
-@pytest.mark.usefixtures("clear_tf_keras_imports")
 def test_import_tf_keras_with_fluent_autolog_enables_tf_autologging():
     mlflow.autolog()
 
@@ -1065,7 +1049,6 @@ def test_import_tf_keras_with_fluent_autolog_enables_tf_autologging():
     Version(tf.__version__) < Version("2.6.0"),
     reason=("TensorFlow autologging is not used for vanilla Keras models in Keras < 2.6.0"),
 )
-@pytest.mark.usefixtures("clear_tf_keras_imports")
 def test_import_keras_with_fluent_autolog_enables_tensorflow_autologging():
     mlflow.autolog()
 

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -1239,10 +1239,10 @@ def test_keras_autolog_infers_model_signature_correctly_with_keras_sequence(
 
 @pytest.mark.large
 def test_keras_autolog_does_not_log_model_signature_when_mlflow_autolog_called():
-    mlflow.autolog() 
+    mlflow.autolog()
     initial_model = create_tf_keras_model()
     initial_model.fit(keras_data_gen_sequence)
-   
+
     mlmodel_path = f"runs:/{mlflow.last_active_run().info.run_id}/model/MLmodel"
     mlmodel_contents = yaml.safe_load(open(mlmodel_path, "r"))
     assert "signature" not in mlmodel_contents

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -1113,7 +1113,7 @@ def test_keras_autolog_input_example_load_and_predict_with_nparray(
 def test_keras_autolog_infers_model_signature_correctly_with_nparray(
     random_train_data, random_one_hot_labels
 ):
-    mlflow.tensorflow.autolog()
+    mlflow.tensorflow.autolog(log_model_signatures=True)
     initial_model = create_tf_keras_model()
     with mlflow.start_run() as run:
         initial_model.fit(random_train_data, random_one_hot_labels)
@@ -1147,7 +1147,7 @@ def test_keras_autolog_input_example_load_and_predict_with_tf_dataset(fashion_mn
     reason="TensorFlow autologging is not used for vanilla Keras models in Keras < 2.6.0",
 )
 def test_keras_autolog_infers_model_signature_correctly_with_tf_dataset(fashion_mnist_tf_dataset):
-    mlflow.tensorflow.autolog()
+    mlflow.tensorflow.autolog(log_model_signatures=True)
     fashion_mnist_model = _create_fashion_mnist_model()
     with mlflow.start_run() as run:
         fashion_mnist_model.fit(fashion_mnist_tf_dataset)
@@ -1187,7 +1187,7 @@ def test_keras_autolog_input_example_load_and_predict_with_dict(
 def test_keras_autolog_infers_model_signature_correctly_with_dict(
     random_train_dict_mapping, random_one_hot_labels
 ):
-    mlflow.tensorflow.autolog()
+    mlflow.tensorflow.autolog(log_model_signatures=True)
     model = _create_model_for_dict_mapping()
     with mlflow.start_run() as run:
         model.fit(random_train_dict_mapping, random_one_hot_labels)
@@ -1226,7 +1226,7 @@ def test_keras_autolog_input_example_load_and_predict_with_keras_sequence(keras_
 def test_keras_autolog_infers_model_signature_correctly_with_keras_sequence(
     keras_data_gen_sequence,
 ):
-    mlflow.tensorflow.autolog()
+    mlflow.tensorflow.autolog(log_model_signatures=True)
     initial_model = create_tf_keras_model()
     with mlflow.start_run() as run:
         initial_model.fit(keras_data_gen_sequence)
@@ -1238,11 +1238,15 @@ def test_keras_autolog_infers_model_signature_correctly_with_keras_sequence(
 
 
 @pytest.mark.large
-def test_keras_autolog_does_not_log_model_signature_when_mlflow_autolog_called():
-    mlflow.autolog()
+def test_keras_autolog_does_not_log_model_signature_when_mlflow_autolog_called(
+    keras_data_gen_sequence
+):
+    mlflow.tensorflow.autolog()
     initial_model = create_tf_keras_model()
     initial_model.fit(keras_data_gen_sequence)
 
-    mlmodel_path = f"runs:/{mlflow.last_active_run().info.run_id}/model/MLmodel"
+    mlmodel_path = mlflow.artifacts.download_artifacts(
+        f"runs:/{mlflow.last_active_run().info.run_id}/model/MLmodel"
+    )
     mlmodel_contents = yaml.safe_load(open(mlmodel_path, "r"))
     assert "signature" not in mlmodel_contents

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -1239,7 +1239,7 @@ def test_keras_autolog_infers_model_signature_correctly_with_keras_sequence(
 
 @pytest.mark.large
 def test_keras_autolog_does_not_log_model_signature_when_mlflow_autolog_called(
-    keras_data_gen_sequence
+    keras_data_gen_sequence,
 ):
     mlflow.tensorflow.autolog()
     initial_model = create_tf_keras_model()


### PR DESCRIPTION
## What changes are proposed in this pull request?

Set `log_model_signatures=False` by default for `mlflow.tensorflow.autolog()` for backwards compatibility. Adding a signature to a TensorFlow module unfortunately changes the pyfunc inference output behavior for Pandas DataFrame inputs (see https://github.com/mlflow/mlflow/pull/5510#discussion_r832862461), so we cannot start logging model signatures by default during TensorFlow autologging until MLflow 2.0.

This PR also addresses some small implementation and test issues related to the feature.

## How is this patch tested?

Integration tests

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [X] No. (Doesn't change existing behavior, just adjusts behavior of the new signature logging impl)
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
