### PR TITLE
Fix KeyError in default evaluator log_model_explanability

### DIFF
--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -549,7 +549,6 @@ class DefaultEvaluator(ModelEvaluator):
         sampled_X = shap.sample(X_df, sample_rows, random_state=0)
 
         mode_or_mean_dict = _compute_df_mode_or_mean(X_df)
-        mode_or_mean_dict = {truncated_feature_name_map[k]: v for k, v in mode_or_mean_dict.items()}
         sampled_X = sampled_X.fillna(mode_or_mean_dict)
 
         # shap explainer might call provided `predict_fn` with a `numpy.ndarray` type

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -1049,3 +1049,27 @@ def test_autologging_is_disabled_during_evaluate(model):
         assert duplicate_metrics == []
     finally:
         mlflow.sklearn.autolog(disable=True)
+
+
+def test_truncation_works_for_long_feature_names(linear_regressor_model_uri, diabetes_dataset):
+    with mlflow.start_run() as run:
+        evaluate(
+            linear_regressor_model_uri,
+            diabetes_dataset._constructor_args["data"],
+            model_type="regressor",
+            targets=diabetes_dataset._constructor_args["targets"],
+            dataset_name=diabetes_dataset.name,
+            feature_names=[
+                "f1",
+                "f2",
+                "f3longnamelongnamelongname",
+                "f4",
+                "f5",
+                "f6",
+                "f7longlonglonglong",
+                "f8",
+                "f9",
+                "f10",
+            ],
+            evaluators="default",
+        )

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -1052,24 +1052,23 @@ def test_autologging_is_disabled_during_evaluate(model):
 
 
 def test_truncation_works_for_long_feature_names(linear_regressor_model_uri, diabetes_dataset):
-    with mlflow.start_run() as run:
-        evaluate(
-            linear_regressor_model_uri,
-            diabetes_dataset._constructor_args["data"],
-            model_type="regressor",
-            targets=diabetes_dataset._constructor_args["targets"],
-            dataset_name=diabetes_dataset.name,
-            feature_names=[
-                "f1",
-                "f2",
-                "f3longnamelongnamelongname",
-                "f4",
-                "f5",
-                "f6",
-                "f7longlonglonglong",
-                "f8",
-                "f9",
-                "f10",
-            ],
-            evaluators="default",
-        )
+    evaluate(
+        linear_regressor_model_uri,
+        diabetes_dataset._constructor_args["data"],
+        model_type="regressor",
+        targets=diabetes_dataset._constructor_args["targets"],
+        dataset_name=diabetes_dataset.name,
+        feature_names=[
+            "f1",
+            "f2",
+            "f3longnamelongnamelongname",
+            "f4",
+            "f5",
+            "f6",
+            "f7longlonglonglong",
+            "f8",
+            "f9",
+            "f10",
+        ],
+        evaluators="default",
+    )


### PR DESCRIPTION
Signed-off-by: apurva-koti <apurva.koti@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## What changes are proposed in this pull request?

Using long feature names that get truncated causes a KeyError in the log_model_explainbility routine in the default evaluator, due to an extraneous line that tries to index a mapping from full name to truncated name on the truncated name.
This line isn't needed.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
