### PR TITLE
fix: fix mlflow server starts in R on windows

### DIFF
--- a/docs/source/R-api.rst
+++ b/docs/source/R-api.rst
@@ -1814,7 +1814,7 @@ Wrapper for ``mlflow server``.
      default_artifact_root = NULL,
      host = "127.0.0.1",
      port = 5000,
-     workers = 4,
+     workers = NULL,
      static_prefix = NULL
    )
 

--- a/hooks/prepare-commit-msg
+++ b/hooks/prepare-commit-msg
@@ -1,3 +1,4 @@
+#!/bin/sh
 # A git hook to block an unsigned-off commit
 
 COMMIT_MSG_FILE=$1

--- a/mlflow/R/mlflow/R/python.R
+++ b/mlflow/R/mlflow/R/python.R
@@ -12,7 +12,11 @@ get_python_bin <- function() {
     stop(paste("MLflow not configured, please run install_mlflow() or ",
                "set MLFLOW_PYTHON_BIN and MLFLOW_BIN environment variables.", sep = ""))
   }
-  file.path(dirname(mlflow_env$python), "python.exe")
+  if (.Platform$OS.type == "windows") {
+    file.path(dirname(mlflow_env$python), "python.exe")
+  } else {
+    mlflow_env$python
+  }
 }
 
 # Returns path to Python executable within conda environment created for the MLflow R package

--- a/mlflow/R/mlflow/R/python.R
+++ b/mlflow/R/mlflow/R/python.R
@@ -12,11 +12,8 @@ get_python_bin <- function() {
     stop(paste("MLflow not configured, please run install_mlflow() or ",
                "set MLFLOW_PYTHON_BIN and MLFLOW_BIN environment variables.", sep = ""))
   }
-  if (.Platform$OS.type == "windows") {
-    file.path(dirname(mlflow_env$python), "python.exe")
-  } else {
-    mlflow_env$python
-  }
+  mlflow_env$python <- normalizePath(mlflow_env$python, winslash = "/", mustWork = FALSE)
+  mlflow_env$python
 }
 
 # Returns path to Python executable within conda environment created for the MLflow R package

--- a/mlflow/R/mlflow/R/python.R
+++ b/mlflow/R/mlflow/R/python.R
@@ -19,6 +19,7 @@ get_python_bin <- function() {
 python_bin <- function() {
   if (is.null(.globals$python_bin)) {
     python <- get_python_bin()
+    python <- file.path(dirname(python), "python.exe")
     .globals$python_bin <- path.expand(python)
   }
 
@@ -33,7 +34,11 @@ python_mlflow_bin <- function() {
     return(in_env)
   }
   python_bin_dir <- dirname(python_bin())
-  file.path(python_bin_dir, "mlflow")
+  if (.Platform$OS.type == "windows") {
+    file.path(python_bin_dir, "Scripts", "mlflow")
+  } else {
+    file.path(python_bin_dir, "mlflow")
+  }
 }
 
 # Return path to conda home directory, such that the `conda` executable can be found

--- a/mlflow/R/mlflow/R/python.R
+++ b/mlflow/R/mlflow/R/python.R
@@ -12,14 +12,13 @@ get_python_bin <- function() {
     stop(paste("MLflow not configured, please run install_mlflow() or ",
                "set MLFLOW_PYTHON_BIN and MLFLOW_BIN environment variables.", sep = ""))
   }
-  mlflow_env$python
+  file.path(dirname(mlflow_env$python), "python.exe")
 }
 
 # Returns path to Python executable within conda environment created for the MLflow R package
 python_bin <- function() {
   if (is.null(.globals$python_bin)) {
     python <- get_python_bin()
-    python <- file.path(dirname(python), "python.exe")
     .globals$python_bin <- path.expand(python)
   }
 

--- a/mlflow/R/mlflow/R/tracking-server.R
+++ b/mlflow/R/mlflow/R/tracking-server.R
@@ -54,16 +54,21 @@ mlflow_cli_param <- function(args, param, value) {
 #' @param static_prefix A prefix which will be prepended to the path of all static paths.
 #' @export
 mlflow_server <- function(file_store = "mlruns", default_artifact_root = NULL,
-                          host = "127.0.0.1", port = 5000, workers = 4, static_prefix = NULL) {
+                          host = "127.0.0.1", port = 5000, workers = NULL, static_prefix = NULL) {
   file_store <- fs::path_abs(file_store)
+  if (.Platform$OS.type == "windows") file_store <- paste0("file://", file_store)
 
   args <- mlflow_cli_param(list(), "--port", port) %>%
     mlflow_cli_param("--backend-store-uri", file_store) %>%
     mlflow_cli_param("--default-artifact-root", default_artifact_root) %>%
     mlflow_cli_param("--host", host) %>%
     mlflow_cli_param("--port", port) %>%
-    mlflow_cli_param("--workers", workers) %>%
     mlflow_cli_param("--static-prefix", static_prefix)
+
+  if (.Platform$OS.type != "windows") {
+    workers <- workers %||% 4
+    args <- args %>% mlflow_cli_param("--workers", workers)
+  }
 
   mlflow_verbose_message("MLflow starting: http://", host, ":", port)
 

--- a/mlflow/R/mlflow/man/mlflow_server.Rd
+++ b/mlflow/R/mlflow/man/mlflow_server.Rd
@@ -9,7 +9,7 @@ mlflow_server(
   default_artifact_root = NULL,
   host = "127.0.0.1",
   port = 5000,
-  workers = 4,
+  workers = NULL,
   static_prefix = NULL
 )
 }


### PR DESCRIPTION
Signed-off-by: Xinyue Ruan <serena.rxy@gmail.com>

## What changes are proposed in this pull request?

Fix mlflow server can not start error in R on windows.
Problems: 
1. Windows local file path format need to be prefixed with file:// in order to work
2. --workers parameter for mlflow_cli doesn't exist so set it as NULL by default and set it as 4 if not under windows environment.
3. Fix mlflow cli path under windows cuz it's under pythion_bin_dir/Scripts/mlflow by default 

## How is this patch tested?

Built R binary and tested below:
`with(mlflow_start_run(), {
  mlflow_log_artifact("corgi.jpg")
  mlflow_log_metric("corgi_face", 1)
  mlflow_log_param("corgi_happy", "yes")
})`

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
4. Click `Details` on the right to open the job page of CircleCI.
5. Click the `Artifacts` tab.
6. Click `docs/build/html/index.html`.
7. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [x] `area/windows`: Windows support

Language
- [x] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
