### PR TITLE
Fix `validate_docker_installation` to throw when docker daemon is not running

### DIFF
--- a/mlflow/projects/docker.py
+++ b/mlflow/projects/docker.py
@@ -5,6 +5,7 @@ import shutil
 import tempfile
 import urllib.parse
 import urllib.request
+import subprocess
 
 import docker
 
@@ -36,11 +37,18 @@ def validate_docker_installation():
         )
 
     cmd = ["docker", "ps"]
-    prc = process._exec_cmd(cmd, throw_on_error=False)
+    prc = process._exec_cmd(
+        cmd,
+        throw_on_error=False,
+        capture_output=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
     if prc.returncode != 0:
         joined_cmd = " ".join(cmd)
         raise ExecutionException(
-            f"Ran `{joined_cmd}` to ensure docker daemon is running but it failed: {prc.stderr}"
+            f"Ran `{joined_cmd}` to ensure docker daemon is running but it failed "
+            f"with the following output:\n{prc.stdout}"
         )
 
 

--- a/mlflow/projects/docker.py
+++ b/mlflow/projects/docker.py
@@ -13,7 +13,7 @@ from mlflow.projects.utils import get_databricks_env_vars
 from mlflow.exceptions import ExecutionException
 from mlflow.projects.utils import MLFLOW_DOCKER_WORKDIR_PATH
 from mlflow.tracking.context.git_context import _get_git_commit
-from mlflow.utils import file_utils
+from mlflow.utils import process, file_utils
 from mlflow.utils.mlflow_tags import MLFLOW_DOCKER_IMAGE_URI, MLFLOW_DOCKER_IMAGE_ID
 from mlflow.utils.file_utils import _handle_readonly_on_windows
 
@@ -31,8 +31,14 @@ def validate_docker_installation():
     if shutil.which("docker") is None:
         raise ExecutionException(
             "Could not find Docker executable. "
-            "Ensure Docker is installed and running as per the instructions "
+            "Ensure Docker is installed as per the instructions "
             "at https://docs.docker.com/install/overview/."
+        )
+
+    prc = process._exec_cmd(["docker", "ps"], throw_on_error=False)
+    if prc.returncode != 0:
+        raise ExecutionException(
+            f"Ran `docker ps` to ensure docker daemon is running but it failed: {prc.stderr}"
         )
 
 

--- a/mlflow/projects/docker.py
+++ b/mlflow/projects/docker.py
@@ -35,10 +35,11 @@ def validate_docker_installation():
             "at https://docs.docker.com/install/overview/."
         )
 
-    prc = process._exec_cmd(["docker", "ps"], throw_on_error=False)
+    cmd = ["docker", "ps"]
+    prc = process._exec_cmd(cmd, throw_on_error=False)
     if prc.returncode != 0:
         raise ExecutionException(
-            f"Ran `docker ps` to ensure docker daemon is running but it failed: {prc.stderr}"
+            f"Ran {cmd} to ensure docker daemon is running but it failed: {prc.stderr}"
         )
 
 

--- a/mlflow/projects/docker.py
+++ b/mlflow/projects/docker.py
@@ -38,8 +38,9 @@ def validate_docker_installation():
     cmd = ["docker", "ps"]
     prc = process._exec_cmd(cmd, throw_on_error=False)
     if prc.returncode != 0:
+        joined_cmd = " ".join(cmd)
         raise ExecutionException(
-            f"Ran {cmd} to ensure docker daemon is running but it failed: {prc.stderr}"
+            f"Ran `{joined_cmd}` to ensure docker daemon is running but it failed: {prc.stderr}"
         )
 
 

--- a/mlflow/projects/docker.py
+++ b/mlflow/projects/docker.py
@@ -36,7 +36,7 @@ def validate_docker_installation():
             "at https://docs.docker.com/install/overview/."
         )
 
-    cmd = ["docker", "ps"]
+    cmd = ["docker", "info"]
     prc = process._exec_cmd(
         cmd,
         throw_on_error=False,

--- a/mlflow/projects/docker.py
+++ b/mlflow/projects/docker.py
@@ -13,7 +13,7 @@ from mlflow.projects.utils import get_databricks_env_vars
 from mlflow.exceptions import ExecutionException
 from mlflow.projects.utils import MLFLOW_DOCKER_WORKDIR_PATH
 from mlflow.tracking.context.git_context import _get_git_commit
-from mlflow.utils import process, file_utils
+from mlflow.utils import file_utils
 from mlflow.utils.mlflow_tags import MLFLOW_DOCKER_IMAGE_URI, MLFLOW_DOCKER_IMAGE_ID
 from mlflow.utils.file_utils import _handle_readonly_on_windows
 
@@ -26,15 +26,12 @@ _PROJECT_TAR_ARCHIVE_NAME = "mlflow-project-docker-build-context"
 
 def validate_docker_installation():
     """
-    Verify if Docker is installed on host machine.
+    Verify if Docker is installed and running on host machine.
     """
-    try:
-        docker_path = "docker"
-        process._exec_cmd([docker_path, "--help"], throw_on_error=False)
-    except EnvironmentError:
+    if shutil.which("docker") is None:
         raise ExecutionException(
             "Could not find Docker executable. "
-            "Ensure Docker is installed as per the instructions "
+            "Ensure Docker is installed and running as per the instructions "
             "at https://docs.docker.com/install/overview/."
         )
 


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

Fixes https://github.com/mlflow/mlflow/issues/5851

## How is this patch tested?

Existing tests

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
