### PR TITLE
Update mlflow.set_tracking_uri to support pathlib.Path (#5820)

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -343,6 +343,7 @@ nitpick_ignore = [
     ("py:class", "scipy.sparse.csc.csc_matrix"),
     ("py:class", "scipy.sparse._csr.csr_matrix"),
     ("py:class", "scipy.sparse._csc.csc_matrix"),
+    ("py:class", "pathlib.Path"),
 ]
 
 

--- a/mlflow/tracking/_tracking_service/utils.py
+++ b/mlflow/tracking/_tracking_service/utils.py
@@ -55,7 +55,7 @@ def set_tracking_uri(uri: Union[str, Path]) -> None:
                   Databricks CLI
                   `profile <https://github.com/databricks/databricks-cli#installation>`_,
                   "databricks://<profileName>".
-                - A :py:class:`pathlib.Path` instance
+                - A ``pathlib.Path`` instance
 
     .. code-block:: python
         :caption: Example

--- a/mlflow/tracking/_tracking_service/utils.py
+++ b/mlflow/tracking/_tracking_service/utils.py
@@ -72,7 +72,7 @@ def set_tracking_uri(uri: Union[str, Path]) -> None:
         Current tracking uri: file:///tmp/my_tracking
     """
     if isinstance(uri, Path):
-        uri = uri.resolve().as_uri()
+        uri = uri.absolute().as_uri()
     global _tracking_uri
     _tracking_uri = uri
 

--- a/mlflow/tracking/_tracking_service/utils.py
+++ b/mlflow/tracking/_tracking_service/utils.py
@@ -72,7 +72,10 @@ def set_tracking_uri(uri: Union[str, Path]) -> None:
         Current tracking uri: file:///tmp/my_tracking
     """
     if isinstance(uri, Path):
-        uri = uri.absolute().as_uri()
+        # On Windows with Python3.7 (https://bugs.python.org/issue38671)
+        # resolve doesn't return the absolute path if the directory doesn't exist
+        uri.mkdir(parents=True, exist_ok=True)
+        uri = uri.resolve().as_uri()
     global _tracking_uri
     _tracking_uri = uri
 

--- a/mlflow/tracking/_tracking_service/utils.py
+++ b/mlflow/tracking/_tracking_service/utils.py
@@ -73,10 +73,10 @@ def set_tracking_uri(uri: Union[str, Path]) -> None:
     """
     if isinstance(uri, Path):
         # On Windows with Python3.7 (https://bugs.python.org/issue38671)
-        # resolve doesn't return the absolute path if the directory doesn't exist
-        if not uri.is_absolute():
-            uri = Path.cwd() / uri
-        uri = uri.resolve().as_uri()
+        # .resolve() doesn't return the absolute path if the directory doesn't exist
+        # so we're calling .absolute() first to get the absolute path on Windows,
+        # then .resolve() to clean the path
+        uri = uri.absolute().resolve().as_uri()
     global _tracking_uri
     _tracking_uri = uri
 

--- a/mlflow/tracking/_tracking_service/utils.py
+++ b/mlflow/tracking/_tracking_service/utils.py
@@ -55,7 +55,7 @@ def set_tracking_uri(uri: Union[str, Path]) -> None:
                   Databricks CLI
                   `profile <https://github.com/databricks/databricks-cli#installation>`_,
                   "databricks://<profileName>".
-                - A ``pathlib.Path`` instance
+                - A :py:class:`pathlib.Path` instance
 
     .. code-block:: python
         :caption: Example

--- a/mlflow/tracking/_tracking_service/utils.py
+++ b/mlflow/tracking/_tracking_service/utils.py
@@ -74,7 +74,8 @@ def set_tracking_uri(uri: Union[str, Path]) -> None:
     if isinstance(uri, Path):
         # On Windows with Python3.7 (https://bugs.python.org/issue38671)
         # resolve doesn't return the absolute path if the directory doesn't exist
-        uri.mkdir(parents=True, exist_ok=True)
+        if not uri.is_absolute():
+            uri = Path.cwd() / uri
         uri = uri.resolve().as_uri()
     global _tracking_uri
     _tracking_uri = uri

--- a/mlflow/tracking/_tracking_service/utils.py
+++ b/mlflow/tracking/_tracking_service/utils.py
@@ -1,6 +1,8 @@
 import os
 from functools import partial
 import logging
+from pathlib import Path
+from typing import Union
 
 from mlflow.store.tracking import DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH
 from mlflow.store.db.db_types import DATABASE_ENGINES
@@ -39,7 +41,7 @@ def is_tracking_uri_set():
     return False
 
 
-def set_tracking_uri(uri: str) -> None:
+def set_tracking_uri(uri: Union[str, Path]) -> None:
     """
     Set the tracking server URI. This does not affect the
     currently active run (if one exists), but takes effect for successive runs.
@@ -53,6 +55,7 @@ def set_tracking_uri(uri: str) -> None:
                   Databricks CLI
                   `profile <https://github.com/databricks/databricks-cli#installation>`_,
                   "databricks://<profileName>".
+                - A :py:class:`pathlib.Path` instance
 
     .. code-block:: python
         :caption: Example
@@ -68,6 +71,8 @@ def set_tracking_uri(uri: str) -> None:
 
         Current tracking uri: file:///tmp/my_tracking
     """
+    if isinstance(uri, Path):
+        uri = uri.resolve().as_uri()
     global _tracking_uri
     _tracking_uri = uri
 

--- a/tests/tracking/_tracking_service/test_utils.py
+++ b/tests/tracking/_tracking_service/test_utils.py
@@ -5,6 +5,7 @@ import itertools
 import pickle
 import os
 import pytest
+from pathlib import Path
 
 import mlflow
 from mlflow.exceptions import MlflowException
@@ -15,6 +16,8 @@ from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
 from mlflow.tracking.registry import UnsupportedModelRegistryStoreURIException
 from mlflow.tracking._tracking_service.registry import TrackingStoreRegistry
 from mlflow.tracking._tracking_service.utils import (
+    set_tracking_uri,
+    get_tracking_uri,
     _get_store,
     _resolve_tracking_uri,
     _TRACKING_INSECURE_TLS_ENV_VAR,
@@ -358,3 +361,14 @@ def test_store_object_can_be_serialized_by_pickle(tmpdir):
     pickle.dump(_get_store("https://example.com"), io.BytesIO())
     # pickle.dump(_get_store(f"sqlite:///{tmpdir.strpath}/mlflow.db"), io.BytesIO())
     # This throws `AttributeError: Can't pickle local object 'create_engine.<locals>.connect'`
+
+
+@pytest.mark.parametrize("absolute", [True, False], ids=["absolute", "relative"])
+def test_set_tracking_uri_with_path(tmp_path, monkeypatch, absolute):
+    monkeypatch.chdir(tmp_path)
+    path = Path("foo/bar")
+    if absolute:
+        path = tmp_path / path
+    with mock.patch("mlflow.tracking._tracking_service.utils._tracking_uri", None):
+        set_tracking_uri(path)
+        assert get_tracking_uri() == path.resolve().as_uri()

--- a/tests/tracking/_tracking_service/test_utils.py
+++ b/tests/tracking/_tracking_service/test_utils.py
@@ -372,3 +372,5 @@ def test_set_tracking_uri_with_path(tmp_path, monkeypatch, absolute):
     with mock.patch("mlflow.tracking._tracking_service.utils._tracking_uri", None):
         set_tracking_uri(path)
         assert get_tracking_uri() == path.resolve().as_uri()
+    assert path.exists()
+    assert path.is_dir()

--- a/tests/tracking/_tracking_service/test_utils.py
+++ b/tests/tracking/_tracking_service/test_utils.py
@@ -371,4 +371,4 @@ def test_set_tracking_uri_with_path(tmp_path, monkeypatch, absolute):
         path = tmp_path / path
     with mock.patch("mlflow.tracking._tracking_service.utils._tracking_uri", None):
         set_tracking_uri(path)
-        assert get_tracking_uri() == path.resolve().as_uri()
+        assert get_tracking_uri() == path.absolute().resolve().as_uri()

--- a/tests/tracking/_tracking_service/test_utils.py
+++ b/tests/tracking/_tracking_service/test_utils.py
@@ -372,5 +372,3 @@ def test_set_tracking_uri_with_path(tmp_path, monkeypatch, absolute):
     with mock.patch("mlflow.tracking._tracking_service.utils._tracking_uri", None):
         set_tracking_uri(path)
         assert get_tracking_uri() == path.resolve().as_uri()
-    assert path.exists()
-    assert path.is_dir()


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes #5820

## How is this patch tested?

Test if `set_tracking_uri` convert a path to a URI string.

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`mlflow.set_tracking_uri` now supports `pathlib.Path`.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
