### PR TITLE
Update broken link in "Fastai" section

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -806,7 +806,7 @@ For more information, see :py:mod:`mlflow.spacy`.
 
 Fastai(``fastai``)
 ^^^^^^^^^^^^^^^^^^^^^^
-The ``fastai`` model flavor enables logging of `fastai Learner models <https://docs.fast.ai/training.html>`_ in MLflow format via
+The ``fastai`` model flavor enables logging of `fastai Learner models <https://docs.fast.ai/learner.html>`_ in MLflow format via
 the :py:func:`mlflow.fastai.save_model()` and :py:func:`mlflow.fastai.log_model()` methods. Additionally, these
 methods add the ``python_function`` flavor to the MLflow Models that they produce, allowing the models to be
 interpreted as generic Python functions for inference via :py:func:`mlflow.pyfunc.load_model()`. This loaded PyFunc model can


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR fixes a broken link in the "Fastai" section of the models page.

## How is this patch tested?

This patch hasn't been tested.

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

See https://output.circle-artifacts.com/output/job/fb4321e2-28a2-4210-8de8-21a2c8a42944/artifacts/0/docs/build/html/models.html#fastai-fastai - the "Learner" link now works as expected.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes