### PR TITLE
Revert #5657

### DIFF
--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -177,15 +177,9 @@ def _save_model_with_class_artifacts_params(
         with TempDir() as tmp_artifacts_dir:
             tmp_artifacts_config = {}
             saved_artifacts_dir_subpath = "artifacts"
-            for artifact_index, (artifact_name, artifact_uri) in enumerate(artifacts.items()):
-                artifact_download_output_path = (
-                    tmp_artifacts_dir.path(str(artifact_index))
-                    if len(artifacts) > 1
-                    else tmp_artifacts_dir.path()
-                )
-                os.makedirs(artifact_download_output_path, exist_ok=True)
+            for artifact_name, artifact_uri in artifacts.items():
                 tmp_artifact_path = _download_artifact_from_uri(
-                    artifact_uri=artifact_uri, output_path=artifact_download_output_path
+                    artifact_uri=artifact_uri, output_path=tmp_artifacts_dir.path()
                 )
                 tmp_artifacts_config[artifact_name] = tmp_artifact_path
                 saved_artifact_subpath = posixpath.join(

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -846,40 +846,6 @@ def test_save_model_correctly_resolves_directory_artifact_with_nested_contents(
 
 
 @pytest.mark.large
-def test_multiple_artifacts_with_common_sub_paths_resolve_correctly_when_saving_model(
-    sklearn_knn_model, model_path, iris_data
-):
-    default_model_path = "model"
-    with mlflow.start_run():
-        model_info = mlflow.sklearn.log_model(
-            sk_model=sklearn_knn_model, artifact_path=default_model_path
-        )
-        first_model_uri = model_info.model_uri
-
-    with mlflow.start_run():
-        model_info = mlflow.sklearn.log_model(
-            sk_model=sklearn_knn_model, artifact_path=default_model_path
-        )
-        second_model_uri = model_info.model_uri
-
-    class ArtifactValidationModel(mlflow.pyfunc.PythonModel):
-        def predict(self, context, model_input):
-            first_model_resolved_path = context.artifacts["first_model"]
-            second_model_resolved_path = context.artifacts["second_model"]
-            return first_model_resolved_path != second_model_resolved_path
-
-    mlflow.pyfunc.save_model(
-        path=model_path,
-        artifacts={"first_model": first_model_uri, "second_model": second_model_uri},
-        python_model=ArtifactValidationModel(),
-        conda_env=_conda_env(),
-    )
-
-    loaded_model = mlflow.pyfunc.load_model(model_uri=model_path)
-    assert loaded_model.predict(iris_data[0])
-
-
-@pytest.mark.large
 def test_save_model_with_no_artifacts_does_not_produce_artifacts_dir(model_path):
     mlflow.pyfunc.save_model(
         path=model_path,


### PR DESCRIPTION
PR #5657 was original made to fix #5582. However, based on the
community feedback / discussion #5657 has caused more problems
then it solved, so a different solution seems preferable.

Signed-off-by: Kyle Jarvis <kyle.jarvis1905@gmail.com>

## Related Issues/PRs

PR #5657 was originally made to address #5582, subsequent discussions in #5657 suggest these changes should be reverted and a different solution found to the original issue.

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Changes originally made in #5657 are reverted.

## How is this patch tested?

Original functionality restored.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
