### PR TITLE
set requirements for pytorchlightning package regression

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -45,6 +45,10 @@ pytorch-lightning:
     requirements:
       "< 1.2.0": ["torch<1.11.0", "torchvision", "scikit-learn"]
       ">= 1.2.0, < 1.3.0": ["torchvision", "scikit-learn"]
+      # torchmetrics==0.8.0 released a breaking change for versions 1.3 and 1.4 where
+      # torchmetrics dependency was defined as non-upper-bounded in its requirements.
+      # see: https://github.com/PyTorchLightning/metrics/commit/c537c9b3e8e801772a7e5670ff273321ed26e77b
+      # for the removed function that causes pytorch-lightning imports to fail with torchmetrics==0.8.0
       ">= 1.3.0, < 1.5.0": ["torchmetrics<0.8.0", "torchvision", "scikit-learn"]
       ">= 1.5.0": ["torchvision", "scikit-learn"]
     run: |

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -44,8 +44,9 @@ pytorch-lightning:
     maximum: "1.6.0"
     requirements:
       "< 1.2.0": ["torch<1.11.0", "torchvision", "scikit-learn"]
-      ">= 1.2.0": ["torchvision", "scikit-learn"]
-      "< 1.5.0": ["torchmetrics<0.8.0"]
+      ">= 1.2.0, < 1.3.0": ["torchvision", "scikit-learn"]
+      ">= 1.3.0, < 1.5.0": ["torchmetrics<0.8.0", "torchvision", "scikit-learn"]
+      ">= 1.5.0": ["torchvision", "scikit-learn"]
     run: |
       pytest tests/pytorch/test_pytorch_autolog.py --large
 

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -45,6 +45,7 @@ pytorch-lightning:
     requirements:
       "< 1.2.0": ["torch<1.11.0", "torchvision", "scikit-learn"]
       ">= 1.2.0": ["torchvision", "scikit-learn"]
+      "< 1.5.0": ["torchmetrics<0.8.0"]
     run: |
       pytest tests/pytorch/test_pytorch_autolog.py --large
 


### PR DESCRIPTION
Signed-off-by: Ben Wilson <benjamin.wilson@databricks.com>

## What changes are proposed in this pull request?

PytorchLightning's torchmetrics release of 0.8.0 had a backwards incompatible change with removing a public function that breaks the import of pytorch-lightning versions >= 1.3.x and <1.5.x. Setting a requirement to use a lower version requirement.

## How is this patch tested?

existing unit tests

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
