### PR TITLE
Adjust auto generated image sizes and formatting

### DIFF
--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -838,7 +838,7 @@ class DefaultEvaluator(ModelEvaluator):
                     "axes.labelsize": 8,
                 }
             ):
-                _, ax = plt.subplots(1, 1, figsize=(6.0, 4.0))
+                _, ax = plt.subplots(1, 1, figsize=(6.0, 4.0), dpi=175)
                 sk_metrics.ConfusionMatrixDisplay(
                     confusion_matrix=confusion_matrix,
                     display_labels=self.label_list,

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -834,8 +834,11 @@ class DefaultEvaluator(ModelEvaluator):
 
             with matplotlib.rc_context(
                 {
-                    "font.size": min(8, 50.0 / self.num_classes),
+                    "font.size": min(8, math.ceil(50.0 / self.num_classes)),
                     "axes.labelsize": 8,
+                    "figure.figsize": [6.0, 4.0],
+                    "figure.autolayout": True,
+                    "savefig.facecolor": "white",
                 }
             ):
                 _, ax = plt.subplots(1, 1, figsize=(6.0, 4.0))

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -838,7 +838,7 @@ class DefaultEvaluator(ModelEvaluator):
                     "axes.labelsize": 8,
                 }
             ):
-                _, ax = plt.subplots(1, 1, figsize=(6, 4))
+                _, ax = plt.subplots(1, 1, figsize=(6.0, 4.0))
                 sk_metrics.ConfusionMatrixDisplay(
                     confusion_matrix=confusion_matrix,
                     display_labels=self.label_list,

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -271,8 +271,10 @@ def _gen_classifier_curve(
 
 
 _matplotlib_config = {
-    "figure.dpi": 288,
+    "figure.dpi": 175,
     "figure.figsize": [6.0, 4.0],
+    "figure.autolayout": True,
+    "font.size": 8,
 }
 
 
@@ -828,17 +830,19 @@ class DefaultEvaluator(ModelEvaluator):
 
         def plot_confusion_matrix():
             import matplotlib
+            import matplotlib.pyplot as plt
 
             with matplotlib.rc_context(
                 {
-                    "font.size": min(10, 50.0 / self.num_classes),
-                    "axes.labelsize": 10,
+                    "font.size": min(8, 50.0 / self.num_classes),
+                    "axes.labelsize": 8,
                 }
             ):
+                _, ax = plt.subplots(1, 1, figsize=(6, 4))
                 sk_metrics.ConfusionMatrixDisplay(
                     confusion_matrix=confusion_matrix,
                     display_labels=self.label_list,
-                ).plot(cmap="Blues")
+                ).plot(cmap="Blues", ax=ax)
 
         if hasattr(sk_metrics, "ConfusionMatrixDisplay"):
             self._log_image_artifact(

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -836,9 +836,6 @@ class DefaultEvaluator(ModelEvaluator):
                 {
                     "font.size": min(8, math.ceil(50.0 / self.num_classes)),
                     "axes.labelsize": 8,
-                    "figure.figsize": [6.0, 4.0],
-                    "figure.autolayout": True,
-                    "savefig.facecolor": "white",
                 }
             ):
                 _, ax = plt.subplots(1, 1, figsize=(6.0, 4.0))


### PR DESCRIPTION
Signed-off-by: Ben Wilson <benjamin.wilson@databricks.com>

## What changes are proposed in this pull request?

Adjust the plots generated in the evaluator API and match rendering of autologging confusion matrix.

## How is this patch tested?

manual validation of artifact image sizes and rendering

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Auto-generated images from auto logging and the evaluator API are smaller and more legible.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
