### PR TITLE
Fix getting run UUID using unexisting pascalCased property name

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.js
@@ -393,7 +393,7 @@ export class ExperimentRunsTableMultiColumnView2 extends React.Component {
         registeredModels: modelVersionsByRunUuid[runInfo.run_uuid] || [],
         loggedModels: Utils.getLoggedModelsFromTags(tags),
         experimentId: runInfo.experiment_id,
-        runUuid: runInfo.runUuid,
+        runUuid: runInfo.run_uuid,
       };
 
       const version = {

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.test.js
@@ -86,33 +86,37 @@ describe('ExperimentRunsTableMultiColumnView2', () => {
     expect(output).toEqual('-');
   });
 
-  test('should render logged model link with valid URL', () => {
-    const tagsList = [
-      {
-        'mlflow.log-model.history': {
-          key: 'mlflow.log-model.history',
-          value: `[{
-            "run_id": "123",
-            "artifact_path": "model",
-            "utc_time_created": "2022-01-01 00:00:00.000000"
-          }]`,
+  test('should render logged model link with correct href', () => {
+    const props = {
+      ...commonProps,
+      runInfos: [
+        RunInfo.fromJs({
+          artifact_uri: 'artifact_uri',
+          end_time: 1,
+          experiment_id: '0',
+          lifecycle_stage: 'active',
+          run_uuid: '123',
+          start_time: 0,
+          status: 'FINISHED',
+          user_id: 'user_id',
+          getRunUuid: () => '123',
+        }),
+      ],
+      metricsList: [[]],
+      paramsList: [[]],
+      tagsList: [
+        {
+          'mlflow.log-model.history': {
+            key: 'mlflow.log-model.history',
+            value: `[{
+              "run_id": "123",
+              "artifact_path": "model",
+              "utc_time_created": "2022-01-01 00:00:00.000000"
+            }]`,
+          },
         },
-      },
-    ];
-    const runInfos = [
-      RunInfo.fromJs({
-        artifact_uri: 'artifact_uri',
-        end_time: 1,
-        experiment_id: '0',
-        lifecycle_stage: 'active',
-        run_uuid: '123',
-        start_time: 0,
-        status: 'FINISHED',
-        user_id: 'user_id',
-        getRunUuid: () => '123',
-      }),
-    ];
-    const props = { ...commonProps, metricsList: [[]], paramsList: [[]], runInfos, tagsList };
+      ],
+    };
     wrapper = mountWithIntl(<ExperimentRunsTableMultiColumnView2 {...props} />);
     const loggedModelLink = wrapper.find('.logged-model-link');
     expect(loggedModelLink).toHaveLength(1);

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.test.js
@@ -6,6 +6,8 @@ import {
 } from './ExperimentRunsTableMultiColumnView2';
 import { COLUMN_TYPES, ATTRIBUTE_COLUMN_LABELS } from '../constants';
 import { MemoryRouter as Router } from 'react-router-dom';
+import { RunInfo } from '../sdk/MlflowMessages';
+import { mountWithIntl } from '../../common/utils/TestUtils';
 
 function getChildColumnNames(columnDefs, parentName) {
   return columnDefs
@@ -82,6 +84,41 @@ describe('ExperimentRunsTableMultiColumnView2', () => {
     };
     const output = ModelsCellRenderer(props);
     expect(output).toEqual('-');
+  });
+
+  test('should render logged model link with valid URL', () => {
+    const tagsList = [
+      {
+        'mlflow.log-model.history': {
+          key: 'mlflow.log-model.history',
+          value: `[{
+            "run_id": "123",
+            "artifact_path": "model",
+            "utc_time_created": "2022-01-01 00:00:00.000000"
+          }]`,
+        },
+      },
+    ];
+    const runInfos = [
+      RunInfo.fromJs({
+        artifact_uri: 'artifact_uri',
+        end_time: 1,
+        experiment_id: '0',
+        lifecycle_stage: 'active',
+        run_uuid: '123',
+        start_time: 0,
+        status: 'FINISHED',
+        user_id: 'user_id',
+        getRunUuid: () => '123',
+      }),
+    ];
+    const props = { ...commonProps, metricsList: [[]], paramsList: [[]], runInfos, tagsList };
+    wrapper = mountWithIntl(<ExperimentRunsTableMultiColumnView2 {...props} />);
+    const loggedModelLink = wrapper.find('.logged-model-link');
+    expect(loggedModelLink).toHaveLength(1);
+    expect(loggedModelLink.first().props()['href']).toEqual(
+      './#/experiments/0/runs/123/artifactPath/model',
+    );
   });
 
   test('should show only logged model link if no registered models', () => {

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.test.js
@@ -116,9 +116,7 @@ describe('ExperimentRunsTableMultiColumnView2', () => {
     wrapper = mountWithIntl(<ExperimentRunsTableMultiColumnView2 {...props} />);
     const loggedModelLink = wrapper.find('.logged-model-link');
     expect(loggedModelLink).toHaveLength(1);
-    expect(loggedModelLink.first().props()['href']).toEqual(
-      './#/experiments/0/runs/123/artifactPath/model',
-    );
+    expect(loggedModelLink.prop('href')).toEqual('./#/experiments/0/runs/123/artifactPath/model');
   });
 
   test('should show only logged model link if no registered models', () => {


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
Close #6011

## What changes are proposed in this pull request?

This fixes the `models` object always having an `undefined` value for its `runUuid` property, since it's attempted to get it from `runInfo` using a pascalCased named property, `runUuid`, which is `undefined`, instead of the snake_cased property `run_uuid`, that contains the value.

The observed behavior of `models.runUuid` being `undefined`, as described in #6011, is that links in the Model column of the Runs table in the Experiments view are broken.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

Not sure this needs any kind of test. Let me know otherwise.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixes wrong links to models in the Runs table of the Experiments view.

### What component(s), interfaces, languages, and integrations does this PR affect?

Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations


<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

