### PR TITLE
Refactor `ExperimentListView` using `@databricks/design-system`'s `Tree` component

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.css
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.css
@@ -8,6 +8,7 @@
   overflow-y: scroll;
   overflow-x: hidden;
   width: 100%;
+  height: 90vh;
   margin-top: 8px;
 }
 

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.css
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.css
@@ -8,78 +8,9 @@
   overflow-y: scroll;
   overflow-x: hidden;
   width: 100%;
+  margin-top: 8px;
 }
 
-.active-experiment-list-item {
-  background: rgba(67, 199, 234, 0.1);
-  font-weight: bold;
-}
-
-.experiment-list-item {
-  overflow:hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-size: 14px;
-  height: 32px;
-  line-height: 32px;
-  padding-left: 12px;
-}
-
-.experiment-list-search-input {
-  flex: 1;
-  overflow-y: scroll;
-  overflow-x: hidden;
-  width: 100%;
-  padding-bottom: 6px;
-  margin-bottom: 8px;
-}
-
-input.experiment-list-search-input[type="text"]:focus{
-  border-color: #258BD2;
-  outline: none;
-}
-
-.experiments-header {
-  font-weight: normal;
-  display: inline-block;
-  margin-bottom: 8px;
-}
-
-.collapser-container {
-  display: inline-block;
-  position: relative;
-  top: -2px;
-}
-
-.collapser {
-  display: inline-block;
-  background-color: #082142d6;
-  color: #FFFFFF;
-  font-size: 16px;
-  line-height: 24px;
-  width: 24px;
-  height: 24px;
-  text-align: center;
-  margin-left: 10px;
-  cursor: pointer;
-}
-
-.experiment-list-create-btn-container {
-  display: inline-block;
-  position: relative;
-  top: -2px;
-}
-
-.experiment-list-create-btn {
-  width: 24px;
-  height: 24px;
-  line-height: inherit;
-  color: #333333;
-  background-color: #f5f5f5;
-  border-color: #cccccc;
-  border-radius: 4px;
-  margin-left: 60px;
-  font-size: 13px;
-  text-align: center;
-  cursor: pointer;
+.du-bois-light-tree-switcher {
+  display: none;
 }

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.js
@@ -224,4 +224,4 @@ export class ExperimentListView extends Component {
   }
 }
 
-// export default withRouter(ExperimentListView);
+export default withRouter(ExperimentListView);

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.js
@@ -124,6 +124,7 @@ export class ExperimentListView extends Component {
         <IconButton
           icon={<i className='far fa-trash-alt' />}
           onClick={this.handleDeleteExperiment(key, title)}
+          // Use a larger margin to avoid overlapping the vertical scrollbar
           style={{ marginRight: 15 }}
           data-test-id='delete-experiment-button'
         />
@@ -188,7 +189,6 @@ export class ExperimentListView extends Component {
               onClick={this.handleCreateExperiment}
               style={{
                 fontSize: '24px',
-                // Align the icon to the right
                 marginLeft: 'auto',
               }}
               title='New Experiment'

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.js
@@ -19,8 +19,12 @@ import { IconButton } from '../../common/components/IconButton';
 export class ExperimentListView extends Component {
   static propTypes = {
     history: PropTypes.object,
-    activeExperimentId: PropTypes.string.isRequired,
+    activeExperimentId: PropTypes.string,
     experiments: PropTypes.arrayOf(Experiment).isRequired,
+  };
+
+  static defaultProps = {
+    activeExperimentId: '0',
   };
 
   state = {
@@ -95,8 +99,11 @@ export class ExperimentListView extends Component {
   };
 
   renderListItem = ({ title, key }) => {
+    const { activeExperimentId } = this.props;
+    const dataTestId =
+      activeExperimentId === key ? 'active-experiment-list-item' : 'experiment-list-item';
     return (
-      <div style={{ display: 'flex', marginLeft: '8px' }}>
+      <div style={{ display: 'flex', marginLeft: '8px' }} data-test-id={dataTestId}>
         <div
           style={{
             width: '180px',
@@ -112,11 +119,13 @@ export class ExperimentListView extends Component {
           icon={<EditOutlined />}
           onClick={this.handleRenameExperiment(key, title)}
           style={{ marginRight: 5 }}
+          data-test-id='rename-experiment-button'
         />
         <IconButton
           icon={<i className='far fa-trash-alt' />}
           onClick={this.handleDeleteExperiment(key, title)}
           style={{ marginRight: 15 }}
+          data-test-id='delete-experiment-button'
         />
       </div>
     );
@@ -183,6 +192,7 @@ export class ExperimentListView extends Component {
                 marginLeft: 'auto',
               }}
               title='New Experiment'
+              data-test-id='create-experiment-button'
             />
             <LeftSquareFilled
               onClick={() => this.setState({ expanded: false })}
@@ -195,6 +205,7 @@ export class ExperimentListView extends Component {
             aria-label='search experiments'
             value={searchInput}
             onChange={this.handleSearchInputChange}
+            data-test-id='search-experiment-input'
           />
           <div className='experiment-list-container'>
             <Tree
@@ -213,4 +224,4 @@ export class ExperimentListView extends Component {
   }
 }
 
-export default withRouter(ExperimentListView);
+// export default withRouter(ExperimentListView);

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.js
@@ -18,7 +18,7 @@ import { IconButton } from '../../common/components/IconButton';
 
 export class ExperimentListView extends Component {
   static propTypes = {
-    history: PropTypes.object.isRequired,
+    history: PropTypes.object,
     activeExperimentId: PropTypes.string.isRequired,
     experiments: PropTypes.arrayOf(Experiment).isRequired,
   };

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.js
@@ -7,7 +7,7 @@ import {
   PlusSquareFilled,
 } from '@ant-design/icons';
 import { Tree, Input, Typography } from '@databricks/design-system';
-import { withRouter } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import './ExperimentListView.css';
 import { Experiment } from '../sdk/MlflowMessages';
 import Routes from '../routes';
@@ -90,31 +90,23 @@ export class ExperimentListView extends Component {
     this.updateSelectedExperiment('0', '');
   };
 
-  onSelect = (experimentId) => () => {
-    const { history, activeExperimentId } = this.props;
-    if (experimentId === activeExperimentId) {
-      return;
-    }
-    history.push(Routes.getExperimentPageRoute(experimentId));
-  };
-
   renderListItem = ({ title, key }) => {
     const { activeExperimentId } = this.props;
     const dataTestId =
       activeExperimentId === key ? 'active-experiment-list-item' : 'experiment-list-item';
     return (
       <div style={{ display: 'flex', marginLeft: '8px' }} data-test-id={dataTestId}>
-        <div
+        <Link
+          to={Routes.getExperimentPageRoute(key)}
           style={{
             width: '180px',
             overflow: 'hidden',
             textOverflow: 'ellipsis',
             whiteSpace: 'nowrap',
           }}
-          onClick={this.onSelect(key)}
         >
           {title}
-        </div>
+        </Link>
         <IconButton
           icon={<EditOutlined />}
           onClick={this.handleRenameExperiment(key, title)}
@@ -224,4 +216,4 @@ export class ExperimentListView extends Component {
   }
 }
 
-export default withRouter(ExperimentListView);
+export default ExperimentListView;

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.js
@@ -28,7 +28,7 @@ export class ExperimentListView extends Component {
   };
 
   state = {
-    expanded: true,
+    hidden: true,
     searchInput: '',
     showCreateExperimentModal: false,
     showDeleteExperimentModal: false,
@@ -133,7 +133,7 @@ export class ExperimentListView extends Component {
   };
 
   render() {
-    const { searchInput, expanded } = this.state;
+    const { searchInput, hidden } = this.state;
     const { experiments, activeExperimentId } = this.props;
     const lowerCasedSearchInput = searchInput.toLowerCase();
     const filteredExperiments = experiments.filter(({ name }) =>
@@ -144,10 +144,10 @@ export class ExperimentListView extends Component {
       key: experiment_id,
     }));
 
-    if (!expanded) {
+    if (hidden) {
       return (
         <RightSquareFilled
-          onClick={() => this.setState({ expanded: true })}
+          onClick={() => this.setState({ hidden: false })}
           style={{ fontSize: '24px' }}
           title='Show experiment list'
         />
@@ -195,7 +195,7 @@ export class ExperimentListView extends Component {
               data-test-id='create-experiment-button'
             />
             <LeftSquareFilled
-              onClick={() => this.setState({ expanded: false })}
+              onClick={() => this.setState({ hidden: true })}
               style={{ fontSize: '24px' }}
               title='Hide experiment list'
             />

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.js
@@ -28,7 +28,7 @@ export class ExperimentListView extends Component {
   };
 
   state = {
-    hidden: true,
+    hidden: false,
     searchInput: '',
     showCreateExperimentModal: false,
     showDeleteExperimentModal: false,

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.js
@@ -116,7 +116,7 @@ export class ExperimentListView extends Component {
         <IconButton
           icon={<i className='far fa-trash-alt' />}
           onClick={this.handleDeleteExperiment(key, title)}
-          style={{ marginRight: 5 }}
+          style={{ marginRight: 15 }}
         />
       </div>
     );

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.js
@@ -8,7 +8,6 @@ import {
 } from '@ant-design/icons';
 import { Tree, Input, Typography } from '@databricks/design-system';
 import { withRouter } from 'react-router-dom';
-import _ from 'lodash';
 import './ExperimentListView.css';
 import { Experiment } from '../sdk/MlflowMessages';
 import Routes from '../routes';

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.test.js
@@ -79,7 +79,7 @@ test('If button to create experiment is pressed then open CreateExperimentModal'
   wrapper
     .find('[data-test-id="create-experiment-button"]')
     .first()
-    .click();
+    .simulate('click');
   expect(wrapper.find(CreateExperimentModal).prop('isOpen')).toEqual(true);
 });
 
@@ -88,7 +88,7 @@ test('If button to delete experiment is pressed then open DeleteExperimentModal'
   wrapper
     .find('[data-test-id="delete-experiment-button"]')
     .first()
-    .click();
+    .simulate('click');
   expect(wrapper.find(DeleteExperimentModal).prop('isOpen')).toEqual(true);
 });
 
@@ -97,6 +97,6 @@ test('If button to edit experiment is pressed then open RenameExperimentModal', 
   wrapper
     .find('[data-test-id="rename-experiment-button"]')
     .first()
-    .click();
+    .simulate('click');
   expect(wrapper.find(RenameExperimentModal).prop('isOpen')).toEqual(true);
 });

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.test.js
@@ -1,123 +1,98 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
+import { BrowserRouter } from 'react-router-dom';
+import { Provider } from 'react-redux';
+import thunk from 'redux-thunk';
+import configureStore from 'redux-mock-store';
+import promiseMiddleware from 'redux-promise-middleware';
 import { ExperimentListView } from './ExperimentListView';
 import Fixtures from '../utils/test-utils/Fixtures';
 import { DeleteExperimentModal } from './modals/DeleteExperimentModal';
 import { RenameExperimentModal } from './modals/RenameExperimentModal';
 import { CreateExperimentModal } from './modals/CreateExperimentModal';
+import { mountWithIntl } from '../../common/utils/TestUtils';
+
+const mountComponent = (props) => {
+  const mockStore = configureStore([thunk, promiseMiddleware()]);
+  return mountWithIntl(
+    <Provider
+      store={mockStore({
+        entities: {
+          experimentsById: {},
+        },
+      })}
+    >
+      <BrowserRouter>
+        <ExperimentListView {...props} />,
+      </BrowserRouter>
+      ,
+    </Provider>,
+  );
+};
 
 test('If activeExperimentId is defined then choose that one', () => {
-  const wrapper = shallow(
-    <ExperimentListView
-      onClickListExperiments={() => {}}
-      experiments={Fixtures.experiments}
-      activeExperimentId={'1'}
-    />,
-  );
+  const wrapper = mountComponent({ experiments: Fixtures.experiments, activeExperimentId: '1' });
   expect(
     wrapper
-      .find('.active-experiment-list-item')
+      .find('[data-test-id="active-experiment-list-item"]')
       .first()
-      .prop('title'),
-  ).toEqual('Test');
+      .text(),
+  ).toContain('Test');
 });
 
 test('If activeExperimentId is undefined then choose first experiment', () => {
-  const wrapper = shallow(
-    <ExperimentListView onClickListExperiments={() => {}} experiments={Fixtures.experiments} />,
-  );
+  const wrapper = mountComponent({
+    experiments: Fixtures.experiments,
+  });
   expect(
     wrapper
-      .find('.active-experiment-list-item')
+      .find('[data-test-id="active-experiment-list-item"]')
       .first()
-      .prop('title'),
-  ).toEqual('Default');
+      .text(),
+  ).toContain('Default');
 });
 
 test('If searchInput is set to "Test" then first shown element in experiment list has the title "Test"', () => {
-  const wrapper = shallow(
-    <ExperimentListView onClickListExperiments={() => {}} experiments={Fixtures.experiments} />,
-  );
-
-  wrapper.setState({ searchInput: 'Test' });
+  const wrapper = mountComponent({ experiments: Fixtures.experiments });
+  console.log(wrapper);
+  wrapper
+    .find('input[data-test-id="search-experiment-input"]')
+    .first()
+    .simulate('change', { target: { value: 'Test' } });
   expect(
     wrapper
-      .find('.experiment-list-item')
+      .find('[data-test-id="experiment-list-item"]')
       .first()
-      .prop('title'),
-  ).toEqual('Test');
+      .text(),
+  ).toContain('Test');
 });
 
 test('If searchInput is set to "Test" and default experiment is active then no active element is shown in the experiment list', () => {
-  const wrapper = shallow(
-    <ExperimentListView
-      onClickListExperiments={() => {}}
-      experiments={Fixtures.experiments}
-      activeExperimentId={'0'}
-    />,
-  );
-
-  wrapper.setState({ searchInput: 'Test' });
-  expect(wrapper.find('.active-experiment-list-item')).toHaveLength(0);
+  const wrapper = mountComponent({ experiments: Fixtures.experiments, activeExperimentId: '0' });
+  wrapper
+    .find('input[data-test-id="search-experiment-input"]')
+    .first()
+    .simulate('change', { target: { value: 'Test' } });
+  expect(wrapper.find('[data-test-id="active-experiment-list-item"]')).toHaveLength(0);
 });
 
 test('If button to create experiment is pressed then open CreateExperimentModal', () => {
-  const wrapper = shallow(
-    <ExperimentListView onClickListExperiments={() => {}} experiments={Fixtures.experiments} />,
-  );
-  // find create experiment link
-  const createExpLink = wrapper.find('.experiment-list-create-btn');
-  // mock event that is passed when clicking the link
+  const wrapper = mountComponent({ experiments: Fixtures.experiments });
+  const createExpLink = wrapper.find('[data-test-id="create-experiment-button"]').first();
   createExpLink.simulate('click');
-
   expect(wrapper.find(CreateExperimentModal).prop('isOpen')).toEqual(true);
 });
 
 test('If button to delete experiment is pressed then open DeleteExperimentModal', () => {
-  const wrapper = shallow(
-    <ExperimentListView onClickListExperiments={() => {}} experiments={Fixtures.experiments} />,
-  );
-  // find delete experiment link
-  const deleteLink = wrapper
-    .find('.active-experiment-list-item')
-    .children()
-    .at(2);
-  // mock event that is passed when clicking the link
-  const mockedExperiment = Fixtures.experiments[0];
-  const mockedEvent = {
-    currentTarget: {
-      dataset: {
-        experimentid: mockedExperiment.experiment_id,
-        experimentname: mockedExperiment.name,
-      },
-    },
-  };
-  deleteLink.simulate('click', mockedEvent);
-
+  const wrapper = mountComponent({ experiments: Fixtures.experiments });
+  const createExpLink = wrapper.find('[data-test-id="delete-experiment-button"]').first();
+  createExpLink.simulate('click');
   expect(wrapper.find(DeleteExperimentModal).prop('isOpen')).toEqual(true);
 });
 
 test('If button to edit experiment is pressed then open RenameExperimentModal', () => {
-  const wrapper = shallow(
-    <ExperimentListView onClickListExperiments={() => {}} experiments={Fixtures.experiments} />,
-  );
-
-  // find edit experiment link
-  const editLink = wrapper
-    .find('.active-experiment-list-item')
-    .children()
-    .at(1);
-  // mock event that is passed when clicking the link
-  const mockedExperiment = Fixtures.experiments[0];
-  const mockedEvent = {
-    currentTarget: {
-      dataset: {
-        experimentid: mockedExperiment.experiment_id,
-        experimentname: mockedExperiment.name,
-      },
-    },
-  };
-  editLink.simulate('click', mockedEvent);
-
+  const wrapper = mountComponent({ experiments: Fixtures.experiments });
+  const createExpLink = wrapper.find('[data-test-id="rename-experiment-button"]').first();
+  createExpLink.simulate('click');
   expect(wrapper.find(RenameExperimentModal).prop('isOpen')).toEqual(true);
 });

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.test.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { shallow, mount } from 'enzyme';
 import { BrowserRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
@@ -54,7 +53,6 @@ test('If activeExperimentId is undefined then choose first experiment', () => {
 
 test('If searchInput is set to "Test" then first shown element in experiment list has the title "Test"', () => {
   const wrapper = mountComponent({ experiments: Fixtures.experiments });
-  console.log(wrapper);
   wrapper
     .find('input[data-test-id="search-experiment-input"]')
     .first()

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.test.js
@@ -76,21 +76,27 @@ test('If searchInput is set to "Test" and default experiment is active then no a
 
 test('If button to create experiment is pressed then open CreateExperimentModal', () => {
   const wrapper = mountComponent({ experiments: Fixtures.experiments });
-  const createExpLink = wrapper.find('[data-test-id="create-experiment-button"]').first();
-  createExpLink.simulate('click');
+  wrapper
+    .find('[data-test-id="create-experiment-button"]')
+    .first()
+    .click();
   expect(wrapper.find(CreateExperimentModal).prop('isOpen')).toEqual(true);
 });
 
 test('If button to delete experiment is pressed then open DeleteExperimentModal', () => {
   const wrapper = mountComponent({ experiments: Fixtures.experiments });
-  const createExpLink = wrapper.find('[data-test-id="delete-experiment-button"]').first();
-  createExpLink.simulate('click');
+  wrapper
+    .find('[data-test-id="delete-experiment-button"]')
+    .first()
+    .click();
   expect(wrapper.find(DeleteExperimentModal).prop('isOpen')).toEqual(true);
 });
 
 test('If button to edit experiment is pressed then open RenameExperimentModal', () => {
   const wrapper = mountComponent({ experiments: Fixtures.experiments });
-  const createExpLink = wrapper.find('[data-test-id="rename-experiment-button"]').first();
-  createExpLink.simulate('click');
+  wrapper
+    .find('[data-test-id="rename-experiment-button"]')
+    .first()
+    .click();
   expect(wrapper.find(RenameExperimentModal).prop('isOpen')).toEqual(true);
 });

--- a/mlflow/server/js/src/experiment-tracking/components/HomeView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/HomeView.js
@@ -80,12 +80,6 @@ class HomeView extends Component {
   }
 }
 
-const styles = {
-  showExperimentListExpander: {
-    marginTop: 24,
-  },
-};
-
 const mapStateToProps = (state) => {
   const experiments = getExperiments(state);
   return { experiments };

--- a/mlflow/server/js/src/experiment-tracking/components/HomeView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/HomeView.js
@@ -16,20 +16,11 @@ export const getFirstActiveExperiment = (experiments) => {
 };
 
 class HomeView extends Component {
-  constructor(props) {
-    super(props);
-    this.onClickListExperiments = this.onClickListExperiments.bind(this);
-  }
-
   static propTypes = {
     history: PropTypes.shape({}),
     experiments: PropTypes.shape({}),
     experimentIds: PropTypes.arrayOf(PropTypes.string),
     compareExperiments: PropTypes.bool,
-  };
-
-  state = {
-    listExperimentsExpanded: true,
   };
 
   componentDidMount() {
@@ -44,65 +35,30 @@ class HomeView extends Component {
     }
   }
 
-  onClickListExperiments() {
-    this.setState({ listExperimentsExpanded: !this.state.listExperimentsExpanded });
-  }
-
   render() {
-    const { experimentIds, compareExperiments } = this.props;
+    const { experimentIds, experiments, compareExperiments } = this.props;
     const headerHeight = process.env.HIDE_HEADER === 'true' ? 0 : 60;
     const containerHeight = 'calc(100% - ' + headerHeight + 'px)';
-    if (process.env.HIDE_EXPERIMENT_LIST === 'true') {
-      return (
-        <div style={{ height: containerHeight }}>
-          {this.props.experimentIds ? (
-            <PageContainer>
-              <ExperimentPage
-                experimentIds={experimentIds}
-                compareExperiments={compareExperiments}
-              />
-            </PageContainer>
-          ) : (
-            <NoExperimentView />
-          )}
-        </div>
-      );
+
+    if (experimentIds === undefined) {
+      return <NoExperimentView />;
     }
+
     return (
-      <div className='outer-container' style={{ height: containerHeight }}>
-        <div>
-          <Spacer />
-          {this.state.listExperimentsExpanded ? (
-            <ExperimentListView
-              activeExperimentId={this.props.experimentIds && this.props.experimentIds[0]}
-              onClickListExperiments={this.onClickListExperiments}
-            />
-          ) : (
-            <i
-              onClick={this.onClickListExperiments}
-              title='Show experiment list'
-              style={styles.showExperimentListExpander}
-              className='expander fa fa-chevron-right login-icon'
-            />
-          )}
-        </div>
+      <div className='outer-container' style={{ height: containerHeight, display: 'flex' }}>
+        {process.env.HIDE_EXPERIMENT_LIST !== 'true' && (
+          <div>
+            <Spacer />
+            <ExperimentListView activeExperimentId={experimentIds[0]} experiments={experiments} />
+          </div>
+        )}
         <PageContainer>
-          {this.props.experimentIds ? (
-            <ExperimentPage experimentIds={experimentIds} compareExperiments={compareExperiments} />
-          ) : (
-            <NoExperimentView />
-          )}
+          <ExperimentPage experimentIds={experimentIds} compareExperiments={compareExperiments} />
         </PageContainer>
       </div>
     );
   }
 }
-
-const styles = {
-  showExperimentListExpander: {
-    marginTop: 24,
-  },
-};
 
 const mapStateToProps = (state) => {
   const experiments = getExperiments(state);

--- a/mlflow/server/js/src/experiment-tracking/components/HomeView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/HomeView.js
@@ -35,30 +35,56 @@ class HomeView extends Component {
     }
   }
 
+  onClickListExperiments() {
+    this.setState({ listExperimentsExpanded: !this.state.listExperimentsExpanded });
+  }
+
   render() {
     const { experimentIds, experiments, compareExperiments } = this.props;
     const headerHeight = process.env.HIDE_HEADER === 'true' ? 0 : 60;
     const containerHeight = 'calc(100% - ' + headerHeight + 'px)';
-
-    if (experimentIds === undefined) {
-      return <NoExperimentView />;
+    if (process.env.HIDE_EXPERIMENT_LIST === 'true') {
+      return (
+        <div style={{ height: containerHeight }}>
+          {this.props.experimentIds ? (
+            <PageContainer>
+              <ExperimentPage
+                experimentIds={experimentIds}
+                compareExperiments={compareExperiments}
+              />
+            </PageContainer>
+          ) : (
+            <NoExperimentView />
+          )}
+        </div>
+      );
     }
-
     return (
-      <div className='outer-container' style={{ height: containerHeight, display: 'flex' }}>
-        {process.env.HIDE_EXPERIMENT_LIST !== 'true' && (
-          <div>
-            <Spacer />
-            <ExperimentListView activeExperimentId={experimentIds[0]} experiments={experiments} />
-          </div>
-        )}
+      <div className='outer-container' style={{ height: containerHeight }}>
+        <div>
+          <Spacer />
+          <ExperimentListView
+            activeExperimentId={this.props.experimentIds && this.props.experimentIds[0]}
+            experiments={experiments}
+          />
+        </div>
         <PageContainer>
-          <ExperimentPage experimentIds={experimentIds} compareExperiments={compareExperiments} />
+          {this.props.experimentIds ? (
+            <ExperimentPage experimentIds={experimentIds} compareExperiments={compareExperiments} />
+          ) : (
+            <NoExperimentView />
+          )}
         </PageContainer>
       </div>
     );
   }
 }
+
+const styles = {
+  showExperimentListExpander: {
+    marginTop: 24,
+  },
+};
 
 const mapStateToProps = (state) => {
   const experiments = getExperiments(state);


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

Refactor the `ExperimentListView` component using `@databricks/design-system`'s `Tree` component to simplify the implementation of multi-experiment run comparison in #5822.

https://user-images.githubusercontent.com/17039389/167283645-f17221e2-9016-44b9-8c20-8ca3976a7542.mov

## How is this patch tested?

- Unit tests
- Manual QA

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
