### PR TITLE
Handle auth required http status code to prevent nested exception

### DIFF
--- a/mlflow/exceptions.py
+++ b/mlflow/exceptions.py
@@ -5,6 +5,7 @@ from mlflow.protos.databricks_pb2 import (
     TEMPORARILY_UNAVAILABLE,
     ENDPOINT_NOT_FOUND,
     PERMISSION_DENIED,
+    CUSTOMER_UNAUTHORIZED,
     REQUEST_LIMIT_EXCEEDED,
     BAD_REQUEST,
     INVALID_PARAMETER_VALUE,
@@ -22,10 +23,22 @@ ERROR_CODE_TO_HTTP_STATUS = {
     ErrorCode.Name(ENDPOINT_NOT_FOUND): 404,
     ErrorCode.Name(RESOURCE_DOES_NOT_EXIST): 404,
     ErrorCode.Name(PERMISSION_DENIED): 403,
+    ErrorCode.Name(CUSTOMER_UNAUTHORIZED): 401,
     ErrorCode.Name(BAD_REQUEST): 400,
     ErrorCode.Name(RESOURCE_ALREADY_EXISTS): 400,
     ErrorCode.Name(INVALID_PARAMETER_VALUE): 400,
 }
+
+HTTP_STATUS_TO_ERROR_CODE = dict((v, k) for k, v in ERROR_CODE_TO_HTTP_STATUS.items())
+HTTP_STATUS_TO_ERROR_CODE[400] = ErrorCode.Name(BAD_REQUEST)
+HTTP_STATUS_TO_ERROR_CODE[404] = ErrorCode.Name(ENDPOINT_NOT_FOUND)
+HTTP_STATUS_TO_ERROR_CODE[500] = ErrorCode.Name(INTERNAL_ERROR)
+
+
+def get_error_code(http_status):
+    return ErrorCode.Value(
+        HTTP_STATUS_TO_ERROR_CODE.get(http_status, ErrorCode.Name(INTERNAL_ERROR))
+    )
 
 
 class MlflowException(Exception):

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -289,15 +289,13 @@ class RestStore(AbstractStore):
                 databricks_pb2.RESOURCE_DOES_NOT_EXIST
             ):
                 return None
-            elif e.error_code == databricks_pb2.ErrorCode.Name(
-                databricks_pb2.REQUEST_LIMIT_EXCEEDED
-            ):
-                raise e
-            # Fall back to using ListExperiments-based implementation.
-            for experiment in self.list_experiments(ViewType.ALL):
-                if experiment.name == experiment_name:
-                    return experiment
-            return None
+            elif e.error_code == databricks_pb2.ErrorCode.Name(databricks_pb2.ENDPOINT_NOT_FOUND):
+                # Fall back to using ListExperiments-based implementation.
+                for experiment in self.list_experiments(ViewType.ALL):
+                    if experiment.name == experiment_name:
+                        return experiment
+                return None
+            raise e
 
     def log_batch(self, run_id, metrics, params, tags):
         metric_protos = [metric.to_proto() for metric in metrics]

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -14,7 +14,7 @@ from mlflow.protos import databricks_pb2
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, ENDPOINT_NOT_FOUND, ErrorCode
 from mlflow.utils.proto_json_utils import parse_dict
 from mlflow.utils.string_utils import strip_suffix
-from mlflow.exceptions import MlflowException, RestException
+from mlflow.exceptions import get_error_code, MlflowException, RestException
 
 RESOURCE_DOES_NOT_EXIST = "RESOURCE_DOES_NOT_EXIST"
 _REST_API_PATH_PREFIX = "/api/2.0"
@@ -188,7 +188,10 @@ def verify_rest_response(response, endpoint):
                 endpoint,
                 response.status_code,
             )
-            raise MlflowException("%s. Response body: '%s'" % (base_msg, response.text))
+            raise MlflowException(
+                "%s. Response body: '%s'" % (base_msg, response.text),
+                error_code=get_error_code(response.status_code),
+            )
 
     # Skip validation for endpoints (e.g. DBFS file-download API) which may return a non-JSON
     # response


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

Related Issue: https://github.com/mlflow/mlflow/issues/6105

## What changes are proposed in this pull request?

The fix to the issue is to:
1. Populate `MlflowException` with the appropriate `error_code` derived from the returned status code of the request.
2. When the exception is being handled in `get_experiment_by_name()` look at the `error_code` and if this error is not temporal raise the exception to the caller.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

I have built a new dev package and tested on my local. With the proposed change, I see that only one exception is raised:

```python-traceback
INFO:root:An error occurred while setting MLflow experiment
Traceback (most recent call last):
  File "/home/bruno/repos/NIH-NEI/mouse-image-segmentation/unet/model/training.py", line 297, in train_model
    mlflow.set_experiment(mlflow_params.experiment)
  File "/home/bruno/anaconda3/envs/oct-seg/lib/python3.9/site-packages/mlflow/tracking/fluent.py", line 110, in set_experiment
    experiment = client.get_experiment_by_name(experiment_name)
  File "/home/bruno/anaconda3/envs/oct-seg/lib/python3.9/site-packages/mlflow/tracking/client.py", line 462, in get_experiment_by_name
    return self._tracking_client.get_experiment_by_name(name)
  File "/home/bruno/anaconda3/envs/oct-seg/lib/python3.9/site-packages/mlflow/tracking/_tracking_service/client.py", line 163, in get_experiment_by_name
    return self.store.get_experiment_by_name(name)
  File "/home/bruno/anaconda3/envs/oct-seg/lib/python3.9/site-packages/mlflow/store/tracking/rest_store.py", line 297, in get_experiment_by_name
    raise e
  File "/home/bruno/anaconda3/envs/oct-seg/lib/python3.9/site-packages/mlflow/store/tracking/rest_store.py", line 286, in get_experiment_by_name
    response_proto = self._call_endpoint(GetExperimentByName, req_body)
  File "/home/bruno/anaconda3/envs/oct-seg/lib/python3.9/site-packages/mlflow/store/tracking/rest_store.py", line 57, in _call_endpoint
    return call_endpoint(self.get_host_creds(), endpoint, method, json_body, response_proto)
  File "/home/bruno/anaconda3/envs/oct-seg/lib/python3.9/site-packages/mlflow/utils/rest_utils.py", line 260, in call_endpoint
    response = verify_rest_response(response, endpoint)
  File "/home/bruno/anaconda3/envs/oct-seg/lib/python3.9/site-packages/mlflow/utils/rest_utils.py", line 192, in verify_rest_response
    raise MlflowException(
mlflow.exceptions.MlflowException: API request to endpoint /api/2.0/mlflow/experiments/get-by-name failed with error code 401 != 200. Response body: '<html>
<head><title>401 Authorization Required</title></head>
<body>
<center><h1>401 Authorization Required</h1></center>
<hr><center>nginx/1.20.0</center>
</body>
</html>
'
```

I would need some guidance to write appropriate tests.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
3. Click `Details` on the right to open the job page of CircleCI.
4. Click the `Artifacts` tab.
5. Click `docs/build/html/index.html`.
6. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
