### PR TITLE
When loading spark model, bind spark.driver.bindAddress to 127.0.0.1

### DIFF
--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -735,6 +735,9 @@ def _load_pyfunc(path):
             # In Spark 3.1 and above, we need to set this conf explicitly to enable creating
             # a SparkSession on the workers
             .config("spark.executor.allowSparkContext", "true")
+            # Bind "spark.driver.bindAddress" to 127.0.0.1 helps avoiding some local hostname
+            # related issues.
+            .config("spark.driver.bindAddress", "127.0.0.1")
             .master("local[1]")
             .getOrCreate()
         )

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -735,8 +735,8 @@ def _load_pyfunc(path):
             # In Spark 3.1 and above, we need to set this conf explicitly to enable creating
             # a SparkSession on the workers
             .config("spark.executor.allowSparkContext", "true")
-            # Bind "spark.driver.bindAddress" to 127.0.0.1 helps avoiding some local hostname
-            # related issues.
+            # Binding "spark.driver.bindAddress" to 127.0.0.1 helps avoiding some local hostname
+            # related issues (e.g. https://github.com/mlflow/mlflow/issues/5733).
             .config("spark.driver.bindAddress", "127.0.0.1")
             .master("local[1]")
             .getOrCreate()


### PR DESCRIPTION
Signed-off-by: Weichen Xu <weichen.xu@databricks.com>

## What changes are proposed in this pull request?

When loading spark model, bind spark.driver.bindAddress to 127.0.0.1
it helps avoiding some local hostname related issues.

closes https://github.com/mlflow/mlflow/issues/5733

## How is this patch tested?

Wait https://github.com/mlflow/mlflow/issues/5733 reporter to test.

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
