### PR TITLE
PyTorch examples - MNIST and Bert multi gpu training

### DIFF
--- a/examples/pytorch/BertNewsClassification/MLproject
+++ b/examples/pytorch/BertNewsClassification/MLproject
@@ -7,7 +7,7 @@ entry_points:
     parameters:
       max_epochs: {type: int, default: 5}
       gpus: {type: int, default: 0}
-      accelerator: {type str, default: "None"}
+      strategy: {type str, default: "None"}
       batch_size: {type: int, default: 64}
       num_workers: {type: int, default: 3}
       learning_rate: {type: float, default: 0.001}
@@ -18,7 +18,7 @@ entry_points:
           python bert_classification.py \
             --max_epochs {max_epochs} \
             --gpus {gpus} \
-            --accelerator {accelerator} \
+            --strategy {strategy} \
             --batch_size {batch_size} \
             --num_workers {num_workers} \
             --num_samples {num_samples} \

--- a/examples/pytorch/BertNewsClassification/README.md
+++ b/examples/pytorch/BertNewsClassification/README.md
@@ -43,7 +43,7 @@ The parameters can be overridden via the command line:
 
 1. max_epochs - Number of epochs to train model. Training can be interrupted early via Ctrl+C
 2. gpus - Number of GPUs
-3. accelerator - [Accelerator backend](https://pytorch-lightning.readthedocs.io/en/latest/trainer.html#trainer-flags) (e.g. "ddp" for the Distributed Data Parallel backend) to use for training. By default, no accelerator is used.
+3. strategy - [strategy](https://pytorch-lightning.readthedocs.io/en/stable/common/trainer.html#trainer-class-api) (e.g. "ddp" for the Distributed Data Parallel backend) to use for training. By default, no strategy is used.
 4. batch_size - Input batch size for training
 5. num_workers - Number of worker threads to load training data
 6. lr - Learning rate
@@ -58,7 +58,7 @@ Or to run the training script directly with custom parameters:
 python bert_classification.py \
     --max_epochs 5 \
     --gpus 1 \
-    --accelerator "ddp" \
+    --strategy "ddp" \
     --batch_size 64 \
     --num_workers 2 \
     --lr 0.001

--- a/examples/pytorch/BertNewsClassification/README.md
+++ b/examples/pytorch/BertNewsClassification/README.md
@@ -50,7 +50,7 @@ The parameters can be overridden via the command line:
 
 For example:
 ```
-mlflow run . -P max_epochs=5 -P gpus=1 -P batch_size=32 -P num_workers=2 -P learning_rate=0.01 -P accelerator="ddp"
+mlflow run . -P max_epochs=5 -P gpus=1 -P batch_size=32 -P num_workers=2 -P learning_rate=0.01 -P strategy="ddp"
 ```
 Or to run the training script directly with custom parameters:
 

--- a/examples/pytorch/BertNewsClassification/bert_classification.py
+++ b/examples/pytorch/BertNewsClassification/bert_classification.py
@@ -434,6 +434,7 @@ if __name__ == "__main__":
             dict_args["accelerator"] = None
 
     dm = BertDataModule(**dict_args)
+    dm.prepare_data()
 
     model = BertNewsClassifier(**dict_args)
     early_stopping = EarlyStopping(monitor="val_loss", mode="min", verbose=True)

--- a/examples/pytorch/BertNewsClassification/bert_classification.py
+++ b/examples/pytorch/BertNewsClassification/bert_classification.py
@@ -429,9 +429,9 @@ if __name__ == "__main__":
     args = parser.parse_args()
     dict_args = vars(args)
 
-    if "accelerator" in dict_args:
-        if dict_args["accelerator"] == "None":
-            dict_args["accelerator"] = None
+    if "strategy" in dict_args:
+        if dict_args["strategy"] == "None":
+            dict_args["strategy"] = None
 
     dm = BertDataModule(**dict_args)
     dm.prepare_data()

--- a/examples/pytorch/BertNewsClassification/conda.yaml
+++ b/examples/pytorch/BertNewsClassification/conda.yaml
@@ -11,5 +11,6 @@ dependencies:
   - transformers>=4.0.0
   - pandas
   - torch>=1.11.0
+  - torchdata
   - torchtext==0.12.0
   - pytorch-lightning==1.6.1

--- a/examples/pytorch/MNIST/MLproject
+++ b/examples/pytorch/MNIST/MLproject
@@ -7,7 +7,7 @@ entry_points:
     parameters:
       max_epochs: {type: int, default: 5}
       gpus: {type: int, default: 0}
-      accelerator: {type str, default: "None"}
+      strategy: {type str, default: "None"}
       batch_size: {type: int, default: 64}
       num_workers: {type: int, default: 3}
       learning_rate: {type: float, default: 0.001}
@@ -20,7 +20,7 @@ entry_points:
           python mnist_autolog_example.py \
             --max_epochs {max_epochs} \
             --gpus {gpus} \
-            --accelerator {accelerator} \
+            --strategy {strategy} \
             --batch_size {batch_size} \
             --num_workers {num_workers} \
             --lr {learning_rate} \

--- a/examples/pytorch/MNIST/README.md
+++ b/examples/pytorch/MNIST/README.md
@@ -47,7 +47,7 @@ The parameters can be overridden via the command line:
 
 1. max_epochs - Number of epochs to train model. Training can be interrupted early via Ctrl+C
 2. gpus - Number of GPUs
-3. accelerator - [Accelerator backend](https://pytorch-lightning.readthedocs.io/en/latest/trainer.html#trainer-flags) (e.g. "ddp" for the Distributed Data Parallel backend) to use for training. By default, no accelerator is used.
+3. strategy - [strategy](https://pytorch-lightning.readthedocs.io/en/stable/common/trainer.html#trainer-class-api) (e.g. "ddp" for the Distributed Data Parallel backend) to use for training. By default, no strategy is used.
 4. batch_size - Input batch size for training
 5. num_workers - Number of worker threads to load training data
 6. lr - Learning rate
@@ -58,7 +58,7 @@ The parameters can be overridden via the command line:
 
 For example:
 ```
-mlflow run . -P max_epochs=5 -P gpus=1 -P batch_size=32 -P num_workers=2 -P learning_rate=0.01 -P accelerator="ddp" -P patience=5 -P mode="min" -P monitor="val_loss" -P verbose=True
+mlflow run . -P max_epochs=5 -P gpus=1 -P batch_size=32 -P num_workers=2 -P learning_rate=0.01 -P strategy="ddp" -P patience=5 -P mode="min" -P monitor="val_loss" -P verbose=True
 ```
 
 Or to run the training script directly with custom parameters:
@@ -66,7 +66,7 @@ Or to run the training script directly with custom parameters:
 python mnist_autolog_example.py \
     --max_epochs 5 \
     --gpus 1 \
-    --accelerator "ddp" \
+    --strategy "ddp" \
     --batch_size 64 \
     --num_workers 3 \
     --lr 0.001 \

--- a/examples/pytorch/MNIST/mnist_autolog_example.py
+++ b/examples/pytorch/MNIST/mnist_autolog_example.py
@@ -279,9 +279,9 @@ if __name__ == "__main__":
     args = parser.parse_args()
     dict_args = vars(args)
 
-    if "accelerator" in dict_args:
-        if dict_args["accelerator"] == "None":
-            dict_args["accelerator"] = None
+    if "strategy" in dict_args:
+        if dict_args["strategy"] == "None":
+            dict_args["strategy"] = None
 
     model = LightningMNISTClassifier(**dict_args)
 


### PR DESCRIPTION
Signed-off-by: Shrinath Suresh <shrinath@ideas2it.com>

## What changes are proposed in this pull request?

New version of pytorch-lightning changed the ddp backend from `accelerator` to `strategy`. 

Adding torchdata to bert example, as latest version of torchtext uses torchdata

## How is this patch tested?

Existing unit tests and logs attached for both cpu and multi gpu scenarios


[mlflow-mnist-mlflow-run.txt](https://github.com/mlflow/mlflow/files/8612873/mlflow-mnist-mlflow-run.txt)
[mlflow-mnist-multi-gpu.txt](https://github.com/mlflow/mlflow/files/8612874/mlflow-mnist-multi-gpu.txt)
[mlflow-bert-mlflow-run.txt](https://github.com/mlflow/mlflow/files/8612875/mlflow-bert-mlflow-run.txt)
[mlflow-bert-ag_news-cpu.txt](https://github.com/mlflow/mlflow/files/8612876/mlflow-bert-ag_news-cpu.txt)
[mlflow-bert-ag_news-multi-gpu.txt](https://github.com/mlflow/mlflow/files/8612877/mlflow-bert-ag_news-multi-gpu.txt)
[mlflow-bert-20newsgroup-cpu.txt](https://github.com/mlflow/mlflow/files/8612878/mlflow-bert-20newsgroup-cpu.txt)
[mlflow-bert-20newsgroup-multi-gpu.txt](https://github.com/mlflow/mlflow/files/8612880/mlflow-bert-20newsgroup-multi-gpu.txt)

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [x] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
