### PR TITLE
Automatically find minimum required python version for ML package in cross version test

### DIFF
--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -125,7 +125,7 @@ jobs:
           then
             python_version=3.8
           else
-            python_version=$(python setup.py -q min_python_version)
+            python_version=$(python dev/get_minimum_required_python.py -p ${{ matrix.package }} -v ${{ matrix.version }} --python-versions "3.7,3.8")
           fi
           echo "::set-output name=version::$python_version"
       - uses: ./.github/actions/setup-python

--- a/dev/get_minimum_required_python.py
+++ b/dev/get_minimum_required_python.py
@@ -32,7 +32,7 @@ def parse_args():
         "--python-versions",
         help=(
             "Comma separated string represeting python versions. "
-            "If `requires_python` is unavailable in a specified package, "
+            "If `requires_python` is unavailable for a specified package, "
             "the minimum version will be selected."
         ),
         required=True,

--- a/dev/get_minimum_required_python.py
+++ b/dev/get_minimum_required_python.py
@@ -1,0 +1,58 @@
+"""
+A script to automatically find the minimum required python version for a specified package.
+
+Usage:
+python dev/get_minimum_required_python.py -p scikit-learn -v 1.1.0 --python-versions "3.7,3.8"
+"""
+import requests
+from packaging.version import Version
+from packaging.specifiers import SpecifierSet
+import typing as t
+import argparse
+
+
+def get_requires_python(package: str, version: str) -> t.Optional[str]:
+    resp = requests.get(f"https://pypi.python.org/pypi/{package}/json")
+    resp.raise_for_status()
+    return next(
+        (
+            distributions[0].get("requires_python")
+            for ver, distributions in resp.json()["releases"].items()
+            if ver == version and distributions
+        ),
+        None,
+    )
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--package", help="Package name", required=True)
+    parser.add_argument("-v", "--version", help="Package version", required=True)
+    parser.add_argument(
+        "--python-versions",
+        help=(
+            "Comma separated string represeting python versions. "
+            "If `requires_python` is unavailable in a specified package, "
+            "the minimum version will be selected."
+        ),
+        required=True,
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    sorted_python_versions = sorted(args.python_versions.split(","), key=Version)
+    min_python_version = sorted_python_versions[0]
+    requires_python = get_requires_python(args.package, args.version)
+    if not requires_python:
+        print(min_python_version)
+        return
+
+    specifier_set = SpecifierSet(requires_python)
+    matched_versions = list(filter(specifier_set.contains, sorted_python_versions))
+    print(matched_versions[0] if matched_versions else min_python_version)
+
+
+if __name__ == "__main__":
+    main()

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -22,8 +22,6 @@ import weakref
 from collections import defaultdict, OrderedDict
 from packaging.version import Version
 
-# DUMMY CHANGE
-
 import mlflow
 from mlflow import pyfunc
 from mlflow.exceptions import MlflowException

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -22,6 +22,8 @@ import weakref
 from collections import defaultdict, OrderedDict
 from packaging.version import Version
 
+# DUMMY CHANGE
+
 import mlflow
 from mlflow import pyfunc
 from mlflow.exceptions import MlflowException


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Add a script to automatically find the minimum required python version for an ML package in cross version test.
- Fix the following test failure sklearn:

https://github.com/mlflow/mlflow/runs/6418800986?check_suite_focus=true#step:10:10

```
ERROR: Ignored the following versions that require a different python version: 1.1.0 Requires-Python >=3.8; 1.1.0rc1 Requires-Python >=3.8
ERROR: Could not find a version that satisfies the requirement scikit-learn==1.1.0 (from versions: 0.9, 0.10, 0.[11](https://github.com/mlflow/mlflow/runs/6418800986?check_suite_focus=true#step:10:11), 0.[12](https://github.com/mlflow/mlflow/runs/6418800986?check_suite_focus=true#step:10:12), 0.12.1, 0.13, 0.13.1, 0.14, 0.14.1, 0.15.0b1, 0.15.0b2, 0.15.0, 0.15.1, 0.15.2, 0.16b1, 0.16.0, 0.16.1, 0.17b1, 0.17, 0.17.1, 0.18, 0.18.1, 0.18.2, 0.19b2, 0.19.0, 0.19.1, 0.19.2, 0.20rc1, 0.20.0, 0.20.1, 0.20.2, 0.20.3, 0.20.4, 0.21rc2, 0.21.0, 0.21.1, 0.21.2, 0.21.3, 0.22rc2.post1, 0.22rc3, 0.22, 0.22.1, 0.22.2, 0.22.2.post1, 0.23.0rc1, 0.23.0, 0.23.1, 0.23.2, 0.24.dev0, 0.24.0rc1, 0.24.0, 0.24.1, 0.24.2, 1.0rc1, 1.0rc2, 1.0, 1.0.1, 1.0.2)
ERROR: No matching distribution found for scikit-learn==1.1.0
```


## How is this patch tested?

Existing tests

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
