### PR TITLE
Resolved typos

### DIFF
--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -301,7 +301,7 @@ def process_requirements(requirements, version=None):
         return requirements
 
     if isinstance(requirements, dict):
-        # The version "dev" should always compare as greater than any exisiting versions.
+        # The version "dev" should always compare as greater than any existing versions.
         dev_numeric = "9999.9999.9999"
 
         if version == DEV_VERSION:

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -210,7 +210,7 @@ class DatabricksJobRunner:
             _logger.warning(
                 (
                     "Your client is running a non-release version of MLFlow. "
-                    "This version is not avaialable on the databricks runtime. "
+                    "This version is not available on the databricks runtime. "
                     "MLFlow will fallback the MLFlow version provided by the runtime. "
                     "This might lead to unforeseen issues. "
                 )

--- a/tests/store/tracking/__init__.py
+++ b/tests/store/tracking/__init__.py
@@ -7,10 +7,10 @@ from mlflow.utils.mlflow_tags import MLFLOW_LOGGED_MODELS
 
 class AbstractStoreTest:
     def create_test_run(self):
-        raise Exception("this should be overriden")
+        raise Exception("this should be overridden")
 
     def get_store(self):
-        raise Exception("this should be overriden")
+        raise Exception("this should be overridden")
 
     def test_record_logged_model(self):
         store = self.get_store()


### PR DESCRIPTION
## What changes are proposed in this pull request?

Resolved (issue id: #5712) the typos in the below files:
[dev/set_matrix.py#l304](https://github.com/mlflow/mlflow/blob/22e69c3bdba7c4af616f6f0ce4e74821dc665b10/dev/set_matrix.py#L304)
[mlflow/projects/databricks.py#L21](https://github.com/mlflow/mlflow/blob/fe6618823a2e6038149ee0da675503d2764552ca/mlflow/projects/databricks.py#L213)
[tests/store/tracking/init.py#L10](https://github.com/mlflow/mlflow/blob/19e84f6cfd0c137925d113621bd7d96d610bb265/tests/store/tracking/__init__.py#L10)


## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
