### PR TITLE
Prometheus exporter

### DIFF
--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -81,7 +81,12 @@ def serve(
         prometheus_metrics_path = tmp_dir + "/metrics"
         os.environ[scoring_server.PROMETHEUS_EXPORTER_ENV_VAR] = prometheus_metrics_path
     return _get_flavor_backend(
-        model_uri, env_manager=env_manager, workers=workers, install_mlflow=install_mlflow
+        model_uri,
+        env_manager=env_manager,
+        workers=workers,
+        install_mlflow=install_mlflow,
+        expose_prometheus=expose_prometheus,
+        app_name=app_name,
     ).serve(
         model_uri=model_uri, port=port, host=host, timeout=timeout, enable_mlserver=enable_mlserver
     )

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -20,6 +20,8 @@ import os
 import pandas as pd
 import sys
 import traceback
+from prometheus_flask_exporter.multiprocess import GunicornInternalPrometheusMetrics
+from flask import request
 
 # NB: We need to be careful what we import form mlflow here. Scoring server is used from within
 # model's conda environment. The version of mlflow doing the serving (outside) and the version of
@@ -50,6 +52,8 @@ except ImportError:
     from io import StringIO
 
 _SERVER_MODEL_PATH = "__pyfunc_model_path__"
+PROMETHEUS_EXPORTER_ENV_VAR = "prometheus_multiproc_dir"
+APP_ENV_VAR = "app"
 
 CONTENT_TYPE_CSV = "text/csv"
 CONTENT_TYPE_JSON = "application/json"
@@ -221,6 +225,19 @@ def init(model: PyFuncModel):
     """
     app = flask.Flask(__name__)
     input_schema = model.metadata.get_input_schema()
+    if os.getenv(APP_ENV_VAR):
+        application = os.getenv(APP_ENV_VAR)
+    else:
+        application = "default"
+
+    if os.getenv(PROMETHEUS_EXPORTER_ENV_VAR):
+        prometheus_metrics_path = os.getenv(PROMETHEUS_EXPORTER_ENV_VAR)
+
+    if not os.path.exists(prometheus_metrics_path):
+        os.makedirs(prometheus_metrics_path)
+
+    metrics = GunicornInternalPrometheusMetrics(app, export_defaults=False)
+    _logger.info("start flask prometheus exporter")
 
     @app.route("/ping", methods=["GET"])
     def ping():  # pylint: disable=unused-variable
@@ -234,6 +251,16 @@ def init(model: PyFuncModel):
 
     @app.route("/invocations", methods=["POST"])
     @catch_mlflow_exception
+    @metrics.histogram(
+        "mlflow_model_server_requests_by_status_and_path",
+        "request latencies and count by status and path(seconds)",
+        labels={
+            "status": lambda r: r.status_code,
+            "path": lambda: request.path,
+            "request_host": lambda: request.host,
+            "application": application,
+        },
+    )
     def transformation():  # pylint: disable=unused-variable
         """
         Do an inference on a single batch of data. In this sample server,

--- a/mlflow/utils/cli_args.py
+++ b/mlflow/utils/cli_args.py
@@ -179,3 +179,18 @@ SERVE_ARTIFACTS = click.option(
     "overridden via the '--artifacts-destination' argument. "
     "Default: False",
 )
+
+EXPOSE_PROMETHEUS = click.option(
+    "--expose-prometheus",
+    default=None,
+    help="Path to the directory where metrics will be stored. If the directory"
+    "doesn't exist, it will be created."
+    "Activate prometheus exporter to expose metrics on /metrics endpoint.",
+)
+
+APP_NAME = click.option(
+    "--app-name",
+    default="default",
+    help="the name of the application, which is used for the models serve prometheus export,"
+    "to distinguish application name in the prometheus metrics",
+)


### PR DESCRIPTION
## What changes are proposed in this pull request?

A new parameter to the mlflow models serve cli allowing to activate a prometheus exporter which expose metrics on the /metrics endpoint. and new paramter to distinguish application from promethues metrics

the following metrics will be expose

http request total
http request delay

All credit goes to @monkeyboy123 . This is the continuation of his work in https://github.com/mlflow/mlflow/pull/3622
I just applied the changes again to the current master, which was easier than rebasing a very old feature branch.

## How is this patch tested?

Locally, by trying to launch the models serve with or without the argument --activate-prometheus and --app-name, and by checking that metrics are indeed available on /metrics endpoint.

I was not able however, to reproduce the unit test failures that were apparently caused by these changes. I would be glad for any assistance to make the tests pass and get this accepted as a proper PR.

## Does this PR change the documentation?

- [] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X ] Yes. Give a description of this change to be included in the release notes for MLflow users.

Served Models can now optionally expose Gunicorn Prometheus Metrics.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
