### PR TITLE
Add `min_python_version` command to get minimum python version mlflow supports easily

### DIFF
--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -24,7 +24,11 @@ runs:
           python_version=$(python setup.py -q min_python_version)
         fi
         if [[ "$python_version" == "3.7" ]]; then
-          python_version="3.7.12"
+          if [ ${{ runner.os }} == "Windows" ]; then
+            python_version="3.7.9"
+          else
+            python_version="3.7.12"
+          fi
         elif [[ "$python_version" == "3.8" ]]; then
           python_version="3.8.12"
         else

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -21,7 +21,7 @@ runs:
       run: |
         python_version="${{ inputs.python-version }}"
         if [ -z "$python_version" ]; then
-          python_version=$(python setup.py min_python_version)
+          python_version=$(python setup.py -q min_python_version)
         fi
         if [[ "$python_version" == "3.7" ]]; then
           python_version="3.7.12"

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -2,8 +2,8 @@ name: "setup-python"
 description: "Ensures to install a python version that's available on Anaconda"
 inputs:
   python-version:
-    description: "The python version to install (e.g. 3.7)"
-    required: true
+    description: "The python version to install. If unspecified, install the minimum python version mlflow supports."
+    required: false
 outputs:
   installed-python-version:
     description: "The installed python version"
@@ -20,6 +20,9 @@ runs:
       # where we trigger more than 100 GitHub Actions runs.
       run: |
         python_version="${{ inputs.python-version }}"
+        if [ -z "$python_version" ]; then
+          python_version=$(python setup.py min_python_version)
+        fi
         if [[ "$python_version" == "3.7" ]]; then
           python_version="3.7.12"
         elif [[ "$python_version" == "3.8" ]]; then

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -125,7 +125,7 @@ jobs:
           then
             python_version=3.8
           else
-            python_version=3.7
+            python_version=$(python setup.py -q min-python-version)
           fi
           echo "::set-output name=version::$python_version"
       - uses: ./.github/actions/setup-python

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -65,8 +65,6 @@ jobs:
         echo "::set-output name=examples_changed::$EXAMPLES_CHANGED"
 
     - uses: ./.github/actions/setup-python
-      with:
-        python-version: "3.7"
 
     - name: Install dependencies
       if: ${{ github.event_name == 'schedule' || steps.check-diff.outputs.examples_changed == 'true' }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -352,6 +352,7 @@ jobs:
         with:
           repository: ${{ github.event.inputs.repository }}
           ref: ${{ github.event.inputs.ref }}
+      - uses: ./.github/actions/setup-python
       - uses: ./.github/actions/setup-pyenv
       - name: Install python dependencies
         run: |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -49,8 +49,6 @@ jobs:
         repository: ${{ github.event.inputs.repository }}
         ref: ${{ github.event.inputs.ref }}
     - uses: ./.github/actions/setup-python
-      with:
-        python-version: "3.7"
     - uses: ./.github/actions/cache-pip
     - name: Add problem matchers
       run: |
@@ -131,8 +129,6 @@ jobs:
         repository: ${{ github.event.inputs.repository }}
         ref: ${{ github.event.inputs.ref }}
     - uses: ./.github/actions/setup-python
-      with:
-        python-version: "3.7"
     - name: Install dependencies
       env:
         INSTALL_SKINNY_PYTHON_DEPS: true
@@ -151,8 +147,6 @@ jobs:
         repository: ${{ github.event.inputs.repository }}
         ref: ${{ github.event.inputs.ref }}
     - uses: ./.github/actions/setup-python
-      with:
-        python-version: "3.7"
     - name: Install dependencies
       env:
         INSTALL_SMALL_PYTHON_DEPS: true
@@ -175,8 +169,6 @@ jobs:
         # https://github.com/actions/virtual-environments/issues/709#issuecomment-612569242
         rm -rf "$AGENT_TOOLSDIRECTORY"
     - uses: ./.github/actions/setup-python
-      with:
-        python-version: "3.7"
     - uses: actions/setup-java@v3
       with:
         java-version: 11
@@ -230,8 +222,6 @@ jobs:
         repository: ${{ github.event.inputs.repository }}
         ref: ${{ github.event.inputs.ref }}
     - uses: ./.github/actions/setup-python
-      with:
-        python-version: "3.7"
     - name: Set up Java
       uses: actions/setup-java@v3
       with:
@@ -282,8 +272,6 @@ jobs:
           # https://github.com/actions/virtual-environments/issues/709#issuecomment-612569242
           rm -rf "$AGENT_TOOLSDIRECTORY"
       - uses: ./.github/actions/setup-python
-        with:
-          python-version: "3.7"
       - uses: ./.github/actions/setup-pyenv
       - uses: actions/setup-java@v3
         with:
@@ -315,8 +303,6 @@ jobs:
           repository: ${{ github.event.inputs.repository }}
           ref: ${{ github.event.inputs.ref }}
       - uses: ./.github/actions/setup-python
-        with:
-          python-version: "3.7"
       - uses: actions/setup-java@v3
         with:
           java-version: 11
@@ -343,8 +329,6 @@ jobs:
           repository: ${{ github.event.inputs.repository }}
           ref: ${{ github.event.inputs.ref }}
       - uses: ./.github/actions/setup-python
-        with:
-          python-version: "3.7"
       - uses: actions/setup-java@v3
         with:
           java-version: 11
@@ -369,8 +353,6 @@ jobs:
           repository: ${{ github.event.inputs.repository }}
           ref: ${{ github.event.inputs.ref }}
       - uses: actions/setup-python@v3
-        with:
-          python-version: "3.7"
       - uses: ./.github/actions/setup-pyenv
       - name: Install python dependencies
         run: |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -352,7 +352,6 @@ jobs:
         with:
           repository: ${{ github.event.inputs.repository }}
           ref: ${{ github.event.inputs.ref }}
-      - uses: actions/setup-python@v3
       - uses: ./.github/actions/setup-pyenv
       - name: Install python dependencies
         run: |

--- a/.github/workflows/test-package-build.yml
+++ b/.github/workflows/test-package-build.yml
@@ -40,10 +40,7 @@ jobs:
         with:
           repository: ${{ github.event.inputs.repository }}
           ref: ${{ github.event.inputs.ref }}
-      - uses: actions/setup-python@v3
-        with:
-          python-version: "3.7"
-
+      - uses: ./.github/actions/setup-python
       - name: Set environment variable for skinny client build
         if: ${{ matrix.type == 'skinny' }}
         run: |

--- a/setup.py
+++ b/setup.py
@@ -107,6 +107,23 @@ class ListDependencies(distutils.cmd.Command):
         print("\n".join(dependencies))
 
 
+MINIMUM_SUPPORTED_PYTHON_VERSION = "3.7"
+
+
+class MinPythonVersion(distutils.cmd.Command):
+    description = "Print out the minimum supported Python version"
+    user_options = []
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        print(MINIMUM_SUPPORTED_PYTHON_VERSION)
+
+
 setup(
     name="mlflow" if not _is_mlflow_skinny else "mlflow-skinny",
     version=version,
@@ -144,7 +161,10 @@ setup(
         [console_scripts]
         mlflow=mlflow.cli:cli
     """,
-    cmdclass={"dependencies": ListDependencies},
+    cmdclass={
+        "dependencies": ListDependencies,
+        "min_python_version": MinPythonVersion,
+    },
     zip_safe=False,
     author="Databricks",
     description="MLflow: A Platform for ML Development and Productionization",
@@ -153,10 +173,13 @@ setup(
     else open("README_SKINNY.rst").read() + open("README.rst").read(),
     long_description_content_type="text/x-rst",
     license="Apache License 2.0",
-    classifiers=["Intended Audience :: Developers", "Programming Language :: Python :: 3.7"],
+    classifiers=[
+        "Intended Audience :: Developers",
+        f"Programming Language :: Python :: {MINIMUM_SUPPORTED_PYTHON_VERSION}",
+    ],
     keywords="ml ai databricks",
     url="https://mlflow.org/",
-    python_requires=">=3.7",
+    python_requires=f">={MINIMUM_SUPPORTED_PYTHON_VERSION}",
     project_urls={
         "Bug Tracker": "https://github.com/mlflow/mlflow/issues",
         "Documentation": "https://mlflow.org/docs/latest/index.html",


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

Add a `min_python_version` command to get the minimum python version mlflow supports easily.

## How is this patch tested?

Updated jobs

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
