### PR TITLE
Fix TensorFlow autologging failures on TF datasets lacking batch size metadata

### DIFF
--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -1046,25 +1046,33 @@ def autolog(
             unlogged_params = ["self", "x", "y", "callbacks", "validation_data", "verbose"]
 
             batch_size = None
-            training_data = kwargs["x"] if "x" in kwargs else args[0]
-            if isinstance(training_data, tensorflow.data.Dataset):
-                batch_size = training_data._batch_size.numpy()
-            elif isinstance(training_data, tensorflow.keras.utils.Sequence):
-                first_batch_inputs, _ = training_data[0]
-                batch_size = len(first_batch_inputs)
-            elif is_iterator(training_data):
-                peek = next(training_data)
-                batch_size = len(peek[0])
+            try:
+                training_data = kwargs["x"] if "x" in kwargs else args[0]
+                if isinstance(training_data, tensorflow.data.Dataset) and hasattr(training_data, "_batch_size"):
+                    batch_size = training_data._batch_size.numpy()
+                elif isinstance(training_data, tensorflow.keras.utils.Sequence):
+                    first_batch_inputs, _ = training_data[0]
+                    batch_size = len(first_batch_inputs)
+                elif is_iterator(training_data):
+                    peek = next(training_data)
+                    batch_size = len(peek[0])
 
-                def __restore_generator(prev_generator):
-                    yield peek
-                    yield from prev_generator
+                    def __restore_generator(prev_generator):
+                        yield peek
+                        yield from prev_generator
 
-                restored_generator = __restore_generator(training_data)
-                if "x" in kwargs:
-                    kwargs["x"] = restored_generator
-                else:
-                    args = (restored_generator,) + args[1:]
+                    restored_generator = __restore_generator(training_data)
+                    if "x" in kwargs:
+                        kwargs["x"] = restored_generator
+                    else:
+                        args = (restored_generator,) + args[1:]
+            except Exception as e:
+                _logger.warning(
+                    "Encountered unexpected error while inferring batch size from training"
+                    " dataset: %s",
+                    e
+                )
+
             if batch_size is not None:
                 mlflow.log_param("batch_size", batch_size)
                 unlogged_params.append("batch_size")

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -1048,7 +1048,9 @@ def autolog(
             batch_size = None
             try:
                 training_data = kwargs["x"] if "x" in kwargs else args[0]
-                if isinstance(training_data, tensorflow.data.Dataset) and hasattr(training_data, "_batch_size"):
+                if isinstance(training_data, tensorflow.data.Dataset) and hasattr(
+                    training_data, "_batch_size"
+                ):
                     batch_size = training_data._batch_size.numpy()
                 elif isinstance(training_data, tensorflow.keras.utils.Sequence):
                     first_batch_inputs, _ = training_data[0]
@@ -1070,7 +1072,7 @@ def autolog(
                 _logger.warning(
                     "Encountered unexpected error while inferring batch size from training"
                     " dataset: %s",
-                    e
+                    e,
                 )
 
             if batch_size is not None:

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -366,7 +366,7 @@ def test_tf_keras_autolog_succeeds_for_tf_datasets_lacking_batch_size_info():
 
     train_ds = tf.data.Dataset.from_tensor_slices((X_train, y_train))
     train_ds = train_ds.batch(50)
-    train_ds = train_ds.cache().prefetch(buffer_size=tf.data.AUTOTUNE)
+    train_ds = train_ds.cache().prefetch(buffer_size=5)
     assert not hasattr(train_ds, "_batch_size")
 
     model = tf.keras.Sequential()

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -370,13 +370,19 @@ def test_tf_keras_autolog_succeeds_for_tf_datasets_lacking_batch_size_info():
     assert not hasattr(train_ds, "_batch_size")
 
     model = tf.keras.Sequential()
-    model.add(tf.keras.Input(100, ))
-    model.add(tf.keras.layers.Dense(256, activation='relu'))
-    model.add(tf.keras.layers.Dropout(rate=.4))
-    model.add(tf.keras.layers.Dense(10, activation='sigmoid'))
-    model.compile(loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=False),
-                  optimizer='Adam',
-                  metrics=['accuracy'])
+    model.add(
+        tf.keras.Input(
+            100,
+        )
+    )
+    model.add(tf.keras.layers.Dense(256, activation="relu"))
+    model.add(tf.keras.layers.Dropout(rate=0.4))
+    model.add(tf.keras.layers.Dense(10, activation="sigmoid"))
+    model.compile(
+        loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=False),
+        optimizer="Adam",
+        metrics=["accuracy"],
+    )
 
     mlflow.tensorflow.autolog()
     model.fit(train_ds, epochs=100)


### PR DESCRIPTION
Signed-off-by: dbczumar <corey.zumar@databricks.com>

## Related Issues/PRs

#6035

## What changes are proposed in this pull request?

This PR addresses #6035 by fixing a regression introduced in https://github.com/mlflow/mlflow/pull/5683 whereby it is erroneously assumed that every `tf.data.Dataset` instance has `_batch_size` attribute for the purpose of inferring the training batch size from the supplied dataset. This is clearly not accurate.

This PR adjusts batch size inference logic to only examine `tf.data.Dataset` objects containing a `_batch_size` attribute and adds exception handling to batch size inference to ensure that autologging does not fail entirely in the event that future issues arise when inferring the batch size, since the batch size parameter is unlikely to be critical to reproducibility.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [X] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

Added integration test to `test_tensorflow2_autolog.py`

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

Fix a regression in ``mlflow.tensorflow.autolog()`` that caused autologging to fail for ``tf.data.Dataset`` objects lacking batch size metadata.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
