### PR TITLE
Pin `cmdstanpy` in `diviner` tests

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -415,6 +415,6 @@ diviner:
     maximum: "0.1.0"
     requirements:
       # https://github.com/alan-turing-institute/sktime/issues/2898
-      ">= 0.0": ["cmdstanpy<1.0.2"]
+      ">= 0.0": ["cmdstanpy!=1.0.2"]
     run: |
       pytest tests/diviner/test_diviner_model_export.py

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -413,5 +413,8 @@ diviner:
   models:
     minimum: "0.1.0"
     maximum: "0.1.0"
+    requirements:
+      # https://github.com/alan-turing-institute/sktime/issues/2898
+      ">= 0.0": ["cmdstanpy<1.0.2"]
     run: |
       pytest tests/diviner/test_diviner_model_export.py


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

`prophet==1.1` is not compatible with `cmdstanpy==1.0.2`. To avoid this problem, pin `cmdstanpy`. See https://github.com/alan-turing-institute/sktime/issues/2898 for more details.

#### Failure log

https://github.com/mlflow/mlflow/runs/7106976579?check_suite_focus=true#step:12:2442

```
/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/cmdstanpy/stanfit/mle.py:56: in __getattr__
    return self.stan_variable(attr)
        attr       = '__setstate__'
        self       = <[RecursionError('maximum recursion depth exceeded while calling a Python object') raised in repr()] CmdStanMLE object at 0x7ff78a965d90>
/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/cmdstanpy/stanfit/mle.py:193: in stan_variable
    if var not in self._metadata.stan_vars_dims:
        inc_iterations = False
        self       = <[RecursionError('maximum recursion depth exceeded while calling a Python object') raised in repr()] CmdStanMLE object at 0x7ff78a965d90>
        var        = '__setstate__'
        warn       = True
/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/cmdstanpy/stanfit/mle.py:56: in __getattr__
    return self.stan_variable(attr)
        attr       = '_metadata'
        self       = <[RecursionError('maximum recursion depth exceeded while calling a Python object') raised in repr()] CmdStanMLE object at 0x7ff78a965d90>
/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/cmdstanpy/stanfit/mle.py:193: in stan_variable
    if var not in self._metadata.stan_vars_dims:
        inc_iterations = False
        self       = <[RecursionError('maximum recursion depth exceeded while calling a Python object') raised in repr()] CmdStanMLE object at 0x7ff78a965d90>
        var        = '_metadata'
        warn       = True
/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/cmdstanpy/stanfit/mle.py:56: in __getattr__
    return self.stan_variable(attr)
E   RecursionError: maximum recursion depth exceeded
```


## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
