### PR TITLE
Implement `RestStore.search_experiments`

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -980,9 +980,6 @@ def _search_experiments():
             "page_token": [_assert_string],
         },
     )
-    # `ListFields` returns a list of (FieldDescriptor, value) tuples for *present* fields:
-    # https://googleapis.dev/python/protobuf/latest/google/protobuf/message.html
-    # #google.protobuf.message.Message.ListFields
     experiment_entities = _get_tracking_store().search_experiments(
         view_type=request_message.view_type,
         max_results=request_message.max_results,

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -34,6 +34,7 @@ from mlflow.protos.service_pb2 import (
     LogParam,
     SetTag,
     ListExperiments,
+    SearchExperiments,
     DeleteExperiment,
     RestoreExperiment,
     RestoreRun,
@@ -967,6 +968,38 @@ def _list_experiments():
 
 
 @catch_mlflow_exception
+@_disable_if_artifacts_only
+def _search_experiments():
+    request_message = _get_request_message(
+        SearchExperiments(),
+        schema={
+            "view_type": [_assert_intlike],
+            "max_results": [_assert_intlike],
+            "order_by": [_assert_array],
+            "filter": [_assert_string],
+            "page_token": [_assert_string],
+        },
+    )
+    # `ListFields` returns a list of (FieldDescriptor, value) tuples for *present* fields:
+    # https://googleapis.dev/python/protobuf/latest/google/protobuf/message.html
+    # #google.protobuf.message.Message.ListFields
+    experiment_entities = _get_tracking_store().search_experiments(
+        view_type=request_message.view_type,
+        max_results=request_message.max_results,
+        order_by=request_message.order_by,
+        filter_string=request_message.filter,
+        page_token=request_message.page_token,
+    )
+    response_message = SearchExperiments.Response()
+    response_message.experiments.extend([e.to_proto() for e in experiment_entities])
+    if experiment_entities.token:
+        response_message.next_page_token = experiment_entities.token
+    response = Response(mimetype="application/json")
+    response.set_data(message_to_json(response_message))
+    return response
+
+
+@catch_mlflow_exception
 def _get_artifact_repo(run):
     return get_artifact_repository(run.info.artifact_uri)
 
@@ -1562,6 +1595,7 @@ HANDLERS = {
     ListArtifacts: _list_artifacts,
     GetMetricHistory: _get_metric_history,
     ListExperiments: _list_experiments,
+    SearchExperiments: _search_experiments,
     # Model Registry APIs
     CreateRegisteredModel: _create_registered_model,
     GetRegisteredModel: _get_registered_model,

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -373,7 +373,3 @@ class DatabricksRestStore(RestStore):
             if not experiments.token:
                 break
             page_token = experiments.token
-
-    # Implement search_experiments to suppress pylint abstract-method error
-    def search_experiments(self, *args, **kwargs):
-        super().search_experiments(*args, **kwargs)

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -74,6 +74,10 @@ class MlflowClient:
         # is assigned lazily by `MlflowClient._get_registry_client()` and should not be referenced
         # outside of the `MlflowClient._get_registry_client()` method
 
+    @property
+    def tracking_uri(self):
+        return self._tracking_client.tracking_uri
+
     def _get_registry_client(self):
         """
         Attempts to create a py:class:`ModelRegistryClient` if one does not already exist.

--- a/tests/store/tracking/test_rest_store.py
+++ b/tests/store/tracking/test_rest_store.py
@@ -62,10 +62,6 @@ class CustomErrorHandlingRestStore(RestStore):
     def _call_endpoint(self, api, json_body):
         raise MyCoolException("cool")
 
-    # Implement search_experiments to suppress pylint abstract-method error
-    def search_experiments(self, *args, **kwargs):
-        return super().search_experiments(*args, **kwargs)
-
 
 def mock_http_request():
     return mock.patch(

--- a/tests/store/tracking/test_rest_store.py
+++ b/tests/store/tracking/test_rest_store.py
@@ -479,33 +479,27 @@ class TestRestStore:
         store = RestStore(lambda: creds)
 
         with mock_http_request() as mock_http:
-            store.search_experiments()
-            self._verify_requests(
-                mock_http,
-                creds,
-                "experiments/search",
-                "POST",
-                message_to_json(SearchExperiments(view_type=ViewType.ACTIVE_ONLY)),
+            store.search_experiments(
+                view_type=ViewType.DELETED_ONLY,
+                max_results=5,
+                filter_string="name",
+                order_by=["name"],
+                page_token="abc",
             )
-
-        with mock_http_request() as mock_http:
-            store.search_experiments(view_type=ViewType.DELETED_ONLY)
             self._verify_requests(
                 mock_http,
                 creds,
                 "experiments/search",
-                "POST",
-                message_to_json(SearchExperiments(view_type=ViewType.DELETED_ONLY)),
-            )
-
-        with mock_http_request() as mock_http:
-            store.search_experiments(order_by=["name DESC"])
-            self._verify_requests(
-                mock_http,
-                creds,
-                "experiments/search",
-                "POST",
-                message_to_json(SearchExperiments(view_type=ViewType.DELETED_ONLY)),
+                "GET",
+                message_to_json(
+                    SearchExperiments(
+                        view_type=ViewType.DELETED_ONLY,
+                        max_results=5,
+                        filter="name",
+                        order_by=["name"],
+                        page_token="abc",
+                    )
+                ),
             )
 
 

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -373,59 +373,53 @@ def test_search_experiments(tmp_path):
         else:
             tags = None
         mlflow.create_experiment(active_experiment_name, tags=tags)
+
     deleted_experiment_names = [f"deleted_{i}" for i in range(num_deleted_experiments)]
     for deleted_experiment_name in deleted_experiment_names:
         exp_id = mlflow.create_experiment(deleted_experiment_name)
         mlflow.delete_experiment(exp_id)
 
-    url, process = _init_server(sqlite_uri, root_artifact_uri=tmp_path.as_uri())
-    mlflow.set_tracking_uri(url)
-    try:
-        # max_results is unspecified
-        experiments = mlflow.search_experiments(view_type=ViewType.ALL)
-        assert len(experiments) == num_all_experiments
-        # max_results is larger than the number of experiments
-        experiments = mlflow.search_experiments(
-            view_type=ViewType.ALL, max_results=num_all_experiments + 1
-        )
-        assert len(experiments) == num_all_experiments
-        # max_results is equal to the number of experiments
-        experiments = mlflow.search_experiments(
-            view_type=ViewType.ALL, max_results=num_all_experiments
-        )
-        assert len(experiments) == num_all_experiments
-        # max_results is smaller than the number of experiments
-        experiments = mlflow.search_experiments(
-            view_type=ViewType.ALL, max_results=num_all_experiments - 1
-        )
-        assert len(experiments) == num_all_experiments - 1
+    # max_results is unspecified
+    experiments = mlflow.search_experiments(view_type=ViewType.ALL)
+    assert len(experiments) == num_all_experiments
+    # max_results is larger than the number of experiments in the database
+    experiments = mlflow.search_experiments(
+        view_type=ViewType.ALL, max_results=num_all_experiments + 1
+    )
+    assert len(experiments) == num_all_experiments
+    # max_results is equal to the number of experiments in the database
+    experiments = mlflow.search_experiments(view_type=ViewType.ALL, max_results=num_all_experiments)
+    assert len(experiments) == num_all_experiments
+    # max_results is smaller than the number of experiments in the database
+    experiments = mlflow.search_experiments(
+        view_type=ViewType.ALL, max_results=num_all_experiments - 1
+    )
+    assert len(experiments) == num_all_experiments - 1
 
-        # Filter by view_type
-        experiments = mlflow.search_experiments(view_type=ViewType.ACTIVE_ONLY)
-        assert [e.name for e in experiments] == active_experiment_names[::-1] + ["Default"]
-        experiments = mlflow.search_experiments(view_type=ViewType.DELETED_ONLY)
-        assert [e.name for e in experiments] == deleted_experiment_names[::-1]
-        experiments = mlflow.search_experiments(view_type=ViewType.ALL)
-        assert [e.name for e in experiments] == (
-            deleted_experiment_names[::-1] + active_experiment_names[::-1] + ["Default"]
-        )
-        # Filter by name
-        experiments = mlflow.search_experiments(filter_string="name = 'active_1'")
-        assert [e.name for e in experiments] == ["active_1"]
-        experiments = mlflow.search_experiments(filter_string="name ILIKE 'active_%'")
-        assert [e.name for e in experiments] == active_experiment_names[::-1]
+    # Filter by view_type
+    experiments = mlflow.search_experiments(view_type=ViewType.ACTIVE_ONLY)
+    assert [e.name for e in experiments] == active_experiment_names[::-1] + ["Default"]
+    experiments = mlflow.search_experiments(view_type=ViewType.DELETED_ONLY)
+    assert [e.name for e in experiments] == deleted_experiment_names[::-1]
+    experiments = mlflow.search_experiments(view_type=ViewType.ALL)
+    assert [e.name for e in experiments] == (
+        deleted_experiment_names[::-1] + active_experiment_names[::-1] + ["Default"]
+    )
+    # Filter by name
+    experiments = mlflow.search_experiments(filter_string="name = 'active_1'")
+    assert [e.name for e in experiments] == ["active_1"]
+    experiments = mlflow.search_experiments(filter_string="name ILIKE 'active_%'")
+    assert [e.name for e in experiments] == active_experiment_names[::-1]
 
-        # Filter by tags
-        experiments = mlflow.search_experiments(filter_string="tags.tag = 'x'")
-        assert [e.name for e in experiments] == active_experiment_names[:2][::-1]
-        experiments = mlflow.search_experiments(filter_string="tags.tag = 'y'")
-        assert [e.experiment_id for e in experiments] == ["3"]
+    # Filter by tags
+    experiments = mlflow.search_experiments(filter_string="tags.tag = 'x'")
+    assert [e.name for e in experiments] == active_experiment_names[:2][::-1]
+    experiments = mlflow.search_experiments(filter_string="tags.tag = 'y'")
+    assert [e.experiment_id for e in experiments] == ["3"]
 
-        # Order by name
-        experiments = mlflow.search_experiments(order_by=["name DESC"], max_results=3)
-        assert [e.name for e in experiments] == sorted(active_experiment_names, reverse=True)[:3]
-    finally:
-        process.terminate()
+    # Order by name
+    experiments = mlflow.search_experiments(order_by=["name DESC"], max_results=3)
+    assert [e.name for e in experiments] == sorted(active_experiment_names, reverse=True)[:3]
 
 
 @pytest.fixture

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -373,53 +373,59 @@ def test_search_experiments(tmp_path):
         else:
             tags = None
         mlflow.create_experiment(active_experiment_name, tags=tags)
-
     deleted_experiment_names = [f"deleted_{i}" for i in range(num_deleted_experiments)]
     for deleted_experiment_name in deleted_experiment_names:
         exp_id = mlflow.create_experiment(deleted_experiment_name)
         mlflow.delete_experiment(exp_id)
 
-    # max_results is unspecified
-    experiments = mlflow.search_experiments(view_type=ViewType.ALL)
-    assert len(experiments) == num_all_experiments
-    # max_results is larger than the number of experiments in the database
-    experiments = mlflow.search_experiments(
-        view_type=ViewType.ALL, max_results=num_all_experiments + 1
-    )
-    assert len(experiments) == num_all_experiments
-    # max_results is equal to the number of experiments in the database
-    experiments = mlflow.search_experiments(view_type=ViewType.ALL, max_results=num_all_experiments)
-    assert len(experiments) == num_all_experiments
-    # max_results is smaller than the number of experiments in the database
-    experiments = mlflow.search_experiments(
-        view_type=ViewType.ALL, max_results=num_all_experiments - 1
-    )
-    assert len(experiments) == num_all_experiments - 1
+    url, process = _init_server(sqlite_uri, root_artifact_uri=tmp_path.as_uri())
+    mlflow.set_tracking_uri(url)
+    try:
+        # max_results is unspecified
+        experiments = mlflow.search_experiments(view_type=ViewType.ALL)
+        assert len(experiments) == num_all_experiments
+        # max_results is larger than the number of experiments
+        experiments = mlflow.search_experiments(
+            view_type=ViewType.ALL, max_results=num_all_experiments + 1
+        )
+        assert len(experiments) == num_all_experiments
+        # max_results is equal to the number of experiments
+        experiments = mlflow.search_experiments(
+            view_type=ViewType.ALL, max_results=num_all_experiments
+        )
+        assert len(experiments) == num_all_experiments
+        # max_results is smaller than the number of experiments
+        experiments = mlflow.search_experiments(
+            view_type=ViewType.ALL, max_results=num_all_experiments - 1
+        )
+        assert len(experiments) == num_all_experiments - 1
 
-    # Filter by view_type
-    experiments = mlflow.search_experiments(view_type=ViewType.ACTIVE_ONLY)
-    assert [e.name for e in experiments] == active_experiment_names[::-1] + ["Default"]
-    experiments = mlflow.search_experiments(view_type=ViewType.DELETED_ONLY)
-    assert [e.name for e in experiments] == deleted_experiment_names[::-1]
-    experiments = mlflow.search_experiments(view_type=ViewType.ALL)
-    assert [e.name for e in experiments] == (
-        deleted_experiment_names[::-1] + active_experiment_names[::-1] + ["Default"]
-    )
-    # Filter by name
-    experiments = mlflow.search_experiments(filter_string="name = 'active_1'")
-    assert [e.name for e in experiments] == ["active_1"]
-    experiments = mlflow.search_experiments(filter_string="name ILIKE 'active_%'")
-    assert [e.name for e in experiments] == active_experiment_names[::-1]
+        # Filter by view_type
+        experiments = mlflow.search_experiments(view_type=ViewType.ACTIVE_ONLY)
+        assert [e.name for e in experiments] == active_experiment_names[::-1] + ["Default"]
+        experiments = mlflow.search_experiments(view_type=ViewType.DELETED_ONLY)
+        assert [e.name for e in experiments] == deleted_experiment_names[::-1]
+        experiments = mlflow.search_experiments(view_type=ViewType.ALL)
+        assert [e.name for e in experiments] == (
+            deleted_experiment_names[::-1] + active_experiment_names[::-1] + ["Default"]
+        )
+        # Filter by name
+        experiments = mlflow.search_experiments(filter_string="name = 'active_1'")
+        assert [e.name for e in experiments] == ["active_1"]
+        experiments = mlflow.search_experiments(filter_string="name ILIKE 'active_%'")
+        assert [e.name for e in experiments] == active_experiment_names[::-1]
 
-    # Filter by tags
-    experiments = mlflow.search_experiments(filter_string="tags.tag = 'x'")
-    assert [e.name for e in experiments] == active_experiment_names[:2][::-1]
-    experiments = mlflow.search_experiments(filter_string="tags.tag = 'y'")
-    assert [e.experiment_id for e in experiments] == ["3"]
+        # Filter by tags
+        experiments = mlflow.search_experiments(filter_string="tags.tag = 'x'")
+        assert [e.name for e in experiments] == active_experiment_names[:2][::-1]
+        experiments = mlflow.search_experiments(filter_string="tags.tag = 'y'")
+        assert [e.experiment_id for e in experiments] == ["3"]
 
-    # Order by name
-    experiments = mlflow.search_experiments(order_by=["name DESC"], max_results=3)
-    assert [e.name for e in experiments] == sorted(active_experiment_names, reverse=True)[:3]
+        # Order by name
+        experiments = mlflow.search_experiments(order_by=["name DESC"], max_results=3)
+        assert [e.name for e in experiments] == sorted(active_experiment_names, reverse=True)[:3]
+    finally:
+        process.terminate()
 
 
 @pytest.fixture

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -57,9 +57,7 @@ def mlflow_client(request, tmp_path):
         path = path_to_local_file_uri(str(tmp_path.joinpath("sqlalchemy.db")))
         uri = ("sqlite://" if sys.platform == "win32" else "sqlite:////") + path[len("file://") :]
 
-    root_artifact_dir = tmp_path.joinpath("artifacts")
-    root_artifact_dir.mkdir()
-    url, process = _init_server(backend_uri=uri, root_artifact_uri=str(root_artifact_dir))
+    url, process = _init_server(backend_uri=uri, root_artifact_uri=str(tmp_path))
 
     yield MlflowClient(url)
 

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -8,11 +8,10 @@ import sys
 import posixpath
 import pytest
 import logging
-import shutil
 import time
 import tempfile
-from unittest import mock
 import urllib.parse
+from unittest import mock
 
 import mlflow.experiments
 from mlflow.exceptions import MlflowException
@@ -40,87 +39,48 @@ from tests.tracking.integration_test_utils import (
     _send_rest_tracking_post_request,
 )
 
-# pylint: disable=unused-argument
-
-# Root directory for all stores (backend or artifact stores) created during this suite
-SUITE_ROOT_DIR = tempfile.mkdtemp("test_rest_tracking")
-# Root directory for all artifact stores created during this suite
-SUITE_ARTIFACT_ROOT_DIR = tempfile.mkdtemp(suffix="artifacts", dir=SUITE_ROOT_DIR)
 
 _logger = logging.getLogger(__name__)
 
 
-def _get_sqlite_uri():
-    path = path_to_local_file_uri(os.path.join(SUITE_ROOT_DIR, "test-database.bd"))
-    path = path[len("file://") :]
-
-    # NB: It looks like windows and posix have different requirements on number of slashes for
-    # whatever reason. Windows needs uri like 'sqlite:///C:/path/to/my/file' whereas posix expects
-    # sqlite://///path/to/my/file
-    prefix = "sqlite://" if sys.platform == "win32" else "sqlite:////"
-    return prefix + path
-
-
-# Backend store URIs to test against
-BACKEND_URIS = [
-    _get_sqlite_uri(),  # SqlAlchemy
-    path_to_local_file_uri(os.path.join(SUITE_ROOT_DIR, "file_store_root")),  # FileStore
-]
-
-# Map of backend URI to tuple (server URL, Process). We populate this map by constructing
-# a server per backend URI
-BACKEND_URI_TO_SERVER_URL_AND_PROC = {
-    uri: _init_server(backend_uri=uri, root_artifact_uri=SUITE_ARTIFACT_ROOT_DIR)
-    for uri in BACKEND_URIS
-}
-
-
-def pytest_generate_tests(metafunc):
-    """
-    Automatically parametrize each each fixture/test that depends on `backend_store_uri` with the
-    list of backend store URIs.
-    """
-    if "backend_store_uri" in metafunc.fixturenames:
-        metafunc.parametrize("backend_store_uri", BACKEND_URIS)
-
-
-@pytest.fixture(scope="module", autouse=True)
-def server_urls():
-    """
-    Clean up all servers created for testing in `pytest_generate_tests`
-    """
-    yield
-    for server_url, process in BACKEND_URI_TO_SERVER_URL_AND_PROC.values():
-        _logger.info(f"Terminating server at {server_url}...")
-        _logger.info(f"type = {type(process)}")
-        process.terminate()
-        _await_server_down_or_die(process)
-    shutil.rmtree(SUITE_ROOT_DIR)
-
-
-@pytest.fixture()
-def tracking_server_uri(backend_store_uri):
-    url, _ = BACKEND_URI_TO_SERVER_URL_AND_PROC[backend_store_uri]
-    return url
-
-
-@pytest.fixture()
-def mlflow_client(tracking_server_uri):
+@pytest.fixture(params=["file", "sqlalchemy"])
+def mlflow_client(request, tmp_path):
     """Provides an MLflow Tracking API client pointed at the local tracking server."""
-    mlflow.set_tracking_uri(tracking_server_uri)
-    yield mock.Mock(wraps=MlflowClient(tracking_server_uri))
-    mlflow.set_tracking_uri(None)
+
+    # TODO: Remove this in https://github.com/mlflow/mlflow/pull/6227
+    if request.param == "file" and request.node.name.startswith("test_search_experiments"):
+        pytest.skip("FileStore does not yet support search_experiments")
+
+    if request.param == "file":
+        uri = path_to_local_file_uri(str(tmp_path.joinpath("file")))
+    elif request.param == "sqlalchemy":
+        path = path_to_local_file_uri(str(tmp_path.joinpath("sqlalchemy.db")))
+        uri = ("sqlite://" if sys.platform == "win32" else "sqlite:////") + path[len("file://") :]
+
+    root_artifact_dir = tmp_path.joinpath("artifacts")
+    root_artifact_dir.mkdir()
+    url, process = _init_server(backend_uri=uri, root_artifact_uri=str(root_artifact_dir))
+
+    yield MlflowClient(url)
+
+    _logger.info(f"Terminating server at {url}...")
+    process.terminate()
+    _await_server_down_or_die(process)
 
 
 @pytest.fixture()
-def cli_env(tracking_server_uri):
+def cli_env(mlflow_client):
     """Provides an environment for the MLflow CLI pointed at the local tracking server."""
     cli_env = {
         "LC_ALL": "en_US.UTF-8",
         "LANG": "en_US.UTF-8",
-        "MLFLOW_TRACKING_URI": tracking_server_uri,
+        "MLFLOW_TRACKING_URI": mlflow_client.tracking_uri,
     }
     return cli_env
+
+
+def create_experiments(client, names):
+    return [client.create_experiment(n) for n in names]
 
 
 def test_create_get_list_experiment(mlflow_client):
@@ -163,10 +123,10 @@ def test_create_get_list_experiment(mlflow_client):
     assert first_page_names.union(second_page_names) == {"Default", "My Experiment"}
 
 
-def test_create_experiment_validation(tracking_server_uri):
+def test_create_experiment_validation(mlflow_client):
     def assert_bad_request(payload, expected_error_message):
         response = _send_rest_tracking_post_request(
-            tracking_server_uri,
+            mlflow_client.tracking_uri,
             "/api/2.0/mlflow/experiments/create",
             payload,
         )
@@ -299,7 +259,7 @@ def test_create_run_defaults(mlflow_client):
     assert run.info.user_id == "unknown"
 
 
-def test_log_metrics_params_tags(mlflow_client, backend_store_uri):
+def test_log_metrics_params_tags(mlflow_client):
     experiment_id = mlflow_client.create_experiment("Oh My")
     created_run = mlflow_client.create_run(experiment_id)
     run_id = created_run.info.run_id
@@ -336,14 +296,14 @@ def test_log_metrics_params_tags(mlflow_client, backend_store_uri):
     assert metric1.step == 0
 
 
-def test_log_metric_validation(mlflow_client, tracking_server_uri):
+def test_log_metric_validation(mlflow_client):
     experiment_id = mlflow_client.create_experiment("metrics validation")
     created_run = mlflow_client.create_run(experiment_id)
     run_id = created_run.info.run_id
 
     def assert_bad_request(payload, expected_error_message):
         response = _send_rest_tracking_post_request(
-            tracking_server_uri,
+            mlflow_client.tracking_uri,
             "/api/2.0/mlflow/runs/log-metric",
             payload,
         )
@@ -422,14 +382,14 @@ def test_log_metric_validation(mlflow_client, tracking_server_uri):
     )
 
 
-def test_log_param_validation(mlflow_client, tracking_server_uri):
+def test_log_param_validation(mlflow_client):
     experiment_id = mlflow_client.create_experiment("params validation")
     created_run = mlflow_client.create_run(experiment_id)
     run_id = created_run.info.run_id
 
     def assert_bad_request(payload, expected_error_message):
         response = _send_rest_tracking_post_request(
-            tracking_server_uri,
+            mlflow_client.tracking_uri,
             "/api/2.0/mlflow/runs/log-parameter",
             payload,
         )
@@ -454,7 +414,7 @@ def test_log_param_validation(mlflow_client, tracking_server_uri):
     )
 
 
-def test_log_param_with_empty_string_as_value(mlflow_client, tracking_server_uri):
+def test_log_param_with_empty_string_as_value(mlflow_client):
     experiment_id = mlflow_client.create_experiment(
         test_log_param_with_empty_string_as_value.__name__
     )
@@ -465,7 +425,7 @@ def test_log_param_with_empty_string_as_value(mlflow_client, tracking_server_uri
     assert {"param_key": ""}.items() <= mlflow_client.get_run(run_id).data.params.items()
 
 
-def test_set_tag_with_empty_string_as_value(mlflow_client, tracking_server_uri):
+def test_set_tag_with_empty_string_as_value(mlflow_client):
     experiment_id = mlflow_client.create_experiment(
         test_set_tag_with_empty_string_as_value.__name__
     )
@@ -476,9 +436,7 @@ def test_set_tag_with_empty_string_as_value(mlflow_client, tracking_server_uri):
     assert {"tag_key": ""}.items() <= mlflow_client.get_run(run_id).data.tags.items()
 
 
-def test_log_batch_containing_params_and_tags_with_empty_string_values(
-    mlflow_client, tracking_server_uri
-):
+def test_log_batch_containing_params_and_tags_with_empty_string_values(mlflow_client):
     experiment_id = mlflow_client.create_experiment(
         test_log_batch_containing_params_and_tags_with_empty_string_values.__name__
     )
@@ -494,14 +452,14 @@ def test_log_batch_containing_params_and_tags_with_empty_string_values(
     assert {"tag_key": ""}.items() <= mlflow_client.get_run(run_id).data.tags.items()
 
 
-def test_set_tag_validation(mlflow_client, tracking_server_uri):
+def test_set_tag_validation(mlflow_client):
     experiment_id = mlflow_client.create_experiment("tags validation")
     created_run = mlflow_client.create_run(experiment_id)
     run_id = created_run.info.run_id
 
     def assert_bad_request(payload, expected_error_message):
         response = _send_rest_tracking_post_request(
-            tracking_server_uri,
+            mlflow_client.tracking_uri,
             "/api/2.0/mlflow/runs/set-tag",
             payload,
         )
@@ -534,7 +492,7 @@ def test_set_tag_validation(mlflow_client, tracking_server_uri):
     )
 
     response = _send_rest_tracking_post_request(
-        tracking_server_uri,
+        mlflow_client.tracking_uri,
         "/api/2.0/mlflow/runs/set-tag",
         {
             "run_uuid": run_id,
@@ -545,7 +503,7 @@ def test_set_tag_validation(mlflow_client, tracking_server_uri):
     assert response.status_code == 200
 
 
-def test_set_experiment_tag(mlflow_client, backend_store_uri):
+def test_set_experiment_tag(mlflow_client):
     experiment_id = mlflow_client.create_experiment("SetExperimentTagTest")
     mlflow_client.set_experiment_tag(experiment_id, "dataset", "imagenet1K")
     experiment = mlflow_client.get_experiment(experiment_id)
@@ -573,7 +531,7 @@ def test_set_experiment_tag(mlflow_client, backend_store_uri):
     )
 
 
-def test_set_experiment_tag_with_empty_string_as_value(mlflow_client, tracking_server_uri):
+def test_set_experiment_tag_with_empty_string_as_value(mlflow_client):
     experiment_id = mlflow_client.create_experiment(
         test_set_experiment_tag_with_empty_string_as_value.__name__
     )
@@ -581,7 +539,7 @@ def test_set_experiment_tag_with_empty_string_as_value(mlflow_client, tracking_s
     assert {"tag_key": ""}.items() <= mlflow_client.get_experiment(experiment_id).tags.items()
 
 
-def test_delete_tag(mlflow_client, backend_store_uri):
+def test_delete_tag(mlflow_client):
     experiment_id = mlflow_client.create_experiment("DeleteTagExperiment")
     created_run = mlflow_client.create_run(experiment_id)
     run_id = created_run.info.run_id
@@ -603,7 +561,7 @@ def test_delete_tag(mlflow_client, backend_store_uri):
         mlflow_client.delete_tag(run_id, "taggity")
 
 
-def test_log_batch(mlflow_client, backend_store_uri):
+def test_log_batch(mlflow_client):
     experiment_id = mlflow_client.create_experiment("Batch em up")
     created_run = mlflow_client.create_run(experiment_id)
     run_id = created_run.info.run_id
@@ -626,14 +584,14 @@ def test_log_batch(mlflow_client, backend_store_uri):
     assert metric.step == 3
 
 
-def test_log_batch_validation(mlflow_client, tracking_server_uri):
+def test_log_batch_validation(mlflow_client):
     experiment_id = mlflow_client.create_experiment("log_batch validation")
     created_run = mlflow_client.create_run(experiment_id)
     run_id = created_run.info.run_id
 
     def assert_bad_request(payload, expected_error_message):
         response = _send_rest_tracking_post_request(
-            tracking_server_uri,
+            mlflow_client.tracking_uri,
             "/api/2.0/mlflow/runs/log-batch",
             payload,
         )
@@ -651,7 +609,7 @@ def test_log_batch_validation(mlflow_client, tracking_server_uri):
 
 
 @pytest.mark.allow_infer_pip_requirements_fallback
-def test_log_model(mlflow_client, backend_store_uri):
+def test_log_model(mlflow_client):
     experiment_id = mlflow_client.create_experiment("Log models")
     with TempDir(chdr=True):
         mlflow.set_experiment("Log models")
@@ -703,12 +661,10 @@ def test_set_terminated_status(mlflow_client):
     assert mlflow_client.get_run(run_id).info.end_time <= int(time.time() * 1000)
 
 
-def test_artifacts(mlflow_client):
+def test_artifacts(mlflow_client, tmp_path):
     experiment_id = mlflow_client.create_experiment("Art In Fact")
     experiment_info = mlflow_client.get_experiment(experiment_id)
-    assert experiment_info.artifact_location.startswith(
-        path_to_local_file_uri(SUITE_ARTIFACT_ROOT_DIR)
-    )
+    assert experiment_info.artifact_location.startswith(path_to_local_file_uri(str(tmp_path)))
     artifact_path = urllib.parse.urlparse(experiment_info.artifact_location).path
     assert posixpath.split(artifact_path)[-1] == experiment_id
 
@@ -759,19 +715,145 @@ def test_search_validation(mlflow_client):
         mlflow_client.search_runs([experiment_id], max_results=123456789)
 
 
-def test_get_experiment_by_name(mlflow_client, backend_store_uri):
+def test_get_experiment_by_name(mlflow_client):
     name = "test_get_experiment_by_name"
-    experiment_id = mlflow_client.create_experiment(name)
-    res = mlflow_client.get_experiment_by_name(name)
-    assert res.experiment_id == experiment_id
-    assert res.name == name
-    assert mlflow_client.get_experiment_by_name("idontexist") is None
-    mlflow_client.list_experiments.assert_not_called()
+    with mock.patch.object(
+        MlflowClient,
+        "list_experiments",
+        side_effect=Exception("should not be called"),
+    ):
+        experiment_id = mlflow_client.create_experiment(name)
+        res = mlflow_client.get_experiment_by_name(name)
+        assert res.experiment_id == experiment_id
+        assert res.name == name
+        assert mlflow_client.get_experiment_by_name("idontexist") is None
 
 
-def test_get_experiment(mlflow_client, backend_store_uri):
+def test_get_experiment(mlflow_client):
     name = "test_get_experiment"
     experiment_id = mlflow_client.create_experiment(name)
     res = mlflow_client.get_experiment(experiment_id)
     assert res.experiment_id == experiment_id
     assert res.name == name
+
+
+def test_search_experiments_view_type(mlflow_client):
+    experiment_names = ["a", "b"]
+    experiment_ids = create_experiments(mlflow_client, experiment_names)
+    mlflow_client.delete_experiment(experiment_ids[1])
+
+    experiments = mlflow_client.search_experiments(view_type=ViewType.ACTIVE_ONLY)
+    assert [e.name for e in experiments] == ["a", "Default"]
+    experiments = mlflow_client.search_experiments(view_type=ViewType.DELETED_ONLY)
+    assert [e.name for e in experiments] == ["b"]
+    experiments = mlflow_client.search_experiments(view_type=ViewType.ALL)
+    assert [e.name for e in experiments] == ["b", "a", "Default"]
+
+
+def test_search_experiments_filter_by_attribute(mlflow_client):
+    experiment_names = ["a", "ab", "Abc"]
+    create_experiments(mlflow_client, experiment_names)
+
+    experiments = mlflow_client.search_experiments(filter_string="name = 'a'")
+    assert [e.name for e in experiments] == ["a"]
+    experiments = mlflow_client.search_experiments(filter_string="attribute.name = 'a'")
+    assert [e.name for e in experiments] == ["a"]
+    experiments = mlflow_client.search_experiments(filter_string="attribute.`name` = 'a'")
+    assert [e.name for e in experiments] == ["a"]
+    experiments = mlflow_client.search_experiments(filter_string="attribute.`name` != 'a'")
+    assert [e.name for e in experiments] == ["Abc", "ab", "Default"]
+    experiments = mlflow_client.search_experiments(filter_string="name LIKE 'a%'")
+    assert [e.name for e in experiments] == ["ab", "a"]
+    experiments = mlflow_client.search_experiments(filter_string="name ILIKE 'a%'")
+    assert [e.name for e in experiments] == ["Abc", "ab", "a"]
+    experiments = mlflow_client.search_experiments(
+        filter_string="name ILIKE 'a%' AND name ILIKE '%b'"
+    )
+    assert [e.name for e in experiments] == ["ab"]
+
+
+def test_search_experiments_filter_by_tag(mlflow_client):
+    experiments = [
+        ("exp1", {"key": "value"}),
+        ("exp2", {"key": "vaLue"}),
+        ("exp3", {"k e y": "value"}),
+    ]
+    for name, tags in experiments:
+        mlflow_client.create_experiment(name, tags=tags)
+
+    experiments = mlflow_client.search_experiments(filter_string="tag.key = 'value'")
+    assert [e.name for e in experiments] == ["exp1"]
+    experiments = mlflow_client.search_experiments(filter_string="tag.`k e y` = 'value'")
+    assert [e.name for e in experiments] == ["exp3"]
+    experiments = mlflow_client.search_experiments(filter_string="tag.\"k e y\" = 'value'")
+    assert [e.name for e in experiments] == ["exp3"]
+    experiments = mlflow_client.search_experiments(filter_string="tag.key != 'value'")
+    assert [e.name for e in experiments] == ["exp2"]
+    experiments = mlflow_client.search_experiments(filter_string="tag.key LIKE 'val%'")
+    assert [e.name for e in experiments] == ["exp1"]
+    experiments = mlflow_client.search_experiments(filter_string="tag.key LIKE '%Lue'")
+    assert [e.name for e in experiments] == ["exp2"]
+    experiments = mlflow_client.search_experiments(filter_string="tag.key ILIKE '%alu%'")
+    assert [e.name for e in experiments] == ["exp2", "exp1"]
+    experiments = mlflow_client.search_experiments(
+        filter_string="tag.key LIKE 'va%' AND tags.key LIKE '%Lue'"
+    )
+    assert [e.name for e in experiments] == ["exp2"]
+
+
+def test_search_experiments_filter_by_attribute_and_tag(mlflow_client):
+    mlflow_client.create_experiment("exp1", tags={"a": "1", "b": "2"})
+    mlflow_client.create_experiment("exp2", tags={"a": "3", "b": "4"})
+    experiments = mlflow_client.search_experiments(
+        filter_string="name ILIKE 'exp%' AND tags.a = '1'"
+    )
+    assert [e.name for e in experiments] == ["exp1"]
+
+
+def test_search_experiments_order_by(mlflow_client):
+    experiment_names = ["x", "y", "z"]
+    create_experiments(mlflow_client, experiment_names)
+
+    experiments = mlflow_client.search_experiments(order_by=["name"])
+    assert [e.name for e in experiments] == ["Default", "x", "y", "z"]
+
+    experiments = mlflow_client.search_experiments(order_by=["name ASC"])
+    assert [e.name for e in experiments] == ["Default", "x", "y", "z"]
+
+    experiments = mlflow_client.search_experiments(order_by=["name DESC"])
+    assert [e.name for e in experiments] == ["z", "y", "x", "Default"]
+
+    experiments = mlflow_client.search_experiments(order_by=["experiment_id DESC"])
+    assert [e.name for e in experiments] == ["z", "y", "x", "Default"]
+
+    experiments = mlflow_client.search_experiments(order_by=["name", "experiment_id"])
+    assert [e.name for e in experiments] == ["Default", "x", "y", "z"]
+
+
+def test_search_experiments_max_results(mlflow_client):
+    experiment_names = list(map(str, range(9)))
+    create_experiments(mlflow_client, experiment_names)
+    reversed_experiment_names = experiment_names[::-1]
+
+    experiments = mlflow_client.search_experiments()
+    assert [e.name for e in experiments] == reversed_experiment_names + ["Default"]
+    experiments = mlflow_client.search_experiments(max_results=3)
+    assert [e.name for e in experiments] == reversed_experiment_names[:3]
+
+
+def test_search_experiments_pagination(mlflow_client):
+    experiment_names = list(map(str, range(9)))
+    create_experiments(mlflow_client, experiment_names)
+    reversed_experiment_names = experiment_names[::-1]
+
+    experiments = mlflow_client.search_experiments(max_results=4)
+    assert [e.name for e in experiments] == reversed_experiment_names[:4]
+    assert experiments.token is not None
+
+    experiments = mlflow_client.search_experiments(max_results=4, page_token=experiments.token)
+    assert [e.name for e in experiments] == reversed_experiment_names[4:8]
+    assert experiments.token is not None
+
+    experiments = mlflow_client.search_experiments(max_results=4, page_token=experiments.token)
+    assert [e.name for e in experiments] == reversed_experiment_names[8:] + ["Default"]
+    assert experiments.token is None


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#6096

## What changes are proposed in this pull request?

- Depends on:
  - #6154
  - #6171 
- Implement `RestStore.search_experiments`.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
