### PR TITLE
Changed to python3 style super() without arguments

### DIFF
--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -1798,7 +1798,7 @@ class SageMakerDeploymentClient(BaseDeploymentClient):
     """
 
     def __init__(self, target_uri):
-        super(SageMakerDeploymentClient, self).__init__(target_uri=target_uri)
+        super().__init__(target_uri=target_uri)
 
         # Default region_name and assumed_role_arn when
         # the target_uri is `sagemaker` or `sagemaker:/`

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -489,7 +489,7 @@ class _SklearnCustomModelPicklingError(pickle.PicklingError):
         :param sk_model: The custom sklearn model to be pickled
         :param original_exception: The original exception raised
         """
-        super(_SklearnCustomModelPicklingError, self).__init__(
+        super().__init__(
             f"Pickling custom sklearn model {sk_model.__class__.__name__} failed "
             f"when saving model: {str(original_exception)}"
         )

--- a/mlflow/utils/autologging_utils/safety.py
+++ b/mlflow/utils/autologging_utils/safety.py
@@ -222,14 +222,14 @@ def with_managed_run(autologging_integration, patch_function, tags=None):
 
         class PatchWithManagedRun(patch_function):
             def __init__(self):
-                super(PatchWithManagedRun, self).__init__()
+                super().__init__()
                 self.managed_run = None
 
             def _patch_implementation(self, original, *args, **kwargs):
                 if not mlflow.active_run():
                     self.managed_run = create_managed_run()
 
-                result = super(PatchWithManagedRun, self)._patch_implementation(
+                result = super()._patch_implementation(
                     original, *args, **kwargs
                 )
 
@@ -241,7 +241,7 @@ def with_managed_run(autologging_integration, patch_function, tags=None):
             def _on_exception(self, e):
                 if self.managed_run:
                     mlflow.end_run(RunStatus.to_string(RunStatus.FAILED))
-                super(PatchWithManagedRun, self)._on_exception(e)
+                super()._on_exception(e)
 
         return PatchWithManagedRun
 

--- a/mlflow/utils/autologging_utils/safety.py
+++ b/mlflow/utils/autologging_utils/safety.py
@@ -229,9 +229,7 @@ def with_managed_run(autologging_integration, patch_function, tags=None):
                 if not mlflow.active_run():
                     self.managed_run = create_managed_run()
 
-                result = super()._patch_implementation(
-                    original, *args, **kwargs
-                )
+                result = super()._patch_implementation(original, *args, **kwargs)
 
                 if self.managed_run:
                     mlflow.end_run(RunStatus.to_string(RunStatus.FINISHED))

--- a/tests/onnx/test_onnx_model_export.py
+++ b/tests/onnx/test_onnx_model_export.py
@@ -106,7 +106,7 @@ def onnx_model(model, sample_input, tmpdir):
 def multi_tensor_model(dataset):
     class MyModel(nn.Module):
         def __init__(self, n):
-            super(MyModel, self).__init__()
+            super().__init__()
             self.linear = torch.nn.Linear(n, 1)
             self._train = True
 

--- a/tests/paddle/test_paddle_model_export.py
+++ b/tests/paddle/test_paddle_model_export.py
@@ -55,7 +55,7 @@ def get_dataset():
 def pd_model():
     class Regressor(paddle.nn.Layer):
         def __init__(self, in_features):
-            super(Regressor, self).__init__()
+            super().__init__()
             self.fc_ = Linear(in_features=in_features, out_features=1)
 
         @paddle.jit.to_static
@@ -277,7 +277,7 @@ def get_dataset_built_in_high_level_api():
 
 class UCIHousing(paddle.nn.Layer):
     def __init__(self):
-        super(UCIHousing, self).__init__()
+        super().__init__()
         self.fc_ = paddle.nn.Linear(13, 1, None)
 
     def forward(self, inputs):  # pylint: disable=arguments-differ


### PR DESCRIPTION
Signed-off-by: Regis-Caelum <khanmf@rknec.edu>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Issues

Fix #5993

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

## What changes are proposed in this pull request?

Switched python2 style `super(class, self)` function to `super()` function.
```
************* Module mlflow.sagemaker
mlflow/sagemaker/__init__.py
************* Module mlflow.sklearn
mlflow/sklearn/__init__.py
************* Module mlflow.utils.autologging_utils.safety
mlflow/utils/autologging_utils/safety.py:
mlflow/utils/autologging_utils/safety.py:
mlflow/utils/autologging_utils/safety.py:
************* Module test_onnx_model_export
tests/onnx/test_onnx_model_export.py:
************* Module test_paddle_model_export
tests/paddle/test_paddle_model_export.py:
tests/paddle/test_paddle_model_export.py:
```
