### PR TITLE
Fix default evaluator behavior for regression models that mutate input datasets

### DIFF
--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1063,7 +1063,7 @@ class DefaultEvaluator(ModelEvaluator):
         """
         Wrapper around a data object that only provides copies of the data object, guarding against
         accidental reuse of the data object after it is mutated, e.g. during inference with
-        scikit-learn models
+        scikit-learn models.
         """
 
         def __init__(self, data):

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -552,7 +552,9 @@ class DefaultEvaluator(ModelEvaluator):
 
         # For some shap explainer, the plot will use the DataFrame column names instead of
         # using feature_names argument value. So rename the dataframe column names.
-        X_df = self.X.copy_in_case_of_mutation().rename(columns=truncated_feature_name_map, copy=False)
+        X_df = self.X.copy_in_case_of_mutation().rename(
+            columns=truncated_feature_name_map, copy=False
+        )
 
         sampled_X = shap.sample(X_df, sample_rows, random_state=0)
 
@@ -677,7 +679,9 @@ class DefaultEvaluator(ModelEvaluator):
     def _evaluate_sklearn_model_score_if_scorable(self):
         if self.model_loader_module == "mlflow.sklearn":
             try:
-                score = self.raw_model.score(self.X.copy_in_case_of_mutation(), self.y.copy_in_case_of_mutation())
+                score = self.raw_model.score(
+                    self.X.copy_in_case_of_mutation(), self.y.copy_in_case_of_mutation()
+                )
                 self.metrics["score"] = score
             except Exception as e:
                 _logger.warning(
@@ -687,7 +691,9 @@ class DefaultEvaluator(ModelEvaluator):
                 _logger.debug("", exc_info=True)
 
     def _log_binary_classifier(self):
-        self.metrics.update(_get_classifier_per_class_metrics(self.y.copy_in_case_of_mutation(), self.y_pred))
+        self.metrics.update(
+            _get_classifier_per_class_metrics(self.y.copy_in_case_of_mutation(), self.y_pred)
+        )
 
         if self.y_probs is not None:
             roc_curve = _gen_classifier_curve(
@@ -925,7 +931,11 @@ class DefaultEvaluator(ModelEvaluator):
 
         self.metrics.update(
             _get_classifier_global_metrics(
-                self.is_binomial, self.y.copy_in_case_of_mutation(), self.y_pred, self.y_probs, self.label_list
+                self.is_binomial,
+                self.y.copy_in_case_of_mutation(),
+                self.y_pred,
+                self.y_probs,
+                self.label_list,
             )
         )
         self._evaluate_sklearn_model_score_if_scorable()
@@ -1047,9 +1057,7 @@ class DefaultEvaluator(ModelEvaluator):
         """
         The labels (`y`) portion of the dataset, guarded against accidental mutations.
         """
-        return DefaultEvaluator._MutationGuardedData(
-            self.dataset.labels_data
-        )
+        return DefaultEvaluator._MutationGuardedData(self.dataset.labels_data)
 
     class _MutationGuardedData:
         """

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -491,8 +491,7 @@ class DefaultEvaluator(ModelEvaluator):
             )
             return
 
-        labels_dtype = self.y.dtype
-        if not (np.issubdtype(labels_dtype, np.number) or labels_dtype == np.bool_):
+        if not (np.issubdtype(self.y.dtype, np.number) or self.y.dtype == np.bool_):
             # Note: python bool type inherits number type but np.bool_ does not inherit np.number.
             _logger.warning(
                 "Skip logging model explainability insights because it requires all label "

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1034,10 +1034,12 @@ class DefaultEvaluator(ModelEvaluator):
                 else:
                     raise ValueError(f"Unsupported model type {model_type}")
 
-    @property 
+    @property
     def X(self):
-        return pd.DataFrame(self.dataset.features_data, columns=self.dataset.feature_names, copy=True)
+        return pd.DataFrame(
+            self.dataset.features_data, columns=self.dataset.feature_names, copy=True
+        )
 
-    @property 
+    @property
     def y(self):
         return self.dataset.labels_data.copy()

--- a/mlflow/pipelines/utils/__init__.py
+++ b/mlflow/pipelines/utils/__init__.py
@@ -53,7 +53,7 @@ def get_pipeline_config(pipeline_root_path: str = None, profile: str = None) -> 
             if not os.path.exists(profile_file_path):
                 raise MlflowException(
                     "Did not find the YAML configuration file for the specified profile"
-                   f" '{profile}' at expected path '{profile_file_path}'.",
+                    f" '{profile}' at expected path '{profile_file_path}'.",
                     error_code=INVALID_PARAMETER_VALUE,
                 )
             return render_and_merge_yaml(
@@ -71,7 +71,6 @@ def get_pipeline_config(pipeline_root_path: str = None, profile: str = None) -> 
             " for template substitutions defined in `pipeline.yaml`.",
             error_code=INVALID_PARAMETER_VALUE,
         ) from e
-
 
 
 def get_pipeline_root_path() -> str:

--- a/mlflow/pipelines/utils/execution.py
+++ b/mlflow/pipelines/utils/execution.py
@@ -399,7 +399,7 @@ ingest:
 # target. Downstream steps depend on the ingested dataset target, rather than the `ingest` target,
 # ensuring that data is only ingested for downstream steps if it is not already present on the
 # local filesystem
-steps/ingest/outputs/dataset.parquet: steps/ingest/conf.yaml steps/ingest.py
+steps/ingest/outputs/dataset.parquet: steps/ingest/conf.yaml {path:prp/steps/ingest.py}
 	$(MAKE) ingest
 
 split_objects = steps/split/outputs/train.parquet steps/split/outputs/validation.parquet steps/split/outputs/test.parquet

--- a/mlflow/pipelines/utils/execution.py
+++ b/mlflow/pipelines/utils/execution.py
@@ -399,7 +399,7 @@ ingest:
 # target. Downstream steps depend on the ingested dataset target, rather than the `ingest` target,
 # ensuring that data is only ingested for downstream steps if it is not already present on the
 # local filesystem
-steps/ingest/outputs/dataset.parquet: steps/ingest/conf.yaml
+steps/ingest/outputs/dataset.parquet: steps/ingest/conf.yaml steps/ingest.py
 	$(MAKE) ingest
 
 split_objects = steps/split/outputs/train.parquet steps/split/outputs/validation.parquet steps/split/outputs/test.parquet

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -31,7 +31,10 @@ from mlflow.models.evaluation.default_evaluator import (
     _CustomMetric,
 )
 import mlflow
+from sklearn.compose import ColumnTransformer
 from sklearn.linear_model import LogisticRegression, LinearRegression
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import FunctionTransformer
 from sklearn.datasets import load_iris
 
 from tempfile import TemporaryDirectory
@@ -1114,4 +1117,34 @@ def test_truncation_works_for_long_feature_names(linear_regressor_model_uri, dia
             "f10",
         ],
         evaluators="default",
+    )
+
+
+def test_evaluation_works_with_model_pipelines_that_modify_input_data():
+    iris = load_iris()
+    X = pd.DataFrame(iris.data)
+    y = pd.Series(iris.target)
+
+    def add_feature(df):
+        df["newfeature"] = 1
+        return df
+
+    # Define a transformer that modifies input data by adding an extra feature column
+    add_feature_transformer = FunctionTransformer(add_feature, validate=False)
+    model_pipeline = Pipeline(steps=[("add_feature", add_feature_transformer), ("predict", LogisticRegression())])
+    model_pipeline.fit(X, y)
+
+    with mlflow.start_run():
+        pipeline_model_uri = mlflow.sklearn.log_model(model_pipeline, "model").model_uri
+
+    evaluation_data = pd.DataFrame(load_iris().data, columns=["0", "1", "2", "3"])
+    evaluation_data["labels"] = load_iris().target
+
+    evaluate(
+        pipeline_model_uri,
+        evaluation_data,
+        model_type="regressor",
+        targets="labels",
+        evaluators="default",
+        evaluator_config={"log_model_explainability": True},
     )

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -31,7 +31,6 @@ from mlflow.models.evaluation.default_evaluator import (
     _CustomMetric,
 )
 import mlflow
-from sklearn.compose import ColumnTransformer
 from sklearn.linear_model import LogisticRegression, LinearRegression
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import FunctionTransformer

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -1131,7 +1131,9 @@ def test_evaluation_works_with_model_pipelines_that_modify_input_data():
 
     # Define a transformer that modifies input data by adding an extra feature column
     add_feature_transformer = FunctionTransformer(add_feature, validate=False)
-    model_pipeline = Pipeline(steps=[("add_feature", add_feature_transformer), ("predict", LogisticRegression())])
+    model_pipeline = Pipeline(
+        steps=[("add_feature", add_feature_transformer), ("predict", LogisticRegression())]
+    )
     model_pipeline.fit(X, y)
 
     with mlflow.start_run() as run:

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -1122,7 +1122,7 @@ def test_truncation_works_for_long_feature_names(linear_regressor_model_uri, dia
 
 def test_evaluation_works_with_model_pipelines_that_modify_input_data():
     iris = load_iris()
-    X = pd.DataFrame(iris.data)
+    X = pd.DataFrame(iris.data, columns=["0", "1", "2", "3"])
     y = pd.Series(iris.target)
 
     def add_feature(df):
@@ -1134,17 +1134,31 @@ def test_evaluation_works_with_model_pipelines_that_modify_input_data():
     model_pipeline = Pipeline(steps=[("add_feature", add_feature_transformer), ("predict", LogisticRegression())])
     model_pipeline.fit(X, y)
 
-    with mlflow.start_run():
+    with mlflow.start_run() as run:
         pipeline_model_uri = mlflow.sklearn.log_model(model_pipeline, "model").model_uri
 
-    evaluation_data = pd.DataFrame(load_iris().data, columns=["0", "1", "2", "3"])
-    evaluation_data["labels"] = load_iris().target
+        evaluation_data = pd.DataFrame(load_iris().data, columns=["0", "1", "2", "3"])
+        evaluation_data["labels"] = load_iris().target
 
-    evaluate(
-        pipeline_model_uri,
-        evaluation_data,
-        model_type="regressor",
-        targets="labels",
-        evaluators="default",
-        evaluator_config={"log_model_explainability": True},
-    )
+        evaluate(
+            pipeline_model_uri,
+            evaluation_data,
+            dataset_name="iris",
+            model_type="regressor",
+            targets="labels",
+            evaluators="default",
+            evaluator_config={
+                "log_model_explainability": True,
+                # Use the kernel explainability algorithm, which fails if there is a mismatch
+                # between the number of features in the input dataset and the number of features
+                # expected by the model
+                "explainability_algorithm": "kernel",
+            },
+        )
+
+        _, _, _, artifacts = get_run_data(run.info.run_id)
+        assert set(artifacts) >= {
+            "shap_beeswarm_plot_on_data_iris.png",
+            "shap_feature_importance_plot_on_data_iris.png",
+            "shap_summary_plot_on_data_iris.png",
+        }


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## What changes are proposed in this pull request?

Fix default evaluator behavior for regression models that mutate input datasets by ensuring that metrics & explanations are only computed on fresh dataset copies.

## How is this patch tested?

Added integration test

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

Fix a bug in ``mlflow.evaluate()`` that caused kernel explanations to fail for models that mutate input data during inference.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
