### PR TITLE
Pin `protobuf` in cross-version test

### DIFF
--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -36,8 +36,8 @@ pytest dev/set_matrix.py --doctest-modules
 import sys
 import argparse
 from packaging.version import Version
+from packaging.specifiers import SpecifierSet
 import json
-import operator
 import os
 import re
 import shutil
@@ -48,6 +48,8 @@ import yaml
 
 VERSIONS_YAML_PATH = "mlflow/ml-package-versions.yml"
 DEV_VERSION = "dev"
+# Treat "dev" as "newer than any existing versions"
+DEV_NUMERIC = "9999.9999.9999"
 
 
 def read_yaml(location, if_error=None):
@@ -222,59 +224,12 @@ def get_changed_flavors(changed_files, flavors):
     return changed_flavors
 
 
-def str_to_operator(s):
-    """
-    Turns a string into the corresponding operator.
-
-    Examples
-    --------
-    >>> str_to_operator("<")(1, 2)  # equivalent to '1 < 2'
-    True
-    """
-    return {
-        # https://docs.python.org/3/library/operator.html#mapping-operators-to-functions
-        "<": operator.lt,
-        "<=": operator.le,
-        "==": operator.eq,
-        "!=": operator.ne,
-        ">=": operator.ge,
-        ">": operator.gt,
-    }[s]
-
-
-def get_operator_and_version(ver_spec):
-    """
-    Converts a version specifier (e.g. "< 3") to a tuple of (operator, version).
-
-    Examples
-    --------
-    >>> get_operator_and_version("< 3")
-    (<built-in function lt>, '3')
-    >>> get_operator_and_version("!= dev")
-    (<built-in function ne>, 'dev')
-    """
-    regexp = r"([<>=!]+)([\w\.]+)"
-    m = re.search(regexp, ver_spec.replace(" ", ""))
-
-    if m is None:
-        raise ValueError(
-            "Invalid value for `ver_spec`: '{}'. Must match this regular expression: '{}'".format(
-                ver_spec,
-                regexp,
-            )
-        )
-
-    return str_to_operator(m.group(1)), m.group(2)
-
-
 def process_requirements(requirements, version=None):
     """
     Examples
     --------
     >>> process_requirements(None)
     []
-    >>> process_requirements(["foo"])
-    ['foo']
     >>> process_requirements({"== 0.1": ["foo"]}, "0.1")
     ['foo']
     >>> process_requirements({"< 0.2": ["foo"]}, "0.1")
@@ -283,6 +238,8 @@ def process_requirements(requirements, version=None):
     ['foo']
     >>> process_requirements({"== 0.1": ["foo"], "== 0.2": ["bar"]}, "0.2")
     ['bar']
+    >>> process_requirements({">= 0.1": ["foo"], ">= 0.2": ["bar"]}, "0.2")
+    ['bar', 'foo']
     >>> process_requirements({"== dev": ["foo"]}, "0.1")
     []
     >>> process_requirements({"< dev": ["foo"]}, "0.1")
@@ -297,30 +254,17 @@ def process_requirements(requirements, version=None):
     if requirements is None:
         return []
 
-    if isinstance(requirements, list):
-        return requirements
+    if not isinstance(requirements, dict):
+        raise TypeError(
+            f"Invalid object type for `requirements`: '{type(requirements)}'. It must be dict."
+        )
 
-    if isinstance(requirements, dict):
-        # The version "dev" should always compare as greater than any existing versions.
-        dev_numeric = "9999.9999.9999"
-
-        if version == DEV_VERSION:
-            version = dev_numeric
-
-        for ver_spec, packages in requirements.items():
-            op_and_ver_pairs = map(get_operator_and_version, ver_spec.split(","))
-            match_all = all(
-                comp_op(
-                    Version(version),
-                    Version(dev_numeric if req_ver == DEV_VERSION else req_ver),
-                )
-                for comp_op, req_ver in op_and_ver_pairs
-            )
-            if match_all:
-                return packages
-        return []
-
-    raise TypeError("Invalid object type for `requirements`: '{}'".format(type(requirements)))
+    reqs = set()
+    for specifier, packages in requirements.items():
+        specifier_set = SpecifierSet(specifier.replace(DEV_VERSION, DEV_NUMERIC))
+        if specifier_set.contains(DEV_NUMERIC if version == DEV_VERSION else version):
+            reqs = reqs.union(packages)
+    return sorted(reqs)
 
 
 def remove_comments(s):

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -254,17 +254,18 @@ def process_requirements(requirements, version=None):
     if requirements is None:
         return []
 
-    if not isinstance(requirements, dict):
-        raise TypeError(
-            f"Invalid object type for `requirements`: '{type(requirements)}'. It must be dict."
-        )
+    if isinstance(requirements, list):
+        return requirements
 
-    reqs = set()
-    for specifier, packages in requirements.items():
-        specifier_set = SpecifierSet(specifier.replace(DEV_VERSION, DEV_NUMERIC))
-        if specifier_set.contains(DEV_NUMERIC if version == DEV_VERSION else version):
-            reqs = reqs.union(packages)
-    return sorted(reqs)
+    if isinstance(requirements, dict):
+        reqs = set()
+        for specifier, packages in requirements.items():
+            specifier_set = SpecifierSet(specifier.replace(DEV_VERSION, DEV_NUMERIC))
+            if specifier_set.contains(DEV_NUMERIC if version == DEV_VERSION else version):
+                reqs = reqs.union(packages)
+        return sorted(reqs)
+
+    raise TypeError("Invalid object type for `requirements`: '{}'".format(type(requirements)))
 
 
 def remove_comments(s):

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -16,7 +16,8 @@ sklearn:
   autologging:
     minimum: "0.22.1"
     maximum: "1.1.0"
-    requirements: ["matplotlib"]
+    requirements:
+      ">= 0.0.0": ["matplotlib"]
     run: |
       pytest tests/sklearn/test_sklearn_autolog.py
 
@@ -29,7 +30,8 @@ pytorch:
   models:
     minimum: "1.6.0"
     maximum: "1.11.0"
-    requirements: ["torchvision", "scikit-learn", "transformers"]
+    requirements::
+      ">= 0.0.0": ["torchvision", "scikit-learn", "transformers"]
     run: |
       pytest tests/pytorch/test_pytorch_model_export.py
 
@@ -43,14 +45,13 @@ pytorch-lightning:
     minimum: "1.0.5"
     maximum: "1.6.3"
     requirements:
-      "< 1.2.0": ["torch<1.11.0", "torchvision", "scikit-learn"]
-      ">= 1.2.0, < 1.3.0": ["torchvision", "scikit-learn"]
+      ">= 0.0.0": ["scikit-learn", "torchvision", "protobuf<4.0.0"]
+      "< 1.2.0": ["torch<1.11.0"]
       # torchmetrics==0.8.0 released a breaking change for versions 1.3 and 1.4 where
       # torchmetrics dependency was defined as non-upper-bounded in its requirements.
       # see: https://github.com/PyTorchLightning/metrics/commit/c537c9b3e8e801772a7e5670ff273321ed26e77b
       # for the removed function that causes pytorch-lightning imports to fail with torchmetrics==0.8.0
-      ">= 1.3.0, < 1.5.0": ["torchmetrics<0.8.0", "torchvision", "scikit-learn"]
-      ">= 1.5.0": ["torchvision", "scikit-learn"]
+      ">= 1.3.0, < 1.5.0": ["torchmetrics<0.8.0"]
     run: |
       pytest tests/pytorch/test_pytorch_autolog.py
 
@@ -64,6 +65,7 @@ tensorflow:
     minimum: "2.3.0"
     maximum: "2.8.0"
     requirements:
+      "< 2.6.0": ["protobuf<4.0.0"]
       # Requirements to run tests for keras
       "== dev": ["scikit-learn", "pyspark", "pyarrow"]
     run: |
@@ -79,6 +81,7 @@ tensorflow:
     minimum: "2.3.0"
     maximum: "2.8.0"
     requirements:
+      "< 2.6.0": ["protobuf<4.0.0"]
       "== dev": ["scikit-learn"]
     run: |
       pytest tests/tensorflow/test_tensorflow2_autolog.py
@@ -95,9 +98,11 @@ keras:
     minimum: "2.3.0"
     maximum: "2.8.0"
     requirements:
-      "<= 2.3.1": ["tensorflow==2.2.1", "scikit-learn", "pyspark", "pyarrow", "transformers<=4.11.3"]
-      "> 2.3.1, < 2.6.0": ["tensorflow<2.5.0", "scikit-learn", "pyspark", "pyarrow", "transformers"]
-      ">= 2.6.0": ["tensorflow", "scikit-learn", "pyspark", "pyarrow", "transformers"]
+      ">= 0.0.0": ["scikit-learn", "pyspark", "pyarrow"]
+      "<= 2.3.1": ["tensorflow==2.2.1", "transformers<=4.11.3"]
+      "> 2.3.1, < 2.6.0": ["tensorflow<2.5.0", "transformers"]
+      "< 2.6.0": ["protobuf<4.0.0"]
+      ">= 2.6.0": ["tensorflow", "transformers"]
     run: |
       pytest tests/keras/test_keras_model_export.py
 
@@ -109,6 +114,7 @@ keras:
       # https://github.com/tensorflow/tensorflow/issues/38589
       "<= 2.3.1": ["tensorflow==2.2.1"]
       "> 2.3.1, < 2.6.0": ["tensorflow<2.5.0"]
+      "< 2.6.0": ["protobuf<4.0.0"]
       ">= 2.6.0": ["tensorflow"]
     run: |
       pytest tests/keras/test_keras_autolog.py
@@ -122,14 +128,16 @@ xgboost:
   models:
     minimum: "1.1.1"
     maximum: "1.6.1"
-    requirements: ["scikit-learn"]
+    requirements:
+      ">= 0.0.0": ["scikit-learn"]
     run: |
       pytest tests/xgboost/test_xgboost_model_export.py
 
   autologging:
     minimum: "1.1.1"
     maximum: "1.6.1"
-    requirements: ["scikit-learn", "matplotlib"]
+    requirements:
+      ">= 0.0.0": ["scikit-learn", "matplotlib"]
     run: |
       pytest tests/xgboost/test_xgboost_autolog.py
 
@@ -142,14 +150,16 @@ lightgbm:
   models:
     minimum: "2.3.1"
     maximum: "3.3.2"
-    requirements: ["scikit-learn"]
+    requirements:
+      ">= 0.0.0": ["scikit-learn"]
     run: |
       pytest tests/lightgbm/test_lightgbm_model_export.py
 
   autologging:
     minimum: "2.3.1"
     maximum: "3.3.2"
-    requirements: ["scikit-learn", "matplotlib"]
+    requirements:
+      ">= 0.0.0": ["scikit-learn", "matplotlib"]
     run: |
       pytest tests/lightgbm/test_lightgbm_autolog.py
 
@@ -167,7 +177,8 @@ catboost:
   models:
     minimum: "0.23.1"
     maximum: "1.0.5"
-    requirements: ["scikit-learn"]
+    requirements:
+      ">= 0.0.0": ["scikit-learn"]
     run: |
       pytest tests/catboost/test_catboost_model_export.py
 
@@ -201,14 +212,16 @@ fastai:
   models:
     minimum: "2.4.1"
     maximum: "2.6.3"
-    requirements: [torch, torchvision]
+    requirements:
+      ">= 0.0.0": [torch, torchvision]
     run: |
       pytest tests/fastai/test_fastai_model_export.py
 
   autologging:
     minimum: "2.4.1"
     maximum: "2.6.3"
-    requirements: [torch, torchvision]
+    requirements:
+      ">= 0.0.0": [torch, torchvision]
     run: |
       pytest tests/fastai/test_fastai_autolog.py
 
@@ -237,7 +250,8 @@ onnx:
   models:
     minimum: "1.5.0"
     maximum: "1.11.0"
-    requirements: ["onnxruntime", "torch", "scikit-learn"]
+    requirements:
+      ">= 0.0.0": ["onnxruntime", "torch", "scikit-learn", "protobuf<4.0.0"]
     run: |
       pytest tests/onnx/test_onnx_model_export.py
 
@@ -251,8 +265,8 @@ spacy:
     minimum: "2.2.4"
     maximum: "3.3.0"
     requirements:
-      "<= 3.0.8": ["scikit-learn", "click<8.1.0", "flask<2.1.0"]
-      "> 3.0.8": ["scikit-learn", "click<8.1.0"]
+      ">= 0.0.0": ["scikit-learn", "click<8.1.0"]
+      "<= 3.0.8": ["flask<2.1.0"]
     run: |
       pytest tests/spacy/test_spacy_model_export.py
 
@@ -298,7 +312,8 @@ spark:
     # autologging use cases in environments where newer versions of pyspark are available
     # prior to their release on PyPI (e.g. Databricks)
     allow_unreleased_max_version: True
-    requirements: ["boto3", "scikit-learn", "pyarrow"]
+    requirements:
+      ">= 0.0.0": ["boto3", "scikit-learn", "pyarrow"]
     run: |
       SAGEMAKER_OUT=$(mktemp)
       if mlflow sagemaker build-and-push-container --no-push --mlflow-home . > $SAGEMAKER_OUT 2>&1; then
@@ -317,7 +332,8 @@ spark:
     # autologging use cases in environments where newer versions of pyspark are available
     # prior to their release on PyPI (e.g. Databricks)
     allow_unreleased_max_version: True
-    requirements: ["scikit-learn"]
+    requirements:
+      ">= 0.0.0": ["scikit-learn"]
     run: |
       find tests/spark/autologging/ml -name 'test*.py' | xargs -L 1 pytest
 
@@ -379,7 +395,8 @@ pmdarima:
   models:
     minimum: "1.8.0"
     maximum: "1.8.5"
-    requirements: ["prophet"]
+    requirements:
+      ">= 0.0.0": ["prophet"]
     run: |
       pytest tests/pmdarima/test_pmdarima_model_export.py
 

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -675,7 +675,12 @@ def test_pyfunc_serve_and_score_transformers():
     model.compile()
 
     with mlflow.start_run():
-        mlflow.keras.log_model(model, artifact_path="model", keras_module=tf.keras)
+        mlflow.keras.log_model(
+            model,
+            artifact_path="model",
+            keras_module=tf.keras,
+            extra_pip_requirements=extra_pip_requirements,
+        )
         model_uri = mlflow.get_artifact_uri("model")
 
     data = json.dumps({"inputs": dummy_inputs.tolist()})

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -40,6 +40,7 @@ from tests.helper_functions import (
     _compare_logged_code_paths,
 )
 from tests.helper_functions import mock_s3_bucket  # pylint: disable=unused-import
+from tests.helper_functions import PROTOBUF_REQUIREMENT
 from tests.pyfunc.test_spark import score_model_as_udf
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 
@@ -47,7 +48,8 @@ from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 import keras
 
 # pylint: disable=no-name-in-module,reimported
-if Version(keras.__version__) >= Version("2.6.0"):
+keras_version = Version(keras.__version__)
+if keras_version >= Version("2.6.0"):
     from tensorflow import keras
     from tensorflow.keras.models import Sequential
     from tensorflow.keras.layers import Layer, Dense
@@ -63,6 +65,7 @@ else:
 EXTRA_PYFUNC_SERVING_TEST_ARGS = (
     [] if _is_available_on_pypi("keras") else ["--env-manager", "local"]
 )
+extra_pip_requirements = [PROTOBUF_REQUIREMENT] if keras_version < Version("2.6.0") else []
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -80,13 +83,7 @@ def fix_random_seed():
 
 @pytest.fixture(scope="module")
 def data():
-    iris = datasets.load_iris()
-    data = pd.DataFrame(
-        data=np.c_[iris["data"], iris["target"]], columns=iris["feature_names"] + ["target"]
-    )
-    y = data["target"]
-    x = data.drop("target", axis=1)
-    return x, y
+    return datasets.load_iris(as_frame=True, return_X_y=True)
 
 
 def get_model(data):
@@ -101,7 +98,7 @@ def get_model(data):
         # `lr` was renamed to `learning_rate` in keras 2.3.0:
         # https://github.com/keras-team/keras/releases/tag/2.3.0
         {"lr": lr}
-        if Version(keras.__version__) < Version("2.3.0")
+        if keras_version < Version("2.3.0")
         else {"learning_rate": lr}
     )
     model.compile(loss="mean_squared_error", optimizer=SGD(**kwargs))
@@ -287,9 +284,19 @@ def test_model_save_load(build_model, save_format, model_path, data):
     pyfunc_loaded = mlflow.pyfunc.load_model(model_path)
     np.testing.assert_allclose(pyfunc_loaded.predict(x).values, expected, rtol=1e-5)
 
-    # pyfunc serve
+
+def test_pyfunc_serve_and_score(data):
+    x, _ = data
+    model = get_model(data)
+    with mlflow.start_run():
+        model_info = mlflow.keras.log_model(
+            model,
+            "model",
+            extra_pip_requirements=[PROTOBUF_REQUIREMENT],
+        )
+    expected = model.predict(x.values)
     scoring_response = pyfunc_serve_and_score_model(
-        model_uri=os.path.abspath(model_path),
+        model_uri=model_info.model_uri,
         data=pd.DataFrame(x),
         content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
         extra_args=EXTRA_PYFUNC_SERVING_TEST_ARGS,
@@ -299,11 +306,17 @@ def test_model_save_load(build_model, save_format, model_path, data):
     ).values.astype(np.float32)
     np.testing.assert_allclose(actual_scoring_response, expected, rtol=1e-5)
 
-    # test spark udf
+
+def test_score_model_as_spark_udf(data):
+    x, _ = data
+    model = get_model(data)
+    with mlflow.start_run():
+        model_info = mlflow.keras.log_model(model, "model")
+    expected = model.predict(x.values)
     spark_udf_preds = score_model_as_udf(
-        model_uri=os.path.abspath(model_path), pandas_df=pd.DataFrame(x), result_type="float"
+        model_uri=model_info.model_uri, pandas_df=pd.DataFrame(x), result_type="float"
     )
-    np.allclose(np.array(spark_udf_preds), expected.reshape(len(spark_udf_preds)))
+    np.testing.assert_allclose(np.array(spark_udf_preds), expected.reshape(len(spark_udf_preds)))
 
 
 def test_signature_and_examples_are_saved_correctly(model, data):
@@ -328,33 +341,12 @@ def test_custom_model_save_load(custom_model, custom_layer, data, custom_predict
     x, _ = data
     custom_objects = {"MyDense": custom_layer}
     mlflow.keras.save_model(custom_model, model_path, custom_objects=custom_objects)
-
     # Loading Keras model
     model_loaded = mlflow.keras.load_model(model_path)
     assert all(model_loaded.predict(x.values) == custom_predicted)
-    # pyfunc serve
-    scoring_response = pyfunc_serve_and_score_model(
-        model_uri=os.path.abspath(model_path),
-        data=pd.DataFrame(x),
-        content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
-        extra_args=EXTRA_PYFUNC_SERVING_TEST_ARGS,
-    )
-    assert np.allclose(
-        pd.read_json(scoring_response.content, orient="records", encoding="utf8").values.astype(
-            np.float32
-        ),
-        custom_predicted,
-        rtol=1e-5,
-        atol=1e-9,
-    )
     # Loading pyfunc model
     pyfunc_loaded = mlflow.pyfunc.load_model(model_path)
     assert all(pyfunc_loaded.predict(x).values == custom_predicted)
-    # test spark udf
-    spark_udf_preds = score_model_as_udf(
-        model_uri=os.path.abspath(model_path), pandas_df=pd.DataFrame(x), result_type="float"
-    )
-    np.allclose(np.array(spark_udf_preds), custom_predicted.reshape(len(spark_udf_preds)))
 
 
 @pytest.mark.allow_infer_pip_requirements_fallback

--- a/tests/tensorflow/test_tensorflow2_model_export.py
+++ b/tests/tensorflow/test_tensorflow2_model_export.py
@@ -16,6 +16,7 @@ import pandas.testing
 import tensorflow as tf
 from tensorflow import estimator as tf_estimator
 import iris_data_utils
+from packaging.version import Version
 
 import mlflow
 import mlflow.tensorflow
@@ -38,11 +39,15 @@ from tests.helper_functions import (
     _assert_pip_requirements,
     _is_available_on_pypi,
     _compare_logged_code_paths,
+    PROTOBUF_REQUIREMENT,
 )
 from tests.helper_functions import mock_s3_bucket  # pylint: disable=unused-import
 
 EXTRA_PYFUNC_SERVING_TEST_ARGS = (
     [] if _is_available_on_pypi("tensorflow") else ["--env-manager", "local"]
+)
+extra_pip_requirements = (
+    [PROTOBUF_REQUIREMENT] if Version(tf.__version__) < Version("2.6.0") else []
 )
 
 SavedModelInfo = collections.namedtuple(
@@ -732,6 +737,7 @@ def test_pyfunc_serve_and_score(saved_tf_iris_model):
             tf_meta_graph_tags=saved_tf_iris_model.meta_graph_tags,
             tf_signature_def_key=saved_tf_iris_model.signature_def_key,
             artifact_path=artifact_path,
+            extra_pip_requirements=extra_pip_requirements,
         )
         model_uri = mlflow.get_artifact_uri(artifact_path)
 


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Pin `protobuf` to fix cross-version test failures:
https://github.com/mlflow/mlflow/actions/runs/2400280896

## How is this patch tested?

Existing tests

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
