### PR TITLE
Fix `unittest-assert-raises` pylint errors

### DIFF
--- a/pylint_plugins/unittest_assert_raises.py
+++ b/pylint_plugins/unittest_assert_raises.py
@@ -1,5 +1,3 @@
-import os
-
 import astroid
 from pylint.interfaces import IAstroidChecker
 from pylint.checkers import BaseChecker
@@ -7,31 +5,6 @@ from pylint.checkers import BaseChecker
 
 def _is_unittest_assert_raises(node: astroid.Call):
     return isinstance(node.func, astroid.Attribute) and node.func.as_string() == "self.assertRaises"
-
-
-IGNORE_FILES = list(
-    map(
-        os.path.abspath,
-        [
-            # Instructions
-            # ============
-            # 1. Select a file in the list below and remove it.
-            # 2. Run pylint and confirm it fails.
-            # 3. Fix the lines printed out in the previous step.
-            # 4. Run pylint again and confirm it succeeds now.
-            # 5. Run pytest and confirm the changed lines don't fail.
-            # 6. Open a PR.
-            "tests/entities/test_run_status.py",
-            "tests/store/db/test_utils.py",
-            "tests/store/tracking/__init__.py",
-            "tests/store/tracking/test_file_store.py",
-        ],
-    )
-)
-
-
-def _should_ignore(path: str):
-    return path in IGNORE_FILES
 
 
 class UnittestAssertRaises(BaseChecker):
@@ -48,5 +21,5 @@ class UnittestAssertRaises(BaseChecker):
     priority = -1
 
     def visit_call(self, node: astroid.Call):
-        if not _should_ignore(node.root().file) and _is_unittest_assert_raises(node):
+        if _is_unittest_assert_raises(node):
             self.add_message(self.name, node=node)

--- a/tests/entities/test_run_status.py
+++ b/tests/entities/test_run_status.py
@@ -34,13 +34,15 @@ class TestRunStatus(unittest.TestCase):
         self.assertEqual("KILLED", RunStatus.to_string(RunStatus.KILLED))
         self.assertEqual(RunStatus.KILLED, RunStatus.from_string("KILLED"))
 
-        with self.assertRaises(Exception) as e:
+        with self.assertRaisesRegex(
+            Exception, r"Could not get string corresponding to run status -120"
+        ):
             RunStatus.to_string(-120)
-        self.assertIn("Could not get string corresponding to run status -120", str(e.exception))
 
-        with self.assertRaises(Exception) as e:
+        with self.assertRaisesRegex(
+            Exception, r"Could not get run status corresponding to string the IMPO"
+        ):
             RunStatus.from_string("the IMPOSSIBLE status string")
-        self.assertIn("Could not get run status corresponding to string the IMPO", str(e.exception))
 
     def test_is_terminated(self):
         self.assertTrue(RunStatus.is_terminated(RunStatus.FAILED))

--- a/tests/store/tracking/__init__.py
+++ b/tests/store/tracking/__init__.py
@@ -48,7 +48,9 @@ class AbstractStoreTest:
                 RunTag(MLFLOW_LOGGED_MODELS, json.dumps([m.to_dict(), m2.to_dict(), m3.to_dict()]))
             ],
         )
-        with self.assertRaises(TypeError):
+        with self.assertRaisesRegex(
+            TypeError, "Argument 'mlflow_model' should be mlflow.models.Model, got '<class 'dict'>'"
+        ):
             store.record_logged_model(run_id, m.to_dict())
 
     @staticmethod

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -135,7 +135,7 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         # Test removing root
         second_file_store = FileStore(self.test_root)
         shutil.rmtree(self.test_root)
-        with self.assertRaises(Exception):
+        with self.assertRaisesRegex(Exception, r"does not exist"):
             second_file_store._check_root_dir()
 
     def test_list_experiments(self):
@@ -176,8 +176,8 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         # test that fake experiments dont exist.
         # look for random experiment ids between 8000, 15000 since created ones are (100, 2000)
         for exp_id in set(random_int(8000, 15000) for x in range(20)):
-            with self.assertRaises(Exception):
-                fs.get_experiment(exp_id)
+            with self.assertRaisesRegex(Exception, f"Could not find experiment with ID {exp_id}"):
+                fs.get_experiment(str(exp_id))
 
     def test_get_experiment_int_experiment_id_backcompat(self):
         fs = FileStore(self.test_root)
@@ -214,9 +214,9 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         fs = FileStore(self.test_root)
 
         # Error cases
-        with self.assertRaises(Exception):
+        with self.assertRaisesRegex(Exception, "Invalid experiment name: 'None'"):
             fs.create_experiment(None)
-        with self.assertRaises(Exception):
+        with self.assertRaisesRegex(Exception, "Invalid experiment name: ''"):
             fs.create_experiment("")
 
         exp_id_ints = (int(exp_id) for exp_id in self.experiments)
@@ -296,7 +296,7 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         fs = FileStore(self.test_root)
         for exp_id in self.experiments:
             name = self.exp_data[exp_id]["name"]
-            with self.assertRaises(Exception):
+            with self.assertRaisesRegex(Exception, f"Experiment '{name}' already exists"):
                 fs.create_experiment(name)
 
     def _extract_ids(self, experiments):
@@ -332,16 +332,17 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         exp_id = self.experiments[random_int(0, len(self.experiments) - 1)]
 
         # Error cases
-        with self.assertRaises(Exception):
+        with self.assertRaisesRegex(Exception, "Invalid experiment name: 'None'"):
             fs.rename_experiment(exp_id, None)
-        with self.assertRaises(Exception):
-            # test that names of existing experiments are checked before renaming
-            other_exp_id = None
-            for exp in self.experiments:
-                if exp != exp_id:
-                    other_exp_id = exp
-                    break
-            fs.rename_experiment(exp_id, fs.get_experiment(other_exp_id).name)
+        # test that names of existing experiments are checked before renaming
+        other_exp_id = None
+        for exp in self.experiments:
+            if exp != exp_id:
+                other_exp_id = exp
+                break
+        name = fs.get_experiment(other_exp_id).name
+        with self.assertRaisesRegex(Exception, f"Experiment '{name}' already exists"):
+            fs.rename_experiment(exp_id, name)
 
         exp_name = self.exp_data[exp_id]["name"]
         new_name = exp_name + "!!!"
@@ -381,13 +382,13 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         exp_id = self.experiments[random_int(0, len(self.experiments) - 1)]
         run_id = self.exp_data[exp_id]["runs"][0]
         fs._hard_delete_run(run_id)
-        with self.assertRaises(MlflowException):
+        with self.assertRaisesRegex(MlflowException, f"Run '{run_id}' not found"):
             fs.get_run(run_id)
-        with self.assertRaises(MlflowException):
+        with self.assertRaisesRegex(MlflowException, f"Run '{run_id}' not found"):
             fs.get_all_tags(run_id)
-        with self.assertRaises(MlflowException):
+        with self.assertRaisesRegex(MlflowException, f"Run '{run_id}' not found"):
             fs.get_all_metrics(run_id)
-        with self.assertRaises(MlflowException):
+        with self.assertRaisesRegex(MlflowException, f"Run '{run_id}' not found"):
             fs.get_all_params(run_id)
 
     def test_get_deleted_runs(self):
@@ -669,9 +670,10 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         for n in [0, 1, 2, 4, 8, 10, 20, 50, 100, 500, 1000, 1200, 2000]:
             assert runs[: min(1200, n)] == self._search(fs, exp, max_results=n)
 
-        with self.assertRaises(MlflowException) as e:
+        with self.assertRaisesRegex(
+            MlflowException, "Invalid value for request parameter max_results. It "
+        ):
             self._search(fs, exp, None, max_results=int(1e10))
-        self.assertIn("Invalid value for request parameter max_results. It ", e.exception.message)
 
     def test_search_with_deterministic_max_results(self):
         fs = FileStore(self.test_root)
@@ -1013,18 +1015,16 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
             ]:
                 log_batch_kwargs = {"metrics": [], "params": [], "tags": []}
                 log_batch_kwargs.update(kwargs)
-                with self.assertRaises(MlflowException) as e:
+                with self.assertRaisesRegex(MlflowException, "Some internal error") as e:
                     fs.log_batch(run.info.run_id, **log_batch_kwargs)
-                self.assertIn(str(e.exception.message), "Some internal error")
                 assert e.exception.error_code == ErrorCode.Name(INTERNAL_ERROR)
 
     def test_log_batch_nonexistent_run(self):
         fs = FileStore(self.test_root)
         nonexistent_uuid = uuid.uuid4().hex
-        with self.assertRaises(MlflowException) as e:
+        with self.assertRaisesRegex(MlflowException, f"Run '{nonexistent_uuid}' not found") as e:
             fs.log_batch(nonexistent_uuid, [], [], [])
         assert e.exception.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
-        assert ("Run '%s' not found" % nonexistent_uuid) in e.exception.message
 
     def test_log_batch_params_idempotency(self):
         fs = FileStore(self.test_root)


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
Close #5680

## What changes are proposed in this pull request?

Fix existing `unittest-assert-raises` pylint errors.

## How is this patch tested?

Existing tests and lint check

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
