### PR TITLE
Autologging of input example and signature for pyspark ml

### DIFF
--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -943,7 +943,7 @@ def autolog(
                     cast_spark_df_with_vector_to_array,
                     get_feature_cols,
                 )
-                from mlflow.spark import find_and_set_features_col_as_vector_if_needed
+                from mlflow.spark import _find_and_set_features_col_as_vector_if_needed
                 from pyspark.sql import SparkSession
 
                 spark = SparkSession.builder.getOrCreate()
@@ -956,7 +956,7 @@ def autolog(
                     return cast_spark_df_with_vector_to_array(limited_input_df).toPandas()
 
                 def _infer_model_signature(input_example_slice):
-                    input_slice_df = find_and_set_features_col_as_vector_if_needed(
+                    input_slice_df = _find_and_set_features_col_as_vector_if_needed(
                         spark.createDataFrame(input_example_slice), spark_model
                     )
                     model_output = spark_model.transform(input_slice_df).drop(

--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -835,14 +835,8 @@ def autolog(
     :param log_model_signatures: If ``True``,
                                  :py:class:`ModelSignatures <mlflow.models.ModelSignature>`
                                  describing model inputs and outputs are collected and logged along
-                                 with tf/keras model artifacts during training. If ``False``,
-                                 signatures are not logged. ``False`` by default because
-                                 logging Spark ML models with signatures changes their pyfunc
-                                 inference behavior when Spark DataFrames are passed to
-                                 ``predict()``: when a signature is present, an ``np.ndarray``
-                                 (for single-output models) or a mapping from
-                                 ``str`` -> ``np.ndarray`` (for multi-output models) is returned;
-                                 when a signature is not present, a Spark DataFrame is returned.
+                                 with spark ml pipeline/estimator artifacts during training. If ``False``,
+                                 signatures are not logged.
     **The default log model allowlist in mlflow**
         .. literalinclude:: ../../../mlflow/pyspark/ml/log_model_allowlist.txt
            :language: text

--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -959,7 +959,9 @@ def autolog(
                     input_slice_df = find_and_set_features_col_as_vector_if_needed(
                         spark.createDataFrame(input_example_slice), spark_model
                     )
-                    model_output = spark_model.transform(input_slice_df)
+                    model_output = spark_model.transform(input_slice_df).drop(
+                        *input_slice_df.columns
+                    )
                     return infer_signature(input_example_slice, model_output.toPandas())
 
                 input_example, signature = resolve_input_example_and_signature(

--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -835,8 +835,9 @@ def autolog(
     :param log_model_signatures: If ``True``,
                                  :py:class:`ModelSignatures <mlflow.models.ModelSignature>`
                                  describing model inputs and outputs are collected and logged along
-                                 with spark ml pipeline/estimator artifacts during training. If ``False``,
-                                 signatures are not logged.
+                                 with spark ml pipeline/estimator artifacts during training.
+                                 If ``False`` signatures are not logged.
+
     **The default log model allowlist in mlflow**
         .. literalinclude:: ../../../mlflow/pyspark/ml/log_model_allowlist.txt
            :language: text

--- a/mlflow/pyspark/ml/_autolog.py
+++ b/mlflow/pyspark/ml/_autolog.py
@@ -60,8 +60,9 @@ def get_feature_cols(
 ) -> Set[str]:
     """
     Finds feature columns from an input dataset. If a dataset
-    contains non-feature columns, those columns are not returned
-    set, which can be feature or non-feature columns
+    contains non-feature columns, those columns are not returned, but
+    if `input_fields` is set to include non-feature columns those
+    will be included in the return set of column names.
 
     :param df_schema: An input spark schema to look for the feature columns
     :param transformer: A pipeline/transformer to get the required feature columns

--- a/mlflow/pyspark/ml/_autolog.py
+++ b/mlflow/pyspark/ml/_autolog.py
@@ -1,0 +1,94 @@
+from pyspark.sql.utils import IllegalArgumentException
+from pyspark.sql import SparkSession, DataFrame
+import re
+from functools import reduce
+from pyspark.ml.functions import vector_to_array
+from pyspark.ml.linalg import VectorUDT
+from pyspark.sql import types as t
+from pyspark.ml.base import Transformer
+from pyspark.ml.pipeline import PipelineModel
+from typing import Union, Set
+
+
+def cast_spark_df_with_vector_to_array(input_spark_df):
+    """
+    Finds columns of vector type in a spark dataframe and
+    casts them to array<double> type.
+
+    :param input_spark_df:
+    :return: a spark dataframe with vector columns transformed to array<double> type
+    """
+    vector_type_columns = [
+        _field.name for _field in input_spark_df.schema if isinstance(_field.dataType, VectorUDT)
+    ]
+    return reduce(
+        lambda df, vector_col: df.withColumn(vector_col, vector_to_array(vector_col)),
+        vector_type_columns,
+        input_spark_df,
+    )
+
+
+def _do_pipeline_transform(df: DataFrame, transformer: Union[Transformer, PipelineModel]):
+    """
+    A util method that runs transform on a pipeline model/transformer
+
+    :param df:a spark dataframe
+    :return: output transformed dataframe using pipeline model/transformer
+    """
+    return transformer.transform(df)
+
+
+def _get_struct_type_by_cols(input_fields: Set[str], df_schema: t.StructType) -> t.StructType:
+    """
+
+    :param input_fields: A set of input columns to be
+                 intersected with the input dataset's columns.
+    :param df_schema: A Spark dataframe schema to compare input_fields
+    :return:A StructType from the intersection of given columns and
+            the columns present in the training dataset
+    """
+    if len(input_fields) > 0:
+        return t.StructType([_field for _field in df_schema.fields if _field.name in input_fields])
+    return []
+
+
+def get_feature_cols(
+    df_schema: t.StructType,
+    transformer: Union[Transformer, PipelineModel],
+    input_fields: Set[str] = None,
+    spark: SparkSession = None,
+) -> Set[str]:
+    """
+    Finds feature columns from an input dataset. If a dataset
+    contains non-feature columns, those columns are not returned
+    set, which can be feature or non-feature columns
+
+    :param df_schema: An input spark schema to look for the feature columns
+    :param transformer: A pipeline/transformer to get the required feature columns
+    :param input_fields: Initial columns to keep in the returned list
+    :param spark: A spark session
+    :return: A set of all the feature columns that are required
+             for the pipeline/transformer plus any initial columns passed in.
+    """
+    if spark is None:
+        spark = SparkSession.builder.getOrCreate()
+    if input_fields is None:
+        input_fields = set()
+        # Using an empty dataset doesn't work for all estimators
+        # such as: pyspark.ml.classification.OneVsRest, so set
+        # a single row and column of double type
+        df = spark.createDataFrame([(1.0,)])
+    else:
+        df = spark.createDataFrame(
+            spark.sparkContext.emptyRDD(),
+            _get_struct_type_by_cols(input_fields, df_schema),
+        )
+    try:
+        _do_pipeline_transform(df, transformer)
+    except IllegalArgumentException as iae:
+        col_name_search = re.search("(.*) does not exist.", iae.desc, re.IGNORECASE)
+        if col_name_search:
+            col_name = col_name_search.group(1)
+            input_fields.add(col_name)
+            get_feature_cols(df_schema, transformer, input_fields, spark)
+    return input_fields

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -776,7 +776,8 @@ def find_and_set_features_col_as_vector_if_needed(spark_df, spark_model):
                 _field
                 for _field in spark_df.schema.fields
                 if _field.name == features_col_name
-                and _field.dataType == t.ArrayType(t.DoubleType())
+                and _field.dataType
+                in [t.ArrayType(t.DoubleType(), True), t.ArrayType(t.DoubleType(), False)]
             ]
             if len(features_col_type) == 1:
                 return spark_df.withColumn(

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -779,7 +779,8 @@ class _PyFuncModelWrapper:
             features_col_type = [
                 _field
                 for _field in spark_df.schema.fields
-                if _field.name == features_col_name and _field.dataType == t.ArrayType(t.DoubleType())
+                if _field.name == features_col_name
+                and _field.dataType == t.ArrayType(t.DoubleType())
             ]
             if len(features_col_type) == 1:
                 spark_df = spark_df.withColumn(

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -777,9 +777,9 @@ class _PyFuncModelWrapper:
                 ml_model_estimator.featuresCol
             )
             features_col_type = [
-                g
-                for g in spark_df.schema.fields
-                if g.name == features_col_name and g.dataType == t.ArrayType(t.DoubleType())
+                _field
+                for _field in spark_df.schema.fields
+                if _field.name == features_col_name and _field.dataType == t.ArrayType(t.DoubleType())
             ]
             if len(features_col_type) == 1:
                 spark_df = spark_df.withColumn(

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -741,7 +741,7 @@ def _load_pyfunc(path):
     return _PyFuncModelWrapper(spark, _load_model(model_uri=path))
 
 
-def find_and_set_features_col_as_vector_if_needed(spark_df, spark_model):
+def _find_and_set_features_col_as_vector_if_needed(spark_df, spark_model):
     """
     Finds the `featuresCol` column in spark_model and
     then tries to cast that column to `vector` type.
@@ -809,7 +809,7 @@ class _PyFuncModelWrapper:
         """
         from pyspark.ml import PipelineModel
 
-        spark_df = find_and_set_features_col_as_vector_if_needed(
+        spark_df = _find_and_set_features_col_as_vector_if_needed(
             self.spark.createDataFrame(pandas_df), self.spark_model
         )
         prediction_column = "prediction"

--- a/tests/spark/autologging/ml/test_pyspark_ml_autologging.py
+++ b/tests/spark/autologging/ml/test_pyspark_ml_autologging.py
@@ -1095,9 +1095,8 @@ def test_spark_df_with_vector_to_array_casts_successfully(dataset_multinomial):
     from pyspark.sql.types import ArrayType, DoubleType
 
     output_df = cast_spark_df_with_vector_to_array(dataset_multinomial)
-    assert [_field for _field in output_df.schema.fields if _field.name == "features"][
-        0
-    ].dataType == ArrayType(
+    features_col = next(filter(lambda f: f.name == "features", output_df.schema.fields))
+    assert features_col.dataType == ArrayType(
         DoubleType(), False
     ), "'features' column isn't of expected type array<double>"
 
@@ -1121,11 +1120,11 @@ def test_find_and_set_features_col_as_vector_if_needed(lr, dataset_binomial):
     df_with_vector_features = find_and_set_features_col_as_vector_if_needed(
         df_with_array_features, pipeline_model
     )
+    features_col = next(
+        filter(lambda f: f.name == "features", df_with_vector_features.schema.fields)
+    )
     assert isinstance(
-        [_field for _field in df_with_vector_features.schema.fields if _field.name == "features"][
-            0
-        ].dataType,
-        VectorUDT,
+        features_col.dataType, VectorUDT
     ), "'features' column wasn't cast to vector type"
     pipeline_model.transform(df_with_vector_features)
     with pytest.raises(

--- a/tests/spark/autologging/ml/test_pyspark_ml_autologging.py
+++ b/tests/spark/autologging/ml/test_pyspark_ml_autologging.py
@@ -1133,12 +1133,6 @@ def test_find_and_set_features_col_as_vector_if_needed(lr, dataset_binomial):
     ), "'features' column wasn't cast to vector type"
     pipeline_model.transform(df_with_vector_features)
     with pytest.raises(
-        IllegalArgumentException,
-        match="requirement failed: Column features must be of "
-        "type class org.apache.spark.ml.linalg."
-        "VectorUDT:struct<type:tinyint,size:int,"
-        "indices:array<int>,values:array<double>> "
-        "but was actually class "
-        "org.apache.spark.sql.types.ArrayType:array<double>.",
+        IllegalArgumentException, match="requirement failed: Column features must be of type"
     ):
         pipeline_model.transform(df_with_array_features)

--- a/tests/spark/autologging/ml/test_pyspark_ml_autologging.py
+++ b/tests/spark/autologging/ml/test_pyspark_ml_autologging.py
@@ -463,7 +463,7 @@ def test_pipeline(dataset_text):
 def test_param_search_estimator(  # pylint: disable=unused-argument
     metric_name, param_search_estimator, spark_session, dataset_regression
 ):
-    mlflow.pyspark.ml.autolog()
+    mlflow.pyspark.ml.autolog(log_input_examples=True)
     lr = LinearRegression(solver="l-bfgs", regParam=0.01)
     lrParamMaps = [
         {lr.maxIter: 1, lr.standardization: False},
@@ -942,7 +942,6 @@ def test_autolog_signature_with_estimator(spark_session, dataset_multinomial, lr
             run,
             [{"name": "features", "type": "string"}],
             [
-                {"name": "features", "type": "string"},
                 {"name": "rawPrediction", "type": "string"},
                 {"name": "probability", "type": "string"},
                 {"name": "prediction", "type": "double"},
@@ -973,7 +972,6 @@ def test_autolog_signature_with_pipeline(lr_pipeline, dataset_text):
                 {"name": "text", "type": "string"},
             ],
             [
-                {"name": "text", "type": "string"},
                 {"name": "words", "type": "string"},
                 {"name": "features", "type": "string"},
                 {"name": "rawPrediction", "type": "string"},
@@ -1032,7 +1030,6 @@ def test_signature_with_index_to_string_stage(
             run,
             [{"name": "id", "type": "long"}],
             [
-                {"name": "id", "type": "long"},
                 {"name": "features", "type": "string"},
                 {"name": "rawPrediction", "type": "string"},
                 {"name": "probability", "type": "string"},
@@ -1084,7 +1081,6 @@ def test_signature_with_non_feature_input_columns(
             run,
             [{"name": "id", "type": "long"}],
             [
-                {"name": "id", "type": "long"},
                 {"name": "features", "type": "string"},
                 {"name": "rawPrediction", "type": "string"},
                 {"name": "probability", "type": "string"},

--- a/tests/spark/autologging/ml/test_pyspark_ml_autologging.py
+++ b/tests/spark/autologging/ml/test_pyspark_ml_autologging.py
@@ -1111,13 +1111,13 @@ def test_get_feature_cols(input_df_with_non_features, pipeline_for_feature_cols)
 
 @pytest.mark.large
 def test_find_and_set_features_col_as_vector_if_needed(lr, dataset_binomial):
-    from mlflow.spark import find_and_set_features_col_as_vector_if_needed
+    from mlflow.spark import _find_and_set_features_col_as_vector_if_needed
     from pyspark.ml.linalg import VectorUDT
     from pyspark.sql.utils import IllegalArgumentException
 
     pipeline_model = lr.fit(dataset_binomial)
     df_with_array_features = cast_spark_df_with_vector_to_array(dataset_binomial)
-    df_with_vector_features = find_and_set_features_col_as_vector_if_needed(
+    df_with_vector_features = _find_and_set_features_col_as_vector_if_needed(
         df_with_array_features, pipeline_model
     )
     features_col = next(

--- a/tests/spark/autologging/ml/test_pyspark_ml_autologging.py
+++ b/tests/spark/autologging/ml/test_pyspark_ml_autologging.py
@@ -280,22 +280,22 @@ def test_fit_with_a_list_of_params(dataset_binomial):
             mock_set_tags.assert_not_called()
 
 
-@pytest.fixture()
+@pytest.fixture
 def tokenizer():
     return Tokenizer(inputCol="text", outputCol="words")
 
 
-@pytest.fixture()
+@pytest.fixture
 def hashing_tf(tokenizer):
     return HashingTF(inputCol=tokenizer.getOutputCol(), outputCol="features")
 
 
-@pytest.fixture()
+@pytest.fixture
 def lr():
     return LogisticRegression(maxIter=2)
 
 
-@pytest.fixture()
+@pytest.fixture
 def lr_pipeline(tokenizer, hashing_tf, lr):
     return Pipeline(stages=[tokenizer, hashing_tf, lr])
 
@@ -981,14 +981,14 @@ def test_autolog_signature_with_pipeline(lr_pipeline, dataset_text):
         )
 
 
-@pytest.fixture()
+@pytest.fixture
 def multinomial_df_with_string_labels(spark_session):
     return spark_session.createDataFrame(
         [(0, "a"), (1, "b"), (2, "c"), (3, "a"), (4, "a"), (5, "c")]
     ).toDF("id", "category")
 
 
-@pytest.fixture()
+@pytest.fixture
 def multinomial_lr_with_index_to_string_stage_pipeline(multinomial_df_with_string_labels):
     string_indexer = StringIndexer(inputCol="category", outputCol="label").fit(
         multinomial_df_with_string_labels
@@ -1039,7 +1039,7 @@ def test_signature_with_index_to_string_stage(
         )
 
 
-@pytest.fixture()
+@pytest.fixture
 def input_df_with_non_features(spark_session):
     return spark_session.createDataFrame(
         [
@@ -1053,7 +1053,7 @@ def input_df_with_non_features(spark_session):
     ).toDF("id", "category", "not_a_feature_1", "not_a_feature_2")
 
 
-@pytest.fixture()
+@pytest.fixture
 def pipeline_for_feature_cols(input_df_with_non_features):
     string_indexer = StringIndexer(inputCol="category", outputCol="label").fit(
         input_df_with_non_features


### PR DESCRIPTION
Signed-off-by: Jas Bali <bali0019@gmail.com>

## What changes are proposed in this pull request?

Autologging of input example/signature for pyspark ml pipelines and estimators.
Unit tests to validate the functionality.

## How is this patch tested?

Unit tests

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Adds autologging of input example and signature for pyspark ml pipeline/estimators

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
