### PR TITLE
Fix `SFTPArtifactRepository` tests

### DIFF
--- a/mlflow/store/artifact/sftp_artifact_repo.py
+++ b/mlflow/store/artifact/sftp_artifact_repo.py
@@ -1,8 +1,8 @@
 import os
-import stat
+import sys
+
 import posixpath
 import urllib.parse
-from contextlib import contextmanager
 
 from mlflow.entities import FileInfo
 from mlflow.store.artifact.artifact_repo import ArtifactRepository
@@ -27,7 +27,7 @@ class SFTPArtifactRepository(ArtifactRepository):
         self.uri = artifact_uri
         parsed = urllib.parse.urlparse(artifact_uri)
         self.config = {
-            "hostname": parsed.hostname,
+            "host": parsed.hostname,
             "port": parsed.port,
             "username": parsed.username,
             "password": parsed.password,
@@ -37,10 +37,11 @@ class SFTPArtifactRepository(ArtifactRepository):
         if client:
             self.sftp = client
         else:
+            import pysftp
             import paramiko
 
-            if self.config["hostname"] is None:
-                self.config["hostname"] = "localhost"
+            if self.config["host"] is None:
+                self.config["host"] = "localhost"
 
             ssh_config = paramiko.SSHConfig()
             user_config_file = os.path.expanduser("~/.ssh/config")
@@ -48,10 +49,10 @@ class SFTPArtifactRepository(ArtifactRepository):
                 with open(user_config_file) as f:
                     ssh_config.parse(f)
 
-            user_config = ssh_config.lookup(self.config["hostname"])
+            user_config = ssh_config.lookup(self.config["host"])
 
             if "hostname" in user_config:
-                self.config["hostname"] = user_config["hostname"]
+                self.config["host"] = user_config["hostname"]
 
             if self.config.get("username", None) is None and "user" in user_config:
                 self.config["username"] = user_config["user"]
@@ -63,115 +64,55 @@ class SFTPArtifactRepository(ArtifactRepository):
                     self.config["port"] = 22
 
             if "identityfile" in user_config:
-                self.config["key_filename"] = user_config["identityfile"][0]
+                self.config["private_key"] = user_config["identityfile"][0]
 
-            ssh_client = paramiko.SSHClient()
-            ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-            ssh_client.connect(**self.config)
-            self.sftp = ssh_client.open_sftp()
+            self.sftp = pysftp.Connection(**self.config)
 
         super().__init__(artifact_uri)
 
-    def _isfile(self, remotepath):
-        try:
-            return stat.S_ISREG(self.sftp.stat(remotepath).st_mode)
-        except IOError:
-            return False
-
-    def _isdir(self, remotepath):
-        try:
-            return stat.S_ISDIR(self.sftp.stat(remotepath).st_mode)
-        except IOError:
-            return False
-
-    def _mkdir(self, remotedir):
-        self.sftp.mkdir(remotedir)
-
-    def _makedirs(self, remotedir):
-        if self._isdir(remotedir):
-            pass
-
-        elif self._isfile(remotedir):
-            raise OSError(
-                "a file with the same name as the remotedir, " "'%s', already exists." % remotedir
-            )
-        else:
-            head, tail = os.path.split(remotedir)
-            if head and not self._isdir(head):
-                self._makedirs(head)
-            if tail:
-                self._mkdir(remotedir)
-
-    def _put(self, localpath, remotepath):
-        self.sftp.put(localpath, remotepath)
-
-    # https://stackoverflow.com/a/58466685
-    def _put_r_portable(self, localdir, remotedir):
-        for entry in os.listdir(localdir):
-            remotepath = posixpath.join(remotedir, entry)
-            localpath = os.path.join(localdir, entry)
-            if not os.path.isfile(localpath):
-                try:
-                    self._mkdir(remotepath)
-                except OSError:
-                    pass
-                self._put_r_portable(localpath, remotepath)
-            else:
-                self._put(localpath, remotepath)
-
-    def _listdir(self, remotepath="."):
-        return self.sftp.listdir(remotepath)
-
-    @contextmanager
-    def _cd(self, remotepath=None):
-        original_cwd = self.sftp.getcwd()
-        try:
-            if remotepath is not None:
-                self.sftp.chdir(remotepath)
-            yield
-        finally:
-            self.sftp.chdir(original_cwd)
-
     def log_artifact(self, local_file, artifact_path=None):
         artifact_dir = posixpath.join(self.path, artifact_path) if artifact_path else self.path
-        self._makedirs(artifact_dir)
-        self._put(local_file, posixpath.join(artifact_dir, os.path.basename(local_file)))
+        self.sftp.makedirs(artifact_dir)
+        self.sftp.put(local_file, posixpath.join(artifact_dir, os.path.basename(local_file)))
 
     def log_artifacts(self, local_dir, artifact_path=None):
         artifact_dir = posixpath.join(self.path, artifact_path) if artifact_path else self.path
-        self._makedirs(artifact_dir)
-        self._put_r_portable(local_dir, artifact_dir)
+        self.sftp.makedirs(artifact_dir)
+        if sys.platform == "win32":
+            _put_r_for_windows(self.sftp, local_dir, artifact_dir)
+        else:
+            self.sftp.put_r(local_dir, artifact_dir)
 
     def _is_directory(self, artifact_path):
         artifact_dir = self.path
         path = posixpath.join(artifact_dir, artifact_path) if artifact_path else artifact_dir
-        return self._isdir(path)
+        return self.sftp.isdir(path)
 
     def list_artifacts(self, path=None):
         artifact_dir = self.path
         list_dir = posixpath.join(artifact_dir, path) if path else artifact_dir
-        if not self._isdir(list_dir):
+        if not self.sftp.isdir(list_dir):
             return []
-        artifact_files = self._listdir(list_dir)
+        artifact_files = self.sftp.listdir(list_dir)
         infos = []
         for file_name in artifact_files:
             file_path = file_name if path is None else posixpath.join(path, file_name)
             full_file_path = posixpath.join(list_dir, file_name)
-            if self._isdir(full_file_path):
+            if self.sftp.isdir(full_file_path):
                 infos.append(FileInfo(file_path, True, None))
             else:
                 infos.append(FileInfo(file_path, False, self.sftp.stat(full_file_path).st_size))
-        return sorted(infos, key=lambda f: (f.is_dir, f.path))
+        return infos
 
     def _download_file(self, remote_file_path, local_path):
         remote_full_path = posixpath.join(self.path, remote_file_path)
         self.sftp.get(remote_full_path, local_path)
 
     def delete_artifacts(self, artifact_path=None):
-        if self._isdir(artifact_path):
-            with self._cd(artifact_path):
-                for element in self._listdir():
+        if self.sftp.isdir(artifact_path):
+            with self.sftp.cd(artifact_path):
+                for element in self.sftp.listdir():
                     self.delete_artifacts(element)
             self.sftp.rmdir(artifact_path)
-        elif self._isfile(artifact_path):
+        elif self.sftp.isfile(artifact_path):
             self.sftp.remove(artifact_path)

--- a/mlflow/store/artifact/sftp_artifact_repo.py
+++ b/mlflow/store/artifact/sftp_artifact_repo.py
@@ -1,8 +1,8 @@
 import os
-import sys
-
+import stat
 import posixpath
 import urllib.parse
+from contextlib import contextmanager
 
 from mlflow.entities import FileInfo
 from mlflow.store.artifact.artifact_repo import ArtifactRepository
@@ -27,7 +27,7 @@ class SFTPArtifactRepository(ArtifactRepository):
         self.uri = artifact_uri
         parsed = urllib.parse.urlparse(artifact_uri)
         self.config = {
-            "host": parsed.hostname,
+            "hostname": parsed.hostname,
             "port": parsed.port,
             "username": parsed.username,
             "password": parsed.password,
@@ -37,11 +37,10 @@ class SFTPArtifactRepository(ArtifactRepository):
         if client:
             self.sftp = client
         else:
-            import pysftp
             import paramiko
 
-            if self.config["host"] is None:
-                self.config["host"] = "localhost"
+            if self.config["hostname"] is None:
+                self.config["hostname"] = "localhost"
 
             ssh_config = paramiko.SSHConfig()
             user_config_file = os.path.expanduser("~/.ssh/config")
@@ -49,10 +48,10 @@ class SFTPArtifactRepository(ArtifactRepository):
                 with open(user_config_file) as f:
                     ssh_config.parse(f)
 
-            user_config = ssh_config.lookup(self.config["host"])
+            user_config = ssh_config.lookup(self.config["hostname"])
 
             if "hostname" in user_config:
-                self.config["host"] = user_config["hostname"]
+                self.config["hostname"] = user_config["hostname"]
 
             if self.config.get("username", None) is None and "user" in user_config:
                 self.config["username"] = user_config["user"]
@@ -64,55 +63,115 @@ class SFTPArtifactRepository(ArtifactRepository):
                     self.config["port"] = 22
 
             if "identityfile" in user_config:
-                self.config["private_key"] = user_config["identityfile"][0]
+                self.config["key_filename"] = user_config["identityfile"][0]
 
-            self.sftp = pysftp.Connection(**self.config)
+            ssh_client = paramiko.SSHClient()
+            ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+            ssh_client.connect(**self.config)
+            self.sftp = ssh_client.open_sftp()
 
         super().__init__(artifact_uri)
 
+    def _isfile(self, remotepath):
+        try:
+            return stat.S_ISREG(self.sftp.stat(remotepath).st_mode)
+        except IOError:
+            return False
+
+    def _isdir(self, remotepath):
+        try:
+            return stat.S_ISDIR(self.sftp.stat(remotepath).st_mode)
+        except IOError:
+            return False
+
+    def _mkdir(self, remotedir):
+        self.sftp.mkdir(remotedir)
+
+    def _makedirs(self, remotedir):
+        if self._isdir(remotedir):
+            pass
+
+        elif self._isfile(remotedir):
+            raise OSError(
+                "a file with the same name as the remotedir, " "'%s', already exists." % remotedir
+            )
+        else:
+            head, tail = os.path.split(remotedir)
+            if head and not self._isdir(head):
+                self._makedirs(head)
+            if tail:
+                self._mkdir(remotedir)
+
+    def _put(self, localpath, remotepath):
+        self.sftp.put(localpath, remotepath)
+
+    # https://stackoverflow.com/a/58466685
+    def _put_r_portable(self, localdir, remotedir):
+        for entry in os.listdir(localdir):
+            remotepath = posixpath.join(remotedir, entry)
+            localpath = os.path.join(localdir, entry)
+            if not os.path.isfile(localpath):
+                try:
+                    self._mkdir(remotepath)
+                except OSError:
+                    pass
+                self._put_r_portable(localpath, remotepath)
+            else:
+                self._put(localpath, remotepath)
+
+    def _listdir(self, remotepath="."):
+        return self.sftp.listdir(remotepath)
+
+    @contextmanager
+    def _cd(self, remotepath=None):
+        original_cwd = self.sftp.getcwd()
+        try:
+            if remotepath is not None:
+                self.sftp.chdir(remotepath)
+            yield
+        finally:
+            self.sftp.chdir(original_cwd)
+
     def log_artifact(self, local_file, artifact_path=None):
         artifact_dir = posixpath.join(self.path, artifact_path) if artifact_path else self.path
-        self.sftp.makedirs(artifact_dir)
-        self.sftp.put(local_file, posixpath.join(artifact_dir, os.path.basename(local_file)))
+        self._makedirs(artifact_dir)
+        self._put(local_file, posixpath.join(artifact_dir, os.path.basename(local_file)))
 
     def log_artifacts(self, local_dir, artifact_path=None):
         artifact_dir = posixpath.join(self.path, artifact_path) if artifact_path else self.path
-        self.sftp.makedirs(artifact_dir)
-        if sys.platform == "win32":
-            _put_r_for_windows(self.sftp, local_dir, artifact_dir)
-        else:
-            self.sftp.put_r(local_dir, artifact_dir)
+        self._makedirs(artifact_dir)
+        self._put_r_portable(local_dir, artifact_dir)
 
     def _is_directory(self, artifact_path):
         artifact_dir = self.path
         path = posixpath.join(artifact_dir, artifact_path) if artifact_path else artifact_dir
-        return self.sftp.isdir(path)
+        return self._isdir(path)
 
     def list_artifacts(self, path=None):
         artifact_dir = self.path
         list_dir = posixpath.join(artifact_dir, path) if path else artifact_dir
-        if not self.sftp.isdir(list_dir):
+        if not self._isdir(list_dir):
             return []
-        artifact_files = self.sftp.listdir(list_dir)
+        artifact_files = self._listdir(list_dir)
         infos = []
         for file_name in artifact_files:
             file_path = file_name if path is None else posixpath.join(path, file_name)
             full_file_path = posixpath.join(list_dir, file_name)
-            if self.sftp.isdir(full_file_path):
+            if self._isdir(full_file_path):
                 infos.append(FileInfo(file_path, True, None))
             else:
                 infos.append(FileInfo(file_path, False, self.sftp.stat(full_file_path).st_size))
-        return infos
+        return sorted(infos, key=lambda f: (f.is_dir, f.path))
 
     def _download_file(self, remote_file_path, local_path):
         remote_full_path = posixpath.join(self.path, remote_file_path)
         self.sftp.get(remote_full_path, local_path)
 
     def delete_artifacts(self, artifact_path=None):
-        if self.sftp.isdir(artifact_path):
-            with self.sftp.cd(artifact_path):
-                for element in self.sftp.listdir():
+        if self._isdir(artifact_path):
+            with self._cd(artifact_path):
+                for element in self._listdir():
                     self.delete_artifacts(element)
             self.sftp.rmdir(artifact_path)
-        elif self.sftp.isfile(artifact_path):
+        elif self._isfile(artifact_path):
             self.sftp.remove(artifact_path)

--- a/tests/store/artifact/test_sftp_artifact_repo.py
+++ b/tests/store/artifact/test_sftp_artifact_repo.py
@@ -1,281 +1,177 @@
-from unittest.mock import MagicMock
+import posixpath
+import uuid
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+from typing import NamedTuple
+
 import pytest
-from tempfile import NamedTemporaryFile
-import pysftp
+
 from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
 from mlflow.store.artifact.sftp_artifact_repo import SFTPArtifactRepository
-from mlflow.utils.file_utils import TempDir
-import os
-import posixpath
+
+URI = "sftp://user:pass@localhost:2222/upload"
 
 
-@pytest.fixture
-def sftp_mock():
-    return MagicMock(autospec=pysftp.Connection)
+class SFTP(NamedTuple):
+    path: Path
 
 
-@pytest.mark.large
-def test_artifact_uri_factory():
-    from paramiko.ssh_exception import SSHException
-
-    with pytest.raises(SSHException, match="No hostkey for host test_sftp found"):
-        get_artifact_repository("sftp://user:pass@test_sftp:123/some/path")
-
-
-@pytest.mark.large
-def test_list_artifacts_empty(sftp_mock):
-    repo = SFTPArtifactRepository("sftp://test_sftp/some/path", sftp_mock)
-    sftp_mock.listdir = MagicMock(return_value=[])
-    assert repo.list_artifacts() == []
-    sftp_mock.listdir.assert_called_once_with("/some/path")
-
-
-@pytest.mark.large
-def test_list_artifacts(sftp_mock):
-    artifact_root_path = "/experiment_id/run_id/"
-    repo = SFTPArtifactRepository("sftp://test_sftp" + artifact_root_path, sftp_mock)
-
-    # mocked file structure
-    #  |- file
-    #  |- model
-    #     |- model.pb
-
-    file_path = "file"
-    file_size = 678
-    dir_path = "model"
-    sftp_mock.isdir = MagicMock(
-        side_effect=lambda path: {
-            artifact_root_path: True,
-            os.path.join(artifact_root_path, file_path): False,
-            os.path.join(artifact_root_path, dir_path): True,
-        }[path]
-    )
-    sftp_mock.listdir = MagicMock(return_value=[file_path, dir_path])
-
-    file_stat = MagicMock()
-    file_stat.configure_mock(st_size=file_size)
-    sftp_mock.stat = MagicMock(return_value=file_stat)
-
-    artifacts = repo.list_artifacts(path=None)
-
-    sftp_mock.listdir.assert_called_once_with(artifact_root_path)
-    sftp_mock.stat.assert_called_once_with(artifact_root_path + file_path)
-
-    assert len(artifacts) == 2
-    assert artifacts[0].path == file_path
-    assert artifacts[0].is_dir is False
-    assert artifacts[0].file_size == file_size
-    assert artifacts[1].path == dir_path
-    assert artifacts[1].is_dir is True
-    assert artifacts[1].file_size is None
-
-
-@pytest.mark.large
-def test_list_artifacts_with_subdir(sftp_mock):
-    artifact_root_path = "/experiment_id/run_id/"
-    repo = SFTPArtifactRepository("sftp://test_sftp" + artifact_root_path, sftp_mock)
-
-    # mocked file structure
-    #  |- model
-    #     |- model.pb
-    #     |- variables
-    dir_name = "model"
-
-    # list artifacts at sub directory level
-    file_path = "model.pb"
-    file_size = 345
-    subdir_name = "variables"
-
-    sftp_mock.listdir = MagicMock(return_value=[file_path, subdir_name])
-
-    sftp_mock.isdir = MagicMock(
-        side_effect=lambda path: {
-            posixpath.join(artifact_root_path, dir_name): True,
-            posixpath.join(artifact_root_path, dir_name, file_path): False,
-            posixpath.join(artifact_root_path, dir_name, subdir_name): True,
-        }[path]
-    )
-
-    file_stat = MagicMock()
-    file_stat.configure_mock(st_size=file_size)
-    sftp_mock.stat = MagicMock(return_value=file_stat)
-
-    artifacts = repo.list_artifacts(path=dir_name)
-
-    sftp_mock.listdir.assert_called_once_with(artifact_root_path + dir_name)
-    sftp_mock.stat.assert_called_once_with(artifact_root_path + dir_name + "/" + file_path)
-
-    assert len(artifacts) == 2
-    assert artifacts[0].path == posixpath.join(dir_name, file_path)
-    assert artifacts[0].is_dir is False
-    assert artifacts[0].file_size == file_size
-    assert artifacts[1].path == posixpath.join(dir_name, subdir_name)
-    assert artifacts[1].is_dir is True
-    assert artifacts[1].file_size is None
-
-
-@pytest.mark.requires_ssh
-def test_log_artifact():
-    for artifact_path in [None, "sub_dir", "very/nested/sub/dir"]:
-        file_content = "A simple test artifact\nThe artifact is located in: " + str(artifact_path)
-        with NamedTemporaryFile(mode="w") as local, TempDir() as remote:
-            local.write(file_content)
-            local.flush()
-
-            sftp_path = "sftp://" + remote.path()
-            store = SFTPArtifactRepository(sftp_path)
-            store.log_artifact(local.name, artifact_path)
-
-            remote_file = posixpath.join(
-                remote.path(),
-                "." if artifact_path is None else artifact_path,
-                os.path.basename(local.name),
-            )
-            assert posixpath.isfile(remote_file)
-
-            with open(remote_file, "r") as remote_content:
-                assert remote_content.read() == file_content
-
-
-@pytest.mark.requires_ssh
-def test_log_artifacts():
-    for artifact_path in [None, "sub_dir", "very/nested/sub/dir"]:
-        file_content_1 = "A simple test artifact\nThe artifact is located in: " + str(artifact_path)
-        file_content_2 = os.urandom(300)
-
-        file1 = "meta.yaml"
-        directory = "saved_model"
-        file2 = "sk_model.pickle"
-        with TempDir() as local, TempDir() as remote:
-            with open(os.path.join(local.path(), file1), "w") as f:
-                f.write(file_content_1)
-            os.mkdir(os.path.join(local.path(), directory))
-            with open(os.path.join(local.path(), directory, file2), "wb") as f:
-                f.write(file_content_2)
-
-            sftp_path = "sftp://" + remote.path()
-            store = SFTPArtifactRepository(sftp_path)
-            store.log_artifacts(local.path(), artifact_path)
-
-            remote_dir = posixpath.join(
-                remote.path(), "." if artifact_path is None else artifact_path
-            )
-            assert posixpath.isdir(remote_dir)
-            assert posixpath.isdir(posixpath.join(remote_dir, directory))
-            assert posixpath.isfile(posixpath.join(remote_dir, file1))
-            assert posixpath.isfile(posixpath.join(remote_dir, directory, file2))
-
-            with open(posixpath.join(remote_dir, file1), "r") as remote_content:
-                assert remote_content.read() == file_content_1
-
-            with open(posixpath.join(remote_dir, directory, file2), "rb") as remote_content:
-                assert remote_content.read() == file_content_2
-
-
-@pytest.mark.requires_ssh
-@pytest.mark.parametrize("artifact_path", [None, "sub_dir", "very/nested/sub/dir"])
-def test_delete_artifact(artifact_path):
-    file_content = f"A simple test artifact\nThe artifact is located in: {artifact_path}"
-    with NamedTemporaryFile(mode="w") as local, TempDir() as remote:
-        local.write(file_content)
-        local.flush()
-
-        sftp_path = f"sftp://{remote.path}"
-        store = SFTPArtifactRepository(sftp_path)
-        store.log_artifact(local.name, artifact_path)
-
-        remote_file = posixpath.join(
-            remote.path(),
-            "." if artifact_path is None else artifact_path,
-            os.path.basename(local.name),
+@pytest.fixture(autouse=True, scope="module")
+def sftp():
+    image = "atmoz/sftp"
+    subprocess.run(["docker", "pull", image], check=True)
+    with tempfile.TemporaryDirectory() as t:
+        tmpdir = Path(t).joinpath("upload")
+        tmpdir.mkdir()
+        tmpdir.chmod(0o0777)
+        container = "mlflow-sftp"
+        # Run an SFTP server in the background
+        process = subprocess.Popen(
+            [
+                "docker",
+                "run",
+                "-p",
+                "2222:22",
+                "-v",
+                f"{tmpdir}:/home/user/upload",
+                "--name",
+                container,
+                "atmoz/sftp",
+                "user:pass:::upload",
+            ],
         )
-        assert posixpath.isfile(remote_file)
-
-        with open(remote_file, "r", encoding="uft8") as remote_content:
-            assert remote_content.read() == file_content
-
-        store.delete_artifacts(remote.path())
-
-        assert not posixpath.exists(remote_file)
-        assert not posixpath.exists(remote.path())
+        time.sleep(5)
+        yield SFTP(tmpdir)
+        # Stop and remove the container
+        subprocess.run(["docker", "stop", container], check=True)
+        subprocess.run(["docker", "rm", container], check=True)
+        process.kill()
 
 
-@pytest.mark.requires_ssh
+def rand_str():
+    return uuid.uuid4().hex
+
+
+def test_artifact_uri_factory():
+    assert isinstance(get_artifact_repository(URI), SFTPArtifactRepository)
+
+
+def test_list_artifacts_empty():
+    artifact_subdir = rand_str()
+    store = SFTPArtifactRepository(URI + "/" + artifact_subdir)
+    assert store.list_artifacts() == []
+
+
 @pytest.mark.parametrize("artifact_path", [None, "sub_dir", "very/nested/sub/dir"])
-def test_delete_artifacts(artifact_path):
-    file_content_1 = f"A simple test artifact\nThe artifact is located in: {artifact_path}"
-    file_content_2 = os.urandom(300)
+def test_list_artifacts(tmp_path, artifact_path):
+    file_content_1 = rand_str()
+    file_content_2 = rand_str()
 
-    file1 = "meta.yaml"
-    directory = "saved_model"
-    file2 = "sk_model.pickle"
-    with TempDir() as local, TempDir() as remote:
-        with open(os.path.join(local.path(), file1), "w", encoding="utf8") as f:
-            f.write(file_content_1)
-        os.mkdir(os.path.join(local.path(), directory))
-        with open(os.path.join(local.path(), directory, file2), "wb") as f:
-            f.write(file_content_2)
+    file_1 = tmp_path.joinpath(rand_str())
+    subdir = tmp_path.joinpath(rand_str())
+    subdir.mkdir()
+    file_2 = subdir.joinpath(rand_str())
+    file_1.write_text(file_content_1)
+    file_2.write_text(file_content_2)
 
-        sftp_path = f"sftp://{remote.path()}"
-        store = SFTPArtifactRepository(sftp_path)
-        store.log_artifacts(local.path(), artifact_path)
-
-        remote_dir = posixpath.join(remote.path(), "." if artifact_path is None else artifact_path)
-        assert posixpath.isdir(remote_dir)
-        assert posixpath.isdir(posixpath.join(remote_dir, directory))
-        assert posixpath.isfile(posixpath.join(remote_dir, file1))
-        assert posixpath.isfile(posixpath.join(remote_dir, directory, file2))
-
-        with open(posixpath.join(remote_dir, file1), "r", encoding="utf8") as remote_content:
-            assert remote_content.read() == file_content_1
-
-        with open(posixpath.join(remote_dir, directory, file2), "rb") as remote_content:
-            assert remote_content.read() == file_content_2
-
-        store.delete_artifacts(remote.path())
-
-        assert not posixpath.exists(posixpath.join(remote_dir, directory))
-        assert not posixpath.exists(posixpath.join(remote_dir, file1))
-        assert not posixpath.exists(posixpath.join(remote_dir, directory, file2))
-        assert not posixpath.exists(remote_dir)
-        assert not posixpath.exists(remote.path())
+    artifact_subdir = rand_str()
+    store = SFTPArtifactRepository(URI + "/" + artifact_subdir)
+    store.log_artifacts(tmp_path, artifact_path)
+    artifacts = store.list_artifacts(artifact_path)
+    assert len(artifacts) == 2
+    remote_file_1 = artifacts[0]
+    assert remote_file_1.is_dir is False
+    assert (
+        remote_file_1.path == posixpath.join(artifact_path, file_1.name)
+        if artifact_path
+        else file_1.name
+    )
+    remote_subdir = artifacts[1]
+    assert remote_file_1.file_size == file_1.stat().st_size
+    assert remote_subdir.is_dir is True
+    assert (
+        remote_subdir.path == posixpath.join(artifact_path, subdir.name)
+        if artifact_path
+        else subdir.name
+    )
 
 
-@pytest.mark.requires_ssh
 @pytest.mark.parametrize("artifact_path", [None, "sub_dir", "very/nested/sub/dir"])
-def test_delete_selective_artifacts(artifact_path):
-    file_content_1 = f"A simple test artifact\nThe artifact is located in: {artifact_path}"
-    file_content_2 = os.urandom(300)
+def test_log_artifact(tmp_path, sftp, artifact_path):
+    file_content = "A simple test artifact\nThe artifact is located in: " + str(artifact_path)
+    tmp_file = tmp_path.joinpath(rand_str())
+    tmp_file.write_text(file_content)
+    store = SFTPArtifactRepository(URI)
+    store.log_artifact(tmp_file, artifact_path)
+    remote_file = sftp.path.joinpath(artifact_path or ".", tmp_file.name)
+    assert remote_file.read_text() == file_content
 
-    file1 = "meta.yaml"
-    directory = "saved_model"
-    file2 = "sk_model.pickle"
-    with TempDir() as local, TempDir() as remote:
-        with open(os.path.join(local.path(), file1), "w", encoding="utf8") as f:
-            f.write(file_content_1)
-        os.mkdir(os.path.join(local.path(), directory))
-        with open(os.path.join(local.path(), directory, file2), "wb") as f:
-            f.write(file_content_2)
 
-        sftp_path = f"sftp://{remote.path()}"
-        store = SFTPArtifactRepository(sftp_path)
-        store.log_artifacts(local.path(), artifact_path)
+@pytest.mark.parametrize("artifact_path", [None, "sub_dir", "very/nested/sub/dir"])
+def test_log_artifacts(tmp_path, sftp, artifact_path):
+    file_content_1 = "A simple test artifact\nThe artifact is located in: " + str(artifact_path)
+    file_content_2 = str(artifact_path)
 
-        remote_dir = posixpath.join(remote.path(), "." if artifact_path is None else artifact_path)
-        assert posixpath.isdir(remote_dir)
-        assert posixpath.isdir(posixpath.join(remote_dir, directory))
-        assert posixpath.isfile(posixpath.join(remote_dir, file1))
-        assert posixpath.isfile(posixpath.join(remote_dir, directory, file2))
+    file_1 = tmp_path.joinpath(rand_str())
+    subdir = tmp_path.joinpath(rand_str())
+    subdir.mkdir()
+    file_2 = subdir.joinpath(rand_str())
+    file_1.write_text(file_content_1)
+    file_2.write_text(file_content_2)
 
-        with open(posixpath.join(remote_dir, file1), "r", encoding="utf8") as remote_content:
-            assert remote_content.read() == file_content_1
+    store = SFTPArtifactRepository(URI)
+    store.log_artifacts(tmp_path, artifact_path)
 
-        with open(posixpath.join(remote_dir, directory, file2), "rb") as remote_content:
-            assert remote_content.read() == file_content_2
+    remote_file_1 = sftp.path.joinpath(artifact_path or ".", file_1.name)
+    assert remote_file_1.read_text() == file_content_1
+    remote_file_2 = sftp.path.joinpath(artifact_path or ".", subdir.name, file_2.name)
+    assert remote_file_2.read_text() == file_content_2
 
-        store.delete_artifacts(posixpath.join(remote_dir, file1))
 
-        assert posixpath.isdir(posixpath.join(remote_dir, directory))
-        assert not posixpath.exists(posixpath.join(remote_dir, file1))
-        assert posixpath.isfile(posixpath.join(remote_dir, directory, file2))
-        assert posixpath.isdir(remote_dir)
+@pytest.mark.parametrize("artifact_path", [None, "sub_dir", "very/nested/sub/dir"])
+def test_delete_artifact(tmp_path, sftp, artifact_path):
+    file_content = "A simple test artifact\nThe artifact is located in: " + str(artifact_path)
+    tmp_file = tmp_path.joinpath(rand_str())
+    tmp_file.write_text(file_content)
+    artifact_subdir = rand_str()
+    store = SFTPArtifactRepository(URI + "/" + artifact_subdir)
+    store.log_artifact(tmp_file, artifact_path)
+    remote_dir = sftp.path.joinpath(artifact_subdir, artifact_path or ".")
+    remote_file = remote_dir.joinpath(tmp_file.name)
+    assert remote_file.read_text() == file_content
+    artifact_path = Path(store.path, artifact_path or ".", tmp_file.name).resolve()
+    store.delete_artifacts(str(artifact_path))
+    assert not remote_file.exists()
+    assert remote_dir.exists()
+
+
+@pytest.mark.parametrize("artifact_path", [None, "sub_dir", "very/nested/sub/dir"])
+def test_delete_artifacts(tmp_path, sftp, artifact_path):
+    file_content_1 = "A simple test artifact\nThe artifact is located in: " + str(artifact_path)
+    file_content_2 = str(artifact_path)
+
+    file_1 = tmp_path.joinpath(rand_str())
+    subdir = tmp_path.joinpath(rand_str())
+    subdir.mkdir()
+    file_2 = subdir.joinpath(rand_str())
+    file_1.write_text(file_content_1)
+    file_2.write_text(file_content_2)
+
+    artifact_subdir = rand_str()
+    store = SFTPArtifactRepository(URI + "/" + artifact_subdir)
+    store.log_artifacts(tmp_path, artifact_path)
+
+    remote_dir = sftp.path.joinpath(artifact_subdir, artifact_path or ".")
+    remote_file_1 = remote_dir.joinpath(file_1.name)
+    assert remote_file_1.read_text() == file_content_1
+    remote_file_2 = remote_dir.joinpath(subdir.name, file_2.name)
+    assert remote_file_2.read_text() == file_content_2
+
+    artifact_dir = Path(store.path, artifact_path or ".").resolve()
+    store.delete_artifacts(str(artifact_dir))
+
+    assert not remote_dir.exists()
+    assert not remote_file_1.exists()
+    assert not remote_file_2.exists()

--- a/tests/store/artifact/test_sftp_artifact_repo.py
+++ b/tests/store/artifact/test_sftp_artifact_repo.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 import subprocess
 import tempfile
 import time
@@ -14,14 +13,13 @@ from mlflow.store.artifact.sftp_artifact_repo import SFTPArtifactRepository
 
 
 pytestmark = pytest.mark.skipif(
-    shutil.which("docker") is None, reason="Docker is required to run tests in this module"
+    os.name == "nt", reason="`atmoz/sftp` image cannot be used on Windows"
 )
-
-ROOT_SFTP_URI = "sftp://user:pass@localhost:2222/upload"
 
 
 class SFTP(NamedTuple):
     path: Path
+    uri: str
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -62,7 +60,7 @@ def sftp():
         else:
             raise Exception(f"Failed to launch SFTP server: {prc.stdout}")
 
-        yield SFTP(tmpdir)
+        yield SFTP(tmpdir, "sftp://user:pass@localhost:2222/upload")
         # Stop and remove the container
         subprocess.run(["docker", "stop", container], check=True)
         subprocess.run(["docker", "rm", container], check=True)
@@ -73,18 +71,18 @@ def rand_str():
     return uuid.uuid4().hex
 
 
-def test_artifact_uri_factory():
-    assert isinstance(get_artifact_repository(ROOT_SFTP_URI), SFTPArtifactRepository)
+def test_artifact_uri_factory(sftp):
+    assert isinstance(get_artifact_repository(sftp.uri), SFTPArtifactRepository)
 
 
-def test_list_artifacts_empty():
+def test_list_artifacts_empty(sftp):
     artifact_subdir = rand_str()
-    store = SFTPArtifactRepository(ROOT_SFTP_URI + "/" + artifact_subdir)
+    store = SFTPArtifactRepository(sftp.uri + "/" + artifact_subdir)
     assert store.list_artifacts() == []
 
 
 @pytest.mark.parametrize("artifact_path", [None, "sub_dir", "very/nested/sub/dir"])
-def test_list_artifacts(tmp_path, artifact_path):
+def test_list_artifacts(tmp_path, sftp, artifact_path):
     file_content1 = rand_str()
     file_content2 = rand_str()
     local_file1 = tmp_path.joinpath("file1")
@@ -95,7 +93,7 @@ def test_list_artifacts(tmp_path, artifact_path):
     local_file2.write_text(file_content2)
 
     artifact_subdir = rand_str()
-    store = SFTPArtifactRepository(ROOT_SFTP_URI + "/" + artifact_subdir)
+    store = SFTPArtifactRepository(sftp.uri + "/" + artifact_subdir)
     store.log_artifacts(tmp_path, artifact_path)
 
     artifacts = store.list_artifacts(artifact_path)
@@ -123,10 +121,11 @@ def test_log_artifact(tmp_path, sftp, artifact_path):
     local_file = tmp_path.joinpath("file")
     local_file.write_text(file_content)
 
-    store = SFTPArtifactRepository(ROOT_SFTP_URI)
+    artifact_subdir = rand_str()
+    store = SFTPArtifactRepository(sftp.uri + "/" + artifact_subdir)
     store.log_artifact(local_file, artifact_path)
 
-    remote_file = sftp.path.joinpath(artifact_path or ".", local_file.name)
+    remote_file = sftp.path.joinpath(artifact_subdir, artifact_path or ".", local_file.name)
     assert remote_file.read_text() == file_content
 
 
@@ -142,7 +141,7 @@ def test_log_artifacts(tmp_path, sftp, artifact_path):
     local_file2.write_text(file_content2)
 
     artifact_subdir = rand_str()
-    store = SFTPArtifactRepository(ROOT_SFTP_URI + "/" + artifact_subdir)
+    store = SFTPArtifactRepository(sftp.uri + "/" + artifact_subdir)
     store.log_artifacts(tmp_path, artifact_path)
 
     remote_dir = sftp.path.joinpath(artifact_subdir, artifact_path or ".")
@@ -157,9 +156,9 @@ def test_delete_artifact(tmp_path, sftp, artifact_path):
     file_content = rand_str()
     local_file = tmp_path.joinpath("file")
     local_file.write_text(file_content)
-    artifact_subdir = rand_str()
 
-    store = SFTPArtifactRepository(ROOT_SFTP_URI + "/" + artifact_subdir)
+    artifact_subdir = rand_str()
+    store = SFTPArtifactRepository(sftp.uri + "/" + artifact_subdir)
     store.log_artifact(local_file, artifact_path)
 
     remote_dir = sftp.path.joinpath(artifact_subdir, artifact_path or ".")
@@ -184,7 +183,7 @@ def test_delete_artifacts(tmp_path, sftp, artifact_path):
     local_file2.write_text(file_content2)
 
     artifact_subdir = rand_str()
-    store = SFTPArtifactRepository(ROOT_SFTP_URI + "/" + artifact_subdir)
+    store = SFTPArtifactRepository(sftp.uri + "/" + artifact_subdir)
     store.log_artifacts(tmp_path, artifact_path)
 
     remote_dir = sftp.path.joinpath(artifact_subdir, artifact_path or ".")


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

Tests for `SFTPArtifactRepository` are not executed at all because of the `require_ssh` marker. This PR removes the marker and run the tests.

## How is this patch tested?

Fixed unit tests

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
