### PR TITLE
fix-sklearn-autolog-without-matplotlib

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -21,6 +21,10 @@ sklearn:
     run: |
       pytest tests/sklearn/test_sklearn_autolog.py
 
+      # Ensure sklearn autologging works without matplotlib
+      pip uninstall -q -y matplotlib
+      pytest tests/sklearn/test_sklearn_autolog_without_matplotlib.py
+
 pytorch:
   package_info:
     pip_release: "torch"

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -543,6 +543,8 @@ def _log_specialized_estimator_content(
                         plt.close(display.figure_)
                 except Exception as e:
                     _log_warning_for_artifacts(artifact.name, artifact.function, e)
+                    if isinstance(e, ImportError):
+                        break
 
             MlflowClient().log_artifacts(run_id, tmp_dir.path())
 

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -541,10 +541,11 @@ def _log_specialized_estimator_content(
                         filepath = tmp_dir.path(artifact_path)
                         display.figure_.savefig(fname=filepath, format="png")
                         plt.close(display.figure_)
+                except ImportError as e:
+                    _log_warning_for_artifacts(artifact.name, artifact.function, e)
+                    break
                 except Exception as e:
                     _log_warning_for_artifacts(artifact.name, artifact.function, e)
-                    if isinstance(e, ImportError):
-                        break
 
             MlflowClient().log_artifacts(run_id, tmp_dir.path())
 

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -521,19 +521,21 @@ def _log_specialized_estimator_content(
                 + str(e)
             )
             _logger.warning(msg)
-            return
+            return metrics
+
+        try:
+            import matplotlib
+            import matplotlib.pyplot as plt
+        except ImportError as ie:
+            _logger.warning(
+                f"Failed to import matplotlib (error: {repr(ie)}). Skipping artifact logging."
+            )
+            return metrics
 
         with TempDir() as tmp_dir:
+            _matplotlib_config = {"savefig.dpi": 175, "figure.autolayout": True, "font.size": 8}
             for artifact in artifacts:
                 try:
-                    import matplotlib
-                    import matplotlib.pyplot as plt
-
-                    _matplotlib_config = {
-                        "savefig.dpi": 175,
-                        "figure.autolayout": True,
-                        "font.size": 8,
-                    }
                     with matplotlib.rc_context(_matplotlib_config):
                         display = artifact.function(**artifact.arguments)
                         display.ax_.set_title(artifact.title)
@@ -541,9 +543,6 @@ def _log_specialized_estimator_content(
                         filepath = tmp_dir.path(artifact_path)
                         display.figure_.savefig(fname=filepath, format="png")
                         plt.close(display.figure_)
-                except ImportError as e:
-                    _log_warning_for_artifacts(artifact.name, artifact.function, e)
-                    break
                 except Exception as e:
                     _log_warning_for_artifacts(artifact.name, artifact.function, e)
 

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -486,7 +486,6 @@ def _log_specialized_estimator_content(
     autologging_client, fitted_estimator, run_id, prefix, X, y_true, sample_weight, pos_label
 ):
     import sklearn
-    import matplotlib
 
     metrics = dict()
 
@@ -524,19 +523,24 @@ def _log_specialized_estimator_content(
             _logger.warning(msg)
             return
 
-        _matplotlib_config = {"savefig.dpi": 175, "figure.autolayout": True, "font.size": 8}
-
-        with TempDir() as tmp_dir, matplotlib.rc_context(_matplotlib_config):
+        with TempDir() as tmp_dir:
             for artifact in artifacts:
                 try:
-                    display = artifact.function(**artifact.arguments)
-                    display.ax_.set_title(artifact.title)
-                    artifact_path = "{}.png".format(artifact.name)
-                    filepath = tmp_dir.path(artifact_path)
-                    display.figure_.savefig(fname=filepath, format="png")
+                    import matplotlib
                     import matplotlib.pyplot as plt
 
-                    plt.close(display.figure_)
+                    _matplotlib_config = {
+                        "savefig.dpi": 175,
+                        "figure.autolayout": True,
+                        "font.size": 8,
+                    }
+                    with matplotlib.rc_context(_matplotlib_config):
+                        display = artifact.function(**artifact.arguments)
+                        display.ax_.set_title(artifact.title)
+                        artifact_path = "{}.png".format(artifact.name)
+                        filepath = tmp_dir.path(artifact_path)
+                        display.figure_.savefig(fname=filepath, format="png")
+                        plt.close(display.figure_)
                 except Exception as e:
                     _log_warning_for_artifacts(artifact.name, artifact.function, e)
 

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -532,8 +532,8 @@ def _log_specialized_estimator_content(
             )
             return metrics
 
+        _matplotlib_config = {"savefig.dpi": 175, "figure.autolayout": True, "font.size": 8}
         with TempDir() as tmp_dir:
-            _matplotlib_config = {"savefig.dpi": 175, "figure.autolayout": True, "font.size": 8}
             for artifact in artifacts:
                 try:
                     with matplotlib.rc_context(_matplotlib_config):

--- a/tests/sklearn/test_sklearn_autolog_without_matplotlib.py
+++ b/tests/sklearn/test_sklearn_autolog_without_matplotlib.py
@@ -1,9 +1,11 @@
 import pytest
 from sklearn.datasets import load_breast_cancer
 from sklearn.ensemble import RandomForestClassifier
+from unittest import mock
 
 import mlflow
 from mlflow.tracking import MlflowClient
+from tests.helper_functions import AnyStringWith
 
 
 def is_matplotlib_installed():
@@ -22,8 +24,11 @@ def test_sklearn_autolog_works_without_matplotlib():
     mlflow.sklearn.autolog()
     model = RandomForestClassifier(max_depth=2, random_state=0, n_estimators=10)
     X, y = load_breast_cancer(return_X_y=True)
-    with mlflow.start_run() as run:
+    with mlflow.start_run() as run, mock.patch(
+        "mlflow.sklearn.utils._logger.warning"
+    ) as mock_warning:
         model.fit(X, y)
+        mock_warning.assert_called_once_with(AnyStringWith("Failed to import matplotlib"))
 
     run = MlflowClient().get_run(run.info.run_id)
     expected_metric_keys = {

--- a/tests/sklearn/test_sklearn_autolog_without_matplotlib.py
+++ b/tests/sklearn/test_sklearn_autolog_without_matplotlib.py
@@ -1,0 +1,37 @@
+import pytest
+from sklearn.datasets import load_breast_cancer
+from sklearn.ensemble import RandomForestClassifier
+
+import mlflow
+from mlflow.tracking import MlflowClient
+
+
+def is_matplotlib_installed():
+    try:
+        import matplotlib  # pylint: disable=unused-import
+
+        return True
+    except ImportError:
+        return False
+
+
+@pytest.mark.skipif(
+    is_matplotlib_installed(), reason="matplotlib must be uninstalled to run this test"
+)
+def test_sklearn_autolog_works_without_matplotlib():
+    mlflow.sklearn.autolog()
+    model = RandomForestClassifier(max_depth=2, random_state=0, n_estimators=10)
+    X, y = load_breast_cancer(return_X_y=True)
+    with mlflow.start_run() as run:
+        model.fit(X, y)
+
+    run = MlflowClient().get_run(run.info.run_id)
+    expected_metric_keys = {
+        "training_score",
+        "training_accuracy_score",
+        "training_precision_score",
+        "training_recall_score",
+        "training_f1_score",
+        "training_log_loss",
+    }
+    assert set(run.data.metrics).issuperset(expected_metric_keys)


### PR DESCRIPTION
Signed-off-by: Felix Altenberger <felix@zenml.io>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

Close #5994

## What changes are proposed in this pull request?

Moved matplotlib import in sklearn/utils.py into try block to prevent mlflow.sklearn.autolog() from breaking when matplotlib is not installed.

## How is this patch tested?

Manually (by testing with our own mlflow integration examples at [zenml](https://github.com/zenml-io/zenml))

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
