### PR TITLE
Fix temp directory permission issue on worker side

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -873,6 +873,8 @@ def _create_model_downloading_tmp_dir(should_use_nfs):
     os.makedirs(root_model_cache_dir, exist_ok=True)
 
     tmp_model_dir = tempfile.mkdtemp(dir=root_model_cache_dir)
+    # mkdtemp create directory with permission 0o700
+    # change it to be 0o777 to ensure it can be seen in spark UDF
     os.chmod(tmp_model_dir, 0o777)
     return tmp_model_dir
 

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -873,6 +873,7 @@ def _create_model_downloading_tmp_dir(should_use_nfs):
     os.makedirs(root_model_cache_dir, exist_ok=True)
 
     tmp_model_dir = tempfile.mkdtemp(dir=root_model_cache_dir)
+    os.chmod(tmp_model_dir, 0o777)
     return tmp_model_dir
 
 

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -873,7 +873,7 @@ def _create_model_downloading_tmp_dir(should_use_nfs):
     os.makedirs(root_model_cache_dir, exist_ok=True)
 
     tmp_model_dir = tempfile.mkdtemp(dir=root_model_cache_dir)
-    # mkdtemp create directory with permission 0o700
+    # mkdtemp creates a directory with permission 0o700
     # change it to be 0o777 to ensure it can be seen in spark UDF
     os.chmod(tmp_model_dir, 0o777)
     return tmp_model_dir

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -503,6 +503,7 @@ def get_or_create_tmp_dir():
         os.makedirs(tmp_dir, exist_ok=True)
     else:
         tmp_dir = tempfile.mkdtemp()
+        os.chmod(tmp_dir, 0o777)
         atexit.register(shutil.rmtree, tmp_dir, ignore_errors=True)
 
     return tmp_dir
@@ -526,6 +527,7 @@ def get_or_create_nfs_tmp_dir():
         os.makedirs(tmp_nfs_dir, exist_ok=True)
     else:
         tmp_nfs_dir = tempfile.mkdtemp(dir=nfs_root_dir)
+        os.chmod(tmp_nfs_dir, 0o777)
         atexit.register(shutil.rmtree, tmp_nfs_dir, ignore_errors=True)
 
     return tmp_nfs_dir

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -503,7 +503,7 @@ def get_or_create_tmp_dir():
         os.makedirs(tmp_dir, exist_ok=True)
     else:
         tmp_dir = tempfile.mkdtemp()
-        # mkdtemp create directory with permission 0o700
+        # mkdtemp creates a directory with permission 0o700
         # change it to be 0o777 to ensure it can be seen in spark UDF
         os.chmod(tmp_dir, 0o777)
         atexit.register(shutil.rmtree, tmp_dir, ignore_errors=True)
@@ -529,7 +529,7 @@ def get_or_create_nfs_tmp_dir():
         os.makedirs(tmp_nfs_dir, exist_ok=True)
     else:
         tmp_nfs_dir = tempfile.mkdtemp(dir=nfs_root_dir)
-        # mkdtemp create directory with permission 0o700
+        # mkdtemp creates a directory with permission 0o700
         # change it to be 0o777 to ensure it can be seen in spark UDF
         os.chmod(tmp_nfs_dir, 0o777)
         atexit.register(shutil.rmtree, tmp_nfs_dir, ignore_errors=True)

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -503,6 +503,8 @@ def get_or_create_tmp_dir():
         os.makedirs(tmp_dir, exist_ok=True)
     else:
         tmp_dir = tempfile.mkdtemp()
+        # mkdtemp create directory with permission 0o700
+        # change it to be 0o777 to ensure it can be seen in spark UDF
         os.chmod(tmp_dir, 0o777)
         atexit.register(shutil.rmtree, tmp_dir, ignore_errors=True)
 
@@ -527,6 +529,8 @@ def get_or_create_nfs_tmp_dir():
         os.makedirs(tmp_nfs_dir, exist_ok=True)
     else:
         tmp_nfs_dir = tempfile.mkdtemp(dir=nfs_root_dir)
+        # mkdtemp create directory with permission 0o700
+        # change it to be 0o777 to ensure it can be seen in spark UDF
         os.chmod(tmp_nfs_dir, 0o777)
         atexit.register(shutil.rmtree, tmp_nfs_dir, ignore_errors=True)
 

--- a/mlflow/utils/nfs_on_spark.py
+++ b/mlflow/utils/nfs_on_spark.py
@@ -1,3 +1,7 @@
+import os
+import uuid
+import shutil
+
 from mlflow.utils.databricks_utils import is_in_databricks_runtime
 from mlflow.utils._spark_utils import _get_active_spark_session
 
@@ -25,7 +29,18 @@ def get_nfs_cache_root_dir():
             == "true"
         )
         if nfs_enabled:
-            return "/local_disk0/.ephemeral_nfs"
+            nfs_root_dir = "/local_disk0/.ephemeral_nfs"
+            # Test whether the NFS directory is writable.
+            test_path = os.path.join(nfs_root_dir, uuid.uuid4().hex)
+            try:
+                os.makedirs(test_path)
+                return nfs_root_dir
+            except Exception:
+                # For databricks cluster enabled Table ACL, we have no permission to access NFS
+                # directory, in this case, return None representing NFS is not available.
+                return None
+            finally:
+                shutil.rmtree(test_path, ignore_errors=True)
         else:
             return None
     else:


### PR DESCRIPTION
Signed-off-by: Weichen Xu <weichen.xu@databricks.com>

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

(Details)

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
