### PR TITLE
Improve UI bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/ui_bug_report_template.yaml
+++ b/.github/ISSUE_TEMPLATE/ui_bug_report_template.yaml
@@ -54,7 +54,7 @@ body:
     attributes:
       label: Steps to reproduce the bug
       description: |
-        **Record** steps to reproduce the bug as a video or GIF and attach it here.
+        **Record steps to reproduce the bug as a video or GIF** (to eliminate ambiguity) and attach it here.
 
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/ui_bug_report_template.yaml
+++ b/.github/ISSUE_TEMPLATE/ui_bug_report_template.yaml
@@ -101,7 +101,7 @@ body:
 
         ![network-panel](https://github.com/mlflow/mlflow/blob/master/.github/ISSUE_TEMPLATE/images/network-panel.png?raw=true)
         <p align="center">Network panel on Chrome</P>
-      value: |
+      placeholder: |
         ```
         # Request URL
         http://localhost:5000/ajax-api/2.0/preview/mlflow/xxx/yyy

--- a/.github/ISSUE_TEMPLATE/ui_bug_report_template.yaml
+++ b/.github/ISSUE_TEMPLATE/ui_bug_report_template.yaml
@@ -21,6 +21,13 @@ body:
     validations:
       required: true
 
+  - type: input
+    validations:
+      required: false
+    attributes:
+      label: MLflow version
+      description: MLflow version (run `mlflow --version`) or commit SHA if you have MLflow installed from source (run `pip freeze | grep mlflow`).
+
   - type: textarea
     validations:
       required: true
@@ -30,7 +37,6 @@ body:
         Describe the system where you encountered the bug.
       value: |
         - **OS Platform and Distribution (e.g., Linux Ubuntu 16.04)**:
-        - **MLflow version (run `mlflow --version`) or commit SHA if you have MLflow installed from source (run `pip freeze | grep mlflow`)**:
         - **Python version**:
         - **yarn version, if running the dev UI**:
 
@@ -68,7 +74,7 @@ body:
     attributes:
       label: Is the console panel showing errors relevant to the bug?
       description: |
-        If the console panel in your browser's DevTools is showing errors (displayed in red) relevant to the bug as shown in the screenshot below, please provide them as text or a screenshot.
+        If the console panel in your browser's DevTools is showing errors (displayed in red) relevant to the bug as shown in the screenshot below, please provide them as text (preferred) or a screenshot.
 
         #### Instructions on how to use DevTools:
         - Chrome: [Chrome DevTools](https://developer.chrome.com/docs/devtools/)
@@ -77,12 +83,33 @@ body:
 
         ![console-panel](https://github.com/mlflow/mlflow/blob/master/.github/ISSUE_TEMPLATE/images/console-panel.png?raw=true)
         <p align="center">Console panel on Chrome</P>
+      placeholder: |
+        ```
+        TypeError: Cannot read properties of undefined (reading 'x')
+          at n.value (HomeView.js:33:22)
+          at za (react-dom.production.min.js:187:188)
+          ...
+        ```
 
   - type: textarea
     attributes:
       label: Does the network panel contain failed requests relevant to the bug?
       description: |
-        If the network panel in your browser's DevTools contain failed requests (displayed in red) relevant to the bug as shown in the screenshot below, provide them as text or a screenshot.
+        If the network panel in your browser's DevTools contain failed requests (displayed in red) relevant to the bug as shown in the screenshot below, please provide them as text (preferred) or a screenshot.
 
         ![network-panel](https://github.com/mlflow/mlflow/blob/master/.github/ISSUE_TEMPLATE/images/network-panel.png?raw=true)
         <p align="center">Network panel on Chrome</P>
+      value: |
+        ```
+        # Request URL:
+        http://localhost:5000/ajax-api/2.0/preview/mlflow/xxx/yyy
+
+        # Status Code:
+        400
+
+        # Payload
+        {"a": 0}
+
+        # Response
+        {"b": 1}
+        ```

--- a/.github/ISSUE_TEMPLATE/ui_bug_report_template.yaml
+++ b/.github/ISSUE_TEMPLATE/ui_bug_report_template.yaml
@@ -88,7 +88,9 @@ body:
         TypeError: Cannot read properties of undefined (reading 'x')
           at n.value (HomeView.js:33:22)
           at za (react-dom.production.min.js:187:188)
-          ...
+          at Za (react-dom.production.min.js:186:173)
+          at qs (react-dom.production.min.js:269:427)
+          at Tl (react-dom.production.min.js:250:347)
         ```
 
   - type: textarea
@@ -101,10 +103,10 @@ body:
         <p align="center">Network panel on Chrome</P>
       value: |
         ```
-        # Request URL:
+        # Request URL
         http://localhost:5000/ajax-api/2.0/preview/mlflow/xxx/yyy
 
-        # Status Code:
+        # Status Code
         400
 
         # Payload

--- a/.github/ISSUE_TEMPLATE/ui_bug_report_template.yaml
+++ b/.github/ISSUE_TEMPLATE/ui_bug_report_template.yaml
@@ -23,7 +23,7 @@ body:
 
   - type: input
     validations:
-      required: false
+      required: true
     attributes:
       label: MLflow version
       description: MLflow version (run `mlflow --version`) or commit SHA if you have MLflow installed from source (run `pip freeze | grep mlflow`).

--- a/.github/ISSUE_TEMPLATE/ui_bug_report_template.yaml
+++ b/.github/ISSUE_TEMPLATE/ui_bug_report_template.yaml
@@ -72,7 +72,7 @@ body:
 
   - type: textarea
     attributes:
-      label: Is the console panel showing errors relevant to the bug?
+      label: Is the console panel in DevTools showing errors relevant to the bug?
       description: |
         If the console panel in your browser's DevTools is showing errors (displayed in red) relevant to the bug as shown in the screenshot below, please provide them as text (preferred) or a screenshot.
 
@@ -95,7 +95,7 @@ body:
 
   - type: textarea
     attributes:
-      label: Does the network panel contain failed requests relevant to the bug?
+      label: Does the network panel in DevTools contain failed requests relevant to the bug?
       description: |
         If the network panel in your browser's DevTools contain failed requests (displayed in red) relevant to the bug as shown in the screenshot below, please provide them as text (preferred) or a screenshot.
 


### PR DESCRIPTION
## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

A follow-up for #5888 

## What changes are proposed in this pull request?

Improve the UI bug template to clarify what information we want.

## How is this patch tested?

https://github.com/harupy/mlflow/issues/new?assignees=&labels=bug%2Carea%2Fuiux&template=ui_bug_report_template.yaml&title=%5BBUG%5D


## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
