### PR TITLE
Rename env_manager `local` to `None`

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -1665,7 +1665,7 @@ The ``mlflow models`` CLI commands provide an optional ``--env-manager`` argumen
     mlflow models serve ... --env-manager=conda
     # Use virtualenv
     mlflow models predict ... --env-manager=virtualenv
-    # Use local environment
+    # Use the current system environment
     mlflow models predict ... --env-manager=None
 
 .. _azureml_deployment:

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -1665,7 +1665,7 @@ The ``mlflow models`` CLI commands provide an optional ``--env-manager`` argumen
     mlflow models serve ... --env-manager=conda
     # Use virtualenv
     mlflow models predict ... --env-manager=virtualenv
-    # Use the current system environment
+    # Use the current Python environment
     mlflow models predict ... --env-manager=None
 
 .. _azureml_deployment:

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -1665,6 +1665,8 @@ The ``mlflow models`` CLI commands provide an optional ``--env-manager`` argumen
     mlflow models serve ... --env-manager=conda
     # Use virtualenv
     mlflow models predict ... --env-manager=virtualenv
+    # Use local environment
+    mlflow models predict ... --env-manager=None
 
 .. _azureml_deployment:
 

--- a/docs/source/projects.rst
+++ b/docs/source/projects.rst
@@ -402,7 +402,7 @@ Environment
     By default, MLflow Projects are run in the environment specified by the project directory
     or the ``MLproject`` file (see :ref:`Specifying Project Environments <project-environments>`).
     You can ignore a project's specified environment and run the project in the current
-    system environment by supplying the ``--env-manager=local`` flag, but this can lead to
+    system environment by supplying the ``--env-manager=None`` flag, but this can lead to
     unexpected results if there are dependency mismatches between the project environment and
     the current system environment.
 

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -258,7 +258,7 @@ def run(
                         are supported:
 
                         - local: Deprecated. Use 'None' instead.
-                        - None: use the local environment
+                        - None: Use the current Python environment.
                         - conda: use conda
                         - virtualenv: use virtualenv (and pyenv for Python version management)
 

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -255,9 +255,10 @@ def run(
                      If ``None``, the MLflow Run name is left unset.
     :param env_manager: Specify an environment manager to create a new environment for the run and
                         install project dependencies within that environment. The following values
-                        are suppported:
+                        are supported:
 
-                        - local: use the local environment
+                        - local: Deprecated. Use 'None' instead.
+                        - None: use the local environment
                         - conda: use conda
                         - virtualenv: use virtualenv (and pyenv for Python version management)
 
@@ -315,9 +316,9 @@ def run(
             FutureWarning,
             stacklevel=2,
         )
-        env_manager = _EnvManager.CONDA if use_conda else _EnvManager.LOCAL
+        env_manager = _EnvManager.CONDA if use_conda else _EnvManager.NONE
     elif env_manager is not None:
-        _EnvManager.validate(env_manager)
+        env_manager = _EnvManager.resolve(env_manager)
 
     if backend == "databricks":
         mlflow.projects.databricks.before_run_validations(mlflow.get_tracking_uri(), backend_config)

--- a/mlflow/projects/backend/local.py
+++ b/mlflow/projects/backend/local.py
@@ -54,7 +54,7 @@ def _env_type_to_env_manager(env_typ):
     elif env_typ == env_type.PYTHON:
         return _EnvManager.VIRTUALENV
     elif env_typ == env_type.DOCKER:
-        return _EnvManager.LOCAL
+        return _EnvManager.NONE
 
 
 class LocalBackend(AbstractBackend):

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -976,11 +976,11 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
                         unaffected. Default value is ``local``, and the following values are
                         supported:
 
-                         - ``conda``: (Recommended) Use Conda to restore the software environment
+                        - ``conda``: (Recommended) Use Conda to restore the software environment
                            that was used to train the model.
-                         - ``virtualenv``: Use virtualenv to restore the python environment that
+                        - ``virtualenv``: Use virtualenv to restore the python environment that
                            was used to train the model.
-                        - ``local``: DEPRECATED. Use ``None`` instead.
+                        - ``local``: Deprecated. Use ``None`` instead.
                         - ``None``: Use the current Python environment for model inference, which
                            may differ from the environment used to train the model and may lead to
                            errors or invalid predictions.

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -76,7 +76,7 @@ class PyFuncBackend(FlavorBackend):
                 env_root_dir=self._env_root_dir,
                 capture_output=capture_output,
             )
-        elif self._env_manager == _EnvManager.LOCAL or ENV not in self._config:
+        elif self._env_manager == _EnvManager.NONE or ENV not in self._config:
             return 0
 
         conda_env_path = os.path.join(local_path, self._config[ENV])
@@ -268,7 +268,7 @@ class PyFuncBackend(FlavorBackend):
             return child_proc
 
     def can_score_model(self):
-        if self._env_manager == _EnvManager.LOCAL:
+        if self._env_manager == _EnvManager.NONE:
             # noconda => already in python and dependencies are assumed to be installed.
             return True
         conda_path = get_conda_bin_executable("conda")

--- a/mlflow/utils/cli_args.py
+++ b/mlflow/utils/cli_args.py
@@ -74,11 +74,11 @@ def _resolve_env_manager(ctx, _, env_manager):
             FutureWarning,
             stacklevel=2,
         )
-        return _EnvManager.LOCAL
+        return _EnvManager.NONE
 
     # Only `--env-manager` is specified
     if env_manager is not None:
-        _EnvManager.validate(env_manager)
+        env_manager = _EnvManager.resolve(env_manager)
         if env_manager == _EnvManager.VIRTUALENV:
             warnings.warn(
                 (

--- a/mlflow/utils/env_manager.py
+++ b/mlflow/utils/env_manager.py
@@ -22,7 +22,7 @@ def resolve(env_manager):
                 "'local' option for `env_manager` is deprecated and will be removed in a future "
                 "release. Use 'None' instead."
             ),
-            UserWarning,
+            FutureWarning,
             stacklevel=2,
         )
         return NONE

--- a/mlflow/utils/env_manager.py
+++ b/mlflow/utils/env_manager.py
@@ -1,11 +1,29 @@
+import warnings
+
 LOCAL = "local"
+NONE = "None"
 CONDA = "conda"
 VIRTUALENV = "virtualenv"
 
 
 def validate(env_manager):
-    allowed_values = [LOCAL, CONDA, VIRTUALENV]
+    allowed_values = [LOCAL, NONE, CONDA, VIRTUALENV]
     if env_manager not in allowed_values:
         raise ValueError(
             f"Invalid value for `env_manager`: {env_manager}. Must be one of {allowed_values}"
         )
+
+
+def resolve(env_manager):
+    validate(env_manager)
+    if env_manager == LOCAL:
+        warnings.warn(
+            (
+                "'local' option for `env_manager` is deprecated and will be removed in a future "
+                "release. Use 'None' instead."
+            ),
+            UserWarning,
+            stacklevel=2,
+        )
+        return NONE
+    return env_manager

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -157,7 +157,7 @@ def pyfunc_serve_and_score_model(
     :param activity_polling_timeout_seconds: The amount of time, in seconds, to wait before
                                              declaring the scoring process to have failed.
     :param extra_args: A list of extra arguments to pass to the pyfunc scoring server command. For
-                       example, passing ``extra_args=["--env-manager", "local"]`` will pass the
+                       example, passing ``extra_args=["--env-manager", "None"]`` will pass the
                        ``--env-manager local`` flag to the scoring server to ensure that conda
                        environment activation is skipped.
     """

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -50,7 +50,7 @@ from mlflow.pyfunc.scoring_server import (
 )
 
 # NB: for now, windows tests do not have conda available.
-no_conda = ["--env-manager", "local"] if sys.platform == "win32" else []
+no_conda = ["--env-manager", "None"] if sys.platform == "win32" else []
 
 # NB: need to install mlflow since the pip version does not have mlflow models cli.
 install_mlflow = ["--install-mlflow"] if not no_conda else []
@@ -236,7 +236,7 @@ def test_predict(iris_data, sk_model):
                 "-o",
                 output_json_path,
                 "--env-manager",
-                "local",
+                "None",
             ],
             stderr=subprocess.PIPE,
             env=env_with_tracking_uri,
@@ -376,7 +376,7 @@ def test_prepare_env_passes(sk_model):
 
         # Test with no conda
         p = subprocess.Popen(
-            ["mlflow", "models", "prepare-env", "-m", model_uri, "--env-manager", "local"],
+            ["mlflow", "models", "prepare-env", "-m", model_uri, "--env-manager", "None"],
             stderr=subprocess.PIPE,
         )
         assert p.wait() == 0
@@ -407,7 +407,7 @@ def test_prepare_env_fails(sk_model):
 
         # Test with no conda
         p = subprocess.Popen(
-            ["mlflow", "models", "prepare-env", "-m", model_uri, "--env-manager", "local"]
+            ["mlflow", "models", "prepare-env", "-m", model_uri, "--env-manager", "None"]
         )
         assert p.wait() == 0
 
@@ -535,7 +535,7 @@ def test_env_manager_local_deprecation_warning(mock_flavor_backend):
     with pytest.warns(FutureWarning, match=r"'local' option for `env_manager` is deprecated"):
         CliRunner().invoke(
             models_cli.serve,
-            ["--model-uri", "model", "--env-manager", "local"],
+            ["--model-uri", "model", "--env-manager", "None"],
             catch_exceptions=False,
         )
     mock_flavor_backend.assert_called_once()

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -531,11 +531,11 @@ def test_env_manager_deprecation_warning_is_raised_when_no_conda_is_specified(mo
 
 
 @patch_get_flavor_backend
-def test_env_manager_local_deprecation_warning(mock_flavor_backend):
+def test_env_manager_deprecation_warning_for_local(mock_flavor_backend):
     with pytest.warns(FutureWarning, match=r"'local' option for `env_manager` is deprecated"):
         CliRunner().invoke(
             models_cli.serve,
-            ["--model-uri", "model", "--env-manager", "None"],
+            ["--model-uri", "model", "--env-manager", "local"],
             catch_exceptions=False,
         )
     mock_flavor_backend.assert_called_once()

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -530,6 +530,17 @@ def test_env_manager_deprecation_warning_is_raised_when_no_conda_is_specified(mo
     mock_flavor_backend.assert_called_once()
 
 
+@patch_get_flavor_backend
+def test_env_manager_local_deprecation_warning(mock_flavor_backend):
+    with pytest.warns(FutureWarning, match=r"'local' option for `env_manager` is deprecated"):
+        CliRunner().invoke(
+            models_cli.serve,
+            ["--model-uri", "model", "--env-manager", "local"],
+            catch_exceptions=False,
+        )
+    mock_flavor_backend.assert_called_once()
+
+
 def test_env_manager_specifying_both_no_conda_and_env_manager_is_not_allowed():
     res = CliRunner().invoke(
         models_cli.serve,

--- a/tests/projects/test_virtualenv_projects.py
+++ b/tests/projects/test_virtualenv_projects.py
@@ -35,7 +35,7 @@ def test_virtualenv_project_execution_without_env_manager(create_virtualenv_spy)
 @spy_on_create_virtualenv
 def test_virtualenv_project_execution_local(create_virtualenv_spy):
     submitted_run = mlflow.projects.run(
-        TEST_VIRTUALENV_PROJECT_DIR, entry_point="main", env_manager="local"
+        TEST_VIRTUALENV_PROJECT_DIR, entry_point="main", env_manager="None"
     )
     submitted_run.wait()
     create_virtualenv_spy.assert_not_called()

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -379,7 +379,7 @@ def test_pyfunc_model_serving_without_conda_env_activation_succeeds_with_main_sc
         model_uri=pyfunc_model_path,
         data=sample_input,
         content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
-        extra_args=["--env-manager", "local"],
+        extra_args=["--env-manager", "None"],
     )
     assert scoring_response.status_code == 200
     np.testing.assert_array_equal(
@@ -441,7 +441,7 @@ def test_pyfunc_model_serving_without_conda_env_activation_succeeds_with_module_
         model_uri=pyfunc_model_path,
         data=sample_input,
         content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
-        extra_args=["--env-manager", "local"],
+        extra_args=["--env-manager", "None"],
     )
     assert scoring_response.status_code == 200
     np.testing.assert_array_equal(
@@ -485,7 +485,7 @@ def test_pyfunc_cli_predict_command_without_conda_env_activation_succeeds(
             "-o",
             output_json_path,
             "--env-manager",
-            "local",
+            "None",
         ],
         stdout=PIPE,
         stderr=PIPE,

--- a/tests/pyfunc/test_scoring_server.py
+++ b/tests/pyfunc/test_scoring_server.py
@@ -545,7 +545,7 @@ def test_serving_model_with_schema(pandas_df_with_all_types):
             model_uri="runs:/{}/model".format(run.info.run_id),
             data=json.dumps(df.to_dict(orient="split"), cls=NumpyEncoder),
             content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
-            extra_args=["--env-manager", "local"],
+            extra_args=["--env-manager", "None"],
         )
         response_json = json.loads(response.content)
 
@@ -556,7 +556,7 @@ def test_serving_model_with_schema(pandas_df_with_all_types):
             model_uri="runs:/{}/model".format(run.info.run_id),
             data=json.dumps(pandas_df_with_all_types.to_dict(orient="records"), cls=NumpyEncoder),
             content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_RECORDS_ORIENTED,
-            extra_args=["--env-manager", "local"],
+            extra_args=["--env-manager", "None"],
         )
         response_json = json.loads(response.content)
         assert response_json == [[k, str(v)] for k, v in expected_types.items()]


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Rename env_manager `local` to `None`.

## How is this patch tested?

- Unit tests
- Manual test:

```
# None
> mlflow models serve -m runs:/a43e6d2090fb4cd082ea480a02574429/model --env-manager None
2022/05/26 23:41:35 INFO mlflow.models.cli: Selected backend for flavor 'python_function'
2022/05/26 23:41:35 INFO mlflow.pyfunc.backend: === Running command 'exec gunicorn --timeout=60 -b 127.0.0.1:5000 -w 1 ${GUNICORN_CMD_ARGS} -- mlflow.pyfunc.scoring_server.wsgi:app'
[2022-05-26 23:41:35 +0900] [438356] [INFO] Starting gunicorn 20.1.0
[2022-05-26 23:41:35 +0900] [438356] [INFO] Listening at: http://127.0.0.1:5000 (438356)
[2022-05-26 23:41:35 +0900] [438356] [INFO] Using worker: sync
[2022-05-26 23:41:35 +0900] [438359] [INFO] Booting worker with pid: 438359
^C[2022-05-26 23:41:49 +0900] [438356] [INFO] Handling signal: int
[2022-05-26 23:41:49 +0900] [438359] [INFO] Worker exiting (pid: 438359)

Aborted!

# local
[2022-05-26 23:41:49 +0900] [438356] [INFO] Shutting down: Master
> mlflow models serve -m runs:/a43e6d2090fb4cd082ea480a02574429/model --env-manager local
/home/haru/Desktop/repositories/mlflow/mlflow/utils/cli_args.py:81: FutureWarning: 'local' option for `env_manager` is deprecated and will be removed in a future release. Use 'None' instead.
  env_manager = _EnvManager.resolve(env_manager)
2022/05/26 23:41:53 INFO mlflow.models.cli: Selected backend for flavor 'python_function'
2022/05/26 23:41:53 INFO mlflow.pyfunc.backend: === Running command 'exec gunicorn --timeout=60 -b 127.0.0.1:5000 -w 1 ${GUNICORN_CMD_ARGS} -- mlflow.pyfunc.scoring_server.wsgi:app'
[2022-05-26 23:41:53 +0900] [438472] [INFO] Starting gunicorn 20.1.0
[2022-05-26 23:41:53 +0900] [438472] [INFO] Listening at: http://127.0.0.1:5000 (438472)
[2022-05-26 23:41:53 +0900] [438472] [INFO] Using worker: sync
[2022-05-26 23:41:53 +0900] [438484] [INFO] Booting worker with pid: 438484
```

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`local` option for `env_manager` is deprecated and will be removed in a future release. Use `None` instead.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
