### PR TITLE
Track git repository URL when creating MLflow Runs from MLflow Pipelines

### DIFF
--- a/mlflow/pipelines/steps/evaluate.py
+++ b/mlflow/pipelines/steps/evaluate.py
@@ -323,5 +323,5 @@ class EvaluateStep(BaseStep):
     @property
     def environment(self):
         environ = get_databricks_env_vars(tracking_uri=self.tracking_config.tracking_uri)
-        environ.update(get_run_tags_env_vars())
+        environ.update(get_run_tags_env_vars(pipeline_root_path=self.pipeline_root))
         return environ

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -297,5 +297,5 @@ class TrainStep(BaseStep):
     @property
     def environment(self):
         environ = get_databricks_env_vars(tracking_uri=self.tracking_config.tracking_uri)
-        environ.update(get_run_tags_env_vars())
+        environ.update(get_run_tags_env_vars(pipeline_root_path=self.pipeline_root))
         return environ

--- a/mlflow/pipelines/utils/tracking.py
+++ b/mlflow/pipelines/utils/tracking.py
@@ -16,9 +16,10 @@ from mlflow.tracking.default_experiment import DEFAULT_EXPERIMENT_ID
 from mlflow.tracking.fluent import set_experiment as fluent_set_experiment, _get_experiment_id
 from mlflow.utils.databricks_utils import is_in_databricks_runtime
 from mlflow.utils.file_utils import path_to_local_sqlite_uri, path_to_local_file_uri
-from mlflow.utils.git_utils import get_git_repo_url, get_git_commit
+from mlflow.utils.git_utils import get_git_repo_url, get_git_commit, get_git_branch
 from mlflow.utils.mlflow_tags import (
     MLFLOW_SOURCE_NAME,
+    MLFLOW_GIT_BRANCH,
     MLFLOW_GIT_COMMIT,
     MLFLOW_GIT_REPO_URL,
     LEGACY_MLFLOW_GIT_REPO_URL,
@@ -215,15 +216,19 @@ def get_run_tags_env_vars(pipeline_root_path: str) -> Dict[str, str]:
     run_context_tags = resolve_tags()
 
     git_tags = {}
-    git_commit = get_git_commit(path=pipeline_root_path)
-    if git_commit:
-        git_tags[MLFLOW_GIT_COMMIT] = git_commit
     git_repo_url = get_git_repo_url(path=pipeline_root_path)
     if git_repo_url:
         git_tags[MLFLOW_SOURCE_NAME] = git_repo_url
         git_tags[MLFLOW_GIT_REPO_URL] = git_repo_url
         git_tags[LEGACY_MLFLOW_GIT_REPO_URL] = git_repo_url
+    git_commit = get_git_commit(path=pipeline_root_path)
+    if git_commit:
+        git_tags[MLFLOW_GIT_COMMIT] = git_commit
+    git_branch = get_git_branch(path=pipeline_root_path)
+    if git_branch:
+        git_tags[MLFLOW_GIT_BRANCH] = git_branch
 
+    print("GIT TAGS", git_tags)
     return {MLFLOW_RUN_CONTEXT_ENV_VAR: json.dumps({**run_context_tags, **git_tags})}
 
 

--- a/mlflow/pipelines/utils/tracking.py
+++ b/mlflow/pipelines/utils/tracking.py
@@ -16,6 +16,13 @@ from mlflow.tracking.default_experiment import DEFAULT_EXPERIMENT_ID
 from mlflow.tracking.fluent import set_experiment as fluent_set_experiment, _get_experiment_id
 from mlflow.utils.databricks_utils import is_in_databricks_runtime
 from mlflow.utils.file_utils import path_to_local_sqlite_uri, path_to_local_file_uri
+from mlflow.utils.git_utils import get_git_repo_url, get_git_commit
+from mlflow.utils.mlflow_tags import (
+    MLFLOW_SOURCE_NAME,
+    MLFLOW_GIT_COMMIT,
+    MLFLOW_GIT_REPO_URL,
+    LEGACY_MLFLOW_GIT_REPO_URL,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -195,15 +202,29 @@ def apply_pipeline_tracking_config(tracking_config: TrackingConfig):
     )
 
 
-def get_run_tags_env_vars() -> Dict[str, str]:
+def get_run_tags_env_vars(pipeline_root_path: str) -> Dict[str, str]:
     """
     Returns environment variables that should be set during step execution to ensure that MLflow
     Run Tags from the current context are applied to any MLflow Runs that are created during
     pipeline execution.
 
+    :param pipeline_root_path: The absolute path of the pipeline root directory on the local
+                               filesystem.
     :return: A dictionary of environment variable names and values.
     """
-    return {MLFLOW_RUN_CONTEXT_ENV_VAR: json.dumps(resolve_tags())}
+    run_context_tags = resolve_tags()
+
+    git_tags = {}
+    git_commit = get_git_commit(path=pipeline_root_path)
+    if git_commit:
+        git_tags[MLFLOW_GIT_COMMIT] = git_commit
+    git_repo_url = get_git_repo_url(path=pipeline_root_path)
+    if git_repo_url:
+        git_tags[MLFLOW_SOURCE_NAME] = git_repo_url
+        git_tags[MLFLOW_GIT_REPO_URL] = git_repo_url
+        git_tags[LEGACY_MLFLOW_GIT_REPO_URL] = git_repo_url
+
+    return {MLFLOW_RUN_CONTEXT_ENV_VAR: json.dumps({**run_context_tags, **git_tags})}
 
 
 def log_code_snapshot(

--- a/mlflow/pipelines/utils/tracking.py
+++ b/mlflow/pipelines/utils/tracking.py
@@ -228,7 +228,6 @@ def get_run_tags_env_vars(pipeline_root_path: str) -> Dict[str, str]:
     if git_branch:
         git_tags[MLFLOW_GIT_BRANCH] = git_branch
 
-    print("GIT TAGS", git_tags)
     return {MLFLOW_RUN_CONTEXT_ENV_VAR: json.dumps({**run_context_tags, **git_tags})}
 
 

--- a/mlflow/projects/docker.py
+++ b/mlflow/projects/docker.py
@@ -13,10 +13,10 @@ from mlflow import tracking
 from mlflow.projects.utils import get_databricks_env_vars
 from mlflow.exceptions import ExecutionException
 from mlflow.projects.utils import MLFLOW_DOCKER_WORKDIR_PATH
-from mlflow.tracking.context.git_context import _get_git_commit
 from mlflow.utils import process, file_utils
 from mlflow.utils.mlflow_tags import MLFLOW_DOCKER_IMAGE_URI, MLFLOW_DOCKER_IMAGE_ID
 from mlflow.utils.file_utils import _handle_readonly_on_windows
+from mlflow.utils.git_utils import get_git_commit
 
 _logger = logging.getLogger(__name__)
 
@@ -108,7 +108,7 @@ def _get_docker_image_uri(repository_uri, work_dir):
     """
     repository_uri = repository_uri if repository_uri else "docker-project"
     # Optionally include first 7 digits of git SHA in tag name, if available.
-    git_commit = _get_git_commit(work_dir)
+    git_commit = get_git_commit(work_dir)
     version_string = ":" + git_commit[:7] if git_commit else ""
     return repository_uri + version_string
 

--- a/mlflow/projects/utils.py
+++ b/mlflow/projects/utils.py
@@ -9,6 +9,7 @@ from distutils import dir_util
 
 import mlflow.utils
 from mlflow.utils import databricks_utils
+from mlflow.utils.git_utils import get_git_repo_url 
 from mlflow.entities import SourceType, Param
 from mlflow.exceptions import ExecutionException
 from mlflow.projects import _project_spec
@@ -70,22 +71,6 @@ def _get_storage_dir(storage_dir):
     if storage_dir is not None and not os.path.exists(storage_dir):
         os.makedirs(storage_dir)
     return tempfile.mkdtemp(dir=storage_dir)
-
-
-def _get_git_repo_url(work_dir):
-    from git import Repo
-    from git.exc import GitCommandError, InvalidGitRepositoryError
-
-    try:
-        repo = Repo(work_dir, search_parent_directories=True)
-        remote_urls = [remote.url for remote in repo.remotes]
-        if len(remote_urls) == 0:
-            return None
-    except GitCommandError:
-        return None
-    except InvalidGitRepositoryError:
-        return None
-    return remote_urls[0]
 
 
 def _expand_uri(uri):
@@ -300,7 +285,7 @@ def _create_run(uri, experiment_id, work_dir, version, entry_point, parameters):
     if parent_run_id is not None:
         tags[MLFLOW_PARENT_RUN_ID] = parent_run_id
 
-    repo_url = _get_git_repo_url(work_dir)
+    repo_url = get_git_repo_url(work_dir)
     if repo_url is not None:
         tags[MLFLOW_GIT_REPO_URL] = repo_url
         tags[LEGACY_MLFLOW_GIT_REPO_URL] = repo_url

--- a/mlflow/projects/utils.py
+++ b/mlflow/projects/utils.py
@@ -9,7 +9,7 @@ from distutils import dir_util
 
 import mlflow.utils
 from mlflow.utils import databricks_utils
-from mlflow.utils.git_utils import get_git_repo_url 
+from mlflow.utils.git_utils import get_git_repo_url
 from mlflow.entities import SourceType, Param
 from mlflow.exceptions import ExecutionException
 from mlflow.projects import _project_spec

--- a/mlflow/projects/utils.py
+++ b/mlflow/projects/utils.py
@@ -9,12 +9,11 @@ from distutils import dir_util
 
 import mlflow.utils
 from mlflow.utils import databricks_utils
-from mlflow.utils.git_utils import get_git_repo_url
+from mlflow.utils.git_utils import get_git_repo_url, get_git_commit
 from mlflow.entities import SourceType, Param
 from mlflow.exceptions import ExecutionException
 from mlflow.projects import _project_spec
 from mlflow import tracking
-from mlflow.tracking.context.git_context import _get_git_commit
 from mlflow.tracking import fluent
 from mlflow.tracking.context.default_context import _get_user
 from mlflow.utils.mlflow_tags import (
@@ -267,7 +266,7 @@ def _create_run(uri, experiment_id, work_dir, version, entry_point, parameters):
         source_name = tracking._tracking_service.utils._get_git_url_if_present(_expand_uri(uri))
     else:
         source_name = _expand_uri(uri)
-    source_version = _get_git_commit(work_dir)
+    source_version = get_git_commit(work_dir)
     existing_run = fluent.active_run()
     if existing_run:
         parent_run_id = existing_run.info.run_id

--- a/mlflow/server/js/src/common/utils/Utils.js
+++ b/mlflow/server/js/src/common/utils/Utils.js
@@ -380,18 +380,14 @@ class Utils {
    */
   static renderSource(tags, queryParams, runUuid) {
     const sourceName = Utils.getSourceName(tags);
-    const sourceType = Utils.getSourceType(tags);
     let res = Utils.formatSource(tags);
-    if (sourceType === 'PROJECT') {
-      const url = Utils.getGitRepoUrl(sourceName);
-      if (url) {
-        res = (
-          <a target='_top' href={url}>
-            {res}
-          </a>
-        );
-      }
-      return res;
+    const gitRepoUrlOrNull = Utils.getGitRepoUrl(sourceName);
+    if (gitRepoUrlOrNull) {
+      res = (
+        <a target='_top' href={gitRepoUrlOrNull}>
+          {res}
+        </a>
+      );
     }
     return res;
   }

--- a/mlflow/tracking/context/git_context.py
+++ b/mlflow/tracking/context/git_context.py
@@ -1,42 +1,17 @@
-import os
 import logging
 
 from mlflow.tracking.context.abstract_context import RunContextProvider
 from mlflow.tracking.context.default_context import _get_main_file
-from mlflow.utils.git_utils import get_git_repo_url
-from mlflow.utils.mlflow_tags import (
-    MLFLOW_GIT_COMMIT,
-    MLFLOW_GIT_REPO_URL,
-    LEGACY_MLFLOW_GIT_REPO_URL,
-)
+from mlflow.utils.git_utils import get_git_repo_url, get_git_commit
+from mlflow.utils.mlflow_tags import MLFLOW_GIT_COMMIT
 
 _logger = logging.getLogger(__name__)
-
-
-def _get_git_commit(path):
-    try:
-        import git
-    except ImportError as e:
-        _logger.warning(
-            "Failed to import Git (the Git executable is probably not on your PATH),"
-            " so Git SHA is not available. Error: %s",
-            e,
-        )
-        return None
-    try:
-        if os.path.isfile(path):
-            path = os.path.dirname(path)
-        repo = git.Repo(path, search_parent_directories=True)
-        commit = repo.head.commit.hexsha
-        return commit
-    except (git.InvalidGitRepositoryError, git.GitCommandNotFound, ValueError, git.NoSuchPathError):
-        return None
 
 
 def _get_source_version():
     main_file = _get_main_file()
     if main_file is not None:
-        return _get_git_commit(main_file)
+        return get_git_commit(main_file)
     return None
 
 
@@ -57,18 +32,8 @@ class GitRunContext(RunContextProvider):
             self._cache["source_version"] = _get_source_version()
         return self._cache["source_version"]
 
-    @property
-    def _git_repo_url(self):
-        if "git_repo_url" not in self._cache:
-            self._cache["git_repo_url"] = _get_git_repo_url()
-        return self._cache["git_repo_url"]
-
     def in_context(self):
         return self._source_version is not None
 
     def tags(self):
-        return {
-            MLFLOW_GIT_COMMIT: self._source_version,
-            MLFLOW_GIT_REPO_URL: self._git_repo_url,
-            LEGACY_MLFLOW_GIT_REPO_URL: self._git_repo_url,
-        }
+        return {MLFLOW_GIT_COMMIT: self._source_version}

--- a/mlflow/tracking/context/git_context.py
+++ b/mlflow/tracking/context/git_context.py
@@ -3,7 +3,12 @@ import logging
 
 from mlflow.tracking.context.abstract_context import RunContextProvider
 from mlflow.tracking.context.default_context import _get_main_file
-from mlflow.utils.mlflow_tags import MLFLOW_GIT_COMMIT
+from mlflow.utils.git_utils import get_git_repo_url
+from mlflow.utils.mlflow_tags import (
+    MLFLOW_GIT_COMMIT,
+    MLFLOW_GIT_REPO_URL,
+    LEGACY_MLFLOW_GIT_REPO_URL,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -35,6 +40,13 @@ def _get_source_version():
     return None
 
 
+def _get_git_repo_url():
+    main_file = _get_main_file()
+    if main_file is not None:
+        return get_git_repo_url(main_file)
+    return None
+
+
 class GitRunContext(RunContextProvider):
     def __init__(self):
         self._cache = {}
@@ -45,8 +57,18 @@ class GitRunContext(RunContextProvider):
             self._cache["source_version"] = _get_source_version()
         return self._cache["source_version"]
 
+    @property
+    def _git_repo_url(self):
+        if "git_repo_url" not in self._cache:
+            self._cache["git_repo_url"] = _get_git_repo_url()
+        return self._cache["git_repo_url"]
+
     def in_context(self):
         return self._source_version is not None
 
     def tags(self):
-        return {MLFLOW_GIT_COMMIT: self._source_version}
+        return {
+            MLFLOW_GIT_COMMIT: self._source_version,
+            MLFLOW_GIT_REPO_URL: self._git_repo_url,
+            LEGACY_MLFLOW_GIT_REPO_URL: self._git_repo_url,
+        }

--- a/mlflow/tracking/context/git_context.py
+++ b/mlflow/tracking/context/git_context.py
@@ -2,7 +2,7 @@ import logging
 
 from mlflow.tracking.context.abstract_context import RunContextProvider
 from mlflow.tracking.context.default_context import _get_main_file
-from mlflow.utils.git_utils import get_git_repo_url, get_git_commit
+from mlflow.utils.git_utils import get_git_commit
 from mlflow.utils.mlflow_tags import MLFLOW_GIT_COMMIT
 
 _logger = logging.getLogger(__name__)
@@ -12,13 +12,6 @@ def _get_source_version():
     main_file = _get_main_file()
     if main_file is not None:
         return get_git_commit(main_file)
-    return None
-
-
-def _get_git_repo_url():
-    main_file = _get_main_file()
-    if main_file is not None:
-        return get_git_repo_url(main_file)
     return None
 
 

--- a/mlflow/utils/git_utils.py
+++ b/mlflow/utils/git_utils.py
@@ -1,4 +1,9 @@
+import logging
+import os
 from typing import Optional
+
+
+_logger = logging.getLogger(__name__)
 
 
 def get_git_repo_url(path: str) -> Optional[str]:
@@ -6,13 +11,43 @@ def get_git_repo_url(path: str) -> Optional[str]:
     Obtains the url of the git repository associated with the specified path,
     returning ``None`` if the path does not correspond to a git repository.
     """
-    from git import Repo
+    try:
+        from git import Repo
+    except ImportError as e:
+        _logger.warning(
+            "Failed to import Git (the Git executable is probably not on your PATH),"
+            " so Git SHA is not available. Error: %s",
+            e,
+        )
+        return None
 
     try:
         repo = Repo(path, search_parent_directories=True)
-        remote_urls = [remote.url for remote in repo.remotes]
-        if len(remote_urls) == 0:
-            return None
+        return next((remote.url for remote in repo.remotes), None)
     except Exception:
         return None
-    return remote_urls[0]
+
+
+def get_git_commit(path: str) -> Optional[str]:
+    """
+    Obtains the hash of the latest commit on the current branch of the git repository associated
+    with the specified path, returning ``None`` if the path does not correspond to a git
+    repository.
+    """
+    try:
+        import git
+    except ImportError as e:
+        _logger.warning(
+            "Failed to import Git (the Git executable is probably not on your PATH),"
+            " so Git SHA is not available. Error: %s",
+            e,
+        )
+        return None
+    try:
+        if os.path.isfile(path):
+            path = os.path.dirname(path)
+        repo = git.Repo(path, search_parent_directories=True)
+        commit = repo.head.commit.hexsha
+        return commit
+    except Exception:
+        return None

--- a/mlflow/utils/git_utils.py
+++ b/mlflow/utils/git_utils.py
@@ -1,0 +1,18 @@
+from typing import Optional
+
+
+def get_git_repo_url(path: str) -> Optional[str]:
+    """
+    Obtains the url of the git repository associated with the specified path,
+    returning ``None`` if the path does not correspond to a git repository.
+    """
+    from git import Repo
+
+    try:
+        repo = Repo(path, search_parent_directories=True)
+        remote_urls = [remote.url for remote in repo.remotes]
+        if len(remote_urls) == 0:
+            return None
+    except Exception:
+        return None
+    return remote_urls[0]

--- a/mlflow/utils/git_utils.py
+++ b/mlflow/utils/git_utils.py
@@ -35,7 +35,7 @@ def get_git_commit(path: str) -> Optional[str]:
     repository.
     """
     try:
-        import git
+        from git import Repo
     except ImportError as e:
         _logger.warning(
             "Failed to import Git (the Git executable is probably not on your PATH),"
@@ -46,8 +46,32 @@ def get_git_commit(path: str) -> Optional[str]:
     try:
         if os.path.isfile(path):
             path = os.path.dirname(path)
-        repo = git.Repo(path, search_parent_directories=True)
+        repo = Repo(path, search_parent_directories=True)
         commit = repo.head.commit.hexsha
         return commit
+    except Exception:
+        return None
+
+
+def get_git_branch(path: str) -> Optional[str]:
+    """
+    Obtains the name of the current branch of the git repository associated with the specified
+    path, returning ``None`` if the path does not correspond to a git repository.
+    """
+    try:
+        from git import Repo
+    except ImportError as e:
+        _logger.warning(
+            "Failed to import Git (the Git executable is probably not on your PATH),"
+            " so Git SHA is not available. Error: %s",
+            e,
+        )
+        return None
+    
+    try:
+        if os.path.isfile(path):
+            path = os.path.dirname(path)
+        repo = Repo(path, search_parent_directories=True)
+        return repo.active_branch.name
     except Exception:
         return None

--- a/mlflow/utils/git_utils.py
+++ b/mlflow/utils/git_utils.py
@@ -67,7 +67,7 @@ def get_git_branch(path: str) -> Optional[str]:
             e,
         )
         return None
-    
+
     try:
         if os.path.isfile(path):
             path = os.path.dirname(path)

--- a/tests/pipelines/test_pipeline.py
+++ b/tests/pipelines/test_pipeline.py
@@ -7,15 +7,22 @@ import yaml
 from unittest import mock
 
 import mlflow
+from mlflow.entities import Run
+from mlflow.entities.model_registry import ModelVersion
+from mlflow.exceptions import MlflowException
 from mlflow.pipelines.pipeline import Pipeline
 from mlflow.pipelines.step import BaseStep
 from mlflow.pipelines.utils.execution import get_step_output_path, _get_execution_directory_basename
-from mlflow.exceptions import MlflowException
 from mlflow.tracking.client import MlflowClient
 from mlflow.tracking.context.registry import resolve_tags
 from mlflow.utils.file_utils import path_to_local_file_uri
-from mlflow.entities import Run
-from mlflow.entities.model_registry import ModelVersion
+from mlflow.utils.mlflow_tags import (
+    MLFLOW_SOURCE_NAME,
+    MLFLOW_GIT_BRANCH,
+    MLFLOW_GIT_COMMIT,
+    MLFLOW_GIT_REPO_URL,
+    LEGACY_MLFLOW_GIT_REPO_URL,
+)
 
 # pylint: disable=unused-import
 from tests.pipelines.helper_functions import (
@@ -134,6 +141,38 @@ def test_pipelines_log_to_expected_mlflow_backend_with_expected_run_tags_once_on
     pipeline.run()
     logged_runs = mlflow.search_runs(experiment_names=[experiment_name], output_format="list")
     assert len(logged_runs) == 1
+
+
+@pytest.mark.usefixtures("enter_pipeline_example_directory")
+def test_pipelines_run_sets_mlflow_git_tags():
+    pipeline = Pipeline(profile="local")
+    pipeline.clean()
+    pipeline.run(step="train")
+
+    profile_path = pathlib.Path.cwd() / "profiles" / "local.yaml"
+    with open(profile_path, "r") as f:
+        profile_contents = yaml.safe_load(f)
+
+    tracking_uri = profile_contents["experiment"]["tracking_uri"]
+    experiment_name = profile_contents["experiment"]["name"]
+
+    mlflow.set_tracking_uri(tracking_uri)
+    logged_runs = mlflow.search_runs(
+        experiment_names=[experiment_name],
+        output_format="list",
+        order_by=["attributes.start_time DESC"],
+    )
+    logged_run = logged_runs[0]
+
+    run_tags = MlflowClient(tracking_uri).get_run(run_id=logged_run.info.run_id).data.tags
+    assert {
+        MLFLOW_SOURCE_NAME,
+        MLFLOW_GIT_COMMIT,
+        MLFLOW_GIT_REPO_URL,
+        MLFLOW_GIT_BRANCH,
+        LEGACY_MLFLOW_GIT_REPO_URL,
+    } < run_tags.keys()
+    assert run_tags[MLFLOW_SOURCE_NAME] == run_tags[MLFLOW_GIT_REPO_URL]
 
 
 @pytest.mark.usefixtures("enter_test_pipeline_directory")

--- a/tests/pipelines/test_pipeline.py
+++ b/tests/pipelines/test_pipeline.py
@@ -18,7 +18,6 @@ from mlflow.tracking.context.registry import resolve_tags
 from mlflow.utils.file_utils import path_to_local_file_uri
 from mlflow.utils.mlflow_tags import (
     MLFLOW_SOURCE_NAME,
-    MLFLOW_GIT_BRANCH,
     MLFLOW_GIT_COMMIT,
     MLFLOW_GIT_REPO_URL,
     LEGACY_MLFLOW_GIT_REPO_URL,
@@ -169,7 +168,6 @@ def test_pipelines_run_sets_mlflow_git_tags():
         MLFLOW_SOURCE_NAME,
         MLFLOW_GIT_COMMIT,
         MLFLOW_GIT_REPO_URL,
-        MLFLOW_GIT_BRANCH,
         LEGACY_MLFLOW_GIT_REPO_URL,
     } < run_tags.keys()
     assert run_tags[MLFLOW_SOURCE_NAME] == run_tags[MLFLOW_GIT_REPO_URL]

--- a/tests/projects/test_docker_projects.py
+++ b/tests/projects/test_docker_projects.py
@@ -132,7 +132,7 @@ def test_docker_uri_mode_validation(docker_example_base_image):  # pylint: disab
         mlflow.projects.run(TEST_DOCKER_PROJECT_DIR, backend="databricks", backend_config={})
 
 
-@mock.patch("mlflow.projects.docker._get_git_commit")
+@mock.patch("mlflow.projects.docker.get_git_commit")
 def test_docker_image_uri_with_git(get_git_commit_mock):
     get_git_commit_mock.return_value = "1234567890"
     image_uri = _get_docker_image_uri("my_project", "my_workdir")
@@ -140,7 +140,7 @@ def test_docker_image_uri_with_git(get_git_commit_mock):
     get_git_commit_mock.assert_called_with("my_workdir")
 
 
-@mock.patch("mlflow.projects.docker._get_git_commit")
+@mock.patch("mlflow.projects.docker.get_git_commit")
 def test_docker_image_uri_no_git(get_git_commit_mock):
     get_git_commit_mock.return_value = None
     image_uri = _get_docker_image_uri("my_project", "my_workdir")

--- a/tests/tracking/context/test_git_context.py
+++ b/tests/tracking/context/test_git_context.py
@@ -2,14 +2,19 @@ import pytest
 import git
 from unittest import mock
 
-from mlflow.utils.mlflow_tags import MLFLOW_GIT_COMMIT
 from mlflow.tracking.context.git_context import GitRunContext
+from mlflow.utils.mlflow_tags import (
+    MLFLOW_GIT_COMMIT,
+    MLFLOW_GIT_REPO_URL,
+    LEGACY_MLFLOW_GIT_REPO_URL,
+)
 
 # pylint: disable=unused-argument
 
 
 MOCK_SCRIPT_NAME = "/path/to/script.py"
 MOCK_COMMIT_HASH = "commit-hash"
+MOCK_REPO_URL = "https://mockurl.com"
 
 
 @pytest.fixture
@@ -24,6 +29,9 @@ def patch_script_name():
 def patch_git_repo():
     mock_repo = mock.Mock()
     mock_repo.head.commit.hexsha = MOCK_COMMIT_HASH
+    mock_repo_remote = mock.Mock()
+    mock_repo_remote.url = MOCK_REPO_URL
+    mock_repo.remotes = [mock_repo_remote]
     with mock.patch("git.Repo", return_value=mock_repo):
         yield mock_repo
 
@@ -38,19 +46,29 @@ def test_git_run_context_in_context_false(patch_script_name):
 
 
 def test_git_run_context_tags(patch_script_name, patch_git_repo):
-    assert GitRunContext().tags() == {MLFLOW_GIT_COMMIT: MOCK_COMMIT_HASH}
+    assert GitRunContext().tags() == {
+        MLFLOW_GIT_COMMIT: MOCK_COMMIT_HASH,
+        MLFLOW_GIT_REPO_URL: MOCK_REPO_URL,
+        LEGACY_MLFLOW_GIT_REPO_URL: MOCK_REPO_URL,
+    }
 
 
 def test_git_run_context_caching(patch_script_name):
-    """Check that the git commit hash is only looked up once."""
+    """Check that the git commit hash and repo URL are only looked up once."""
 
     mock_repo = mock.Mock()
     mock_hexsha = mock.PropertyMock(return_value=MOCK_COMMIT_HASH)
     type(mock_repo.head.commit).hexsha = mock_hexsha
+    mock_repo_remote = mock.Mock()
+    mock_repo_url = mock.PropertyMock(return_value=MOCK_REPO_URL)
+    type(mock_repo_remote).url = mock_repo_url
+    mock_repo.remotes = [mock_repo_remote]
 
     with mock.patch("git.Repo", return_value=mock_repo):
         context = GitRunContext()
         context.in_context()
         context.tags()
+        context.tags()
 
     assert mock_hexsha.call_count == 1
+    assert mock_repo_url.call_count == 1

--- a/tests/tracking/context/test_git_context.py
+++ b/tests/tracking/context/test_git_context.py
@@ -2,19 +2,14 @@ import pytest
 import git
 from unittest import mock
 
+from mlflow.utils.mlflow_tags import MLFLOW_GIT_COMMIT
 from mlflow.tracking.context.git_context import GitRunContext
-from mlflow.utils.mlflow_tags import (
-    MLFLOW_GIT_COMMIT,
-    MLFLOW_GIT_REPO_URL,
-    LEGACY_MLFLOW_GIT_REPO_URL,
-)
 
 # pylint: disable=unused-argument
 
 
 MOCK_SCRIPT_NAME = "/path/to/script.py"
 MOCK_COMMIT_HASH = "commit-hash"
-MOCK_REPO_URL = "https://mockurl.com"
 
 
 @pytest.fixture
@@ -29,9 +24,6 @@ def patch_script_name():
 def patch_git_repo():
     mock_repo = mock.Mock()
     mock_repo.head.commit.hexsha = MOCK_COMMIT_HASH
-    mock_repo_remote = mock.Mock()
-    mock_repo_remote.url = MOCK_REPO_URL
-    mock_repo.remotes = [mock_repo_remote]
     with mock.patch("git.Repo", return_value=mock_repo):
         yield mock_repo
 
@@ -46,29 +38,19 @@ def test_git_run_context_in_context_false(patch_script_name):
 
 
 def test_git_run_context_tags(patch_script_name, patch_git_repo):
-    assert GitRunContext().tags() == {
-        MLFLOW_GIT_COMMIT: MOCK_COMMIT_HASH,
-        MLFLOW_GIT_REPO_URL: MOCK_REPO_URL,
-        LEGACY_MLFLOW_GIT_REPO_URL: MOCK_REPO_URL,
-    }
+    assert GitRunContext().tags() == {MLFLOW_GIT_COMMIT: MOCK_COMMIT_HASH}
 
 
 def test_git_run_context_caching(patch_script_name):
-    """Check that the git commit hash and repo URL are only looked up once."""
+    """Check that the git commit hash is only looked up once."""
 
     mock_repo = mock.Mock()
     mock_hexsha = mock.PropertyMock(return_value=MOCK_COMMIT_HASH)
     type(mock_repo.head.commit).hexsha = mock_hexsha
-    mock_repo_remote = mock.Mock()
-    mock_repo_url = mock.PropertyMock(return_value=MOCK_REPO_URL)
-    type(mock_repo_remote).url = mock_repo_url
-    mock_repo.remotes = [mock_repo_remote]
 
     with mock.patch("git.Repo", return_value=mock_repo):
         context = GitRunContext()
         context.in_context()
         context.tags()
-        context.tags()
 
     assert mock_hexsha.call_count == 1
-    assert mock_repo_url.call_count == 1


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## What changes are proposed in this pull request?

Track git repository URL when creating MLflow Runs from MLflow Pipelines

## How is this patch tested?

Unit tests, manual verification:

<img width="1227" alt="Screen Shot 2022-06-27 at 1 33 40 PM" src="https://user-images.githubusercontent.com/39497902/176030764-a39a3b26-bae1-4589-ae4b-c19069bae7b3.png">


## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

When running an MLflow Pipeline, the URL of the repository is now tracked with the corresponding MLflow Run.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [X] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
