### PR TITLE
Use r-base Docker image as initial layer for R package build

### DIFF
--- a/mlflow/R/mlflow/Dockerfile.dev
+++ b/mlflow/R/mlflow/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM rocker/r-ver:4.1.2
+FROM r-base:latest
 
 WORKDIR /mlflow/mlflow/R/mlflow
 RUN apt-get update -y

--- a/mlflow/R/mlflow/Dockerfile.dev
+++ b/mlflow/R/mlflow/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM r-base:latest
+FROM rocker/r-ver:4.1.2
 
 WORKDIR /mlflow/mlflow/R/mlflow
 RUN apt-get update -y

--- a/mlflow/R/mlflow/Dockerfile.r-devel
+++ b/mlflow/R/mlflow/Dockerfile.r-devel
@@ -4,27 +4,18 @@ FROM rocker/r-ver:devel
 # https://developer.r-project.org/blosxom.cgi/R-devel
 
 WORKDIR /mlflow/mlflow/R/mlflow
+# Apply a fix for apt-get update failures on Ubuntu 22.04,
+# as discussed in https://stackoverflow.com/a/71982514/11952869
 RUN sed -i -e 's/^APT/# APT/' -e 's/^DPkg/# DPkg/' \
       /etc/apt/apt.conf.d/docker-clean
 RUN apt-get update -y
 RUN apt-get install git wget libxml2-dev libgit2-dev libfontconfig1-dev \
     libssl-dev libharfbuzz-dev libfribidi-dev libcurl4-openssl-dev \
     libfreetype6-dev libpng-dev libtiff5-dev libjpeg-dev -y
-# RUN sed -i -e 's/# APT/APT/' -e 's/# DPkg/DPkg/' \
-#       /etc/apt/apt.conf.d/docker-clean
 # pandoc installed by `apt-get` is too old and contains a bug, so we install it
-# from source using Haskell platform, as discussed in https://pandoc.org/installing.html#linux
+# from source via tarball as discussed in https://pandoc.org/installing.html#linux
 RUN wget https://github.com/jgm/pandoc/releases/download/2.18/pandoc-2.18-linux-arm64.tar.gz && \
     tar xvzf pandoc-2.18-linux-arm64.tar.gz --strip-components 1 -C /usr/local
-RUN echo $(pandoc --version)
-
-# RUN apt-get install haskell-platform -y
-# RUN cabal update
-# RUN cabal install pandoc
-# RUN TEMP_DEB=$(mktemp) && \
-#     wget --directory-prefix $TEMP_DEB https://github.com/jgm/pandoc/releases/download/2.16.2/pandoc-2.16.2-1-amd64.deb && \
-#     dpkg --install $(find $TEMP_DEB -name '*.deb') && \
-#     rm -rf $TEMP_DEB
 COPY DESCRIPTION .
 COPY .install-deps.R .
 RUN Rscript -e 'source(".install-deps.R", echo = TRUE)'

--- a/mlflow/R/mlflow/Dockerfile.r-devel
+++ b/mlflow/R/mlflow/Dockerfile.r-devel
@@ -19,5 +19,5 @@ RUN wget https://github.com/jgm/pandoc/releases/download/2.18/pandoc-2.18-linux-
 COPY DESCRIPTION .
 COPY .install-deps.R .
 ENV OMP_NUM_THREADS=1
-ENV USE_SIMPLE_THREADED_LEVEL3= 1
+ENV USE_SIMPLE_THREADED_LEVEL3=1
 RUN Rscript -e 'source(".install-deps.R", echo = TRUE)'

--- a/mlflow/R/mlflow/Dockerfile.r-devel
+++ b/mlflow/R/mlflow/Dockerfile.r-devel
@@ -4,6 +4,8 @@ FROM rocker/r-ver:devel
 # https://developer.r-project.org/blosxom.cgi/R-devel
 
 WORKDIR /mlflow/mlflow/R/mlflow
+RUN sed -i -e 's/^APT/# APT/' -e 's/^DPkg/# DPkg/' \
+      /etc/apt/apt.conf.d/docker-clean
 RUN apt-get update -y
 RUN apt-get install git wget libxml2-dev libgit2-dev libfontconfig1-dev \
     libssl-dev libharfbuzz-dev libfribidi-dev libcurl4-openssl-dev \

--- a/mlflow/R/mlflow/Dockerfile.r-devel
+++ b/mlflow/R/mlflow/Dockerfile.r-devel
@@ -20,4 +20,5 @@ COPY DESCRIPTION .
 COPY .install-deps.R .
 ENV OMP_NUM_THREADS=1
 ENV USE_SIMPLE_THREADED_LEVEL3=1
+RUN free -m
 RUN Rscript -e 'source(".install-deps.R", echo = TRUE)'

--- a/mlflow/R/mlflow/Dockerfile.r-devel
+++ b/mlflow/R/mlflow/Dockerfile.r-devel
@@ -21,4 +21,4 @@ COPY .install-deps.R .
 ENV OMP_NUM_THREADS=1
 ENV USE_SIMPLE_THREADED_LEVEL3=1
 RUN free -m
-RUN Rscript -e 'source(".install-deps.R", echo = TRUE)'
+RUN Rscript .install-deps.R

--- a/mlflow/R/mlflow/Dockerfile.r-devel
+++ b/mlflow/R/mlflow/Dockerfile.r-devel
@@ -10,17 +10,17 @@ RUN apt-get update -y
 RUN apt-get install git wget libxml2-dev libgit2-dev libfontconfig1-dev \
     libssl-dev libharfbuzz-dev libfribidi-dev libcurl4-openssl-dev \
     libfreetype6-dev libpng-dev libtiff5-dev libjpeg-dev -y
-RUN sed -i -e 's/# APT/APT/' -e 's/# DPkg/DPkg/' \
-      /etc/apt/apt.conf.d/docker-clean
+# RUN sed -i -e 's/# APT/APT/' -e 's/# DPkg/DPkg/' \
+#       /etc/apt/apt.conf.d/docker-clean
 # pandoc installed by `apt-get` is too old and contains a bug, so we install it
 # from source using Haskell platform, as discussed in https://pandoc.org/installing.html#linux
-# RUN apt-get install haskell-platform -y
-# RUN cabal update
-# RUN cabal install pandoc
-RUN TEMP_DEB=$(mktemp) && \
-    wget --directory-prefix $TEMP_DEB https://github.com/jgm/pandoc/releases/download/2.16.2/pandoc-2.16.2-1-amd64.deb && \
-    dpkg --install $(find $TEMP_DEB -name '*.deb') && \
-    rm -rf $TEMP_DEB
+RUN apt-get install haskell-platform -y
+RUN cabal update
+RUN cabal install pandoc
+# RUN TEMP_DEB=$(mktemp) && \
+#     wget --directory-prefix $TEMP_DEB https://github.com/jgm/pandoc/releases/download/2.16.2/pandoc-2.16.2-1-amd64.deb && \
+#     dpkg --install $(find $TEMP_DEB -name '*.deb') && \
+#     rm -rf $TEMP_DEB
 COPY DESCRIPTION .
 COPY .install-deps.R .
 RUN Rscript -e 'source(".install-deps.R", echo = TRUE)'

--- a/mlflow/R/mlflow/Dockerfile.r-devel
+++ b/mlflow/R/mlflow/Dockerfile.r-devel
@@ -14,9 +14,13 @@ RUN apt-get install git wget libxml2-dev libgit2-dev libfontconfig1-dev \
 #       /etc/apt/apt.conf.d/docker-clean
 # pandoc installed by `apt-get` is too old and contains a bug, so we install it
 # from source using Haskell platform, as discussed in https://pandoc.org/installing.html#linux
-RUN apt-get install haskell-platform -y
-RUN cabal update
-RUN cabal install pandoc
+RUN wget https://github.com/jgm/pandoc/releases/download/2.18/pandoc-2.18-linux-arm64.tar.gz && \
+    tar xvzf pandoc-2.18-linux-arm64.tar.gz --strip-components 1 -C /usr/local
+RUN echo $(pandoc --version)
+
+# RUN apt-get install haskell-platform -y
+# RUN cabal update
+# RUN cabal install pandoc
 # RUN TEMP_DEB=$(mktemp) && \
 #     wget --directory-prefix $TEMP_DEB https://github.com/jgm/pandoc/releases/download/2.16.2/pandoc-2.16.2-1-amd64.deb && \
 #     dpkg --install $(find $TEMP_DEB -name '*.deb') && \

--- a/mlflow/R/mlflow/Dockerfile.r-devel
+++ b/mlflow/R/mlflow/Dockerfile.r-devel
@@ -18,4 +18,6 @@ RUN wget https://github.com/jgm/pandoc/releases/download/2.18/pandoc-2.18-linux-
     tar xvzf pandoc-2.18-linux-arm64.tar.gz --strip-components 1 -C /usr/local
 COPY DESCRIPTION .
 COPY .install-deps.R .
+ENV OMP_NUM_THREADS=1
+ENV USE_SIMPLE_THREADED_LEVEL3= 1
 RUN Rscript -e 'source(".install-deps.R", echo = TRUE)'

--- a/mlflow/R/mlflow/Dockerfile.r-devel
+++ b/mlflow/R/mlflow/Dockerfile.r-devel
@@ -1,4 +1,4 @@
-FROM rocker/r-ver:devel
+FROM r-base:latest
 
 # Daily News about R-devel:
 # https://developer.r-project.org/blosxom.cgi/R-devel
@@ -6,8 +6,8 @@ FROM rocker/r-ver:devel
 WORKDIR /mlflow/mlflow/R/mlflow
 # Apply a fix for apt-get update failures on Ubuntu 22.04,
 # as discussed in https://stackoverflow.com/a/71982514/11952869
-RUN sed -i -e 's/^APT/# APT/' -e 's/^DPkg/# DPkg/' \
-      /etc/apt/apt.conf.d/docker-clean
+# RUN sed -i -e 's/^APT/# APT/' -e 's/^DPkg/# DPkg/' \
+#       /etc/apt/apt.conf.d/docker-clean
 RUN apt-get update -y
 RUN apt-get install git wget libxml2-dev libgit2-dev libfontconfig1-dev \
     libssl-dev libharfbuzz-dev libfribidi-dev libcurl4-openssl-dev \
@@ -20,5 +20,4 @@ COPY DESCRIPTION .
 COPY .install-deps.R .
 ENV OMP_NUM_THREADS=1
 ENV USE_SIMPLE_THREADED_LEVEL3=1
-RUN free -m
 RUN Rscript .install-deps.R

--- a/mlflow/R/mlflow/Dockerfile.r-devel
+++ b/mlflow/R/mlflow/Dockerfile.r-devel
@@ -4,20 +4,15 @@ FROM r-base:latest
 # https://developer.r-project.org/blosxom.cgi/R-devel
 
 WORKDIR /mlflow/mlflow/R/mlflow
-# Apply a fix for apt-get update failures on Ubuntu 22.04,
-# as discussed in https://stackoverflow.com/a/71982514/11952869
-# RUN sed -i -e 's/^APT/# APT/' -e 's/^DPkg/# DPkg/' \
-#       /etc/apt/apt.conf.d/docker-clean
 RUN apt-get update -y
 RUN apt-get install git wget libxml2-dev libgit2-dev libfontconfig1-dev \
     libssl-dev libharfbuzz-dev libfribidi-dev libcurl4-openssl-dev \
     libfreetype6-dev libpng-dev libtiff5-dev libjpeg-dev -y
-# pandoc installed by `apt-get` is too old and contains a bug, so we install it
-# from source via tarball as discussed in https://pandoc.org/installing.html#linux
-RUN wget https://github.com/jgm/pandoc/releases/download/2.18/pandoc-2.18-linux-arm64.tar.gz && \
-    tar xvzf pandoc-2.18-linux-arm64.tar.gz --strip-components 1 -C /usr/local
+# pandoc installed by `apt-get` is too old and contains a bug.
+RUN TEMP_DEB=$(mktemp) && \
+    wget --directory-prefix $TEMP_DEB https://github.com/jgm/pandoc/releases/download/2.16.2/pandoc-2.16.2-1-amd64.deb && \
+    dpkg --install $(find $TEMP_DEB -name '*.deb') && \
+    rm -rf $TEMP_DEB
 COPY DESCRIPTION .
 COPY .install-deps.R .
-# ENV OMP_NUM_THREADS=1
-# ENV USE_SIMPLE_THREADED_LEVEL3=1
-RUN Rscript .install-deps.R
+RUN Rscript -e 'source(".install-deps.R", echo = TRUE)'

--- a/mlflow/R/mlflow/Dockerfile.r-devel
+++ b/mlflow/R/mlflow/Dockerfile.r-devel
@@ -4,13 +4,19 @@ FROM rocker/r-ver:devel
 # https://developer.r-project.org/blosxom.cgi/R-devel
 
 WORKDIR /mlflow/mlflow/R/mlflow
-RUN sed -i -e 's/^APT/# APT/' \
+RUN sed -i -e 's/^APT/# APT/' -e 's/^DPkg/# DPkg/' \
       /etc/apt/apt.conf.d/docker-clean
 RUN apt-get update -y
 RUN apt-get install git wget libxml2-dev libgit2-dev libfontconfig1-dev \
     libssl-dev libharfbuzz-dev libfribidi-dev libcurl4-openssl-dev \
     libfreetype6-dev libpng-dev libtiff5-dev libjpeg-dev -y
-# pandoc installed by `apt-get` is too old and contains a bug.
+RUN sed -i -e 's/# APT/APT/' -e 's/# DPkg/DPkg/' \
+      /etc/apt/apt.conf.d/docker-clean
+# pandoc installed by `apt-get` is too old and contains a bug, so we install it
+# from source using Haskell platform, as discussed in https://pandoc.org/installing.html#linux
+# RUN apt-get install haskell-platform -y
+# RUN cabal update
+# RUN cabal install pandoc
 RUN TEMP_DEB=$(mktemp) && \
     wget --directory-prefix $TEMP_DEB https://github.com/jgm/pandoc/releases/download/2.16.2/pandoc-2.16.2-1-amd64.deb && \
     dpkg --install $(find $TEMP_DEB -name '*.deb') && \

--- a/mlflow/R/mlflow/Dockerfile.r-devel
+++ b/mlflow/R/mlflow/Dockerfile.r-devel
@@ -18,6 +18,6 @@ RUN wget https://github.com/jgm/pandoc/releases/download/2.18/pandoc-2.18-linux-
     tar xvzf pandoc-2.18-linux-arm64.tar.gz --strip-components 1 -C /usr/local
 COPY DESCRIPTION .
 COPY .install-deps.R .
-ENV OMP_NUM_THREADS=1
-ENV USE_SIMPLE_THREADED_LEVEL3=1
+# ENV OMP_NUM_THREADS=1
+# ENV USE_SIMPLE_THREADED_LEVEL3=1
 RUN Rscript .install-deps.R

--- a/mlflow/R/mlflow/Dockerfile.r-devel
+++ b/mlflow/R/mlflow/Dockerfile.r-devel
@@ -4,7 +4,7 @@ FROM rocker/r-ver:devel
 # https://developer.r-project.org/blosxom.cgi/R-devel
 
 WORKDIR /mlflow/mlflow/R/mlflow
-RUN sed -i -e 's/^APT/# APT/' -e 's/^DPkg/# DPkg/' \
+RUN sed -i -e 's/^APT/# APT/' \
       /etc/apt/apt.conf.d/docker-clean
 RUN apt-get update -y
 RUN apt-get install git wget libxml2-dev libgit2-dev libfontconfig1-dev \


### PR DESCRIPTION
## What changes are proposed in this pull request?

Use r-base Docker image as initial layer for R package build because `rocker/r-devel` now requires Ubuntu 22.04, which is incompatible with the CI systems that run the R package build. R base uses Debian 12.

## How is this patch tested?

Tested on CI system

## Does this PR change the documentation?

- X ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [X] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
