### PR TITLE
Fix mlflow.tensorflow.autolog(log_model=False) doesn't log earlystopping callback

### DIFF
--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -1180,10 +1180,10 @@ def autolog(
                 if log_models:
                     _log_keras_model(result, args)
 
-                    _flush_queue()
-                    mlflow.log_artifacts(
-                        local_dir=self.log_dir.location, artifact_path="tensorboard_logs"
-                    )
+                _flush_queue()
+                mlflow.log_artifacts(
+                    local_dir=self.log_dir.location, artifact_path="tensorboard_logs"
+                )
                 if self.log_dir.is_temp:
                     shutil.rmtree(self.log_dir.location)
 

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -1111,17 +1111,17 @@ def autolog(
                 if log_models:
                     _log_keras_model(history, args)
 
-                    _log_early_stop_callback_metrics(
-                        callback=early_stop_callback,
-                        history=history,
-                        metrics_logger=metrics_logger,
-                    )
+                _log_early_stop_callback_metrics(
+                    callback=early_stop_callback,
+                    history=history,
+                    metrics_logger=metrics_logger,
+                )
 
-                    _flush_queue()
-                    mlflow.log_artifacts(
-                        local_dir=self.log_dir.location,
-                        artifact_path="tensorboard_logs",
-                    )
+                _flush_queue()
+                mlflow.log_artifacts(
+                    local_dir=self.log_dir.location,
+                    artifact_path="tensorboard_logs",
+                )
             if self.log_dir.is_temp:
                 shutil.rmtree(self.log_dir.location)
             return history

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -599,6 +599,7 @@ def test_tf_keras_autolog_batch_metrics_logger_logs_expected_metrics(
             restore_weights,
             patience,
             initial_epoch,
+            log_models=False
         )
     patched_metrics_data = dict(patched_metrics_data)
     original_metrics = run.data.metrics

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -473,9 +473,10 @@ def get_tf_keras_random_data_run_with_callback(
     restore_weights,
     patience,
     initial_epoch,
+    log_models,
 ):
     # pylint: disable=unused-argument
-    mlflow.tensorflow.autolog(every_n_iter=1)
+    mlflow.tensorflow.autolog(every_n_iter=1, log_models=log_models)
 
     data = random_train_data
     labels = random_one_hot_labels
@@ -514,6 +515,7 @@ def tf_keras_random_data_run_with_callback(
     restore_weights,
     patience,
     initial_epoch,
+    log_models,
 ):
     return get_tf_keras_random_data_run_with_callback(
         random_train_data,
@@ -522,9 +524,11 @@ def tf_keras_random_data_run_with_callback(
         restore_weights,
         patience,
         initial_epoch,
+        log_models=log_models,
     )
 
 
+@pytest.mark.parametrize("log_models", [True, False])
 @pytest.mark.parametrize("restore_weights", [True])
 @pytest.mark.parametrize("callback", ["early"])
 @pytest.mark.parametrize("patience", [0, 1, 5])
@@ -556,6 +560,9 @@ def test_tf_keras_autolog_early_stop_logs(tf_keras_random_data_run_with_callback
     assert steps == [*history.epoch, callback.stopped_epoch + 1]
     # Check that MLflow has logged the correct metric values
     np.testing.assert_allclose(values, [*loss, callback.best])
+
+    artifacts = [f.path for f in client.list_artifacts(run.info.run_id)]
+    assert "tensorboard_logs" in artifacts
 
 
 @pytest.mark.parametrize("restore_weights", [True])
@@ -603,6 +610,7 @@ def test_tf_keras_autolog_batch_metrics_logger_logs_expected_metrics(
     assert restored_epoch == initial_epoch
 
 
+@pytest.mark.parametrize("log_models", [False])
 @pytest.mark.parametrize("restore_weights", [True])
 @pytest.mark.parametrize("callback", ["early"])
 @pytest.mark.parametrize("patience", [11])
@@ -628,6 +636,7 @@ def test_tf_keras_autolog_early_stop_no_stop_does_not_log(tf_keras_random_data_r
     assert len(metric_history) == num_of_epochs
 
 
+@pytest.mark.parametrize("log_models", [False])
 @pytest.mark.parametrize("restore_weights", [False])
 @pytest.mark.parametrize("callback", ["early"])
 @pytest.mark.parametrize("patience", [5])
@@ -653,6 +662,7 @@ def test_tf_keras_autolog_early_stop_no_restore_doesnt_log(tf_keras_random_data_
     assert len(metric_history) == num_of_epochs
 
 
+@pytest.mark.parametrize("log_models", [False])
 @pytest.mark.parametrize("restore_weights", [False])
 @pytest.mark.parametrize("callback", ["not-early"])
 @pytest.mark.parametrize("patience", [5])
@@ -1266,8 +1276,9 @@ def test_autolog_text_vec_model(tmpdir):
     np.testing.assert_array_equal(loaded_model.predict(train_samples), model.predict(train_samples))
 
 
-def test_fit_generator(random_train_data, random_one_hot_labels):
-    mlflow.tensorflow.autolog()
+@pytest.mark.parametrize("log_models", [True, False])
+def test_fit_generator(random_train_data, random_one_hot_labels, log_models):
+    mlflow.tensorflow.autolog(log_models=log_models)
     model = create_tf_keras_model()
 
     def generator():
@@ -1277,15 +1288,18 @@ def test_fit_generator(random_train_data, random_one_hot_labels):
     with mlflow.start_run() as run:
         model.fit_generator(generator(), epochs=10, steps_per_epoch=1)
 
-    run = MlflowClient().get_run(run.info.run_id)
+    client = MlflowClient()
+    run = client.get_run(run.info.run_id)
     params = run.data.params
     metrics = run.data.metrics
+    artifacts = [f.path for f in client.list_artifacts(run.info.run_id)]
     assert "epochs" in params
     assert params["epochs"] == "10"
     assert "steps_per_epoch" in params
     assert params["steps_per_epoch"] == "1"
     assert "accuracy" in metrics
     assert "loss" in metrics
+    assert "tensorboard_logs" in artifacts
 
 
 def test_tf_keras_model_autolog_registering_model(random_train_data, random_one_hot_labels):


### PR DESCRIPTION
Signed-off-by: Weichen Xu <weichen.xu@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
https://github.com/mlflow/mlflow/issues/6155

## What changes are proposed in this pull request?

Fix https://github.com/mlflow/mlflow/issues/6155
Close https://github.com/mlflow/mlflow/issues/6155

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
