### PR TITLE
Refactor `tests/test_mlflow_lazily_imports_ml_packages.py`

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -228,9 +228,6 @@ jobs:
         env:
           SPARK_LOCAL_IP: 127.0.0.1
         run: |
-          # Install libopenblas-dev for mxnet 1.8.0.post0
-          sudo apt-get update -y
-          sudo apt-get install libopenblas-dev -y
           ./dev/run-python-flavor-tests.sh;
 
   # It takes 9 ~ 10 minutes to run tests in `tests/models`. To make CI finish faster,

--- a/conftest.py
+++ b/conftest.py
@@ -20,22 +20,11 @@ def pytest_addoption(parser):
         default=False,
         help="Ignore tests for model flavors.",
     )
-    parser.addoption(
-        "--lazy-import",
-        action="store_true",
-        dest="lazy_import",
-        default=False,
-        help=(
-            "Special flag that should be enabled when running "
-            "tests/test_mlflow_lazily_imports_ml_packages.py"
-        ),
-    )
 
 
 def pytest_configure(config):
     # Register markers to suppress `PytestUnknownMarkWarning`
     config.addinivalue_line("markers", "requires_ssh")
-    config.addinivalue_line("markers", "lazy_import")
     config.addinivalue_line("markers", "notrackingurimock")
     config.addinivalue_line("markers", "allow_infer_pip_requirements_fallback")
 
@@ -44,9 +33,6 @@ def pytest_runtest_setup(item):
     markers = [mark.name for mark in item.iter_markers()]
     if "requires_ssh" in markers and not item.config.getoption("--requires-ssh"):
         pytest.skip("use `--requires-ssh` to run this test")
-
-    if "lazy_import" in markers and not item.config.getoption("--lazy-import"):
-        pytest.skip("use `--lazy-import` to run this test")
 
 
 @pytest.hookimpl(hookwrapper=True)

--- a/conftest.py
+++ b/conftest.py
@@ -67,6 +67,7 @@ def pytest_ignore_collect(path, config):
             "tests/prophet",
             "tests/pmdarima",
             "tests/diviner",
+            "tests/test_mlflow_lazily_imports_ml_packages.py",
             "tests/utils/test_model_utils.py",
             # this test is included here because it imports many big libraries like tf, keras, etc
             "tests/tracking/fluent/test_fluent_autolog.py",

--- a/dev/run-python-flavor-tests.sh
+++ b/dev/run-python-flavor-tests.sh
@@ -12,4 +12,4 @@ pytest \
   tests/paddle \
   tests/tracking/fluent/test_fluent_autolog.py \
   tests/autologging \
-  tests/test_mlflow_lazily_imports_ml_packages.py \
+  tests/test_mlflow_lazily_imports_ml_packages.py

--- a/dev/run-python-flavor-tests.sh
+++ b/dev/run-python-flavor-tests.sh
@@ -1,23 +1,15 @@
 #!/usr/bin/env bash
 set -x
-# Set err=1 if any commands exit with non-zero status as described in
-# https://stackoverflow.com/a/42219754
-err=0
-trap 'err=1' ERR
+
 export MLFLOW_HOME=$(pwd)
 
-# Run ML framework tests in their own Python processes to avoid OOM issues due to per-framework
-# overhead
-pytest tests/azureml
-pytest tests/utils/test_model_utils.py
-
 # TODO: Run tests for h2o, shap, and paddle in the cross-version-tests workflow
-pytest tests/h2o
-pytest tests/shap
-pytest tests/paddle
-
-pytest tests/tracking/fluent/test_fluent_autolog.py
-pytest tests/autologging
-pytest tests/test_mlflow_lazily_imports_ml_packages.py --lazy-import
-
-test $err = 0
+pytest \
+  tests/azureml \
+  tests/utils/test_model_utils.py \
+  tests/h2o \
+  tests/shap \
+  tests/paddle \
+  tests/tracking/fluent/test_fluent_autolog.py \
+  tests/autologging \
+  tests/test_mlflow_lazily_imports_ml_packages.py \

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --cov=./mlflow --cov-report html --color=yes --durations=5 --showlocals --verbose
+addopts = --cov=./mlflow --cov-report html --color=yes --durations=10 --showlocals --verbose
 # Prevent deprecated numpy type aliases from being used
 filterwarnings =
   error:^`np\.[a-z]+` is a deprecated alias for.+:DeprecationWarning:mlflow

--- a/requirements/extra-ml-requirements.txt
+++ b/requirements/extra-ml-requirements.txt
@@ -36,8 +36,6 @@ onnxruntime
 tf2onnx
 # Required by mlflow.spark
 pyspark
-# Required by mlflow.mleap
-mleap
 # Required by mlflow.shap
 shap
 # Required by mlflow.paddle

--- a/requirements/extra-ml-requirements.txt
+++ b/requirements/extra-ml-requirements.txt
@@ -36,6 +36,8 @@ onnxruntime
 tf2onnx
 # Required by mlflow.spark
 pyspark
+# Required by mlflow.mleap
+mleap
 # Required by mlflow.shap
 shap
 # Required by mlflow.paddle

--- a/tests/test_mlflow_lazily_imports_ml_packages.py
+++ b/tests/test_mlflow_lazily_imports_ml_packages.py
@@ -26,11 +26,6 @@ import pytest
     ),
 )
 def test_mlflow_lazily_imports_ml_packages(package):
-    # Ensure the package is importable
-    __import__(package)
-
-    assert package in sys.modules
-
     cached_packages = list(sys.modules.keys())
     for pkg in cached_packages:
         if pkg.split(".")[0] == pkg:

--- a/tests/test_mlflow_lazily_imports_ml_packages.py
+++ b/tests/test_mlflow_lazily_imports_ml_packages.py
@@ -1,23 +1,14 @@
-# If test test script is run after other test script that imports ML packages in the same pytest
-# session, this test script fails. As a workaround, this test script needs to be run in a separate
-# pytest session with the following command:
-# $ pytest tests/test_mlflow_lazily_imports_ml_packages.py --lazy-import
 import sys
 
 import pytest
 
 
-def _get_loaded_packages():
-    return {k.split(".")[0] for k in sys.modules.keys()}
-
-
-# Run this test only when the `--lazy-import` flag is specified
-@pytest.mark.lazy_import
-def test_mlflow_lazily_import_ml_packages():
-    ml_packages = {
+@pytest.mark.parametrize(
+    "package",
+    (
         "catboost",
         "fastai",
-        "gluon",
+        "mxnet",
         "h2o",
         "keras",
         "lightgbm",
@@ -32,12 +23,23 @@ def test_mlflow_lazily_import_ml_packages():
         "tensorflow",
         "torch",
         "xgboost",
-    }
+    ),
+)
+def test_mlflow_lazily_imports_ml_package(package):
+    # Ensure the package is importable
+    __import__(package)
 
-    # Ensure ML packages are not loaded before importing mlflow
-    assert _get_loaded_packages().intersection(ml_packages) == set()
+    assert package in sys.modules
+
+    cached_packages = list(sys.modules.keys())
+    for pkg in cached_packages:
+        if pkg.split(".")[0] == pkg:
+            sys.modules.pop(package, None)
+
+    # Ensure the package is not loaded
+    assert package not in sys.modules
 
     import mlflow  # pylint: disable=unused-import
 
-    # Ensure ML packages are not loaded after importing mlflow
-    assert _get_loaded_packages().intersection(ml_packages) == set()
+    # Ensure mlflow didn't load the package
+    assert package not in sys.modules

--- a/tests/test_mlflow_lazily_imports_ml_packages.py
+++ b/tests/test_mlflow_lazily_imports_ml_packages.py
@@ -25,7 +25,7 @@ import pytest
         "xgboost",
     ),
 )
-def test_mlflow_lazily_imports_ml_package(package):
+def test_mlflow_lazily_imports_ml_packages(package):
     # Ensure the package is importable
     __import__(package)
 


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Refactor `tests/test_mlflow_lazily_imports_ml_packages.py` and remove the `--lazy-import` flag. This changes allows us to simplify `dev/run-python-flavor-tests.sh` and make it easier to check the test results.

## How is this patch tested?

Existing tests

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
