### PR TITLE
Make `DefaultEvaluator` log sklearn model score if model is scorable

### DIFF
--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -577,7 +577,8 @@ class DefaultEvaluator(ModelEvaluator):
             except Exception as e:
                 _logger.warning(
                     f"Computing sklearn model score failed: {repr(e)}. Set logging level to "
-                    "DEBUG to see the full traceback.")
+                    "DEBUG to see the full traceback."
+                )
                 _logger.debug("", exc_info=True)
 
     def _log_binary_classifier(self):

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -569,6 +569,11 @@ class DefaultEvaluator(ModelEvaluator):
             "shap_feature_importance_plot",
         )
 
+    def _log_sklearn_model_score_if_needed(self):
+        if self.model_loader_module == "mlflow.sklearn" and \
+                hasattr(self.raw_model, "scoring") and self.raw_model.scoring is not None:
+            self.metrics["score"] = self.raw_model.score(self.X, self.y)
+
     def _log_binary_classifier(self):
         self.metrics.update(_get_classifier_per_class_metrics(self.y, self.y_pred))
 
@@ -811,6 +816,7 @@ class DefaultEvaluator(ModelEvaluator):
                 self.is_binomial, self.y, self.y_pred, self.y_probs, self.label_list
             )
         )
+        self._log_sklearn_model_score_if_needed()
 
         if self.is_binomial:
             self._log_binary_classifier()
@@ -855,6 +861,7 @@ class DefaultEvaluator(ModelEvaluator):
     def _evaluate_regressor(self):
         self.y_pred = self.model.predict(self.X)
         self.metrics.update(_get_regressor_metrics(self.y, self.y_pred))
+        self._log_sklearn_model_score_if_needed()
 
         return self._log_and_return_evaluation_result()
 

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -573,10 +573,12 @@ class DefaultEvaluator(ModelEvaluator):
         if self.model_loader_module == "mlflow.sklearn":
             try:
                 score = self.raw_model.score(self.X, self.y)
+                self.metrics["score"] = score
             except Exception as e:
-                _logger.warning(f"Computing sklearn model score failed, error {repr(e)}")
+                _logger.warning(
+                    f"Computing sklearn model score failed: {repr(e)}. Set logging level to "
+                    "DEBUG to see the full traceback.")
                 _logger.debug("", exc_info=True)
-            self.metrics["score"] = score
 
     def _log_binary_classifier(self):
         self.metrics.update(_get_classifier_per_class_metrics(self.y, self.y_pred))

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -934,9 +934,11 @@ def test_custom_metric_logs_artifacts_from_objects(
 def test_evaluate_sklearn_model_score_skip_when_not_scorable(
     linear_regressor_model_uri, diabetes_dataset
 ):
-    with mock.patch("sklearn.linear_model.LinearRegression.score",
-                    side_effect=RuntimeError("LinearRegression.score failed")):
-        with mlflow.start_run() as run:
+    with mock.patch(
+        "sklearn.linear_model.LinearRegression.score",
+        side_effect=RuntimeError("LinearRegression.score failed"),
+    ) as mock_score:
+        with mlflow.start_run():
             result = evaluate(
                 linear_regressor_model_uri,
                 diabetes_dataset._constructor_args["data"],
@@ -945,4 +947,5 @@ def test_evaluate_sklearn_model_score_skip_when_not_scorable(
                 dataset_name=diabetes_dataset.name,
                 evaluators="default",
             )
+        mock_score.assert_called_once()
         assert "score" not in result.metrics

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -1,5 +1,5 @@
 import matplotlib.pyplot as plt
-import mock
+from unittest import mock
 import numpy as np
 import json
 import pandas as pd

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -76,6 +76,9 @@ def test_regressor_evaluation(linear_regressor_model_uri, diabetes_dataset):
     y_pred = model.predict(diabetes_dataset.features_data)
 
     expected_metrics = _get_regressor_metrics(y, y_pred)
+    expected_metrics["score"] = model._model_impl.score(
+        diabetes_dataset.features_data, diabetes_dataset.labels_data
+    )
     for metric_key in expected_metrics:
         assert np.isclose(
             expected_metrics[metric_key],
@@ -121,7 +124,9 @@ def test_multi_classifier_evaluation(multiclass_logistic_regressor_model_uri, ir
     y_probs = predict_proba_fn(iris_dataset.features_data)
 
     expected_metrics = _get_classifier_global_metrics(False, y, y_pred, y_probs, labels=None)
-
+    expected_metrics["score"] = model._model_impl.score(
+        iris_dataset.features_data, iris_dataset.labels_data
+    )
     for metric_key in expected_metrics:
         assert np.isclose(
             expected_metrics[metric_key], metrics[metric_key + "_on_data_iris_dataset"], rtol=1e-3
@@ -174,7 +179,9 @@ def test_bin_classifier_evaluation(binary_logistic_regressor_model_uri, breast_c
     y_probs = predict_proba_fn(breast_cancer_dataset.features_data)
 
     expected_metrics = _get_classifier_global_metrics(True, y, y_pred, y_probs, labels=None)
-
+    expected_metrics["score"] = model._model_impl.score(
+        breast_cancer_dataset.features_data, breast_cancer_dataset.labels_data
+    )
     for metric_key in expected_metrics:
         assert np.isclose(
             expected_metrics[metric_key],
@@ -267,7 +274,9 @@ def test_svm_classifier_evaluation(svm_model_uri, breast_cancer_dataset):
     y_pred = predict_fn(breast_cancer_dataset.features_data)
 
     expected_metrics = _get_classifier_global_metrics(True, y, y_pred, None, labels=None)
-
+    expected_metrics["score"] = model._model_impl.score(
+        breast_cancer_dataset.features_data, breast_cancer_dataset.labels_data
+    )
     for metric_key in expected_metrics:
         assert np.isclose(
             expected_metrics[metric_key],

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -931,7 +931,9 @@ def test_custom_metric_logs_artifacts_from_objects(
     assert result.artifacts["test_pickled_artifact"].content == _ExampleToBePickledObject()
 
 
-def test_evaluate_sklearn_model_score_skip_when_not_scorable(linear_regressor_model_uri, diabetes_dataset):
+def test_evaluate_sklearn_model_score_skip_when_not_scorable(
+    linear_regressor_model_uri, diabetes_dataset
+):
     with mock.patch("sklearn.linear_model.LinearRegression.score") as score_mock:
         score_mock.side_effect = RuntimeError("LinearRegression.score failed")
         with mlflow.start_run() as run:

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -934,8 +934,8 @@ def test_custom_metric_logs_artifacts_from_objects(
 def test_evaluate_sklearn_model_score_skip_when_not_scorable(
     linear_regressor_model_uri, diabetes_dataset
 ):
-    with mock.patch("sklearn.linear_model.LinearRegression.score") as score_mock:
-        score_mock.side_effect = RuntimeError("LinearRegression.score failed")
+    with mock.patch("sklearn.linear_model.LinearRegression.score",
+                    side_effect=RuntimeError("LinearRegression.score failed")):
         with mlflow.start_run() as run:
             result = evaluate(
                 linear_regressor_model_uri,

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -943,5 +943,4 @@ def test_evaluate_sklearn_model_score_skip_when_not_scorable(linear_regressor_mo
                 dataset_name=diabetes_dataset.name,
                 evaluators="default",
             )
-
         assert "score" not in result.metrics


### PR DESCRIPTION
Signed-off-by: Weichen Xu <weichen.xu@databricks.com>

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Make `DefaultEvaluator` log sklearn model score if model is scorable.

## How is this patch tested?

TODO

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Make `DefaultEvaluator` log sklearn model score if model is scorable.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
