### PR TITLE
Update closing-PR github action to label multiple issues

### DIFF
--- a/.github/workflows/closing-pr.js
+++ b/.github/workflows/closing-pr.js
@@ -1,8 +1,8 @@
 // Regular expressions to capture a closing syntax in the PR body
 // https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
 const CLOSING_SYNTAX_PATTERNS = [
-  /(?:close|fixe?|resolve)[sd]?\s+(?:mlflow\/mlflow)?#(\d+)/gi,
-  /(?:close|fixe?|resolve)[sd]?\s+(?:https?:\/\/github.com\/mlflow\/mlflow\/issues\/)(\d+)/gi,
+  /(?:(?:close|fixe|resolve)[sd]?|fix)\s+(?:mlflow\/mlflow)?#(\d+)/gi,
+  /(?:(?:close|fixe|resolve)[sd]?|fix)\s+(?:https?:\/\/github.com\/mlflow\/mlflow\/issues\/)(\d+)/gi,
 ];
 const HAS_CLOSING_PR_LABEL = 'has-closing-pr';
 
@@ -25,9 +25,17 @@ const assertArrayEqual = (a1, a2) => {
   }
 };
 
+const capitalizeFirstLetter = (string) => {
+  return string.charAt(0).toUpperCase() + string.slice(1);
+};
+
 const test = () => {
-  const body1 = 'Close #123';
-  assertArrayEqual(getIssuesToClose(body1), ['123']);
+  ['close', 'closes', 'closed', 'fix', 'fixes', 'fixed', 'resolve', 'resolves', 'resolved'].forEach(
+    (keyword) => {
+      assertArrayEqual(getIssuesToClose(`${keyword} #123`), ['123']);
+      assertArrayEqual(getIssuesToClose(`${capitalizeFirstLetter(keyword)} #123`), ['123']);
+    },
+  );
 
   const body2 = `
 Fix mlflow/mlflow#123
@@ -46,6 +54,9 @@ Close #123
 
   const body5 = '<!-- close #123 -->';
   assertArrayEqual(getIssuesToClose(body5), []);
+
+  const body6 = 'Fixs #123 Fixd #456';
+  assertArrayEqual(getIssuesToClose(body6), []);
 };
 
 // `node .github/workflows/closing-pr.js` runs this block

--- a/.github/workflows/closing-pr.js
+++ b/.github/workflows/closing-pr.js
@@ -40,7 +40,7 @@ Close #78
   assertArrayEqual(getIssuesToClose(body3), ['78']);
 };
 
-// `node .github/workflows/closing-pr.js` to run
+// `node .github/workflows/closing-pr.js` runs this block
 if (require.main === module) {
   test();
 }

--- a/.github/workflows/closing-pr.js
+++ b/.github/workflows/closing-pr.js
@@ -26,18 +26,26 @@ const assertArrayEqual = (a1, a2) => {
 };
 
 const test = () => {
-  const body1 = 'Close #12';
-  assertArrayEqual(getIssuesToClose(body1), ['12']);
+  const body1 = 'Close #123';
+  assertArrayEqual(getIssuesToClose(body1), ['123']);
+
   const body2 = `
-Fix mlflow/mlflow#34
-Resolve https://github.com/mlflow/mlflow/issues/56
+Fix mlflow/mlflow#123
+Resolve https://github.com/mlflow/mlflow/issues/456
 `;
-  assertArrayEqual(getIssuesToClose(body2), ['34', '56']);
+  assertArrayEqual(getIssuesToClose(body2), ['123', '456']);
+
   const body3 = `
-Fix #78
-Close #78
+Fix #123
+Close #123
 `;
-  assertArrayEqual(getIssuesToClose(body3), ['78']);
+  assertArrayEqual(getIssuesToClose(body3), ['123']);
+
+  const body4 = 'Relates to #123';
+  assertArrayEqual(getIssuesToClose(body4), []);
+
+  const body5 = '<!-- close #123 -->';
+  assertArrayEqual(getIssuesToClose(body5), []);
 };
 
 // `node .github/workflows/closing-pr.js` runs this block

--- a/.github/workflows/closing-pr.js
+++ b/.github/workflows/closing-pr.js
@@ -1,26 +1,42 @@
 // Regular expressions to capture a closing syntax in the PR body
 // https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
 const CLOSING_SYNTAX_PATTERNS = [
-  /(?:close|fixe?|resolve)[sd]?\s+(?:mlflow\/mlflow)?#(\d+)/i,
-  /(?:close|fixe?|resolve)[sd]?\s+(?:https?:\/\/github.com\/mlflow\/mlflow\/issues\/)(\d+)/i,
+  /(?:close|fixe?|resolve)[sd]?\s+(?:mlflow\/mlflow)?#(\d+)/gi,
+  /(?:close|fixe?|resolve)[sd]?\s+(?:https?:\/\/github.com\/mlflow\/mlflow\/issues\/)(\d+)/gi,
 ];
 const HAS_CLOSING_PR_LABEL = 'has-closing-pr';
 
+const getIssuesToLabel = (body) => {
+  const commentsExcluded = body.replace(/<!--(.+?)-->/gs, ''); // remove comments
+  const matches = CLOSING_SYNTAX_PATTERNS.flatMap((pattern) =>
+    Array.from(commentsExcluded.matchAll(pattern)),
+  );
+  const issueNumbers = matches.map((match) => match[1]);
+  return [...new Set(issueNumbers)];
+};
+
 module.exports = async ({ context, github }) => {
   const { body } = context.payload.pull_request;
-  // Find a closing syntax after removing comments
-  const commentsExcluded = body.replace(/<!--(.+?)-->/gs, '');
-  const match = CLOSING_SYNTAX_PATTERNS.map((pattern) => commentsExcluded.match(pattern)).find(
-    (match) => match,
-  );
-  if (match) {
-    const issue_number = match[1];
-    const { owner, repo } = context.repo;
+  getIssuesToLabel(body).forEach(async (issue_number) => {
     await github.issues.addLabels({
       owner,
       repo,
       issue_number,
       labels: [HAS_CLOSING_PR_LABEL],
     });
-  }
+  });
 };
+
+const main = () => {
+  const body1 = 'Close #123';
+  console.log(getIssuesToLabel(body1));
+  const body2 = `
+Fix mlflow/mlflow#456
+Resolve https://github.com/mlflow/mlflow/issues/789
+`;
+  console.log(getIssuesToLabel(body2));
+};
+
+if (require.main === module) {
+  main();
+}


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#6190

## What changes are proposed in this pull request?

One PR can close multiple issues (e.g. https://github.com/mlflow/mlflow/pull/6206), but the closing-PR github action assumes one PR can close a single issue. This PR updates the body parsing logic to support extracting multiple issues.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

Manually tested by running:

```
node .github/workflows/closing-pr.js
```

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
