### PR TITLE
`mlflow server`: Fix log batch and set tag validation for empty string values

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -782,7 +782,7 @@ def _set_tag():
         schema={
             "run_id": [_assert_required, _assert_string],
             "key": [_assert_required, _assert_string],
-            "value": [_assert_required, _assert_string],
+            "value": [_assert_string],
         },
     )
     tag = RunTag(request_message.key, request_message.value)

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -763,7 +763,7 @@ def _set_experiment_tag():
         schema={
             "experiment_id": [_assert_required, _assert_string],
             "key": [_assert_required, _assert_string],
-            "value": [_assert_required, _assert_string],
+            "value": [_assert_string],
         },
     )
     tag = ExperimentTag(request_message.key, request_message.value)
@@ -1203,7 +1203,7 @@ def _set_registered_model_tag():
         schema={
             "name": [_assert_string, _assert_required],
             "key": [_assert_string, _assert_required],
-            "value": [_assert_string, _assert_required],
+            "value": [_assert_string],
         },
     )
     tag = RegisteredModelTag(key=request_message.key, value=request_message.value)
@@ -1373,7 +1373,7 @@ def _set_model_version_tag():
             "name": [_assert_string, _assert_required],
             "version": [_assert_string, _assert_required],
             "key": [_assert_string, _assert_required],
-            "value": [_assert_string, _assert_required],
+            "value": [_assert_string],
         },
     )
     tag = ModelVersionTag(key=request_message.key, value=request_message.value)

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -984,7 +984,6 @@ def _log_batch():
     def _assert_params_tags_fields_present(params):
         for p in params:
             _assert_required(p["key"])
-            _assert_required(p["value"])
 
     _validate_batch_log_api_req(_get_request_json())
     request_message = _get_request_message(

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -981,9 +981,9 @@ def _log_batch():
             _assert_required(m["timestamp"])
             _assert_required(m["step"])
 
-    def _assert_params_tags_fields_present(params):
-        for p in params:
-            _assert_required(p["key"])
+    def _assert_params_tags_fields_present(params_or_tags):
+        for param_or_tag in params_or_tags:
+            _assert_required(param_or_tag["key"])
 
     _validate_batch_log_api_req(_get_request_json())
     request_message = _get_request_message(

--- a/tests/tracking/test_model_registry.py
+++ b/tests/tracking/test_model_registry.py
@@ -344,6 +344,13 @@ def test_set_delete_registered_model_tag_flow(mlflow_client, backend_store_uri):
     assert registered_model_detailed.tags == {"numeric value": "12345"}
 
 
+def test_set_registered_model_tag_with_empty_string_as_value(mlflow_client):
+    name = "SetRMTagEmptyValueTest"
+    mlflow_client.create_registered_model(name)
+    mlflow_client.set_registered_model_tag(name, "tag_key", "")
+    assert {"tag_key": ""}.items() <= mlflow_client.get_registered_model(name).tags.items()
+
+
 def test_create_and_query_model_version_flow(mlflow_client, backend_store_uri):
     name = "CreateMVTest"
     tags = {"key": "value", "another key": "some other value", "numeric value": 12345}
@@ -583,3 +590,11 @@ def test_set_delete_model_version_tag_flow(mlflow_client, backend_store_uri):
     mlflow_client.delete_model_version_tag(name, "1", "key")
     model_version_detailed = mlflow_client.get_model_version(name, "1")
     assert model_version_detailed.tags == {"numeric value": "12345"}
+
+
+def test_set_model_version_tag_with_empty_string_as_value(mlflow_client):
+    name = "SetMVTagEmptyValueTest"
+    mlflow_client.create_registered_model(name)
+    mlflow_client.create_model_version(name, "path/to/model", "run_id_1")
+    mlflow_client.set_model_version_tag(name, "1", "tag_key", "")
+    assert {"tag_key": ""}.items() <= mlflow_client.get_model_version(name, "1").tags.items()

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -473,6 +473,62 @@ def test_log_param_with_empty_string_as_value(mlflow_client, tracking_server_uri
     assert response.status_code == 200
 
 
+def test_set_tag_with_empty_string_as_value(mlflow_client, tracking_server_uri):
+    experiment_id = mlflow_client.create_experiment(
+        test_log_param_with_empty_string_as_value.__name__
+    )
+    created_run = mlflow_client.create_run(experiment_id)
+    run_id = created_run.info.run_id
+
+    response = _send_rest_tracking_post_request(
+        tracking_server_uri,
+        "/api/2.0/mlflow/runs/set-tag",
+        {
+            "run_id": run_id,
+            "key": "tag",
+            "value": "",
+        },
+    )
+    assert response.status_code == 200
+
+
+def test_log_batch_containing_params_and_tags_with_empty_string_values(mlflow_client, tracking_server_uri):
+    experiment_id = mlflow_client.create_experiment(
+        test_log_param_with_empty_string_as_value.__name__
+    )
+    created_run = mlflow_client.create_run(experiment_id)
+    run_id = created_run.info.run_id
+
+    response = _send_rest_tracking_post_request(
+        tracking_server_uri,
+        "/api/2.0/mlflow/runs/log-batch",
+        {
+            "run_id": run_id,
+            "params": [
+                {
+                    "key": "param",
+                    "value": "",
+                },
+                {
+                    "key": "param",
+                    "value": "nonempty_param",
+                },
+            ],
+            "tags": [
+                {
+                    "key": "tag",
+                    "value": "",
+                },
+                {
+                    "key": "tag",
+                    "value": "nonempty_tag",
+                },
+            ],
+        },
+    )
+    assert response.status_code == 200
+
+
 def test_set_tag_validation(mlflow_client, tracking_server_uri):
     experiment_id = mlflow_client.create_experiment("tags validation")
     created_run = mlflow_client.create_run(experiment_id)

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -492,7 +492,9 @@ def test_set_tag_with_empty_string_as_value(mlflow_client, tracking_server_uri):
     assert response.status_code == 200
 
 
-def test_log_batch_containing_params_and_tags_with_empty_string_values(mlflow_client, tracking_server_uri):
+def test_log_batch_containing_params_and_tags_with_empty_string_values(
+    mlflow_client, tracking_server_uri
+):
     experiment_id = mlflow_client.create_experiment(
         test_log_param_with_empty_string_as_value.__name__
     )

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -475,7 +475,7 @@ def test_log_param_with_empty_string_as_value(mlflow_client, tracking_server_uri
 
 def test_set_tag_with_empty_string_as_value(mlflow_client, tracking_server_uri):
     experiment_id = mlflow_client.create_experiment(
-        test_log_param_with_empty_string_as_value.__name__
+        test_set_tag_with_empty_string_as_value.__name__
     )
     created_run = mlflow_client.create_run(experiment_id)
     run_id = created_run.info.run_id
@@ -496,7 +496,7 @@ def test_log_batch_containing_params_and_tags_with_empty_string_values(
     mlflow_client, tracking_server_uri
 ):
     experiment_id = mlflow_client.create_experiment(
-        test_log_param_with_empty_string_as_value.__name__
+        test_log_batch_containing_params_and_tags_with_empty_string_values.__name__
     )
     created_run = mlflow_client.create_run(experiment_id)
     run_id = created_run.info.run_id

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -461,16 +461,8 @@ def test_log_param_with_empty_string_as_value(mlflow_client, tracking_server_uri
     created_run = mlflow_client.create_run(experiment_id)
     run_id = created_run.info.run_id
 
-    response = _send_rest_tracking_post_request(
-        tracking_server_uri,
-        "/api/2.0/mlflow/runs/log-parameter",
-        {
-            "run_id": run_id,
-            "key": "param",
-            "value": "",
-        },
-    )
-    assert response.status_code == 200
+    mlflow_client.log_param(run_id, "param_key", "")
+    assert {"param_key": ""}.items() <= mlflow_client.get_run(run_id).data.params.items()
 
 
 def test_set_tag_with_empty_string_as_value(mlflow_client, tracking_server_uri):
@@ -480,16 +472,8 @@ def test_set_tag_with_empty_string_as_value(mlflow_client, tracking_server_uri):
     created_run = mlflow_client.create_run(experiment_id)
     run_id = created_run.info.run_id
 
-    response = _send_rest_tracking_post_request(
-        tracking_server_uri,
-        "/api/2.0/mlflow/runs/set-tag",
-        {
-            "run_id": run_id,
-            "key": "tag",
-            "value": "",
-        },
-    )
-    assert response.status_code == 200
+    mlflow_client.set_tag(run_id, "tag_key", "")
+    assert {"tag_key": ""}.items() <= mlflow_client.get_run(run_id).data.tags.items()
 
 
 def test_log_batch_containing_params_and_tags_with_empty_string_values(
@@ -501,34 +485,13 @@ def test_log_batch_containing_params_and_tags_with_empty_string_values(
     created_run = mlflow_client.create_run(experiment_id)
     run_id = created_run.info.run_id
 
-    response = _send_rest_tracking_post_request(
-        tracking_server_uri,
-        "/api/2.0/mlflow/runs/log-batch",
-        {
-            "run_id": run_id,
-            "params": [
-                {
-                    "key": "param",
-                    "value": "",
-                },
-                {
-                    "key": "param",
-                    "value": "nonempty_param",
-                },
-            ],
-            "tags": [
-                {
-                    "key": "tag",
-                    "value": "",
-                },
-                {
-                    "key": "tag",
-                    "value": "nonempty_tag",
-                },
-            ],
-        },
+    mlflow_client.log_batch(
+        run_id=run_id,
+        params=[Param("param_key", "")],
+        tags=[RunTag("tag_key", "")],
     )
-    assert response.status_code == 200
+    assert {"param_key": ""}.items() <= mlflow_client.get_run(run_id).data.params.items()
+    assert {"tag_key": ""}.items() <= mlflow_client.get_run(run_id).data.tags.items()
 
 
 def test_set_tag_validation(mlflow_client, tracking_server_uri):
@@ -608,6 +571,14 @@ def test_set_experiment_tag(mlflow_client, backend_store_uri):
         "multiline tag" in experiment.tags
         and experiment.tags["multiline tag"] == "value2\nvalue2\nvalue2"
     )
+
+
+def test_set_experiment_tag_with_empty_string_as_value(mlflow_client, tracking_server_uri):
+    experiment_id = mlflow_client.create_experiment(
+        test_set_experiment_tag_with_empty_string_as_value.__name__
+    )
+    mlflow_client.set_experiment_tag(experiment_id, "tag_key", "")
+    assert {"tag_key": ""}.items() <= mlflow_client.get_experiment(experiment_id).tags.items()
 
 
 def test_delete_tag(mlflow_client, backend_store_uri):


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

Closes #6177 

## What changes are proposed in this pull request?

Fix a bug in `mlflow server` that causes `SetTag` and `LogBatch` requests to be erroneously rejected if empty strings are used as parameter / tag values.

## How is this patch tested?

Added integration tests

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

Fix a bug in `mlflow server` that causes `SetTag` and `LogBatch` requests to be erroneously rejected if empty strings are used as parameter / tag values.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [X] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
