### PR TITLE
Fix tests for SFTP artifact repository

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -106,17 +106,13 @@ jobs:
     - name: Run tests
       run: |
         # Establish SSH to localhost for test_sftp_artifact_repo.py
-        ssh -V
         ssh-keygen -t rsa -N '' -f ~/.ssh/id_rsa
         cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
-        chmod 600 ~/.ssh/authorized_keys
-        chmod 700 ~/.ssh
         ssh-keyscan -H localhost >> ~/.ssh/known_hosts
-        ssh -vvv $(whoami)@localhost exit
+        ssh -v $(whoami)@localhost exit
         export LOGNAME=$(whoami)
 
-        pytest tests/store/artifact/test_sftp_artifact_repo.py -s
-        # ./dev/run-small-python-tests.sh
+        ./dev/run-small-python-tests.sh
 
   python-large:
     runs-on: ubuntu-latest

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -105,7 +105,18 @@ jobs:
         source ./dev/install-common-deps.sh
     - name: Run tests
       run: |
-        ./dev/run-small-python-tests.sh
+        # Establish SSH to localhost for test_sftp_artifact_repo.py
+        ssh -V
+        ssh-keygen -t rsa -N '' -f ~/.ssh/id_rsa
+        cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
+        chmod 600 ~/.ssh/authorized_keys
+        chmod 700 ~/.ssh
+        ssh-keyscan -H localhost >> ~/.ssh/known_hosts
+        ssh -vvv $(whoami)@localhost exit
+        export LOGNAME=$(whoami)
+
+        pytest tests/store/artifact/test_sftp_artifact_repo.py -s
+        # ./dev/run-small-python-tests.sh
 
   python-large:
     runs-on: ubuntu-latest

--- a/dev/run-small-python-tests.sh
+++ b/dev/run-small-python-tests.sh
@@ -7,6 +7,6 @@ trap 'err=1' ERR
 export MLFLOW_HOME=$(pwd)
 
 # NB: Also add --ignore'd tests to run-large-python-tests.sh
-pytest --ignore-flavors
+pytest --ignore-flavors --requires-ssh
 
 test $err = 0

--- a/tests/store/artifact/test_sftp_artifact_repo.py
+++ b/tests/store/artifact/test_sftp_artifact_repo.py
@@ -18,7 +18,7 @@ def sftp_mock():
 
 
 def test_artifact_uri_factory(tmp_path):
-    assert isinstance(get_artifact_repository(f"sftp:/{tmp_path}"), SFTPArtifactRepository)
+    assert isinstance(get_artifact_repository(f"sftp://{tmp_path}"), SFTPArtifactRepository)
 
 
 def test_list_artifacts_empty(sftp_mock):

--- a/tests/store/artifact/test_sftp_artifact_repo.py
+++ b/tests/store/artifact/test_sftp_artifact_repo.py
@@ -17,10 +17,8 @@ def sftp_mock():
     return MagicMock(autospec=pysftp.Connection)
 
 
-def test_artifact_uri_factory():
-    assert isinstance(
-        get_artifact_repository("sftp://user:pass@test_sftp:123/some/path"), SFTPArtifactRepository
-    )
+def test_artifact_uri_factory(tmp_path):
+    assert isinstance(get_artifact_repository(f"sftp:/{tmp_path}"), SFTPArtifactRepository)
 
 
 def test_list_artifacts_empty(sftp_mock):

--- a/tests/store/artifact/test_sftp_artifact_repo.py
+++ b/tests/store/artifact/test_sftp_artifact_repo.py
@@ -14,15 +14,12 @@ def sftp_mock():
     return MagicMock(autospec=pysftp.Connection)
 
 
-@pytest.mark.large
 def test_artifact_uri_factory():
-    from paramiko.ssh_exception import SSHException
+    assert isinstance(
+        get_artifact_repository("sftp://user:pass@test_sftp:123/some/path"), SFTPArtifactRepository
+    )
 
-    with pytest.raises(SSHException, match="No hostkey for host test_sftp found"):
-        get_artifact_repository("sftp://user:pass@test_sftp:123/some/path")
 
-
-@pytest.mark.large
 def test_list_artifacts_empty(sftp_mock):
     repo = SFTPArtifactRepository("sftp://test_sftp/some/path", sftp_mock)
     sftp_mock.listdir = MagicMock(return_value=[])
@@ -30,7 +27,6 @@ def test_list_artifacts_empty(sftp_mock):
     sftp_mock.listdir.assert_called_once_with("/some/path")
 
 
-@pytest.mark.large
 def test_list_artifacts(sftp_mock):
     artifact_root_path = "/experiment_id/run_id/"
     repo = SFTPArtifactRepository("sftp://test_sftp" + artifact_root_path, sftp_mock)
@@ -70,7 +66,6 @@ def test_list_artifacts(sftp_mock):
     assert artifacts[1].file_size is None
 
 
-@pytest.mark.large
 def test_list_artifacts_with_subdir(sftp_mock):
     artifact_root_path = "/experiment_id/run_id/"
     repo = SFTPArtifactRepository("sftp://test_sftp" + artifact_root_path, sftp_mock)
@@ -114,7 +109,6 @@ def test_list_artifacts_with_subdir(sftp_mock):
     assert artifacts[1].file_size is None
 
 
-@pytest.mark.requires_ssh
 def test_log_artifact():
     for artifact_path in [None, "sub_dir", "very/nested/sub/dir"]:
         file_content = "A simple test artifact\nThe artifact is located in: " + str(artifact_path)
@@ -137,7 +131,6 @@ def test_log_artifact():
                 assert remote_content.read() == file_content
 
 
-@pytest.mark.requires_ssh
 def test_log_artifacts():
     for artifact_path in [None, "sub_dir", "very/nested/sub/dir"]:
         file_content_1 = "A simple test artifact\nThe artifact is located in: " + str(artifact_path)
@@ -172,7 +165,6 @@ def test_log_artifacts():
                 assert remote_content.read() == file_content_2
 
 
-@pytest.mark.requires_ssh
 @pytest.mark.parametrize("artifact_path", [None, "sub_dir", "very/nested/sub/dir"])
 def test_delete_artifact(artifact_path):
     file_content = f"A simple test artifact\nThe artifact is located in: {artifact_path}"
@@ -180,7 +172,7 @@ def test_delete_artifact(artifact_path):
         local.write(file_content)
         local.flush()
 
-        sftp_path = f"sftp://{remote.path}"
+        sftp_path = f"sftp://{remote.path()}"
         store = SFTPArtifactRepository(sftp_path)
         store.log_artifact(local.name, artifact_path)
 
@@ -191,7 +183,7 @@ def test_delete_artifact(artifact_path):
         )
         assert posixpath.isfile(remote_file)
 
-        with open(remote_file, "r", encoding="uft8") as remote_content:
+        with open(remote_file, "r") as remote_content:
             assert remote_content.read() == file_content
 
         store.delete_artifacts(remote.path())
@@ -200,7 +192,6 @@ def test_delete_artifact(artifact_path):
         assert not posixpath.exists(remote.path())
 
 
-@pytest.mark.requires_ssh
 @pytest.mark.parametrize("artifact_path", [None, "sub_dir", "very/nested/sub/dir"])
 def test_delete_artifacts(artifact_path):
     file_content_1 = f"A simple test artifact\nThe artifact is located in: {artifact_path}"
@@ -241,7 +232,6 @@ def test_delete_artifacts(artifact_path):
         assert not posixpath.exists(remote.path())
 
 
-@pytest.mark.requires_ssh
 @pytest.mark.parametrize("artifact_path", [None, "sub_dir", "very/nested/sub/dir"])
 def test_delete_selective_artifacts(artifact_path):
     file_content_1 = f"A simple test artifact\nThe artifact is located in: {artifact_path}"

--- a/tests/store/artifact/test_sftp_artifact_repo.py
+++ b/tests/store/artifact/test_sftp_artifact_repo.py
@@ -9,6 +9,9 @@ import os
 import posixpath
 
 
+pytestmark = pytest.mark.requires_ssh
+
+
 @pytest.fixture
 def sftp_mock():
     return MagicMock(autospec=pysftp.Connection)


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

Fix tests for SFTP artifact repository that haven't been executed at all for a while.

## How is this patch tested?

Fixed tests

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
