### PR TITLE
[MLflow Pipelines] Throw clear exception when pipeline / profile YAML parsing fails

### DIFF
--- a/tests/pipelines/regression/v1/test_regression_pipeline.py
+++ b/tests/pipelines/regression/v1/test_regression_pipeline.py
@@ -36,7 +36,10 @@ def test_create_pipeline_fails_with_invalid_input(
     pipeline_root_path = os.path.join(
         os.path.dirname(enter_pipeline_example_directory), pipeline_name
     )
-    with pytest.raises(MlflowException, match=r"(Failed to find|does not exist)"):
+    with pytest.raises(
+        MlflowException,
+        match=r"(Failed to find|Did not find the YAML configuration)",
+    ):
         RegressionPipeline(pipeline_root_path=pipeline_root_path, profile=profile)
 
 

--- a/tests/pipelines/test_pipeline.py
+++ b/tests/pipelines/test_pipeline.py
@@ -29,7 +29,10 @@ _STEP_NAMES = ["ingest", "split", "train", "transform", "evaluate"]
 
 @pytest.mark.usefixtures("enter_pipeline_example_directory")
 def test_create_pipeline_fails_with_invalid_profile():
-    with pytest.raises(MlflowException, match=r".*(Failed to find|does not exist).*"):
+    with pytest.raises(
+        MlflowException,
+        match=r"(Failed to find|Did not find the YAML configuration)",
+    ):
         Pipeline(profile="local123")
 
 

--- a/tests/pipelines/test_utils.py
+++ b/tests/pipelines/test_utils.py
@@ -99,7 +99,7 @@ def test_get_pipeline_config_supports_empty_profile():
 
 @pytest.mark.usefixtures("enter_pipeline_example_directory")
 def test_get_pipeline_config_throws_for_nonexistent_profile():
-    with pytest.raises(MlflowException, match="Yaml file.*badprofile.*does not exist"):
+    with pytest.raises(MlflowException, match="Did not find the YAML configuration.*badprofile"):
         get_pipeline_config(profile="badprofile")
 
 
@@ -110,3 +110,15 @@ def test_get_default_profile_works():
     ) as patched_is_in_databricks_runtime:
         assert get_default_profile() == "databricks"
         patched_is_in_databricks_runtime.assert_called_once()
+
+
+@pytest.mark.usefixtures("enter_test_pipeline_directory")
+def test_get_pipeline_config_throws_clear_error_for_invalid_profile():
+    with open("profiles/badcontent.yaml", "w") as f:
+        f.write(r"\BAD")
+
+    with pytest.raises(
+        MlflowException,
+        match="Failed to read pipeline configuration.*verify.*syntactically correct"
+    ):
+        get_pipeline_config(profile="badcontent")

--- a/tests/pipelines/test_utils.py
+++ b/tests/pipelines/test_utils.py
@@ -119,6 +119,6 @@ def test_get_pipeline_config_throws_clear_error_for_invalid_profile():
 
     with pytest.raises(
         MlflowException,
-        match="Failed to read pipeline configuration.*verify.*syntactically correct"
+        match="Failed to read pipeline configuration.*verify.*syntactically correct",
     ):
         get_pipeline_config(profile="badcontent")


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

[MLflow Pipelines] Throw clear exception when pipeline / profile YAML parsing fails

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [X] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

[MLflow Pipelines] Throw clear exception when pipeline / profile YAML parsing fails

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
