### PR TITLE
Deletion of an experiment to mark runs associated with that experiment to be deleted

### DIFF
--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -405,12 +405,31 @@ class SqlAlchemyStore(AbstractStore):
         with self.ManagedSessionMaker() as session:
             experiment = self._get_experiment(session, experiment_id, ViewType.ACTIVE_ONLY)
             experiment.lifecycle_stage = LifecycleStage.DELETED
+            runs = self._list_run_infos(session, experiment_id)
+            for run in runs:
+                self._mark_run_for_delete(session, run)
             self._save_to_db(objs=experiment, session=session)
+
+    def _mark_run_for_delete(self, session, run):
+        self._check_run_is_active(run)
+        run.lifecycle_stage = LifecycleStage.DELETED
+        self._save_to_db(objs=run, session=session)
+
+    def _mark_run_for_active(self, session, run):
+        run.lifecycle_stage = LifecycleStage.ACTIVE
+        self._save_to_db(objs=run, session=session)
+
+    def _list_run_infos(self, session, experiment_id):
+        runs = session.query(SqlRun).filter(SqlRun.experiment_id == experiment_id).all()
+        return runs
 
     def restore_experiment(self, experiment_id):
         with self.ManagedSessionMaker() as session:
             experiment = self._get_experiment(session, experiment_id, ViewType.DELETED_ONLY)
             experiment.lifecycle_stage = LifecycleStage.ACTIVE
+            runs = self._list_run_infos(session, experiment_id)
+            for run in runs:
+                self._mark_run_for_active(session, run)
             self._save_to_db(objs=experiment, session=session)
 
     def rename_experiment(self, experiment_id, new_name):

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -407,15 +407,15 @@ class SqlAlchemyStore(AbstractStore):
             experiment.lifecycle_stage = LifecycleStage.DELETED
             runs = self._list_run_infos(session, experiment_id)
             for run in runs:
-                self._mark_run_for_delete(session, run)
+                self._mark_run_deleted(session, run)
             self._save_to_db(objs=experiment, session=session)
 
-    def _mark_run_for_delete(self, session, run):
+    def _mark_run_deleted(self, session, run):
         self._check_run_is_active(run)
         run.lifecycle_stage = LifecycleStage.DELETED
         self._save_to_db(objs=run, session=session)
 
-    def _mark_run_for_active(self, session, run):
+    def _mark_run_active(self, session, run):
         run.lifecycle_stage = LifecycleStage.ACTIVE
         self._save_to_db(objs=run, session=session)
 
@@ -429,7 +429,7 @@ class SqlAlchemyStore(AbstractStore):
             experiment.lifecycle_stage = LifecycleStage.ACTIVE
             runs = self._list_run_infos(session, experiment_id)
             for run in runs:
-                self._mark_run_for_active(session, run)
+                self._mark_run_active(session, run)
             self._save_to_db(objs=experiment, session=session)
 
     def rename_experiment(self, experiment_id, new_name):

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -255,6 +255,56 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
 
         self.assertEqual(len(self.store.list_experiments()), len(all_experiments) - 1)
 
+    def test_delete_experiment_with_runs(self):
+        # Create run with experiment
+        run = self._run_factory()
+        all_experiments = self.store.list_experiments()
+        len_of_experiments = 2  # default + current experiment, hence 2 experiments
+        self.assertEqual(len(all_experiments), len_of_experiments)
+
+        exp_id = run.info.experiment_id  # Find experiment id
+        run_id = run.info.run_id  # Find run id
+
+        self.store.delete_experiment(exp_id)
+
+        updated_exp = self.store.get_experiment(exp_id)
+        self.assertEqual(updated_exp.lifecycle_stage, entities.LifecycleStage.DELETED)
+
+        updated_run = self.store.get_run(run_id)
+        self.assertEqual(updated_run.info.lifecycle_stage, entities.LifecycleStage.DELETED)
+
+        self.assertEqual(len(self.store.list_experiments()), len_of_experiments - 1)
+
+    def test_restore_experiment_with_runs(self):
+        # Create run with experiment
+        run = self._run_factory()
+        all_experiments = self.store.list_experiments()
+        len_of_experiments = 2  # default + current experiment, hence 2 experiments
+        self.assertEqual(len(all_experiments), len_of_experiments)
+
+        exp_id = run.info.experiment_id  # Find experiment id
+        run_id = run.info.run_id  # Find run id
+
+        self.store.delete_experiment(exp_id)
+
+        updated_exp = self.store.get_experiment(exp_id)
+        self.assertEqual(updated_exp.lifecycle_stage, entities.LifecycleStage.DELETED)
+
+        updated_run = self.store.get_run(run_id)
+        self.assertEqual(updated_run.info.lifecycle_stage, entities.LifecycleStage.DELETED)
+
+        self.assertEqual(len(self.store.list_experiments()), len_of_experiments - 1)
+
+        self.store.restore_experiment(exp_id)
+
+        updated_exp = self.store.get_experiment(exp_id)
+        self.assertEqual(updated_exp.lifecycle_stage, entities.LifecycleStage.ACTIVE)
+
+        updated_run = self.store.get_run(run_id)
+        self.assertEqual(updated_run.info.lifecycle_stage, entities.LifecycleStage.ACTIVE)
+
+        self.assertEqual(len(all_experiments), len_of_experiments)
+
     def test_get_experiment(self):
         name = "goku"
         experiment_id = self._experiment_factory(name)


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## https://github.com/mlflow/mlflow/issues/5819

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#5819

## What changes are proposed in this pull request?

1. Deleting an experiment from UI to also mark runs associated with that experiment to be deleted
2. Restoring an experiment should also mark the runs to a non-deleted state.
3. Tests to check whether deleting/ restoring experiments would also mark the runs associated with the experiment to be deleted/ restored.


## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

1. By having the backend store as a SQLite database:

- Deleting an experiment would mark the lifecycle_stage of the runs associated with this experiment to "deleted" in the runs table.
- Restoring an experiment would mark the lifecycle_stage of the runs associated with this experiment to "active" in the runs table.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
4. Click `Details` on the right to open the job page of CircleCI.
5. Click the `Artifacts` tab.
6. Click `docs/build/html/index.html`.
7. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
