### PR TITLE
Change log scale on UI charts to show official scientific notation

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/MetricsPlotPanel.js
+++ b/mlflow/server/js/src/experiment-tracking/components/MetricsPlotPanel.js
@@ -304,7 +304,11 @@ export class MetricsPlotPanel extends React.Component {
     // Otherwise, if plot previously had no y axis range configured, simply set the axis type to
     // log or linear scale appropriately
     if (!state.layout.yaxis || !state.layout.yaxis.range) {
-      newLayout.yaxis = { type: newAxisType, autorange: true, exponentformat: 'e' };
+      newLayout.yaxis = {
+        type: newAxisType,
+        autorange: true,
+        ...(newAxisType === 'log' ? { exponentformat: 'e' } : {}),
+      };
       this.updateUrlState({ layout: newLayout, lastLinearYAxisRange: [] });
       return;
     }
@@ -441,6 +445,9 @@ export class MetricsPlotPanel extends React.Component {
         state.layout && state.layout.yaxis && state.layout.yaxis.type === 'log' ? 'log' : 'linear';
       newYAxis.autorange = true;
       newYAxis.type = axisType;
+    }
+    if (newYAxis.type === 'log') {
+      newYAxis.exponentformat = 'e';
     }
     // Merge new X & Y axis info into layout
     mergedLayout = {

--- a/mlflow/server/js/src/experiment-tracking/components/MetricsPlotPanel.js
+++ b/mlflow/server/js/src/experiment-tracking/components/MetricsPlotPanel.js
@@ -304,7 +304,7 @@ export class MetricsPlotPanel extends React.Component {
     // Otherwise, if plot previously had no y axis range configured, simply set the axis type to
     // log or linear scale appropriately
     if (!state.layout.yaxis || !state.layout.yaxis.range) {
-      newLayout.yaxis = { type: newAxisType, autorange: true };
+      newLayout.yaxis = { type: newAxisType, autorange: true, exponentformat: 'e' };
       this.updateUrlState({ layout: newLayout, lastLinearYAxisRange: [] });
       return;
     }
@@ -333,11 +333,13 @@ export class MetricsPlotPanel extends React.Component {
         newLayout.yaxis = {
           type: 'log',
           autorange: true,
+          exponentformat: 'e',
         };
       } else {
         newLayout.yaxis = {
           type: 'log',
           range: [Math.log(oldYRange[0]) / Math.log(10), Math.log(oldYRange[1]) / Math.log(10)],
+          exponentformat: 'e',
         };
       }
     } else {

--- a/mlflow/server/js/src/experiment-tracking/components/MetricsPlotPanel.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/MetricsPlotPanel.test.js
@@ -238,9 +238,7 @@ describe('unit tests', () => {
       yaxis: { type: 'log', autorange: true, exponentformat: 'e' },
     });
     instance.handleYAxisLogScaleChange(false);
-    expect(instance.getUrlState().layout).toEqual({
-      yaxis: { type: 'linear', autorange: true },
-    });
+    expect(instance.getUrlState().layout).toEqual({ yaxis: { type: 'linear', autorange: true } });
     // Test converting to & from log scale for a layout with specified y axis range bounds
     instance.handleLayoutChange({
       'xaxis.range[0]': 2,

--- a/mlflow/server/js/src/experiment-tracking/components/MetricsPlotPanel.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/MetricsPlotPanel.test.js
@@ -234,9 +234,13 @@ describe('unit tests', () => {
     // Test converting to & from log scale for an empty layout (e.g. a layout without any
     // user-specified zoom)
     instance.handleYAxisLogScaleChange(true);
-    expect(instance.getUrlState().layout).toEqual({ yaxis: { type: 'log', autorange: true } });
+    expect(instance.getUrlState().layout).toEqual({
+      yaxis: { type: 'log', autorange: true, exponentformat: 'e' },
+    });
     instance.handleYAxisLogScaleChange(false);
-    expect(instance.getUrlState().layout).toEqual({ yaxis: { type: 'linear', autorange: true } });
+    expect(instance.getUrlState().layout).toEqual({
+      yaxis: { type: 'linear', autorange: true },
+    });
     // Test converting to & from log scale for a layout with specified y axis range bounds
     instance.handleLayoutChange({
       'xaxis.range[0]': 2,
@@ -247,7 +251,7 @@ describe('unit tests', () => {
     instance.handleYAxisLogScaleChange(true);
     expect(instance.getUrlState().layout).toEqual({
       xaxis: { range: [2, 4], autorange: false },
-      yaxis: { range: [0, 2], type: 'log' },
+      yaxis: { range: [0, 2], type: 'log', exponentformat: 'e' },
     });
     instance.handleYAxisLogScaleChange(false);
     expect(instance.getUrlState().layout).toEqual({
@@ -264,7 +268,7 @@ describe('unit tests', () => {
     instance.handleYAxisLogScaleChange(true);
     expect(instance.getUrlState().layout).toEqual({
       xaxis: { range: [-5, 5], autorange: false },
-      yaxis: { autorange: true, type: 'log' },
+      yaxis: { autorange: true, type: 'log', exponentformat: 'e' },
     });
     instance.handleYAxisLogScaleChange(false);
     expect(instance.getUrlState().layout).toEqual({
@@ -276,7 +280,7 @@ describe('unit tests', () => {
     instance.handleYAxisLogScaleChange(true);
     expect(instance.getUrlState().layout).toEqual({
       xaxis: { range: [-5, 5], autorange: false },
-      yaxis: { autorange: true, type: 'log' },
+      yaxis: { autorange: true, type: 'log', exponentformat: 'e' },
     });
     instance.handleYAxisLogScaleChange(false);
     expect(instance.getUrlState().layout).toEqual({


### PR DESCRIPTION
Signed-off-by: Rajesh Somasundaram <rajeshsomasundaram@ninjacart.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
Close #6081 

## What changes are proposed in this pull request?

Change log scale on UI charts to show official scientific notation

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

### **Before the change:**

![image](https://user-images.githubusercontent.com/30373242/176903363-27f7bfec-169e-4eeb-80dc-af4eaf906661.png)

### **After the change:**

<img width="1436" alt="after_scientific_notation_change" src="https://user-images.githubusercontent.com/30373242/176903852-227b0538-df02-42af-8953-d525e4d1ef45.png">


<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Change log scale on UI charts to show official scientific notation

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

