### PR TITLE
Ad-hoc connection pool for SFTPArtifactRepository

### DIFF
--- a/mlflow/store/artifact/artifact_repo.py
+++ b/mlflow/store/artifact/artifact_repo.py
@@ -34,9 +34,7 @@ class ArtifactRepository:
         # Limit the number of threads used for artifact uploads/downloads. Use at most
         # constants._NUM_MAX_THREADS threads or 2 * the number of CPU cores available on the
         # system (whichever is smaller)
-        num_cpus = os.cpu_count() or _NUM_DEFAULT_CPUS
-        num_artifact_workers = min(num_cpus * _NUM_MAX_THREADS_PER_CPU, _NUM_MAX_THREADS)
-        self.thread_pool = ThreadPoolExecutor(max_workers=num_artifact_workers)
+        self.thread_pool = ThreadPoolExecutor(max_workers=self.max_workers)
 
     @abstractmethod
     def log_artifact(self, local_file, artifact_path=None):
@@ -293,6 +291,12 @@ class ArtifactRepository:
         :param artifact_path: Path of the artifact to delete
         """
         pass
+
+    @property
+    def max_workers(self) -> int:
+        """Compute the number of workers to use for multi-threading."""
+        num_cpus = os.cpu_count() or _NUM_DEFAULT_CPUS
+        return min(num_cpus * _NUM_MAX_THREADS_PER_CPU, _NUM_MAX_THREADS)
 
 
 def verify_artifact_path(artifact_path):

--- a/tests/store/artifact/test_sftp_artifact_repo.py
+++ b/tests/store/artifact/test_sftp_artifact_repo.py
@@ -196,3 +196,18 @@ def test_delete_selective_artifacts(artifact_path):
         assert not posixpath.exists(posixpath.join(remote_dir, file1))
         assert posixpath.isfile(posixpath.join(remote_dir, directory, file2))
         assert posixpath.isdir(remote_dir)
+
+
+def test_download_sklearn():
+    from mlflow import create_experiment, start_run, sklearn
+
+    with TempDir() as remote:
+        experiment_id = create_experiment(
+            name="sklearn-model-experiment", artifact_location=f"sftp://{remote.path()}"
+        )
+
+        with start_run(experiment_id=experiment_id):
+            original = {"not": "a", "real": "model"}
+            model_uri = sklearn.log_model(original, "model").model_uri
+            downloaded = sklearn.load_model(model_uri)
+            assert downloaded == original


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix #5656.

Add an ad-hoc pool for SFTP Connection objects to prevent deadlocks when fetching directories, which triggers the multi-threaded in the parent class.

## How is this patch tested?

Existing unit tests + local verification of the use case which that started failing as of 1.24.0

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
