### PR TITLE
Improve `is_in_databricks_runtime` function

### DIFF
--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -103,12 +103,7 @@ def is_databricks_default_tracking_uri(tracking_uri):
 
 @_use_repl_context_if_available("isInNotebook")
 def is_in_databricks_notebook():
-    if _get_property_from_spark_context("spark.databricks.notebook.id") is not None:
-        return True
-    try:
-        return acl_path_of_acl_root().startswith("/workspace")
-    except Exception:
-        return False
+    return "DATABRICKS_RUNTIME_VERSION" in os.environ
 
 
 @_use_repl_context_if_available("isInJob")

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -103,7 +103,12 @@ def is_databricks_default_tracking_uri(tracking_uri):
 
 @_use_repl_context_if_available("isInNotebook")
 def is_in_databricks_notebook():
-    return "DATABRICKS_RUNTIME_VERSION" in os.environ
+    if _get_property_from_spark_context("spark.databricks.notebook.id") is not None:
+        return True
+    try:
+        return acl_path_of_acl_root().startswith("/workspace")
+    except Exception:
+        return False
 
 
 @_use_repl_context_if_available("isInJob")
@@ -123,13 +128,7 @@ def is_in_databricks_repo_notebook():
 
 
 def is_in_databricks_runtime():
-    try:
-        # pylint: disable=unused-import,import-error,no-name-in-module,unused-variable
-        import pyspark.databricks
-
-        return True
-    except ModuleNotFoundError:
-        return False
+    return "DATABRICKS_RUNTIME_VERSION" in os.environ
 
 
 def is_dbfs_fuse_available():

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from unittest import mock
 import pytest
@@ -212,20 +213,10 @@ def test_databricks_params_throws_errors(ProfileConfigProvider):
 
 
 def test_is_in_databricks_runtime():
-    with mock.patch(
-        "sys.modules",
-        new={**sys.modules, "pyspark": mock.MagicMock(), "pyspark.databricks": mock.MagicMock()},
-    ):
-        # pylint: disable=unused-import,import-error,no-name-in-module,unused-variable
-        import pyspark.databricks
-
+    with mock.patch.dict(os.environ, {"DATABRICKS_RUNTIME_VERSION": "11.x"}):
         assert databricks_utils.is_in_databricks_runtime()
 
-    with mock.patch("sys.modules", new={**sys.modules, "pyspark": mock.MagicMock()}):
-        with pytest.raises(ModuleNotFoundError, match="No module named 'pyspark.databricks'"):
-            # pylint: disable=unused-import,import-error,no-name-in-module,unused-variable
-            import pyspark.databricks
-        assert not databricks_utils.is_in_databricks_runtime()
+    assert not databricks_utils.is_in_databricks_runtime()
 
 
 def test_get_repl_id():


### PR DESCRIPTION
Signed-off-by: Weichen Xu <weichen.xu@databricks.com>

## What changes are proposed in this pull request?

Use `DATABRICKS_RUNTIME_VERSION` environment variable to check whether it is in databricks runtime.
Current implementation there's a side-effect of importing pyspark when calling `is_in_databricks_runtime` in non-databricks runtime.

## How is this patch tested?

Unit tests.

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
