### PR TITLE
Use `NumpyEncoder` when dumping evaluation metrics

### DIFF
--- a/mlflow/models/evaluation/artifacts.py
+++ b/mlflow/models/evaluation/artifacts.py
@@ -10,6 +10,7 @@ from collections import namedtuple
 
 from mlflow.exceptions import MlflowException
 from mlflow.models.evaluation.base import EvaluationArtifact
+from mlflow.utils.proto_json_utils import NumpyEncoder
 
 
 class ImageEvaluationArtifact(EvaluationArtifact):
@@ -171,7 +172,7 @@ def _infer_artifact_type_and_ext(artifact_name, raw_artifact, custom_metric_tupl
     # Given as other python object, we first attempt to infer as JsonEvaluationArtifact. If that
     # fails, we store it as PickleEvaluationArtifact
     try:
-        json.dumps(raw_artifact)
+        json.dumps(raw_artifact, cls=NumpyEncoder)
         return _InferredArtifactProperties(
             from_path=False, type=JsonEvaluationArtifact, ext=".json"
         )

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -11,6 +11,7 @@ from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils import _get_fully_qualified_class_name
 from mlflow.utils.class_utils import _get_class_from_string
 from mlflow.utils.annotations import experimental
+from mlflow.utils.proto_json_utils import NumpyEncoder
 import logging
 import struct
 import sys
@@ -119,7 +120,7 @@ class EvaluationResult:
         """Write the evaluation results to the specified local filesystem path"""
         os.makedirs(path, exist_ok=True)
         with open(os.path.join(path, "metrics.json"), "w") as fp:
-            json.dump(self.metrics, fp)
+            json.dump(self.metrics, fp, cls=NumpyEncoder)
 
         artifacts_metadata = {
             artifact_name: {

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -16,6 +16,7 @@ from mlflow.models.evaluation.artifacts import (
     _infer_artifact_type_and_ext,
     JsonEvaluationArtifact,
 )
+from mlflow.utils.proto_json_utils import NumpyEncoder
 
 from sklearn import metrics as sk_metrics
 from sklearn.pipeline import Pipeline as sk_Pipeline
@@ -793,7 +794,7 @@ class DefaultEvaluator(ModelEvaluator):
                 if isinstance(raw_artifact, str):
                     f.write(raw_artifact)
                 else:
-                    json.dump(raw_artifact, f)
+                    json.dump(raw_artifact, f, cls=NumpyEncoder)
         elif inferred_type is CsvEvaluationArtifact:
             raw_artifact.to_csv(artifact_file_local_path, index=False)
         elif inferred_type is NumpyEvaluationArtifact:

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -108,6 +108,21 @@ def test_regressor_evaluation(linear_regressor_model_uri, diabetes_dataset):
     }
 
 
+def test_regressor_evaluation_with_int_targets(
+    linear_regressor_model_uri, diabetes_dataset, tmp_path
+):
+    with mlflow.start_run():
+        result = evaluate(
+            linear_regressor_model_uri,
+            diabetes_dataset._constructor_args["data"],
+            model_type="regressor",
+            targets=diabetes_dataset._constructor_args["targets"].astype(np.int64),
+            dataset_name=diabetes_dataset.name,
+            evaluators="default",
+        )
+        result.save(tmp_path)
+
+
 def test_multi_classifier_evaluation(multiclass_logistic_regressor_model_uri, iris_dataset):
     with mlflow.start_run() as run:
         result = evaluate(
@@ -957,7 +972,11 @@ def test_custom_metric_logs_artifacts_from_objects(
     def example_custom_metric(_, __):
         return {}, {
             "test_image_artifact": fig,
-            "test_json_artifact": [1, 2, 3],
+            "test_json_artifact": {
+                "list": [1, 2, 3],
+                "numpy_int": np.int64(0),
+                "numpy_float": np.float64(0.5),
+            },
             "test_npy_artifact": np.array([1, 2, 3, 4, 5]),
             "test_csv_artifact": pd.DataFrame({"a": [1, 2, 3]}),
             "test_json_text_artifact": '{"a": [1, 2, 3], "c": 3.4}',
@@ -977,7 +996,11 @@ def test_custom_metric_logs_artifacts_from_objects(
     assert "test_json_artifact" in result.artifacts
     assert "test_json_artifact_on_data_breast_cancer_dataset.json" in artifacts
     assert isinstance(result.artifacts["test_json_artifact"], JsonEvaluationArtifact)
-    assert result.artifacts["test_json_artifact"].content == [1, 2, 3]
+    assert result.artifacts["test_json_artifact"].content == {
+        "list": [1, 2, 3],
+        "numpy_int": 0,
+        "numpy_float": 0.5,
+    }
 
     assert "test_npy_artifact" in result.artifacts
     assert "test_npy_artifact_on_data_breast_cancer_dataset.npy" in artifacts


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Use `NumpyEncoder` when dumping evaluation metrics to serialize numpy objects.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
