### PR TITLE
Add `run-dev-server.sh` to quickly launch development server from repository root

### DIFF
--- a/dev/run-dev-server.sh
+++ b/dev/run-dev-server.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+log_file="outputs/mlflow-server.log"
+
 function wait_server_ready {
   for backoff in 0 1 2 4 8; do
     echo "Waiting for server to be ready..."
@@ -10,11 +12,12 @@ function wait_server_ready {
       return 0
     fi
   done
+  echo "Failed to launch mlflow server"
+  cat $log_file
   return 1
 }
 
 mkdir -p outputs
-log_file="outputs/mlflow-server.log"
 echo 'Running mlflow server in the background'
 echo "Logging to $log_file"
 if [ -z "$MLFLOW_TRACKING_URI" ]; then

--- a/dev/run-dev-server.sh
+++ b/dev/run-dev-server.sh
@@ -12,8 +12,8 @@ function wait_server_ready {
       return 0
     fi
   done
-  echo "Failed to launch mlflow server"
   cat $log_file
+  echo -e "\nFailed to launch mlflow server"
   return 1
 }
 

--- a/dev/run-dev-server.sh
+++ b/dev/run-dev-server.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+
+function wait_server_ready {
+  for backoff in 0 1 2 4 8; do
+    echo "Waiting for server to be ready..."
+    sleep $backoff
+    if curl --fail --silent --show-error --output /dev/null $1; then
+      echo "Server is ready"
+      return 0
+    fi
+  done
+  return 1
+}
+
+mkdir -p outputs
+log_file="outputs/mlflow-server.log"
+echo 'Running mlflow server in the background'
+echo "Logging to $log_file"
+if [ -z "$MLFLOW_TRACKING_URI" ]; then
+  backend_store_uri=""
+  default_artifact_root=""
+else
+  backend_store_uri="--backend-store-uri $MLFLOW_TRACKING_URI"
+  default_artifact_root="--default-artifact-root mlruns"
+fi
+mlflow server $backend_store_uri $default_artifact_root --gunicorn-opts="--log-level debug" > $log_file 2>&1 &
+wait_server_ready localhost:5000/health
+
+# `FORCE_COLOR=true ... | cat` prevents `yarn start` from clearing the console:
+# https://github.com/facebook/create-react-app/issues/2495#issuecomment-344537005
+FORCE_COLOR=true yarn --cwd mlflow/server/js start | cat

--- a/dev/run-dev-server.sh
+++ b/dev/run-dev-server.sh
@@ -26,7 +26,4 @@ else
 fi
 mlflow server $backend_store_uri $default_artifact_root --gunicorn-opts="--log-level debug" > $log_file 2>&1 &
 wait_server_ready localhost:5000/health
-
-# `FORCE_COLOR=true ... | cat` prevents `yarn start` from clearing the console:
-# https://github.com/facebook/create-react-app/issues/2495#issuecomment-344537005
-FORCE_COLOR=true yarn --cwd mlflow/server/js start | cat
+yarn --cwd mlflow/server/js start


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

Add `run-dev-server.sh` to quickly launch development server.

## How is this patch tested?

Manually

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
