### PR TITLE
Remove `sftp_mock` in `tests/store/artifact/test_sftp_artifact_repo.py`

### DIFF
--- a/mlflow/store/artifact/sftp_artifact_repo.py
+++ b/mlflow/store/artifact/sftp_artifact_repo.py
@@ -23,7 +23,7 @@ def _put_r_for_windows(sftp, local_dir, remote_dir, preserve_mtime=False):
 class SFTPArtifactRepository(ArtifactRepository):
     """Stores artifacts as files in a remote directory, via sftp."""
 
-    def __init__(self, artifact_uri, client=None):
+    def __init__(self, artifact_uri):
         self.uri = artifact_uri
         parsed = urllib.parse.urlparse(artifact_uri)
         self.config = {
@@ -34,39 +34,36 @@ class SFTPArtifactRepository(ArtifactRepository):
         }
         self.path = parsed.path
 
-        if client:
-            self.sftp = client
-        else:
-            import pysftp
-            import paramiko
+        import pysftp
+        import paramiko
 
-            if self.config["host"] is None:
-                self.config["host"] = "localhost"
+        if self.config["host"] is None:
+            self.config["host"] = "localhost"
 
-            ssh_config = paramiko.SSHConfig()
-            user_config_file = os.path.expanduser("~/.ssh/config")
-            if os.path.exists(user_config_file):
-                with open(user_config_file) as f:
-                    ssh_config.parse(f)
+        ssh_config = paramiko.SSHConfig()
+        user_config_file = os.path.expanduser("~/.ssh/config")
+        if os.path.exists(user_config_file):
+            with open(user_config_file) as f:
+                ssh_config.parse(f)
 
-            user_config = ssh_config.lookup(self.config["host"])
+        user_config = ssh_config.lookup(self.config["host"])
 
-            if "hostname" in user_config:
-                self.config["host"] = user_config["hostname"]
+        if "hostname" in user_config:
+            self.config["host"] = user_config["hostname"]
 
-            if self.config.get("username", None) is None and "user" in user_config:
-                self.config["username"] = user_config["user"]
+        if self.config.get("username", None) is None and "user" in user_config:
+            self.config["username"] = user_config["user"]
 
-            if self.config.get("port", None) is None:
-                if "port" in user_config:
-                    self.config["port"] = int(user_config["port"])
-                else:
-                    self.config["port"] = 22
+        if self.config.get("port", None) is None:
+            if "port" in user_config:
+                self.config["port"] = int(user_config["port"])
+            else:
+                self.config["port"] = 22
 
-            if "identityfile" in user_config:
-                self.config["private_key"] = user_config["identityfile"][0]
+        if "identityfile" in user_config:
+            self.config["private_key"] = user_config["identityfile"][0]
 
-            self.sftp = pysftp.Connection(**self.config)
+        self.sftp = pysftp.Connection(**self.config)
 
         super().__init__(artifact_uri)
 

--- a/tests/store/artifact/test_sftp_artifact_repo.py
+++ b/tests/store/artifact/test_sftp_artifact_repo.py
@@ -38,60 +38,58 @@ def test_list_artifacts(tmp_path, artifact_path):
     assert artifacts[1].file_size is None
 
 
-def test_log_artifact():
-    for artifact_path in [None, "sub_dir", "very/nested/sub/dir"]:
-        file_content = "A simple test artifact\nThe artifact is located in: " + str(artifact_path)
-        with NamedTemporaryFile(mode="w") as local, TempDir() as remote:
-            local.write(file_content)
-            local.flush()
+@pytest.mark.parametrize("artifact_path", [None, "sub_dir", "very/nested/sub/dir"])
+def test_log_artifact(artifact_path):
+    file_content = "A simple test artifact\nThe artifact is located in: " + str(artifact_path)
+    with NamedTemporaryFile(mode="w") as local, TempDir() as remote:
+        local.write(file_content)
+        local.flush()
 
-            sftp_path = "sftp://" + remote.path()
-            store = SFTPArtifactRepository(sftp_path)
-            store.log_artifact(local.name, artifact_path)
+        sftp_path = "sftp://" + remote.path()
+        store = SFTPArtifactRepository(sftp_path)
+        store.log_artifact(local.name, artifact_path)
 
-            remote_file = posixpath.join(
-                remote.path(),
-                "." if artifact_path is None else artifact_path,
-                os.path.basename(local.name),
-            )
-            assert posixpath.isfile(remote_file)
+        remote_file = posixpath.join(
+            remote.path(),
+            "." if artifact_path is None else artifact_path,
+            os.path.basename(local.name),
+        )
+        assert posixpath.isfile(remote_file)
 
-            with open(remote_file, "r") as remote_content:
-                assert remote_content.read() == file_content
+        with open(remote_file, "r") as remote_content:
+            assert remote_content.read() == file_content
 
 
-def test_log_artifacts():
-    for artifact_path in [None, "sub_dir", "very/nested/sub/dir"]:
-        file_content_1 = "A simple test artifact\nThe artifact is located in: " + str(artifact_path)
-        file_content_2 = os.urandom(300)
+@pytest.mark.parametrize("artifact_path", [None, "sub_dir", "very/nested/sub/dir"])
+def test_log_artifacts(artifact_path):
+    file_content_1 = "A simple test artifact\nThe artifact is located in: " + str(artifact_path)
+    file_content_2 = os.urandom(300)
 
-        file1 = "meta.yaml"
-        directory = "saved_model"
-        file2 = "sk_model.pickle"
-        with TempDir() as local, TempDir() as remote:
-            with open(os.path.join(local.path(), file1), "w") as f:
-                f.write(file_content_1)
-            os.mkdir(os.path.join(local.path(), directory))
-            with open(os.path.join(local.path(), directory, file2), "wb") as f:
-                f.write(file_content_2)
+    file1 = "meta.yaml"
+    directory = "saved_model"
+    file2 = "sk_model.pickle"
+    with TempDir() as local, TempDir() as remote:
+        with open(os.path.join(local.path(), file1), "w") as f:
+            f.write(file_content_1)
+        os.mkdir(os.path.join(local.path(), directory))
+        with open(os.path.join(local.path(), directory, file2), "wb") as f:
+            f.write(file_content_2)
 
-            sftp_path = "sftp://" + remote.path()
-            store = SFTPArtifactRepository(sftp_path)
-            store.log_artifacts(local.path(), artifact_path)
+        sftp_path = "sftp://" + remote.path()
+        store = SFTPArtifactRepository(sftp_path)
+        store.log_artifacts(local.path(), artifact_path)
 
-            remote_dir = posixpath.join(
-                remote.path(), "." if artifact_path is None else artifact_path
-            )
-            assert posixpath.isdir(remote_dir)
-            assert posixpath.isdir(posixpath.join(remote_dir, directory))
-            assert posixpath.isfile(posixpath.join(remote_dir, file1))
-            assert posixpath.isfile(posixpath.join(remote_dir, directory, file2))
+        remote_dir = posixpath.join(remote.path(), "." if artifact_path is None else artifact_path)
+        assert posixpath.isdir(remote_dir)
+        assert posixpath.isdir(posixpath.join(remote_dir, directory))
+        assert posixpath.isfile(posixpath.join(remote_dir, file1))
+        assert posixpath.isfile(posixpath.join(remote_dir, directory, file2))
 
-            with open(posixpath.join(remote_dir, file1), "r") as remote_content:
-                assert remote_content.read() == file_content_1
+        with open(posixpath.join(remote_dir, file1), "r") as remote_content:
+            assert remote_content.read() == file_content_1
 
-            with open(posixpath.join(remote_dir, directory, file2), "rb") as remote_content:
-                assert remote_content.read() == file_content_2
+        with open(posixpath.join(remote_dir, directory, file2), "rb") as remote_content:
+            assert remote_content.read() == file_content_2
 
 
 @pytest.mark.parametrize("artifact_path", [None, "sub_dir", "very/nested/sub/dir"])


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#5840

## What changes are proposed in this pull request?

Remove `sftp_mock` in `tests/store/artifact/test_sftp_artifact_repo.py` and run tests using real files.

## How is this patch tested?

Fixed tests

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
