### PR TITLE
Cache pyenv to run CI checks faster

### DIFF
--- a/.github/actions/cache-pyenv/action.yml
+++ b/.github/actions/cache-pyenv/action.yml
@@ -1,0 +1,14 @@
+name: "cache-pyenv"
+description: "Cache pyenv"
+runs:
+  using: "composite"
+  steps:
+    - name: Get cache key prefix
+      id: get-cache-key-prefix
+      shell: bash
+      run: |
+        echo "::set-output name=prefix::$ImageOS-$ImageVersion"
+    - uses: actions/cache@v2
+      with:
+        path: ~/.pyenv
+        key: ${{ steps.get-cache-key-prefix.outputs.prefix }}-pyenv-0-

--- a/.github/actions/cache-pyenv/action.yml
+++ b/.github/actions/cache-pyenv/action.yml
@@ -11,4 +11,5 @@ runs:
     - uses: actions/cache@v2
       with:
         path: ~/.pyenv
-        key: ${{ steps.get-cache-key-prefix.outputs.prefix }}-pyenv-0-
+        # Increment (or decrement) the number at the end to manually invalidate cache
+        key: ${{ steps.get-cache-key-prefix.outputs.prefix }}-pyenv-0

--- a/.github/actions/setup-pyenv/action.yml
+++ b/.github/actions/setup-pyenv/action.yml
@@ -17,7 +17,9 @@ runs:
       if: runner.os == 'Linux'
       shell: bash
       run: |
-        git clone --depth 1 https://github.com/pyenv/pyenv.git "$HOME/.pyenv"
+        if [ ! -d "$HOME/.pyenv" ]; then
+          git clone --depth 1 https://github.com/pyenv/pyenv.git "$HOME/.pyenv"
+        fi
     - name: Setup environment variables
       if: runner.os == 'Linux'
       shell: bash

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -264,6 +264,7 @@ jobs:
           repository: ${{ github.event.inputs.repository }}
           ref: ${{ github.event.inputs.ref }}
       - uses: ./.github/actions/setup-python
+      - uses: ./.github/actions/cache-pyenv
       - uses: ./.github/actions/setup-pyenv
       - uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Cache pyenv to run CI checks faster.

## How is this patch tested?

Existing tests

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
