### PR TITLE
Fixed models link is broken in MLflow Runs table

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.js
@@ -393,7 +393,7 @@ export class ExperimentRunsTableMultiColumnView2 extends React.Component {
         registeredModels: modelVersionsByRunUuid[runInfo.run_uuid] || [],
         loggedModels: Utils.getLoggedModelsFromTags(tags),
         experimentId: runInfo.experiment_id,
-        runUuid: runInfo.runUuid,
+        runUuid: runInfo.run_uuid,
       };
 
       const version = {


### PR DESCRIPTION
Signed-off-by: Arpit Jasapara <arpit.jasapara@databricks.com>

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
Close #6011

## What changes are proposed in this pull request?
Fixes reference to `runInfo.run_uuid`

