### PR TITLE
Use HEAD branch when running a git project

### DIFF
--- a/mlflow/projects/utils.py
+++ b/mlflow/projects/utils.py
@@ -209,11 +209,14 @@ def _fetch_git_repo(uri, version, dst_dir):
             )
     else:
         g = git.cmd.Git(dst_dir)
-        output = g.execute(["git", "remote", "show", "origin"])
+        cmd = ["git", "remote", "show", "origin"]
+        output = g.execute(cmd)
         head_branch = _get_head_branch(output)
         if head_branch is None:
             raise ExecutionException(
-                f"Failed to find HEAD branch. Output of `git remote show origin`:\n{output}"
+                "Failed to find HEAD branch. Output of `{cmd}`:\n{output}".format(
+                    cmd=" ".join(cmd), output=output
+                )
             )
         origin.fetch(head_branch, depth=GIT_FETCH_DEPTH)
         ref = origin.refs[0]

--- a/mlflow/projects/utils.py
+++ b/mlflow/projects/utils.py
@@ -212,7 +212,9 @@ def _fetch_git_repo(uri, version, dst_dir):
         output = g.execute(["git", "remote", "show", "origin"])
         head_branch = _get_head_branch(output)
         if head_branch is None:
-            raise ExecutionException("Failed to find HEAD branch")
+            raise ExecutionException(
+                f"Failed to find HEAD branch. Output of `git remote show origin`:\n{output}"
+            )
         origin.fetch(head_branch, depth=GIT_FETCH_DEPTH)
         ref = origin.refs[0]
         _logger.info("Fetched '%s' branch", head_branch)

--- a/mlflow/projects/utils.py
+++ b/mlflow/projects/utils.py
@@ -201,6 +201,7 @@ def _fetch_git_repo(uri, version, dst_dir):
     else:
         origin.fetch(depth=GIT_FETCH_DEPTH)
         branch = str(origin.refs[0].name).split("/")[-1]
+        _logger.info("Fetched '%s' branch", branch)
         repo.create_head(branch, origin.refs[0])
         repo.heads[branch].checkout()
     repo.submodule_update(init=True, recursive=True)

--- a/mlflow/projects/utils.py
+++ b/mlflow/projects/utils.py
@@ -200,8 +200,8 @@ def _fetch_git_repo(uri, version, dst_dir):
             )
     else:
         origin.fetch(depth=GIT_FETCH_DEPTH)
-        repo.create_head("master", origin.refs.master)
-        repo.heads.master.checkout()
+        repo.create_head("head", origin.refs[0])
+        repo.heads["head"].checkout()
     repo.submodule_update(init=True, recursive=True)
 
 

--- a/mlflow/projects/utils.py
+++ b/mlflow/projects/utils.py
@@ -200,7 +200,7 @@ def _fetch_git_repo(uri, version, dst_dir):
             )
     else:
         origin.fetch(depth=GIT_FETCH_DEPTH)
-        branch = origin.refs[0].split("/")[-1]
+        branch = origin.refs[0].name.split("/")[-1]
         repo.create_head(branch, origin.refs[0])
         repo.heads[branch].checkout()
     repo.submodule_update(init=True, recursive=True)

--- a/mlflow/projects/utils.py
+++ b/mlflow/projects/utils.py
@@ -200,8 +200,9 @@ def _fetch_git_repo(uri, version, dst_dir):
             )
     else:
         origin.fetch(depth=GIT_FETCH_DEPTH)
-        repo.create_head("head", origin.refs[0])
-        repo.heads["head"].checkout()
+        branch = origin.refs[0].split("/")[-1]
+        repo.create_head(branch, origin.refs[0])
+        repo.heads[branch].checkout()
     repo.submodule_update(init=True, recursive=True)
 
 

--- a/mlflow/projects/utils.py
+++ b/mlflow/projects/utils.py
@@ -200,7 +200,7 @@ def _fetch_git_repo(uri, version, dst_dir):
             )
     else:
         origin.fetch(depth=GIT_FETCH_DEPTH)
-        branch = origin.refs[0].name.split("/")[-1]
+        branch = str(origin.refs[0].name).split("/")[-1]
         repo.create_head(branch, origin.refs[0])
         repo.heads[branch].checkout()
     repo.submodule_update(init=True, recursive=True)

--- a/mlflow/projects/utils.py
+++ b/mlflow/projects/utils.py
@@ -200,9 +200,10 @@ def _fetch_git_repo(uri, version, dst_dir):
             )
     else:
         origin.fetch(depth=GIT_FETCH_DEPTH)
-        branch = str(origin.refs[0].name).split("/")[-1]
+        ref = origin.refs[0]
+        branch = str(ref).split("/")[-1]
         _logger.info("Fetched '%s' branch", branch)
-        repo.create_head(branch, origin.refs[0])
+        repo.create_head(branch, ref)
         repo.heads[branch].checkout()
     repo.submodule_update(init=True, recursive=True)
 


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
Fix #5718

## What changes are proposed in this pull request?

Use the default branch when running a git project.

## How is this patch tested?

- Existing tests
- Manual test using https://github.com/rcallagh/mlflow_submodule_test.git whose default branch is `main`:

```
mlflow run https://github.com/rcallagh/mlflow_submodule_test.git
```

Output:

```
2022/05/18 19:38:53 INFO mlflow.projects.utils: === Fetching project from https://github.com/rcallagh/mlflow_submodule_test.git into /tmp/tmpqnqml3rs ===
2022/05/18 19:38:54 INFO mlflow.projects.utils: Fetched 'main' branch
2022/05/18 19:38:55 INFO mlflow.utils.conda: Conda environment mlflow-e0da0cbf5df659be70121b5a48408e944761dbd4 already exists.
2022/05/18 19:38:55 INFO mlflow.projects.utils: === Created directory /tmp/tmp2nqfuwse for downloading remote URIs passed to arguments of type 'path' ===
2022/05/18 19:38:55 INFO mlflow.projects.backend.local: === Running command 'source /home/haru/miniconda3/bin/../etc/profile.d/conda.sh && conda activate mlflow-e0da0cbf5df659be70121b5a48408e944761dbd4 1>&2 && python main.py' in run with ID '1def7ea3ffd44470968cdd06f12a6055' === 
Running the mlflow test
Running a submodule function 
Hello from the submodule
Mlflow worked on commit: 4ed55d3d2655a710e0de3887e2166be585a66544
2022/05/18 19:38:55 INFO mlflow.projects: === Run (ID '1def7ea3ffd44470968cdd06f12a6055') succeeded ===
```

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
