### PR TITLE
Replace `_EnvManager` enum with enum-like module

### DIFF
--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -185,7 +185,7 @@ def run(
             docker_args=args_dict,
             backend=backend,
             backend_config=backend_config,
-            env_manager=str(env_manager),
+            env_manager=env_manager,
             storage_dir=storage_dir,
             synchronous=backend in ("local", "kubernetes") or backend is None,
             run_id=run_id,

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -27,7 +27,7 @@ from mlflow.projects.utils import (
 from mlflow.projects.backend import loader
 from mlflow.tracking.fluent import _get_experiment_id
 from mlflow.utils.mlflow_tags import MLFLOW_PROJECT_ENV, MLFLOW_PROJECT_BACKEND, MLFLOW_RUN_NAME
-from mlflow.utils.environment import _EnvManager
+from mlflow.utils import env_manager as _EnvManager
 import mlflow.utils.uri
 
 _logger = logging.getLogger(__name__)
@@ -313,7 +313,7 @@ def run(
         )
 
     if env_manager:
-        env_manager = _EnvManager.from_string(env_manager)
+        _EnvManager.validate(env_manager)
     else:
         env_manager = _EnvManager.CONDA if use_conda else _EnvManager.LOCAL
 

--- a/mlflow/projects/backend/local.py
+++ b/mlflow/projects/backend/local.py
@@ -31,7 +31,7 @@ from mlflow.store.artifact.gcs_artifact_repo import GCSArtifactRepository
 from mlflow.store.artifact.hdfs_artifact_repo import HdfsArtifactRepository
 from mlflow.store.artifact.local_artifact_repo import LocalArtifactRepository
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
-from mlflow.utils.environment import _EnvManager
+from mlflow.utils import env_manager as _EnvManager
 from mlflow import tracking
 from mlflow.utils.mlflow_tags import MLFLOW_PROJECT_ENV
 
@@ -85,7 +85,7 @@ class LocalBackend(AbstractBackend):
             )
         # Synchronously create a conda environment (even though this may take some time)
         # to avoid failures due to multiple concurrent attempts to create the same conda env.
-        elif env_manager is _EnvManager.CONDA:
+        elif env_manager == _EnvManager.CONDA:
             tracking.MlflowClient().set_tag(active_run.info.run_id, MLFLOW_PROJECT_ENV, "conda")
             command_separator = " && "
             conda_env_name = get_or_create_conda_env(project.conda_env_path)

--- a/mlflow/projects/backend/local.py
+++ b/mlflow/projects/backend/local.py
@@ -149,7 +149,7 @@ def _build_mlflow_run_cmd(
             mlflow_run_arr.extend(["--docker-args", args])
     if storage_dir is not None:
         mlflow_run_arr.extend(["--storage-dir", storage_dir])
-    mlflow_run_arr.extend(["--env-manager", str(env_manager)])
+    mlflow_run_arr.extend(["--env-manager", env_manager])
     for key, value in parameters.items():
         mlflow_run_arr.extend(["-P", "%s=%s" % (key, value)])
     return mlflow_run_arr

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -249,7 +249,6 @@ from mlflow.utils.model_utils import (
 )
 from mlflow.utils.uri import append_to_uri_path
 from mlflow.utils.environment import (
-    _EnvManager,
     _validate_env_arguments,
     _process_pip_requirements,
     _process_conda_env,
@@ -259,6 +258,7 @@ from mlflow.utils.environment import (
     _PYTHON_ENV_FILE_NAME,
     _PythonEnv,
 )
+from mlflow.utils import env_manager as _EnvManager
 from mlflow.utils.docstring_utils import format_docstring, LOG_MODEL_PARAM_DOCS
 from mlflow.utils.databricks_utils import is_in_databricks_runtime
 from mlflow.utils.file_utils import get_or_create_tmp_dir, get_or_create_nfs_tmp_dir
@@ -1000,7 +1000,7 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
     from pyspark.sql.types import DoubleType, IntegerType, FloatType, LongType, StringType
     from mlflow.models.cli import _get_flavor_backend
 
-    env_manager = _EnvManager.from_string(env_manager)
+    _EnvManager.validate(env_manager)
 
     # Check whether spark is in local or local-cluster mode
     # this case all executors and driver share the same filesystem
@@ -1031,7 +1031,7 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
         artifact_uri=model_uri, output_path=_create_model_downloading_tmp_dir(should_use_nfs)
     )
 
-    if env_manager is _EnvManager.LOCAL:
+    if env_manager == _EnvManager.LOCAL:
         # Assume spark executor python environment is the same with spark driver side.
         _warn_dependency_requirement_mismatches(local_model_path)
         _logger.warning(
@@ -1067,7 +1067,7 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
         # "capture_output=False" is the output will be printed immediately, otherwise you have
         # to wait conda command fail and suddenly get all output printed (included in error
         # message).
-        if env_manager is _EnvManager.CONDA:
+        if env_manager == _EnvManager.CONDA:
             _get_flavor_backend(
                 local_model_path,
                 env_manager=_EnvManager.CONDA,
@@ -1163,7 +1163,7 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
         scoring_server_proc = None
 
         # TODO: Support virtual env.
-        if env_manager is _EnvManager.CONDA:
+        if env_manager == _EnvManager.CONDA:
             if should_use_spark_to_broadcast_file:
                 local_model_path_on_executor = _SparkDirectoryDistributor.get_or_extract(
                     archive_path
@@ -1244,7 +1244,7 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
             def batch_predict_fn(pdf):
                 return client.invoke(pdf)
 
-        elif env_manager is _EnvManager.LOCAL:
+        elif env_manager == _EnvManager.LOCAL:
             if should_use_spark_to_broadcast_file:
                 loaded_model, _ = SparkModelCache.get_or_load(archive_path)
             else:

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -15,7 +15,7 @@ from mlflow.utils.conda import get_or_create_conda_env, get_conda_bin_executable
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.file_utils import path_to_local_file_uri
 from mlflow.utils.conda import _get_conda_extra_env_vars
-from mlflow.utils.environment import _EnvManager
+from mlflow.utils import env_manager as _EnvManager
 from mlflow.utils.virtualenv import (
     _get_or_create_virtualenv,
     _execute_in_virtualenv,
@@ -60,11 +60,11 @@ class PyFuncBackend(FlavorBackend):
 
     def prepare_env(self, model_uri, capture_output=False):
         local_path = _download_artifact_from_uri(model_uri)
-        if self._env_manager is _EnvManager.LOCAL or ENV not in self._config:
+        if self._env_manager == _EnvManager.LOCAL or ENV not in self._config:
             return 0
 
         command = 'python -c ""'
-        if self._env_manager is _EnvManager.VIRTUALENV:
+        if self._env_manager == _EnvManager.VIRTUALENV:
             activate_cmd = _get_or_create_virtualenv(local_path, self._env_id)
             return _execute_in_virtualenv(activate_cmd, command, self._install_mlflow)
 
@@ -104,13 +104,13 @@ class PyFuncBackend(FlavorBackend):
             content_type=repr(content_type),
             json_format=repr(json_format),
         )
-        if self._env_manager is _EnvManager.CONDA and ENV in self._config:
+        if self._env_manager == _EnvManager.CONDA and ENV in self._config:
             conda_env_path = os.path.join(local_path, self._config[ENV])
             conda_env_name = get_or_create_conda_env(
                 conda_env_path, env_id=self._env_id, capture_output=False
             )
             return _execute_in_conda_env(conda_env_name, command, self._install_mlflow)
-        elif self._env_manager is _EnvManager.VIRTUALENV:
+        elif self._env_manager == _EnvManager.VIRTUALENV:
             activate_cmd = _get_or_create_virtualenv(local_path, self._env_id)
             return _execute_in_virtualenv(activate_cmd, command, self._install_mlflow)
         else:
@@ -169,7 +169,7 @@ class PyFuncBackend(FlavorBackend):
         else:
             setup_sigterm_on_parent_death = None
 
-        if self._env_manager is _EnvManager.CONDA and ENV in self._config:
+        if self._env_manager == _EnvManager.CONDA and ENV in self._config:
             conda_env_path = os.path.join(local_path, self._config[ENV])
 
             conda_env_name = get_or_create_conda_env(
@@ -190,7 +190,7 @@ class PyFuncBackend(FlavorBackend):
                 stderr=stderr,
                 env_root_dir=self._env_root_dir,
             )
-        elif self._env_manager is _EnvManager.VIRTUALENV:
+        elif self._env_manager == _EnvManager.VIRTUALENV:
             activate_cmd = _get_or_create_virtualenv(local_path, self._env_id)
             child_proc = _execute_in_virtualenv(
                 activate_cmd, command, self._install_mlflow, command_env
@@ -222,7 +222,7 @@ class PyFuncBackend(FlavorBackend):
             return child_proc
 
     def can_score_model(self):
-        if self._env_manager is _EnvManager.LOCAL:
+        if self._env_manager == _EnvManager.LOCAL:
             # noconda => already in python and dependencies are assumed to be installed.
             return True
         conda_path = get_conda_bin_executable("conda")

--- a/mlflow/utils/cli_args.py
+++ b/mlflow/utils/cli_args.py
@@ -4,7 +4,7 @@ Definitions of click options shared by several CLI commands.
 import click
 import warnings
 
-from mlflow.utils.environment import _EnvManager
+from mlflow.utils import env_manager as _EnvManager
 
 MODEL_PATH = click.option(
     "--model-path",
@@ -56,10 +56,10 @@ NO_CONDA = click.option(
 )
 
 
-def _resolve_env_manager(ctx, _, value):
+def _resolve_env_manager(ctx, _, env_manager):
     no_conda = ctx.params.get("no_conda", False)
     # Both `--no-conda` and `--env-manager` are specified
-    if no_conda and value is not None:
+    if no_conda and env_manager is not None:
         raise click.BadParameter(
             "`--no-conda` (deprecated) and `--env-manager` cannot be used at the same time."
         )
@@ -77,9 +77,9 @@ def _resolve_env_manager(ctx, _, value):
         return _EnvManager.LOCAL
 
     # Only `--env-manager` is specified
-    if value is not None:
-        env_manager = _EnvManager.from_string(value)
-        if env_manager is _EnvManager.VIRTUALENV:
+    if env_manager is not None:
+        _EnvManager.validate(env_manager)
+        if env_manager == _EnvManager.VIRTUALENV:
             warnings.warn(
                 (
                     "Virtualenv support is still experimental and may be changed in a future "

--- a/mlflow/utils/env_manager.py
+++ b/mlflow/utils/env_manager.py
@@ -1,0 +1,11 @@
+LOCAL = "local"
+CONDA = "conda"
+VIRTUALENV = "virtualenv"
+
+
+def validate(env_manager):
+    allowed_values = [LOCAL, CONDA, VIRTUALENV]
+    if env_manager not in allowed_values:
+        raise ValueError(
+            f"Invalid value for `env_manager`: {env_manager}. Must be one of {allowed_values}"
+        )

--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -4,7 +4,6 @@ import logging
 import sys
 import re
 import hashlib
-from enum import Enum
 
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
@@ -156,22 +155,6 @@ class _PythonEnv:
     @classmethod
     def from_conda_yaml(cls, path):
         return cls.from_dict(cls.get_dependencies_from_conda_yaml(path))
-
-
-class _EnvManager(Enum):
-    LOCAL = "local"
-    CONDA = "conda"
-    VIRTUALENV = "virtualenv"
-
-    @classmethod
-    def from_string(cls, value):
-        allowed_values = [e.value for e in cls]
-        if value not in allowed_values:
-            raise ValueError(f"Expected one of {allowed_values} but got '{value}'")
-        return cls[value.upper()]
-
-    def __str__(self):
-        return self.name.lower()
 
 
 def _mlflow_conda_env(

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -30,7 +30,7 @@ import mlflow.models.cli as models_cli
 
 from mlflow.utils.file_utils import TempDir, path_to_local_file_uri
 from mlflow.utils.environment import _mlflow_conda_env
-from mlflow.utils.env_manager import _EnvManager
+from mlflow.utils import env_manager as _EnvManager
 from mlflow.utils import PYTHON_VERSION
 from tests.models import test_pyfunc
 from tests.helper_functions import (

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -29,7 +29,8 @@ from mlflow.pyfunc.backend import _execute_in_conda_env
 import mlflow.models.cli as models_cli
 
 from mlflow.utils.file_utils import TempDir, path_to_local_file_uri
-from mlflow.utils.environment import _mlflow_conda_env, _EnvManager
+from mlflow.utils.environment import _mlflow_conda_env
+from mlflow.utils.env_manager import _EnvManager
 from mlflow.utils import PYTHON_VERSION
 from tests.models import test_pyfunc
 from tests.helper_functions import (

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -534,10 +534,10 @@ def test_env_manager_specifying_both_no_conda_and_env_manager_is_not_allowed():
 
 
 def test_env_manager_unsupported_value():
-    with pytest.raises(ValueError, match=r"Expected .+ but got 'abc'"):
+    with pytest.raises(ValueError, match=r"Invalid value for `env_manager`"):
         CliRunner().invoke(
             models_cli.serve,
-            ["--model-uri", "model", "--env-manager=abc"],
+            ["--model-uri", "model", "--env-manager", "abc"],
             catch_exceptions=False,
         )
 

--- a/tests/pyfunc/test_scoring_server.py
+++ b/tests/pyfunc/test_scoring_server.py
@@ -27,7 +27,7 @@ from mlflow.pyfunc.scoring_server import get_cmd
 from mlflow.types import Schema, ColSpec, DataType
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils.proto_json_utils import NumpyEncoder
-from mlflow.utils.environment import _EnvManager
+from mlflow.utils import env_manager as _EnvManager
 
 from tests.helper_functions import pyfunc_serve_and_score_model, random_int, random_str
 

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -20,7 +20,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.models import ModelSignature
 from mlflow.pyfunc import spark_udf, PythonModel, PyFuncModel
 from mlflow.pyfunc.spark_model_cache import SparkModelCache
-from mlflow.utils.environment import _EnvManager
+from mlflow.utils import env_manager as _EnvManager
 
 import tests
 from mlflow.types import Schema, ColSpec


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

Remove `_EnvManager` enum because we  always need to think about what the type of `env_mangaer` is (`str` or `_EnvManager`), which is inconvenient and error-prone. Processing everything as string is much easier.

## How is this patch tested?

Existing tests.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
