### PR TITLE
Patch model serving container for protobuf compatibility

### DIFF
--- a/mlflow/models/container/__init__.py
+++ b/mlflow/models/container/__init__.py
@@ -124,7 +124,7 @@ def _install_pyfunc_deps(model_path=None, install_mlflow=False, enable_mlserver=
 
     if has_env and install_mlflow:
         # Explicitly install protobuf==3.20.1 to replace any potential protobuf >= 4.0  versions
-        # preinstalled in the model serving container. This is necessary for compatibility with
+        # preinstalled in the model's conda environment. This is necessary for compatibility with
         # MLflow versions <= 1.26.0, which are incompatible with protobuf >= 4.0 but do not
         # explicitly require protobuf < 4.0 in the package requirements
         install_protobuf_cmd = ["pip install protobuf==3.20.1"]

--- a/mlflow/models/container/__init__.py
+++ b/mlflow/models/container/__init__.py
@@ -123,10 +123,10 @@ def _install_pyfunc_deps(model_path=None, install_mlflow=False, enable_mlserver=
         raise Exception("Failed to install serving dependencies into the model environment.")
 
     if has_env and install_mlflow:
-        # Explicitly install protobuf==3.20.1 to replace any potential protobuf >= 4.0  versions
-        # preinstalled in the model's conda environment. This is necessary for compatibility with
-        # MLflow versions <= 1.26.0, which are incompatible with protobuf >= 4.0 but do not
-        # explicitly require protobuf < 4.0 in the package requirements
+        # Explicitly install protobuf==3.20.1 before installing MLflow in the model's conda
+        # environment. Otherwise, installing MLflow <= 1.26.0 would install protobuf >= 4.0, which
+        # is not compatible with MLflow <= 1.26.0, because MLflow <= 1.26.0 does not place an
+        # upper bound on the protobuf library version in its requirements
         install_protobuf_cmd = ["pip install protobuf==3.20.1"]
         install_mlflow_cmd = [
             "pip install /opt/mlflow/."

--- a/mlflow/sagemaker/cli.py
+++ b/mlflow/sagemaker/cli.py
@@ -588,6 +588,12 @@ def build_and_push_container(build, push, container, mlflow_home):
             return "\n".join(
                 [
                     'ENV {disable_env}="false"',
+                    # Explicitly install protobuf==3.20.1 to replace any potential protobuf >= 4.0
+                    # versions preinstalled in the model serving container. This is necessary for
+                    # compatibility with MLflow versions <= 1.26.0, which are incompatible with
+                    # protobuf >= 4.0 but do not explicitly require protobuf < 4.0 in the package
+                    # requirements
+                    "RUN pip install protobuf==3.20.1",
                     'RUN python -c "from mlflow.models.container import _install_pyfunc_deps;'
                     '_install_pyfunc_deps(None, False)"',
                 ]

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ SKINNY_REQUIREMENTS = [
     "entrypoints",
     "gitpython>=2.1.0",
     "pyyaml>=5.1",
-    "protobuf>=3.7.0",
+    "protobuf>=3.7.0,<4",
     "pytz",
     "requests>=2.17.3",
     "packaging",


### PR DESCRIPTION
Signed-off-by: dbczumar <corey.zumar@databricks.com>

## What changes are proposed in this pull request?

The MLflow model serving container (& by extension, the SageMaker container) on MLflow <= 1.26.0 fails to initialize the model's conda environment due to a protobuf compatibility issue: during environment setup, `mlflow<=1.26.0` is installed (e.g. `mlflow==1.25.0` for containers built on MLflow 1.25, `mlfflow==1.24.0` for containers built on MLflow 1.24, etc.), which installs `protobuf>=4.0` because versions of MLflow <= 1.26.0 do not specify an upper bound for the protobuf library. Unfortunately, `protobuf>=4.0` is incompatible with `mlflow<=1.26.0` and causes `import mlflow` to fail.

This PR addresses the issue by explicitly installing `protobuf==3.20.1` in the container when MLflow is installed. This PR is initially filed against `branch-1.25`; it will be cherry-picked to the remaining release branches once it has been approved / merged.

## How is this patch tested?

Ran the following scripts / shell commands and confirmed that the model server starts properly: 

```
mlflow sagemaker build-and-push-container --mlflow-home ~/mlflow --no-push
```

```py
import mlflow.pyfunc

class Mod(mlflow.pyfunc.PythonModel):
    def predict(self, ctx, inp):
        return 7

model_uri = mlflow.pyfunc.log_model(
    python_model=Mod(),
    artifact_path="model",
).model_uri

print(model_uri)
```

```
mlflow sagemaker run-local -i mlflow-pyfunc -m runs:/af9c6109d53d48268da885b54bfb36f9/model
...
[2022-07-07 18:39:52 +0000] [226] [INFO] Starting gunicorn 20.1.0
[2022-07-07 18:39:52 +0000] [226] [INFO] Listening at: http://127.0.0.1:8000 (226)
[2022-07-07 18:39:52 +0000] [226] [INFO] Using worker: gevent
[2022-07-07 18:39:52 +0000] [239] [INFO] Booting worker with pid: 239
[2022-07-07 18:39:52 +0000] [240] [INFO] Booting worker with pid: 240
[2022-07-07 18:39:52 +0000] [241] [INFO] Booting worker with pid: 241
[2022-07-07 18:39:52 +0000] [242] [INFO] Booting worker with pid: 242
[2022-07-07 18:39:52 +0000] [243] [INFO] Booting worker with pid: 243
[2022-07-07 18:39:52 +0000] [244] [INFO] Booting worker with pid: 244
[2022-07-07 18:39:52 +0000] [245] [INFO] Booting worker with pid: 245
[2022-07-07 18:39:52 +0000] [246] [INFO] Booting worker with pid: 246
```

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
5. Click `Details` on the right to open the job page of CircleCI.
6. Click the `Artifacts` tab.
7. Click `docs/build/html/index.html`.
8. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [X] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
