### PR TITLE
Fix bug in profile existence check from pipeline subdirectory

### DIFF
--- a/mlflow/pipelines/utils/__init__.py
+++ b/mlflow/pipelines/utils/__init__.py
@@ -49,7 +49,9 @@ def get_pipeline_config(pipeline_root_path: str = None, profile: str = None) -> 
     _verify_is_pipeline_root_directory(pipeline_root_path=pipeline_root_path)
     try:
         if profile:
-            profile_file_path = os.path.join(_PIPELINE_PROFILE_DIR, f"{profile}.yaml")
+            profile_file_path = os.path.join(
+                pipeline_root_path, _PIPELINE_PROFILE_DIR, f"{profile}.yaml"
+            )
             if not os.path.exists(profile_file_path):
                 raise MlflowException(
                     "Did not find the YAML configuration file for the specified profile"

--- a/tests/pipelines/test_utils.py
+++ b/tests/pipelines/test_utils.py
@@ -105,6 +105,16 @@ def test_get_default_profile_works():
 
 
 @pytest.mark.usefixtures("enter_test_pipeline_directory")
+@pytest.mark.parametrize("get_config_from_subdirectory", [False, True])
+def test_get_pipeline_config_succeeds_for_valid_profile(get_config_from_subdirectory):
+    if get_config_from_subdirectory:
+        with chdir("notebooks"):
+            get_pipeline_config(profile="local")
+    else:
+        get_pipeline_config(profile="local")
+
+
+@pytest.mark.usefixtures("enter_test_pipeline_directory")
 def test_get_pipeline_config_throws_clear_error_for_invalid_profile():
     with open("profiles/badcontent.yaml", "w") as f:
         f.write(r"\BAD")


### PR DESCRIPTION
Signed-off-by: dbczumar <corey.zumar@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## What changes are proposed in this pull request?

Fixes a regression introduced by https://github.com/mlflow/mlflow/pull/6134 where we check for the existence of a profile in the incorrect location when running a pipeline from a subdirectory of the pipeline root.

## How is this patch tested?

Added integration test that fails on `master` and passes on PR branch

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [X] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
