### PR TITLE
Replace `unittest.TestCase.assertRaises` with `unittest.TestCase.assertRaisesRegex`

### DIFF
--- a/pylint_plugins/unittest_assert_raises.py
+++ b/pylint_plugins/unittest_assert_raises.py
@@ -22,11 +22,9 @@ IGNORE_FILES = list(
             # 5. Run pytest and confirm the changed lines don't fail.
             # 6. Open a PR.
             "tests/entities/test_run_status.py",
-            "tests/store/model_registry/test_sqlalchemy_store.py",
             "tests/store/db/test_utils.py",
             "tests/store/tracking/__init__.py",
             "tests/store/tracking/test_file_store.py",
-            "tests/store/tracking/test_sqlalchemy_store.py",
         ],
     )
 )

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -105,12 +105,12 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
 
         # invalid model name will fail
         with self.assertRaisesRegex(
-            MlflowException, "Registered model name cannot be empty"
+            MlflowException, r"Registered model name cannot be empty"
         ) as exception_context:
             self._rm_maker(None)
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
         with self.assertRaisesRegex(
-            MlflowException, "Registered model name cannot be empty"
+            MlflowException, r"Registered model name cannot be empty"
         ) as exception_context:
             self._rm_maker("")
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
@@ -172,7 +172,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
 
         # test accessing the model with the old name will fail
         with self.assertRaisesRegex(
-            MlflowException, f"Registered Model with name={original_name} not found"
+            MlflowException, rf"Registered Model with name={original_name} not found"
         ) as exception_context:
             self.store.get_registered_model(original_name)
         assert exception_context.exception.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
@@ -187,12 +187,12 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         assert exception_context.exception.error_code == ErrorCode.Name(RESOURCE_ALREADY_EXISTS)
         # invalid model name will fail
         with self.assertRaisesRegex(
-            MlflowException, "Registered model name cannot be empty"
+            MlflowException, r"Registered model name cannot be empty"
         ) as exception_context:
             self.store.rename_registered_model(original_name, None)
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
         with self.assertRaisesRegex(
-            MlflowException, "Registered model name cannot be empty"
+            MlflowException, r"Registered model name cannot be empty"
         ) as exception_context:
             self.store.rename_registered_model(original_name, "")
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
@@ -211,21 +211,21 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
 
         # cannot get model
         with self.assertRaisesRegex(
-            MlflowException, f"Registered Model with name={name} not found"
+            MlflowException, rf"Registered Model with name={name} not found"
         ) as exception_context:
             self.store.get_registered_model(name=name)
         assert exception_context.exception.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
 
         # cannot update a delete model
         with self.assertRaisesRegex(
-            MlflowException, f"Registered Model with name={name} not found"
+            MlflowException, rf"Registered Model with name={name} not found"
         ) as exception_context:
             self.store.update_registered_model(name=name, description="deleted")
         assert exception_context.exception.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
 
         # cannot delete it again
         with self.assertRaisesRegex(
-            MlflowException, f"Registered Model with name={name} not found"
+            MlflowException, rf"Registered Model with name={name} not found"
         ) as exception_context:
             self.store.delete_registered_model(name=name)
         assert exception_context.exception.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
@@ -306,14 +306,14 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         rms = [self._rm_maker("RM{:03}".format(i)).name for i in range(50)]
         # test that providing a completely invalid page token throws
         with self.assertRaisesRegex(
-            MlflowException, "Invalid page token, could not base64-decode"
+            MlflowException, r"Invalid page token, could not base64-decode"
         ) as exception_context:
             self._list_registered_models(page_token="evilhax", max_results=20)
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
         # test that providing too large of a max_results throws
         with self.assertRaisesRegex(
-            MlflowException, "Invalid value for request parameter max_results"
+            MlflowException, r"Invalid value for request parameter max_results"
         ) as exception_context:
             self._list_registered_models(page_token="evilhax", max_results=1e15)
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
@@ -435,7 +435,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         # can not set tag on deleted (non-existed) registered model
         self.store.delete_registered_model(name1)
         with self.assertRaisesRegex(
-            MlflowException, f"Registered Model with name={name1} not found"
+            MlflowException, rf"Registered Model with name={name1} not found"
         ) as exception_context:
             self.store.set_registered_model_tag(name1, overriding_tag)
         assert exception_context.exception.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
@@ -452,13 +452,13 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self.store.set_registered_model_tag(name2, long_tag)
         # can not set invalid tag
         with self.assertRaisesRegex(
-            MlflowException, "Tag name cannot be None"
+            MlflowException, r"Tag name cannot be None"
         ) as exception_context:
             self.store.set_registered_model_tag(name2, RegisteredModelTag(key=None, value=""))
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
         # can not use invalid model name
         with self.assertRaisesRegex(
-            MlflowException, "Registered model name cannot be empty"
+            MlflowException, r"Registered model name cannot be empty"
         ) as exception_context:
             self.store.set_registered_model_tag(None, RegisteredModelTag(key="key", value="value"))
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
@@ -493,19 +493,19 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         # can not delete tag on deleted (non-existed) registered model
         self.store.delete_registered_model(name1)
         with self.assertRaisesRegex(
-            MlflowException, f"Registered Model with name={name1} not found"
+            MlflowException, rf"Registered Model with name={name1} not found"
         ) as exception_context:
             self.store.delete_registered_model_tag(name1, "anotherKey")
         assert exception_context.exception.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
         # can not delete tag with invalid key
         with self.assertRaisesRegex(
-            MlflowException, "Tag name cannot be None"
+            MlflowException, r"Tag name cannot be None"
         ) as exception_context:
             self.store.delete_registered_model_tag(name2, None)
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
         # can not use invalid model name
         with self.assertRaisesRegex(
-            MlflowException, "Registered model name cannot be empty"
+            MlflowException, r"Registered model name cannot be empty"
         ) as exception_context:
             self.store.delete_registered_model_tag(None, "key")
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
@@ -605,7 +605,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
 
         # only valid stages can be set
         with self.assertRaisesRegex(
-            MlflowException, "Invalid Model Version stage unknown"
+            MlflowException, r"Invalid Model Version stage unknown"
         ) as exception_context:
             self.store.transition_model_version_stage(
                 mv1.name, mv1.version, stage="unknown", archive_existing_versions=False
@@ -847,9 +847,9 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         with self.assertRaisesRegex(
             MlflowException,
             (
-                "While parsing a list in the query, "
-                "expected string value or punctuation, "
-                "but got different type in list"
+                r"While parsing a list in the query, "
+                r"expected string value or punctuation, "
+                r"but got different type in list"
             ),
         ) as exception_context:
             search_versions("run_id IN (1,2,3)")
@@ -859,9 +859,9 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         with self.assertRaisesRegex(
             MlflowException,
             (
-                "While parsing a list in the query, "
-                "expected a non-empty list of string values, "
-                "but got empty list"
+                r"While parsing a list in the query, "
+                r"expected a non-empty list of string values, "
+                r"but got empty list"
             ),
         ) as exception_context:
             search_versions("run_id IN ()")
@@ -874,16 +874,16 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
             search_versions("run_id IN (")
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
-        with self.assertRaisesRegex(MlflowException, "Invalid filter '.+'") as exception_context:
+        with self.assertRaisesRegex(MlflowException, r"Invalid filter '.+'") as exception_context:
             search_versions("run_id IN")
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
         with self.assertRaisesRegex(
             MlflowException,
             (
-                "While parsing a list in the query, "
-                "expected a non-empty list of string values, "
-                "but got ill-formed list"
+                r"While parsing a list in the query, "
+                r"expected a non-empty list of string values, "
+                r"but got ill-formed list"
             ),
         ) as exception_context:
             search_versions("run_id IN (,)")
@@ -892,9 +892,9 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         with self.assertRaisesRegex(
             MlflowException,
             (
-                "While parsing a list in the query, "
-                "expected a non-empty list of string values, "
-                "but got ill-formed list"
+                r"While parsing a list in the query, "
+                r"expected a non-empty list of string values, "
+                r"but got ill-formed list"
             ),
         ) as exception_context:
             search_versions("run_id IN ('runid1',,'runid2')")
@@ -902,7 +902,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
 
         # search using the IN operator is not allowed with other additional filters
         with self.assertRaisesRegex(
-            MlflowException, "Search filter '.+' contains multiple expressions"
+            MlflowException, r"Search filter '.+' contains multiple expressions"
         ) as exception_context:
             search_versions(
                 "name='{name}]' AND run_id IN ('{run_id_1}','{run_id_2}')".format(
@@ -1028,21 +1028,21 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
 
         # cannot search by invalid comparator types
         with self.assertRaisesRegex(
-            MlflowException, "Expected a quoted string value for attributes"
+            MlflowException, r"Expected a quoted string value for attributes"
         ) as exception_context:
             self._search_registered_models("name!=something")
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
         # cannot search by run_id
         with self.assertRaisesRegex(
-            MlflowException, "Invalid attribute key '.+' specified"
+            MlflowException, r"Invalid attribute key '.+' specified"
         ) as exception_context:
             self._search_registered_models("run_id='%s'" % "somerunID")
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
         # cannot search by source_path
         with self.assertRaisesRegex(
-            MlflowException, "Invalid attribute key '.+' specified"
+            MlflowException, r"Invalid attribute key '.+' specified"
         ) as exception_context:
             self._search_registered_models("source_path = 'A/D'")
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
@@ -1140,14 +1140,14 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
 
         # test that providing a completely invalid page token throws
         with self.assertRaisesRegex(
-            MlflowException, "Invalid page token, could not base64-decode"
+            MlflowException, r"Invalid page token, could not base64-decode"
         ) as exception_context:
             self._search_registered_models(query, page_token="evilhax", max_results=20)
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
         # test that providing too large of a max_results throws
         with self.assertRaisesRegex(
-            MlflowException, "Invalid value for request parameter max_results"
+            MlflowException, r"Invalid value for request parameter max_results"
         ) as exception_context:
             self._search_registered_models(query, page_token="evilhax", max_results=1e15)
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
@@ -1279,7 +1279,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         query = "name LIKE 'RM%'"
         # test that invalid columns throw even if they come after valid columns
         with self.assertRaisesRegex(
-            MlflowException, "Invalid order by key '.+' specified"
+            MlflowException, r"Invalid order by key '.+' specified"
         ) as exception_context:
             self._search_registered_models(
                 query,
@@ -1290,7 +1290,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
         # test that invalid columns with random text throw even if they come after valid columns
         with self.assertRaisesRegex(
-            MlflowException, "Invalid order_by clause '.+'"
+            MlflowException, r"Invalid order_by clause '.+'"
         ) as exception_context:
             self._search_registered_models(
                 query,
@@ -1353,18 +1353,18 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self.store.set_model_version_tag(name1, 1, long_tag)
         # can not set invalid tag
         with self.assertRaisesRegex(
-            MlflowException, "Tag name cannot be None"
+            MlflowException, r"Tag name cannot be None"
         ) as exception_context:
             self.store.set_model_version_tag(name2, 1, ModelVersionTag(key=None, value=""))
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
         # can not use invalid model name or version
         with self.assertRaisesRegex(
-            MlflowException, "Registered model name cannot be empty"
+            MlflowException, r"Registered model name cannot be empty"
         ) as exception_context:
             self.store.set_model_version_tag(None, 1, ModelVersionTag(key="key", value="value"))
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
         with self.assertRaisesRegex(
-            MlflowException, "Model version must be an integer"
+            MlflowException, r"Model version must be an integer"
         ) as exception_context:
             self.store.set_model_version_tag(
                 name2, "I am not a version", ModelVersionTag(key="key", value="value")
@@ -1415,18 +1415,18 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         assert exception_context.exception.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
         # can not delete tag with invalid key
         with self.assertRaisesRegex(
-            MlflowException, "Tag name cannot be None"
+            MlflowException, r"Tag name cannot be None"
         ) as exception_context:
             self.store.delete_model_version_tag(name1, 2, None)
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
         # can not use invalid model name or version
         with self.assertRaisesRegex(
-            MlflowException, "Registered model name cannot be empty"
+            MlflowException, r"Registered model name cannot be empty"
         ) as exception_context:
             self.store.delete_model_version_tag(None, 2, "key")
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
         with self.assertRaisesRegex(
-            MlflowException, "Model version must be an integer"
+            MlflowException, r"Model version must be an integer"
         ) as exception_context:
             self.store.delete_model_version_tag(name1, "I am not a version", "key")
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -70,7 +70,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
 
         # error on duplicate
         with self.assertRaisesRegex(
-            MlflowException, r"Registered Model \(name={}\) already exists".format(name)
+            MlflowException, rf"Registered Model \(name={name}\) already exists"
         ) as exception_context:
             self._rm_maker(name)
         assert exception_context.exception.error_code == ErrorCode.Name(RESOURCE_ALREADY_EXISTS)
@@ -105,12 +105,12 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
 
         # invalid model name will fail
         with self.assertRaisesRegex(
-            MlflowException, r"Registered model name cannot be empty"
+            MlflowException, "Registered model name cannot be empty"
         ) as exception_context:
             self._rm_maker(None)
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
         with self.assertRaisesRegex(
-            MlflowException, r"Registered model name cannot be empty"
+            MlflowException, "Registered model name cannot be empty"
         ) as exception_context:
             self._rm_maker("")
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
@@ -172,7 +172,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
 
         # test accessing the model with the old name will fail
         with self.assertRaisesRegex(
-            MlflowException, r"Registered Model with name={} not found".format(original_name)
+            MlflowException, f"Registered Model with name={original_name} not found"
         ) as exception_context:
             self.store.get_registered_model(original_name)
         assert exception_context.exception.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
@@ -181,19 +181,18 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self._rm_maker(original_name)
         # cannot rename model to conflict with an existing model
         with self.assertRaisesRegex(
-            MlflowException,
-            r"Registered Model \(name={}\) already exists".format(original_name),
+            MlflowException, rf"Registered Model \(name={original_name}\) already exists"
         ) as exception_context:
             self.store.rename_registered_model(new_name, original_name)
         assert exception_context.exception.error_code == ErrorCode.Name(RESOURCE_ALREADY_EXISTS)
         # invalid model name will fail
         with self.assertRaisesRegex(
-            MlflowException, r"Registered model name cannot be empty"
+            MlflowException, "Registered model name cannot be empty"
         ) as exception_context:
             self.store.rename_registered_model(original_name, None)
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
         with self.assertRaisesRegex(
-            MlflowException, r"Registered model name cannot be empty"
+            MlflowException, "Registered model name cannot be empty"
         ) as exception_context:
             self.store.rename_registered_model(original_name, "")
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
@@ -212,28 +211,28 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
 
         # cannot get model
         with self.assertRaisesRegex(
-            MlflowException, r"Registered Model with name={} not found".format(name)
+            MlflowException, f"Registered Model with name={name} not found"
         ) as exception_context:
             self.store.get_registered_model(name=name)
         assert exception_context.exception.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
 
         # cannot update a delete model
         with self.assertRaisesRegex(
-            MlflowException, r"Registered Model with name={} not found".format(name)
+            MlflowException, f"Registered Model with name={name} not found"
         ) as exception_context:
             self.store.update_registered_model(name=name, description="deleted")
         assert exception_context.exception.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
 
         # cannot delete it again
         with self.assertRaisesRegex(
-            MlflowException, r"Registered Model with name={} not found".format(name)
+            MlflowException, f"Registered Model with name={name} not found"
         ) as exception_context:
             self.store.delete_registered_model(name=name)
         assert exception_context.exception.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
 
         # model versions are cascade deleted with the registered model
         with self.assertRaisesRegex(
-            MlflowException, r"Model Version \(name={}, version=1\) not found".format(name)
+            MlflowException, rf"Model Version \(name={name}, version=1\) not found"
         ) as exception_context:
             self.store.get_model_version(name, 1)
         assert exception_context.exception.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
@@ -307,14 +306,14 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         rms = [self._rm_maker("RM{:03}".format(i)).name for i in range(50)]
         # test that providing a completely invalid page token throws
         with self.assertRaisesRegex(
-            MlflowException, r"Invalid page token, could not base64-decode"
+            MlflowException, "Invalid page token, could not base64-decode"
         ) as exception_context:
             self._list_registered_models(page_token="evilhax", max_results=20)
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
         # test that providing too large of a max_results throws
         with self.assertRaisesRegex(
-            MlflowException, r"Invalid value for request parameter max_results"
+            MlflowException, "Invalid value for request parameter max_results"
         ) as exception_context:
             self._list_registered_models(page_token="evilhax", max_results=1e15)
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
@@ -436,7 +435,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         # can not set tag on deleted (non-existed) registered model
         self.store.delete_registered_model(name1)
         with self.assertRaisesRegex(
-            MlflowException, r"Registered Model with name={} not found".format(name1)
+            MlflowException, f"Registered Model with name={name1} not found"
         ) as exception_context:
             self.store.set_registered_model_tag(name1, overriding_tag)
         assert exception_context.exception.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
@@ -453,13 +452,13 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self.store.set_registered_model_tag(name2, long_tag)
         # can not set invalid tag
         with self.assertRaisesRegex(
-            MlflowException, r"Tag name cannot be None"
+            MlflowException, "Tag name cannot be None"
         ) as exception_context:
             self.store.set_registered_model_tag(name2, RegisteredModelTag(key=None, value=""))
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
         # can not use invalid model name
         with self.assertRaisesRegex(
-            MlflowException, r"Registered model name cannot be empty"
+            MlflowException, "Registered model name cannot be empty"
         ) as exception_context:
             self.store.set_registered_model_tag(None, RegisteredModelTag(key="key", value="value"))
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
@@ -494,19 +493,19 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         # can not delete tag on deleted (non-existed) registered model
         self.store.delete_registered_model(name1)
         with self.assertRaisesRegex(
-            MlflowException, r"Registered Model with name={} not found".format(name1)
+            MlflowException, f"Registered Model with name={name1} not found"
         ) as exception_context:
             self.store.delete_registered_model_tag(name1, "anotherKey")
         assert exception_context.exception.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
         # can not delete tag with invalid key
         with self.assertRaisesRegex(
-            MlflowException, r"Tag name cannot be None"
+            MlflowException, "Tag name cannot be None"
         ) as exception_context:
             self.store.delete_registered_model_tag(name2, None)
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
         # can not use invalid model name
         with self.assertRaisesRegex(
-            MlflowException, r"Registered model name cannot be empty"
+            MlflowException, "Registered model name cannot be empty"
         ) as exception_context:
             self.store.delete_registered_model_tag(None, "key")
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
@@ -606,7 +605,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
 
         # only valid stages can be set
         with self.assertRaisesRegex(
-            MlflowException, r"Invalid Model Version stage unknown"
+            MlflowException, "Invalid Model Version stage unknown"
         ) as exception_context:
             self.store.transition_model_version_stage(
                 mv1.name, mv1.version, stage="unknown", archive_existing_versions=False
@@ -729,24 +728,21 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
 
         # cannot get a deleted model version
         with self.assertRaisesRegex(
-            MlflowException,
-            r"Model Version \(name={}, version={}\) not found".format(mv.name, mv.version),
+            MlflowException, rf"Model Version \(name={mv.name}, version={mv.version}\) not found"
         ) as exception_context:
             self.store.get_model_version(name=mv.name, version=mv.version)
         assert exception_context.exception.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
 
         # cannot update a delete
         with self.assertRaisesRegex(
-            MlflowException,
-            r"Model Version \(name={}, version={}\) not found".format(mv.name, mv.version),
+            MlflowException, rf"Model Version \(name={mv.name}, version={mv.version}\) not found"
         ) as exception_context:
             self.store.update_model_version(mv.name, mv.version, description="deleted!")
         assert exception_context.exception.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
 
         # cannot delete it again
         with self.assertRaisesRegex(
-            MlflowException,
-            r"Model Version \(name={}, version={}\) not found".format(mv.name, mv.version),
+            MlflowException, rf"Model Version \(name={mv.name}, version={mv.version}\) not found"
         ) as exception_context:
             self.store.delete_model_version(name=mv.name, version=mv.version)
         assert exception_context.exception.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
@@ -802,8 +798,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         # cannot retrieve download URI for deleted model versions
         self.store.delete_model_version(name=mv.name, version=mv.version)
         with self.assertRaisesRegex(
-            MlflowException,
-            r"Model Version \(name={}, version={}\) not found".format(mv.name, mv.version),
+            MlflowException, rf"Model Version \(name={mv.name}, version={mv.version}\) not found"
         ) as exception_context:
             self.store.get_model_version_download_uri(name=mv.name, version=mv.version)
         assert exception_context.exception.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
@@ -852,9 +847,9 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         with self.assertRaisesRegex(
             MlflowException,
             (
-                r"While parsing a list in the query, "
-                r"expected string value or punctuation, "
-                r"but got different type in list"
+                "While parsing a list in the query, "
+                "expected string value or punctuation, "
+                "but got different type in list"
             ),
         ) as exception_context:
             search_versions("run_id IN (1,2,3)")
@@ -864,9 +859,9 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         with self.assertRaisesRegex(
             MlflowException,
             (
-                r"While parsing a list in the query, "
-                r"expected a non-empty list of string values, "
-                r"but got empty list"
+                "While parsing a list in the query, "
+                "expected a non-empty list of string values, "
+                "but got empty list"
             ),
         ) as exception_context:
             search_versions("run_id IN ()")
@@ -879,16 +874,16 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
             search_versions("run_id IN (")
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
-        with self.assertRaisesRegex(MlflowException, r"Invalid filter '.+'") as exception_context:
+        with self.assertRaisesRegex(MlflowException, "Invalid filter '.+'") as exception_context:
             search_versions("run_id IN")
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
         with self.assertRaisesRegex(
             MlflowException,
             (
-                r"While parsing a list in the query, "
-                r"expected a non-empty list of string values, "
-                r"but got ill-formed list"
+                "While parsing a list in the query, "
+                "expected a non-empty list of string values, "
+                "but got ill-formed list"
             ),
         ) as exception_context:
             search_versions("run_id IN (,)")
@@ -897,9 +892,9 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         with self.assertRaisesRegex(
             MlflowException,
             (
-                r"While parsing a list in the query, "
-                r"expected a non-empty list of string values, "
-                r"but got ill-formed list"
+                "While parsing a list in the query, "
+                "expected a non-empty list of string values, "
+                "but got ill-formed list"
             ),
         ) as exception_context:
             search_versions("run_id IN ('runid1',,'runid2')")
@@ -907,7 +902,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
 
         # search using the IN operator is not allowed with other additional filters
         with self.assertRaisesRegex(
-            MlflowException, r"Search filter '.+' contains multiple expressions"
+            MlflowException, "Search filter '.+' contains multiple expressions"
         ) as exception_context:
             search_versions(
                 "name='{name}]' AND run_id IN ('{run_id_1}','{run_id_2}')".format(
@@ -1033,21 +1028,21 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
 
         # cannot search by invalid comparator types
         with self.assertRaisesRegex(
-            MlflowException, r"Expected a quoted string value for attributes"
+            MlflowException, "Expected a quoted string value for attributes"
         ) as exception_context:
             self._search_registered_models("name!=something")
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
         # cannot search by run_id
         with self.assertRaisesRegex(
-            MlflowException, r"Invalid attribute key '.+' specified"
+            MlflowException, "Invalid attribute key '.+' specified"
         ) as exception_context:
             self._search_registered_models("run_id='%s'" % "somerunID")
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
         # cannot search by source_path
         with self.assertRaisesRegex(
-            MlflowException, r"Invalid attribute key '.+' specified"
+            MlflowException, "Invalid attribute key '.+' specified"
         ) as exception_context:
             self._search_registered_models("source_path = 'A/D'")
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
@@ -1145,14 +1140,14 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
 
         # test that providing a completely invalid page token throws
         with self.assertRaisesRegex(
-            MlflowException, r"Invalid page token, could not base64-decode"
+            MlflowException, "Invalid page token, could not base64-decode"
         ) as exception_context:
             self._search_registered_models(query, page_token="evilhax", max_results=20)
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
         # test that providing too large of a max_results throws
         with self.assertRaisesRegex(
-            MlflowException, r"Invalid value for request parameter max_results"
+            MlflowException, "Invalid value for request parameter max_results"
         ) as exception_context:
             self._search_registered_models(query, page_token="evilhax", max_results=1e15)
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
@@ -1284,7 +1279,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         query = "name LIKE 'RM%'"
         # test that invalid columns throw even if they come after valid columns
         with self.assertRaisesRegex(
-            MlflowException, r"Invalid order by key '.+' specified"
+            MlflowException, "Invalid order by key '.+' specified"
         ) as exception_context:
             self._search_registered_models(
                 query,
@@ -1295,7 +1290,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
         # test that invalid columns with random text throw even if they come after valid columns
         with self.assertRaisesRegex(
-            MlflowException, r"Invalid order_by clause '.+'"
+            MlflowException, "Invalid order_by clause '.+'"
         ) as exception_context:
             self._search_registered_models(
                 query,
@@ -1341,7 +1336,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         # can not set tag on deleted (non-existed) model version
         self.store.delete_model_version(name1, 2)
         with self.assertRaisesRegex(
-            MlflowException, r"Model Version \(name={}, version=2\) not found".format(name1)
+            MlflowException, rf"Model Version \(name={name1}, version=2\) not found"
         ) as exception_context:
             self.store.set_model_version_tag(name1, 2, overriding_tag)
         assert exception_context.exception.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
@@ -1358,18 +1353,18 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self.store.set_model_version_tag(name1, 1, long_tag)
         # can not set invalid tag
         with self.assertRaisesRegex(
-            MlflowException, r"Tag name cannot be None"
+            MlflowException, "Tag name cannot be None"
         ) as exception_context:
             self.store.set_model_version_tag(name2, 1, ModelVersionTag(key=None, value=""))
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
         # can not use invalid model name or version
         with self.assertRaisesRegex(
-            MlflowException, r"Registered model name cannot be empty"
+            MlflowException, "Registered model name cannot be empty"
         ) as exception_context:
             self.store.set_model_version_tag(None, 1, ModelVersionTag(key="key", value="value"))
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
         with self.assertRaisesRegex(
-            MlflowException, r"Model version must be an integer"
+            MlflowException, "Model version must be an integer"
         ) as exception_context:
             self.store.set_model_version_tag(
                 name2, "I am not a version", ModelVersionTag(key="key", value="value")
@@ -1414,24 +1409,24 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         # can not delete tag on deleted (non-existed) model version
         self.store.delete_model_version(name2, 1)
         with self.assertRaisesRegex(
-            MlflowException, r"Model Version \(name={}, version=1\) not found".format(name2)
+            MlflowException, rf"Model Version \(name={name2}, version=1\) not found"
         ) as exception_context:
             self.store.delete_model_version_tag(name2, 1, "key")
         assert exception_context.exception.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
         # can not delete tag with invalid key
         with self.assertRaisesRegex(
-            MlflowException, r"Tag name cannot be None"
+            MlflowException, "Tag name cannot be None"
         ) as exception_context:
             self.store.delete_model_version_tag(name1, 2, None)
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
         # can not use invalid model name or version
         with self.assertRaisesRegex(
-            MlflowException, r"Registered model name cannot be empty"
+            MlflowException, "Registered model name cannot be empty"
         ) as exception_context:
             self.store.delete_model_version_tag(None, 2, "key")
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
         with self.assertRaisesRegex(
-            MlflowException, r"Model version must be an integer"
+            MlflowException, "Model version must be an integer"
         ) as exception_context:
             self.store.delete_model_version_tag(name1, "I am not a version", "key")
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -69,7 +69,9 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self.assertEqual(rm1.description, None)
 
         # error on duplicate
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException, r"Registered Model \(name={}\) already exists".format(name)
+        ) as exception_context:
             self._rm_maker(name)
         assert exception_context.exception.error_code == ErrorCode.Name(RESOURCE_ALREADY_EXISTS)
 
@@ -102,10 +104,14 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self.assertEqual(rmd3.description, description)
 
         # invalid model name will fail
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException, r"Registered model name cannot be empty"
+        ) as exception_context:
             self._rm_maker(None)
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException, r"Registered model name cannot be empty"
+        ) as exception_context:
             self._rm_maker("")
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
@@ -165,21 +171,30 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self.assertEqual(mv2.name, new_name)
 
         # test accessing the model with the old name will fail
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException, r"Registered Model with name={} not found".format(original_name)
+        ) as exception_context:
             self.store.get_registered_model(original_name)
         assert exception_context.exception.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
 
         # test name another model with the replaced name is ok
         self._rm_maker(original_name)
         # cannot rename model to conflict with an existing model
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException,
+            r"Registered Model \(name={}\) already exists".format(original_name),
+        ) as exception_context:
             self.store.rename_registered_model(new_name, original_name)
         assert exception_context.exception.error_code == ErrorCode.Name(RESOURCE_ALREADY_EXISTS)
         # invalid model name will fail
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException, r"Registered model name cannot be empty"
+        ) as exception_context:
             self.store.rename_registered_model(original_name, None)
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException, r"Registered model name cannot be empty"
+        ) as exception_context:
             self.store.rename_registered_model(original_name, "")
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
@@ -196,22 +211,30 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self.store.delete_registered_model(name=name)
 
         # cannot get model
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException, r"Registered Model with name={} not found".format(name)
+        ) as exception_context:
             self.store.get_registered_model(name=name)
         assert exception_context.exception.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
 
         # cannot update a delete model
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException, r"Registered Model with name={} not found".format(name)
+        ) as exception_context:
             self.store.update_registered_model(name=name, description="deleted")
         assert exception_context.exception.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
 
         # cannot delete it again
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException, r"Registered Model with name={} not found".format(name)
+        ) as exception_context:
             self.store.delete_registered_model(name=name)
         assert exception_context.exception.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
 
         # model versions are cascade deleted with the registered model
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException, r"Model Version \(name={}, version=1\) not found".format(name)
+        ) as exception_context:
             self.store.get_model_version(name, 1)
         assert exception_context.exception.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
 
@@ -283,17 +306,18 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
     def test_list_registered_model_paginated_errors(self):
         rms = [self._rm_maker("RM{:03}".format(i)).name for i in range(50)]
         # test that providing a completely invalid page token throws
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException, r"Invalid page token, could not base64-decode"
+        ) as exception_context:
             self._list_registered_models(page_token="evilhax", max_results=20)
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
         # test that providing too large of a max_results throws
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException, r"Invalid value for request parameter max_results"
+        ) as exception_context:
             self._list_registered_models(page_token="evilhax", max_results=1e15)
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
-        self.assertIn(
-            "Invalid value for request parameter max_results", exception_context.exception.message
-        )
         # list should not return deleted models
         self.store.delete_registered_model(name="RM{0:03}".format(0))
         self.assertEqual(set(self._list_registered_models(max_results=100)), set(rms[1:]))
@@ -411,23 +435,32 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
 
         # can not set tag on deleted (non-existed) registered model
         self.store.delete_registered_model(name1)
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException, r"Registered Model with name={} not found".format(name1)
+        ) as exception_context:
             self.store.set_registered_model_tag(name1, overriding_tag)
         assert exception_context.exception.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
         # test cannot set tags that are too long
         long_tag = RegisteredModelTag("longTagKey", "a" * 5001)
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException,
+            r"Registered model value '.+' had length \d+, which exceeded length limit of 5000",
+        ) as exception_context:
             self.store.set_registered_model_tag(name2, long_tag)
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
         # test can set tags that are somewhat long
         long_tag = RegisteredModelTag("longTagKey", "a" * 4999)
         self.store.set_registered_model_tag(name2, long_tag)
         # can not set invalid tag
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException, r"Tag name cannot be None"
+        ) as exception_context:
             self.store.set_registered_model_tag(name2, RegisteredModelTag(key=None, value=""))
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
         # can not use invalid model name
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException, r"Registered model name cannot be empty"
+        ) as exception_context:
             self.store.set_registered_model_tag(None, RegisteredModelTag(key="key", value="value"))
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
@@ -460,15 +493,21 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
 
         # can not delete tag on deleted (non-existed) registered model
         self.store.delete_registered_model(name1)
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException, r"Registered Model with name={} not found".format(name1)
+        ) as exception_context:
             self.store.delete_registered_model_tag(name1, "anotherKey")
         assert exception_context.exception.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
         # can not delete tag with invalid key
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException, r"Tag name cannot be None"
+        ) as exception_context:
             self.store.delete_registered_model_tag(name2, None)
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
         # can not use invalid model name
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException, r"Registered model name cannot be empty"
+        ) as exception_context:
             self.store.delete_registered_model_tag(None, "key")
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
@@ -566,7 +605,9 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self.assertEqual(mvd3.description, "test model version")
 
         # only valid stages can be set
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException, r"Invalid Model Version stage unknown"
+        ) as exception_context:
             self.store.transition_model_version_stage(
                 mv1.name, mv1.version, stage="unknown", archive_existing_versions=False
             )
@@ -626,7 +667,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
 
         msg = (
             r"Model version transition cannot archive existing model versions "
-            r"because .+ is not an Active stage. Valid stages are .+"
+            r"because .+ is not an Active stage"
         )
 
         # test that when `archive_existing_versions` is True, transitioning a model version
@@ -687,17 +728,26 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self.store.delete_model_version(name=mv.name, version=mv.version)
 
         # cannot get a deleted model version
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException,
+            r"Model Version \(name={}, version={}\) not found".format(mv.name, mv.version),
+        ) as exception_context:
             self.store.get_model_version(name=mv.name, version=mv.version)
         assert exception_context.exception.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
 
         # cannot update a delete
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException,
+            r"Model Version \(name={}, version={}\) not found".format(mv.name, mv.version),
+        ) as exception_context:
             self.store.update_model_version(mv.name, mv.version, description="deleted!")
         assert exception_context.exception.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
 
         # cannot delete it again
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException,
+            r"Model Version \(name={}, version={}\) not found".format(mv.name, mv.version),
+        ) as exception_context:
             self.store.delete_model_version(name=mv.name, version=mv.version)
         assert exception_context.exception.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
 
@@ -751,7 +801,10 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
 
         # cannot retrieve download URI for deleted model versions
         self.store.delete_model_version(name=mv.name, version=mv.version)
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException,
+            r"Model Version \(name={}, version={}\) not found".format(mv.name, mv.version),
+        ) as exception_context:
             self.store.get_model_version_download_uri(name=mv.name, version=mv.version)
         assert exception_context.exception.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
 
@@ -796,47 +849,72 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         )
 
         # search using the IN operator with bad lists should return exceptions
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException,
+            (
+                r"While parsing a list in the query, "
+                r"expected string value or punctuation, "
+                r"but got different type in list"
+            ),
+        ) as exception_context:
             search_versions("run_id IN (1,2,3)")
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
-        assert "expected string value or punctuation" in exception_context.exception.message
 
         # search using the IN operator with empty lists should return exceptions
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException,
+            (
+                r"While parsing a list in the query, "
+                r"expected a non-empty list of string values, "
+                r"but got empty list"
+            ),
+        ) as exception_context:
             search_versions("run_id IN ()")
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
-        assert "expected a non-empty list of string values" in exception_context.exception.message
 
         # search using an ill-formed IN operator correctly throws exception
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException, r"Invalid clause\(s\) in filter string"
+        ) as exception_context:
             search_versions("run_id IN (")
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
-        assert "Invalid clause" in exception_context.exception.message
 
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(MlflowException, r"Invalid filter '.+'") as exception_context:
             search_versions("run_id IN")
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
-        assert "Invalid filter" in exception_context.exception.message
 
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException,
+            (
+                r"While parsing a list in the query, "
+                r"expected a non-empty list of string values, "
+                r"but got ill-formed list"
+            ),
+        ) as exception_context:
             search_versions("run_id IN (,)")
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
-        assert "ill-formed list" in exception_context.exception.message
 
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException,
+            (
+                r"While parsing a list in the query, "
+                r"expected a non-empty list of string values, "
+                r"but got ill-formed list"
+            ),
+        ) as exception_context:
             search_versions("run_id IN ('runid1',,'runid2')")
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
-        assert "ill-formed list" in exception_context.exception.message
 
         # search using the IN operator is not allowed with other additional filters
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException, r"Search filter '.+' contains multiple expressions"
+        ) as exception_context:
             search_versions(
                 "name='{name}]' AND run_id IN ('{run_id_1}','{run_id_2}')".format(
                     name=name, run_id_1=run_id_1, run_id_2=run_id_2
                 )
             )
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
-        assert "contains multiple expressions" in exception_context.exception.message
 
         # search using source_path "A/D" should return version 3 and 4
         self.assertEqual(set(search_versions("source_path = 'A/D'")), set([3, 4]))
@@ -954,22 +1032,30 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self.assertEqual(rms, names[4:])
 
         # cannot search by invalid comparator types
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException, r"Expected a quoted string value for attributes"
+        ) as exception_context:
             self._search_registered_models("name!=something")
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
         # cannot search by run_id
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException, r"Invalid attribute key '.+' specified"
+        ) as exception_context:
             self._search_registered_models("run_id='%s'" % "somerunID")
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
         # cannot search by source_path
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException, r"Invalid attribute key '.+' specified"
+        ) as exception_context:
             self._search_registered_models("source_path = 'A/D'")
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
         # cannot search by other params
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException, r"Invalid clause\(s\) in filter string"
+        ) as exception_context:
             self._search_registered_models("evilhax = true")
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
@@ -1058,12 +1144,16 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self.assertEqual(result, rms[35:])
 
         # test that providing a completely invalid page token throws
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException, r"Invalid page token, could not base64-decode"
+        ) as exception_context:
             self._search_registered_models(query, page_token="evilhax", max_results=20)
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
         # test that providing too large of a max_results throws
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException, r"Invalid value for request parameter max_results"
+        ) as exception_context:
             self._search_registered_models(query, page_token="evilhax", max_results=1e15)
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
         self.assertIn(
@@ -1193,7 +1283,9 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
     def test_search_registered_model_order_by_errors(self):
         query = "name LIKE 'RM%'"
         # test that invalid columns throw even if they come after valid columns
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException, r"Invalid order by key '.+' specified"
+        ) as exception_context:
             self._search_registered_models(
                 query,
                 page_token=None,
@@ -1202,7 +1294,9 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
             )
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
         # test that invalid columns with random text throw even if they come after valid columns
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException, r"Invalid order_by clause '.+'"
+        ) as exception_context:
             self._search_registered_models(
                 query,
                 page_token=None,
@@ -1246,26 +1340,37 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
 
         # can not set tag on deleted (non-existed) model version
         self.store.delete_model_version(name1, 2)
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException, r"Model Version \(name={}, version=2\) not found".format(name1)
+        ) as exception_context:
             self.store.set_model_version_tag(name1, 2, overriding_tag)
         assert exception_context.exception.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
         # test cannot set tags that are too long
         long_tag = ModelVersionTag("longTagKey", "a" * 5001)
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException,
+            r"Model version value '.+' had length \d+, which exceeded length limit of 5000",
+        ) as exception_context:
             self.store.set_model_version_tag(name1, 1, long_tag)
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
         # test can set tags that are somewhat long
         long_tag = ModelVersionTag("longTagKey", "a" * 4999)
         self.store.set_model_version_tag(name1, 1, long_tag)
         # can not set invalid tag
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException, r"Tag name cannot be None"
+        ) as exception_context:
             self.store.set_model_version_tag(name2, 1, ModelVersionTag(key=None, value=""))
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
         # can not use invalid model name or version
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException, r"Registered model name cannot be empty"
+        ) as exception_context:
             self.store.set_model_version_tag(None, 1, ModelVersionTag(key="key", value="value"))
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException, r"Model version must be an integer"
+        ) as exception_context:
             self.store.set_model_version_tag(
                 name2, "I am not a version", ModelVersionTag(key="key", value="value")
             )
@@ -1308,17 +1413,25 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
 
         # can not delete tag on deleted (non-existed) model version
         self.store.delete_model_version(name2, 1)
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException, r"Model Version \(name={}, version=1\) not found".format(name2)
+        ) as exception_context:
             self.store.delete_model_version_tag(name2, 1, "key")
         assert exception_context.exception.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
         # can not delete tag with invalid key
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException, r"Tag name cannot be None"
+        ) as exception_context:
             self.store.delete_model_version_tag(name1, 2, None)
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
         # can not use invalid model name or version
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException, r"Registered model name cannot be empty"
+        ) as exception_context:
             self.store.delete_model_version_tag(None, 2, "key")
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException, r"Model version must be an integer"
+        ) as exception_context:
             self.store.delete_model_version_tag(name1, "I am not a version", "key")
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -116,11 +116,11 @@ class TestParseDbUri(unittest.TestCase):
             "://...",
             "abcdefg",
         ]
-        self._db_uri_error(bad_db_uri_strings, r"Invalid database engine")
+        self._db_uri_error(bad_db_uri_strings, "Invalid database engine")
 
     def test_fail_on_multiple_drivers(self):
         bad_db_uri_strings = ["mysql+pymsql+pyodbc://..."]
-        self._db_uri_error(bad_db_uri_strings, r"Invalid database URI")
+        self._db_uri_error(bad_db_uri_strings, "Invalid database URI")
 
 
 class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
@@ -238,7 +238,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
             self._experiment_factory(["test", "test"])
 
     def test_raise_experiment_dont_exist(self):
-        with self.assertRaisesRegex(Exception, r"No Experiment with id=.+ exists"):
+        with self.assertRaisesRegex(Exception, "No Experiment with id=.+ exists"):
             self.store.get_experiment(experiment_id=100)
 
     def test_delete_experiment(self):
@@ -331,14 +331,14 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
     def test_list_experiments_paginated_errors(self):
         # test that providing a completely invalid page token throws
         with self.assertRaisesRegex(
-            MlflowException, r"Invalid page token, could not base64-decode"
+            MlflowException, "Invalid page token, could not base64-decode"
         ) as exception_context:
             self.store.list_experiments(page_token="evilhax", max_results=20)
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
         # test that providing too large of a max_results throws
         with self.assertRaisesRegex(
-            MlflowException, r"Invalid value for request parameter max_results"
+            MlflowException, "Invalid value for request parameter max_results"
         ) as exception_context:
             self.store.list_experiments(page_token=None, max_results=int(1e15))
             assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
@@ -535,7 +535,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         # exceptions, including IntegrityError (sqlite) and FlushError (MysQL).
         # Therefore, we check for the more generic 'SQLAlchemyError'
         with self.assertRaisesRegex(
-            MlflowException, r"NOT NULL constraint failed"
+            MlflowException, "NOT NULL constraint failed"
         ) as exception_context:
             with self.store.ManagedSessionMaker() as session:
                 run = models.SqlRun()
@@ -831,7 +831,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         metric = entities.Metric(tkey, tval, int(1000 * time.time()), 0)
 
         with self.assertRaisesRegex(
-            MlflowException, r"Got invalid value None for metric"
+            MlflowException, "Got invalid value None for metric"
         ) as exception_context:
             self.store.log_metric(run.info.run_id, metric)
             warnings.resetwarnings()
@@ -861,7 +861,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         param2 = entities.Param(tkey, "newval")
         self.store.log_param(run.info.run_id, param)
 
-        with self.assertRaisesRegex(MlflowException, r"Changing param values is not allowed"):
+        with self.assertRaisesRegex(MlflowException, "Changing param values is not allowed"):
             self.store.log_param(run.info.run_id, param2)
 
     def test_log_empty_str(self):
@@ -886,7 +886,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         param = entities.Param(tkey, tval)
 
         with self.assertRaisesRegex(
-            MlflowException, r"NOT NULL constraint failed"
+            MlflowException, "NOT NULL constraint failed"
         ) as exception_context:
             self.store.log_param(run.info.run_id, param)
         assert exception_context.exception.error_code == ErrorCode.Name(BAD_REQUEST)
@@ -1060,11 +1060,11 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         run = self._run_factory()
         self.assertEqual(run.info.lifecycle_stage, entities.LifecycleStage.ACTIVE)
 
-        with self.assertRaisesRegex(MlflowException, r"The run .+ must be in the 'deleted' state"):
+        with self.assertRaisesRegex(MlflowException, "The run .+ must be in the 'deleted' state"):
             self.store.restore_run(run.info.run_id)
 
         self.store.delete_run(run.info.run_id)
-        with self.assertRaisesRegex(MlflowException, r"The run .+ must be in the 'active' state"):
+        with self.assertRaisesRegex(MlflowException, "The run .+ must be in the 'active' state"):
             self.store.delete_run(run.info.run_id)
 
         deleted = self.store.get_run(run.info.run_id)
@@ -1072,7 +1072,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         self.assertEqual(deleted.info.lifecycle_stage, entities.LifecycleStage.DELETED)
 
         self.store.restore_run(run.info.run_id)
-        with self.assertRaisesRegex(MlflowException, r"The run .+ must be in the 'deleted' state"):
+        with self.assertRaisesRegex(MlflowException, "The run .+ must be in the 'deleted' state"):
             self.store.restore_run(run.info.run_id)
         restored = self.store.get_run(run.info.run_id)
         self.assertEqual(restored.info.run_id, run.info.run_id)
@@ -1086,13 +1086,13 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         self.assertEqual(
             self.store.get_run(run_id).info.lifecycle_stage, entities.LifecycleStage.DELETED
         )
-        with self.assertRaisesRegex(MlflowException, r"The run .+ must be in the 'active' state"):
+        with self.assertRaisesRegex(MlflowException, "The run .+ must be in the 'active' state"):
             self.store.log_param(run_id, entities.Param("p1345", "v1"))
 
-        with self.assertRaisesRegex(MlflowException, r"The run .+ must be in the 'active' state"):
+        with self.assertRaisesRegex(MlflowException, "The run .+ must be in the 'active' state"):
             self.store.log_metric(run_id, entities.Metric("m1345", 1.0, 123, 0))
 
-        with self.assertRaisesRegex(MlflowException, r"The run .+ must be in the 'active' state"):
+        with self.assertRaisesRegex(MlflowException, "The run .+ must be in the 'active' state"):
             self.store.set_tag(run_id, entities.RunTag("t1345", "tv1"))
 
         # restore this run and try again
@@ -1546,7 +1546,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
             "run_id": r1,
             "run_uuid": r2,
         }.items():
-            with self.assertRaisesRegex(MlflowException, r"Invalid attribute key '.+' specified"):
+            with self.assertRaisesRegex(MlflowException, "Invalid attribute key '.+' specified"):
                 self._search([e1, e2], "attribute.{} = '{}'".format(k, v))
 
     def test_search_full(self):
@@ -1625,7 +1625,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
             assert runs[: min(1200, n)] == self._search(exp, max_results=n)
 
         with self.assertRaisesRegex(
-            MlflowException, r"Invalid value for request parameter max_results"
+            MlflowException, "Invalid value for request parameter max_results"
         ):
             self._search(exp, max_results=int(1e10))
 
@@ -1714,7 +1714,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         tag = entities.RunTag("tag-key", "tag-val")
         metric = entities.Metric("metric-key", 3.0, 12345, 0)
         with self.assertRaisesRegex(
-            MlflowException, r"Changing param values is not allowed"
+            MlflowException, "Changing param values is not allowed"
         ) as exception_context:
             self.store.log_batch(
                 run.info.run_id, metrics=[metric], params=[overwrite_param], tags=[tag]
@@ -1731,7 +1731,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         tag = entities.RunTag("tag-key", "tag-val")
         metric = entities.Metric("metric-key", 3.0, 12345, 0)
         with self.assertRaisesRegex(
-            MlflowException, r"Duplicate parameter keys have been submitted"
+            MlflowException, "Duplicate parameter keys have been submitted"
         ) as exception_context:
             self.store.log_batch(
                 run.info.run_id, metrics=[metric], params=[param0, param1], tags=[tag]
@@ -1767,7 +1767,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
                 log_batch_kwargs = {"metrics": [], "params": [], "tags": []}
                 log_batch_kwargs.update(kwargs)
                 with self.assertRaisesRegex(
-                    MlflowException, r"Some internal error"
+                    MlflowException, "Some internal error"
                 ) as exception_context:
                     self.store.log_batch(run.info.run_id, **log_batch_kwargs)
                 self.assertIn(str(exception_context.exception.message), "Some internal error")
@@ -1775,7 +1775,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
     def test_log_batch_nonexistent_run(self):
         nonexistent_run_id = uuid.uuid4().hex
         with self.assertRaisesRegex(
-            MlflowException, r"Run with id={} not found".format(nonexistent_run_id)
+            MlflowException, f"Run with id={nonexistent_run_id} not found"
         ) as exception_context:
             self.store.log_batch(nonexistent_run_id, [], [], [])
         assert exception_context.exception.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
@@ -1891,7 +1891,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         metrics = [metric_1, metric_2]
 
         with self.assertRaisesRegex(
-            MlflowException, r"Got invalid value None for metric"
+            MlflowException, "Got invalid value None for metric"
         ) as exception_context:
             self.store.log_batch(run.info.run_id, metrics=metrics, params=[], tags=[])
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -120,14 +120,7 @@ class TestParseDbUri(unittest.TestCase):
 
     def test_fail_on_multiple_drivers(self):
         bad_db_uri_strings = ["mysql+pymsql+pyodbc://..."]
-        self._db_uri_error(
-            bad_db_uri_strings,
-            (
-                r"Invalid database URI: '.+'\. "
-                r"Please refer to https://mlflow\.org/docs/latest/tracking\.html#storage "
-                r"for format specifications\."
-            ),
-        )
+        self._db_uri_error(bad_db_uri_strings, r"Invalid database URI")
 
 
 class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -103,11 +103,10 @@ class TestParseDbUri(unittest.TestCase):
                 parsed_db_type = extract_db_type_from_uri(uri)
                 self.assertEqual(target_db_type, parsed_db_type)
 
-    def _db_uri_error(self, db_uris, expected_message_part):
+    def _db_uri_error(self, db_uris, expected_message_regex):
         for db_uri in db_uris:
-            with self.assertRaises(MlflowException) as e:
+            with self.assertRaisesRegex(MlflowException, expected_message_regex):
                 extract_db_type_from_uri(db_uri)
-            self.assertIn(expected_message_part, e.exception.message)
 
     def test_fail_on_unsupported_db_type(self):
         bad_db_uri_strings = [
@@ -117,13 +116,17 @@ class TestParseDbUri(unittest.TestCase):
             "://...",
             "abcdefg",
         ]
-        self._db_uri_error(bad_db_uri_strings, "Supported database engines are ")
+        self._db_uri_error(bad_db_uri_strings, r"Invalid database engine")
 
     def test_fail_on_multiple_drivers(self):
         bad_db_uri_strings = ["mysql+pymsql+pyodbc://..."]
         self._db_uri_error(
             bad_db_uri_strings,
-            "mlflow.org/docs/latest/tracking.html#storage for format specifications",
+            (
+                r"Invalid database URI: '.+'\. "
+                r"Please refer to https://mlflow\.org/docs/latest/tracking\.html#storage "
+                r"for format specifications\."
+            ),
         )
 
 
@@ -238,11 +241,11 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         self.assertEqual("aNothEr", another.name)
 
     def test_raise_duplicate_experiments(self):
-        with self.assertRaises(Exception):
+        with self.assertRaisesRegex(Exception, r"Experiment\(name=.+\) already exists"):
             self._experiment_factory(["test", "test"])
 
     def test_raise_experiment_dont_exist(self):
-        with self.assertRaises(Exception):
+        with self.assertRaisesRegex(Exception, r"No Experiment with id=.+ exists"):
             self.store.get_experiment(experiment_id=100)
 
     def test_delete_experiment(self):
@@ -334,17 +337,18 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
 
     def test_list_experiments_paginated_errors(self):
         # test that providing a completely invalid page token throws
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException, r"Invalid page token, could not base64-decode"
+        ) as exception_context:
             self.store.list_experiments(page_token="evilhax", max_results=20)
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
         # test that providing too large of a max_results throws
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException, r"Invalid value for request parameter max_results"
+        ) as exception_context:
             self.store.list_experiments(page_token=None, max_results=int(1e15))
             assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
-        self.assertIn(
-            "Invalid value for request parameter max_results", exception_context.exception.message
-        )
 
     def test_create_experiments(self):
         with self.store.ManagedSessionMaker() as session:
@@ -537,7 +541,9 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         # Depending on the implementation, a NULL identity key may result in different
         # exceptions, including IntegrityError (sqlite) and FlushError (MysQL).
         # Therefore, we check for the more generic 'SQLAlchemyError'
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException, r"NOT NULL constraint failed"
+        ) as exception_context:
             with self.store.ManagedSessionMaker() as session:
                 run = models.SqlRun()
                 session.add(run)
@@ -831,7 +837,9 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         tval = None
         metric = entities.Metric(tkey, tval, int(1000 * time.time()), 0)
 
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException, r"Got invalid value None for metric"
+        ) as exception_context:
             self.store.log_metric(run.info.run_id, metric)
             warnings.resetwarnings()
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
@@ -860,9 +868,8 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         param2 = entities.Param(tkey, "newval")
         self.store.log_param(run.info.run_id, param)
 
-        with self.assertRaises(MlflowException) as e:
+        with self.assertRaisesRegex(MlflowException, r"Changing param values is not allowed"):
             self.store.log_param(run.info.run_id, param2)
-        self.assertIn("Changing param values is not allowed. Param with key=", e.exception.message)
 
     def test_log_empty_str(self):
         run = self._run_factory()
@@ -885,7 +892,9 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         tval = None
         param = entities.Param(tkey, tval)
 
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException, r"NOT NULL constraint failed"
+        ) as exception_context:
             self.store.log_param(run.info.run_id, param)
         assert exception_context.exception.error_code == ErrorCode.Name(BAD_REQUEST)
 
@@ -1058,23 +1067,20 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         run = self._run_factory()
         self.assertEqual(run.info.lifecycle_stage, entities.LifecycleStage.ACTIVE)
 
-        with self.assertRaises(MlflowException) as e:
+        with self.assertRaisesRegex(MlflowException, r"The run .+ must be in the 'deleted' state"):
             self.store.restore_run(run.info.run_id)
-        self.assertIn("must be in the 'deleted' state", e.exception.message)
 
         self.store.delete_run(run.info.run_id)
-        with self.assertRaises(MlflowException) as e:
+        with self.assertRaisesRegex(MlflowException, r"The run .+ must be in the 'active' state"):
             self.store.delete_run(run.info.run_id)
-        self.assertIn("must be in the 'active' state", e.exception.message)
 
         deleted = self.store.get_run(run.info.run_id)
         self.assertEqual(deleted.info.run_id, run.info.run_id)
         self.assertEqual(deleted.info.lifecycle_stage, entities.LifecycleStage.DELETED)
 
         self.store.restore_run(run.info.run_id)
-        with self.assertRaises(MlflowException) as e:
+        with self.assertRaisesRegex(MlflowException, r"The run .+ must be in the 'deleted' state"):
             self.store.restore_run(run.info.run_id)
-            self.assertIn("must be in the 'deleted' state", e.exception.message)
         restored = self.store.get_run(run.info.run_id)
         self.assertEqual(restored.info.run_id, run.info.run_id)
         self.assertEqual(restored.info.lifecycle_stage, entities.LifecycleStage.ACTIVE)
@@ -1087,17 +1093,14 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         self.assertEqual(
             self.store.get_run(run_id).info.lifecycle_stage, entities.LifecycleStage.DELETED
         )
-        with self.assertRaises(MlflowException) as e:
+        with self.assertRaisesRegex(MlflowException, r"The run .+ must be in the 'active' state"):
             self.store.log_param(run_id, entities.Param("p1345", "v1"))
-        self.assertIn("must be in the 'active' state", e.exception.message)
 
-        with self.assertRaises(MlflowException) as e:
+        with self.assertRaisesRegex(MlflowException, r"The run .+ must be in the 'active' state"):
             self.store.log_metric(run_id, entities.Metric("m1345", 1.0, 123, 0))
-        self.assertIn("must be in the 'active' state", e.exception.message)
 
-        with self.assertRaises(MlflowException) as e:
+        with self.assertRaisesRegex(MlflowException, r"The run .+ must be in the 'active' state"):
             self.store.set_tag(run_id, entities.RunTag("t1345", "tv1"))
-        self.assertIn("must be in the 'active' state", e.exception.message)
 
         # restore this run and try again
         self.store.restore_run(run_id)
@@ -1550,9 +1553,8 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
             "run_id": r1,
             "run_uuid": r2,
         }.items():
-            with self.assertRaises(MlflowException) as e:
+            with self.assertRaisesRegex(MlflowException, r"Invalid attribute key '.+' specified"):
                 self._search([e1, e2], "attribute.{} = '{}'".format(k, v))
-            self.assertIn("Invalid attribute key", e.exception.message)
 
     def test_search_full(self):
         experiment_id = self._experiment_factory("search_params")
@@ -1629,9 +1631,10 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
                 continue
             assert runs[: min(1200, n)] == self._search(exp, max_results=n)
 
-        with self.assertRaises(MlflowException) as e:
+        with self.assertRaisesRegex(
+            MlflowException, r"Invalid value for request parameter max_results"
+        ):
             self._search(exp, max_results=int(1e10))
-        self.assertIn("Invalid value for request parameter max_results. It ", e.exception.message)
 
     def test_search_with_deterministic_max_results(self):
         exp = self._experiment_factory("test_search_with_deterministic_max_results")
@@ -1717,14 +1720,13 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         overwrite_param = entities.Param(tkey, "newval")
         tag = entities.RunTag("tag-key", "tag-val")
         metric = entities.Metric("metric-key", 3.0, 12345, 0)
-        with self.assertRaises(MlflowException) as e:
+        with self.assertRaisesRegex(
+            MlflowException, r"Changing param values is not allowed"
+        ) as exception_context:
             self.store.log_batch(
                 run.info.run_id, metrics=[metric], params=[overwrite_param], tags=[tag]
             )
-        self.assertIn(
-            "Changing param values is not allowed. Params were already logged=", e.exception.message
-        )
-        assert e.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+        assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
         self._verify_logged(self.store, run.info.run_id, metrics=[], params=[param], tags=[])
 
     def test_log_batch_param_overwrite_disallowed_single_req(self):
@@ -1735,12 +1737,13 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         param1 = entities.Param(pkey, "newval")
         tag = entities.RunTag("tag-key", "tag-val")
         metric = entities.Metric("metric-key", 3.0, 12345, 0)
-        with self.assertRaises(MlflowException) as e:
+        with self.assertRaisesRegex(
+            MlflowException, r"Duplicate parameter keys have been submitted"
+        ) as exception_context:
             self.store.log_batch(
                 run.info.run_id, metrics=[metric], params=[param0, param1], tags=[tag]
             )
-        self.assertIn("Duplicate parameter keys have been submitted:", e.exception.message)
-        assert e.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+        assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
         self._verify_logged(self.store, run.info.run_id, metrics=[], params=[], tags=[])
 
     def test_log_batch_accepts_empty_payload(self):
@@ -1770,16 +1773,19 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
             ]:
                 log_batch_kwargs = {"metrics": [], "params": [], "tags": []}
                 log_batch_kwargs.update(kwargs)
-                with self.assertRaises(MlflowException) as e:
+                with self.assertRaisesRegex(
+                    MlflowException, r"Some internal error"
+                ) as exception_context:
                     self.store.log_batch(run.info.run_id, **log_batch_kwargs)
-                self.assertIn(str(e.exception.message), "Some internal error")
+                self.assertIn(str(exception_context.exception.message), "Some internal error")
 
     def test_log_batch_nonexistent_run(self):
         nonexistent_run_id = uuid.uuid4().hex
-        with self.assertRaises(MlflowException) as e:
+        with self.assertRaisesRegex(
+            MlflowException, r"Run with id={} not found".format(nonexistent_run_id)
+        ) as exception_context:
             self.store.log_batch(nonexistent_run_id, [], [], [])
-        assert e.exception.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
-        assert "Run with id=%s not found" % nonexistent_run_id in e.exception.message
+        assert exception_context.exception.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
 
     def test_log_batch_params_idempotency(self):
         run = self._run_factory()
@@ -1891,7 +1897,9 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
 
         metrics = [metric_1, metric_2]
 
-        with self.assertRaises(MlflowException) as exception_context:
+        with self.assertRaisesRegex(
+            MlflowException, r"Got invalid value None for metric"
+        ) as exception_context:
             self.store.log_batch(run.info.run_id, metrics=metrics, params=[], tags=[])
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 


### PR DESCRIPTION
## Related Issues/PRs

#5680

## What changes are proposed in this pull request?

Replace `unittest.TestCase.assertRaises` with `unittest.TestCase.assertRaisesRegex` in `tests/store/model_registry/test_sqlalchemy_store.py` and `tests/store/tracking/test_sqlalchemy_store.py`

## How is this patch tested?

Unit tests

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
