### PR TITLE
Add endpoint changes to the deployment CLI.

### DIFF
--- a/mlflow/deployments/cli.py
+++ b/mlflow/deployments/cli.py
@@ -137,9 +137,10 @@ def create_deployment(flavor, model_uri, target, name, config, endpoint):
     client = interface.get_deploy_client(target)
 
     sig = signature(client.create_deployment)
-    if 'endpoint' in sig.parameters:
-        deployment = client.create_deployment(name, model_uri, flavor, config=config_dict,
-                                              endpoint=endpoint)
+    if "endpoint" in sig.parameters:
+        deployment = client.create_deployment(
+            name, model_uri, flavor, config=config_dict, endpoint=endpoint
+        )
     else:
         deployment = client.create_deployment(name, model_uri, flavor, config=config_dict)
     click.echo("\n{} deployment {} is created".format(deployment["flavor"], deployment["name"]))
@@ -178,9 +179,10 @@ def update_deployment(flavor, model_uri, target, name, config, endpoint):
     client = interface.get_deploy_client(target)
 
     sig = signature(client.update_deployment)
-    if 'endpoint' in sig.parameters:
-        ret = client.update_deployment(name, model_uri=model_uri, flavor=flavor, config=config_dict,
-                                       endpoint=endpoint)
+    if "endpoint" in sig.parameters:
+        ret = client.update_deployment(
+            name, model_uri=model_uri, flavor=flavor, config=config_dict, endpoint=endpoint
+        )
     else:
         ret = client.update_deployment(name, model_uri=model_uri, flavor=flavor, config=config_dict)
     click.echo("Deployment {} is updated (with flavor {})".format(name, ret["flavor"]))
@@ -200,12 +202,12 @@ def delete_deployment(target, name, config, endpoint):
     sig = signature(client.delete_deployment)
     if "config" in sig.parameters:
         config_dict = _user_args_to_dict(config)
-        if 'endpoint' in sig.parameters:
+        if "endpoint" in sig.parameters:
             client.delete_deployment(name, config=config_dict, endpoint=endpoint)
         else:
             client.delete_deployment(name, config=config_dict)
     else:
-        if 'endpoint' in sig.parameters:
+        if "endpoint" in sig.parameters:
             client.delete_deployment(name, endpoint=endpoint)
         else:
             client.delete_endpoint(name)
@@ -352,9 +354,9 @@ def explain(target, name, input_path, output_path, endpoint):
     metavar="NAME=VALUE",
     multiple=True,
     help="Extra target-specific config for the endpoint, "
-         "of the form -C name=value. See "
-         "documentation/help for your deployment target for a "
-         "list of supported config options.",
+    "of the form -C name=value. See "
+    "documentation/help for your deployment target for a "
+    "list of supported config options.",
 )
 @required_endpoint_param
 @target_details
@@ -376,9 +378,9 @@ def create_endpoint(target, name, config):
     metavar="NAME=VALUE",
     multiple=True,
     help="Extra target-specific config for the endpoint, "
-         "of the form -C name=value. See "
-         "documentation/help for your deployment target for a "
-         "list of supported config options.",
+    "of the form -C name=value. See "
+    "documentation/help for your deployment target for a "
+    "list of supported config options.",
 )
 @required_endpoint_param
 @target_details

--- a/mlflow/deployments/cli.py
+++ b/mlflow/deployments/cli.py
@@ -208,7 +208,7 @@ def delete_deployment(target, name, config, endpoint):
         if 'endpoint' in sig.parameters:
             client.delete_deployment(name, endpoint=endpoint)
         else:
-            client.delete_endpoint(name)
+            client.delete_deployment(name)
 
     click.echo("Deployment {} is deleted".format(name))
 
@@ -346,6 +346,7 @@ def explain(target, name, input_path, output_path, endpoint):
         predictions_to_json(result, sys.stdout)
 
 
+@commands.command("create-endpoint")
 @click.option(
     "--config",
     "-C",
@@ -370,6 +371,7 @@ def create_endpoint(target, name, config):
     click.echo("\nEndpoint {} is created".format(endpoint["name"]))
 
 
+@commands.command("update-endpoint")
 @click.option(
     "--config",
     "-C",
@@ -390,10 +392,11 @@ def update_endpoint(target, endpoint, config):
     """
     config_dict = _user_args_to_dict(config)
     client = interface.get_deploy_client(target)
-    updated_endpoint = client.update_endpoint(endpoint, config=config_dict)
-    click.echo("\nEndpoint {} is updated".format(updated_endpoint["name"]))
+    client.update_endpoint(endpoint, config=config_dict)
+    click.echo("\nEndpoint {} is updated".format(endpoint))
 
 
+@commands.command("delete-endpoint")
 @required_endpoint_param
 @target_details
 def delete_endpoint(target, endpoint):
@@ -405,6 +408,7 @@ def delete_endpoint(target, endpoint):
     click.echo("\nEndpoint {} is deleted".format(endpoint))
 
 
+@commands.command("list-endpoints")
 @target_details
 def list_endpoints(target):
     """
@@ -415,6 +419,7 @@ def list_endpoints(target):
     click.echo("List of all endpoints:\n{}".format(ids))
 
 
+@commands.command("get-endpoint")
 @required_endpoint_param
 @target_details
 def get_endpoint(target, endpoint):


### PR DESCRIPTION
Signed-off-by: trangevi <trangevi@microsoft.com>

## What changes are proposed in this pull request?

This PR introduces the CLI changes to match with the new Endpoint concept introduced in #5378

## How is this patch tested?

Relies on automated tests

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Introduces the CLI side changes to match with the new Endpoint concept introduced in #5378

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
