### PR TITLE
Specify verson when fetching git repository

### DIFF
--- a/mlflow/projects/utils.py
+++ b/mlflow/projects/utils.py
@@ -188,9 +188,9 @@ def _fetch_git_repo(uri, version, dst_dir):
 
     repo = git.Repo.init(dst_dir)
     origin = repo.create_remote("origin", uri)
-    origin.fetch(refspec=version, depth=GIT_FETCH_DEPTH)
     if version is not None:
         try:
+            origin.fetch(refspec=version, depth=GIT_FETCH_DEPTH)
             repo.git.checkout(version)
         except git.exc.GitCommandError as e:
             raise ExecutionException(

--- a/mlflow/projects/utils.py
+++ b/mlflow/projects/utils.py
@@ -199,6 +199,7 @@ def _fetch_git_repo(uri, version, dst_dir):
                 "Error: %s" % (version, uri, e)
             )
     else:
+        origin.fetch(depth=GIT_FETCH_DEPTH)
         repo.create_head("master", origin.refs.master)
         repo.heads.master.checkout()
     repo.submodule_update(init=True, recursive=True)

--- a/mlflow/projects/utils.py
+++ b/mlflow/projects/utils.py
@@ -188,7 +188,7 @@ def _fetch_git_repo(uri, version, dst_dir):
 
     repo = git.Repo.init(dst_dir)
     origin = repo.create_remote("origin", uri)
-    origin.fetch(depth=GIT_FETCH_DEPTH)
+    origin.fetch(refspec=version, depth=GIT_FETCH_DEPTH)
     if version is not None:
         try:
             repo.git.checkout(version)

--- a/tests/projects/test_utils.py
+++ b/tests/projects/test_utils.py
@@ -2,6 +2,7 @@ import git
 import os
 import tempfile
 
+import requests
 import pytest
 from unittest import mock
 
@@ -103,6 +104,19 @@ def test__fetch_git_repo(local_git_repo, local_git_repo_uri, version, expected_v
     _fetch_git_repo(local_git_repo_uri, version, local_git_repo)
     repo = git.Repo(local_git_repo)
     assert repo.active_branch.name == expected_version
+
+
+@pytest.mark.parametrize(
+    "commit", requests.get(" https://api.github.com/repos/mlflow/mlflow-example/commits").json()[:2]
+)
+def test_fetch_git_repo_commit(tmp_path, commit):
+    _fetch_git_repo(
+        "https://github.com/mlflow/mlflow-example.git",
+        commit["sha"],
+        tmp_path,
+    )
+    repo = git.Repo(tmp_path)
+    assert repo.commit().hexsha == commit["sha"]
 
 
 def test_fetching_non_existing_version_fails(local_git_repo, local_git_repo_uri):

--- a/tests/projects/test_utils.py
+++ b/tests/projects/test_utils.py
@@ -107,7 +107,9 @@ def test__fetch_git_repo(local_git_repo, local_git_repo_uri, version, expected_v
 
 
 @pytest.mark.parametrize(
-    "commit", requests.get(" https://api.github.com/repos/mlflow/mlflow-example/commits").json()[:2]
+    "commit",
+    # Fetch the most recent two commits
+    requests.get("https://api.github.com/repos/mlflow/mlflow-example/commits").json()[:2],
 )
 def test_fetch_git_repo_commit(tmp_path, commit):
     _fetch_git_repo(


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

Fix #5660 which reports the issue where `mlflow run` doesn't work when we pass an old commit to the command:

```bash
# latest commit -> works
mlflow run https://github.com/rcallagh/mlflow_submodule_test.git -v 4ed55d3d2655a710e0de3887e2166be585a66544

# old commit -> doesn't work
mlflow run https://github.com/rcallagh/mlflow_submodule_test.git -v 42886f166fd550ebc56925af36ff80fd92d0095b
```

## How is this patch tested?

Unit test

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
