### PR TITLE
Fixed Typos

### DIFF
--- a/mlflow/projects/utils.py
+++ b/mlflow/projects/utils.py
@@ -183,7 +183,7 @@ def _fetch_git_repo(uri, version, dst_dir):
     helper.
     """
     # We defer importing git until the last moment, because the import requires that the git
-    # executable is availble on the PATH, so we only want to fail if we actually need it.
+    # executable is available on the PATH, so we only want to fail if we actually need it.
     import git
 
     repo = git.Repo.init(dst_dir)

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -935,8 +935,8 @@ def _get_metric_history():
     )
     response_message = GetMetricHistory.Response()
     run_id = request_message.run_id or request_message.run_uuid
-    metric_entites = _get_tracking_store().get_metric_history(run_id, request_message.metric_key)
-    response_message.metrics.extend([m.to_proto() for m in metric_entites])
+    metric_entities = _get_tracking_store().get_metric_history(run_id, request_message.metric_key)
+    response_message.metrics.extend([m.to_proto() for m in metric_entities])
     response = Response(mimetype="application/json")
     response.set_data(message_to_json(response_message))
     return response

--- a/mlflow/tracking/context/registry.py
+++ b/mlflow/tracking/context/registry.py
@@ -69,7 +69,7 @@ def resolve_tags(tags=None):
 
     :param tags: A dictionary of tags to override. If specified, tags passed in this argument will
                  override those inferred from the context.
-    :return: A dicitonary of resolved tags.
+    :return: A dictionary of resolved tags.
     """
 
     all_tags = {}


### PR DESCRIPTION
## What changes are proposed in this pull request?

Corrects typos in #5712 for the following files:
* [mlflow/projects/utils.py#l186](https://github.com/mlflow/mlflow/blob/c423e3ef6c648fdcdf1546d11e6768a536edfa85/mlflow/projects/utils.py#L186)
* [mlflow/server/handlers.py#l726](https://github.com/mlflow/mlflow/blob/a274c5b7d540d05b5f7b9c512cdc3ac8b30f9498/mlflow/server/handlers.py#L726)
* [mlflow/tracking/context/registry.py#L72](https://github.com/mlflow/mlflow/blob/19e84f6cfd0c137925d113621bd7d96d610bb265/mlflow/tracking/context/registry.py#L72)

## How is this patch tested?

N/A

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
