### PR TITLE
add CatBoostRanker support

### DIFF
--- a/mlflow/catboost.py
+++ b/mlflow/catboost.py
@@ -91,8 +91,8 @@ def save_model(
     """
     Save a CatBoost model to a path on the local file system.
 
-    :param cb_model: CatBoost model (an instance of `CatBoost`_, `CatBoostClassifier`_, `CatBoostRanker`_,
-                     or `CatBoostRegressor`_) to be saved.
+    :param cb_model: CatBoost model (an instance of `CatBoost`_, `CatBoostClassifier`_,
+                    `CatBoostRanker`_, or `CatBoostRegressor`_) to be saved.
     :param path: Local path where the model is to be saved.
     :param conda_env: {{ conda_env }}
     :param code_paths: A list of local filesystem paths to Python file dependencies (or directories
@@ -210,8 +210,8 @@ def log_model(
     """
     Log a CatBoost model as an MLflow artifact for the current run.
 
-    :param cb_model: CatBoost model (an instance of `CatBoost`_, `CatBoostClassifier`_, `CatBoostRanker`_,
-                     or `CatBoostRegressor`_) to be saved.
+    :param cb_model: CatBoost model (an instance of `CatBoost`_, `CatBoostClassifier`_,
+                    `CatBoostRanker`_, or `CatBoostRegressor`_) to be saved.
     :param artifact_path: Run-relative artifact path.
     :param conda_env: {{ conda_env }}
     :param code_paths: A list of local filesystem paths to Python file dependencies (or directories
@@ -269,7 +269,14 @@ def log_model(
 def _init_model(model_type):
     from catboost import CatBoost, CatBoostClassifier, CatBoostRanker, CatBoostRegressor
 
-    model_types = {c.__name__: c for c in [CatBoost, CatBoostClassifier, CatBoostRanker, CatBoostRegressor]}
+    model_types = {
+        c.__name__: c for c in [
+            CatBoost,
+            CatBoostClassifier,
+            CatBoostRanker,
+            CatBoostRegressor
+        ]
+    }
 
     if model_type not in model_types:
         raise TypeError(

--- a/mlflow/catboost.py
+++ b/mlflow/catboost.py
@@ -276,7 +276,7 @@ def _init_model(model_type):
     try:
         from catboost import CatBoostRanker
 
-        model_types["CatBoostRanker"] = CatBoostRanker
+        model_types[CatBoostRanker.__name__] = CatBoostRanker
     except ImportError:
         pass
 

--- a/mlflow/catboost.py
+++ b/mlflow/catboost.py
@@ -270,12 +270,7 @@ def _init_model(model_type):
     from catboost import CatBoost, CatBoostClassifier, CatBoostRanker, CatBoostRegressor
 
     model_types = {
-        c.__name__: c for c in [
-            CatBoost,
-            CatBoostClassifier,
-            CatBoostRanker,
-            CatBoostRegressor
-        ]
+        c.__name__: c for c in [CatBoost, CatBoostClassifier, CatBoostRanker, CatBoostRegressor]
     }
 
     if model_type not in model_types:

--- a/mlflow/catboost.py
+++ b/mlflow/catboost.py
@@ -267,11 +267,18 @@ def log_model(
 
 
 def _init_model(model_type):
-    from catboost import CatBoost, CatBoostClassifier, CatBoostRanker, CatBoostRegressor
+    from catboost import CatBoost, CatBoostClassifier, CatBoostRegressor
 
     model_types = {
-        c.__name__: c for c in [CatBoost, CatBoostClassifier, CatBoostRanker, CatBoostRegressor]
+        c.__name__: c for c in [CatBoost, CatBoostClassifier, CatBoostRegressor]
     }
+
+    try:
+        from catboost import CatBoostRanker
+
+        model_types["CatBoostRanker"] = CatBoostRanker
+    except ImportError:
+        pass
 
     if model_type not in model_types:
         raise TypeError(

--- a/mlflow/catboost.py
+++ b/mlflow/catboost.py
@@ -269,9 +269,7 @@ def log_model(
 def _init_model(model_type):
     from catboost import CatBoost, CatBoostClassifier, CatBoostRegressor
 
-    model_types = {
-        c.__name__: c for c in [CatBoost, CatBoostClassifier, CatBoostRegressor]
-    }
+    model_types = {c.__name__: c for c in [CatBoost, CatBoostClassifier, CatBoostRegressor]}
 
     try:
         from catboost import CatBoostRanker

--- a/mlflow/catboost.py
+++ b/mlflow/catboost.py
@@ -13,6 +13,8 @@ CatBoost (native) format
     https://catboost.ai/docs/concepts/python-reference_catboost_save_model.html
 .. _CatBoostClassifier:
     https://catboost.ai/docs/concepts/python-reference_catboostclassifier.html
+.. _CatBoostRanker:
+    https://catboost.ai/docs/concepts/python-reference_catboostranker.html
 .. _CatBoostRegressor:
     https://catboost.ai/docs/concepts/python-reference_catboostregressor.html
 """
@@ -89,7 +91,7 @@ def save_model(
     """
     Save a CatBoost model to a path on the local file system.
 
-    :param cb_model: CatBoost model (an instance of `CatBoost`_, `CatBoostClassifier`_,
+    :param cb_model: CatBoost model (an instance of `CatBoost`_, `CatBoostClassifier`_, `CatBoostRanker`_,
                      or `CatBoostRegressor`_) to be saved.
     :param path: Local path where the model is to be saved.
     :param conda_env: {{ conda_env }}
@@ -208,7 +210,7 @@ def log_model(
     """
     Log a CatBoost model as an MLflow artifact for the current run.
 
-    :param cb_model: CatBoost model (an instance of `CatBoost`_, `CatBoostClassifier`_,
+    :param cb_model: CatBoost model (an instance of `CatBoost`_, `CatBoostClassifier`_, `CatBoostRanker`_,
                      or `CatBoostRegressor`_) to be saved.
     :param artifact_path: Run-relative artifact path.
     :param conda_env: {{ conda_env }}
@@ -265,9 +267,9 @@ def log_model(
 
 
 def _init_model(model_type):
-    from catboost import CatBoost, CatBoostClassifier, CatBoostRegressor
+    from catboost import CatBoost, CatBoostClassifier, CatBoostRanker, CatBoostRegressor
 
-    model_types = {c.__name__: c for c in [CatBoost, CatBoostClassifier, CatBoostRegressor]}
+    model_types = {c.__name__: c for c in [CatBoost, CatBoostClassifier, CatBoostRanker, CatBoostRegressor]}
 
     if model_type not in model_types:
         raise TypeError(
@@ -317,7 +319,7 @@ def load_model(model_uri, dst_path=None):
                      This directory must already exist. If unspecified, a local output
                      path will be created.
 
-    :return: A CatBoost model (an instance of `CatBoost`_, `CatBoostClassifier`_,
+    :return: A CatBoost model (an instance of `CatBoost`_, `CatBoostClassifier`_, `CatBoostRanker`_,
              or `CatBoostRegressor`_)
     """
     local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)

--- a/tests/catboost/test_catboost_model_export.py
+++ b/tests/catboost/test_catboost_model_export.py
@@ -1,11 +1,11 @@
 from collections import namedtuple
 from unittest import mock
+from packaging import Version
 import os
 import pytest
 import yaml
 
 import catboost as cb
-from packaging import Version
 import numpy as np
 import pandas as pd
 import sklearn.datasets as datasets
@@ -108,12 +108,14 @@ def test_log_catboost_ranker(tmpdir):
     # we are creating a dummy group_id here that doesn't make any sense for the Iris dataset, but is ok for testing
     # if the code is running correctly
 
+    X, y = get_iris()
+
     indices = np.arange(len(X))
 
     dummy_group_id = np.zeros(len(X))
     dummy_group_id[indices % 2 == 0] = 1  # fill every 2nd value with 1
     dummy_group_id[indices % 3 == 0] = 2  # fill every 3rd value with 2
-    dummy_group_id = dummy_group_ids.astype("int64")
+    dummy_group_id = dummy_group_id.astype("int64")
     dummy_group_id.sort()
 
     model.fit(X, y, group_id=dummy_group_id)

--- a/tests/catboost/test_catboost_model_export.py
+++ b/tests/catboost/test_catboost_model_export.py
@@ -1,6 +1,6 @@
 from collections import namedtuple
 from unittest import mock
-from packaging import Version
+from packaging.version import Version
 import os
 import pytest
 import yaml

--- a/tests/catboost/test_catboost_model_export.py
+++ b/tests/catboost/test_catboost_model_export.py
@@ -76,6 +76,7 @@ def cb_model(request):
         dummy_group_id[indices % 2 == 0] = 1  # fill every 2nd value with 1
         dummy_group_id[indices % 3 == 0] = 2  # fill every 3rd value with 2
         dummy_group_id = dummy_group_ids.astype("int64")
+        dummy_group_id.sort()
 
         return ModelWithData(model=model.fit(X, y, group_id=dummy_group_id), inference_dataframe=X)
 

--- a/tests/catboost/test_catboost_model_export.py
+++ b/tests/catboost/test_catboost_model_export.py
@@ -92,7 +92,7 @@ def test_init_model(model_type):
     assert model.__class__.__name__ == model_type
 
 
-@pytest.mark.skip(
+@pytest.mark.skipif(
     Version(cb.__version__) < Version("0.26.0"),
     reason="catboost < 0.26.0 does not support CatBoostRanker",
 )

--- a/tests/catboost/test_catboost_model_export.py
+++ b/tests/catboost/test_catboost_model_export.py
@@ -70,9 +70,9 @@ def cb_model(request):
         # we are creating a dummy group_id here that doesn't make any sense for the Iris dataset, but is ok for testing
         # if the code is running correctly
 
-        indices = np.arange(len(candidates))
+        indices = np.arange(len(X))
 
-        dummy_group_id = np.zeros(len(candidates))
+        dummy_group_id = np.zeros(len(X))
         dummy_group_id[indices % 2 == 0] = 1  # fill every 2nd value with 1
         dummy_group_id[indices % 3 == 0] = 2  # fill every 3rd value with 2
         dummy_group_id = dummy_group_ids.astype("int64")

--- a/tests/catboost/test_catboost_model_export.py
+++ b/tests/catboost/test_catboost_model_export.py
@@ -94,7 +94,7 @@ def test_init_model(model_type):
 
 @pytest.mark.skip(
     Version(cb.__version__) < Version("0.26.0"),
-    reason="catboost < 0.26.0 does not support CatBoostRanker"
+    reason="catboost < 0.26.0 does not support CatBoostRanker",
 )
 def test_log_catboost_ranker(tmpdir):
     """

--- a/tests/catboost/test_catboost_model_export.py
+++ b/tests/catboost/test_catboost_model_export.py
@@ -65,7 +65,7 @@ def cb_model(request):
     model = request.param
     X, y = get_iris()
 
-    if isinstance(model, CatBoostRanker):
+    if isinstance(model, cb.CatBoostRanker):
         # the ranking task requires setting a group_id
         # we are creating a dummy group_id here that doesn't make any sense for the Iris dataset, but is ok for testing
         # if the code is running correctly

--- a/tests/catboost/test_catboost_model_export.py
+++ b/tests/catboost/test_catboost_model_export.py
@@ -99,14 +99,14 @@ def test_init_model(model_type):
 def test_log_catboost_ranker(tmpdir):
     """
     This is a separate test for the CatBoostRanker model.
-    It is separate since the ranking task requires a group_id column which makes the code different .
+    It is separate since the ranking task requires a group_id column which makes the code different.
     """
     model = mlflow.catboost._init_model("CatBoostRanker")
     assert model.__class__.__name__ == "CatBoostRanker"
 
     # the ranking task requires setting a group_id
-    # we are creating a dummy group_id here that doesn't make any sense for the Iris dataset, but is ok for testing
-    # if the code is running correctly
+    # we are creating a dummy group_id here that doesn't make any sense for the Iris dataset,
+    # but is ok for testing if the code is running correctly
 
     X, y = get_iris()
 

--- a/tests/catboost/test_catboost_model_export.py
+++ b/tests/catboost/test_catboost_model_export.py
@@ -96,7 +96,7 @@ def test_init_model(model_type):
     Version(cb.__version__) < Version("0.26.0"),
     reason="catboost < 0.26.0 does not support CatBoostRanker",
 )
-def test_log_catboost_ranker(tmpdir):
+def test_log_catboost_ranker():
     """
     This is a separate test for the CatBoostRanker model.
     It is separate since the ranking task requires a group_id column which makes the code different.
@@ -112,11 +112,7 @@ def test_log_catboost_ranker(tmpdir):
     model.fit(X, y, group_id=dummy_group_id)
 
     with mlflow.start_run():
-        artifact_path = "model"
-        conda_env = os.path.join(tmpdir.strpath, "conda_env.yaml")
-        _mlflow_conda_env(conda_env, additional_pip_deps=["catboost"])
-
-        model_info = mlflow.catboost.log_model(model, artifact_path, conda_env=conda_env)
+        model_info = mlflow.catboost.log_model(model, "model")
         loaded_model = mlflow.catboost.load_model(model_info.model_uri)
         assert isinstance(loaded_model, cb.CatBoostRanker)
         np.testing.assert_array_almost_equal(model.predict(X), loaded_model.predict(X))


### PR DESCRIPTION
## What changes are proposed in this pull request?

Added support for `CatBoostRanker` model type. In fact, it was already supported and worked perfectly, the only real issue was the type check on loading (but not on saving??) that didn't allow creating this model type for some reason.

## How is this patch tested?

All the loading and saving code for `CatBoostRanker` is absolutely the same. I added `CatBoostRanker`  to the list of tested models. This also required adding a `group_id` parameter to `CatBoostRanker.fit()` call. 

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
