### PR TITLE
Added longName to RunLinkPopover

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/MetricsPlotPanel.js
+++ b/mlflow/server/js/src/experiment-tracking/components/MetricsPlotPanel.js
@@ -540,7 +540,7 @@ export class MetricsPlotPanel extends React.Component {
           .sort((a, b) => b.y - a.y)
           .map((point) => ({
             runId: point.data.runId,
-            name: point.data.name,
+            name: point.data.longName,
             color: point.fullData.marker.color,
             y: point.y,
           }));

--- a/mlflow/server/js/src/experiment-tracking/components/MetricsPlotPanel.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/MetricsPlotPanel.test.js
@@ -361,14 +361,14 @@ describe('unit tests', () => {
       },
       points: [
         {
-          data: { runId: 'runUuid1', name: 'run1' },
+          data: { runId: 'runUuid1', name: 'run1', longName: 'run1_long' },
           fullData: {
             marker: { color: 'rgb(1, 1, 1)' },
           },
           y: 0.2,
         },
         {
-          data: { runId: 'runUuid2', name: 'run2' },
+          data: { runId: 'runUuid2', name: 'run2', longName: 'run2_long' },
           fullData: {
             marker: { color: 'rgb(2, 2, 2)' },
           },
@@ -384,13 +384,13 @@ describe('unit tests', () => {
       runItems: [
         {
           runId: 'runUuid1',
-          name: 'run1',
+          name: 'run1_long',
           color: 'rgb(1, 1, 1)',
           y: 0.2,
         },
         {
           runId: 'runUuid2',
-          name: 'run2',
+          name: 'run2_long',
           color: 'rgb(2, 2, 2)',
           y: 0.1,
         },

--- a/mlflow/server/js/src/experiment-tracking/components/MetricsPlotView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/MetricsPlotView.js
@@ -55,10 +55,14 @@ export class MetricsPlotView extends React.Component {
     deselectedCurves: PropTypes.arrayOf(PropTypes.string).isRequired,
   };
 
-  static getLineLegend = (metricKey, runDisplayName, isComparing) => {
+  static getLineLegend = (metricKey, runDisplayName, isComparing, shorten) => {
     let legend = metricKey;
     if (isComparing) {
-      legend += `, ${Utils.truncateString(runDisplayName, MAX_RUN_NAME_DISPLAY_LENGTH)}`;
+      if (shorten) {
+        legend += `, ${Utils.truncateString(runDisplayName, MAX_RUN_NAME_DISPLAY_LENGTH)}`;
+      } else {
+        legend += `, ${runDisplayName}`;
+      }
     }
     return legend;
   };
@@ -89,7 +93,8 @@ export class MetricsPlotView extends React.Component {
         ? true
         : 'legendonly';
       return {
-        name: MetricsPlotView.getLineLegend(metricKey, runDisplayName, isComparing),
+        name: MetricsPlotView.getLineLegend(metricKey, runDisplayName, isComparing, true),
+        longName: MetricsPlotView.getLineLegend(metricKey, runDisplayName, isComparing, false),
         x: history.map((entry) => {
           if (xAxis === X_AXIS_STEP) {
             return entry.step;

--- a/mlflow/server/js/src/experiment-tracking/components/MetricsPlotView.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/MetricsPlotView.test.js
@@ -295,6 +295,7 @@ describe('unit tests', () => {
         {
           metricName: 'metric_0',
           name: 'metric_0',
+          longName: 'metric_0',
           runId: 'runUuid1',
           x: [0, 1],
           y: [100, 200],
@@ -308,6 +309,7 @@ describe('unit tests', () => {
         {
           metricName: 'metric_1',
           name: 'metric_1',
+          longName: 'metric_1',
           runId: 'runUuid2',
           x: [0, 1],
           y: [300, 400],
@@ -321,6 +323,7 @@ describe('unit tests', () => {
         {
           metricName: 'metric_2',
           name: 'metric_2',
+          longName: 'metric_2',
           runId: 'runUuid3',
           x: [0],
           y: [300],
@@ -334,6 +337,7 @@ describe('unit tests', () => {
         {
           metricName: 'metric_3',
           name: 'metric_3',
+          longName: 'metric_3',
           runId: 'runUuid3',
           x: [],
           y: [],
@@ -357,6 +361,7 @@ describe('unit tests', () => {
         {
           metricName: 'metric_0',
           name: 'metric_0',
+          longName: 'metric_0',
           runId: 'runUuid1',
           x: [0, 1, 2],
           y: [100, 200, NaN],
@@ -370,6 +375,7 @@ describe('unit tests', () => {
         {
           metricName: 'metric_1',
           name: 'metric_1',
+          longName: 'metric_1',
           runId: 'runUuid2',
           x: [0, 1],
           y: [NaN, 400],
@@ -383,6 +389,7 @@ describe('unit tests', () => {
         {
           metricName: 'metric_2',
           name: 'metric_2',
+          longName: 'metric_2',
           runId: 'runUuid3',
           x: [0],
           y: [NaN],
@@ -396,6 +403,7 @@ describe('unit tests', () => {
         {
           metricName: 'metric_3',
           name: 'metric_3',
+          longName: 'metric_3',
           runId: 'runUuid3',
           x: [0, 1],
           y: [NaN, NaN],
@@ -419,6 +427,7 @@ describe('unit tests', () => {
         {
           metricName: 'metric_0',
           name: 'metric_0',
+          longName: 'metric_0',
           runId: 'runUuid1',
           x: [0, 1],
           y: [100, 166.88741721854302],
@@ -432,6 +441,7 @@ describe('unit tests', () => {
         {
           metricName: 'metric_1',
           name: 'metric_1',
+          longName: 'metric_1',
           runId: 'runUuid2',
           x: [0, 1],
           y: [300, 366.887417218543],
@@ -445,6 +455,7 @@ describe('unit tests', () => {
         {
           metricName: 'metric_2',
           name: 'metric_2',
+          longName: 'metric_2',
           runId: 'runUuid3',
           x: [0],
           y: [300],
@@ -458,6 +469,7 @@ describe('unit tests', () => {
         {
           metricName: 'metric_3',
           name: 'metric_3',
+          longName: 'metric_3',
           runId: 'runUuid3',
           x: [],
           y: [],
@@ -481,6 +493,7 @@ describe('unit tests', () => {
         {
           metricName: 'metric_0',
           name: 'metric_0',
+          longName: 'metric_0',
           runId: 'runUuid1',
           x: [0, 1, 2],
           y: [100, 166.88741721854302, NaN],
@@ -494,6 +507,7 @@ describe('unit tests', () => {
         {
           metricName: 'metric_1',
           name: 'metric_1',
+          longName: 'metric_1',
           runId: 'runUuid2',
           x: [0, 1],
           y: [NaN, 400],
@@ -507,6 +521,7 @@ describe('unit tests', () => {
         {
           metricName: 'metric_2',
           name: 'metric_2',
+          longName: 'metric_2',
           runId: 'runUuid3',
           x: [0],
           y: [NaN],
@@ -520,6 +535,7 @@ describe('unit tests', () => {
         {
           metricName: 'metric_3',
           name: 'metric_3',
+          longName: 'metric_3',
           runId: 'runUuid3',
           x: [0, 1],
           y: [NaN, NaN],
@@ -589,9 +605,14 @@ describe('unit tests', () => {
 
   test('getLineLegend()', () => {
     // how both metric and run name when comparing multiple runs
-    expect(MetricsPlotView.getLineLegend('metric_1', 'Run abc', true)).toBe('metric_1, Run abc');
+    const name = 'abcdefghijklmnopqrstuvwxyz';
+    const nameShortened = 'abcdefghijklmnopqrstu...';
+    expect(MetricsPlotView.getLineLegend('metric_1', name, true, false)).toBe(`metric_1, ${name}`);
+    expect(MetricsPlotView.getLineLegend('metric_1', name, true, true)).toBe(
+      `metric_1, ${nameShortened}`,
+    );
     // only show metric name when there
-    expect(MetricsPlotView.getLineLegend('metric_1', 'Run abc', false)).toBe('metric_1');
+    expect(MetricsPlotView.getLineLegend('metric_1', name, false, true)).toBe('metric_1');
   });
 
   test('parseTimestamp()', () => {


### PR DESCRIPTION
Signed-off-by: Pim de Haan <pimdehaan@gmail.com>

## What changes are proposed in this pull request?

I added a property `longName` to the metrics data object in `getPlotPropsForLineChart` in `MetricsPlotView`, which does not abbreviate the run name. This long name is then shown in the RunLinkPopover.

Fixes #5796.

## How is this patch tested?
Added a test to the creation of the unabbreviated name. Modified the test in `click into RunLinksPopover` to ensure the long name is shown.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes
Show the unabbreviated run name in RunLinkPopover.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Show the unabbreviated run name in RunLinkPopover.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
