### PR TITLE
Validate experiment_id in fluent API start_run

### DIFF
--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -38,7 +38,7 @@ from mlflow.utils.mlflow_tags import (
     MLFLOW_RUN_NAME,
     MLFLOW_RUN_NOTE,
 )
-from mlflow.utils.validation import _validate_run_id
+from mlflow.utils.validation import _validate_run_id, _validate_start_run_experiment_id
 
 if TYPE_CHECKING:
     import pandas  # pylint: disable=unused-import
@@ -231,6 +231,7 @@ def start_run(
         0  78b3b0d264b44cd29e8dc389749bb4be          yes           CHILD_RUN
     """
     global _active_run_stack
+    _validate_start_run_experiment_id(experiment_id)
     # back compat for int experiment_id
     experiment_id = str(experiment_id) if isinstance(experiment_id, int) else experiment_id
     if len(_active_run_stack) > 0 and not nested:

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -38,7 +38,7 @@ from mlflow.utils.mlflow_tags import (
     MLFLOW_RUN_NAME,
     MLFLOW_RUN_NOTE,
 )
-from mlflow.utils.validation import _validate_run_id, _validate_start_run_experiment_id
+from mlflow.utils.validation import _validate_run_id, _validate_experiment_id_type
 
 if TYPE_CHECKING:
     import pandas  # pylint: disable=unused-import
@@ -231,7 +231,7 @@ def start_run(
         0  78b3b0d264b44cd29e8dc389749bb4be          yes           CHILD_RUN
     """
     global _active_run_stack
-    _validate_start_run_experiment_id(experiment_id)
+    _validate_experiment_id_type(experiment_id)
     # back compat for int experiment_id
     experiment_id = str(experiment_id) if isinstance(experiment_id, int) else experiment_id
     if len(_active_run_stack) > 0 and not nested:

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -345,7 +345,7 @@ def _validate_experiment_name(experiment_name):
         )
 
 
-def _validate_start_run_experiment_id(experiment_id):
+def _validate_experiment_id_type(experiment_id):
     """
     Check that a user-provided experiment_id is either a string, int, or None and raise an
     exception if it isn't.

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -347,8 +347,8 @@ def _validate_experiment_name(experiment_name):
 
 def _validate_start_run_experiment_id(experiment_id):
     """
-    Check that a user-provided experiment_id is a valid string or int and raise and exception if
-    it isn't.
+    Check that a user-provided experiment_id is either a string, int, or None and raise an
+    exception if it isn't.
     """
     if experiment_id and not isinstance(experiment_id, (str, int)):
         raise MlflowException(

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -345,6 +345,19 @@ def _validate_experiment_name(experiment_name):
         )
 
 
+def _validate_start_run_experiment_id(experiment_id):
+    """
+    Check that a user-provided experiment_id is a valid string or int and raise and exception if
+    it isn't.
+    """
+    if experiment_id and not isinstance(experiment_id, (str, int)):
+        raise MlflowException(
+            f"Invalid experiment id: {experiment_id} of type {type(experiment_id)}. "
+            "Must be either str or int.",
+            error_code=INVALID_PARAMETER_VALUE,
+        )
+
+
 def _validate_model_name(model_name):
     if model_name is None or model_name == "":
         raise MlflowException("Registered model name cannot be empty.", INVALID_PARAMETER_VALUE)

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -350,10 +350,10 @@ def _validate_experiment_id_type(experiment_id):
     Check that a user-provided experiment_id is either a string, int, or None and raise an
     exception if it isn't.
     """
-    if experiment_id and not isinstance(experiment_id, (str, int)):
+    if experiment_id is not None and not isinstance(experiment_id, (str, int)):
         raise MlflowException(
             f"Invalid experiment id: {experiment_id} of type {type(experiment_id)}. "
-            "Must be either str or int.",
+            "Must be one of str, int, or None.",
             error_code=INVALID_PARAMETER_VALUE,
         )
 

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -487,7 +487,9 @@ def test_start_run_defaults_databricks_notebook(
         assert is_from_run(active_run, MlflowClient.create_run.return_value)
 
 
-@pytest.mark.parametrize("experiment_id", [("a", "b"), {"a", "b"}, ["a", "b"], {"a": 1}])
+@pytest.mark.parametrize(
+    "experiment_id", [("a", "b"), {"a", "b"}, ["a", "b"], {"a": 1}, [], (), {}]
+)
 def test_start_run_raises_invalid_experiment_id(experiment_id):
     with pytest.raises(MlflowException, match="Invalid experiment id: "):
         start_run(experiment_id=experiment_id)

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -487,6 +487,12 @@ def test_start_run_defaults_databricks_notebook(
         assert is_from_run(active_run, MlflowClient.create_run.return_value)
 
 
+@pytest.mark.parametrize("experiment_id", [("a", "b"), {"a", "b"}, ["a", "b"], {"a": 1}])
+def test_start_run_raises_invalid_experiment_id(experiment_id):
+    with pytest.raises(MlflowException, match="Invalid experiment id: "):
+        start_run(experiment_id=experiment_id)
+
+
 @pytest.mark.usefixtures(empty_active_run_stack.__name__)
 def test_start_run_creates_new_run_with_user_specified_tags():
     mock_experiment_id = mock.Mock()
@@ -553,7 +559,7 @@ def test_start_run_resumes_existing_run_and_sets_user_specified_tags():
 
 def test_start_run_with_parent():
     parent_run = mock.Mock()
-    mock_experiment_id = mock.Mock()
+    mock_experiment_id = mock.Mock(return_value="123456789")
     mock_source_name = mock.Mock()
 
     active_run_stack_patch = mock.patch("mlflow.tracking.fluent._active_run_stack", [parent_run])
@@ -581,9 +587,9 @@ def test_start_run_with_parent():
         user_patch,
         source_name_patch,
     ):
-        active_run = start_run(experiment_id=mock_experiment_id, nested=True)
+        active_run = start_run(experiment_id=mock_experiment_id.return_value, nested=True)
         MlflowClient.create_run.assert_called_once_with(
-            experiment_id=mock_experiment_id, tags=expected_tags
+            experiment_id=mock_experiment_id.return_value, tags=expected_tags
         )
         assert is_from_run(active_run, MlflowClient.create_run.return_value)
 

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -559,7 +559,7 @@ def test_start_run_resumes_existing_run_and_sets_user_specified_tags():
 
 def test_start_run_with_parent():
     parent_run = mock.Mock()
-    mock_experiment_id = mock.Mock(return_value="123456789")
+    mock_experiment_id = "123456"
     mock_source_name = mock.Mock()
 
     active_run_stack_patch = mock.patch("mlflow.tracking.fluent._active_run_stack", [parent_run])
@@ -587,9 +587,9 @@ def test_start_run_with_parent():
         user_patch,
         source_name_patch,
     ):
-        active_run = start_run(experiment_id=mock_experiment_id.return_value, nested=True)
+        active_run = start_run(experiment_id=mock_experiment_id, nested=True)
         MlflowClient.create_run.assert_called_once_with(
-            experiment_id=mock_experiment_id.return_value, tags=expected_tags
+            experiment_id=mock_experiment_id, tags=expected_tags
         )
         assert is_from_run(active_run, MlflowClient.create_run.return_value)
 


### PR DESCRIPTION
Signed-off-by: Ben Wilson <benjamin.wilson@databricks.com>

## What changes are proposed in this pull request?

Perform a validation check on fluent API start_run() to raise an exception if the type is not int or str to prevent tracking server retries with unhandled input validation. Fixes #5713 

## How is this patch tested?

additional unit test with validating exception raising on dict, set, list, and tuple inputs.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
