### PR TITLE
Fix bug where LocalArtifactRepository.delete_artifacts() throws if artifacts don't exist

### DIFF
--- a/mlflow/store/artifact/local_artifact_repo.py
+++ b/mlflow/store/artifact/local_artifact_repo.py
@@ -104,7 +104,9 @@ class LocalArtifactRepository(ArtifactRepository):
         shutil.copyfile(remote_file_path, local_path)
 
     def delete_artifacts(self, artifact_path=None):
-        artifact_path = (
+        artifact_path = local_file_uri_to_path(
             os.path.join(self._artifact_dir, artifact_path) if artifact_path else self._artifact_dir
         )
-        shutil.rmtree(local_file_uri_to_path(artifact_path))
+        
+        if os.path.exists(artifact_path):
+            shutil.rmtree(artifact_path)

--- a/mlflow/store/artifact/local_artifact_repo.py
+++ b/mlflow/store/artifact/local_artifact_repo.py
@@ -107,6 +107,6 @@ class LocalArtifactRepository(ArtifactRepository):
         artifact_path = local_file_uri_to_path(
             os.path.join(self._artifact_dir, artifact_path) if artifact_path else self._artifact_dir
         )
-        
+
         if os.path.exists(artifact_path):
             shutil.rmtree(artifact_path)

--- a/tests/store/artifact/test_local_artifact_repo.py
+++ b/tests/store/artifact/test_local_artifact_repo.py
@@ -186,3 +186,7 @@ def test_delete_artifacts(local_artifact_repo):
         assert os.path.exists(os.path.join(local_artifact_repo._artifact_dir, "b.txt"))
         local_artifact_repo.delete_artifacts()
         assert not os.path.exists(os.path.join(local_artifact_repo._artifact_dir))
+
+
+def test_delete_artifacts_with_nonexistent_path_succeeds(local_artifact_repo):
+    local_artifact_repo.delete_artifacts("nonexistent")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -164,6 +164,7 @@ def test_mlflow_gc_sqlite(sqlite_store, create_artifacts_in_run):
     artifact_path = url2pathname(unquote(urlparse(run.info.artifact_uri).path))
     assert not os.path.exists(artifact_path)
 
+
 @pytest.mark.parametrize("create_artifacts_in_run", [True, False])
 def test_mlflow_gc_file_store(file_store, create_artifacts_in_run):
     store = file_store[0]
@@ -177,6 +178,7 @@ def test_mlflow_gc_file_store(file_store, create_artifacts_in_run):
 
     artifact_path = url2pathname(unquote(urlparse(run.info.artifact_uri).path))
     assert not os.path.exists(artifact_path)
+
 
 def test_mlflow_gc_file_store_passing_explicit_run_ids(file_store):
     store = file_store[0]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -135,7 +135,7 @@ def file_store():
     shutil.rmtree(ROOT_LOCATION)
 
 
-def _create_run_in_store(store):
+def _create_run_in_store(store, create_artifacts=True):
     config = {
         "experiment_id": "0",
         "user_id": "Anderson",
@@ -143,15 +143,17 @@ def _create_run_in_store(store):
         "tags": {},
     }
     run = store.create_run(**config)
-    artifact_path = url2pathname(unquote(urlparse(run.info.artifact_uri).path))
-    if not os.path.exists(artifact_path):
-        os.makedirs(artifact_path)
+    if create_artifacts:
+        artifact_path = url2pathname(unquote(urlparse(run.info.artifact_uri).path))
+        if not os.path.exists(artifact_path):
+            os.makedirs(artifact_path)
     return run
 
 
-def test_mlflow_gc_sqlite(sqlite_store):
+@pytest.mark.parametrize("create_artifacts_in_run", [True, False])
+def test_mlflow_gc_sqlite(sqlite_store, create_artifacts_in_run):
     store = sqlite_store[0]
-    run = _create_run_in_store(store)
+    run = _create_run_in_store(store, create_artifacts=create_artifacts_in_run)
     store.delete_run(run.info.run_uuid)
     subprocess.check_output(["mlflow", "gc", "--backend-store-uri", sqlite_store[1]])
     runs = store.search_runs(experiment_ids=["0"], filter_string="", run_view_type=ViewType.ALL)
@@ -159,10 +161,13 @@ def test_mlflow_gc_sqlite(sqlite_store):
     with pytest.raises(MlflowException, match=r"Run .+ not found"):
         store.get_run(run.info.run_uuid)
 
+    artifact_path = url2pathname(unquote(urlparse(run.info.artifact_uri).path))
+    assert not os.path.exists(artifact_path)
 
-def test_mlflow_gc_file_store(file_store):
+@pytest.mark.parametrize("create_artifacts_in_run", [True, False])
+def test_mlflow_gc_file_store(file_store, create_artifacts_in_run):
     store = file_store[0]
-    run = _create_run_in_store(store)
+    run = _create_run_in_store(store, create_artifacts=create_artifacts_in_run)
     store.delete_run(run.info.run_uuid)
     subprocess.check_output(["mlflow", "gc", "--backend-store-uri", file_store[1]])
     runs = store.search_runs(experiment_ids=["0"], filter_string="", run_view_type=ViewType.ALL)
@@ -170,6 +175,8 @@ def test_mlflow_gc_file_store(file_store):
     with pytest.raises(MlflowException, match=r"Run .+ not found"):
         store.get_run(run.info.run_uuid)
 
+    artifact_path = url2pathname(unquote(urlparse(run.info.artifact_uri).path))
+    assert not os.path.exists(artifact_path)
 
 def test_mlflow_gc_file_store_passing_explicit_run_ids(file_store):
     store = file_store[0]


### PR DESCRIPTION
Signed-off-by: dbczumar <corey.zumar@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## What changes are proposed in this pull request?

Fix bug where LocalArtifactRepository.delete_artifacts() throws if artifacts don't exist

## How is this patch tested?

Added integration tests

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [X] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
