### PR TITLE
Fix bug where clicking mlflow logo returns "No Experiments Exist"

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/HomeView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/HomeView.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { Redirect } from 'react-router';
 import { Spacer } from '@databricks/design-system';
 import ExperimentListView from './ExperimentListView';
 import ExperimentPage from './ExperimentPage';
@@ -17,36 +18,28 @@ export const getFirstActiveExperiment = (experiments) => {
 
 class HomeView extends Component {
   static propTypes = {
-    history: PropTypes.shape({}),
-    experiments: PropTypes.shape({}),
+    experiments: PropTypes.arrayOf(PropTypes.object),
     experimentIds: PropTypes.arrayOf(PropTypes.string),
     compareExperiments: PropTypes.bool,
   };
-
-  componentDidMount() {
-    const { history, experiments, experimentIds } = this.props;
-    if (experimentIds === undefined) {
-      const firstExp = getFirstActiveExperiment(experiments);
-      if (firstExp) {
-        // Reported during ESLint upgrade
-        // eslint-disable-next-line react/prop-types
-        history.push(Routes.getExperimentPageRoute(firstExp.experiment_id));
-      }
-    }
-  }
-
-  onClickListExperiments() {
-    this.setState({ listExperimentsExpanded: !this.state.listExperimentsExpanded });
-  }
 
   render() {
     const { experimentIds, experiments, compareExperiments } = this.props;
     const headerHeight = process.env.HIDE_HEADER === 'true' ? 0 : 60;
     const containerHeight = 'calc(100% - ' + headerHeight + 'px)';
+    const hasExperiments = experiments.length === 0;
+
+    if (experimentIds === undefined) {
+      const firstExp = getFirstActiveExperiment(experiments);
+      if (firstExp) {
+        return <Redirect to={Routes.getExperimentPageRoute(firstExp.experiment_id)} />;
+      }
+    }
+
     if (process.env.HIDE_EXPERIMENT_LIST === 'true') {
       return (
         <div style={{ height: containerHeight }}>
-          {this.props.experimentIds ? (
+          {hasExperiments ? (
             <PageContainer>
               <ExperimentPage
                 experimentIds={experimentIds}
@@ -64,12 +57,12 @@ class HomeView extends Component {
         <div>
           <Spacer />
           <ExperimentListView
-            activeExperimentId={this.props.experimentIds && this.props.experimentIds[0]}
+            activeExperimentId={experimentIds && experimentIds[0]}
             experiments={experiments}
           />
         </div>
         <PageContainer>
-          {this.props.experimentIds ? (
+          {hasExperiments ? (
             <ExperimentPage experimentIds={experimentIds} compareExperiments={compareExperiments} />
           ) : (
             <NoExperimentView />

--- a/mlflow/server/js/src/experiment-tracking/components/HomeView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/HomeView.js
@@ -27,7 +27,7 @@ class HomeView extends Component {
     const { experimentIds, experiments, compareExperiments } = this.props;
     const headerHeight = process.env.HIDE_HEADER === 'true' ? 0 : 60;
     const containerHeight = 'calc(100% - ' + headerHeight + 'px)';
-    const hasExperiments = experiments.length === 0;
+    const hasExperiments = experiments.length > 0;
 
     if (experimentIds === undefined) {
       const firstExp = getFirstActiveExperiment(experiments);

--- a/mlflow/server/js/src/experiment-tracking/components/HomeView.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/HomeView.test.js
@@ -18,14 +18,11 @@ describe('HomeView', () => {
   let wrapper;
   let minimalStore;
   let minimalProps;
-  let mockHistory;
 
   const mockStore = configureStore([thunk, promiseMiddleware()]);
 
   beforeEach(() => {
-    mockHistory = { push: jest.fn() };
     minimalProps = {
-      history: mockHistory,
       experimentIds: undefined,
       compareExperiments: false,
     };
@@ -64,6 +61,6 @@ describe('HomeView', () => {
         </BrowserRouter>
       </Provider>,
     );
-    expect(mockHistory.push).toHaveBeenCalledWith('/experiments/2');
+    expect(window.location.pathname).toBe('/experiments/2');
   });
 });


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## What changes are proposed in this pull request?

Fixes #5849

## How is this patch tested?

### Before:

https://user-images.githubusercontent.com/17039389/168104213-dc2f3757-7943-4249-a67e-da67a1dae3b1.mov

### After:

https://user-images.githubusercontent.com/17039389/168104278-56d9d65a-5c7d-4bc9-ad3d-6f64b1919698.mov

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
