### PR TITLE
Fix: Removed get_experiment_by_name as not required

### DIFF
--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -80,11 +80,10 @@ def set_experiment(experiment_name: str = None, experiment_id: str = None) -> Ex
 
         import mlflow
 
-        # Set an experiment name, which must be unique and case sensitive.
-        mlflow.set_experiment("Social NLP Experiments")
+        # Set an experiment name, which must be unique and case-sensitive.
+        experiment = mlflow.set_experiment("Social NLP Experiments")
 
         # Get Experiment Details
-        experiment = mlflow.get_experiment_by_name("Social NLP Experiments")
         print("Experiment_id: {}".format(experiment.experiment_id))
         print("Artifact Location: {}".format(experiment.artifact_location))
         print("Tags: {}".format(experiment.tags))


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes #5808

URL(s) with the issue:
https://mlflow.org/docs/latest/_modules/mlflow/tracking/fluent.html#set_experiment
https://github.com/mlflow/mlflow/blob/master/mlflow/tracking/fluent.py

Change documentation / code example from
```
import mlflow
# Set an experiment name, which must be unique and case sensitive.
mlflow.set_experiment("Social NLP Experiments")
# Get Experiment Details
experiment = mlflow.get_experiment_by_name("Social NLP Experiments")
print("Experiment_id: {}".format(experiment.experiment_id))
print("Artifact Location: {}".format(experiment.artifact_location))
print("Tags: {}".format(experiment.tags))
print("Lifecycle_stage: {}".format(experiment.lifecycle_stage))
```
to 
```
import mlflow
# Set an experiment name, which must be unique and case-sensitive.
experiment = mlflow.set_experiment("Social NLP Experiments")
# Get Experiment Details
print("Experiment_id: {}".format(experiment.experiment_id))
print("Artifact Location: {}".format(experiment.artifact_location))
print("Tags: {}".format(experiment.tags))
print("Lifecycle_stage: {}".format(experiment.lifecycle_stage))
```
