### PR TITLE
Indicate that MLflow Pipelines requires Make in the docs

### DIFF
--- a/docs/source/pipelines.rst
+++ b/docs/source/pipelines.rst
@@ -35,6 +35,10 @@ from PyPI as follows:
   pip install mlflow[pipelines]
 
 .. note::
+  MLflow Pipelines requires Make, which may not be preinstalled on Windows systems. In order to use
+  MLflow Pipelines on Windows, you must install Make first.
+
+.. note::
   You can install MLflow Pipelines from a Databricks Notebook by running
   ``%pip install mlflow[pipelines]`` or install MLflow Pipelines on a Databricks Cluster
   by following the instructions at

--- a/docs/source/pipelines.rst
+++ b/docs/source/pipelines.rst
@@ -35,8 +35,8 @@ from PyPI as follows:
   pip install mlflow[pipelines]
 
 .. note::
-  MLflow Pipelines requires Make, which may not be preinstalled on Windows systems. In order to use
-  MLflow Pipelines on Windows, you must install Make first.
+  MLflow Pipelines requires Make, which may not be preinstalled on some systems (e.g. Windows).
+  Please ensure Make is installed before using MLflow Pipelines.
 
 .. note::
   You can install MLflow Pipelines from a Databricks Notebook by running


### PR DESCRIPTION
Signed-off-by: dbczumar <corey.zumar@databricks.com>

## Related Issues/PRs

#6201 

## What changes are proposed in this pull request?

Indicate that MLflow Pipelines requires Make in the docs

## How is this patch tested?

Manual inspection of docs

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

Update the installation instructions for MLflow Pipelines to specify that Make is required.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [X] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [X] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [X] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
