### PR TITLE
Pass in the `pos_label` parameter to `eval_and_log_metrics`

### DIFF
--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -1731,9 +1731,12 @@ def eval_and_log_metrics(model, X, y_true, *, prefix, sample_weight=None, pos_la
     :param prefix: Prefix used to name metrics and artifacts.
     :param sample_weight: Per-sample weights to apply in the computation of metrics/artifacts.
     :param pos_label: The positive label used to compute binary classification metrics such as
-        precision, recall, f1, etc. This parameter is only used for classification metrics.
-        If set to `None`, the function will calculate metrics for each label and find their
-        average weighted by support (number of true instances for each label).
+        precision, recall, f1, etc. This parameter is only used for binary classification model
+        - if used on multi-label model, the evaluation will fail;
+        - if used for regression model, the parameter will be ignored.
+        For multi-label classification, keep `pos_label` unset (or set to `None`), and the
+        function will calculate metrics for each label and find their average weighted by support
+        (number of true instances for each label).
     :return: The dict of logged metrics. Artifacts can be retrieved by inspecting the run.
 
     ** Example **

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -1719,7 +1719,7 @@ def _autolog(
         )
 
 
-def eval_and_log_metrics(model, X, y_true, *, prefix, sample_weight=None):
+def eval_and_log_metrics(model, X, y_true, *, prefix, sample_weight=None, pos_label=None):
     """
     Computes and logs metrics (and artifacts) for the given model and labeled dataset.
     The metrics/artifacts mirror what is auto-logged when training a model
@@ -1730,6 +1730,10 @@ def eval_and_log_metrics(model, X, y_true, *, prefix, sample_weight=None):
     :param y_true: The labels for the evaluation dataset.
     :param prefix: Prefix used to name metrics and artifacts.
     :param sample_weight: Per-sample weights to apply in the computation of metrics/artifacts.
+    :param pos_label: The positive label used to compute binary classification metrics such as
+        precision, recall, f1, etc. This parameter is only used for classification metrics.
+        If set to `None`, the function will calculate metrics for each label and find their
+        average weighted by support (number of true instances for each label).
     :return: The dict of logged metrics. Artifacts can be retrieved by inspecting the run.
 
     ** Example **
@@ -1769,11 +1773,11 @@ def eval_and_log_metrics(model, X, y_true, *, prefix, sample_weight=None):
     metrics_manager = _AUTOLOGGING_METRICS_MANAGER
     with metrics_manager.disable_log_post_training_metrics():
         return _eval_and_log_metrics_impl(
-            model, X, y_true, prefix=prefix, sample_weight=sample_weight
+            model, X, y_true, prefix=prefix, sample_weight=sample_weight, pos_label=pos_label
         )
 
 
-def _eval_and_log_metrics_impl(model, X, y_true, *, prefix, sample_weight=None):
+def _eval_and_log_metrics_impl(model, X, y_true, *, prefix, sample_weight, pos_label):
     from mlflow.sklearn.utils import _log_estimator_content
     from sklearn.base import BaseEstimator
 
@@ -1804,6 +1808,7 @@ def _eval_and_log_metrics_impl(model, X, y_true, *, prefix, sample_weight=None):
             X=X,
             y_true=y_true,
             sample_weight=sample_weight,
+            pos_label=pos_label,
         )
 
     return metrics

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -196,21 +196,33 @@ def _get_classifier_metrics(fitted_estimator, prefix, X, y_true, sample_weight, 
             name=prefix + "precision_score",
             function=sklearn.metrics.precision_score,
             arguments=dict(
-                y_true=y_true, y_pred=y_pred, pos_label=pos_label, average=average, sample_weight=sample_weight
+                y_true=y_true,
+                y_pred=y_pred,
+                pos_label=pos_label,
+                average=average,
+                sample_weight=sample_weight
             ),
         ),
         _SklearnMetric(
             name=prefix + "recall_score",
             function=sklearn.metrics.recall_score,
             arguments=dict(
-                y_true=y_true, y_pred=y_pred, pos_label=pos_label, average=average, sample_weight=sample_weight
+                y_true=y_true,
+                y_pred=y_pred,
+                pos_label=pos_label,
+                average=average,
+                sample_weight=sample_weight
             ),
         ),
         _SklearnMetric(
             name=prefix + "f1_score",
             function=sklearn.metrics.f1_score,
             arguments=dict(
-                y_true=y_true, y_pred=y_pred, pos_label=pos_label, average=average, sample_weight=sample_weight
+                y_true=y_true,
+                y_pred=y_pred,
+                pos_label=pos_label,
+                average=average,
+                sample_weight=sample_weight
             ),
         ),
         _SklearnMetric(

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -200,7 +200,7 @@ def _get_classifier_metrics(fitted_estimator, prefix, X, y_true, sample_weight, 
                 y_pred=y_pred,
                 pos_label=pos_label,
                 average=average,
-                sample_weight=sample_weight
+                sample_weight=sample_weight,
             ),
         ),
         _SklearnMetric(
@@ -211,7 +211,7 @@ def _get_classifier_metrics(fitted_estimator, prefix, X, y_true, sample_weight, 
                 y_pred=y_pred,
                 pos_label=pos_label,
                 average=average,
-                sample_weight=sample_weight
+                sample_weight=sample_weight,
             ),
         ),
         _SklearnMetric(
@@ -222,7 +222,7 @@ def _get_classifier_metrics(fitted_estimator, prefix, X, y_true, sample_weight, 
                 y_pred=y_pred,
                 pos_label=pos_label,
                 average=average,
-                sample_weight=sample_weight
+                sample_weight=sample_weight,
             ),
         ),
         _SklearnMetric(
@@ -542,7 +542,13 @@ def _log_specialized_estimator_content(
 
 
 def _log_estimator_content(
-    autologging_client, estimator, run_id, prefix, X, y_true=None, sample_weight=None,
+    autologging_client,
+    estimator,
+    run_id,
+    prefix,
+    X,
+    y_true=None,
+    sample_weight=None,
     pos_label=None,
 ):
     """

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -1199,6 +1199,7 @@ def test_eval_and_log_metrics_for_binary_classifier_with_pos_label():
     mlflow.sklearn.autolog(disable=True)
 
     import sklearn.ensemble
+
     model = sklearn.ensemble.RandomForestClassifier(max_depth=2, random_state=0, n_estimators=10)
     X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
     X_eval = X[:-1, :]

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -1230,7 +1230,7 @@ def test_eval_and_log_metrics_for_binary_classifier_with_pos_label():
             average="weighted",
             multi_class="ovo",
         )
-    assert eval_metrics == expected_metrics
+    assert eval_metrics == pytest.approx(expected_metrics)
 
     eval_artifacts = []
     if _is_plotting_supported():

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -1194,6 +1194,61 @@ def test_eval_and_log_metrics_for_binary_classifier():
     assert sorted(artifacts) == sorted(eval_artifacts)
 
 
+def test_eval_and_log_metrics_for_binary_classifier_with_pos_label():
+    # disable autologging so that we can check for the sole existence of eval-time metrics
+    mlflow.sklearn.autolog(disable=True)
+
+    model = sklearn.linear_model.LogisticRegression()
+    X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
+    X_eval = X[:-1, :]
+    y_eval = y[:-1]
+
+    with mlflow.start_run() as run:
+        model = fit_model(model, X, y, "fit")
+        eval_metrics = mlflow.sklearn.eval_and_log_metrics(
+            model=model, X=X_eval, y_true=y_eval, prefix="val_", pos_label=1
+        )
+
+    y_pred = model.predict(X_eval)
+    y_pred_prob = model.predict_proba(X_eval)
+    # For binary classification, y_score only accepts the probability of greater label
+    y_pred_prob_roc = y_pred_prob[:, 1]
+
+    expected_metrics = {
+        "val_score": model.score(X_eval, y_eval),
+        "val_accuracy_score": sklearn.metrics.accuracy_score(y_eval, y_pred),
+        "val_precision_score": sklearn.metrics.precision_score(y_eval, y_pred, pos_label=1),
+        "val_recall_score": sklearn.metrics.recall_score(y_eval, y_pred, pos_label=1),
+        "val_f1_score": sklearn.metrics.f1_score(y_eval, y_pred, pos_label=1),
+        "val_log_loss": sklearn.metrics.log_loss(y_eval, y_pred_prob),
+    }
+    if _is_metric_supported("roc_auc_score"):
+        expected_metrics["val_roc_auc_score"] = sklearn.metrics.roc_auc_score(
+            y_eval,
+            y_score=y_pred_prob_roc,
+            average="weighted",
+            multi_class="ovo",
+        )
+    assert eval_metrics == expected_metrics
+
+    eval_artifacts = []
+    if _is_plotting_supported():
+        eval_artifacts.extend(
+            [
+                "{}.png".format("val_confusion_matrix"),
+                "{}.png".format("val_roc_curve"),
+                "{}.png".format("val_precision_recall_curve"),
+            ]
+        )
+
+    # Check that logged artifacts/metrics are the same as the ones returned by the method
+    run_id = run.info.run_id
+    _, metrics, _, artifacts = get_run_data(run_id)
+
+    assert metrics == eval_metrics
+    assert sorted(artifacts) == sorted(eval_artifacts)
+
+
 def test_eval_and_log_metrics_matches_training_metrics():
     mlflow.sklearn.autolog()
 

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -1198,7 +1198,8 @@ def test_eval_and_log_metrics_for_binary_classifier_with_pos_label():
     # disable autologging so that we can check for the sole existence of eval-time metrics
     mlflow.sklearn.autolog(disable=True)
 
-    model = sklearn.linear_model.LogisticRegression()
+    import sklearn.ensemble
+    model = sklearn.ensemble.RandomForestClassifier(max_depth=2, random_state=0, n_estimators=10)
     X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
     X_eval = X[:-1, :]
     y_eval = y[:-1]


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes #5512 .

## How is this patch tested?

Added new unit tests.

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Pass in the `pos_label` parameter to `eval_and_log_metrics` for binary classification.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
