### PR TITLE
Prevent calling `unittest.TestCase.assertRaises` without `msg` argument

### DIFF
--- a/pylint_plugins/__init__.py
+++ b/pylint_plugins/__init__.py
@@ -1,7 +1,9 @@
 from .pytest_raises_without_match import PytestRaisesWithoutMatch
 from .print_function import PrintFunction
+from .assert_raises_without_msg import AssertRaisesWithoutMsg
 
 
 def register(linter):
     linter.register_checker(PytestRaisesWithoutMatch(linter))
     linter.register_checker(PrintFunction(linter))
+    linter.register_checker(AssertRaisesWithoutMsg(linter))

--- a/pylint_plugins/assert_raises_without_msg.py
+++ b/pylint_plugins/assert_raises_without_msg.py
@@ -48,7 +48,7 @@ class AssertRaisesWithoutMsg(BaseChecker):
         "W0003": (
             "assertRaises must be called with `msg` argument",
             name,
-            "Use assertRaisesRegex with ",
+            "Use `msg` argument",
         ),
     }
     priority = -1

--- a/pylint_plugins/assert_raises_without_msg.py
+++ b/pylint_plugins/assert_raises_without_msg.py
@@ -25,7 +25,7 @@ IGNORE_FILES = list(
             # 4. Run pylint again and confirm it succeeds now.
             # 5. Run pytest and confirm the changed lines don't fail.
             # 6. Open a PR.
-            # "tests/entities/test_run_status.py",
+            "tests/entities/test_run_status.py",
             "tests/store/model_registry/test_sqlalchemy_store.py",
             "tests/store/db/test_utils.py",
             "tests/store/tracking/__init__.py",

--- a/pylint_plugins/assert_raises_without_msg.py
+++ b/pylint_plugins/assert_raises_without_msg.py
@@ -1,0 +1,58 @@
+import os
+
+import astroid
+from pylint.interfaces import IAstroidChecker
+from pylint.checkers import BaseChecker
+
+
+def _is_assert_raises_without_msg(node: astroid.Call):
+    return (
+        isinstance(node.func, astroid.Attribute)
+        and node.func.as_string() == "self.assertRaises"
+        and "msg" not in [k.arg for k in node.keywords]
+    )
+
+
+IGNORE_FILES = list(
+    map(
+        os.path.abspath,
+        [
+            # Instructions
+            # ============
+            # 1. Select a file in the list below and remove it.
+            # 2. Run pylint and confirm it fails.
+            # 3. Fix the lines printed out in the previous step.
+            # 4. Run pylint again and confirm it succeeds now.
+            # 5. Run pytest and confirm the changed lines don't fail.
+            # 6. Open a PR.
+            # "tests/entities/test_run_status.py",
+            "tests/store/model_registry/test_sqlalchemy_store.py",
+            "tests/store/db/test_utils.py",
+            "tests/store/tracking/__init__.py",
+            "tests/store/tracking/test_file_store.py",
+            "tests/store/tracking/test_sqlalchemy_store.py",
+        ],
+    )
+)
+
+
+def _should_ignore(path: str):
+    return path in IGNORE_FILES
+
+
+class AssertRaisesWithoutMsg(BaseChecker):
+    __implements__ = IAstroidChecker
+
+    name = "assert-raises"
+    msgs = {
+        "W0003": (
+            "assertRaises must be called with `msg` argument",
+            name,
+            "Use assertRaisesRegex with ",
+        ),
+    }
+    priority = -1
+
+    def visit_call(self, node: astroid.Call):
+        if not _should_ignore(node.root().file) and _is_assert_raises_without_msg(node):
+            self.add_message(self.name, node=node)

--- a/tests/pylint_plugins/test_assert_raises_without_msg.py
+++ b/tests/pylint_plugins/test_assert_raises_without_msg.py
@@ -1,0 +1,33 @@
+import pytest
+
+from tests.pylint_plugins.utils import create_message, extract_node, skip_if_pylint_unavailable
+
+pytestmark = skip_if_pylint_unavailable()
+
+
+@pytest.fixture(scope="module")
+def test_case():
+    import pylint.testutils
+    from pylint_plugins import AssertRaisesWithoutMsg
+
+    class TestAssertRaisesWithoutMsg(pylint.testutils.CheckerTestCase):
+        CHECKER_CLASS = AssertRaisesWithoutMsg
+
+    test_case = TestAssertRaisesWithoutMsg()
+    test_case.setup_method()
+    return test_case
+
+
+def test_assert_raises_without_msg(test_case):
+    node = extract_node("self.assertRaises(Exception)")
+    with test_case.assertAddsMessages(create_message(test_case.CHECKER_CLASS.name, node)):
+        test_case.walk(node)
+
+    node = extract_node("self.assertRaises(Exception, msg='test')")
+    print(node)
+    with test_case.assertNoMessages():
+        test_case.walk(node)
+
+    node = extract_node("pandas.assertRaises(Exception)")
+    with test_case.assertNoMessages():
+        test_case.walk(node)

--- a/tests/pylint_plugins/test_assert_raises_without_msg.py
+++ b/tests/pylint_plugins/test_assert_raises_without_msg.py
@@ -24,7 +24,6 @@ def test_assert_raises_without_msg(test_case):
         test_case.walk(node)
 
     node = extract_node("self.assertRaises(Exception, msg='test')")
-    print(node)
     with test_case.assertNoMessages():
         test_case.walk(node)
 


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Prevent calling `unittest.TestCase.assertRaises` without `msg` argument to avoid catching incorrect exceptions.

## How is this patch tested?

Unit test

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
