### PR TITLE
Add GitHub Action to add has-closing-pr label

### DIFF
--- a/.github/workflows/closing-pr.js
+++ b/.github/workflows/closing-pr.js
@@ -1,0 +1,19 @@
+// https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
+const CLOSING_SYNTAX_REGEX = /(?:close|fix|resolve)[sd]?\s+#(\d+)/i;
+const HAS_CLOSING_PR_LABEL = 'has-closing-pr';
+
+module.exports = async ({ context, github }) => {
+  const { body } = context.payload.pull_request;
+  // Find a closing syntax after removing comments
+  const match = body.replace(/<!--(.+?)-->/gs, '').match(CLOSING_SYNTAX_REGEX);
+  if (match) {
+    const issue_number = match[1];
+    const { owner, repo } = context.repo;
+    await github.issues.addLabels({
+      owner,
+      repo,
+      issue_number,
+      labels: [HAS_CLOSING_PR_LABEL],
+    });
+  }
+};

--- a/.github/workflows/closing-pr.js
+++ b/.github/workflows/closing-pr.js
@@ -1,5 +1,5 @@
 // https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-const CLOSING_SYNTAX_REGEX = /(?:close|fix|resolve)[sd]?\s+#(\d+)/i;
+const CLOSING_SYNTAX_REGEX = /(?:close|fixe?|resolve)[sd]?\s+#(\d+)/i;
 const HAS_CLOSING_PR_LABEL = 'has-closing-pr';
 
 module.exports = async ({ context, github }) => {

--- a/.github/workflows/closing-pr.yml
+++ b/.github/workflows/closing-pr.yml
@@ -1,0 +1,26 @@
+name: Closing PR
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+
+defaults:
+  run:
+    shell: bash --noprofile --norc -exo pipefail {0}
+
+jobs:
+  labeling:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - uses: actions/github-script@v4
+        with:
+          script: |
+            const script = require(
+              `${process.env.GITHUB_WORKSPACE}/.github/workflows/closing-pr.js`
+            );
+            script({ context, github });

--- a/.github/workflows/closing-pr.yml
+++ b/.github/workflows/closing-pr.yml
@@ -1,7 +1,7 @@
 name: Closing PR
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - edited

--- a/.github/workflows/closing-pr.yml
+++ b/.github/workflows/closing-pr.yml
@@ -11,7 +11,7 @@ defaults:
     shell: bash --noprofile --norc -exo pipefail {0}
 
 jobs:
-  labeling:
+  closing-pr:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
https://github.com/harupy/stale/pull/1

## What changes are proposed in this pull request?

Add a GitHub Action to add a has-closing-pr label. The stale bot uses this label to determine whether the issue has a closing PR.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

Manually tested on my fork.

https://user-images.githubusercontent.com/17039389/177250532-40b40fdb-adfc-4ef3-b125-3ce3a3af354b.mov

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
