### PR TITLE
Create test coverage reports by default in pytest

### DIFF
--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -55,7 +55,7 @@ jobs:
           python-version: "3.7"
       - name: Install dependencies
         run: |
-          pip install packaging requests pyyaml pytest
+          pip install packaging requests pyyaml pytest pytest-cov
       - name: Check labels
         uses: actions/github-script@v4
         id: enable-dev-tests

--- a/dev/run-small-python-tests.sh
+++ b/dev/run-small-python-tests.sh
@@ -7,6 +7,6 @@ trap 'err=1' ERR
 export MLFLOW_HOME=$(pwd)
 
 # NB: Also add --ignore'd tests to run-large-python-tests.sh
-pytest --cov=./mlflow --ignore-flavors
+pytest --ignore-flavors
 
 test $err = 0

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --cov-report html --cov=./mlflow --color=yes --durations=5 --showlocals --verbose
+addopts = --cov=./mlflow --cov-report html --color=yes --durations=5 --showlocals --verbose
 # Prevent deprecated numpy type aliases from being used
 filterwarnings =
   error:^`np\.[a-z]+` is a deprecated alias for.+:DeprecationWarning:mlflow

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --color=yes --durations=5 --showlocals --verbose
+addopts = --cov-report html --cov=./mlflow --color=yes --durations=5 --showlocals --verbose
 # Prevent deprecated numpy type aliases from being used
 filterwarnings =
   error:^`np\.[a-z]+` is a deprecated alias for.+:DeprecationWarning:mlflow

--- a/tests/db/Dockerfile
+++ b/tests/db/Dockerfile
@@ -2,6 +2,6 @@ FROM python:3.7
 
 ARG DEPENDENCIES
 
-RUN pip install psycopg2 pymysql mysqlclient pytest
+RUN pip install psycopg2 pymysql mysqlclient pytest pytest-cov
 RUN echo "${DEPENDENCIES}" > /tmp/requriements.txt && pip install -r /tmp/requriements.txt
 RUN pip list

--- a/tests/db/Dockerfile.mssql
+++ b/tests/db/Dockerfile.mssql
@@ -14,6 +14,6 @@ RUN curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list > /etc/apt
 # install SQL Server drivers and tools
 RUN apt-get update && ACCEPT_EULA=Y apt-get install -y mssql-tools unixodbc-dev
 
-RUN pip install pyodbc pytest
+RUN pip install pyodbc pytest pytest-cov
 RUN echo "${DEPENDENCIES}" > /tmp/requriements.txt && pip install -r /tmp/requriements.txt
 RUN pip list


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Create test coverage reports by default in pytest:

<img width="761" alt="image" src="https://user-images.githubusercontent.com/17039389/162886256-d5e65809-16cc-4daa-8bae-b0c23a37c899.png">

The reports are created in `htmlcov` and can be view on the broswer.

## Motivation

To make it easier to find lines that are not covered by tests.

## How is this patch tested?

Manually

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
