### PR TITLE
Pyfunc: Fix code dir resolution of subdirectories

### DIFF
--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -77,7 +77,6 @@ def _get_code_dirs(src_code_path, dst_code_path=None):
     """
     Obtains the names of the subdirectories contained under the specified source code
     path and joins them with the specified destination code path.
-
     :param src_code_path: The path of the source code directory for which to list subdirectories.
     :param dst_code_path: The destination directory path to which subdirectory names should be
                           joined.

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -87,7 +87,7 @@ def _get_code_dirs(src_code_path, dst_code_path=None):
     return [
         (os.path.join(dst_code_path, x))
         for x in os.listdir(src_code_path)
-        if os.path.isdir(x) and not x == "__pycache__"
+        if os.path.isdir(os.path.join(src_code_path, x)) and not x == "__pycache__"
     ]
 
 

--- a/tests/utils/test_model_utils.py
+++ b/tests/utils/test_model_utils.py
@@ -10,6 +10,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.models import Model
 from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST
 from mlflow.mleap import FLAVOR_NAME as MLEAP_FLAVOR_NAME
+from mlflow.utils.file_utils import TempDir
 
 
 @pytest.fixture(scope="module")
@@ -79,7 +80,10 @@ def test_add_code_to_system_path(sklearn_knn_model, model_path):
     sklearn_flavor_config = mlflow_model_utils._get_flavor_configuration(
         model_path=model_path, flavor_name=mlflow.sklearn.FLAVOR_NAME
     )
-    with pytest.raises(ModuleNotFoundError, match="No module named 'dummy_module'"):
+    with TempDir(chdr=True):
+        # Load the model from a new directory that is not a parent of the source code path to
+        # verify that source code paths and their subdirectories are resolved correctly
+        with pytest.raises(ModuleNotFoundError, match="No module named 'dummy_module'"):
+            import dummy_module
+        mlflow_model_utils._add_code_from_conf_to_system_path(model_path, sklearn_flavor_config)
         import dummy_module
-    mlflow_model_utils._add_code_from_conf_to_system_path(model_path, sklearn_flavor_config)
-    import dummy_module


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes https://github.com/mlflow/mlflow/issues/5786

## How is this patch tested?

Improved unit test coverage

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

Fix a bug where code subdirectories were not properly added to the system path when loading a model with ``mlflow.pyfunc.load_model()``.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
