### PR TITLE
Fix Spelling Mistake

### DIFF
--- a/mlflow/utils/cli_args.py
+++ b/mlflow/utils/cli_args.py
@@ -120,8 +120,8 @@ INSTALL_MLFLOW = click.option(
     is_flag=True,
     default=False,
     help="If specified and there is a conda environment to be activated "
-    "mlflow will be installed into the environment after it has been"
-    " activated. The version of installed mlflow will be the same as "
+    "mlflow will be installed into the environment after it has been "
+    "activated. The version of installed mlflow will be the same as "
     "the one used to invoke this command.",
 )
 

--- a/mlflow/utils/cli_args.py
+++ b/mlflow/utils/cli_args.py
@@ -121,7 +121,7 @@ INSTALL_MLFLOW = click.option(
     default=False,
     help="If specified and there is a conda environment to be activated "
     "mlflow will be installed into the environment after it has been"
-    " activated. The version of installed mlflow will be the same as"
+    " activated. The version of installed mlflow will be the same as "
     "the one used to invoke this command.",
 )
 


### PR DESCRIPTION
[DOC-FIX]: Address spelling mistake

This fixes spelling mistake in [build-docker section](https://mlflow.org/docs/latest/cli.html#cmdoption-mlflow-models-build-docker-install-mlflow):
asthe -> as the

Fixes [5740](https://github.com/mlflow/mlflow/issues/5740)
