### PR TITLE
Fix two models one code name #5923

### DIFF
--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -118,13 +118,15 @@ def _validate_and_copy_code_paths(code_paths, path, default_subpath="code"):
 
 def _add_code_to_system_path(code_path):
     sys.path = [code_path] + _get_code_dirs(code_path) + sys.path
-    # delete code modules that are already in sys.modules 
+    # delete code modules that are already in sys.modules
     # so they will get reloaded anew from the correct code path
-    # othterwise python will use the alredy loaded modules 
+    # othterwise python will use the alredy loaded modules
     modules = []
     for path in [code_path] + _get_code_dirs(code_path):
         modules_py = glob.glob(join(path, "*.py"))
-        modules += [ basename(f)[:-3] for f in modules_py if isfile(f) and not f.endswith('__init__.py')]
+        modules += [
+            basename(f)[:-3] for f in modules_py if isfile(f) and not f.endswith("__init__.py")
+        ]
     for module in modules:
         if module in sys.modules:
             sys.modules.pop(module)

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -121,11 +121,9 @@ def _add_code_to_system_path(code_path):
     sys.path = [code_path] + _get_code_dirs(code_path) + sys.path
     # Delete cached modules so they will get reloaded anew from the correct code path
     # Otherwise python will use the cached modules
-    modules = []
-    for path in [code_path] + _get_code_dirs(code_path):
-        modules += [
-            p.stem for p in Path(path).rglob("*.py") if p.is_file() and p.name != "__init__.py"
-        ]
+    modules = [
+        p.stem for p in Path(code_path).rglob("*.py") if p.is_file() and p.name != "__init__.py"
+    ]
     for module in modules:
         sys.modules.pop(module, None)
 

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -119,8 +119,7 @@ def _validate_and_copy_code_paths(code_paths, path, default_subpath="code"):
 
 def _add_code_to_system_path(code_path):
     sys.path = [code_path] + _get_code_dirs(code_path) + sys.path
-    # Delete modules cached in sys.modules
-    # so they will get reloaded anew from the correct code path
+    # Delete cached modules so they will get reloaded anew from the correct code path
     # Otherwise python will use the cached modules
     modules = []
     for path in [code_path] + _get_code_dirs(code_path):

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -1,6 +1,6 @@
 import os
 import sys
-import glob
+from pathlib import Path
 
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model
@@ -119,14 +119,13 @@ def _validate_and_copy_code_paths(code_paths, path, default_subpath="code"):
 
 def _add_code_to_system_path(code_path):
     sys.path = [code_path] + _get_code_dirs(code_path) + sys.path
-    # delete code modules that are already in sys.modules
+    # Delete modules cached in sys.modules
     # so they will get reloaded anew from the correct code path
-    # othterwise python will use the alredy loaded modules
+    # Otherwise python will use the cached modules
     modules = []
     for path in [code_path] + _get_code_dirs(code_path):
-        modules_py = glob.glob(os.path.join(path, "*.py"))
         modules += [
-            os.path.basename(f)[:-3] for f in modules_py if os.path.isfile(f) and not f.endswith("__init__.py")
+            p.stem for p in Path(path).rglob("*.py") if p.is_file() and p.name != "__init__.py"
         ]
     for module in modules:
         sys.modules.pop(module, None)

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -118,6 +118,16 @@ def _validate_and_copy_code_paths(code_paths, path, default_subpath="code"):
 
 def _add_code_to_system_path(code_path):
     sys.path = [code_path] + _get_code_dirs(code_path) + sys.path
+    # delete code modules that are already in sys.modules 
+    # so they will get reloaded anew from the correct code path
+    # othterwise python will use the alredy loaded modules 
+    modules = []
+    for path in [code_path] + _get_code_dirs(code_path):
+        modules_py = glob.glob(join(path, "*.py"))
+        modules += [ basename(f)[:-3] for f in modules_py if isfile(f) and not f.endswith('__init__.py')]
+    for module in modules:
+        if module in sys.modules:
+            sys.modules.pop(module)
 
 
 def _validate_and_prepare_target_save_path(path):

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -1,5 +1,7 @@
 import os
 import sys
+import glob
+from os.path import join, basename, isfile
 
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import glob
-from os.path import join, basename, isfile
 
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model
@@ -125,13 +124,12 @@ def _add_code_to_system_path(code_path):
     # othterwise python will use the alredy loaded modules
     modules = []
     for path in [code_path] + _get_code_dirs(code_path):
-        modules_py = glob.glob(join(path, "*.py"))
+        modules_py = glob.glob(os.path.join(path, "*.py"))
         modules += [
-            basename(f)[:-3] for f in modules_py if isfile(f) and not f.endswith("__init__.py")
+            os.path.basename(f)[:-3] for f in modules_py if os.path.isfile(f) and not f.endswith("__init__.py")
         ]
     for module in modules:
-        if module in sys.modules:
-            sys.modules.pop(module)
+        sys.modules.pop(module, None)
 
 
 def _validate_and_prepare_target_save_path(path):

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -1069,3 +1069,53 @@ def test_save_and_load_model_with_special_chars(
         loaded_pyfunc_model.predict(iris_data[0]),
         test_predict(sk_model=sklearn_knn_model, model_input=iris_data[0]),
     )
+
+
+class CustomModel(mlflow.pyfunc.PythonModel):
+    def __init__(self):
+        pass
+
+    def predict(self, context, model_input):
+        import custom_module
+
+        return custom_module.predict()
+
+
+def test_custom_code_does_not_use_cached_module(tmp_path):
+    dir1 = tmp_path.joinpath("1")
+    dir2 = tmp_path.joinpath("2")
+    dir1.mkdir()
+    dir2.mkdir()
+    mod1 = dir1.joinpath("custom_module.py")
+    mod2 = dir2.joinpath("custom_module.py")
+    mod1.write_text(
+        """
+def predict():
+    return 1
+"""
+    )
+    mod2.write_text(
+        """
+def predict():
+    return 2
+"""
+    )
+
+    custom_model = CustomModel()
+    with mlflow.start_run():
+        model_info1 = mlflow.pyfunc.log_model(
+            artifact_path="model1",
+            python_model=custom_model,
+            code_path=[str(mod1)],
+        )
+        model_info2 = mlflow.pyfunc.log_model(
+            artifact_path="model2",
+            python_model=custom_model,
+            code_path=[str(mod2)],
+        )
+
+    model_input = pd.DataFrame([[1, 2, 3]])
+    loaded_model1 = mlflow.pyfunc.load_model(model_info1.model_uri)
+    assert loaded_model1.predict(model_input) == 1
+    loaded_model2 = mlflow.pyfunc.load_model(model_info2.model_uri)
+    assert loaded_model2.predict(model_input) == 2

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -1081,7 +1081,7 @@ class CustomModel(mlflow.pyfunc.PythonModel):
         return custom_module.predict()
 
 
-def test_custom_code_does_not_use_cached_module(tmp_path):
+def test_model_with_code_path_does_not_use_cached_module(tmp_path):
     dir1 = tmp_path.joinpath("1")
     dir2 = tmp_path.joinpath("2")
     dir1.mkdir()


### PR DESCRIPTION
Signed-off-by: Anas BELFADIL <56280198+BFAnas@users.noreply.github.com>

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
Close #5923

## What changes are proposed in this pull request?

Prevent a model with `code_path` from using cached modules.

## How is this patch tested?

Unit test

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
