### PR TITLE
Fix `test_get_params_returns_dict_that_has_more_keys_than_max_params_tags_per_bat`

### DIFF
--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -385,7 +385,7 @@ def test_meta_estimator():
 
 @contextlib.contextmanager
 def disable_parameter_validation():
-    return (
+    yield (
         mock.patch("sklearn.cluster.KMeans._validate_params")
         if Version(sklearn.__version__) > Version("1.1.0")
         else contextlib.nullcontext()

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -1974,6 +1974,7 @@ class UnpicklableKmeans(sklearn.cluster.KMeans):
         super().__init__(n_clusters)
         self.generator = (i for i in range(3))
 
+    # Ignore parameter validation in scikit-learn > 1.1.0
     def _validate_params(self):
         pass
 

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -1974,7 +1974,7 @@ class UnpicklableKmeans(sklearn.cluster.KMeans):
         super().__init__(n_clusters)
         self.generator = (i for i in range(3))
 
-    # Ignore parameter validation in scikit-learn > 1.1.0
+    # Ignore parameter validation added in scikit-learn > 1.1.0
     def _validate_params(self):
         pass
 
@@ -1985,11 +1985,11 @@ def test_autolog_print_warning_if_custom_estimator_pickling_raise_error():
     mlflow.sklearn.autolog()
 
     with mlflow.start_run() as run, mock.patch("mlflow.sklearn._logger.warning") as mock_warning:
-        unpickable_kmeans = UnpicklableKmeans()
+        unpicklable_kmeans = UnpicklableKmeans()
         with pytest.raises(TypeError, match=r"(can't|cannot) pickle.+generator"):
-            pickle.dumps(unpickable_kmeans)
+            pickle.dumps(unpicklable_kmeans)
 
-        unpickable_kmeans.fit(*get_iris())
+        unpicklable_kmeans.fit(*get_iris())
         assert any(
             call_args[0][0].startswith("Pickling custom sklearn model UnpicklableKmeans failed")
             for call_args in mock_warning.call_args_list

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -383,9 +383,8 @@ def test_meta_estimator():
     assert_predict_equal(load_model_by_run_id(run_id), model, X)
 
 
-@contextlib.contextmanager
 def disable_parameter_validation():
-    yield (
+    return (
         mock.patch("sklearn.cluster.KMeans._validate_params")
         if Version(sklearn.__version__) > Version("1.1.0")
         else contextlib.nullcontext()


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

https://github.com/scikit-learn/scikit-learn/pull/22722

## What changes are proposed in this pull request?

In `test_get_params_returns_dict_that_has_more_keys_than_max_params_tags_per_bat`, we mock `sklearn.cluster.KMeans.get_params` to make it return a dict that has more items than `MAX_PARAMS_TAGS_PER_BATCH`. This test started failing after https://github.com/scikit-learn/scikit-learn/pull/22722 was merged. This PR fixes this issue by mocking `_validate_params` to disable parameter validation.

https://github.com/mlflow/mlflow/runs/6465869522?check_suite_focus=true#step:12:188

```
E           ValueError: The parameter constraints ['n_clusters', 'init', 'n_init', 'max_iter', 'tol', 'verbose', 'random_state', 'copy_x', 'algorithm'] do not match the parameters to validate ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', '34', '35', '36', '37', '38', '39', '40', '41', '42', '43', '44', '45', '46', '47', '48', '49', '50', '51', '52', '53', '54', '55', '56', '57', '58', '59', '60', '61', '62', '63', '64', '65', '66', '67', '68', '69', '70', '71', '72', '73', '74', '75', '76', '77', '78', '79', '80', '81', '82', '83', '84', '85', '86', '87', '88', '89', '90', '91', '92', '93', '94', '95', '96', '97', '98', '99', '100'].
```

## How is this patch tested?

Fixed test

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
