### PR TITLE
Replace `npm` with `yarn`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_template.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report_template.yaml
@@ -31,7 +31,7 @@ body:
         - **MLflow installed from (source or binary)**:
         - **MLflow version (run ``mlflow --version``)**:
         - **Python version**:
-        - **npm version, if running the dev UI**:
+        - **yarn version, if running the dev UI**:
     validations:
       required: true
   - type: textarea

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -248,7 +248,7 @@ dependencies via:
    yarn install
    cd - # return to root repository directory
 
-If modifying dependencies in ``mlflow/server/js/package.json``, run ``yarn update`` within
+If modifying dependencies in ``mlflow/server/js/package.json``, run ``yarn upgrade`` within
 ``mlflow/server/js`` to install the updated dependencies.
 
 Launching the Development UI

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -553,7 +553,7 @@ Generate JS files in ``mlflow/server/js/build``:
 .. code-block:: bash
 
    cd mlflow/server/js
-   yarn run build
+   yarn build
 
 Build a pip-installable wheel in ``dist/``:
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -222,9 +222,9 @@ Finally, we use ``pytest`` to test all Python contributed code. Install ``pytest
 JavaScript and UI
 ~~~~~~~~~~~~~~~~~
 
-The MLflow UI is written in JavaScript. ``npm`` is required to run the Javascript dev server and the tracking UI.
-You can verify that ``npm`` is on the PATH by running ``npm -v``, and
-`install npm <https://www.npmjs.com/get-npm>`_ if needed.
+The MLflow UI is written in JavaScript. ``yarn`` is required to run the Javascript dev server and the tracking UI.
+You can verify that ``yarn`` is on the PATH by running ``yarn -v``, and
+`install yarn <https://classic.yarnpkg.com/lang/en/docs/install>`_ if needed.
 
 Install Node Module Dependencies
 ++++++++++++++++++++++++++++++++
@@ -245,10 +245,10 @@ dependencies via:
 .. code-block:: bash
 
    cd mlflow/server/js
-   npm install
+   yarn install
    cd - # return to root repository directory
 
-If modifying dependencies in ``mlflow/server/js/package.json``, run ``npm update`` within
+If modifying dependencies in ``mlflow/server/js/package.json``, run ``yarn update`` within
 ``mlflow/server/js`` to install the updated dependencies.
 
 Launching the Development UI
@@ -274,7 +274,7 @@ In another shell:
 .. code-block:: bash
 
    cd mlflow/server/js
-   npm start
+   yarn start
 
 The MLflow Tracking UI will show runs logged in ``./mlruns`` at `<http://localhost:3000>`_.
 
@@ -553,7 +553,7 @@ Generate JS files in ``mlflow/server/js/build``:
 .. code-block:: bash
 
    cd mlflow/server/js
-   npm run build
+   yarn run build
 
 Build a pip-installable wheel in ``dist/``:
 


### PR DESCRIPTION
## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
Close #5878 

## What changes are proposed in this pull request?
Replaced `npm` with `yarn` in CONTRIBUTING.rst and in the issue template.

## How is this patch tested?
No need to test, just a change in a text file.

## Does this PR change the documentation?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
