### PR TITLE
Test compatibility with protobuf 3.12.x

### DIFF
--- a/dev/install-common-deps.sh
+++ b/dev/install-common-deps.sh
@@ -21,9 +21,9 @@ pip install --upgrade pip wheel
 pip --version
 
 if [[ "$MLFLOW_SKINNY" == "true" ]]; then
-  pip install . --upgrade
+  pip install . --upgrade --use-deprecated=legacy-resolver
 else
-  pip install .[extras] --upgrade
+  pip install .[extras] --upgrade --use-deprecated=legacy-resolver
 fi
 export MLFLOW_HOME=$(pwd)
 
@@ -40,7 +40,7 @@ if [[ "$INSTALL_ML_DEPENDENCIES" == "true" ]]; then
     tmp_dir=$(mktemp -d)
     pip download --no-deps --dest $tmp_dir --no-cache-dir prophet
     tar -zxvf $tmp_dir/*.tar.gz -C $tmp_dir
-    pip install -r $(find $tmp_dir -name requirements.txt)
+    pip install -r $(find $tmp_dir -name requirements.txt) --use-deprecated=legacy-resolver
     rm -rf $tmp_dir
   fi
 
@@ -48,11 +48,11 @@ if [[ "$INSTALL_ML_DEPENDENCIES" == "true" ]]; then
 fi
 
 if [[ ! -z $req_files ]]; then
-  retry-with-backoff pip install $req_files
+  retry-with-backoff pip install $req_files --use-deprecated=legacy-resolver
 fi
 
 # Install `mlflow-test-plugin` without dependencies
-pip install --no-dependencies tests/resources/mlflow-test-plugin
+pip install --no-dependencies tests/resources/mlflow-test-plugin --use-deprecated=legacy-resolver
 
 # Print current environment info
 python dev/show_package_release_dates.py

--- a/requirements/extra-ml-requirements.txt
+++ b/requirements/extra-ml-requirements.txt
@@ -36,8 +36,6 @@ onnxruntime
 tf2onnx
 # Required by mlflow.spark
 pyspark
-# Required by mlflow.shap
-shap
 # Required by mlflow.paddle
 paddlepaddle
 # Required by mlflow.prophet

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ SKINNY_REQUIREMENTS = [
     "entrypoints",
     "gitpython>=2.1.0",
     "pyyaml>=5.1",
-    "protobuf>=3.7.0",
+    "protobuf==3.11.2",
     "pytz",
     "requests>=2.17.3",
     "packaging",

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ SKINNY_REQUIREMENTS = [
     "entrypoints",
     "gitpython>=2.1.0",
     "pyyaml>=5.1",
-    "protobuf==3.12.0",
+    "protobuf~=3.12.0",
     "pytz",
     "requests>=2.17.3",
     "packaging",

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ SKINNY_REQUIREMENTS = [
     "entrypoints",
     "gitpython>=2.1.0",
     "pyyaml>=5.1",
-    "protobuf==3.11.2",
+    "protobuf==3.12.0",
     "pytz",
     "requests>=2.17.3",
     "packaging",


### PR DESCRIPTION
Signed-off-by: dbczumar <corey.zumar@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

(Details)

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
