### PR TITLE
Add python code to print out tracking URI and artifact URI in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_template.md
@@ -31,7 +31,7 @@ Describe the problem clearly here. Include descriptions of the expected behavior
 
 <!-- This section is optional -->
 
-For bugs related to the tracking features (e.g. mlflow should log a run in my database but it doesn't), please insert the following code in your python script / notebook that where you encountered the bug and run it:
+For bugs related to the tracking features (e.g. mlflow should log a run in my database but it doesn't), please insert the following code in your python script / notebook where you encountered the bug and run it:
 
 ```python
 print("MLflow version:", mlflow.__version__)

--- a/.github/ISSUE_TEMPLATE/bug_report_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_template.md
@@ -51,8 +51,10 @@ If you know the command that was used to launch your tracking server (e.g. `mlfl
 
 ### Code to reproduce issue
 Provide a reproducible test case that is the bare minimum necessary to generate the problem.
+
 ### Other info / logs
 Include any logs or source code that would be helpful to diagnose the problem. If including tracebacks, please include the full traceback. Large logs and files should be attached.
+
 
 ### What component(s), interfaces, languages, and integrations does this bug affect?
 Components 

--- a/.github/ISSUE_TEMPLATE/bug_report_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_template.md
@@ -26,6 +26,7 @@ The MLflow Community encourages bug fix contributions. Would you or another memb
 
 ### Describe the problem
 Describe the problem clearly here. Include descriptions of the expected behavior and the actual behavior.
+
 ### Tracking information
 
 <!-- This section is optional -->

--- a/.github/ISSUE_TEMPLATE/bug_report_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_template.md
@@ -27,7 +27,7 @@ The MLflow Community encourages bug fix contributions. Would you or another memb
 ### Describe the problem
 Describe the problem clearly here. Include descriptions of the expected behavior and the actual behavior.
 
-For issues related to the tracking features (e.g. mlflow doesn't log a run in my database), please insert the following lines in your python script / notebook and run them:
+For issues related to the tracking features (e.g. mlflow doesn't log a run in my database), please insert the following code in your python script / notebook where you encountered the bug and run it:
 
 ```python
 print("MLflow version:", mlflow.__version__)
@@ -35,7 +35,7 @@ print("Tracking URI:", mlflow.get_tracking_uri())
 print("Artifact URI:", mlflow.get_artifact_uri())
 ```
 
-Then, paste the result here:
+Then, paste the result in the code block below:
 
 ```
 

--- a/.github/ISSUE_TEMPLATE/bug_report_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_template.md
@@ -31,7 +31,7 @@ Describe the problem clearly here. Include descriptions of the expected behavior
 
 <!-- This section is optional -->
 
-For bugs related to the tracking features (e.g. mlflow should log a run in my database but it doesn't), please insert the following code in your python script / notebook that caused the bug and run it:
+For bugs related to the tracking features (e.g. mlflow should log a run in my database but it doesn't), please insert the following code in your python script / notebook that where you encountered the bug and run it:
 
 ```python
 print("MLflow version:", mlflow.__version__)

--- a/.github/ISSUE_TEMPLATE/bug_report_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_template.md
@@ -44,7 +44,7 @@ Then, make sure the printed out information matches what you expect and paste it
 ```
 ```
 
-If you know the command that was used to launch the tracking server (e.g. `mlflow server -h 0.0.0.0 --p 5000`), please provide it:
+If you know the command that was used to launch your tracking server (e.g. `mlflow server -h 0.0.0.0 --p 5000`), please provide it:
 
 ```
 ```

--- a/.github/ISSUE_TEMPLATE/bug_report_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_template.md
@@ -27,12 +27,24 @@ The MLflow Community encourages bug fix contributions. Would you or another memb
 ### Describe the problem
 Describe the problem clearly here. Include descriptions of the expected behavior and the actual behavior.
 
+For issues related to the tracking features (e.g. mlflow doesn't log a run in my database), please run the following code:
+
+```python
+print("MLflow version:", mlflow.__version__)
+print("Tracking URI:", mlflow.get_tracking_uri())
+print("Artifact URI:", mlflow.get_artifact_uri())
+```
+
+and paste the result here:
+
+```bash
+# paste the result here
+```
+
 ### Code to reproduce issue
 Provide a reproducible test case that is the bare minimum necessary to generate the problem.
-
 ### Other info / logs
 Include any logs or source code that would be helpful to diagnose the problem. If including tracebacks, please include the full traceback. Large logs and files should be attached.
-
 
 ### What component(s), interfaces, languages, and integrations does this bug affect?
 Components 

--- a/.github/ISSUE_TEMPLATE/bug_report_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_template.md
@@ -27,7 +27,7 @@ The MLflow Community encourages bug fix contributions. Would you or another memb
 ### Describe the problem
 Describe the problem clearly here. Include descriptions of the expected behavior and the actual behavior.
 
-For issues related to the tracking features (e.g. mlflow doesn't log a run in my database), please run the following code:
+For issues related to the tracking features (e.g. mlflow doesn't log a run in my database), please insert the following lines in your python script / notebook and run them:
 
 ```python
 print("MLflow version:", mlflow.__version__)
@@ -35,10 +35,10 @@ print("Tracking URI:", mlflow.get_tracking_uri())
 print("Artifact URI:", mlflow.get_artifact_uri())
 ```
 
-and paste the result here:
+Then, paste the result here:
 
-```bash
-# paste the result here
+```
+
 ```
 
 ### Code to reproduce issue

--- a/.github/ISSUE_TEMPLATE/bug_report_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_template.md
@@ -44,7 +44,7 @@ Then, make sure the printed out information matches what you expect and paste it
 ```
 ```
 
-If you know the command that was used to launch your tracking server (e.g. `mlflow server -h 0.0.0.0 --p 5000`), please provide it:
+If you know the command that was used to launch your tracking server (e.g. `mlflow server -h 0.0.0.0 -p 5000`), please provide it:
 
 ```
 ```

--- a/.github/ISSUE_TEMPLATE/bug_report_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_template.md
@@ -26,8 +26,11 @@ The MLflow Community encourages bug fix contributions. Would you or another memb
 
 ### Describe the problem
 Describe the problem clearly here. Include descriptions of the expected behavior and the actual behavior.
+### Tracking information
 
-For issues related to the tracking features (e.g. mlflow doesn't log a run in my database), please insert the following code in your python script / notebook where you encountered the bug and run it:
+<!-- This section is optional -->
+
+For bugs related to the tracking features (e.g. mlflow should log a run in my database but it doesn't), please insert the following code in your python script / notebook that caused the bug and run it:
 
 ```python
 print("MLflow version:", mlflow.__version__)
@@ -35,10 +38,14 @@ print("Tracking URI:", mlflow.get_tracking_uri())
 print("Artifact URI:", mlflow.get_artifact_uri())
 ```
 
-Then, paste the result in the code block below:
+Then, make sure the printed out information matches what you expect and paste it (with sensitive information masked) in the box below:
 
 ```
+```
 
+If you know the command that was used to launch the tracking server (e.g. `mlflow server -h 0.0.0.0 --p 5000`), please provide it:
+
+```
 ```
 
 ### Code to reproduce issue


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

Add python code to print out tracking URI and artifact URI in the bug report template to make it easier to debug issues and encourage issue reporters to check the URIs by themselves.

## How is this patch tested?

NA

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
