### PR TITLE
Fix `get_model_dependencies` to support models URI containing artifact path

### DIFF
--- a/mlflow/store/artifact/models_artifact_repo.py
+++ b/mlflow/store/artifact/models_artifact_repo.py
@@ -42,6 +42,20 @@ class ModelsArtifactRepository(ArtifactRepository):
         return urllib.parse.urlparse(uri).scheme == "models"
 
     @staticmethod
+    def split_models_uri(uri):
+        """
+        Split 'models:/<name>/<version>/path/to/model' into
+        ('models:/<name>/<version>', '/path/to/model').
+        """
+        path = urllib.parse.urlparse(uri).path
+        if path.count("/") >= 3 and not path.endswith("/"):
+            splits = path.split("/", 3)
+            model_name_and_version = splits[:3]
+            artifact_path = splits[-1]
+            return "models:" + "/".join(model_name_and_version), artifact_path
+        return uri, ""
+
+    @staticmethod
     def get_underlying_uri(uri):
         # Note: to support a registry URI that is different from the tracking URI here,
         # we'll need to add setting of registry URIs via environment variables.

--- a/mlflow/store/artifact/models_artifact_repo.py
+++ b/mlflow/store/artifact/models_artifact_repo.py
@@ -45,7 +45,7 @@ class ModelsArtifactRepository(ArtifactRepository):
     def split_models_uri(uri):
         """
         Split 'models:/<name>/<version>/path/to/model' into
-        ('models:/<name>/<version>', '/path/to/model').
+        ('models:/<name>/<version>', 'path/to/model').
         """
         path = urllib.parse.urlparse(uri).path
         if path.count("/") >= 3 and not path.endswith("/"):

--- a/mlflow/tracking/artifact_utils.py
+++ b/mlflow/tracking/artifact_utils.py
@@ -85,8 +85,7 @@ def _download_artifact_from_uri(artifact_uri, output_path=None):
     # For models:/ URIs, it doesn't make sense to initialize a ModelsArtifactRepository with only
     # the model name portion of the URI, then call download_artifacts with the version info.
     if ModelsArtifactRepository.is_models_uri(artifact_uri):
-        root_uri = artifact_uri
-        artifact_path = ""
+        root_uri, artifact_path = ModelsArtifactRepository.split_models_uri(artifact_uri)
     else:
         artifact_path = posixpath.basename(parsed_uri.path)
         parsed_uri = parsed_uri._replace(path=posixpath.dirname(parsed_uri.path))

--- a/tests/pyfunc/test_dependencies_functions.py
+++ b/tests/pyfunc/test_dependencies_functions.py
@@ -2,6 +2,7 @@ from unittest import mock
 import pytest
 import cloudpickle
 import sklearn
+from sklearn.linear_model import LinearRegression
 from pathlib import Path
 
 from mlflow.pyfunc import _warn_dependency_requirement_mismatches, get_model_dependencies
@@ -216,3 +217,11 @@ dependencies:
 
     with pytest.raises(MlflowException, match="No pip section found in conda.yaml file"):
         get_model_dependencies(model_path, format="pip")
+
+
+def test_get_model_dependencies_with_model_version_uri():
+    with mlflow.start_run():
+        mlflow.sklearn.log_model(LinearRegression(), "model", registered_model_name="linear")
+
+    deps = get_model_dependencies("models:/linear/1", format="pip")
+    assert f"scikit-learn=={sklearn.__version__}" in Path(deps).read_text()

--- a/tests/store/artifact/test_models_artifact_repo.py
+++ b/tests/store/artifact/test_models_artifact_repo.py
@@ -105,3 +105,15 @@ def test_models_artifact_repo_uses_repo_download_artifacts():
         models_repo.repo = Mock()
         models_repo.download_artifacts("artifact_path", "dst_path")
         models_repo.repo.download_artifacts.assert_called_once()
+
+
+def test_split_models_uri():
+    assert ModelsArtifactRepository.split_models_uri("models:/model/1") == ("models:/model/1", "")
+    assert ModelsArtifactRepository.split_models_uri("models:/model/1/path") == (
+        "models:/model/1",
+        "path",
+    )
+    assert ModelsArtifactRepository.split_models_uri("models:/model/1/path/to/artifact") == (
+        "models:/model/1",
+        "path/to/artifact",
+    )


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
Fix #5850

## What changes are proposed in this pull request?

Fix `get_model_dependencies` to support a models URI containing an artifact path.

## How is this patch tested?

Unit tests

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`get_model_dependencies` now supports loading dependencies from a models URI (e,g. `models:/model/1`).

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
