### PR TITLE
Made YAML parsing strict

### DIFF
--- a/mlflow/pipelines/utils/__init__.py
+++ b/mlflow/pipelines/utils/__init__.py
@@ -53,7 +53,7 @@ def get_pipeline_config(pipeline_root_path: str = None, profile: str = None) -> 
             if not os.path.exists(profile_file_path):
                 raise MlflowException(
                     "Did not find the YAML configuration file for the specified profile"
-                   f" '{profile}' at expected path '{profile_file_path}'.",
+                    f" '{profile}' at expected path '{profile_file_path}'.",
                     error_code=INVALID_PARAMETER_VALUE,
                 )
             return render_and_merge_yaml(
@@ -71,7 +71,6 @@ def get_pipeline_config(pipeline_root_path: str = None, profile: str = None) -> 
             " for template substitutions defined in `pipeline.yaml`.",
             error_code=INVALID_PARAMETER_VALUE,
         ) from e
-
 
 
 def get_pipeline_root_path() -> str:

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -219,7 +219,9 @@ def render_and_merge_yaml(root, template_name, context_name):
     with codecs.open(context_path, mode="r", encoding=ENCODING) as context_file:
         context_dict = yaml.load(context_file, Loader=UniqueKeyLoader) or {}
 
-    j2_env = jinja2.Environment(loader=jinja2.FileSystemLoader(root, encoding=ENCODING))
+    j2_env = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(root, encoding=ENCODING), undefined=jinja2.StrictUndefined
+    )
     source = j2_env.get_template(template_name).render(context_dict)
     rendered_template_dict = yaml.load(source, Loader=UniqueKeyLoader)
     return merge_dicts(rendered_template_dict, context_dict)

--- a/tests/pipelines/test_tracking_utils.py
+++ b/tests/pipelines/test_tracking_utils.py
@@ -100,7 +100,7 @@ def test_get_pipeline_tracking_config_returns_expected_config_on_databricks(
         if experiment_id is not None:
             profile_contents["experiment"]["id"] = experiment_id
 
-        profile_path = os.path.join(pathlib.Path.cwd(), "profiles/test_profile.yaml")
+        profile_path = pathlib.Path.cwd() / "profiles" / "testprofile.yaml"
         with open(profile_path, "w") as f:
             yaml.safe_dump(profile_contents, f)
 

--- a/tests/pipelines/test_tracking_utils.py
+++ b/tests/pipelines/test_tracking_utils.py
@@ -41,7 +41,7 @@ def test_get_pipeline_tracking_config_returns_expected_config(
     )
     default_experiment_name = "sklearn_regression"  # equivalent to pipeline name
 
-    profile_contents = {"experiment": {}}
+    profile_contents = {"experiment": {}, "INGEST_DATA_LOCATION": None}
     if tracking_uri is not None:
         profile_contents["experiment"]["tracking_uri"] = tracking_uri
     if artifact_location is not None:
@@ -90,7 +90,7 @@ def test_get_pipeline_tracking_config_returns_expected_config_on_databricks(
         default_tracking_uri = "databricks"
         default_experiment_name = "sklearn_regression"  # equivalent to pipeline name
 
-        profile_contents = {"experiment": {}}
+        profile_contents = {"experiment": {}, "INGEST_DATA_LOCATION": None}
         if tracking_uri is not None:
             profile_contents["experiment"]["tracking_uri"] = tracking_uri
         if artifact_location is not None:
@@ -100,7 +100,7 @@ def test_get_pipeline_tracking_config_returns_expected_config_on_databricks(
         if experiment_id is not None:
             profile_contents["experiment"]["id"] = experiment_id
 
-        profile_path = pathlib.Path.cwd() / "profiles" / "testprofile.yaml"
+        profile_path = os.path.join(pathlib.Path.cwd(), "profiles/test_profile.yaml")
         with open(profile_path, "w") as f:
             yaml.safe_dump(profile_contents, f)
 

--- a/tests/pipelines/test_utils.py
+++ b/tests/pipelines/test_utils.py
@@ -89,14 +89,6 @@ def test_get_pipeline_config_throws_for_invalid_pipeline_directory(tmp_path):
         get_pipeline_config(pipeline_root_path=tmp_path)
 
 
-@pytest.mark.usefixtures("enter_test_pipeline_directory")
-def test_get_pipeline_config_supports_empty_profile():
-    with open("profiles/empty.yaml", "w"):
-        pass
-
-    get_pipeline_config(profile="empty")
-
-
 @pytest.mark.usefixtures("enter_pipeline_example_directory")
 def test_get_pipeline_config_throws_for_nonexistent_profile():
     with pytest.raises(MlflowException, match="Did not find the YAML configuration.*badprofile"):

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -4,6 +4,8 @@ import filecmp
 import hashlib
 import os
 import shutil
+
+import jinja2.exceptions
 import pytest
 import tarfile
 import stat
@@ -125,6 +127,18 @@ def test_render_and_merge_yaml_raise_on_non_existent_yamls(tmpdir):
         file_utils.render_and_merge_yaml("invalid_path", template_yaml_file, context_yaml_file)
     with pytest.raises(MissingConfigException, match="does not exist"):
         file_utils.render_and_merge_yaml(tmpdir, template_yaml_file, "invalid_name")
+
+
+def test_render_and_merge_yaml_raise_on_not_found_key(tmpdir):
+    template_yaml_file = random_file("yaml")
+    with open(tmpdir / template_yaml_file, "w") as f:
+        f.write("""test_1: {{ TEST_VAR_1 }}""")
+
+    context_yaml_file = random_file("yaml")
+    file_utils.write_yaml(str(tmpdir), context_yaml_file, {})
+
+    with pytest.raises(jinja2.exceptions.UndefinedError, match="'TEST_VAR_1' is undefined"):
+        file_utils.render_and_merge_yaml(tmpdir, template_yaml_file, context_yaml_file)
 
 
 def test_yaml_write_sorting(tmpdir):


### PR DESCRIPTION
Signed-off-by: Jin Zhang <jin.zhang@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Made rendering YAML templates to require all variables to be defined.

Example error traceback:
```
Traceback (most recent call last):
  File "/Users/jin.zhang/Code/mlflow/mlflow/pipelines/utils/__init__.py", line 59, in get_pipeline_config
    return render_and_merge_yaml(
  File "/Users/jin.zhang/Code/mlflow/mlflow/utils/file_utils.py", line 225, in render_and_merge_yaml
    source = j2_env.get_template(template_name).render(context_dict)
  File "/opt/homebrew/anaconda3/envs/mlflow-env/lib/python3.8/site-packages/jinja2/environment.py", line 1291, in render
    self.environment.handle_exception()
  File "/opt/homebrew/anaconda3/envs/mlflow-env/lib/python3.8/site-packages/jinja2/environment.py", line 925, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "/Users/jin.zhang/Code/mlp-regression-template/pipeline.yaml", line 3, in top-level template code
    # such as {{INGEST_DATA_LOCATION }}.
jinja2.exceptions.UndefinedError: 'INGEST_DATA_LOCATION' is undefined
```

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
