### PR TITLE
Stop installing prophet build dependencies

### DIFF
--- a/dev/dev-env-setup.sh
+++ b/dev/dev-env-setup.sh
@@ -221,12 +221,6 @@ echo "$(tput setaf 3)Activated environment is located: $(tput bold) $directory/b
 echo "Installing pip dependencies for development environment."
 
 if [[ -n "$full" ]]; then
-  # Install required dependencies for Prophet
-  tmp_dir=$(mktemp -d)
-  pip download $(quiet_command) --no-deps --dest "$tmp_dir" --no-cache-dir prophet
-  tar -zxvf "$tmp_dir"/*.tar.gz -C "$tmp_dir"
-  pip install $(quiet_command) -r "$(find "$tmp_dir" -name requirements.txt)"
-  rm -rf "$tmp_dir"
   # Install dev requirements and test plugin
   pip install $(quiet_command) -r "$MLFLOW_HOME/requirements/dev-requirements.txt"
   # Install current checked out version of MLflow (local)

--- a/dev/install-common-deps.sh
+++ b/dev/install-common-deps.sh
@@ -35,15 +35,6 @@ else
   req_files+=" -r requirements/test-requirements.txt"
 fi
 if [[ "$INSTALL_ML_DEPENDENCIES" == "true" ]]; then
-  # Install prophet's dependencies beforehand, otherwise pip would fail to build a wheel for prophet
-  if [[ -z "$(pip cache list prophet --format abspath)" ]]; then
-    tmp_dir=$(mktemp -d)
-    pip download --no-deps --dest $tmp_dir --no-cache-dir prophet
-    tar -zxvf $tmp_dir/*.tar.gz -C $tmp_dir
-    pip install -r $(find $tmp_dir -name requirements.txt)
-    rm -rf $tmp_dir
-  fi
-
   req_files+=" -r requirements/extra-ml-requirements.txt"
 fi
 


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Prophet started providing pre-built wheels from 1.1 so we no longer need to install build dependencies: https://pypi.org/project/prophet/1.1/

This PR fixes the following error:

https://github.com/mlflow/mlflow/runs/7057209205?check_suite_focus=true#step:5:415

```
Collecting prophet
  Downloading prophet-1.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (8.9 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 8.9/8.9 MB 100.1 MB/s eta 0:00:00
Saved /tmp/tmp.X6dd0PWQyq/prophet-1.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
Successfully downloaded prophet
++ tar -zxvf '/tmp/tmp.X6dd0PWQyq/*.tar.gz' -C /tmp/tmp.X6dd0PWQyq
tar (child): /tmp/tmp.X6dd0PWQyq/*.tar.gz: Cannot open: No such file or directory
tar (child): Error is not recoverable: exiting now
tar: Child returned status 2
tar: Error is not recoverable: exiting now
```

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

Existing tests

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
