### PR TITLE
Remove redundant protobuf requirements

### DIFF
--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -37,7 +37,6 @@ from tests.helper_functions import (
     RestEndpoint,
     get_safe_port,
     pyfunc_serve_and_score_model,
-    PROTOBUF_REQUIREMENT,
 )
 from mlflow.protos.databricks_pb2 import ErrorCode, BAD_REQUEST
 from mlflow.pyfunc.scoring_server import (
@@ -419,9 +418,7 @@ def test_build_docker(iris_data, sk_model, enable_mlserver):
         if enable_mlserver:
             # MLServer requires Python 3.7, so we'll force that Python version
             with mock.patch("mlflow.utils.environment.PYTHON_VERSION", "3.7"):
-                mlflow.sklearn.log_model(
-                    sk_model, "model", extra_pip_requirements=[PROTOBUF_REQUIREMENT]
-                )
+                mlflow.sklearn.log_model(sk_model, "model")
         else:
             mlflow.sklearn.log_model(sk_model, "model")
         model_uri = "runs:/{run_id}/model".format(run_id=active_run.info.run_id)
@@ -459,9 +456,7 @@ def test_build_docker_with_env_override(iris_data, sk_model, enable_mlserver):
         if enable_mlserver:
             # MLServer requires Python 3.7, so we'll force that Python version
             with mock.patch("mlflow.utils.environment.PYTHON_VERSION", "3.7"):
-                mlflow.sklearn.log_model(
-                    sk_model, "model", extra_pip_requirements=[PROTOBUF_REQUIREMENT]
-                )
+                mlflow.sklearn.log_model(sk_model, "model")
         else:
             mlflow.sklearn.log_model(sk_model, "model")
         model_uri = "runs:/{run_id}/model".format(run_id=active_run.info.run_id)

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -37,6 +37,7 @@ from tests.helper_functions import (
     RestEndpoint,
     get_safe_port,
     pyfunc_serve_and_score_model,
+    PROTOBUF_REQUIREMENT,
 )
 from mlflow.protos.databricks_pb2 import ErrorCode, BAD_REQUEST
 from mlflow.pyfunc.scoring_server import (
@@ -418,7 +419,9 @@ def test_build_docker(iris_data, sk_model, enable_mlserver):
         if enable_mlserver:
             # MLServer requires Python 3.7, so we'll force that Python version
             with mock.patch("mlflow.utils.environment.PYTHON_VERSION", "3.7"):
-                mlflow.sklearn.log_model(sk_model, "model")
+                mlflow.sklearn.log_model(
+                    sk_model, "model", extra_pip_requirements=[PROTOBUF_REQUIREMENT]
+                )
         else:
             mlflow.sklearn.log_model(sk_model, "model")
         model_uri = "runs:/{run_id}/model".format(run_id=active_run.info.run_id)
@@ -456,7 +459,9 @@ def test_build_docker_with_env_override(iris_data, sk_model, enable_mlserver):
         if enable_mlserver:
             # MLServer requires Python 3.7, so we'll force that Python version
             with mock.patch("mlflow.utils.environment.PYTHON_VERSION", "3.7"):
-                mlflow.sklearn.log_model(sk_model, "model")
+                mlflow.sklearn.log_model(
+                    sk_model, "model", extra_pip_requirements=[PROTOBUF_REQUIREMENT]
+                )
         else:
             mlflow.sklearn.log_model(sk_model, "model")
         model_uri = "runs:/{run_id}/model".format(run_id=active_run.info.run_id)

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -29,7 +29,6 @@ from collections import namedtuple
 from sklearn.neighbors import KNeighborsClassifier
 
 from pyspark.sql.functions import pandas_udf
-from tests.helper_functions import PROTOBUF_REQUIREMENT
 
 
 prediction = [int(1), int(2), "class1", float(0.1), 0.2]
@@ -182,7 +181,6 @@ def test_spark_udf_env_manager_can_restore_env(spark, model_path, sklearn_versio
             "pandas==1.3.0",
             f"scikit-learn=={sklearn_version}",
             "pytest==6.2.5",
-            PROTOBUF_REQUIREMENT,
         ],
     )
 
@@ -196,7 +194,7 @@ def test_spark_udf_env_manager_can_restore_env(spark, model_path, sklearn_versio
 def test_spark_udf_env_manager_predict_sklearn_model(spark, sklearn_model, model_path, env_manager):
     model, inference_data = sklearn_model
 
-    mlflow.sklearn.save_model(model, model_path, extra_pip_requirements=[PROTOBUF_REQUIREMENT])
+    mlflow.sklearn.save_model(model, model_path)
     expected_pred_result = model.predict(inference_data)
 
     infer_data = pd.DataFrame(inference_data, columns=["a", "b"])
@@ -405,9 +403,7 @@ def test_spark_udf_embedded_model_server_killed_when_job_canceled(
     from mlflow.pyfunc.scoring_server.client import ScoringServerClient
     from mlflow.models.cli import _get_flavor_backend
 
-    mlflow.sklearn.save_model(
-        sklearn_model.model, model_path, extra_pip_requirements=[PROTOBUF_REQUIREMENT]
-    )
+    mlflow.sklearn.save_model(sklearn_model.model, model_path)
 
     server_port = 51234
     timeout = 60


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#5945

## What changes are proposed in this pull request?

Remove `protobuf` requirements added in #5945. They are no longer required because the latest version of `mlflow` (1.26.1) works with the latest version of `protobuf`. Note we still need to pin `protobuf` in the following test modules because `tensorflow`, `keras`, and `paddlepaddle` are still incompatible with `protobuf >= 4.0.0`:

- [tests/paddle/test_paddle_model_export.py](https://github.com/mlflow/mlflow/blob/8b8914aa6257dfc00803362adbd4da8094f0aec1/tests/paddle/test_paddle_model_export.py)
- [tests/tensorflow/test_tensorflow2_model_export.py](https://github.com/mlflow/mlflow/blob/0bc7d2097270942d083c1168a1990c9091cb7ce4/tests/tensorflow/test_tensorflow2_model_export.py)
- [tests/keras/test_keras_model_export.py](https://github.com/mlflow/mlflow/blob/8b8914aa6257dfc00803362adbd4da8094f0aec1/tests/keras/test_keras_model_export.py)


## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
