### PR TITLE
Fix `r` job broken by R 4.2.0

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -117,6 +117,7 @@ jobs:
         LINTR_COMMENT_BOT: false
       run: |
         cd tests
+        Rscript --version
         Rscript -e 'source("../.run-tests.R", echo=TRUE)'
 
   # python-skinny tests cover a subset of mlflow functionality

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -101,6 +101,8 @@ jobs:
         key: ${{ steps.os-name.outputs.os-name }}-${{ hashFiles('mlflow/R/mlflow/R-version') }}-0-${{ hashFiles('mlflow/R/mlflow/depends.Rds') }}
     - name: Install dependencies
       run: |
+        sudo apt-get update -y
+        sudo apt-get install libharfbuzz-dev libfribidi-dev
         Rscript -e 'source(".install-deps.R", echo=TRUE)'
         # TODO: Remove this line once h2o 3.36.0.2 is uploaded to https://packagemanager.rstudio.com
         Rscript -e 'install.packages("h2o", repos="http://cran.r-project.org")'

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -101,8 +101,6 @@ jobs:
         key: ${{ steps.os-name.outputs.os-name }}-${{ hashFiles('mlflow/R/mlflow/R-version') }}-0-${{ hashFiles('mlflow/R/mlflow/depends.Rds') }}
     - name: Install dependencies
       run: |
-        sudo apt-get update -y
-        sudo apt-get install libharfbuzz-dev libfribidi-dev
         Rscript -e 'source(".install-deps.R", echo=TRUE)'
         # TODO: Remove this line once h2o 3.36.0.2 is uploaded to https://packagemanager.rstudio.com
         Rscript -e 'install.packages("h2o", repos="http://cran.r-project.org")'

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -115,7 +115,6 @@ jobs:
         LINTR_COMMENT_BOT: false
       run: |
         cd tests
-        Rscript --version
         Rscript -e 'source("../.run-tests.R", echo=TRUE)'
 
   # python-skinny tests cover a subset of mlflow functionality

--- a/mlflow/R/mlflow/Dockerfile.dev
+++ b/mlflow/R/mlflow/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM r-base:latest
+FROM rocker/r-ver:latest
 
 WORKDIR /mlflow/mlflow/R/mlflow
 RUN apt-get update -y

--- a/mlflow/R/mlflow/Dockerfile.dev
+++ b/mlflow/R/mlflow/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM rocker/r-ver:4.1.2
+FROM rocker/r-ver:4.2.0
 
 WORKDIR /mlflow/mlflow/R/mlflow
 RUN apt-get update -y

--- a/mlflow/R/mlflow/Dockerfile.dev
+++ b/mlflow/R/mlflow/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM rocker/r-ver:4.2.0
+FROM r-base:latest
 
 WORKDIR /mlflow/mlflow/R/mlflow
 RUN apt-get update -y

--- a/mlflow/R/mlflow/tests/testthat/test-keras-model.R
+++ b/mlflow/R/mlflow/tests/testthat/test-keras-model.R
@@ -29,6 +29,6 @@ test_that("mlflow can save keras model ", {
   expect_equal(
     predict(model, train_x),
     predict(model_reloaded, train_x),
-    mlflow_predict(model_reloaded, iris[, 1:4]))
+  )
   Sys.setenv(PATH = PATH)
 })

--- a/mlflow/rfunc/backend.py
+++ b/mlflow/rfunc/backend.py
@@ -63,6 +63,7 @@ class RFuncBackend(FlavorBackend):
         _execute(command)
 
     def can_score_model(self):
+        # `Rscript --version` writes to stderr in R < 4.2.0, but stdout in R >= 4.2.0
         process = subprocess.Popen(
             ["Rscript", "--version"],
             close_fds=True,

--- a/mlflow/rfunc/backend.py
+++ b/mlflow/rfunc/backend.py
@@ -63,7 +63,7 @@ class RFuncBackend(FlavorBackend):
         _execute(command)
 
     def can_score_model(self):
-        # `Rscript --version` writes to stderr in R < 4.2.0, but stdout in R >= 4.2.0
+        # `Rscript --version` writes to stderr in R < 4.2.0 but stdout in R >= 4.2.0.
         process = subprocess.Popen(
             ["Rscript", "--version"],
             close_fds=True,

--- a/mlflow/rfunc/backend.py
+++ b/mlflow/rfunc/backend.py
@@ -16,7 +16,7 @@ class RFuncBackend(FlavorBackend):
     Predict and serve locally models with 'crate' flavor.
     """
 
-    version_pattern = re.compile("version ([0-9]+[.][0-9]+[.][0-9]+)")
+    version_pattern = re.compile(r"version ([0-9]+\.[0-9]+\.[0-9]+)")
 
     def predict(self, model_uri, input_path, output_path, content_type, json_format):
         """
@@ -64,13 +64,16 @@ class RFuncBackend(FlavorBackend):
 
     def can_score_model(self):
         process = subprocess.Popen(
-            ["Rscript", "--version"], close_fds=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            ["Rscript", "--version"],
+            close_fds=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
         )
-        _, stderr = process.communicate()
+        stdout, _ = process.communicate()
         if process.wait() != 0:
             return False
 
-        version = self.version_pattern.search(stderr.decode("utf-8"))
+        version = self.version_pattern.search(stdout.decode("utf-8"))
         if not version:
             return False
         version = [int(x) for x in version.group(1).split(".")]


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

Fix `r` job broken by R 4.2.0:

https://github.com/mlflow/mlflow/runs/6138928272?check_suite_focus=true#step:8:2475

## How is this patch tested?

Existing tests

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
