### PR TITLE
Add virtualenv support for `mlflow models docker-build`

### DIFF
--- a/dev/run-python-sagemaker-tests.sh
+++ b/dev/run-python-sagemaker-tests.sh
@@ -6,14 +6,16 @@ err=0
 trap 'err=1' ERR
 export MLFLOW_HOME=$(pwd)
 
-SAGEMAKER_OUT=$(mktemp)
-if mlflow sagemaker build-and-push-container --no-push --mlflow-home . > $SAGEMAKER_OUT 2>&1; then
-  echo "Sagemaker container build succeeded.";
-  # output the last few lines for the timing information (defaults to 10 lines)
-else
-  echo "Sagemaker container build failed, output:";
-  cat $SAGEMAKER_OUT;
-fi
+for env_manager in conda virtualenv; do
+  SAGEMAKER_OUT=$(mktemp)
+  if mlflow sagemaker build-and-push-container --no-push --mlflow-home . --env-manager $env_manager > $SAGEMAKER_OUT 2>&1; then
+    echo "Sagemaker container build with $env_manager succeeded.";
+    # output the last few lines for the timing information (defaults to 10 lines)
+  else
+    echo "Sagemaker container build with $env_manager failed, output:";
+    cat $SAGEMAKER_OUT;
+  fi
+done
 
 pytest tests/sagemaker --large
 pytest tests/sagemaker/mock --large

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -151,9 +151,10 @@ def prepare_env(
 @commands.command("build-docker")
 @cli_args.MODEL_URI
 @click.option("--name", "-n", default="mlflow-pyfunc-servable", help="Name to use for built image")
+@cli_args.ENV_MANAGER
 @cli_args.INSTALL_MLFLOW
 @cli_args.ENABLE_MLSERVER
-def build_docker(model_uri, name, install_mlflow, enable_mlserver):
+def build_docker(model_uri, name, env_manager, install_mlflow, enable_mlserver):
     """
     Builds a Docker image whose default entrypoint serves the specified MLflow
     model at port 8080 within the container, using the 'python_function' flavor.
@@ -184,7 +185,7 @@ def build_docker(model_uri, name, install_mlflow, enable_mlserver):
     'python_function' flavor.
     """
     mlflow_home = os.environ.get("MLFLOW_HOME", None)
-    _get_flavor_backend(model_uri, docker_build=True).build_image(
+    _get_flavor_backend(model_uri, docker_build=True, env_manager=env_manager).build_image(
         model_uri,
         name,
         mlflow_home=mlflow_home,

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -1,6 +1,5 @@
 import logging
 import click
-import os
 
 from mlflow.models import Model
 from mlflow.models.model import MLMODEL_FILE_NAME
@@ -156,9 +155,10 @@ def prepare_env(
 @cli_args.MODEL_URI
 @click.option("--name", "-n", default="mlflow-pyfunc-servable", help="Name to use for built image")
 @cli_args.ENV_MANAGER
+@cli_args.MLFLOW_HOME
 @cli_args.INSTALL_MLFLOW
 @cli_args.ENABLE_MLSERVER
-def build_docker(model_uri, name, env_manager, install_mlflow, enable_mlserver):
+def build_docker(model_uri, name, env_manager, mlflow_home, install_mlflow, enable_mlserver):
     """
     Builds a Docker image whose default entrypoint serves the specified MLflow
     model at port 8080 within the container, using the 'python_function' flavor.
@@ -188,7 +188,6 @@ def build_docker(model_uri, name, env_manager, install_mlflow, enable_mlserver):
     See https://www.mlflow.org/docs/latest/python_api/mlflow.pyfunc.html for more information on the
     'python_function' flavor.
     """
-    mlflow_home = os.environ.get("MLFLOW_HOME", None)
     env_manager = env_manager or _EnvManager.CONDA
     _get_flavor_backend(model_uri, docker_build=True, env_manager=env_manager).build_image(
         model_uri,

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -189,6 +189,7 @@ def build_docker(model_uri, name, env_manager, install_mlflow, enable_mlserver):
     'python_function' flavor.
     """
     mlflow_home = os.environ.get("MLFLOW_HOME", None)
+    env_manager = env_manager or _EnvManager.CONDA
     _get_flavor_backend(model_uri, docker_build=True, env_manager=env_manager).build_image(
         model_uri,
         name,

--- a/mlflow/models/docker_utils.py
+++ b/mlflow/models/docker_utils.py
@@ -17,14 +17,17 @@ RUN bash ./miniconda.sh -b -p /miniconda && rm ./miniconda.sh
 ENV PATH="/miniconda/bin:$PATH"
 """
 
-SETUP_PYENV_AND_VIRTUALENV = """
+SETUP_PYENV_AND_VIRTUALENV = r"""
 # Setup pyenv
 RUN apt -y update
 RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata
 RUN apt-get install -y \
     libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
     libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
-RUN git clone --depth 1 https://github.com/pyenv/pyenv.git "/root/.pyenv"
+RUN git clone \
+    --depth 1 \
+    --branch $(git ls-remote --tags https://github.com/pyenv/pyenv.git | grep -o -E 'v[1-9]+(\.[1-9]+)+$' | tail -1) \
+    https://github.com/pyenv/pyenv.git /root/.pyenv
 ENV PYENV_ROOT="/root/.pyenv"
 ENV PATH="$PYENV_ROOT/bin:$PATH"
 RUN apt install -y python3.7

--- a/mlflow/models/docker_utils.py
+++ b/mlflow/models/docker_utils.py
@@ -88,28 +88,26 @@ def _get_mlflow_install_step(dockerfile_context_dir, mlflow_home):
         return (
             "COPY {mlflow_dir} /opt/mlflow\n"
             "RUN pip install /opt/mlflow\n"
-            # Temporarily commented out for faster development
-            # "RUN cd /opt/mlflow/mlflow/java/scoring && "
-            # "mvn --batch-mode package -DskipTests && "
-            # "mkdir -p /opt/java/jars && "
-            # "mv /opt/mlflow/mlflow/java/scoring/target/"
-            # "mlflow-scoring-*-with-dependencies.jar /opt/java/jars\n"
+            "RUN cd /opt/mlflow/mlflow/java/scoring && "
+            "mvn --batch-mode package -DskipTests && "
+            "mkdir -p /opt/java/jars && "
+            "mv /opt/mlflow/mlflow/java/scoring/target/"
+            "mlflow-scoring-*-with-dependencies.jar /opt/java/jars\n"
         ).format(mlflow_dir=mlflow_dir)
     else:
         return (
             "RUN pip install mlflow=={version}\n"
-            # Temporarily commented out for faster development
-            # "RUN mvn "
-            # " --batch-mode dependency:copy"
-            # " -Dartifact=org.mlflow:mlflow-scoring:{version}:pom"
-            # " -DoutputDirectory=/opt/java\n"
-            # "RUN mvn "
-            # " --batch-mode dependency:copy"
-            # " -Dartifact=org.mlflow:mlflow-scoring:{version}:jar"
-            # " -DoutputDirectory=/opt/java/jars\n"
-            # "RUN cp /opt/java/mlflow-scoring-{version}.pom /opt/java/pom.xml\n"
-            # "RUN cd /opt/java && mvn "
-            # "--batch-mode dependency:copy-dependencies -DoutputDirectory=/opt/java/jars\n"
+            "RUN mvn "
+            " --batch-mode dependency:copy"
+            " -Dartifact=org.mlflow:mlflow-scoring:{version}:pom"
+            " -DoutputDirectory=/opt/java\n"
+            "RUN mvn "
+            " --batch-mode dependency:copy"
+            " -Dartifact=org.mlflow:mlflow-scoring:{version}:jar"
+            " -DoutputDirectory=/opt/java/jars\n"
+            "RUN cp /opt/java/mlflow-scoring-{version}.pom /opt/java/pom.xml\n"
+            "RUN cd /opt/java && mvn "
+            "--batch-mode dependency:copy-dependencies -DoutputDirectory=/opt/java/jars\n"
         ).format(version=mlflow.version.VERSION)
 
 

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -293,7 +293,8 @@ class PyFuncBackend(FlavorBackend):
                 _install_pyfunc_deps(\
                     "/opt/ml/model", \
                     install_mlflow={install_mlflow}, \
-                    enable_mlserver={enable_mlserver})'
+                    enable_mlserver={enable_mlserver}, \
+                    env_manager="{env_manager}")'
                 ENV {disable_env}="true"
                 ENV {ENABLE_MLSERVER}={enable_mlserver}
                 """.format(
@@ -302,11 +303,13 @@ class PyFuncBackend(FlavorBackend):
                 install_mlflow=repr(install_mlflow),
                 ENABLE_MLSERVER=ENABLE_MLSERVER,
                 enable_mlserver=repr(enable_mlserver),
+                env_manager=self._env_manager,
             )
 
         # The pyfunc image runs the same server as the Sagemaker image
         pyfunc_entrypoint = (
-            'ENTRYPOINT ["python", "-c", "from mlflow.models import container as C; C._serve()"]'
+            'ENTRYPOINT ["python", "-c", "from mlflow.models import container as C;'
+            f'C._serve({repr(self._env_manager)})"]'
         )
         _build_image(
             image_name=image_name,

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -311,6 +311,7 @@ class PyFuncBackend(FlavorBackend):
         _build_image(
             image_name=image_name,
             mlflow_home=mlflow_home,
+            env_manager=self._env_manager,
             custom_setup_steps_hook=copy_model_into_container,
             entrypoint=pyfunc_entrypoint,
         )

--- a/mlflow/sagemaker/cli.py
+++ b/mlflow/sagemaker/cli.py
@@ -582,8 +582,10 @@ def build_and_push_container(build, push, container, env_manager, mlflow_home):
     if build:
         sagemaker_image_entrypoint = """
         ENTRYPOINT ["python", "-c", "import sys; from mlflow.models import container as C; \
-        C._init(sys.argv[1])"]
-        """
+        C._init(sys.argv[1], '{env_manager}')"]
+        """.format(
+            env_manager=env_manager
+        )
 
         def setup_container(_):
             return "\n".join(

--- a/mlflow/sagemaker/cli.py
+++ b/mlflow/sagemaker/cli.py
@@ -9,6 +9,7 @@ from mlflow.sagemaker import DEFAULT_IMAGE_NAME as IMAGE
 from mlflow.utils import cli_args
 from mlflow.utils.annotations import experimental
 import mlflow.models.docker_utils
+from mlflow.utils import env_manager as em
 
 
 @click.group("sagemaker")
@@ -577,6 +578,7 @@ def build_and_push_container(build, push, container, env_manager, mlflow_home):
     The image is built locally and it requires Docker to run.
     The image is pushed to ECR under current active AWS account and to current active AWS region.
     """
+    env_manager = env_manager or em.CONDA
     if not (build or push):
         click.echo("skipping both build and push, have nothing to do!")
     if build:

--- a/mlflow/sagemaker/cli.py
+++ b/mlflow/sagemaker/cli.py
@@ -567,8 +567,9 @@ def run_local(model_uri, port, image, flavor):
 @click.option("--build/--no-build", default=True, help="Build the container if set.")
 @click.option("--push/--no-push", default=True, help="Push the container to AWS ECR if set.")
 @click.option("--container", "-c", default=IMAGE, help="image name")
+@cli_args.ENV_MANAGER
 @cli_args.MLFLOW_HOME
-def build_and_push_container(build, push, container, mlflow_home):
+def build_and_push_container(build, push, container, env_manager, mlflow_home):
     """
     Build new MLflow Sagemaker image, assign it a name, and push to ECR.
 
@@ -598,6 +599,7 @@ def build_and_push_container(build, push, container, mlflow_home):
             mlflow_home=os.path.abspath(mlflow_home) if mlflow_home else None,
             entrypoint=sagemaker_image_entrypoint,
             custom_setup_steps_hook=setup_container,
+            env_manager=env_manager,
         )
     if push:
         mlflow.sagemaker.push_image_to_ecr(container)

--- a/mlflow/utils/cli_args.py
+++ b/mlflow/utils/cli_args.py
@@ -119,7 +119,7 @@ INSTALL_MLFLOW = click.option(
     "--install-mlflow",
     is_flag=True,
     default=False,
-    help="If specified and there is a conda environment to be activated "
+    help="If specified and there is a conda or virtualenv environment to be activated "
     "mlflow will be installed into the environment after it has been"
     " activated. The version of installed mlflow will be the same as"
     "the one used to invoke this command.",

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -93,6 +93,9 @@ def pyfunc_build_image(model_uri, extra_args=None):
     """
     name = uuid.uuid4().hex
     cmd = ["mlflow", "models", "build-docker", "-m", model_uri, "-n", name]
+    mlflow_home = os.environ.get("MLFLOW_HOME")
+    if mlflow_home:
+        cmd += ["--mlflow-home", mlflow_home]
     if extra_args:
         cmd += extra_args
     p = subprocess.Popen(cmd)


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

Add virtualenv support for `mlflow models docker-build`.

## How is this patch tested?

mlflow models:

```bash
# Log a model to serve
python examples/xgboost/xgboost_native/train.py

# Build a docker image that serves the model
mlflow models serve -m runs:/<run_id>/model --env-manager virtualenv

# Serve the model
docker run --rm -p 5001:8080 mlflow-pyfunc-servable:latest

# Send a request
curl -X POST -d "{\"data\":[[1,2,3,4]]}" -H "Content-Type: application/json; format=pandas-split" http://localhost:5001/invocations

# The command above should print out something similar to:
# [[0.11640435457229614, 0.21829040348529816, 0.6653051972389221]]
```

sagemaker:

```
mlflow sagemaker build-and-push-container --no-push --mlflow-home . --env-manager virtualenv
```

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
