### PR TITLE
Remove unnecessary lines in tests/test_skinny_client_omits_sql_libs.py

### DIFF
--- a/tests/test_skinny_client_omits_sql_libs.py
+++ b/tests/test_skinny_client_omits_sql_libs.py
@@ -6,11 +6,8 @@ import os
     "MLFLOW_SKINNY" not in os.environ, reason="This test is only valid for the skinny client"
 )
 def test_fails_import_sqlalchemy():
-    import mlflow
-
-    assert mlflow is not None  # pylint or flake8 disabling is not working
+    
+    import mlflow  # pylint: disable=unused-import
 
     with pytest.raises(ImportError, match="sqlalchemy"):
         import sqlalchemy  # pylint: disable=unused-import
-
-        assert sqlalchemy is not None  # pylint or flake8 disabling is not working

--- a/tests/test_skinny_client_omits_sql_libs.py
+++ b/tests/test_skinny_client_omits_sql_libs.py
@@ -6,7 +6,7 @@ import os
     "MLFLOW_SKINNY" not in os.environ, reason="This test is only valid for the skinny client"
 )
 def test_fails_import_sqlalchemy():
-    
+
     import mlflow  # pylint: disable=unused-import
 
     with pytest.raises(ImportError, match="sqlalchemy"):


### PR DESCRIPTION
## Related Issues/PRs 

Close #5905 

## What changes are proposed in this pull request?
Removed unnecessary lines in `tests/test_skinny_client_omits_sql_libs.py`

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
