### PR TITLE
Make pyfunc.spark_udf support empty partition

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1268,7 +1268,8 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
                 else:
                     row_batch_args = input_batch
 
-                yield _predict_row_batch(batch_predict_fn, row_batch_args)
+                if len(row_batch_args[0]) > 0:
+                    yield _predict_row_batch(batch_predict_fn, row_batch_args)
         finally:
             if scoring_server_proc is not None:
                 os.kill(scoring_server_proc.pid, signal.SIGTERM)

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -266,7 +266,10 @@ def test_spark_udf_autofills_no_arguments(spark):
                 columns=["x", "b", "c", "d"], data={"x": [1], "b": [2], "c": [3], "d": [4]}
             )
         )
-        with pytest.raises(AnalysisException, match=r"cannot resolve 'a' given input columns"):
+        with pytest.raises(
+            AnalysisException,
+            match=r"cannot resolve 'a' given input columns|Column 'a' does not exist",
+        ):
             bad_data.withColumn("res", udf())
 
     nameless_signature = ModelSignature(

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -29,6 +29,7 @@ from collections import namedtuple
 from sklearn.neighbors import KNeighborsClassifier
 
 from pyspark.sql.functions import pandas_udf
+from pyspark.sql.functions import col, struct
 
 
 prediction = [int(1), int(2), "class1", float(0.1), 0.2]
@@ -211,8 +212,6 @@ def test_spark_udf_env_manager_predict_sklearn_model(spark, sklearn_model, model
 
 
 def test_spark_udf_with_single_arg(spark):
-    from pyspark.sql.functions import struct
-
     class TestModel(PythonModel):
         def predict(self, context, model_input):
             return [",".join(model_input.columns.tolist())] * len(model_input)
@@ -344,6 +343,40 @@ def test_spark_udf_with_datetime_columns(spark):
         res = data.withColumn("res", udf("timestamp", "date")).select("res")
         res = res.toPandas()
         assert res["res"][0] == ["timestamp", "date"]
+
+
+def test_spark_udf_over_empty_partition(spark):
+    class TestModel(PythonModel):
+        def predict(self, context, model_input):
+            if len(model_input) == 0:
+                raise ValueError("Empty input is not allowed.")
+            else:
+                return model_input.a + model_input.b
+
+    signature = ModelSignature(
+        inputs=Schema([ColSpec("long", "a"), ColSpec("long", "b")]),
+        outputs=Schema([ColSpec("long")]),
+    )
+
+    # Create a spark dataframe with 2 partitions, one partition has one record and
+    # the other partition is empty.
+    spark_df = spark.createDataFrame(
+        pd.DataFrame(columns=["x", "y"], data={"x": [11], "y": [21]})
+    ).repartition(2)
+    with mlflow.start_run() as run:
+        mlflow.pyfunc.log_model("model", python_model=TestModel(), signature=signature)
+        python_udf = mlflow.pyfunc.spark_udf(
+            spark, "runs:/{}/model".format(run.info.run_id), result_type=LongType()
+        )
+        res_df = spark_df.withColumn("res", python_udf("x", "y")).select("res").toPandas()
+        assert res_df.res[0] == 32
+
+        res_df2 = (
+            spark_df.withColumn("res", python_udf(struct(col("x").alias("a"), col("y").alias("b"))))
+            .select("res")
+            .toPandas()
+        )
+        assert res_df2.res[0] == 32
 
 
 def test_model_cache(spark, model_path):


### PR DESCRIPTION
Signed-off-by: Weichen Xu <weichen.xu@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Make pyfunc.spark_udf support empty partition
This relates to issue: https://databricks.slack.com/archives/C0JCGEF17/p1655243815311009

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
