### PR TITLE
[FIX-5789] Added sticky header to experiment run list

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.js
@@ -540,15 +540,24 @@ export class ExperimentRunsTableMultiColumnView2 extends React.Component {
     const agGridOverrides = css({
       '--ag-border-color': 'rgba(0, 0, 0, 0.06)',
       '--ag-header-foreground-color': '#20272e',
-      '.ag-root-wrapper': {
-        border: '0!important',
+      '&.ag-grid-sticky .ag-header': {
+        position: 'sticky',
+        top: 0,
+        zIndex: 1,
+      },
+      '&.ag-grid-sticky .ag-root': {
+        overflow: 'visible',
+      },
+      '&.ag-grid-sticky .ag-root-wrapper': {
+        border: '0',
         borderRadius: '4px',
+        overflow: 'visible',
       },
     });
 
     return (
       <div
-        className={`ag-theme-balham multi-column-view ${agGridOverrides}`}
+      className={`ag-theme-balham multi-column-view ag-grid-sticky ${agGridOverrides}`}
         data-test-id='detailed-runs-table-view'
       >
         <AgGridReact

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.js
@@ -557,7 +557,7 @@ export class ExperimentRunsTableMultiColumnView2 extends React.Component {
 
     return (
       <div
-      className={`ag-theme-balham multi-column-view ag-grid-sticky ${agGridOverrides}`}
+        className={`ag-theme-balham multi-column-view ag-grid-sticky ${agGridOverrides}`}
         data-test-id='detailed-runs-table-view'
       >
         <AgGridReact


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixing https://github.com/mlflow/mlflow/issues/5789 - added sticky header in the ag-grid.

## How is this patch tested?

Visual tests done.

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Multi-column ag-grid powered table used in Experiment Runs list view's table has now a "sticky" header attaching to the top of the viewport.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [X] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
