### PR TITLE
stage parameter support in set_model_version_tag 

### DIFF
--- a/mlflow/entities/model_registry/model_version_stages.py
+++ b/mlflow/entities/model_registry/model_version_stages.py
@@ -17,7 +17,7 @@ def get_canonical_stage(stage):
     key = stage.lower()
     if key not in _CANONICAL_MAPPING:
         raise MlflowException(
-            "Invalid Model Version stage {}. Value must be one of {}".format(
+            "Invalid Model Version stage: {}. Value must be one of {}.".format(
                 stage, ", ".join(ALL_STAGES)
             ),
             INVALID_PARAMETER_VALUE,

--- a/mlflow/entities/model_registry/model_version_stages.py
+++ b/mlflow/entities/model_registry/model_version_stages.py
@@ -17,6 +17,9 @@ def get_canonical_stage(stage):
     key = stage.lower()
     if key not in _CANONICAL_MAPPING:
         raise MlflowException(
-            "Invalid Model Version stage {}.".format(stage), INVALID_PARAMETER_VALUE
+            "Invalid Model Version stage {}. Value must be one of {}".format(
+                stage, ", ".join(ALL_STAGES)
+            ),
+            INVALID_PARAMETER_VALUE,
         )
     return _CANONICAL_MAPPING[key]

--- a/mlflow/tracking/_model_registry/client.py
+++ b/mlflow/tracking/_model_registry/client.py
@@ -306,7 +306,7 @@ class ModelRegistryClient:
         """
         return self.store.get_model_version_stages(name, version)
 
-    def set_model_version_tag(self, name, version, key, value):
+    def set_model_version_tag(self, name, version=None, key=None, value=None, stage=None):
         """
         Set a tag for the model version.
 
@@ -316,6 +316,9 @@ class ModelRegistryClient:
         :param value: Tag value to log.
         :return: None
         """
+        if not version and stage:
+            model_versions = self.get_latest_versions(name, [stage])
+            version = model_versions[0].version if model_versions else None
         self.store.set_model_version_tag(name, version, ModelVersionTag(key, str(value)))
 
     def delete_model_version_tag(self, name, version, key):

--- a/mlflow/tracking/_model_registry/client.py
+++ b/mlflow/tracking/_model_registry/client.py
@@ -306,7 +306,7 @@ class ModelRegistryClient:
         """
         return self.store.get_model_version_stages(name, version)
 
-    def set_model_version_tag(self, name, version=None, key=None, value=None):
+    def set_model_version_tag(self, name, version, key, value):
         """
         Set a tag for the model version.
 

--- a/mlflow/tracking/_model_registry/client.py
+++ b/mlflow/tracking/_model_registry/client.py
@@ -306,7 +306,7 @@ class ModelRegistryClient:
         """
         return self.store.get_model_version_stages(name, version)
 
-    def set_model_version_tag(self, name, version=None, key=None, value=None, stage=None):
+    def set_model_version_tag(self, name, version=None, key=None, value=None):
         """
         Set a tag for the model version.
 
@@ -316,9 +316,6 @@ class ModelRegistryClient:
         :param value: Tag value to log.
         :return: None
         """
-        if not version and stage:
-            model_versions = self.get_latest_versions(name, [stage])
-            version = model_versions[0].version if model_versions else None
         self.store.set_model_version_tag(name, version, ModelVersionTag(key, str(value)))
 
     def delete_model_version_tag(self, name, version, key):

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -2687,7 +2687,7 @@ class MlflowClient:
     ) -> None:
         """
         Set a tag for the model version.
-        When stage is set, tag will be set only for latest model version of the stage.
+        When stage is set, tag will be set for latest model version of the stage.
 
         :param name: Registered model name.
         :param version: Registered model version.
@@ -2761,7 +2761,7 @@ class MlflowClient:
     ) -> None:
         """
         Delete a tag associated with the model version.
-        When stage is set, tag will be deleted only for latest model version of the stage.
+        When stage is set, tag will be deleted for latest model version of the stage.
 
         :param name: Registered model name.
         :param version: Registered model version.

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -2802,6 +2802,7 @@ class MlflowClient:
             mv = client.create_model_version(name, model_uri, run.info.run_id, tags=tags)
             print_model_version_info(mv)
             print("--")
+            #using version to delete tag
             client.delete_model_version_tag(name, mv.version, "t")
 
             #using stage to delete tag

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -2691,8 +2691,8 @@ class MlflowClient:
 
         :param name: Registered model name.
         :param version: Registered model version.
-        :param key: Tag key to log.
-        :param value: Tag value to log.
+        :param key: Tag key to log. key is required.
+        :param value: Tag value to log. value is required.
         :param stage: Registered model stage.
         :return: None
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -2733,7 +2733,7 @@ class MlflowClient:
             client.set_model_version_tag(name, mv.version, "t", "1")
 
             # Tag using model stage
-            client.set_model_version_tag(name, key="t", value="1", stage=mv.current_stage)
+            client.set_model_version_tag(name, key="t1", value="1", stage=mv.current_stage)
 
             mv = client.get_model_version(name, mv.version)
             print_model_version_info(mv)
@@ -2747,7 +2747,7 @@ class MlflowClient:
             --
             Name: RandomForestRegression
             Version: 1
-            Tags: {'t': '1'}
+            Tags: {'t': '1', 't1': '1'}
         """
         _validate_model_version_or_stage_exists(version, stage)
         if stage:
@@ -2765,7 +2765,7 @@ class MlflowClient:
 
         :param name: Registered model name.
         :param version: Registered model version.
-        :param key: Tag key.
+        :param key: Tag key. key is required.
         :param stage: Registered model stage.
         :return: None
 
@@ -2798,7 +2798,7 @@ class MlflowClient:
             # Create a new version of the rfr model under the registered model name
             # and delete a tag
             model_uri = "runs:/{}/sklearn-model".format(run.info.run_id)
-            tags = {'t': "t1"}
+            tags = {'t': "1", "t1" : "2"}
             mv = client.create_model_version(name, model_uri, run.info.run_id, tags=tags)
             print_model_version_info(mv)
             print("--")
@@ -2806,7 +2806,7 @@ class MlflowClient:
             client.delete_model_version_tag(name, mv.version, "t")
 
             #using stage to delete tag
-            client.delete_model_version_tag(name, key="t", stage=mv.current_stage)
+            client.delete_model_version_tag(name, key="t1", stage=mv.current_stage)
             mv = client.get_model_version(name, mv.version)
             print_model_version_info(mv)
 
@@ -2815,7 +2815,7 @@ class MlflowClient:
 
             Name: RandomForestRegression
             Version: 1
-            Tags: {'t': 't1'}
+            Tags: {'t': '1', 't1': '2'}
             --
             Name: RandomForestRegression
             Version: 1

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -2687,6 +2687,7 @@ class MlflowClient:
     ) -> None:
         """
         Set a tag for the model version.
+        When stage is set, tag will be set only for latest model version of the stage.
 
         :param name: Registered model name.
         :param version: Registered model version.
@@ -2760,10 +2761,12 @@ class MlflowClient:
     ) -> None:
         """
         Delete a tag associated with the model version.
+        When stage is set, tag will be deleted only for latest model version of the stage.
 
         :param name: Registered model name.
         :param version: Registered model version.
         :param key: Tag key.
+        :param stage: Registered model stage.
         :return: None
 
         .. code-block:: python

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -2755,7 +2755,9 @@ class MlflowClient:
 
         self._get_registry_client().set_model_version_tag(name, version, key, value)
 
-    def delete_model_version_tag(self, name: str, version: str, key: str) -> None:
+    def delete_model_version_tag(
+        self, name: str, version: str = None, key: str = None, stage: str = None
+    ) -> None:
         """
         Delete a tag associated with the model version.
 
@@ -2798,6 +2800,9 @@ class MlflowClient:
             print_model_version_info(mv)
             print("--")
             client.delete_model_version_tag(name, mv.version, "t")
+
+            #using stage to delete tag
+            client.delete_model_version_tag(name, key="t", stage=mv.current_stage)
             mv = client.get_model_version(name, mv.version)
             print_model_version_info(mv)
 
@@ -2812,4 +2817,8 @@ class MlflowClient:
             Version: 1
             Tags: {}
         """
+        _validate_model_version_or_stage_exists(version, stage)
+        if stage:
+            latest_versions = self.get_latest_versions(name, stages=[stage])
+            version = latest_versions[0].version if latest_versions else None
         self._get_registry_client().delete_model_version_tag(name, version, key)

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -2752,7 +2752,13 @@ class MlflowClient:
         _validate_model_version_or_stage_exists(version, stage)
         if stage:
             latest_versions = self.get_latest_versions(name, stages=[stage])
-            version = latest_versions[0].version if latest_versions else None
+            if not latest_versions:
+                raise MlflowException(
+                    "Could not find any model version for {} stage".format(
+                        stage,
+                    )
+                )
+            version = latest_versions[0].version
 
         self._get_registry_client().set_model_version_tag(name, version, key, value)
 
@@ -2824,5 +2830,11 @@ class MlflowClient:
         _validate_model_version_or_stage_exists(version, stage)
         if stage:
             latest_versions = self.get_latest_versions(name, stages=[stage])
-            version = latest_versions[0].version if latest_versions else None
+            if not latest_versions:
+                raise MlflowException(
+                    "Could not find any model version for {} stage".format(
+                        stage,
+                    )
+                )
+            version = latest_versions[0].version
         self._get_registry_client().delete_model_version_tag(name, version, key)

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -2681,7 +2681,9 @@ class MlflowClient:
         """
         return ALL_STAGES
 
-    def set_model_version_tag(self, name: str, version: str, key: str, value: Any) -> None:
+    def set_model_version_tag(
+        self, name: str, version: str = None, key: str = None, value: Any = None, stage: str = None
+    ) -> None:
         """
         Set a tag for the model version.
 
@@ -2738,7 +2740,7 @@ class MlflowClient:
             Version: 1
             Tags: {'t': '1'}
         """
-        self._get_registry_client().set_model_version_tag(name, version, key, value)
+        self._get_registry_client().set_model_version_tag(name, version, key, value, stage)
 
     def delete_model_version_tag(self, name: str, version: str, key: str) -> None:
         """

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -2688,6 +2688,7 @@ class MlflowClient:
         """
         Set a tag for the model version.
         When stage is set, tag will be set for latest model version of the stage.
+        Setting both version and stage parameter will result in error.
 
         :param name: Registered model name.
         :param version: Registered model version.
@@ -2768,6 +2769,7 @@ class MlflowClient:
         """
         Delete a tag associated with the model version.
         When stage is set, tag will be deleted for latest model version of the stage.
+        Setting both version and stage parameter will result in error.
 
         :param name: Registered model name.
         :param version: Registered model version.

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -388,6 +388,9 @@ def _validate_db_type_string(db_type):
         raise MlflowException(error_msg, INVALID_PARAMETER_VALUE)
 
 
-def _validate_version_or_stage(version, stage):
+def _validate_model_version_or_stage_exists(version, stage):
+    if version and stage:
+        raise MlflowException("Only version or stage should be set")
+
     if not (version or stage):
         raise MlflowException("version or stage should be set")

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -9,9 +9,6 @@ from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.store.db.db_types import DATABASE_ENGINES
 from mlflow.utils.string_utils import is_string_type
-from mlflow.entities.model_registry.model_version_stages import (
-    ALL_STAGES,
-)
 
 _VALID_PARAM_AND_METRIC_NAMES = re.compile(r"^[/\w.\- ]*$")
 
@@ -398,12 +395,6 @@ def _validate_model_version_or_stage_exists(version, stage):
 
     if not (version or stage):
         raise MlflowException("version or stage must be set", INVALID_PARAMETER_VALUE)
-
-    if stage and stage not in ALL_STAGES:
-        raise MlflowException(
-            "Invalid stage value: %s. Must be one of %s" % (stage, ", ".join(ALL_STAGES)),
-            INVALID_PARAMETER_VALUE,
-        )
 
 
 def _validate_tag_value(value):

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -9,6 +9,9 @@ from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.store.db.db_types import DATABASE_ENGINES
 from mlflow.utils.string_utils import is_string_type
+from mlflow.entities.model_registry.model_version_stages import (
+    ALL_STAGES,
+)
 
 _VALID_PARAM_AND_METRIC_NAMES = re.compile(r"^[/\w.\- ]*$")
 
@@ -394,7 +397,13 @@ def _validate_model_version_or_stage_exists(version, stage):
         raise MlflowException("version and stage cannot be set together", INVALID_PARAMETER_VALUE)
 
     if not (version or stage):
-        raise MlflowException("version or stage should be set", INVALID_PARAMETER_VALUE)
+        raise MlflowException("version or stage must be set", INVALID_PARAMETER_VALUE)
+
+    if stage and stage not in ALL_STAGES:
+        raise MlflowException(
+            "Invalid stage value: %s. Must be one of %s" % (stage, ", ".join(ALL_STAGES)),
+            INVALID_PARAMETER_VALUE,
+        )
 
 
 def _validate_tag_value(value):

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -180,6 +180,7 @@ def _validate_model_version_tag(key, value):
     Check that a tag with the specified key & value is valid and raise an exception if it isn't.
     """
     _validate_tag_name(key)
+    _validate_tag_value(value)
     _validate_length_limit("Model version key", MAX_MODEL_REGISTRY_TAG_KEY_LENGTH, key)
     _validate_length_limit("Model version value", MAX_MODEL_REGISTRY_TAG_VALUE_LENGTH, value)
 
@@ -390,7 +391,12 @@ def _validate_db_type_string(db_type):
 
 def _validate_model_version_or_stage_exists(version, stage):
     if version and stage:
-        raise MlflowException("Only version or stage should be set")
+        raise MlflowException("version and stage cannot be set together", INVALID_PARAMETER_VALUE)
 
     if not (version or stage):
-        raise MlflowException("version or stage should be set")
+        raise MlflowException("version or stage should be set", INVALID_PARAMETER_VALUE)
+
+
+def _validate_tag_value(value):
+    if value == None:
+        raise MlflowException("Tag value cannot be None", INVALID_PARAMETER_VALUE)

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -386,3 +386,8 @@ def _validate_db_type_string(db_type):
     if db_type not in DATABASE_ENGINES:
         error_msg = "Invalid database engine: '%s'. '%s'" % (db_type, _UNSUPPORTED_DB_TYPE_MSG)
         raise MlflowException(error_msg, INVALID_PARAMETER_VALUE)
+
+
+def _validate_version_or_stage(version, stage):
+    if not (version or stage):
+        raise MlflowException("version or stage should be set")

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -605,7 +605,9 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
 
         # only valid stages can be set
         with self.assertRaisesRegex(
-            MlflowException, r"Invalid Model Version stage unknown"
+            MlflowException,
+            "Invalid Model Version stage: unknown. "
+            "Value must be one of None, Staging, Production, Archived.",
         ) as exception_context:
             self.store.transition_model_version_stage(
                 mv1.name, mv1.version, stage="unknown", archive_existing_versions=False

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -611,6 +611,7 @@ def mock_registry_store_with_get_latest_version(mock_registry_store):
 
 def test_set_model_version_tag(mock_registry_store_with_get_latest_version):
 
+    # set_model_version_tag using version
     MlflowClient().set_model_version_tag("model_name", 1, "tag1", "foobar")
     mock_registry_store_with_get_latest_version.set_model_version_tag.assert_called_once_with(
         "model_name", 1, ModelVersionTag(key="tag1", value="foobar")
@@ -618,14 +619,33 @@ def test_set_model_version_tag(mock_registry_store_with_get_latest_version):
 
     mock_registry_store_with_get_latest_version.reset_mock()
 
+    # set_model_version_tag using stage
     MlflowClient().set_model_version_tag("model_name", key="tag1", value="foobar", stage="Staging")
     mock_registry_store_with_get_latest_version.set_model_version_tag.assert_called_once_with(
         "model_name", 1, ModelVersionTag(key="tag1", value="foobar")
     )
 
+    # set_model_version_tag with version and stage set
+    with pytest.raises(MlflowException, match="version and stage cannot be set together"):
+        MlflowClient().set_model_version_tag("model_name", 1, "tag1", "foobar", stage="Staging")
+
+    # set_model_version_tag with version and stage not set
+    with pytest.raises(MlflowException, match="version or stage must be set"):
+        MlflowClient().set_model_version_tag("model_name", key="tag1", value="foobar")
+
+    # set_model_version_tag with invalid stage value
+    with pytest.raises(
+        MlflowException,
+        match="Invalid stage value: staging. Must be one of None, Staging, Production, Archived",
+    ):
+        MlflowClient().set_model_version_tag(
+            "model_name", key="tag1", value="foobar", stage="staging"
+        )
+
 
 def test_delete_model_version_tag(mock_registry_store_with_get_latest_version):
 
+    # delete_model_version_tag using version
     MlflowClient().delete_model_version_tag("model_name", 1, "tag1")
     mock_registry_store_with_get_latest_version.delete_model_version_tag.assert_called_once_with(
         "model_name", 1, "tag1"
@@ -633,7 +653,25 @@ def test_delete_model_version_tag(mock_registry_store_with_get_latest_version):
 
     mock_registry_store_with_get_latest_version.reset_mock()
 
+    # delete_model_version_tag using stage
     MlflowClient().delete_model_version_tag("model_name", key="tag1", stage="Staging")
     mock_registry_store_with_get_latest_version.delete_model_version_tag.assert_called_once_with(
         "model_name", 1, "tag1"
     )
+
+    # delete_model_version_tag with version and stage set
+    with pytest.raises(MlflowException, match="version and stage cannot be set together"):
+        MlflowClient().delete_model_version_tag(
+            "model_name", version=1, key="tag1", stage="staging"
+        )
+
+    # delete_model_version_tag with version and stage not set
+    with pytest.raises(MlflowException, match="version or stage must be set"):
+        MlflowClient().delete_model_version_tag("model_name", key="tag1")
+
+    # delete_model_version_tag with invalid stage value
+    with pytest.raises(
+        MlflowException,
+        match="Invalid stage value: staging. Must be one of None, Staging, Production, Archived",
+    ):
+        MlflowClient().delete_model_version_tag("model_name", key="tag1", stage="staging")

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -592,3 +592,31 @@ def test_client_can_be_serialized_with_pickle(tmpdir):
     client.create_experiment("test_experiment")
     client.create_registered_model("test_model")
     pickle.dumps(client)
+
+
+def test_set_model_version_tag(mock_registry_store):
+
+    mock_get_latest_versions = mock.Mock()
+    mock_get_latest_versions.return_value = [
+        ModelVersion(
+            "test_model_name",
+            "1",
+            0,
+        )
+    ]
+
+    mock_registry_store.get_latest_versions = mock_get_latest_versions
+
+    MlflowClient().set_model_version_tag("model_name", "1", "tag1", "foobar")
+    mock_registry_store.set_model_version_tag.assert_called_once_with(
+        "model_name", "1", ModelVersionTag(key="tag1", value="foobar")
+    )
+
+    mock_registry_store.reset_mock()
+
+    MlflowClient().set_model_version_tag(
+        "model_name", version=None, key="tag1", value="foobar", stage="Staging"
+    )
+    mock_registry_store.set_model_version_tag.assert_called_once_with(
+        "model_name", "1", ModelVersionTag(key="tag1", value="foobar")
+    )

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -633,15 +633,6 @@ def test_set_model_version_tag(mock_registry_store_with_get_latest_version):
     with pytest.raises(MlflowException, match="version or stage must be set"):
         MlflowClient().set_model_version_tag("model_name", key="tag1", value="foobar")
 
-    # set_model_version_tag with invalid stage value
-    with pytest.raises(
-        MlflowException,
-        match="Invalid stage value: staging. Must be one of None, Staging, Production, Archived",
-    ):
-        MlflowClient().set_model_version_tag(
-            "model_name", key="tag1", value="foobar", stage="staging"
-        )
-
 
 def test_delete_model_version_tag(mock_registry_store_with_get_latest_version):
 
@@ -668,10 +659,3 @@ def test_delete_model_version_tag(mock_registry_store_with_get_latest_version):
     # delete_model_version_tag with version and stage not set
     with pytest.raises(MlflowException, match="version or stage must be set"):
         MlflowClient().delete_model_version_tag("model_name", key="tag1")
-
-    # delete_model_version_tag with invalid stage value
-    with pytest.raises(
-        MlflowException,
-        match="Invalid stage value: staging. Must be one of None, Staging, Production, Archived",
-    ):
-        MlflowClient().delete_model_version_tag("model_name", key="tag1", stage="staging")


### PR DESCRIPTION
## Related Issues/PRs

Closes #5327 

## What changes are proposed in this pull request?
`set_model_stage_tag` and `delete_model_stage_tag` supports additional model stage parameter. 
stage parameter cannot be used along with version parameter.
when stage parameter is set, only the latest model version will be updated.


## How is this patch tested?

- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.


## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

current_stage of ModelVersion can be used to tag the model version.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations


<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
