### PR TITLE
Increase repl timeout for Java test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,7 @@ venv.bak/
 *.idea
 *.vscode
 *.iml
+*.devcontainer
 *~
 
 # mkdocs documentation

--- a/.gitignore
+++ b/.gitignore
@@ -80,7 +80,6 @@ venv.bak/
 *.idea
 *.vscode
 *.iml
-*.devcontainer
 *~
 
 # mkdocs documentation

--- a/mlflow/java/spark/pom.xml
+++ b/mlflow/java/spark/pom.xml
@@ -51,8 +51,8 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.9.5</version>
+      <artifactId>mockito-scala</artifactId>
+      <version>1.17.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/mlflow/java/spark/pom.xml
+++ b/mlflow/java/spark/pom.xml
@@ -51,8 +51,8 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-scala-scalatest_${scala.compat.version}</artifactId>
-      <version>1.17.5</version>
+      <artifactId>mockito-all</artifactId>
+      <version>1.10.19</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/mlflow/java/spark/pom.xml
+++ b/mlflow/java/spark/pom.xml
@@ -51,7 +51,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-scala</artifactId>
+      <artifactId>mockito-scala-scalatest_${scala.compat.version}</artifactId>
       <version>1.17.5</version>
       <scope>test</scope>
     </dependency>

--- a/mlflow/java/spark/src/test/scala/org/mlflow/spark/autologging/SparkAutologgingIntegrationSuite.scala
+++ b/mlflow/java/spark/src/test/scala/org/mlflow/spark/autologging/SparkAutologgingIntegrationSuite.scala
@@ -182,8 +182,8 @@ class SparkAutologgingSuite extends FunSuite with Matchers with BeforeAndAfterAl
     val subscriber = spy(new MockSubscriber())
     MlflowAutologEventPublisher.register(subscriber)
     leftDf.join(rightDf).collect()
-    // Sleep a second to let the SparkListener trigger read
-    Thread.sleep(1000)
+    // Sleep a few seconds to let the SparkListener trigger read
+    Thread.sleep(4000)
     verify(subscriber, times(2)).notify(any(), any(), any())
     verify(subscriber, times(1)).notify(getFileUri(leftPath), "unknown", leftFormat)
     verify(subscriber, times(1)).notify(getFileUri(rightPath), "unknown", rightFormat)
@@ -210,7 +210,7 @@ class SparkAutologgingSuite extends FunSuite with Matchers with BeforeAndAfterAl
     // Register subscribers & collect the DF to trigger a datasource read event
     subscriberSeq.foreach(MockPublisher.register)
     df.collect()
-    Thread.sleep(1000)
+    Thread.sleep(4000)
     verify(subscriber, times(1)).notify(any(), any(), any())
     verify(subscriber, times(1)).notify(
       getFileUri(path), "unknown", format)

--- a/mlflow/java/spark/src/test/scala/org/mlflow/spark/autologging/SparkAutologgingIntegrationSuite.scala
+++ b/mlflow/java/spark/src/test/scala/org/mlflow/spark/autologging/SparkAutologgingIntegrationSuite.scala
@@ -182,9 +182,9 @@ class SparkAutologgingSuite extends FunSuite with Matchers with BeforeAndAfterAl
     val subscriber = spy(new MockSubscriber())
     MlflowAutologEventPublisher.register(subscriber)
     leftDf.join(rightDf).collect()
-    // Sleep a few seconds to let the SparkListener trigger read
-    Thread.sleep(4000)
-    verify(subscriber, times(2)).notify(any(), any(), any())
+    // Sleep to let the SparkListener trigger read
+    Thread.sleep(1000)
+    verify(subscriber, atLeast(1)).notify(any(), any(), any())
     verify(subscriber, times(1)).notify(getFileUri(leftPath), "unknown", leftFormat)
     verify(subscriber, times(1)).notify(getFileUri(rightPath), "unknown", rightFormat)
   }
@@ -210,7 +210,7 @@ class SparkAutologgingSuite extends FunSuite with Matchers with BeforeAndAfterAl
     // Register subscribers & collect the DF to trigger a datasource read event
     subscriberSeq.foreach(MockPublisher.register)
     df.collect()
-    Thread.sleep(4000)
+    Thread.sleep(1000)
     verify(subscriber, times(1)).notify(any(), any(), any())
     verify(subscriber, times(1)).notify(
       getFileUri(path), "unknown", format)

--- a/mlflow/java/spark/src/test/scala/org/mlflow/spark/autologging/SparkAutologgingIntegrationSuite.scala
+++ b/mlflow/java/spark/src/test/scala/org/mlflow/spark/autologging/SparkAutologgingIntegrationSuite.scala
@@ -356,6 +356,9 @@ class SparkAutologgingSuite extends FunSuite with Matchers with BeforeAndAfterAl
     val df4 = df1.union(df2).union(df3)
     df4.collect()
 
+    // Sleep to give time for the execution to complete
+    Thread.sleep(1000)
+    
     // Verify that the only time subscriber1 was notified of a datasource read was when
     // `path2` was read via `df2` with `spark.databricks.replId` set to `subscriber1.replId`
     verify(subscriber1, times(1)).notify(any(), any(), any())

--- a/mlflow/java/spark/src/test/scala/org/mlflow/spark/autologging/SparkAutologgingIntegrationSuite.scala
+++ b/mlflow/java/spark/src/test/scala/org/mlflow/spark/autologging/SparkAutologgingIntegrationSuite.scala
@@ -184,7 +184,7 @@ class SparkAutologgingSuite extends FunSuite with Matchers with BeforeAndAfterAl
     leftDf.join(rightDf).collect()
     // Sleep to let the SparkListener trigger read
     Thread.sleep(1000)
-    verify(subscriber, atLeast(1)).notify(any(), any(), any())
+    verify(subscriber, times(2)).notify(any(), any(), any())
     verify(subscriber, times(1)).notify(getFileUri(leftPath), "unknown", leftFormat)
     verify(subscriber, times(1)).notify(getFileUri(rightPath), "unknown", rightFormat)
   }


### PR DESCRIPTION
Signed-off-by: Ben Wilson <benjamin.wilson@databricks.com>

## Related Issues/PRs

For flaky java test

## What changes are proposed in this pull request?

Increase lazy eval thread sleep for repl id's to ensure context is not stopped before validation occurs

## How is this patch tested?

adjusting existing tests

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [x] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
