### PR TITLE
Update `setup.py` to build MLflow UI if `MLFLOW_BUILD_UI` is defined

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 import os
 import logging
 import distutils
+import subprocess
+import shutil
+from pathlib import Path
 
 from importlib.machinery import SourceFileLoader
 from setuptools import setup, find_packages
@@ -124,6 +127,24 @@ class MinPythonVersion(distutils.cmd.Command):
         print(MINIMUM_SUPPORTED_PYTHON_VERSION)
 
 
+def build_mlflow_ui():
+    if os.getenv("MLFLOW_BUILD_UI", "false") == "true":
+        if shutil.which("yarn") is None:
+            url = "https://classic.yarnpkg.com/lang/en/docs/install"
+            raise Exception(
+                f"Yarn is required to build MLflow UI. See {url} for installation instructions."
+            )
+        print("Building MLflow UI. This may take a few minutes.")
+        cmd = """
+set -ex
+yarn install
+yarn build
+"""
+        js_dir = Path(__file__).parent.resolve().joinpath("mlflow", "server", "js")
+        subprocess.run(["bash", "-c", cmd], check=True, cwd=js_dir)
+
+
+build_mlflow_ui()
 setup(
     name="mlflow" if not _is_mlflow_skinny else "mlflow-skinny",
     version=version,

--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,11 @@ class MinPythonVersion(distutils.cmd.Command):
 
 
 def build_mlflow_ui():
-    if os.getenv("MLFLOW_BUILD_UI", "false") == "true":
+    js_dir = Path(__file__).parent.resolve().joinpath("mlflow", "server", "js")
+    build_dir = js_dir.joinpath("build")
+    if os.getenv("MLFLOW_BUILD_UI", "false") == "true" and (
+        not build_dir.exists() or next(build_dir.iterdir(), None) is None
+    ):
         if shutil.which("yarn") is None:
             url = "https://classic.yarnpkg.com/lang/en/docs/install"
             raise Exception(
@@ -140,7 +144,6 @@ set -ex
 yarn install
 yarn build
 """
-        js_dir = Path(__file__).parent.resolve().joinpath("mlflow", "server", "js")
         subprocess.run(["bash", "-c", cmd], check=True, cwd=js_dir)
 
 


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Update `setup.py` to build MLflow UI if `MLFLOW_BUILD_UI` is defined.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

Verified the following command launches MLflow UI:

```
docker run --rm -p 5000:5000 nikolaik/python-nodejs bash -c "MLFLOW_BUILD_UI=true pip install git+https://github.com/harupy/mlflow.git@update-setup.py-to-build-ui && mlflow ui --host 0.0.0.0"
```

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
