### PR TITLE
Add `pos_label` parameter for `mlflow.sklearn.autolog`

### DIFF
--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -1184,11 +1184,10 @@ def autolog(
                                   new model version of the registered model with this name.
                                   The registered model is created if it does not already exist.
     :param pos_label: If given, used as the positive label to compute binary classification
-                      training metrics such as precision, recall, f1, etc. This parameter
-                      should only be set for binary classification model
-                      - if used on multi-label model, the training metrics calculation will fail
-                        and the training metrics won't be logged.
-                      - if used for regression model, the parameter will be ignored.
+                      training metrics such as precision, recall, f1, etc. This parameter should
+                      only be set for binary classification model. If used for multi-label model,
+                      the training metrics calculation will fail and the training metrics won't
+                      be logged. If used for regression model, the parameter will be ignored.
     """
     _autolog(
         flavor_name=FLAVOR_NAME,

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -1183,9 +1183,9 @@ def autolog(
     :param registered_model_name: If given, each time a model is trained, it is registered as a
                                   new model version of the registered model with this name.
                                   The registered model is created if it does not already exist.
-    :param pos_label: If given, used as the positive label to compute binary classification metrics such as
+    :param pos_label: If given, used as the positive label to compute binary classification training metrics such as
                       precision, recall, f1, etc. This parameter should only be set for binary classification model
-                      - if used on multi-label model, the evaluation will fail;
+                      - if used on multi-label model, the training metrics calculation will fail and won't be logged.
                       - if used for regression model, the parameter will be ignored.
     """
     _autolog(

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -1183,9 +1183,11 @@ def autolog(
     :param registered_model_name: If given, each time a model is trained, it is registered as a
                                   new model version of the registered model with this name.
                                   The registered model is created if it does not already exist.
-    :param pos_label: If given, used as the positive label to compute binary classification training metrics such as
-                      precision, recall, f1, etc. This parameter should only be set for binary classification model
-                      - if used on multi-label model, the training metrics calculation will fail and won't be logged.
+    :param pos_label: If given, used as the positive label to compute binary classification
+                      training metrics such as precision, recall, f1, etc. This parameter
+                      should only be set for binary classification model
+                      - if used on multi-label model, the training metrics calculation will fail
+                        and the training metrics won't be logged.
                       - if used for regression model, the parameter will be ignored.
     """
     _autolog(

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -925,6 +925,7 @@ def autolog(
     log_post_training_metrics=True,
     serialization_format=SERIALIZATION_FORMAT_CLOUDPICKLE,
     registered_model_name=None,
+    pos_label=None,
 ):  # pylint: disable=unused-argument
     """
     Enables (or disables) and configures autologging for scikit-learn estimators.
@@ -1182,6 +1183,10 @@ def autolog(
     :param registered_model_name: If given, each time a model is trained, it is registered as a
                                   new model version of the registered model with this name.
                                   The registered model is created if it does not already exist.
+    :param pos_label: If given, used as the positive label to compute binary classification metrics such as
+                      precision, recall, f1, etc. This parameter should only be set for binary classification model
+                      - if used on multi-label model, the evaluation will fail;
+                      - if used for regression model, the parameter will be ignored.
     """
     _autolog(
         flavor_name=FLAVOR_NAME,
@@ -1195,6 +1200,7 @@ def autolog(
         max_tuning_runs=max_tuning_runs,
         log_post_training_metrics=log_post_training_metrics,
         serialization_format=serialization_format,
+        pos_label=pos_label,
     )
 
 
@@ -1210,6 +1216,7 @@ def _autolog(
     max_tuning_runs=5,
     log_post_training_metrics=True,
     serialization_format=SERIALIZATION_FORMAT_CLOUDPICKLE,
+    pos_label=None,
 ):  # pylint: disable=unused-argument
     """
     Internal autologging function for scikit-learn models.
@@ -1365,6 +1372,7 @@ def _autolog(
             X=X,
             y_true=y_true,
             sample_weight=sample_weight,
+            pos_label=pos_label,
         )
         if y_true is None and not logged_metrics:
             _logger.warning(

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -2020,7 +2020,8 @@ def test_autolog_emits_warning_message_when_pos_label_used_for_multilabel():
 
     with mlflow.start_run(), mock.patch("mlflow.sklearn.utils._logger.warning") as mock_warning:
         model.fit(X, y)
-        mock_warning.called_once_with(
+        assert mock_warning.call_count == 3  # for precision, recall and f1_score
+        mock_warning.assert_any_call(
             "precision_score failed. The metric training_precision_score will not be recorded. "
             "Metric error: Target is multiclass but average='binary'. Please choose another "
             "average setting, one of [None, 'micro', 'macro', 'weighted']."

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -2013,3 +2013,18 @@ def test_autolog_pos_label_used_for_training_metric():
     assert training_metrics == expected_training_metrics
 
     mlflow.end_run()
+
+
+def test_autolog_emits_warning_message_when_pos_label_used_for_multilabel():
+    mlflow.sklearn.autolog(pos_label=1)
+
+    model = sklearn.svm.SVC()
+    X, y = get_iris()
+
+    with mlflow.start_run(), mock.patch("mlflow.sklearn.utils._logger.warning") as mock_warning:
+        model.fit(X, y)
+        mock_warning.called_once_with(
+            "precision_score failed. The metric training_precision_score will not be recorded. "
+            "Metric error: Target is multiclass but average='binary'. Please choose another "
+            "average setting, one of [None, 'micro', 'macro', 'weighted']."
+        )

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -2002,17 +2002,14 @@ def test_autolog_pos_label_used_for_training_metric():
     model = sklearn.ensemble.RandomForestClassifier(max_depth=2, random_state=0, n_estimators=10)
     X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
 
-    mlflow.start_run()
-    model = fit_model(model, X, y, "fit")
+    with mlflow.start_run() as run:
+        model = fit_model(model, X, y, "fit")
+        _, training_metrics, _, _ = get_run_data(run.info.run_id)
+        expected_training_metrics = mlflow.sklearn.eval_and_log_metrics(
+            model=model, X=X, y_true=y, prefix="training_", pos_label=1
+        )
 
-    run_id = mlflow.active_run().info.run_id
-    _, training_metrics, _, _ = get_run_data(run_id)
-    expected_training_metrics = mlflow.sklearn.eval_and_log_metrics(
-        model=model, X=X, y_true=y, prefix="training_", pos_label=1
-    )
     assert training_metrics == expected_training_metrics
-
-    mlflow.end_run()
 
 
 def test_autolog_emits_warning_message_when_pos_label_used_for_multilabel():

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -1998,6 +1998,7 @@ def test_autolog_pos_label_used_for_training_metric():
     mlflow.sklearn.autolog(pos_label=1)
 
     import sklearn.ensemble
+
     model = sklearn.ensemble.RandomForestClassifier(max_depth=2, random_state=0, n_estimators=10)
     X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
 
@@ -2007,7 +2008,7 @@ def test_autolog_pos_label_used_for_training_metric():
     run_id = mlflow.active_run().info.run_id
     _, training_metrics, _, _ = get_run_data(run_id)
     expected_training_metrics = mlflow.sklearn.eval_and_log_metrics(
-            model=model, X=X, y_true=y, prefix="training_", pos_label=1
+        model=model, X=X, y_true=y, prefix="training_", pos_label=1
     )
     assert training_metrics == expected_training_metrics
 


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

Related PR https://github.com/mlflow/mlflow/issues/5512

## What changes are proposed in this pull request?

The previous PR https://github.com/mlflow/mlflow/issues/5512 exposes the same parameter `pos_label` in `mlflow.sklearn.eval_and_log_metrics` to allow user to optionally fill in the `pos_label` if they are doing binary classification. This PR adds `pos_label` parameter for `mlflow.sklearn.autolog`. If set, the `pos_label` will be used for the autologged training metrics.

## How is this patch tested?
New unit test

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Allow user passing in `pos_label` in sklearn autologging.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
