### PR TITLE
Enable multi-experiment run comparison

### DIFF
--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -760,7 +760,7 @@ machine, including any remote machine that can connect to your tracking server.
 
 The UI contains the following key features:
 
-* Experiment-based run listing and comparison
+* Experiment-based run listing and comparison (including run comparison across multiple experiments)
 * Searching for runs by parameter or metric value
 * Visualizing run metrics
 * Downloading run results

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.css
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.css
@@ -45,6 +45,11 @@ input.experiment-list-search-input[type="text"]:focus{
   margin-bottom: 8px;
 }
 
+.experiments-checkbox {
+  vertical-align: center;
+  margin-right: 8px;
+}
+
 .collapser-container {
   display: inline-block;
   position: relative;
@@ -82,4 +87,78 @@ input.experiment-list-search-input[type="text"]:focus{
   font-size: 13px;
   text-align: center;
   cursor: pointer;
+}
+
+.experiment-input-field {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
+
+.experiment-input-wrapper {
+    display: flex;
+    flex: 1 1 auto;
+    align-items: center;
+    line-height: normal;
+    position: relative;
+}
+
+.experiment-link-like-checkbox-wrapper {
+    font-family: "agGridBalham";
+    font-size: 16px;
+    line-height: 16px;
+    font-style: normal;
+    font-weight: normal;
+    font-variant: normal;
+    text-transform: none;
+    /* Better Font Rendering =========== */
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    width: 16px;
+    height: 16px;
+    background-color: white;
+    background-color: white;
+    border-radius: 3px;
+    display: inline-block;
+    vertical-align: middle;
+    flex: none;
+    cursor: default;
+}
+
+.experiment-link-like-checkbox-wrapper a {
+    opacity: 0;
+    width: 100%;
+    height: 100%;
+    cursor: default;
+}
+
+.experiment-link-like-checkbox-wrapper::after {
+    content: "\f108";
+    color: #7f8c8d;
+    color: #7f8c8d;
+    position: absolute;
+    top: 0;
+    left: 0;
+    pointer-events: none;
+    cursor: default;
+}
+
+.experiment-link-like-checkbox-wrapper.checked::after {
+    content: "\f106";
+    color: #0091ea;
+    color: #0091ea;
+    position: absolute;
+    top: 0;
+    left: 0;
+    pointer-events: none;
+    cursor: default;
+}
+
+.experiment-link-like-checkbox-wrapper:focus-within, .experiment-link-like-checkbox-wrapper:active {
+    outline: none;
+    box-shadow: 0 0 2px 1px #719ECE;
+}
+
+.experiment-link-like-checkbox-wrapper.disabled {
+    opacity: 0.5;
 }

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.css
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.css
@@ -103,7 +103,7 @@ input.experiment-list-search-input[type="text"]:focus{
     position: relative;
 }
 
-.experiment-link-like-checkbox-wrapper {
+.experiment-link-checkbox-wrapper {
     font-family: "agGridBalham";
     font-size: 16px;
     line-height: 16px;
@@ -125,14 +125,14 @@ input.experiment-list-search-input[type="text"]:focus{
     cursor: default;
 }
 
-.experiment-link-like-checkbox-wrapper a {
+.experiment-link-checkbox-wrapper a {
     opacity: 0;
     width: 100%;
     height: 100%;
     cursor: default;
 }
 
-.experiment-link-like-checkbox-wrapper::after {
+.experiment-link-checkbox-wrapper::after {
     content: "\f108";
     color: #7f8c8d;
     color: #7f8c8d;
@@ -143,7 +143,7 @@ input.experiment-list-search-input[type="text"]:focus{
     cursor: default;
 }
 
-.experiment-link-like-checkbox-wrapper.checked::after {
+.experiment-link-checkbox-wrapper.checked::after {
     content: "\f106";
     color: #0091ea;
     color: #0091ea;
@@ -154,11 +154,11 @@ input.experiment-list-search-input[type="text"]:focus{
     cursor: default;
 }
 
-.experiment-link-like-checkbox-wrapper:focus-within, .experiment-link-like-checkbox-wrapper:active {
+.experiment-link-checkbox-wrapper:focus-within, .experiment-link-checkbox-wrapper:active {
     outline: none;
     box-shadow: 0 0 2px 1px #719ECE;
 }
 
-.experiment-link-like-checkbox-wrapper.disabled {
+.experiment-link-checkbox-wrapper.disabled {
     opacity: 0.5;
 }

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.js
@@ -13,7 +13,6 @@ import { DeleteExperimentModal } from './modals/DeleteExperimentModal';
 import { RenameExperimentModal } from './modals/RenameExperimentModal';
 import { IconButton } from '../../common/components/IconButton';
 import Utils from '../../common/utils/Utils';
-import ExperimentViewUtil from './ExperimentViewUtil';
 
 export class ExperimentListView extends Component {
   static propTypes = {
@@ -112,14 +111,14 @@ export class ExperimentListView extends Component {
     if (experiments === undefined || searchInput === undefined || searchInput === '') {
       return activeExperimentIds;
     }
-    const filteredExperimentIds =
-      experiments
-        .filter((exp) =>
-          exp
-            .getName()
-            .toLowerCase()
-            .includes(searchInput.toLowerCase())
-        ).map((exp) => exp.experiment_id);
+    const filteredExperimentIds = experiments
+      .filter((exp) =>
+        exp
+          .getName()
+          .toLowerCase()
+          .includes(searchInput.toLowerCase()),
+      )
+      .map((exp) => exp.experiment_id);
 
     return activeExperimentIds.filter((exp_id) => filteredExperimentIds.includes(exp_id));
   };
@@ -130,16 +129,16 @@ export class ExperimentListView extends Component {
       const activeIds = [...this.getFilteredActiveExperimentIds()];
       const index = activeIds.indexOf(experimentId);
       if (index > -1) {
-          activeIds.splice(index, 1)
+        activeIds.splice(index, 1);
       } else {
-          activeIds.push(experimentId);
+        activeIds.push(experimentId);
       }
       // Route to a currently selected experiment if there are no active ones
       if (activeIds.length === 0) {
-        return Routes.getExperimentPageRoute(this.state.selectedExperimentId)
+        return Routes.getExperimentPageRoute(this.state.selectedExperimentId);
       }
       return Routes.getCompareExperimentsPageRoute(activeIds);
-    }
+    };
   };
 
   handleMultiSelect = (ev) => {
@@ -164,7 +163,6 @@ export class ExperimentListView extends Component {
         <DeleteExperimentModal
           isOpen={this.state.showDeleteExperimentModal}
           onClose={this.handleCloseDeleteExperimentModal}
-//          activeExperimentId={this.props.activeExperimentId}
           activeExperimentIds={this.props.activeExperimentIds}
           experimentId={this.state.selectedExperimentId}
           experimentName={this.state.selectedExperimentName}
@@ -215,23 +213,37 @@ export class ExperimentListView extends Component {
                     ? this.props.activeExperimentIds.indexOf(experiment_id) > -1
                     : idx === 0;
                 const clickable =
-                  this.props.activeExperimentIds === undefined
-                  || this.props.activeExperimentIds.length !== 1
-                  || !active;
+                  this.props.activeExperimentIds === undefined ||
+                  this.props.activeExperimentIds.length !== 1 ||
+                  !active;
                 const className = `experiment-list-item ${
                   active ? 'active-experiment-list-item' : ''
                 }`;
 
                 return (
-                  <div key={experiment_id} title={name} className={`header-container ${className}`} style={{ padding: '0' }}>
+                  <div
+                    key={experiment_id}
+                    title={name}
+                    className={`header-container ${className}`}
+                    style={{ padding: '0' }}
+                  >
                     {/*  Decorate a link as a checkbox for multi-experiment selection */}
-                    <div className="experiment-input-field" style={{ width: '30px', left: '0', padding: '0' }}>
-                      <div className={`experiment-input-wrapper experiment-link-like-checkbox-wrapper ${active ? 'checked' : ''}`}>
+                    <div
+                      className='experiment-input-field'
+                      style={{ width: '30px', left: '0', padding: '0' }}
+                    >
+                      <div
+                        className={`experiment-input-wrapper experiment-link-checkbox-wrapper ${
+                          active ? 'checked' : ''
+                        }`}
+                      >
                         <Link
                           to={this.getCompareExperimentsPageRoute(experiment_id)}
                           onClick={this.handleMultiSelect}
                           data-experimentid={experiment_id}
-                        >&nbsp;&nbsp;&nbsp;</Link>
+                        >
+                          &nbsp;&nbsp;&nbsp;
+                        </Link>
                       </div>
                     </div>
                     {/*  This link allow one click drop of multi-experiment selection */}
@@ -240,7 +252,17 @@ export class ExperimentListView extends Component {
                       to={Routes.getExperimentPageRoute(experiment_id)}
                       onClick={clickable ? (ev) => ev : (ev) => ev.preventDefault()}
                     >
-                      <div style={{ textDecoration: 'none', color: 'unset', width: '80%', overflow: 'hidden', textOverflow: 'ellipsis' }}>{name}</div>
+                      <div
+                        style={{
+                          textDecoration: 'none',
+                          color: 'unset',
+                          width: '80%',
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                        }}
+                      >
+                        {name}
+                      </div>
                     </Link>
                     {/*  Edit/Rename Experiment Option */}
                     <IconButton

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.test.js
@@ -6,34 +6,6 @@ import { DeleteExperimentModal } from './modals/DeleteExperimentModal';
 import { RenameExperimentModal } from './modals/RenameExperimentModal';
 import { CreateExperimentModal } from './modals/CreateExperimentModal';
 
-test('If activeExperimentId is defined then choose that one', () => {
-  const wrapper = shallow(
-    <ExperimentListView
-      onClickListExperiments={() => {}}
-      experiments={Fixtures.experiments}
-      activeExperimentId={'1'}
-    />,
-  );
-  expect(
-    wrapper
-      .find('.active-experiment-list-item')
-      .first()
-      .prop('title'),
-  ).toEqual('Test');
-});
-
-test('If activeExperimentId is undefined then choose first experiment', () => {
-  const wrapper = shallow(
-    <ExperimentListView onClickListExperiments={() => {}} experiments={Fixtures.experiments} />,
-  );
-  expect(
-    wrapper
-      .find('.active-experiment-list-item')
-      .first()
-      .prop('title'),
-  ).toEqual('Default');
-});
-
 test('If searchInput is set to "Test" then first shown element in experiment list has the title "Test"', () => {
   const wrapper = shallow(
     <ExperimentListView onClickListExperiments={() => {}} experiments={Fixtures.experiments} />,
@@ -53,7 +25,7 @@ test('If searchInput is set to "Test" and default experiment is active then no a
     <ExperimentListView
       onClickListExperiments={() => {}}
       experiments={Fixtures.experiments}
-      activeExperimentId={'0'}
+      activeExperimentIds={['0']}
     />,
   );
 
@@ -81,7 +53,7 @@ test('If button to delete experiment is pressed then open DeleteExperimentModal'
   const deleteLink = wrapper
     .find('.active-experiment-list-item')
     .children()
-    .at(2);
+    .at(3);
   // mock event that is passed when clicking the link
   const mockedExperiment = Fixtures.experiments[0];
   const mockedEvent = {
@@ -106,7 +78,7 @@ test('If button to edit experiment is pressed then open RenameExperimentModal', 
   const editLink = wrapper
     .find('.active-experiment-list-item')
     .children()
-    .at(1);
+    .at(2);
   // mock event that is passed when clicking the link
   const mockedExperiment = Fixtures.experiments[0];
   const mockedEvent = {
@@ -120,4 +92,41 @@ test('If button to edit experiment is pressed then open RenameExperimentModal', 
   editLink.simulate('click', mockedEvent);
 
   expect(wrapper.find(RenameExperimentModal).prop('isOpen')).toEqual(true);
+});
+
+test('If activeExperimentIds is defined then choose all the corresponding experiments', () => {
+  const experiments = [
+    Fixtures.createExperiment(),
+    Fixtures.createExperiment({ experiment_id: '1', name: 'Test' }),
+    Fixtures.createExperiment({ experiment_id: '2', name: 'Second' }),
+    Fixtures.createExperiment({ experiment_id: '3', name: 'Third' })
+  ];
+  const wrapper = shallow(
+    <ExperimentListView
+      onClickListExperiments={() => {}}
+      experiments={experiments}
+      activeExperimentIds={['1', '3']}
+    />,
+  );
+  expect(wrapper.find('.active-experiment-list-item').length).toEqual(2);
+  expect(wrapper.find('.active-experiment-list-item').first().prop('title')).toEqual('Test');
+  expect(wrapper.find('.active-experiment-list-item').at(1).prop('title')).toEqual('Third');
+});
+
+test('If activeExperimentIds is undefined then choose the first experiment', () => {
+  const experiments = [
+    Fixtures.createExperiment(),
+    Fixtures.createExperiment({ experiment_id: '1', name: 'Test' }),
+    Fixtures.createExperiment({ experiment_id: '2', name: 'Second' }),
+    Fixtures.createExperiment({ experiment_id: '3', name: 'Third' })
+  ];
+  const wrapper = shallow(
+    <ExperimentListView onClickListExperiments={() => {}} experiments={experiments} />,
+  );
+  expect(
+    wrapper
+      .find('.active-experiment-list-item')
+      .first()
+      .prop('title'),
+  ).toEqual('Default');
 });

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.test.js
@@ -99,7 +99,7 @@ test('If activeExperimentIds is defined then choose all the corresponding experi
     Fixtures.createExperiment(),
     Fixtures.createExperiment({ experiment_id: '1', name: 'Test' }),
     Fixtures.createExperiment({ experiment_id: '2', name: 'Second' }),
-    Fixtures.createExperiment({ experiment_id: '3', name: 'Third' })
+    Fixtures.createExperiment({ experiment_id: '3', name: 'Third' }),
   ];
   const wrapper = shallow(
     <ExperimentListView
@@ -109,8 +109,18 @@ test('If activeExperimentIds is defined then choose all the corresponding experi
     />,
   );
   expect(wrapper.find('.active-experiment-list-item').length).toEqual(2);
-  expect(wrapper.find('.active-experiment-list-item').first().prop('title')).toEqual('Test');
-  expect(wrapper.find('.active-experiment-list-item').at(1).prop('title')).toEqual('Third');
+  expect(
+    wrapper
+      .find('.active-experiment-list-item')
+      .first()
+      .prop('title'),
+  ).toEqual('Test');
+  expect(
+    wrapper
+      .find('.active-experiment-list-item')
+      .at(1)
+      .prop('title'),
+  ).toEqual('Third');
 });
 
 test('If activeExperimentIds is undefined then choose the first experiment', () => {
@@ -118,7 +128,7 @@ test('If activeExperimentIds is undefined then choose the first experiment', () 
     Fixtures.createExperiment(),
     Fixtures.createExperiment({ experiment_id: '1', name: 'Test' }),
     Fixtures.createExperiment({ experiment_id: '2', name: 'Second' }),
-    Fixtures.createExperiment({ experiment_id: '3', name: 'Third' })
+    Fixtures.createExperiment({ experiment_id: '3', name: 'Third' }),
   ];
   const wrapper = shallow(
     <ExperimentListView onClickListExperiments={() => {}} experiments={experiments} />,

--- a/mlflow/server/js/src/experiment-tracking/components/HomeView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/HomeView.js
@@ -74,7 +74,7 @@ class HomeView extends Component {
           <Spacer />
           {this.state.listExperimentsExpanded ? (
             <ExperimentListView
-              activeExperimentId={this.props.experimentIds && this.props.experimentIds[0]}
+              activeExperimentIds={this.props.experimentIds}
               onClickListExperiments={this.onClickListExperiments}
             />
           ) : (

--- a/mlflow/server/js/src/experiment-tracking/components/modals/DeleteExperimentModal.js
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/DeleteExperimentModal.js
@@ -12,7 +12,7 @@ export class DeleteExperimentModalImpl extends Component {
   static propTypes = {
     isOpen: PropTypes.bool.isRequired,
     onClose: PropTypes.func.isRequired,
-    activeExperimentId: PropTypes.string,
+    activeExperimentIds: PropTypes.arrayOf(PropTypes.string),
     experimentId: PropTypes.string.isRequired,
     experimentName: PropTypes.string.isRequired,
     deleteExperimentApi: PropTypes.func.isRequired,
@@ -21,14 +21,14 @@ export class DeleteExperimentModalImpl extends Component {
   };
 
   handleSubmit = () => {
-    const { experimentId, activeExperimentId } = this.props;
+    const { experimentId, activeExperimentIds } = this.props;
     const deleteExperimentRequestId = getUUID();
 
     const deletePromise = this.props
       .deleteExperimentApi(experimentId, deleteExperimentRequestId)
       .then(() => {
         // check whether the deleted experiment is currently selected
-        if (experimentId === activeExperimentId) {
+        if (activeExperimentIds !== undefined && activeExperimentIds.indexOf(experimentId) > -1) {
           // navigate to root URL and let route pick the next active experiment to show
           this.props.history.push(Routes.rootRoute);
         }

--- a/mlflow/server/js/src/experiment-tracking/components/modals/DeleteExperimentModal.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/DeleteExperimentModal.test.js
@@ -21,7 +21,7 @@ describe('DeleteExperimentModal', () => {
     minimalProps = {
       isOpen: false,
       onClose: jest.fn(),
-      activeExperimentId: '0',
+      activeExperimentIds: ['0'],
       experimentId: '0',
       experimentName: 'myFirstExperiment',
       deleteExperimentApi: (experimentId, deleteExperimentRequestId) => {
@@ -40,7 +40,7 @@ describe('DeleteExperimentModal', () => {
     expect(wrapper.length).toBe(1);
   });
 
-  test('handleSubmit redirects user to root page if active experiment is current experiment', (done) => {
+  test('handleSubmit redirects user to root page if current experiment is one of the active experiments', (done) => {
     instance = wrapper.instance();
     instance.handleSubmit().then(() => {
       expect(location.search).toEqual('/');
@@ -63,7 +63,7 @@ describe('DeleteExperimentModal', () => {
 
   test('handleSubmit does not perform redirection if deleted experiment is not active experiment', (done) => {
     wrapper = shallow(
-      <DeleteExperimentModalImpl {...{ ...minimalProps, activeExperimentId: undefined }} />,
+      <DeleteExperimentModalImpl {...{ ...minimalProps, activeExperimentIds: undefined }} />,
     );
     instance = wrapper.instance();
     instance.handleSubmit().then(() => {


### PR DESCRIPTION
Signed-off-by: Nikolay Ulmasov <ulmasov@hotmail.com>

## What changes are proposed in this pull request?
Add checkboxes to the experiments listing to allow multi-experiment run listing (and comparison). Clicking the single experiment name reverts to listing only one experiment runs whereas clicking on checkboxes allows selecting multiple experiments.

## How is this patch tested?

Modified existing and added new tests

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Multiple experiments can be selected by ticking the checkboxes shown before the experiment names. Clicking on the experiment name directly (as opposed to clicking on the checkbox) clears the selection and shows the runs for only that experiment (as it worked in the version prior to the introduction of multi-experiment selection).

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
