### PR TITLE
ameya-parab:feature/sagemaker_proxies

### DIFF
--- a/mlflow/models/docker_utils.py
+++ b/mlflow/models/docker_utils.py
@@ -41,23 +41,25 @@ RUN pip install virtualenv
 if os.getenv("http_proxy") is not None and os.getenv("https_proxy") is not None:
 
     # Expects proxies as PROTOCOL://HOSTNAME:PORT
-    _http_proxy = urlparse(os.environ["http_proxy"])
-    assert _http_proxy.hostname is not None, "Invalid `http_proxy` hostname."
-    assert isinstance(_http_proxy.port, int), f"Invalid Proxy Port: {_http_proxy.port}"
+    parsed_http_proxy = urlparse(os.environ["http_proxy"])
+    assert parsed_http_proxy.hostname is not None, "Invalid `http_proxy` hostname."
+    assert isinstance(parsed_http_proxy.port, int), f"Invalid Proxy Port: {parsed_http_proxy.port}"
 
-    _https_proxy = urlparse(os.environ["https_proxy"])
-    assert _https_proxy.hostname is not None, "Invalid `https_proxy` hostname."
-    assert isinstance(_https_proxy.port, int), f"Invalid Proxy Port: {_https_proxy.port}"
+    parsed_https_proxy = urlparse(os.environ["https_proxy"])
+    assert parsed_https_proxy.hostname is not None, "Invalid `https_proxy` hostname."
+    assert isinstance(
+        parsed_https_proxy.port, int
+    ), f"Invalid Proxy Port: {parsed_https_proxy.port}"
 
     MAVEN_PROXY = (
         " -DproxySet=true -Dhttp.proxyHost={http_proxy_host} "
         "-Dhttp.proxyPort={http_proxy_port} -Dhttps.proxyHost={https_proxy_host} "
         "-Dhttps.proxyPort={https_proxy_port} -Dhttps.nonProxyHosts=repo.maven.apache.org"
     ).format(
-        http_proxy_host=_http_proxy.hostname,
-        http_proxy_port=_http_proxy.port,
-        https_proxy_host=_https_proxy.hostname,
-        https_proxy_port=_https_proxy.port,
+        http_proxy_host=parsed_http_proxy.hostname,
+        http_proxy_port=parsed_http_proxy.port,
+        https_proxy_host=parsed_https_proxy.hostname,
+        https_proxy_port=parsed_https_proxy.port,
     )
 else:
     MAVEN_PROXY = ""  # No Proxy

--- a/mlflow/models/docker_utils.py
+++ b/mlflow/models/docker_utils.py
@@ -40,7 +40,8 @@ RUN pip install virtualenv
 
 if os.getenv("http_proxy") is not None and os.getenv("https_proxy") is not None:
 
-    # Expects proxies as PROTOCOL://HOSTNAME:PORT
+    # Expects proxies as either PROTOCOL://{USER}:{PASSWORD}@HOSTNAME:PORT
+    # or PROTOCOL://HOSTNAME:PORT
     parsed_http_proxy = urlparse(os.environ["http_proxy"])
     assert parsed_http_proxy.hostname is not None, "Invalid `http_proxy` hostname."
     assert isinstance(parsed_http_proxy.port, int), f"Invalid Proxy Port: {parsed_http_proxy.port}"
@@ -61,6 +62,15 @@ if os.getenv("http_proxy") is not None and os.getenv("https_proxy") is not None:
         https_proxy_host=parsed_https_proxy.hostname,
         https_proxy_port=parsed_https_proxy.port,
     )
+
+    if parsed_http_proxy.username is not None and parsed_http_proxy.password is not None:
+
+        MAVEN_PROXY += (
+            " -Dhttp.proxyUser={proxy_username} -Dhttp.proxyPassword={proxy_password}".format(
+                proxy_username=parsed_http_proxy.username, proxy_password=parsed_http_proxy.password
+            )
+        )
+
 else:
     MAVEN_PROXY = ""  # No Proxy
 

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -1237,6 +1237,16 @@ def _get_deployment_config(flavor_name):
         DEPLOYMENT_CONFIG_KEY_FLAVOR_NAME: flavor_name,
         SERVING_ENVIRONMENT: SAGEMAKER_SERVING_ENVIRONMENT,
     }
+
+    if os.getenv("http_proxy") is not None:
+        deployment_config.update({"http_proxy": os.environ["http_proxy"]})
+
+    if os.getenv("https_proxy") is not None:
+        deployment_config.update({"https_proxy": os.environ["https_proxy"]})
+
+    if os.getenv("no_proxy") is not None:
+        deployment_config.update({"no_proxy": os.environ["no_proxy"]})
+
     return deployment_config
 
 

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -27,6 +27,7 @@ from mlflow.utils.environment import (
     _CONSTRAINTS_FILE_NAME,
 )
 
+AWS_METADATA_IP = "169.254.169.254"  # Used to fetch AWS Instance and User metadata.
 LOCALHOST = "127.0.0.1"
 PROTOBUF_REQUIREMENT = "protobuf<4.0.0"
 

--- a/tests/sagemaker/test_deployment.py
+++ b/tests/sagemaker/test_deployment.py
@@ -215,14 +215,39 @@ def test_attempting_to_deploy_in_asynchronous_mode_without_archiving_throws_exce
     assert exc.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
 
+@pytest.mark.parametrize("proxies_enabled", [True, False])
 @mock_sagemaker_aws_services
 def test_deploy_creates_sagemaker_and_s3_resources_with_expected_names_and_env_from_local(
-    pretrained_model, sagemaker_client
+    proxies_enabled, pretrained_model, sagemaker_client
 ):
-    app_name = "test-app"
-    mfs.deploy(
-        app_name=app_name, model_uri=pretrained_model.model_uri, mode=mfs.DEPLOYMENT_MODE_CREATE
-    )
+    expected_model_environment = {
+        "MLFLOW_DEPLOYMENT_FLAVOR_NAME": "python_function",
+        "SERVING_ENVIRONMENT": "SageMaker",
+    }
+
+    if proxies_enabled:
+        proxy_variables = {
+            "http_proxy": "http://proxy.example.net:1234",
+            "https_proxy": "https://proxy.example.net:1234",
+            "no_proxy": "localhost",
+        }
+        expected_model_environment.update(proxy_variables)
+        app_name = "test-app-proxies"
+        with mock.patch.dict(os.environ, proxy_variables, clear=True):
+            mfs.deploy(
+                app_name=app_name,
+                model_uri=pretrained_model.model_uri,
+                mode=mfs.DEPLOYMENT_MODE_CREATE,
+            )
+
+    else:
+        app_name = "test-app"
+        with mock.patch.dict(os.environ, {}, clear=True):
+            mfs.deploy(
+                app_name=app_name,
+                model_uri=pretrained_model.model_uri,
+                mode=mfs.DEPLOYMENT_MODE_CREATE,
+            )
 
     region_name = sagemaker_client.meta.region_name
     s3_client = boto3.client("s3", region_name=region_name)
@@ -246,39 +271,61 @@ def test_deploy_creates_sagemaker_and_s3_resources_with_expected_names_and_env_f
     model_environment = sagemaker_client.describe_model(ModelName=model_name)["PrimaryContainer"][
         "Environment"
     ]
-    expected_model_environment = {
-        "MLFLOW_DEPLOYMENT_FLAVOR_NAME": "python_function",
-        "SERVING_ENVIRONMENT": "SageMaker",
-    }
-    if os.getenv("http_proxy") is not None:
-        expected_model_environment.update({"http_proxy": os.environ["http_proxy"]})
-
-    if os.getenv("https_proxy") is not None:
-        expected_model_environment.update({"https_proxy": os.environ["https_proxy"]})
-
-    if os.getenv("no_proxy") is not None:
-        expected_model_environment.update({"no_proxy": os.environ["no_proxy"]})
 
     assert model_environment == expected_model_environment
 
 
+@pytest.mark.parametrize("proxies_enabled", [True, False])
 @mock_sagemaker_aws_services
 def test_deploy_cli_creates_sagemaker_and_s3_resources_with_expected_names_and_env_from_local(
-    pretrained_model, sagemaker_client
+    proxies_enabled, pretrained_model, sagemaker_client
 ):
-    app_name = "test-app"
-    result = CliRunner(env={"LC_ALL": "en_US.UTF-8", "LANG": "en_US.UTF-8"}).invoke(
-        mfscli.commands,
-        [
-            "deploy",
-            "-a",
-            app_name,
-            "-m",
-            pretrained_model.model_uri,
-            "--mode",
-            mfs.DEPLOYMENT_MODE_CREATE,
-        ],
-    )
+    environment_variables = {"LC_ALL": "en_US.UTF-8", "LANG": "en_US.UTF-8"}
+    expected_model_environment = {
+        "MLFLOW_DEPLOYMENT_FLAVOR_NAME": "python_function",
+        "SERVING_ENVIRONMENT": "SageMaker",
+    }
+
+    if proxies_enabled:
+        proxy_variables = {
+            "http_proxy": "http://proxy.example.net:1234",
+            "https_proxy": "https://proxy.example.net:1234",
+            "no_proxy": "localhost",
+        }
+        expected_model_environment.update(proxy_variables)
+        app_name = "test-app-proxies"
+        result = CliRunner(env={**environment_variables, **proxy_variables}).invoke(
+            mfscli.commands,
+            [
+                "deploy",
+                "-a",
+                app_name,
+                "-m",
+                pretrained_model.model_uri,
+                "--mode",
+                mfs.DEPLOYMENT_MODE_CREATE,
+            ],
+        )
+    else:
+        proxy_variables = {
+            "http_proxy": None,
+            "https_proxy": None,
+            "no_proxy": None,
+        }
+        app_name = "test-app"
+        result = CliRunner(env={**environment_variables, **proxy_variables}).invoke(
+            mfscli.commands,
+            [
+                "deploy",
+                "-a",
+                app_name,
+                "-m",
+                pretrained_model.model_uri,
+                "--mode",
+                mfs.DEPLOYMENT_MODE_CREATE,
+            ],
+        )
+
     assert result.exit_code == 0
 
     region_name = sagemaker_client.meta.region_name
@@ -303,25 +350,14 @@ def test_deploy_cli_creates_sagemaker_and_s3_resources_with_expected_names_and_e
     model_environment = sagemaker_client.describe_model(ModelName=model_name)["PrimaryContainer"][
         "Environment"
     ]
-    expected_model_environment = {
-        "MLFLOW_DEPLOYMENT_FLAVOR_NAME": "python_function",
-        "SERVING_ENVIRONMENT": "SageMaker",
-    }
-    if os.getenv("http_proxy") is not None:
-        expected_model_environment.update({"http_proxy": os.environ["http_proxy"]})
-
-    if os.getenv("https_proxy") is not None:
-        expected_model_environment.update({"https_proxy": os.environ["https_proxy"]})
-
-    if os.getenv("no_proxy") is not None:
-        expected_model_environment.update({"no_proxy": os.environ["no_proxy"]})
 
     assert model_environment == expected_model_environment
 
 
+@pytest.mark.parametrize("proxies_enabled", [True, False])
 @mock_sagemaker_aws_services
 def test_deploy_creates_sagemaker_and_s3_resources_with_expected_names_and_env_from_s3(
-    pretrained_model, sagemaker_client
+    proxies_enabled, pretrained_model, sagemaker_client
 ):
     local_model_path = _download_artifact_from_uri(pretrained_model.model_uri)
     artifact_path = "model"
@@ -332,9 +368,25 @@ def test_deploy_creates_sagemaker_and_s3_resources_with_expected_names_and_env_f
     model_s3_uri = "s3://{bucket_name}/{artifact_path}".format(
         bucket_name=default_bucket, artifact_path=pretrained_model.model_path
     )
+    expected_model_environment = {
+        "MLFLOW_DEPLOYMENT_FLAVOR_NAME": "python_function",
+        "SERVING_ENVIRONMENT": "SageMaker",
+    }
 
-    app_name = "test-app"
-    mfs.deploy(app_name=app_name, model_uri=model_s3_uri, mode=mfs.DEPLOYMENT_MODE_CREATE)
+    if proxies_enabled:
+        proxy_variables = {
+            "http_proxy": "http://proxy.example.net:1234",
+            "https_proxy": "https://proxy.example.net:1234",
+            "no_proxy": "localhost",
+        }
+        expected_model_environment.update(proxy_variables)
+        app_name = "test-app-proxies"
+        with mock.patch.dict(os.environ, proxy_variables, clear=True):
+            mfs.deploy(app_name=app_name, model_uri=model_s3_uri, mode=mfs.DEPLOYMENT_MODE_CREATE)
+    else:
+        app_name = "test-app"
+        with mock.patch.dict(os.environ, {}, clear=True):
+            mfs.deploy(app_name=app_name, model_uri=model_s3_uri, mode=mfs.DEPLOYMENT_MODE_CREATE)
 
     endpoint_description = sagemaker_client.describe_endpoint(EndpointName=app_name)
     endpoint_production_variants = endpoint_description["ProductionVariants"]
@@ -357,25 +409,14 @@ def test_deploy_creates_sagemaker_and_s3_resources_with_expected_names_and_env_f
     model_environment = sagemaker_client.describe_model(ModelName=model_name)["PrimaryContainer"][
         "Environment"
     ]
-    expected_model_environment = {
-        "MLFLOW_DEPLOYMENT_FLAVOR_NAME": "python_function",
-        "SERVING_ENVIRONMENT": "SageMaker",
-    }
-    if os.getenv("http_proxy") is not None:
-        expected_model_environment.update({"http_proxy": os.environ["http_proxy"]})
-
-    if os.getenv("https_proxy") is not None:
-        expected_model_environment.update({"https_proxy": os.environ["https_proxy"]})
-
-    if os.getenv("no_proxy") is not None:
-        expected_model_environment.update({"no_proxy": os.environ["no_proxy"]})
 
     assert model_environment == expected_model_environment
 
 
+@pytest.mark.parametrize("proxies_enabled", [True, False])
 @mock_sagemaker_aws_services
 def test_deploy_cli_creates_sagemaker_and_s3_resources_with_expected_names_and_env_from_s3(
-    pretrained_model, sagemaker_client
+    proxies_enabled, pretrained_model, sagemaker_client
 ):
     local_model_path = _download_artifact_from_uri(pretrained_model.model_uri)
     artifact_path = "model"
@@ -386,12 +427,35 @@ def test_deploy_cli_creates_sagemaker_and_s3_resources_with_expected_names_and_e
     model_s3_uri = "s3://{bucket_name}/{artifact_path}".format(
         bucket_name=default_bucket, artifact_path=pretrained_model.model_path
     )
+    environment_variables = {"LC_ALL": "en_US.UTF-8", "LANG": "en_US.UTF-8"}
+    expected_model_environment = {
+        "MLFLOW_DEPLOYMENT_FLAVOR_NAME": "python_function",
+        "SERVING_ENVIRONMENT": "SageMaker",
+    }
 
-    app_name = "test-app"
-    result = CliRunner(env={"LC_ALL": "en_US.UTF-8", "LANG": "en_US.UTF-8"}).invoke(
-        mfscli.commands,
-        ["deploy", "-a", app_name, "-m", model_s3_uri, "--mode", mfs.DEPLOYMENT_MODE_CREATE],
-    )
+    if proxies_enabled:
+        proxy_variables = {
+            "http_proxy": "http://proxy.example.net:1234",
+            "https_proxy": "https://proxy.example.net:1234",
+            "no_proxy": "localhost",
+        }
+        expected_model_environment.update(proxy_variables)
+        app_name = "test-app-proxies"
+        result = CliRunner(env={**environment_variables, **proxy_variables}).invoke(
+            mfscli.commands,
+            ["deploy", "-a", app_name, "-m", model_s3_uri, "--mode", mfs.DEPLOYMENT_MODE_CREATE],
+        )
+    else:
+        proxy_variables = {
+            "http_proxy": None,
+            "https_proxy": None,
+            "no_proxy": None,
+        }
+        app_name = "test-app"
+        result = CliRunner(env={**environment_variables, **proxy_variables}).invoke(
+            mfscli.commands,
+            ["deploy", "-a", app_name, "-m", model_s3_uri, "--mode", mfs.DEPLOYMENT_MODE_CREATE],
+        )
     assert result.exit_code == 0
 
     region_name = sagemaker_client.meta.region_name
@@ -416,18 +480,6 @@ def test_deploy_cli_creates_sagemaker_and_s3_resources_with_expected_names_and_e
     model_environment = sagemaker_client.describe_model(ModelName=model_name)["PrimaryContainer"][
         "Environment"
     ]
-    expected_model_environment = {
-        "MLFLOW_DEPLOYMENT_FLAVOR_NAME": "python_function",
-        "SERVING_ENVIRONMENT": "SageMaker",
-    }
-    if os.getenv("http_proxy") is not None:
-        expected_model_environment.update({"http_proxy": os.environ["http_proxy"]})
-
-    if os.getenv("https_proxy") is not None:
-        expected_model_environment.update({"https_proxy": os.environ["https_proxy"]})
-
-    if os.getenv("no_proxy") is not None:
-        expected_model_environment.update({"no_proxy": os.environ["no_proxy"]})
 
     assert model_environment == expected_model_environment
 

--- a/tests/sagemaker/test_deployment.py
+++ b/tests/sagemaker/test_deployment.py
@@ -229,7 +229,7 @@ def test_deploy_creates_sagemaker_and_s3_resources_with_expected_names_and_env_f
         proxy_variables = {
             "http_proxy": "http://proxy.example.net:1234",
             "https_proxy": "https://proxy.example.net:1234",
-            "no_proxy": "localhost",
+            "no_proxy": "169.254.169.254,localhost",
         }
         expected_model_environment.update(proxy_variables)
         app_name = "test-app-proxies"
@@ -290,7 +290,7 @@ def test_deploy_cli_creates_sagemaker_and_s3_resources_with_expected_names_and_e
         proxy_variables = {
             "http_proxy": "http://proxy.example.net:1234",
             "https_proxy": "https://proxy.example.net:1234",
-            "no_proxy": "localhost",
+            "no_proxy": "169.254.169.254,localhost",
         }
         expected_model_environment.update(proxy_variables)
         app_name = "test-app-proxies"
@@ -377,7 +377,7 @@ def test_deploy_creates_sagemaker_and_s3_resources_with_expected_names_and_env_f
         proxy_variables = {
             "http_proxy": "http://proxy.example.net:1234",
             "https_proxy": "https://proxy.example.net:1234",
-            "no_proxy": "localhost",
+            "no_proxy": "169.254.169.254,localhost",
         }
         expected_model_environment.update(proxy_variables)
         app_name = "test-app-proxies"
@@ -437,7 +437,7 @@ def test_deploy_cli_creates_sagemaker_and_s3_resources_with_expected_names_and_e
         proxy_variables = {
             "http_proxy": "http://proxy.example.net:1234",
             "https_proxy": "https://proxy.example.net:1234",
-            "no_proxy": "localhost",
+            "no_proxy": "169.254.169.254,localhost",
         }
         expected_model_environment.update(proxy_variables)
         app_name = "test-app-proxies"

--- a/tests/sagemaker/test_deployment.py
+++ b/tests/sagemaker/test_deployment.py
@@ -246,10 +246,20 @@ def test_deploy_creates_sagemaker_and_s3_resources_with_expected_names_and_env_f
     model_environment = sagemaker_client.describe_model(ModelName=model_name)["PrimaryContainer"][
         "Environment"
     ]
-    assert model_environment == {
+    expected_model_environment = {
         "MLFLOW_DEPLOYMENT_FLAVOR_NAME": "python_function",
         "SERVING_ENVIRONMENT": "SageMaker",
     }
+    if os.getenv("http_proxy") is not None:
+        expected_model_environment.update({"http_proxy": os.environ["http_proxy"]})
+
+    if os.getenv("https_proxy") is not None:
+        expected_model_environment.update({"https_proxy": os.environ["https_proxy"]})
+
+    if os.getenv("no_proxy") is not None:
+        expected_model_environment.update({"no_proxy": os.environ["no_proxy"]})
+
+    assert model_environment == expected_model_environment
 
 
 @mock_sagemaker_aws_services
@@ -293,10 +303,20 @@ def test_deploy_cli_creates_sagemaker_and_s3_resources_with_expected_names_and_e
     model_environment = sagemaker_client.describe_model(ModelName=model_name)["PrimaryContainer"][
         "Environment"
     ]
-    assert model_environment == {
+    expected_model_environment = {
         "MLFLOW_DEPLOYMENT_FLAVOR_NAME": "python_function",
         "SERVING_ENVIRONMENT": "SageMaker",
     }
+    if os.getenv("http_proxy") is not None:
+        expected_model_environment.update({"http_proxy": os.environ["http_proxy"]})
+
+    if os.getenv("https_proxy") is not None:
+        expected_model_environment.update({"https_proxy": os.environ["https_proxy"]})
+
+    if os.getenv("no_proxy") is not None:
+        expected_model_environment.update({"no_proxy": os.environ["no_proxy"]})
+
+    assert model_environment == expected_model_environment
 
 
 @mock_sagemaker_aws_services
@@ -337,10 +357,20 @@ def test_deploy_creates_sagemaker_and_s3_resources_with_expected_names_and_env_f
     model_environment = sagemaker_client.describe_model(ModelName=model_name)["PrimaryContainer"][
         "Environment"
     ]
-    assert model_environment == {
+    expected_model_environment = {
         "MLFLOW_DEPLOYMENT_FLAVOR_NAME": "python_function",
         "SERVING_ENVIRONMENT": "SageMaker",
     }
+    if os.getenv("http_proxy") is not None:
+        expected_model_environment.update({"http_proxy": os.environ["http_proxy"]})
+
+    if os.getenv("https_proxy") is not None:
+        expected_model_environment.update({"https_proxy": os.environ["https_proxy"]})
+
+    if os.getenv("no_proxy") is not None:
+        expected_model_environment.update({"no_proxy": os.environ["no_proxy"]})
+
+    assert model_environment == expected_model_environment
 
 
 @mock_sagemaker_aws_services
@@ -386,10 +416,20 @@ def test_deploy_cli_creates_sagemaker_and_s3_resources_with_expected_names_and_e
     model_environment = sagemaker_client.describe_model(ModelName=model_name)["PrimaryContainer"][
         "Environment"
     ]
-    assert model_environment == {
+    expected_model_environment = {
         "MLFLOW_DEPLOYMENT_FLAVOR_NAME": "python_function",
         "SERVING_ENVIRONMENT": "SageMaker",
     }
+    if os.getenv("http_proxy") is not None:
+        expected_model_environment.update({"http_proxy": os.environ["http_proxy"]})
+
+    if os.getenv("https_proxy") is not None:
+        expected_model_environment.update({"https_proxy": os.environ["https_proxy"]})
+
+    if os.getenv("no_proxy") is not None:
+        expected_model_environment.update({"no_proxy": os.environ["no_proxy"]})
+
+    assert model_environment == expected_model_environment
 
 
 @mock_sagemaker_aws_services

--- a/tests/sagemaker/test_sagemaker_deployment_client.py
+++ b/tests/sagemaker/test_sagemaker_deployment_client.py
@@ -335,10 +335,20 @@ def test_create_deployment_create_sagemaker_and_s3_resources_with_expected_names
     model_environment = sagemaker_client.describe_model(ModelName=model_name)["PrimaryContainer"][
         "Environment"
     ]
-    assert model_environment == {
+    expected_model_environment = {
         "MLFLOW_DEPLOYMENT_FLAVOR_NAME": "python_function",
         "SERVING_ENVIRONMENT": "SageMaker",
     }
+    if os.getenv("http_proxy") is not None:
+        expected_model_environment.update({"http_proxy": os.environ["http_proxy"]})
+
+    if os.getenv("https_proxy") is not None:
+        expected_model_environment.update({"https_proxy": os.environ["https_proxy"]})
+
+    if os.getenv("no_proxy") is not None:
+        expected_model_environment.update({"no_proxy": os.environ["no_proxy"]})
+
+    assert model_environment == expected_model_environment
 
 
 @mock_sagemaker_aws_services
@@ -370,10 +380,20 @@ def test_deploy_cli_creates_sagemaker_and_s3_resources_with_expected_names_and_e
     model_environment = sagemaker_client.describe_model(ModelName=model_name)["PrimaryContainer"][
         "Environment"
     ]
-    assert model_environment == {
+    expected_model_environment = {
         "MLFLOW_DEPLOYMENT_FLAVOR_NAME": "python_function",
         "SERVING_ENVIRONMENT": "SageMaker",
     }
+    if os.getenv("http_proxy") is not None:
+        expected_model_environment.update({"http_proxy": os.environ["http_proxy"]})
+
+    if os.getenv("https_proxy") is not None:
+        expected_model_environment.update({"https_proxy": os.environ["https_proxy"]})
+
+    if os.getenv("no_proxy") is not None:
+        expected_model_environment.update({"no_proxy": os.environ["no_proxy"]})
+
+    assert model_environment == expected_model_environment
 
 
 @mock_sagemaker_aws_services
@@ -417,10 +437,20 @@ def test_create_deployment_creates_sagemaker_and_s3_resources_with_expected_name
     model_environment = sagemaker_client.describe_model(ModelName=model_name)["PrimaryContainer"][
         "Environment"
     ]
-    assert model_environment == {
+    expected_model_environment = {
         "MLFLOW_DEPLOYMENT_FLAVOR_NAME": "python_function",
         "SERVING_ENVIRONMENT": "SageMaker",
     }
+    if os.getenv("http_proxy") is not None:
+        expected_model_environment.update({"http_proxy": os.environ["http_proxy"]})
+
+    if os.getenv("https_proxy") is not None:
+        expected_model_environment.update({"https_proxy": os.environ["https_proxy"]})
+
+    if os.getenv("no_proxy") is not None:
+        expected_model_environment.update({"no_proxy": os.environ["no_proxy"]})
+
+    assert model_environment == expected_model_environment
 
 
 @mock_sagemaker_aws_services
@@ -462,10 +492,20 @@ def test_deploy_cli_creates_sagemaker_and_s3_resources_with_expected_names_and_e
     model_environment = sagemaker_client.describe_model(ModelName=model_name)["PrimaryContainer"][
         "Environment"
     ]
-    assert model_environment == {
+    expected_model_environment = {
         "MLFLOW_DEPLOYMENT_FLAVOR_NAME": "python_function",
         "SERVING_ENVIRONMENT": "SageMaker",
     }
+    if os.getenv("http_proxy") is not None:
+        expected_model_environment.update({"http_proxy": os.environ["http_proxy"]})
+
+    if os.getenv("https_proxy") is not None:
+        expected_model_environment.update({"https_proxy": os.environ["https_proxy"]})
+
+    if os.getenv("no_proxy") is not None:
+        expected_model_environment.update({"no_proxy": os.environ["no_proxy"]})
+
+    assert model_environment == expected_model_environment
 
 
 @mock_sagemaker_aws_services
@@ -1005,10 +1045,20 @@ def test_deploy_cli_updates_sagemaker_and_s3_resources_in_replace_mode(
     model_environment = sagemaker_client.describe_model(ModelName=model_name)["PrimaryContainer"][
         "Environment"
     ]
-    assert model_environment == {
+    expected_model_environment = {
         "MLFLOW_DEPLOYMENT_FLAVOR_NAME": "python_function",
         "SERVING_ENVIRONMENT": "SageMaker",
     }
+    if os.getenv("http_proxy") is not None:
+        expected_model_environment.update({"http_proxy": os.environ["http_proxy"]})
+
+    if os.getenv("https_proxy") is not None:
+        expected_model_environment.update({"https_proxy": os.environ["https_proxy"]})
+
+    if os.getenv("no_proxy") is not None:
+        expected_model_environment.update({"no_proxy": os.environ["no_proxy"]})
+
+    assert model_environment == expected_model_environment
 
 
 @mock_sagemaker_aws_services

--- a/tests/sagemaker/test_sagemaker_deployment_client.py
+++ b/tests/sagemaker/test_sagemaker_deployment_client.py
@@ -317,8 +317,8 @@ def test_create_deployment_create_sagemaker_and_s3_resources_with_expected_names
 
     if proxies_enabled:
         proxy_variables = {
-            "http_proxy": "http://proxy.example.net:1234",
-            "https_proxy": "https://proxy.example.net:1234",
+            "http_proxy": "http://user:password@proxy.example.net:1234",
+            "https_proxy": "https://user:password@proxy.example.net:1234",
             "no_proxy": "localhost",
         }
         expected_model_environment.update(proxy_variables)
@@ -376,8 +376,8 @@ def test_deploy_cli_creates_sagemaker_and_s3_resources_with_expected_names_and_e
 
     if proxies_enabled:
         proxy_variables = {
-            "http_proxy": "http://proxy.example.net:1234",
-            "https_proxy": "https://proxy.example.net:1234",
+            "http_proxy": "http://user:password@proxy.example.net:1234",
+            "https_proxy": "http://user:password@proxy.example.net:1234",
             "no_proxy": "localhost",
         }
         expected_model_environment.update(proxy_variables)
@@ -448,8 +448,8 @@ def test_create_deployment_creates_sagemaker_and_s3_resources_with_expected_name
 
     if proxies_enabled:
         proxy_variables = {
-            "http_proxy": "http://proxy.example.net:1234",
-            "https_proxy": "https://proxy.example.net:1234",
+            "http_proxy": "http://user:password@proxy.example.net:1234",
+            "https_proxy": "http://user:password@proxy.example.net:1234",
             "no_proxy": "localhost",
         }
         expected_model_environment.update(proxy_variables)
@@ -514,8 +514,8 @@ def test_deploy_cli_creates_sagemaker_and_s3_resources_with_expected_names_and_e
 
     if proxies_enabled:
         proxy_variables = {
-            "http_proxy": "http://proxy.example.net:1234",
-            "https_proxy": "https://proxy.example.net:1234",
+            "http_proxy": "http://user:password@proxy.example.net:1234",
+            "https_proxy": "https://user:password@proxy.example.net:1234",
             "no_proxy": "localhost",
         }
         expected_model_environment.update(proxy_variables)

--- a/tests/sagemaker/test_sagemaker_deployment_client.py
+++ b/tests/sagemaker/test_sagemaker_deployment_client.py
@@ -60,8 +60,10 @@ def sagemaker_deployment_client():
     )
 
 
-def create_sagemaker_deployment_through_cli(app_name, model_uri, region_name):
-    result = CliRunner(env={"LC_ALL": "en_US.UTF-8", "LANG": "en_US.UTF-8"}).invoke(
+def create_sagemaker_deployment_through_cli(app_name, model_uri, region_name, env=None):
+    if env is None:
+        env = {"LC_ALL": "en_US.UTF-8", "LANG": "en_US.UTF-8"}
+    result = CliRunner(env=env).invoke(
         cli_commands,
         [
             "create",
@@ -303,15 +305,36 @@ def test_attempting_to_deploy_in_asynchronous_mode_without_archiving_throws_exce
     assert exc.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
 
+@pytest.mark.parametrize("proxies_enabled", [True, False])
 @mock_sagemaker_aws_services
 def test_create_deployment_create_sagemaker_and_s3_resources_with_expected_names_and_env_from_local(
-    pretrained_model, sagemaker_client, sagemaker_deployment_client
+    proxies_enabled, pretrained_model, sagemaker_client, sagemaker_deployment_client
 ):
-    name = "test-app"
-    sagemaker_deployment_client.create_deployment(
-        name=name,
-        model_uri=pretrained_model.model_uri,
-    )
+    expected_model_environment = {
+        "MLFLOW_DEPLOYMENT_FLAVOR_NAME": "python_function",
+        "SERVING_ENVIRONMENT": "SageMaker",
+    }
+
+    if proxies_enabled:
+        proxy_variables = {
+            "http_proxy": "http://proxy.example.net:1234",
+            "https_proxy": "https://proxy.example.net:1234",
+            "no_proxy": "localhost",
+        }
+        expected_model_environment.update(proxy_variables)
+        name = "test-app-proxies"
+        with mock.patch.dict(os.environ, proxy_variables, clear=True):
+            sagemaker_deployment_client.create_deployment(
+                name=name,
+                model_uri=pretrained_model.model_uri,
+            )
+    else:
+        name = "test-app"
+        with mock.patch.dict(os.environ, {}, clear=True):
+            sagemaker_deployment_client.create_deployment(
+                name=name,
+                model_uri=pretrained_model.model_uri,
+            )
 
     region_name = sagemaker_client.meta.region_name
     s3_client = boto3.client("s3", region_name=region_name)
@@ -335,29 +358,49 @@ def test_create_deployment_create_sagemaker_and_s3_resources_with_expected_names
     model_environment = sagemaker_client.describe_model(ModelName=model_name)["PrimaryContainer"][
         "Environment"
     ]
-    expected_model_environment = {
-        "MLFLOW_DEPLOYMENT_FLAVOR_NAME": "python_function",
-        "SERVING_ENVIRONMENT": "SageMaker",
-    }
-    if os.getenv("http_proxy") is not None:
-        expected_model_environment.update({"http_proxy": os.environ["http_proxy"]})
-
-    if os.getenv("https_proxy") is not None:
-        expected_model_environment.update({"https_proxy": os.environ["https_proxy"]})
-
-    if os.getenv("no_proxy") is not None:
-        expected_model_environment.update({"no_proxy": os.environ["no_proxy"]})
 
     assert model_environment == expected_model_environment
 
 
+@pytest.mark.parametrize("proxies_enabled", [True, False])
 @mock_sagemaker_aws_services
 def test_deploy_cli_creates_sagemaker_and_s3_resources_with_expected_names_and_env_from_local(
-    pretrained_model, sagemaker_client
+    proxies_enabled, pretrained_model, sagemaker_client
 ):
-    app_name = "test-app"
     region_name = sagemaker_client.meta.region_name
-    create_sagemaker_deployment_through_cli(app_name, pretrained_model.model_uri, region_name)
+    environment_variables = {"LC_ALL": "en_US.UTF-8", "LANG": "en_US.UTF-8"}
+    expected_model_environment = {
+        "MLFLOW_DEPLOYMENT_FLAVOR_NAME": "python_function",
+        "SERVING_ENVIRONMENT": "SageMaker",
+    }
+
+    if proxies_enabled:
+        proxy_variables = {
+            "http_proxy": "http://proxy.example.net:1234",
+            "https_proxy": "https://proxy.example.net:1234",
+            "no_proxy": "localhost",
+        }
+        expected_model_environment.update(proxy_variables)
+        app_name = "test-app-proxies"
+        create_sagemaker_deployment_through_cli(
+            app_name,
+            pretrained_model.model_uri,
+            region_name,
+            {**environment_variables, **proxy_variables},
+        )
+    else:
+        proxy_variables = {
+            "http_proxy": None,
+            "https_proxy": None,
+            "no_proxy": None,
+        }
+        app_name = "test-app"
+        create_sagemaker_deployment_through_cli(
+            app_name,
+            pretrained_model.model_uri,
+            region_name,
+            {**environment_variables, **proxy_variables},
+        )
 
     s3_client = boto3.client("s3", region_name=region_name)
     default_bucket = mfs._get_default_s3_bucket(region_name)
@@ -380,25 +423,14 @@ def test_deploy_cli_creates_sagemaker_and_s3_resources_with_expected_names_and_e
     model_environment = sagemaker_client.describe_model(ModelName=model_name)["PrimaryContainer"][
         "Environment"
     ]
-    expected_model_environment = {
-        "MLFLOW_DEPLOYMENT_FLAVOR_NAME": "python_function",
-        "SERVING_ENVIRONMENT": "SageMaker",
-    }
-    if os.getenv("http_proxy") is not None:
-        expected_model_environment.update({"http_proxy": os.environ["http_proxy"]})
-
-    if os.getenv("https_proxy") is not None:
-        expected_model_environment.update({"https_proxy": os.environ["https_proxy"]})
-
-    if os.getenv("no_proxy") is not None:
-        expected_model_environment.update({"no_proxy": os.environ["no_proxy"]})
 
     assert model_environment == expected_model_environment
 
 
+@pytest.mark.parametrize("proxies_enabled", [True, False])
 @mock_sagemaker_aws_services
 def test_create_deployment_creates_sagemaker_and_s3_resources_with_expected_names_and_env_from_s3(
-    pretrained_model, sagemaker_client, sagemaker_deployment_client
+    proxies_enabled, pretrained_model, sagemaker_client, sagemaker_deployment_client
 ):
     local_model_path = _download_artifact_from_uri(pretrained_model.model_uri)
     artifact_path = "model"
@@ -409,12 +441,31 @@ def test_create_deployment_creates_sagemaker_and_s3_resources_with_expected_name
     model_s3_uri = "s3://{bucket_name}/{artifact_path}".format(
         bucket_name=default_bucket, artifact_path=pretrained_model.model_path
     )
+    expected_model_environment = {
+        "MLFLOW_DEPLOYMENT_FLAVOR_NAME": "python_function",
+        "SERVING_ENVIRONMENT": "SageMaker",
+    }
 
-    name = "test-app"
-    sagemaker_deployment_client.create_deployment(
-        name=name,
-        model_uri=model_s3_uri,
-    )
+    if proxies_enabled:
+        proxy_variables = {
+            "http_proxy": "http://proxy.example.net:1234",
+            "https_proxy": "https://proxy.example.net:1234",
+            "no_proxy": "localhost",
+        }
+        expected_model_environment.update(proxy_variables)
+        name = "test-app-proxies"
+        with mock.patch.dict(os.environ, proxy_variables, clear=True):
+            sagemaker_deployment_client.create_deployment(
+                name=name,
+                model_uri=model_s3_uri,
+            )
+    else:
+        name = "test-app"
+        with mock.patch.dict(os.environ, {}, clear=True):
+            sagemaker_deployment_client.create_deployment(
+                name=name,
+                model_uri=model_s3_uri,
+            )
 
     endpoint_description = sagemaker_client.describe_endpoint(EndpointName=name)
     endpoint_production_variants = endpoint_description["ProductionVariants"]
@@ -437,25 +488,14 @@ def test_create_deployment_creates_sagemaker_and_s3_resources_with_expected_name
     model_environment = sagemaker_client.describe_model(ModelName=model_name)["PrimaryContainer"][
         "Environment"
     ]
-    expected_model_environment = {
-        "MLFLOW_DEPLOYMENT_FLAVOR_NAME": "python_function",
-        "SERVING_ENVIRONMENT": "SageMaker",
-    }
-    if os.getenv("http_proxy") is not None:
-        expected_model_environment.update({"http_proxy": os.environ["http_proxy"]})
-
-    if os.getenv("https_proxy") is not None:
-        expected_model_environment.update({"https_proxy": os.environ["https_proxy"]})
-
-    if os.getenv("no_proxy") is not None:
-        expected_model_environment.update({"no_proxy": os.environ["no_proxy"]})
 
     assert model_environment == expected_model_environment
 
 
+@pytest.mark.parametrize("proxies_enabled", [True, False])
 @mock_sagemaker_aws_services
 def test_deploy_cli_creates_sagemaker_and_s3_resources_with_expected_names_and_env_from_s3(
-    pretrained_model, sagemaker_client
+    proxies_enabled, pretrained_model, sagemaker_client
 ):
     local_model_path = _download_artifact_from_uri(pretrained_model.model_uri)
     artifact_path = "model"
@@ -466,9 +506,39 @@ def test_deploy_cli_creates_sagemaker_and_s3_resources_with_expected_names_and_e
     model_s3_uri = "s3://{bucket_name}/{artifact_path}".format(
         bucket_name=default_bucket, artifact_path=pretrained_model.model_path
     )
+    environment_variables = {"LC_ALL": "en_US.UTF-8", "LANG": "en_US.UTF-8"}
+    expected_model_environment = {
+        "MLFLOW_DEPLOYMENT_FLAVOR_NAME": "python_function",
+        "SERVING_ENVIRONMENT": "SageMaker",
+    }
 
-    app_name = "test-app"
-    create_sagemaker_deployment_through_cli(app_name, model_s3_uri, region_name)
+    if proxies_enabled:
+        proxy_variables = {
+            "http_proxy": "http://proxy.example.net:1234",
+            "https_proxy": "https://proxy.example.net:1234",
+            "no_proxy": "localhost",
+        }
+        expected_model_environment.update(proxy_variables)
+        app_name = "test-app-proxies"
+        create_sagemaker_deployment_through_cli(
+            app_name,
+            model_s3_uri,
+            region_name,
+            {**environment_variables, **proxy_variables},
+        )
+    else:
+        proxy_variables = {
+            "http_proxy": None,
+            "https_proxy": None,
+            "no_proxy": None,
+        }
+        app_name = "test-app"
+        create_sagemaker_deployment_through_cli(
+            app_name,
+            model_s3_uri,
+            region_name,
+            {**environment_variables, **proxy_variables},
+        )
 
     region_name = sagemaker_client.meta.region_name
     s3_client = boto3.client("s3", region_name=region_name)
@@ -492,18 +562,6 @@ def test_deploy_cli_creates_sagemaker_and_s3_resources_with_expected_names_and_e
     model_environment = sagemaker_client.describe_model(ModelName=model_name)["PrimaryContainer"][
         "Environment"
     ]
-    expected_model_environment = {
-        "MLFLOW_DEPLOYMENT_FLAVOR_NAME": "python_function",
-        "SERVING_ENVIRONMENT": "SageMaker",
-    }
-    if os.getenv("http_proxy") is not None:
-        expected_model_environment.update({"http_proxy": os.environ["http_proxy"]})
-
-    if os.getenv("https_proxy") is not None:
-        expected_model_environment.update({"https_proxy": os.environ["https_proxy"]})
-
-    if os.getenv("no_proxy") is not None:
-        expected_model_environment.update({"no_proxy": os.environ["no_proxy"]})
 
     assert model_environment == expected_model_environment
 


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
Close #6119 

## What changes are proposed in this pull request?

1. Injecting proxies during docker build `mlflow sagemaker build-and-push-container`
2. Injecting proxies as environment variables inside the deployed Sagemaker endpoint.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
3. Click `Details` on the right to open the job page of CircleCI.
4. Click the `Artifacts` tab.
5. Click `docs/build/html/index.html`.
6. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [x] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
