### PR TITLE
detailed annotation for black formatting issue

### DIFF
--- a/.github/workflows/matchers/black.json
+++ b/.github/workflows/matchers/black.json
@@ -5,7 +5,7 @@
       "severity": "error",
       "pattern": [
         {
-          "regexp": "^([^:]+\\.py): (This file is unformatted .+)",
+          "regexp": "^([^:]+\\.py): (This file is unformatted\\. .+)",
           "file": 1,
           "message": 2
         }

--- a/.github/workflows/matchers/black.json
+++ b/.github/workflows/matchers/black.json
@@ -5,9 +5,9 @@
       "severity": "error",
       "pattern": [
         {
-          "regexp": "^(Run `black \.`.+): (.+)$",
-          "file": 2,
-          "message": 1
+          "regexp": "^([^:]+): (.+)",
+          "file": 1,
+          "message": 2
         }
       ]
     }

--- a/.github/workflows/matchers/black.json
+++ b/.github/workflows/matchers/black.json
@@ -5,7 +5,7 @@
       "severity": "error",
       "pattern": [
         {
-          "regexp": "^(would reformat) (.+)$",
+          "regexp": "^(Run `black \.`.+): (.+)$",
           "file": 2,
           "message": 1
         }

--- a/.github/workflows/matchers/black.json
+++ b/.github/workflows/matchers/black.json
@@ -5,7 +5,7 @@
       "severity": "error",
       "pattern": [
         {
-          "regexp": "^([^:]+): (.+)",
+          "regexp": "^([^:]+\\.py): (This file is unformatted .+)",
           "file": 1,
           "message": 2
         }

--- a/dev/lint.sh
+++ b/dev/lint.sh
@@ -6,9 +6,7 @@ err=0
 trap 'err=1' ERR
 
 echo -e "\n========== black ==========\n"
-# Exclude proto files because they are auto-generated
-black --check . 2>&1 | sed 's/would reformat/Run `black .` or comment `autoformat` on the PR to format this file: /g'
-
+black --check . 2>&1 | sed 's/^would reformat \(.*\)/\1: This file is unformatted. Run `black .` or comment `autoformat` on the PR to format./'
 
 echo -e "\n========== pylint ==========\n"
 pylint $(git ls-files | grep '\.py$')

--- a/dev/lint.sh
+++ b/dev/lint.sh
@@ -7,14 +7,8 @@ trap 'err=1' ERR
 
 echo -e "\n========== black ==========\n"
 # Exclude proto files because they are auto-generated
-black --check .
+black --check . 2>&1 | sed 's/would reformat/Run `black .` or comment `autoformat` on the PR to format this file: /g'
 
-if [ $? -ne 0 ]; then
-  echo '
-To apply black foramtting, do one of the following:
-- Run `pip install $(cat requirements/lint-requirements.txt | grep "^black==") && black .`
-- Comment `autoformat` on the PR'
-fi
 
 echo -e "\n========== pylint ==========\n"
 pylint $(git ls-files | grep '\.py$')

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -199,5 +199,6 @@ __all__ = [
     "list_run_infos",
     "autolog",
     "evaluate",
-    "last_active_run",
+    "last_alast_active_runlast_active_runlast_active_runlast_active_runlast_active_runlast_active_runlast_active_runctive_run",
 ] + _model_flavors_supported
+

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -199,6 +199,5 @@ __all__ = [
     "list_run_infos",
     "autolog",
     "evaluate",
-    "last_alast_active_runlast_active_runlast_active_runlast_active_runlast_active_runlast_active_runlast_active_runctive_run",
+    "last_active_run",
 ] + _model_flavors_supported
-


### PR DESCRIPTION
Signed-off-by: subramaniam02 <subramaniam02@gmail.com>

## Related Issues/PRs

Close #6003 

## What changes are proposed in this pull request?

Improved Annotation message for black formatting issue

## How is this patch tested?

- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.


## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
