### PR TITLE
Adding a alias shortcut for mlflow pipelines to mlp

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,8 @@ jobs:
           name: Run example
           working_directory: examples/pipelines/sklearn_regression
           command: |
-            mlflow pipelines run --profile='local'
+            export MLFLOW_PIPELINES_PROFILE=local
+            mlp run
       - store_artifacts:
           path: ~/.mlflow/pipelines
 

--- a/setup.py
+++ b/setup.py
@@ -180,6 +180,7 @@ setup(
     entry_points="""
         [console_scripts]
         mlflow=mlflow.cli:cli
+        mlp=mlflow.pipelines.cli:commands
     """,
     cmdclass={
         "dependencies": ListDependencies,


### PR DESCRIPTION
## What changes are proposed in this pull request?
Adding a alias shortcut for mlflow pipelines to mlp

## How is this patch tested?
Ran locally:
```
mlp run --step='ingest' --profile='local'
2022/06/24 14:21:26 INFO mlflow.pipelines.pipeline: Creating MLflow Pipeline 'sklearn_regression' with profile: 'local'
2022/06/24 14:21:28 INFO mlflow.pipelines.steps.ingest.datasets: Resolving input data from '['/Users/Sunish.Sheth/workspace/databricks/mlflow/examples/pipelines/sklearn_regression/data/sample.parquet']'
2022/06/24 14:21:28 INFO mlflow.pipelines.steps.ingest.datasets: Resolved input data to '/private/var/folders/yj/xndhp9wx17q5d81y01nhd9500000gp/T/tmp3p0l9cf4/sample.parquet'
2022/06/24 14:21:28 INFO mlflow.pipelines.steps.ingest.datasets: Converting dataset to parquet format, if necessary
2022/06/24 14:21:28 INFO mlflow.pipelines.steps.ingest: Successfully stored data in parquet format at '/Users/Sunish.Sheth/.mlflow/pipelines/9b4ad43f50d2d7c31f63e062ab5dc972cfa1face4909e0bebdf0dedfad118d0a/steps/ingest/outputs/dataset.parquet'
2022/06/24 14:21:28 INFO mlflow.pipelines.steps.ingest: Profiling ingested dataset
2022/06/24 14:21:33 INFO mlflow.pipelines.steps.ingest: Wrote dataset profile to '/Users/Sunish.Sheth/.mlflow/pipelines/9b4ad43f50d2d7c31f63e062ab5dc972cfa1face4909e0bebdf0dedfad118d0a/steps/ingest/outputs/dataset_profile.html'
2022/06/24 14:21:33 INFO mlflow.pipelines.utils.step: Opening HTML file at: '/Users/Sunish.Sheth/.mlflow/pipelines/9b4ad43f50d2d7c31f63e062ab5dc972cfa1face4909e0bebdf0dedfad118d0a/steps/ingest/outputs/card.html'
```

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
