### PR TITLE
Spark Datasource autologging: Fix REPL ID propagation from datasource listener to publisher

### DIFF
--- a/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/ReplAwareSparkDataSourceListener.scala
+++ b/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/ReplAwareSparkDataSourceListener.scala
@@ -50,7 +50,7 @@ class ReplAwareSparkDataSourceListener(
     val replIdOpt = popReplIdOpt(event)
     if (replIdOpt.isDefined) {
       tableInfos.foreach { tableInfo =>
-        publisher.publishEvent(replIdOpt, sparkTableInfo = tableInfo)
+        publisher.publishEvent(replIdOpt = replIdOpt, sparkTableInfo = tableInfo)
       }
     }
   }

--- a/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/ReplAwareSparkDataSourceListener.scala
+++ b/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/ReplAwareSparkDataSourceListener.scala
@@ -44,7 +44,7 @@ class ReplAwareSparkDataSourceListener(
     executionIdToReplId.put(executionId, replIdOpt.get)
   }
 
-  override protected def getReplIdOpt(event: SparkListenerSQLExecutionEnd): Option[String] = {
+  override protected def popReplIdOpt(event: SparkListenerSQLExecutionEnd): Option[String] = {
     executionIdToReplId.remove(event.executionId)
   }
 }

--- a/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/ReplAwareSparkDataSourceListener.scala
+++ b/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/ReplAwareSparkDataSourceListener.scala
@@ -44,7 +44,18 @@ class ReplAwareSparkDataSourceListener(
     executionIdToReplId.put(executionId, replIdOpt.get)
   }
 
-  override protected def popReplIdOpt(event: SparkListenerSQLExecutionEnd): Option[String] = {
+  protected[autologging] override def onSQLExecutionEnd(event: SparkListenerSQLExecutionEnd): Unit = {
+    val extractor = getDatasourceAttributeExtractor
+    val tableInfos = extractor.getTableInfos(event)
+    val replIdOpt = popReplIdOpt(event)
+    if (replIdOpt.isDefined) {
+      tableInfos.foreach { tableInfo =>
+        publisher.publishEvent(replIdOpt, sparkTableInfo = tableInfo)
+      }
+    }
+  }
+
+  private def popReplIdOpt(event: SparkListenerSQLExecutionEnd): Option[String] = {
     executionIdToReplId.remove(event.executionId)
   }
 }

--- a/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/SparkDataSourceListener.scala
+++ b/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/SparkDataSourceListener.scala
@@ -17,7 +17,6 @@ class SparkDataSourceListener(
     DatasourceAttributeExtractor
   }
 
-  // Exposed for testing
   protected[autologging] def onSQLExecutionEnd(event: SparkListenerSQLExecutionEnd): Unit = {
     val extractor = getDatasourceAttributeExtractor
     val tableInfos = extractor.getTableInfos(event)

--- a/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/SparkDataSourceListener.scala
+++ b/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/SparkDataSourceListener.scala
@@ -17,14 +17,15 @@ class SparkDataSourceListener(
     DatasourceAttributeExtractor
   }
 
-  protected def getReplIdOpt(event: SparkListenerSQLExecutionEnd): Option[String] = None
+  protected def popReplIdOpt(event: SparkListenerSQLExecutionEnd): Option[String] = None
 
   // Exposed for testing
   private[autologging] def onSQLExecutionEnd(event: SparkListenerSQLExecutionEnd): Unit = {
     val extractor = getDatasourceAttributeExtractor
     val tableInfos = extractor.getTableInfos(event)
+    val replIdOpt = popReplIdOpt(event)
     tableInfos.foreach { tableInfo =>
-      publisher.publishEvent(getReplIdOpt(event), tableInfo)
+      publisher.publishEvent(replIdOpt, tableInfo)
     }
   }
 

--- a/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/SparkDataSourceListener.scala
+++ b/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/SparkDataSourceListener.scala
@@ -17,15 +17,12 @@ class SparkDataSourceListener(
     DatasourceAttributeExtractor
   }
 
-  protected def popReplIdOpt(event: SparkListenerSQLExecutionEnd): Option[String] = None
-
   // Exposed for testing
-  private[autologging] def onSQLExecutionEnd(event: SparkListenerSQLExecutionEnd): Unit = {
+  protected[autologging] def onSQLExecutionEnd(event: SparkListenerSQLExecutionEnd): Unit = {
     val extractor = getDatasourceAttributeExtractor
     val tableInfos = extractor.getTableInfos(event)
-    val replIdOpt = popReplIdOpt(event)
     tableInfos.foreach { tableInfo =>
-      publisher.publishEvent(replIdOpt, tableInfo)
+      publisher.publishEvent(replIdOpt = None, sparkTableInfo = tableInfo)
     }
   }
 

--- a/mlflow/java/spark/src/test/scala/org/mlflow/spark/autologging/SparkAutologgingIntegrationSuite.scala
+++ b/mlflow/java/spark/src/test/scala/org/mlflow/spark/autologging/SparkAutologgingIntegrationSuite.scala
@@ -293,6 +293,8 @@ class SparkAutologgingSuite extends FunSuite with Matchers with BeforeAndAfterAl
   }
 
   test("repl-ID-aware listener publishes events with expected REPL IDs") {
+    MlflowAutologEventPublisher.stop()
+
     // Create a ReplAwareSparkDataSourceListener that uses a DatasourceAttributeExtractor instead
     // of a ReplAwareDatasourceAttributeExtractor for testing, since
     // ReplAwareDatasourceAttributeExtractor requires Databricks-specific packages that are not
@@ -301,7 +303,7 @@ class SparkAutologgingSuite extends FunSuite with Matchers with BeforeAndAfterAl
         publisher: MlflowAutologEventPublisherImpl = MlflowAutologEventPublisher)
       extends ReplAwareSparkDataSourceListener(publisher) {
       override protected def getDatasourceAttributeExtractor: DatasourceAttributeExtractorBase = {
-        DatasourceAttributeExtractor 
+        DatasourceAttributeExtractor
       }
     }
 
@@ -323,10 +325,10 @@ class SparkAutologgingSuite extends FunSuite with Matchers with BeforeAndAfterAl
 
     val sc = spark.sparkContext
     val formatToTablePathList = formatToTablePath.toList
-    
+
     // Read a collection of Spark DataFrames from different sources with different REPL ID
     // context for each read
-    
+
     // Because `spark.databricks.replId` is null, we expect that none of the subscribers will
     // be notified when `path1` is read via `df1`
     sc.setLocalProperty("spark.databricks.replId", null)

--- a/mlflow/java/spark/src/test/scala/org/mlflow/spark/autologging/SparkAutologgingIntegrationSuite.scala
+++ b/mlflow/java/spark/src/test/scala/org/mlflow/spark/autologging/SparkAutologgingIntegrationSuite.scala
@@ -110,190 +110,193 @@ class SparkAutologgingSuite extends FunSuite with Matchers with BeforeAndAfterAl
     s"${Paths.get("file:", absolutePath).toString}"
   }
 
-  // test("MlflowAutologEventPublisher can be idempotently initialized & stopped within " +
-  //   "single thread") {
-  //   // We expect a listener to already be created by calling init() in beforeEach
-  //   val listeners0 = MlflowSparkAutologgingTestUtils.getListeners(spark)
-  //   assert(listeners0.length == 1)
-  //   val listener0 = listeners0.head
-  //   // Call init() again, verify listener is unchanged
-  //   MlflowAutologEventPublisher.init()
-  //   val listeners1 = MlflowSparkAutologgingTestUtils.getListeners(spark)
-  //   assert(listeners1.length == 1)
-  //   val listener1 = listeners1.head
-  //   assert(listener0 == listener1)
-  //   // Call stop() multiple times
-  //   MlflowAutologEventPublisher.stop()
-  //   assert(MlflowSparkAutologgingTestUtils.getListeners(spark).isEmpty)
-  //   MlflowAutologEventPublisher.stop()
-  //   assert(MlflowSparkAutologgingTestUtils.getListeners(spark).isEmpty)
-  //   // Call init() after stop(), verify that we create a new listener
-  //   MlflowAutologEventPublisher.init()
-  //   val listeners2 = MlflowSparkAutologgingTestUtils.getListeners(spark)
-  //   assert(listeners2.length == 1)
-  //   val listener2 = listeners2.head
-  //   assert(listener2 != listener1)
-  // }
-  //
-  // test("MlflowAutologEventPublisher triggers publishEvent with appropriate arguments " +
-  //   "when reading datasources corresponding to different formats") {
-  //     val formatToTestDFs = formatToTablePath.map { case (format, tablePath) =>
-  //       val baseDf = spark.read.format(format).option("inferSchema", "true")
-  //         .option("header", "true").load(tablePath)
-  //       format -> Seq(
-  //         baseDf,
-  //         baseDf.filter("number > 0"),
-  //         baseDf.select("number"),
-  //         baseDf.limit(2),
-  //         baseDf.filter("number > 0").select("number").limit(2)
-  //       )
-  //     }
-  //
-  //       formatToTestDFs.foreach { case (format, dfs) =>
-  //         dfs.foreach { df =>
-  //           df.printSchema()
-  //           MlflowAutologEventPublisher.init()
-  //           val subscriber = spy(new MockSubscriber())
-  //           MlflowAutologEventPublisher.register(subscriber)
-  //           assert(MlflowAutologEventPublisher.subscribers.size == 1)
-  //           // Read DF
-  //           df.collect()
-  //           // Verify events logged
-  //           Thread.sleep(1000)
-  //           val tablePath = formatToTablePath(format)
-  //           val expectedPath = getFileUri(tablePath)
-  //           verify(subscriber, times(1)).notify(any(), any(), any())
-  //           verify(subscriber, times(1)).notify(expectedPath, "unknown", format)
-  //           MlflowAutologEventPublisher.stop()
-  //         }
-  //       }
-  // }
-  //
-  // test("MlflowAutologEventPublisher triggers publishEvent with appropriate arguments " +
-  //   "when reading a JOIN of two tables") {
-  //   val formats = formatToTablePath.keys
-  //   val leftFormat = formats.head
-  //   val rightFormat = formats.last
-  //   val leftPath = formatToTablePath(leftFormat)
-  //   val rightPath = formatToTablePath(rightFormat)
-  //   val leftDf = spark.read.format(leftFormat).load(leftPath)
-  //   val rightDf = spark.read.format(rightFormat).load(rightPath)
-  //   MlflowAutologEventPublisher.init()
-  //   val subscriber = spy(new MockSubscriber())
-  //   MlflowAutologEventPublisher.register(subscriber)
-  //   leftDf.join(rightDf).collect()
-  //   // Sleep a second to let the SparkListener trigger read
-  //   Thread.sleep(1000)
-  //   verify(subscriber, times(2)).notify(any(), any(), any())
-  //   verify(subscriber, times(1)).notify(getFileUri(leftPath), "unknown", leftFormat)
-  //   verify(subscriber, times(1)).notify(getFileUri(rightPath), "unknown", rightFormat)
-  // }
-  //
-  // test("MlflowAutologEventPublisher can publish to working subscribers even when " +
-  //   "others are broken") {
-  //   MlflowAutologEventPublisher.stop()
-  //   val subscriber = spy(new MockSubscriber())
-  //   // Publish to a broken subscriber, then a working one, and finally another broken one
-  //   val subscriberSeq = Seq(new BrokenSubscriber(), subscriber, new BrokenSubscriber())
-  //   object MockPublisher extends MlflowAutologEventPublisherImpl {
-  //     // Override subscriber iteration logic to yield subscribers in the desired order
-  //     override def getSubscribers: Seq[(String, MlflowAutologEventSubscriber)] = {
-  //       subscriberSeq.map(subscriber => (subscriber.replId, subscriber))
-  //     }
-  //   }
-  //   // Disable GC of dead subscribers so that they get published-to
-  //   MockPublisher.init(gcDeadSubscribersIntervalSec = 10000)
-  //   val listeners1 = MlflowSparkAutologgingTestUtils.getListeners(spark)
-  //   assert(listeners1.length == 1)
-  //   val (format, path) = formatToTablePath.head
-  //   val df = spark.read.format(format).load(path)
-  //   // Register subscribers & collect the DF to trigger a datasource read event
-  //   subscriberSeq.foreach(MockPublisher.register)
-  //   df.collect()
-  //   Thread.sleep(1000)
-  //   verify(subscriber, times(1)).notify(any(), any(), any())
-  //   verify(subscriber, times(1)).notify(
-  //     getFileUri(path), "unknown", format)
-  // }
-  //
-  // test("Exceptions while extracting datasource information from Spark query plan " +
-  //   "do not fail the query") {
-  //   MlflowAutologEventPublisher.stop()
-  //   object MockPublisher extends MlflowAutologEventPublisherImpl {
-  //     // Return a custom listener that throws while processing SparkListenerSQLExecutionEnd events
-  //     override def getSparkDataSourceListener: SparkDataSourceListener = {
-  //       new SparkDataSourceListener {
-  //         override def onSQLExecutionEnd(event: SparkListenerSQLExecutionEnd): Unit = {
-  //           throw new NoSuchMethodException("Mock failure while extracting datasource info from " +
-  //             "query plan!")
-  //         }
-  //       }
-  //     }
-  //   }
-  //   MockPublisher.init()
-  //   val (format, path) = formatToTablePath.head
-  //   val df = spark.read.format(format).load(path)
-  //   val subscriber = new MockSubscriber()
-  //   MockPublisher.register(subscriber)
-  //   df.collect()
-  // }
-  //
-  // test("MlflowAutologEventPublisher correctly unregisters broken subscribers") {
-  //   MlflowAutologEventPublisher.register(new BrokenSubscriber())
-  //   Thread.sleep(2000)
-  //   assert(MlflowAutologEventPublisher.subscribers.isEmpty)
-  // }
-  //
-  // test("Subscriber registration fails if init() not called") {
-  //   MlflowAutologEventPublisher.stop()
-  //   intercept[RuntimeException] {
-  //     MlflowAutologEventPublisher.register(new MockSubscriber())
-  //   }
-  // }
-  //
-  // test("Initializing MlflowAutologEventPublisher fails if SparkSession doesn't exixt") {
-  //   MlflowAutologEventPublisher.stop()
-  //   spark.stop()
-  //   try {
-  //     intercept[RuntimeException] {
-  //       MlflowAutologEventPublisher.init()
-  //     }
-  //   } finally {
-  //     spark = getOrCreateSparkSession()
-  //   }
-  // }
-  //
-  // test("Delegates to repl-ID-aware listener if REPL ID property is set in SparkContext") {
-  //   // Verify instance created by init() in beforeEach is not REPL-ID-aware
-  //   assert(MlflowAutologEventPublisher.sparkQueryListener.isInstanceOf[SparkDataSourceListener])
-  //   assert(!MlflowAutologEventPublisher.sparkQueryListener.isInstanceOf[ReplAwareSparkDataSourceListener])
-  //   // Call stop, update SparkContext to contain repl ID property, call init(), verify instance is
-  //   // REPL-ID-aware
-  //   MlflowAutologEventPublisher.stop()
-  //   assert(MlflowSparkAutologgingTestUtils.getListeners(spark).isEmpty)
-  //   val sc = spark.sparkContext
-  //   sc.setLocalProperty("spark.databricks.replId", "myCoolReplId")
-  //   MlflowAutologEventPublisher.init()
-  //   assert(MlflowAutologEventPublisher.sparkQueryListener.isInstanceOf[ReplAwareSparkDataSourceListener])
-  //   sc.setLocalProperty("spark.databricks.replId", null)
-  //   MlflowAutologEventPublisher.stop()
-  //   MlflowAutologEventPublisher.init()
-  //   assert(MlflowAutologEventPublisher.sparkQueryListener.isInstanceOf[SparkDataSourceListener])
-  // }
-  //
-  // test("Delegates to repl-ID-aware listener if Databricks cluster ID is set in Spark Conf") {
-  //   // Verify instance created by init() in beforeEach is not REPL-ID-aware
-  //   assert(MlflowAutologEventPublisher.sparkQueryListener.isInstanceOf[SparkDataSourceListener])
-  //   assert(!MlflowAutologEventPublisher.sparkQueryListener.isInstanceOf[ReplAwareSparkDataSourceListener])
-  //   MlflowAutologEventPublisher.stop()
-  //
-  //   spark.conf.set("spark.databricks.clusterUsageTags.clusterId", "myCoolClusterId")
-  //   MlflowAutologEventPublisher.init()
-  //   assert(MlflowAutologEventPublisher.sparkQueryListener.isInstanceOf[ReplAwareSparkDataSourceListener])
-  // }
+  test("MlflowAutologEventPublisher can be idempotently initialized & stopped within " +
+    "single thread") {
+    // We expect a listener to already be created by calling init() in beforeEach
+    val listeners0 = MlflowSparkAutologgingTestUtils.getListeners(spark)
+    assert(listeners0.length == 1)
+    val listener0 = listeners0.head
+    // Call init() again, verify listener is unchanged
+    MlflowAutologEventPublisher.init()
+    val listeners1 = MlflowSparkAutologgingTestUtils.getListeners(spark)
+    assert(listeners1.length == 1)
+    val listener1 = listeners1.head
+    assert(listener0 == listener1)
+    // Call stop() multiple times
+    MlflowAutologEventPublisher.stop()
+    assert(MlflowSparkAutologgingTestUtils.getListeners(spark).isEmpty)
+    MlflowAutologEventPublisher.stop()
+    assert(MlflowSparkAutologgingTestUtils.getListeners(spark).isEmpty)
+    // Call init() after stop(), verify that we create a new listener
+    MlflowAutologEventPublisher.init()
+    val listeners2 = MlflowSparkAutologgingTestUtils.getListeners(spark)
+    assert(listeners2.length == 1)
+    val listener2 = listeners2.head
+    assert(listener2 != listener1)
+  }
 
-  // test("repl-ID-aware listener publishes events with expected REPL IDs") {
-  test("bazbar") {
+  test("MlflowAutologEventPublisher triggers publishEvent with appropriate arguments " +
+    "when reading datasources corresponding to different formats") {
+      val formatToTestDFs = formatToTablePath.map { case (format, tablePath) =>
+        val baseDf = spark.read.format(format).option("inferSchema", "true")
+          .option("header", "true").load(tablePath)
+        format -> Seq(
+          baseDf,
+          baseDf.filter("number > 0"),
+          baseDf.select("number"),
+          baseDf.limit(2),
+          baseDf.filter("number > 0").select("number").limit(2)
+        )
+      }
+
+        formatToTestDFs.foreach { case (format, dfs) =>
+          dfs.foreach { df =>
+            df.printSchema()
+            MlflowAutologEventPublisher.init()
+            val subscriber = spy(new MockSubscriber())
+            MlflowAutologEventPublisher.register(subscriber)
+            assert(MlflowAutologEventPublisher.subscribers.size == 1)
+            // Read DF
+            df.collect()
+            // Verify events logged
+            Thread.sleep(1000)
+            val tablePath = formatToTablePath(format)
+            val expectedPath = getFileUri(tablePath)
+            verify(subscriber, times(1)).notify(any(), any(), any())
+            verify(subscriber, times(1)).notify(expectedPath, "unknown", format)
+            MlflowAutologEventPublisher.stop()
+          }
+        }
+  }
+
+  test("MlflowAutologEventPublisher triggers publishEvent with appropriate arguments " +
+    "when reading a JOIN of two tables") {
+    val formats = formatToTablePath.keys
+    val leftFormat = formats.head
+    val rightFormat = formats.last
+    val leftPath = formatToTablePath(leftFormat)
+    val rightPath = formatToTablePath(rightFormat)
+    val leftDf = spark.read.format(leftFormat).load(leftPath)
+    val rightDf = spark.read.format(rightFormat).load(rightPath)
+    MlflowAutologEventPublisher.init()
+    val subscriber = spy(new MockSubscriber())
+    MlflowAutologEventPublisher.register(subscriber)
+    leftDf.join(rightDf).collect()
+    // Sleep a second to let the SparkListener trigger read
+    Thread.sleep(1000)
+    verify(subscriber, times(2)).notify(any(), any(), any())
+    verify(subscriber, times(1)).notify(getFileUri(leftPath), "unknown", leftFormat)
+    verify(subscriber, times(1)).notify(getFileUri(rightPath), "unknown", rightFormat)
+  }
+
+  test("MlflowAutologEventPublisher can publish to working subscribers even when " +
+    "others are broken") {
+    MlflowAutologEventPublisher.stop()
+    val subscriber = spy(new MockSubscriber())
+    // Publish to a broken subscriber, then a working one, and finally another broken one
+    val subscriberSeq = Seq(new BrokenSubscriber(), subscriber, new BrokenSubscriber())
+    object MockPublisher extends MlflowAutologEventPublisherImpl {
+      // Override subscriber iteration logic to yield subscribers in the desired order
+      override def getSubscribers: Seq[(String, MlflowAutologEventSubscriber)] = {
+        subscriberSeq.map(subscriber => (subscriber.replId, subscriber))
+      }
+    }
+    // Disable GC of dead subscribers so that they get published-to
+    MockPublisher.init(gcDeadSubscribersIntervalSec = 10000)
+    val listeners1 = MlflowSparkAutologgingTestUtils.getListeners(spark)
+    assert(listeners1.length == 1)
+    val (format, path) = formatToTablePath.head
+    val df = spark.read.format(format).load(path)
+    // Register subscribers & collect the DF to trigger a datasource read event
+    subscriberSeq.foreach(MockPublisher.register)
+    df.collect()
+    Thread.sleep(1000)
+    verify(subscriber, times(1)).notify(any(), any(), any())
+    verify(subscriber, times(1)).notify(
+      getFileUri(path), "unknown", format)
+  }
+
+  test("Exceptions while extracting datasource information from Spark query plan " +
+    "do not fail the query") {
+    MlflowAutologEventPublisher.stop()
+    object MockPublisher extends MlflowAutologEventPublisherImpl {
+      // Return a custom listener that throws while processing SparkListenerSQLExecutionEnd events
+      override def getSparkDataSourceListener: SparkDataSourceListener = {
+        new SparkDataSourceListener {
+          override def onSQLExecutionEnd(event: SparkListenerSQLExecutionEnd): Unit = {
+            throw new NoSuchMethodException("Mock failure while extracting datasource info from " +
+              "query plan!")
+          }
+        }
+      }
+    }
+    MockPublisher.init()
+    val (format, path) = formatToTablePath.head
+    val df = spark.read.format(format).load(path)
+    val subscriber = new MockSubscriber()
+    MockPublisher.register(subscriber)
+    df.collect()
+  }
+
+  test("MlflowAutologEventPublisher correctly unregisters broken subscribers") {
+    MlflowAutologEventPublisher.register(new BrokenSubscriber())
+    Thread.sleep(2000)
+    assert(MlflowAutologEventPublisher.subscribers.isEmpty)
+  }
+
+  test("Subscriber registration fails if init() not called") {
+    MlflowAutologEventPublisher.stop()
+    intercept[RuntimeException] {
+      MlflowAutologEventPublisher.register(new MockSubscriber())
+    }
+  }
+
+  test("Initializing MlflowAutologEventPublisher fails if SparkSession doesn't exixt") {
+    MlflowAutologEventPublisher.stop()
+    spark.stop()
+    try {
+      intercept[RuntimeException] {
+        MlflowAutologEventPublisher.init()
+      }
+    } finally {
+      spark = getOrCreateSparkSession()
+    }
+  }
+
+  test("Delegates to repl-ID-aware listener if REPL ID property is set in SparkContext") {
+    // Verify instance created by init() in beforeEach is not REPL-ID-aware
+    assert(MlflowAutologEventPublisher.sparkQueryListener.isInstanceOf[SparkDataSourceListener])
+    assert(!MlflowAutologEventPublisher.sparkQueryListener.isInstanceOf[ReplAwareSparkDataSourceListener])
+    // Call stop, update SparkContext to contain repl ID property, call init(), verify instance is
+    // REPL-ID-aware
+    MlflowAutologEventPublisher.stop()
+    assert(MlflowSparkAutologgingTestUtils.getListeners(spark).isEmpty)
+    val sc = spark.sparkContext
+    sc.setLocalProperty("spark.databricks.replId", "myCoolReplId")
+    MlflowAutologEventPublisher.init()
+    assert(MlflowAutologEventPublisher.sparkQueryListener.isInstanceOf[ReplAwareSparkDataSourceListener])
+    sc.setLocalProperty("spark.databricks.replId", null)
+    MlflowAutologEventPublisher.stop()
+    MlflowAutologEventPublisher.init()
+    assert(MlflowAutologEventPublisher.sparkQueryListener.isInstanceOf[SparkDataSourceListener])
+  }
+
+  test("Delegates to repl-ID-aware listener if Databricks cluster ID is set in Spark Conf") {
+    // Verify instance created by init() in beforeEach is not REPL-ID-aware
+    assert(MlflowAutologEventPublisher.sparkQueryListener.isInstanceOf[SparkDataSourceListener])
+    assert(!MlflowAutologEventPublisher.sparkQueryListener.isInstanceOf[ReplAwareSparkDataSourceListener])
+    MlflowAutologEventPublisher.stop()
+
+    spark.conf.set("spark.databricks.clusterUsageTags.clusterId", "myCoolClusterId")
+    MlflowAutologEventPublisher.init()
+    assert(MlflowAutologEventPublisher.sparkQueryListener.isInstanceOf[ReplAwareSparkDataSourceListener])
+  }
+
+  test("repl-ID-aware listener publishes events with expected REPL IDs") {
+    // Create a ReplAwareSparkDataSourceListener that uses a DatasourceAttributeExtractor instead
+    // of a ReplAwareDatasourceAttributeExtractor for testing, since
+    // ReplAwareDatasourceAttributeExtractor requires Databricks-specific packages that are not
+    // available in OSS test environments
     class ReplAwareSparkDataSourceListenerWithDefaultDatasourceAttributeExtractor(
         publisher: MlflowAutologEventPublisherImpl = MlflowAutologEventPublisher)
       extends ReplAwareSparkDataSourceListener(publisher) {
@@ -302,12 +305,15 @@ class SparkAutologgingSuite extends FunSuite with Matchers with BeforeAndAfterAl
       }
     }
 
+    // Create and initialize a publisher that uses the ReplAwareSparkDataSourceListener containing
+    // the DatasourceAttributeExtractor defined above
     object MockReplAwarePublisher extends MlflowAutologEventPublisherImpl {
       override def getSparkDataSourceListener: SparkDataSourceListener = {
         new ReplAwareSparkDataSourceListenerWithDefaultDatasourceAttributeExtractor(this)
       }
     }
     MockReplAwarePublisher.init()
+    // Register several subcribers with different REPL IDs
     val subscriber1 = spy(new MockSubscriber())
     val subscriber2 = spy(new MockSubscriber())
     val subscriber3 = spy(new MockSubscriber())
@@ -318,31 +324,49 @@ class SparkAutologgingSuite extends FunSuite with Matchers with BeforeAndAfterAl
     val sc = spark.sparkContext
     val formatToTablePathList = formatToTablePath.toList
     
+    // Read a collection of Spark DataFrames from different sources with different REPL ID
+    // context for each read
+    
+    // Because `spark.databricks.replId` is null, we expect that none of the subscribers will
+    // be notified when `path1` is read via `df1`
     sc.setLocalProperty("spark.databricks.replId", null)
     val (format1, path1) = formatToTablePathList.head
     val df1 = spark.read.format(format1).load(path1)
     df1.collect()
 
+    // Because `spark.databricks.replId` is set to `subscriber1.replId`, we expect that only
+    // `subscriber1` will be notified when `path2` is read via `df2`
     sc.setLocalProperty("spark.databricks.replId", subscriber1.replId)
     val (format2, path2) = formatToTablePathList(1)
     val df2 = spark.read.format(format2).load(path2)
     df2.collect()
 
+    // Because `spark.databricks.replId` is set to `subscriber2.replId`, we expect that only
+    // `subscriber2` will be notified when `path3` is read via `df3`
     sc.setLocalProperty("spark.databricks.replId", subscriber2.replId)
     val (format3, path3) = formatToTablePathList(2)
     val df3 = spark.read.format(format3).load(path3)
     df3.collect()
 
+    // Because `spark.databricks.replId` is set to `subscriber3.replId`, we expect that only
+    // `subscriber3` will be notified when `path1`, `path2`, and `path3` are read via `df4`
     sc.setLocalProperty("spark.databricks.replId", subscriber3.replId)
     val df4 = df1.union(df2).union(df3)
     df4.collect()
 
+    // Verify that the only time subscriber1 was notified of a datasource read was when
+    // `path2` was read via `df2` with `spark.databricks.replId` set to `subscriber1.replId`
     verify(subscriber1, times(1)).notify(any(), any(), any())
     verify(subscriber1, times(1)).notify(meq(s"file:$path2"), any(), meq(format2))
 
+    // Verify that the only time subscriber2 was notified of a datasource read was when
+    // `path3` was read via `df3` with `spark.databricks.replId` set to `subscriber2.replId`
     verify(subscriber2, times(1)).notify(any(), any(), any())
     verify(subscriber2, times(1)).notify(meq(s"file:$path3"), any(), meq(format3))
 
+    // Verify that subscriber3 was notified of three datasource reads - one for each of
+    // `path1`, `path2`, and `path3` - via `df4` with `spark.databricks.replId` set to
+    // `subscriber3.replId`
     verify(subscriber3, times(3)).notify(any(), any(), any())
     verify(subscriber3, times(1)).notify(meq(s"file:$path1"), any(), meq(format1))
     verify(subscriber3, times(1)).notify(meq(s"file:$path2"), any(), meq(format2))


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR addresses two issues with `ReplAwareSparkDataSourceListener`:

1. When multiple tables are read as part of the same SparkSQL operation, REPL ID information is only passed to the first call to `publisher.publishEvent` corresponding to the first table.

2. When the REPL ID is missing, `publisher.publishEvent` is still called and subscribers are still notified of the event, even though we emit a warning log indicating that the event will be dropped

## How is this patch tested?

Improved integration test coverage

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
3. Click `Details` on the right to open the job page of CircleCI.
4. Click the `Artifacts` tab.
5. Click `docs/build/html/index.html`.
6. Find the changed pages / sections and make sure they render correctly.

## Release Notes

Fix a bug in Spark Datasource autologging on Databricks that caused table reads initiated by other users on the same cluster to be included in datasource tags.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
