### PR TITLE
Fix tf-serving parsing when input are columnar formatter

### DIFF
--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -344,8 +344,9 @@ def parse_tf_serving_input(inp_dict, schema=None):
             " https://www.tensorflow.org/tfx/serving/api_rest#request_format_2"
         )
 
-    # Sanity check inputted data
-    if isinstance(data, dict):
+    # Sanity check inputted data. This check will only be applied when the row-format `instances`
+    # is used since it requires same 0-th dimension for all items.
+    if isinstance(data, dict) and "instances" in inp_dict:
         # ensure all columns have the same number of items
         expected_len = len(list(data.values())[0])
         if not all(len(v) == expected_len for v in data.values()):


### PR DESCRIPTION
Signed-off-by: Arjun DCunha <arjun.dcunha@databricks.com>

## What changes are proposed in this pull request?
This PR fixes https://github.com/mlflow/mlflow/issues/5469. 
If the tf-serving input is row based, then it enforces all the items to have the same 0th dimension. However, this enforcement is not applied to columnar based inputs on tf-serving's api documentation (https://www.tensorflow.org/tfx/serving/api_rest#specifying_input_tensors_in_row_format)

## How is this patch tested?
Unit test added.
(Details)

## Does this PR change the documentation?

- [ x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

Fixed bug where the parsing a tf_serving input was enforcing all columnar inputs to have the same 0th dimension. This enforcement will now only be applied to row based inputs. This follows https://www.tensorflow.org/tfx/serving/api_rest#specifying_input_tensors_in_row_format.