### PR TITLE
Make `pyfunc.spark_udf` support virtualenv

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1178,7 +1178,7 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
                 local_model_path_on_executor,
                 workers=1,
                 install_mlflow=False,
-                env_manager=_EnvManager.CONDA,
+                env_manager=env_manager,
                 env_root_dir=env_root_dir_on_executor,
             )
 

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -969,15 +969,17 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
 
         - ``ArrayType(StringType)``: All columns converted to ``string``.
 
-    :param env_manager: The environment manager to use in order to create the
-                        software environment for model inference. Default value is ``local``,
-                        The following values are supported:
+    :param env_manager: The environment manager to use in order to create the software environment
+                        for model inference. Note that environment is only restored in the context
+                        of the PySpark UDF; the software environment outside of the UDF is
+                        unaffected. Default value is ``local``, and the following values are
+                        supported:
 
                          - ``conda``: (Recommended) Use Conda to restore the software environment
                            that was used to train the model. Note that environment is only restored
                            in the context of the PySpark UDF; the software environment outside of
                            the UDF is unaffected.
-                        - ``virtualenv``: Use virtualenv to restore the software environment
+                         - ``virtualenv``: Use virtualenv to restore the software environment.
                          - ``local``: Use the current Python environment for model inference, which
                            may differ from the environment used to train the model and may lead to
                            errors or invalid predictions.

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -969,7 +969,7 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
 
         - ``ArrayType(StringType)``: All columns converted to ``string``.
 
-    :param env_manager: The environment manager to use in order to create the software environment
+    :param env_manager: The environment manager to use in order to create the python environment
                         for model inference. Note that environment is only restored in the context
                         of the PySpark UDF; the software environment outside of the UDF is
                         unaffected. Default value is ``local``, and the following values are

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -977,6 +977,7 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
                            that was used to train the model. Note that environment is only restored
                            in the context of the PySpark UDF; the software environment outside of
                            the UDF is unaffected.
+                        - ``virtualenv``: Use virtualenv to restore the software environment
                          - ``local``: Use the current Python environment for model inference, which
                            may differ from the environment used to train the model and may lead to
                            errors or invalid predictions.
@@ -1009,7 +1010,7 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
     nfs_root_dir = get_nfs_cache_root_dir()
     should_use_nfs = nfs_root_dir is not None
     should_use_spark_to_broadcast_file = not (is_spark_in_local_mode or should_use_nfs)
-    conda_env_root_dir = _get_or_create_env_root_dir(should_use_nfs)
+    env_root_dir = _get_or_create_env_root_dir(should_use_nfs)
 
     if not isinstance(result_type, SparkDataType):
         result_type = _parse_datatype_string(result_type)
@@ -1067,12 +1068,12 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
         # "capture_output=False" is the output will be printed immediately, otherwise you have
         # to wait conda command fail and suddenly get all output printed (included in error
         # message).
-        if env_manager is _EnvManager.CONDA:
+        if env_manager is not _EnvManager.LOCAL:
             _get_flavor_backend(
                 local_model_path,
-                env_manager=_EnvManager.CONDA,
+                env_manager=env_manager,
                 install_mlflow=False,
-                env_root_dir=conda_env_root_dir,
+                env_root_dir=env_root_dir,
             ).prepare_env(model_uri=local_model_path, capture_output=is_in_databricks_runtime())
 
     # Broadcast local model directory to remote worker if needed.
@@ -1162,24 +1163,23 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
 
         scoring_server_proc = None
 
-        # TODO: Support virtual env.
-        if env_manager is _EnvManager.CONDA:
+        if env_manager is not _EnvManager.LOCAL:
             if should_use_spark_to_broadcast_file:
                 local_model_path_on_executor = _SparkDirectoryDistributor.get_or_extract(
                     archive_path
                 )
                 # Create individual conda_env_root_dir for each spark UDF task process.
-                conda_env_root_dir_on_executor = _get_or_create_env_root_dir(should_use_nfs)
+                env_root_dir_on_executor = _get_or_create_env_root_dir(should_use_nfs)
             else:
                 local_model_path_on_executor = local_model_path
-                conda_env_root_dir_on_executor = conda_env_root_dir
+                env_root_dir_on_executor = env_root_dir
 
             pyfunc_backend = _get_flavor_backend(
                 local_model_path_on_executor,
                 workers=1,
                 install_mlflow=False,
                 env_manager=_EnvManager.CONDA,
-                env_root_dir=conda_env_root_dir_on_executor,
+                env_root_dir=env_root_dir_on_executor,
             )
 
             if should_use_spark_to_broadcast_file:

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -977,7 +977,7 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
 
                          - ``conda``: (Recommended) Use Conda to restore the software environment
                            that was used to train the model.
-                         - ``virtualenv``: Use virtualenv to restore the software environment that
+                         - ``virtualenv``: Use virtualenv to restore the python environment that
                            was used to train the model.
                          - ``local``: Use the current Python environment for model inference, which
                            may differ from the environment used to train the model and may lead to

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -976,10 +976,9 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
                         supported:
 
                          - ``conda``: (Recommended) Use Conda to restore the software environment
-                           that was used to train the model. Note that environment is only restored
-                           in the context of the PySpark UDF; the software environment outside of
-                           the UDF is unaffected.
-                         - ``virtualenv``: Use virtualenv to restore the software environment.
+                           that was used to train the model.
+                         - ``virtualenv``: Use virtualenv to restore the software environment that
+                           was used to train the model.
                          - ``local``: Use the current Python environment for model inference, which
                            may differ from the environment used to train the model and may lead to
                            errors or invalid predictions.

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -219,6 +219,7 @@ class PyFuncBackend(FlavorBackend):
                 command,
                 self._install_mlflow,
                 command_env=command_env,
+                capture_output=False,
                 synchronous=False,
                 env_root_dir=self._env_root_dir,
                 preexec_fn=setup_sigterm_on_parent_death,

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -62,7 +62,7 @@ class PyFuncBackend(FlavorBackend):
         local_path = _download_artifact_from_uri(model_uri)
 
         command = 'python -c ""'
-        if self._env_manager is _EnvManager.VIRTUALENV:
+        if self._env_manager == _EnvManager.VIRTUALENV:
             activate_cmd = _get_or_create_virtualenv(
                 local_path,
                 self._env_id,

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -211,7 +211,11 @@ class PyFuncBackend(FlavorBackend):
             )
             child_proc = _execute_in_virtualenv(
                 activate_cmd, command, self._install_mlflow,
-                extra_env=_get_virtualenv_extra_env_vars(self._env_root_dir)
+                extra_env=_get_virtualenv_extra_env_vars(self._env_root_dir),
+                synchronous=False,
+                preexec_fn=setup_sigterm_on_parent_death,
+                stdout=stdout,
+                stderr=stderr,
             )
         else:
             _logger.info("=== Running command '%s'", command)

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -61,18 +61,20 @@ class PyFuncBackend(FlavorBackend):
 
     def prepare_env(self, model_uri, capture_output=False):
         local_path = _download_artifact_from_uri(model_uri)
-        if self._env_manager is _EnvManager.LOCAL or ENV not in self._config:
-            return 0
 
         command = 'python -c ""'
         if self._env_manager is _EnvManager.VIRTUALENV:
             activate_cmd = _get_or_create_virtualenv(
-                local_path, self._env_id, env_root_dir=self._env_root_dir
+                local_path, self._env_id, env_root_dir=self._env_root_dir,
+                capture_output=capture_output
             )
             return _execute_in_virtualenv(
                 activate_cmd, command, self._install_mlflow,
-                extra_env=_get_virtualenv_extra_env_vars(self._env_root_dir)
+                extra_env=_get_virtualenv_extra_env_vars(self._env_root_dir),
+                capture_output=capture_output
             )
+        elif self._env_manager is _EnvManager.LOCAL or ENV not in self._config:
+            return 0
 
         conda_env_path = os.path.join(local_path, self._config[ENV])
         conda_env_name = get_or_create_conda_env(

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -210,7 +210,7 @@ class PyFuncBackend(FlavorBackend):
                 local_path, self._env_id, env_root_dir=self._env_root_dir
             )
             child_proc = _execute_in_virtualenv(
-                activate_cmd, command, self._install_mlflow, command_env,
+                activate_cmd, command, self._install_mlflow,
                 extra_env=_get_virtualenv_extra_env_vars(self._env_root_dir)
             )
         else:

--- a/mlflow/utils/conda.py
+++ b/mlflow/utils/conda.py
@@ -143,7 +143,7 @@ def _get_conda_extra_env_vars(env_root_dir=None):
         "CONDA_ENVS_PATH": conda_envs_path,
         "CONDA_PKGS_DIRS": conda_pkgs_path,
         "PIP_CACHE_DIR": pip_cache_dir,
-        # PIP_NO_INPUT=1 make pip run in non-interactive mode,
+        # PIP_NO_INPUT=1 makes pip run in non-interactive mode,
         # otherwise pip might prompt "yes or no" and ask stdin input
         "PIP_NO_INPUT": "1",
     }

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -499,7 +499,9 @@ def get_or_create_tmp_dir():
         # Note: For python process attached to databricks notebook, atexit does not work.
         # The /tmp/repl_tmp_data/{repl_id} directory will be removed once databricks notebook
         # detaches.
-        tmp_dir = os.path.join("/tmp", "repl_tmp_data", get_repl_id())
+        # The repl_tmp_data directory is designed to be used by all kinds of applications,
+        # so create a child directory "mlflow" for storing mlflow temp data.
+        tmp_dir = os.path.join("/tmp", "repl_tmp_data", get_repl_id(), "mlflow")
         os.makedirs(tmp_dir, exist_ok=True)
     else:
         tmp_dir = tempfile.mkdtemp()
@@ -525,7 +527,9 @@ def get_or_create_nfs_tmp_dir():
         # Note: In databricks, atexit hook does not work.
         # The {nfs_root_dir}/repl_tmp_data/{repl_id} directory will be removed once databricks
         # notebook detaches.
-        tmp_nfs_dir = os.path.join(nfs_root_dir, "repl_tmp_data", get_repl_id())
+        # The repl_tmp_data directory is designed to be used by all kinds of applications,
+        # so create a child directory "mlflow" for storing mlflow temp data.
+        tmp_nfs_dir = os.path.join(nfs_root_dir, "repl_tmp_data", get_repl_id(), "mlflow")
         os.makedirs(tmp_nfs_dir, exist_ok=True)
     else:
         tmp_nfs_dir = tempfile.mkdtemp(dir=nfs_root_dir)

--- a/mlflow/utils/process.py
+++ b/mlflow/utils/process.py
@@ -47,7 +47,7 @@ def _exec_cmd(
                             message on failure; if False, these streams won't be captured.
     :param: synchronous: If True, wait process complete and return a CompletedProcess instance,
                          If False, does not wait process complete and return a Popen instance,
-                         and ignore the `throw_on_error`, `check`, `capture_output` argument.
+                         and ignore the `throw_on_error`, `check`, argument.
     :param kwargs: Keyword arguments (except `check` and `text`) passed to `subprocess.run` or
                    `subproces.Popen`.
     :return:  If synchronous is True, return a `subprocess.CompletedProcess` instance,
@@ -81,6 +81,10 @@ def _exec_cmd(
             raise ShellCommandException.from_completed_process(prc)
         return prc
     else:
+        if capture_output:
+            kwargs['stdout'] = subprocess.PIPE
+            kwargs['stderr'] = subprocess.PIPE
+
         return subprocess.Popen(
             cmd,
             env=env,

--- a/mlflow/utils/process.py
+++ b/mlflow/utils/process.py
@@ -48,7 +48,7 @@ def _exec_cmd(
     :param: synchronous: If True, wait for the command to complete and return a CompletedProcess
                          instance, If False, does not wait for the command to complete and return
                          a Popen instance, and ignore the `throw_on_error` argument.
-    :param kwargs: Keyword arguments (except `text`) passed to `subproces.Popen`.
+    :param kwargs: Keyword arguments (except `text`) passed to `subprocess.Popen`.
     :return:  If synchronous is True, return a `subprocess.CompletedProcess` instance,
               otherwise return a Popen instance.
     """

--- a/mlflow/utils/process.py
+++ b/mlflow/utils/process.py
@@ -47,7 +47,7 @@ def _exec_cmd(
                             message on failure; if False, these streams won't be captured.
     :param: synchronous: If True, wait process complete and return a CompletedProcess instance,
                          If False, does not wait process complete and return a Popen instance,
-                         and ignore the `throw_on_error`, `check`, argument.
+                         and ignore the `throw_on_error` argument.
     :param kwargs: Keyword arguments (except `check` and `text`) passed to `subprocess.run` or
                    `subproces.Popen`.
     :return:  If synchronous is True, return a `subprocess.CompletedProcess` instance,
@@ -63,34 +63,39 @@ def _exec_cmd(
 
     env = env if extra_env is None else {**os.environ, **extra_env}
 
-    # In Python < 3.8, `subprocess.Popen` doesn't accpet a command containing path-like
+    # In Python < 3.8, `subprocess.Popen` doesn't accept a command containing path-like
     # objects (e.g. `["ls", pathlib.Path("abc")]`) on Windows. To avoid this issue,
     # stringify all elements in `cmd`. Note `str(pathlib.Path("abc"))` returns 'abc'.
     cmd = list(map(str, cmd))
 
-    if synchronous:
-        prc = subprocess.run(
-            cmd,
-            env=env,
-            check=False,
-            capture_output=capture_output,
-            text=True,
-            **kwargs,
-        )
-        if throw_on_error and prc.returncode != 0:
-            raise ShellCommandException.from_completed_process(prc)
-        return prc
-    else:
-        if capture_output:
-            kwargs["stdout"] = subprocess.PIPE
-            kwargs["stderr"] = subprocess.PIPE
+    if capture_output:
+        if kwargs.get('stdout') is not None or kwargs.get('stderr') is not None:
+            raise ValueError(
+                'stdout and stderr arguments may not be used with capture_output.'
+            )
+        kwargs["stdout"] = subprocess.PIPE
+        kwargs["stderr"] = subprocess.PIPE
 
-        return subprocess.Popen(
-            cmd,
-            env=env,
-            text=True,
-            **kwargs,
-        )
+    process = subprocess.Popen(
+        cmd,
+        env=env,
+        text=True,
+        **kwargs,
+    )
+    if not synchronous:
+        return process
+
+    stdout, stderr = process.communicate()
+    returncode = process.poll()
+    comp_process = subprocess.CompletedProcess(
+        process.args,
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+    if throw_on_error and returncode != 0:
+        raise ShellCommandException.from_completed_process(comp_process)
+    return comp_process
 
 
 def _join_commands(*commands):

--- a/mlflow/utils/process.py
+++ b/mlflow/utils/process.py
@@ -82,8 +82,8 @@ def _exec_cmd(
         return prc
     else:
         if capture_output:
-            kwargs['stdout'] = subprocess.PIPE
-            kwargs['stderr'] = subprocess.PIPE
+            kwargs["stdout"] = subprocess.PIPE
+            kwargs["stderr"] = subprocess.PIPE
 
         return subprocess.Popen(
             cmd,

--- a/mlflow/utils/process.py
+++ b/mlflow/utils/process.py
@@ -45,9 +45,9 @@ def _exec_cmd(
                       If this argument is specified, `kwargs` cannot contain `env`.
     :param: capture_output: If True, stdout and stderr will be captured and included in an exception
                             message on failure; if False, these streams won't be captured.
-    :param: synchronous: If True, wait process complete and return a CompletedProcess instance,
-                         If False, does not wait process complete and return a Popen instance,
-                         and ignore the `throw_on_error` argument.
+    :param: synchronous: If True, wait for the command to complete and return a CompletedProcess
+                         instance, If False, does not wait for the command to complete and return
+                         a Popen instance, and ignore the `throw_on_error` argument.
     :param kwargs: Keyword arguments (except `text`) passed to `subproces.Popen`.
     :return:  If synchronous is True, return a `subprocess.CompletedProcess` instance,
               otherwise return a Popen instance.

--- a/mlflow/utils/process.py
+++ b/mlflow/utils/process.py
@@ -68,10 +68,8 @@ def _exec_cmd(
     cmd = list(map(str, cmd))
 
     if capture_output:
-        if kwargs.get('stdout') is not None or kwargs.get('stderr') is not None:
-            raise ValueError(
-                'stdout and stderr arguments may not be used with capture_output.'
-            )
+        if kwargs.get("stdout") is not None or kwargs.get("stderr") is not None:
+            raise ValueError("stdout and stderr arguments may not be used with capture_output.")
         kwargs["stdout"] = subprocess.PIPE
         kwargs["stderr"] = subprocess.PIPE
 

--- a/mlflow/utils/process.py
+++ b/mlflow/utils/process.py
@@ -37,7 +37,7 @@ def _exec_cmd(
     **kwargs,
 ):
     """
-    A convenience wrapper of `subprocess.run` for running a command from a Python script.
+    A convenience wrapper of `subprocess.Popen` for running a command from a Python script.
 
     :param cmd: The command to run, as a list of strings.
     :param throw_on_error: If True, raises an Exception if the exit code of the program is nonzero.
@@ -48,12 +48,11 @@ def _exec_cmd(
     :param: synchronous: If True, wait process complete and return a CompletedProcess instance,
                          If False, does not wait process complete and return a Popen instance,
                          and ignore the `throw_on_error` argument.
-    :param kwargs: Keyword arguments (except `check` and `text`) passed to `subprocess.run` or
-                   `subproces.Popen`.
+    :param kwargs: Keyword arguments (except `text`) passed to `subproces.Popen`.
     :return:  If synchronous is True, return a `subprocess.CompletedProcess` instance,
               otherwise return a Popen instance.
     """
-    illegal_kwargs = set(kwargs.keys()).intersection(("check", "text"))
+    illegal_kwargs = set(kwargs.keys()).intersection({"text"})
     if illegal_kwargs:
         raise ValueError(f"`kwargs` cannot contain {list(illegal_kwargs)}")
 

--- a/mlflow/utils/virtualenv.py
+++ b/mlflow/utils/virtualenv.py
@@ -103,9 +103,8 @@ def _install_python(version, pyenv_root=None, capture_output=False):
     binary.
 
     :param version: Python version to install.
-    :param pyenv_root: PYENV_ROOT path string. If None, use default PYENV_ROOT. The path is used
-                       to hold the python binaries downloaded by pyenv. We can still use "pyenv"
-                       command installed in other directory.
+    :param pyenv_root: The value of the "PYENV_ROOT" environment variable used when running
+                       `pyenv install` which installs python in `{PYENV_ROOT}/versions/{version}`.
     :param capture_output: Set the `capture_output` argument when calling `_exec_cmd`
     :return: Path to the installed python binary.
     """

--- a/mlflow/utils/virtualenv.py
+++ b/mlflow/utils/virtualenv.py
@@ -212,7 +212,7 @@ def _get_virtualenv_extra_env_vars(env_root_dir=None):
         "PIP_NO_INPUT": "1",
     }
     if env_root_dir is not None:
-        extra_env["PIP_CACHE_DIR"] = str(env_root_dir / "pip_cache_pkgs")
+        extra_env["PIP_CACHE_DIR"] = os.path.join(env_root_dir, "pip_cache_pkgs")
     return extra_env
 
 
@@ -239,16 +239,16 @@ def _get_or_create_virtualenv(local_model_path, env_id=None, env_root_dir=None):
 
     extra_env = _get_virtualenv_extra_env_vars(env_root_dir)
     if env_root_dir is not None:
-        virtual_envs_root_path = env_root_dir / "virtualenv_envs"
-        pyenv_root = str(env_root_dir / "pyenv")
+        virtual_envs_root_path = Path(env_root_dir) / "virtualenv_envs"
+        pyenv_root_dir = os.path.join(env_root_dir, "pyenv")
     else:
         virtual_envs_root_path = Path(_get_mlflow_virtualenv_root())
-        pyenv_root = None
+        pyenv_root_dir = None
 
     virtual_envs_root_path.mkdir(parents=True, exist_ok=True)
 
     # Create an environment
-    python_bin_path = _install_python(python_env.python, pyenv_root=pyenv_root)
+    python_bin_path = _install_python(python_env.python, pyenv_root=pyenv_root_dir)
     requirements = _parse_requirements(
         python_env.dependencies,
         is_constraint=False,

--- a/mlflow/utils/virtualenv.py
+++ b/mlflow/utils/virtualenv.py
@@ -103,7 +103,9 @@ def _install_python(version, pyenv_root=None, capture_output=False):
     binary.
 
     :param version: Python version to install.
-    :param pyenv_root: PYENV_ROOT path string. If None, use default PYENV_ROOT.
+    :param pyenv_root: PYENV_ROOT path string. If None, use default PYENV_ROOT. The path is used
+                       to hold the python binaries downloaded by pyenv. We can still use "pyenv"
+                       command installed in other directory.
     :param capture_output: Set the `capture_output` argument when calling `_exec_cmd`
     :return: Path to the installed python binary.
     """

--- a/mlflow/utils/virtualenv.py
+++ b/mlflow/utils/virtualenv.py
@@ -16,7 +16,7 @@ from mlflow.utils.environment import (
     _get_mlflow_env_name,
     _get_pip_install_mlflow,
 )
-from mlflow.utils.conda import _get_conda_dependencies
+from mlflow.utils.conda import _get_conda_dependencies, _PIP_CACHE_DIR
 from mlflow.utils.databricks_utils import is_in_databricks_runtime
 
 _MLFLOW_ENV_ROOT_ENV_VAR = "MLFLOW_ENV_ROOT"
@@ -218,8 +218,13 @@ def _get_virtualenv_extra_env_vars(env_root_dir=None):
         "PIP_NO_INPUT": "1",
     }
     if env_root_dir is not None:
-        extra_env["PIP_CACHE_DIR"] = os.path.join(env_root_dir, "pip_cache_pkgs")
+        # Note: Both conda pip and virtualenv can use the pip cache directory.
+        extra_env["PIP_CACHE_DIR"] = os.path.join(env_root_dir, _PIP_CACHE_DIR)
     return extra_env
+
+
+_VIRTUALENV_ENVS_DIR = "virtualenv_envs"
+_PYENV_ROOT_DIR = "pyenv_root"
 
 
 def _get_or_create_virtualenv(
@@ -247,8 +252,9 @@ def _get_or_create_virtualenv(
 
     extra_env = _get_virtualenv_extra_env_vars(env_root_dir)
     if env_root_dir is not None:
-        virtual_envs_root_path = Path(env_root_dir) / "virtualenv_envs"
-        pyenv_root_dir = os.path.join(env_root_dir, "pyenv")
+        virtual_envs_root_path = Path(env_root_dir) / _VIRTUALENV_ENVS_DIR
+        pyenv_root_dir = os.path.join(env_root_dir, _PYENV_ROOT_DIR)
+        pyenv_root_dir.mkdir(parents=True, exist_ok=True)
     else:
         virtual_envs_root_path = Path(_get_mlflow_virtualenv_root())
         pyenv_root_dir = None

--- a/mlflow/utils/virtualenv.py
+++ b/mlflow/utils/virtualenv.py
@@ -216,7 +216,7 @@ def _create_virtualenv(
 
 def _get_virtualenv_extra_env_vars(env_root_dir=None):
     extra_env = {
-        # PIP_NO_INPUT=1 make pip run in non-interactive mode,
+        # PIP_NO_INPUT=1 makes pip run in non-interactive mode,
         # otherwise pip might prompt "yes or no" and ask stdin input
         "PIP_NO_INPUT": "1",
     }

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -20,7 +20,6 @@ from mlflow.exceptions import MlflowException
 from mlflow.models import ModelSignature
 from mlflow.pyfunc import spark_udf, PythonModel, PyFuncModel
 from mlflow.pyfunc.spark_model_cache import SparkModelCache
-from mlflow.utils import env_manager as _EnvManager
 
 import tests
 from mlflow.types import Schema, ColSpec

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -401,7 +401,9 @@ def test_model_cache(spark, model_path):
 )
 @pytest.mark.large
 @pytest.mark.parametrize("env_manager", ["virtualenv", "conda"])
-def test_spark_udf_embedded_model_server_killed_when_job_canceled(spark, sklearn_model, model_path, env_manager):
+def test_spark_udf_embedded_model_server_killed_when_job_canceled(
+    spark, sklearn_model, model_path, env_manager
+):
     from mlflow.pyfunc.scoring_server.client import ScoringServerClient
     from mlflow.models.cli import _get_flavor_backend
 
@@ -433,9 +435,9 @@ def test_spark_udf_embedded_model_server_killed_when_job_canceled(spark, sklearn
         # and the udf task starts a mlflow model server process.
         spark.range(1).repartition(1).select(udf_with_model_server("id")).collect()
 
-    _get_flavor_backend(
-        model_path, env_manager=env_manager, install_mlflow=False
-    ).prepare_env(model_uri=model_path)
+    _get_flavor_backend(model_path, env_manager=env_manager, install_mlflow=False).prepare_env(
+        model_uri=model_path
+    )
 
     job_thread = threading.Thread(target=run_job)
     job_thread.start()

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -407,7 +407,6 @@ def test_spark_udf_embedded_model_server_killed_when_job_canceled(
     from mlflow.pyfunc.scoring_server.client import ScoringServerClient
     from mlflow.models.cli import _get_flavor_backend
 
-    env_manager = _EnvManager.from_string(env_manager)
     mlflow.sklearn.save_model(sklearn_model.model, model_path)
 
     server_port = 51234


### PR DESCRIPTION
## What changes are proposed in this pull request?

Make `pyfunc.spark_udf` support using virtualenv to restore python environment.

## How is this patch tested?

Unit tests.

Manually tests on databricks spark cluster:

(enable nfs)
https://e2-dogfood.staging.cloud.databricks.com/?o=6051921418418893#notebook/4182715196395444/command/4182715196395447

(disable nfs)
https://e2-dogfood.staging.cloud.databricks.com/?o=6051921418418893#notebook/2161901739220879/command/2161901739220880


## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Make `pyfunc.spark_udf` support using virtualenv to restore python environment.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
