### PR TITLE
Disable autologging during `mlflow.evaluate`

### DIFF
--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -869,7 +869,10 @@ class DefaultEvaluator(ModelEvaluator):
         return self._log_and_return_evaluation_result()
 
     def _evaluate_regressor(self):
-        self.y_pred = self.model.predict(self.X)
+        from mlflow.sklearn import _AUTOLOGGING_METRICS_MANAGER
+
+        with _AUTOLOGGING_METRICS_MANAGER.disable_log_post_training_metrics():
+            self.y_pred = self.model.predict(self.X)
         self.metrics.update(_get_regressor_metrics(self.y, self.y_pred))
         self._evaluate_sklearn_model_score_if_scorable()
 

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -884,7 +884,6 @@ class DefaultEvaluator(ModelEvaluator):
         **kwargs,
     ):
         import matplotlib
-        from mlflow.sklearn import _AUTOLOGGING_METRICS_MANAGER
 
         with TempDir() as temp_dir, matplotlib.rc_context(_matplotlib_config):
             self.client = mlflow.tracking.MlflowClient()
@@ -924,7 +923,7 @@ class DefaultEvaluator(ModelEvaluator):
                     f"verify that you set the `model_type` and `dataset` arguments correctly."
                 )
 
-            with _AUTOLOGGING_METRICS_MANAGER.disable_log_post_training_metrics():
+            with mlflow.utils.autologging_utils.disable_autologging():
                 if model_type == "classifier":
                     return self._evaluate_classifier()
                 elif model_type == "regressor":

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -784,11 +784,13 @@ class DefaultEvaluator(ModelEvaluator):
 
     def _evaluate_classifier(self):
         from mlflow.models.evaluation.lift_curve import plot_lift_curve
+        from mlflow.sklearn import _AUTOLOGGING_METRICS_MANAGER
 
         self.label_list = np.unique(self.y)
         self.num_classes = len(self.label_list)
 
-        self.y_pred = self.predict_fn(self.X)
+        with _AUTOLOGGING_METRICS_MANAGER.disable_log_post_training_metrics():
+            self.y_pred = self.predict_fn(self.X)
         self.is_binomial = self.num_classes <= 2
 
         if self.is_binomial:
@@ -809,7 +811,8 @@ class DefaultEvaluator(ModelEvaluator):
             )
 
         if self.predict_proba_fn is not None:
-            self.y_probs = self.predict_proba_fn(self.X)
+            with _AUTOLOGGING_METRICS_MANAGER.disable_log_post_training_metrics():
+                self.y_probs = self.predict_proba_fn(self.X)
             if self.is_binomial:
                 self.y_prob = self.y_probs[:, 1]
             else:

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -29,7 +29,7 @@ from mlflow.models.evaluation.default_evaluator import (
     _CustomMetric,
 )
 import mlflow
-from sklearn.linear_model import LogisticRegression
+from sklearn.linear_model import LogisticRegression, LinearRegression
 from sklearn.datasets import load_iris
 
 from tempfile import TemporaryDirectory
@@ -952,7 +952,7 @@ def test_evaluate_sklearn_model_score_skip_when_not_scorable(
         assert "score" not in result.metrics
 
 
-def test_post_training_metrics_autologging_is_disabled_in_evaluate():
+def test_post_training_metrics_autologging_is_disabled_in_evaluate_classifier():
     mlflow.sklearn.autolog()
     try:
         X, y = load_iris(as_frame=True, return_X_y=True)
@@ -963,6 +963,37 @@ def test_post_training_metrics_autologging_is_disabled_in_evaluate():
                 model_info.model_uri,
                 X.assign(target=y),
                 model_type="classifier",
+                targets="target",
+                dataset_name="iris",
+                evaluators="default",
+            )
+
+        run_data = get_run_data(run.info.run_id)
+        duplicate_metrics = []
+        for evaluate_metric_key in result.metrics.keys():
+            matched_keys = [k for k in run_data.metrics.keys() if k.startswith(evaluate_metric_key)]
+            if len(matched_keys) > 1:
+                duplicate_metrics += matched_keys
+        assert duplicate_metrics == []
+    finally:
+        mlflow.sklearn.autolog(disable=True)
+
+
+@pytest.mark.parametrize(
+    "model",
+    [LogisticRegression(), LinearRegression()],
+)
+def test_post_training_metrics_autologging_is_disabled_in_evaluate(model):
+    mlflow.sklearn.autolog()
+    try:
+        X, y = load_iris(as_frame=True, return_X_y=True)
+        with mlflow.start_run() as run:
+            model.fit(X, y)
+            model_info = mlflow.sklearn.log_model(model, "model")
+            result = evaluate(
+                model_info.model_uri,
+                X.assign(target=y),
+                model_type="classifier" if isinstance(model, LogisticRegression) else "regressor",
                 targets="target",
                 dataset_name="iris",
                 evaluators="default",

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -956,7 +956,7 @@ def test_evaluate_sklearn_model_score_skip_when_not_scorable(
     "model",
     [LogisticRegression(), LinearRegression()],
 )
-def test_autologging_is_disable_during_evaluate(model):
+def test_autologging_is_disabled_during_evaluate(model):
     mlflow.sklearn.autolog()
     try:
         X, y = load_iris(as_frame=True, return_X_y=True)

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -952,33 +952,6 @@ def test_evaluate_sklearn_model_score_skip_when_not_scorable(
         assert "score" not in result.metrics
 
 
-def test_post_training_metrics_autologging_is_disabled_in_evaluate_classifier():
-    mlflow.sklearn.autolog()
-    try:
-        X, y = load_iris(as_frame=True, return_X_y=True)
-        with mlflow.start_run() as run:
-            clf = LogisticRegression(max_iter=2).fit(X, y)
-            model_info = mlflow.sklearn.log_model(clf, "model")
-            result = evaluate(
-                model_info.model_uri,
-                X.assign(target=y),
-                model_type="classifier",
-                targets="target",
-                dataset_name="iris",
-                evaluators="default",
-            )
-
-        run_data = get_run_data(run.info.run_id)
-        duplicate_metrics = []
-        for evaluate_metric_key in result.metrics.keys():
-            matched_keys = [k for k in run_data.metrics.keys() if k.startswith(evaluate_metric_key)]
-            if len(matched_keys) > 1:
-                duplicate_metrics += matched_keys
-        assert duplicate_metrics == []
-    finally:
-        mlflow.sklearn.autolog(disable=True)
-
-
 @pytest.mark.parametrize(
     "model",
     [LogisticRegression(), LinearRegression()],

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -956,7 +956,7 @@ def test_evaluate_sklearn_model_score_skip_when_not_scorable(
     "model",
     [LogisticRegression(), LinearRegression()],
 )
-def test_post_training_metrics_autologging_is_disabled_in_evaluate(model):
+def test_autologging_is_disable_during_evaluate(model):
     mlflow.sklearn.autolog()
     try:
         X, y = load_iris(as_frame=True, return_X_y=True)


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Disable post training metrics logging in `mlflow.evaluate`.

## How is this patch tested?

Unit tests

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix a bug where `mlflow.evaluate` logs the same metric twice with different names when autologging is enabled.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
