### PR TITLE
Remove old ML packages versions in `ml-package-versions.yml`

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -8,13 +8,13 @@ sklearn:
       pip install $CACHE_DIR/scikit_learn-*.whl
 
   models:
-    minimum: "0.20.3"
+    minimum: "0.22.1"
     maximum: "1.0.2"
     run: |
       pytest tests/sklearn/test_sklearn_model_export.py --large
 
   autologging:
-    minimum: "0.20.3"
+    minimum: "0.22.1"
     maximum: "1.0.2"
     requirements: ["matplotlib"]
     run: |
@@ -27,7 +27,7 @@ pytorch:
       pip install --upgrade --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
 
   models:
-    minimum: "1.4.0"
+    minimum: "1.6.0"
     maximum: "1.11.0"
     requirements: ["torchvision", "scikit-learn", "transformers"]
     run: |
@@ -61,10 +61,9 @@ tensorflow:
       pip install tf-nightly
 
   models:
-    minimum: "2.0.0"
+    minimum: "2.3.0"
     maximum: "2.8.0"
     requirements:
-      "< 2.2": ["h5py<3.0", "scikit-learn"]
       # Requirements to run tests for keras
       "== dev": ["scikit-learn", "pyspark", "pyarrow"]
     run: |
@@ -77,10 +76,9 @@ tensorflow:
       fi
 
   autologging:
-    minimum: "2.0.0"
+    minimum: "2.3.0"
     maximum: "2.8.0"
     requirements:
-      "< 2.2": ["h5py<3.0"]
       "== dev": ["scikit-learn"]
     run: |
       pytest tests/tensorflow/test_tensorflow2_autolog.py --large
@@ -122,14 +120,14 @@ xgboost:
       pip install git+https://github.com/dmlc/xgboost.git#subdirectory=python-package
 
   models:
-    minimum: "0.90"
+    minimum: "1.1.1"
     maximum: "1.5.2"
     requirements: ["scikit-learn"]
     run: |
       pytest tests/xgboost/test_xgboost_model_export.py --large
 
   autologging:
-    minimum: "0.90"
+    minimum: "1.1.1"
     maximum: "1.5.2"
     requirements: ["scikit-learn", "matplotlib"]
     run: |
@@ -338,7 +336,7 @@ mleap:
     pip_release: "mleap"
 
   models:
-    minimum: "0.15.0"
+    minimum: "0.16.1"
     maximum: "0.20.0"
     requirements:
       "<= 0.17.0": ["pyspark==2.4.5"]


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

Update `mlflow/ml-package-versions.yml` to drop old ML package versions that are older than the ones installed in MLR 7.3.

https://docs.databricks.com/release-notes/runtime/7.3ml.html#python-libraries-on-cpu-clusters

## How is this patch tested?

Existing tests.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
