### PR TITLE
Pin some ML dependencies to prevent pip from filling up diskspace while resolving  dependencies

### DIFF
--- a/.github/actions/cache-pip/action.yml
+++ b/.github/actions/cache-pip/action.yml
@@ -11,6 +11,6 @@ runs:
     - uses: actions/cache@v2
       with:
         path: ~/.cache/pip
-        key: ${{ steps.get-cache-key-prefix.outputs.prefix }}-pip-0-${{ hashFiles('requirements/*-requirements.txt') }}
+        key: ${{ steps.get-cache-key-prefix.outputs.prefix }}-pip-${{ hashFiles('requirements/*-requirements.txt') }}
         restore-keys: |
-          ${{ steps.get-cache-key-prefix.outputs.prefix }}-pip-0-
+          ${{ steps.get-cache-key-prefix.outputs.prefix }}-pip-

--- a/.github/actions/cache-pip/action.yml
+++ b/.github/actions/cache-pip/action.yml
@@ -11,6 +11,6 @@ runs:
     - uses: actions/cache@v2
       with:
         path: ~/.cache/pip
-        key: ${{ steps.get-cache-key-prefix.outputs.prefix }}-pip-${{ hashFiles('requirements/*-requirements.txt') }}
+        key: ${{ steps.get-cache-key-prefix.outputs.prefix }}-pip-0-${{ hashFiles('requirements/*-requirements.txt') }}
         restore-keys: |
-          ${{ steps.get-cache-key-prefix.outputs.prefix }}-pip-
+          ${{ steps.get-cache-key-prefix.outputs.prefix }}-pip-0-

--- a/dev/install-common-deps.sh
+++ b/dev/install-common-deps.sh
@@ -3,7 +3,7 @@
 set -ex
 
 function retry-with-backoff() {
-    for BACKOFF in 0; do
+    for BACKOFF in 0 1 2; do
         sleep $BACKOFF
         if "$@"; then
             return 0

--- a/dev/install-common-deps.sh
+++ b/dev/install-common-deps.sh
@@ -3,7 +3,7 @@
 set -ex
 
 function retry-with-backoff() {
-    for BACKOFF in 0 1 2 4 8 16 32 64; do
+    for BACKOFF in 0; do
         sleep $BACKOFF
         if "$@"; then
             return 0

--- a/requirements/extra-ml-requirements.txt
+++ b/requirements/extra-ml-requirements.txt
@@ -19,7 +19,7 @@ tensorflow>=2.8.0
 # Required by mlflow.pytorch
 torch>=1.11.0
 torchvision>=0.12.0
-pytorch_lightning>=1.6.3
+pytorch_lightning>=1.5.10
 # Required by mlflow.xgboost
 xgboost>=0.82
 # Required by mlflow.lightgbm

--- a/requirements/extra-ml-requirements.txt
+++ b/requirements/extra-ml-requirements.txt
@@ -17,8 +17,8 @@ spacy
 # Required by mlflow.tensorflow
 tensorflow>=2.8.0
 # Required by mlflow.pytorch
-torch
-torchvision>=1.11.0
+torch>=1.11.0
+torchvision
 pytorch_lightning>=1.0.2
 # Required by mlflow.xgboost
 xgboost>=0.82

--- a/requirements/extra-ml-requirements.txt
+++ b/requirements/extra-ml-requirements.txt
@@ -15,7 +15,7 @@ fastai>=2.4.1
 # Required by mlflow.spacy
 spacy
 # Required by mlflow.tensorflow
-tensorflow
+tensorflow==2.8.0
 # Required by mlflow.pytorch
 torch
 torchvision

--- a/requirements/extra-ml-requirements.txt
+++ b/requirements/extra-ml-requirements.txt
@@ -19,7 +19,7 @@ tensorflow>=2.8.0
 # Required by mlflow.pytorch
 torch>=1.11.0
 torchvision
-pytorch_lightning>=1.0.2
+pytorch_lightning>=1.6.3
 # Required by mlflow.xgboost
 xgboost>=0.82
 # Required by mlflow.lightgbm
@@ -31,7 +31,7 @@ statsmodels
 # Required by mlflow.h2o
 h2o
 # Required by mlflow.onnx
-onnx
+onnx>=1.11.0
 onnxruntime
 # Required by mlflow.spark
 pyspark

--- a/requirements/extra-ml-requirements.txt
+++ b/requirements/extra-ml-requirements.txt
@@ -13,7 +13,7 @@ mxnet!=1.8.0
 # Required by mlflow.fastai
 fastai>=2.4.1
 # Required by mlflow.spacy
-spacy
+spacy>=3.3.0
 # Required by mlflow.tensorflow
 tensorflow>=2.8.0
 # Required by mlflow.pytorch

--- a/requirements/extra-ml-requirements.txt
+++ b/requirements/extra-ml-requirements.txt
@@ -15,10 +15,10 @@ fastai>=2.4.1
 # Required by mlflow.spacy
 spacy
 # Required by mlflow.tensorflow
-tensorflow==2.8.0
+tensorflow>=2.8.0
 # Required by mlflow.pytorch
 torch
-torchvision
+torchvision>=1.11.0
 pytorch_lightning>=1.0.2
 # Required by mlflow.xgboost
 xgboost>=0.82

--- a/requirements/extra-ml-requirements.txt
+++ b/requirements/extra-ml-requirements.txt
@@ -18,7 +18,7 @@ spacy>=3.3.0
 tensorflow>=2.8.0
 # Required by mlflow.pytorch
 torch>=1.11.0
-torchvision
+torchvision>=0.12.0
 pytorch_lightning>=1.6.3
 # Required by mlflow.xgboost
 xgboost>=0.82


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

Pin some ML dependencies to prevent pip from filling up diskspace while resolving dependencies.

## How is this patch tested?

Existing tests

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
