### PR TITLE
Implement `FileStore.search_experiments`

### DIFF
--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -1009,10 +1009,8 @@ def _get_search_experiments_filters(parsed_filters):
         comparator = f["comparator"]
         value = f["value"]
         if type_ == "attribute":
-            f = _comparator_to_func(comparator, value)
             filters.append(filter_by_attribute(key, comparator, value))
         elif type_ == "tag":
-            f = _comparator_to_func(comparator, value)
             filters.append(filter_by_tags(key, comparator, value))
         else:
             raise MlflowException.invalid_parameter_value(f"Invalid token type: {type_}")

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -998,7 +998,14 @@ def filter_by_attribute(key, comparator, value):
 
 def filter_by_tags(key, comparator, value):
     f = _comparator_to_func(comparator, value)
-    return lambda exp: any(f(tag[1]) for tag in filter(lambda tag: tag[0] == key, exp.tags.items()))
+
+    def func(exp):
+        val = exp.tags.get(key)
+        if val is not None:
+            return f(val)
+        return False
+
+    return func
 
 
 def _get_search_experiments_filters(parsed_filters):

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -401,7 +401,7 @@ class SearchUtils:
         return pattern.replace("_", ".").replace("%", ".*")
 
     @classmethod
-    def _does_match_clause(cls, run, sed):
+    def _does_run_match_clause(cls, run, sed):
         key_type = sed.get("type")
         key = sed.get("key")
         value = sed.get("value")
@@ -904,7 +904,7 @@ class SearchExperimentsUtils(SearchUtils):
         return False
 
     @classmethod
-    def _does_match_clause(cls, experiment, sed):  # pylint: disable=arguments-renamed
+    def _does_experiment_match_clause(cls, experiment, sed):  # pylint: disable=arguments-renamed
         key_type = sed.get("type")
         key = sed.get("key")
         value = sed.get("value")
@@ -929,6 +929,17 @@ class SearchExperimentsUtils(SearchUtils):
             return cls.filter_ops.get(comparator)(lhs, value)
         else:
             return False
+
+    @classmethod
+    def filter(cls, experiments, filter_string):  # pylint: disable=arguments-renamed
+        if not filter_string:
+            return experiments
+        parsed = cls.parse_search_filter(filter_string)
+
+        def experiment_matches(experiment):
+            return all(cls._does_experiment_match_clause(experiment, s) for s in parsed)
+
+        return list(filter(experiment_matches, experiments))
 
     @classmethod
     def _get_sort_key(cls, order_by_list):

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -945,9 +945,8 @@ class SearchExperimentsUtils(SearchUtils):
                 return other.obj < self.obj
 
         order_by = []
-        for type_, key, ascending in map(
-            cls.parse_order_by_for_search_experiments, order_by_list or []
-        ):
+        parsed_order_by = map(cls.parse_order_by_for_search_experiments, order_by_list or [])
+        for type_, key, ascending in parsed_order_by:
             if type_ == "attribute":
                 order_by.append((key, ascending))
             else:
@@ -957,8 +956,12 @@ class SearchExperimentsUtils(SearchUtils):
         if not any(key == "experiment_id" for key, _ in order_by):
             order_by.append(("experiment_id", False))
 
-        return lambda exp: tuple(
-            getattr(exp, k) if asc else _Reversor(getattr(exp, k)) for k, asc in order_by
+        def _apply_reversor(experiment, key, ascending):
+            attr = getattr(experiment, key)
+            return attr if ascending else _Reversor(attr)
+
+        return lambda experiment: tuple(
+            _apply_reversor(experiment, k, asc) for (k, asc) in order_by
         )
 
     @classmethod

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -952,18 +952,6 @@ class SearchExperimentsUtils(SearchUtils):
 
     @classmethod
     def _get_sort_key(cls, order_by_list):
-        # https://stackoverflow.com/a/56842689
-        class _Reversor:
-            def __init__(self, obj):
-                self.obj = obj
-
-            # Only need < and == are needed for use as a key parameter in the sorted function
-            def __eq__(self, other):
-                return other.obj == self.obj
-
-            def __lt__(self, other):
-                return other.obj < self.obj
-
         order_by = []
         parsed_order_by = map(cls.parse_order_by_for_search_experiments, order_by_list or [])
         for type_, key, ascending in parsed_order_by:
@@ -975,6 +963,18 @@ class SearchExperimentsUtils(SearchUtils):
         # Add a tie-breaker
         if not any(key == "experiment_id" for key, _ in order_by):
             order_by.append(("experiment_id", False))
+
+        # https://stackoverflow.com/a/56842689
+        class _Reversor:
+            def __init__(self, obj):
+                self.obj = obj
+
+            # Only need < and == are needed for use as a key parameter in the sorted function
+            def __eq__(self, other):
+                return other.obj == self.obj
+
+            def __lt__(self, other):
+                return other.obj < self.obj
 
         def _apply_reversor(experiment, key, ascending):
             attr = getattr(experiment, key)

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -434,16 +434,16 @@ class SearchUtils:
             return False
 
     @classmethod
-    def filter(cls, items, filter_string):
-        """Filters a set of items based on a search filter string."""
+    def filter(cls, runs, filter_string):
+        """Filters a set of runs based on a search filter string."""
         if not filter_string:
-            return items
+            return runs
         parsed = cls.parse_search_filter(filter_string)
 
-        def matches(item):
-            return all(cls._does_match_clause(item, s) for s in parsed)
+        def run_matches(run):
+            return all(cls._does_run_match_clause(run, s) for s in parsed)
 
-        return list(filter(matches, items))
+        return [run for run in runs if run_matches(run)]
 
     @classmethod
     def _validate_order_by_and_generate_token(cls, order_by):

--- a/tests/resources/mlflow-test-plugin/mlflow_test_plugin/file_store.py
+++ b/tests/resources/mlflow-test-plugin/mlflow_test_plugin/file_store.py
@@ -10,7 +10,3 @@ class PluginFileStore(FileStore):
         path = urllib.parse.urlparse(store_uri).path if store_uri else None
         self.is_plugin = True
         super().__init__(path, artifact_uri)
-
-    # Implement search_experiments to suppress pylint abstract-method error
-    def search_experiments(self, *args, **kwargs):
-        return super().search_experiments(*args, **kwargs)

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -53,7 +53,7 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
 
     def initialize(self):
         shutil.rmtree(self.test_root, ignore_errors=True)
-        self.store = self.get_store()
+        self.store = self.get_store()  # pylint: disable=attribute-defined-outside-init
 
     def setUp(self):
         self._create_root(TestFileStore.ROOT_LOCATION)

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -45,6 +45,16 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         fs = FileStore(self.test_root)
         return self._create_run(fs)
 
+    def create_experiments(self, experiment_names):
+        ids = []
+        for name in experiment_names:
+            ids.append(self.store.create_experiment(name))
+        return ids
+
+    def initialize(self):
+        shutil.rmtree(self.test_root, ignore_errors=True)
+        self.store = self.get_store()
+
     def setUp(self):
         self._create_root(TestFileStore.ROOT_LOCATION)
         self.maxDiff = None
@@ -161,6 +171,141 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         self.assertLessEqual(len(exps3), 500)
         if len(exps3) < 500:
             self.assertIsNone(exps3.token)
+
+    def test_search_experiments_view_type(self):
+        self.initialize()
+        experiment_names = ["a", "b"]
+        experiment_ids = self.create_experiments(experiment_names)
+        self.store.delete_experiment(experiment_ids[1])
+
+        experiments = self.store.search_experiments(view_type=ViewType.ACTIVE_ONLY)
+        assert [e.name for e in experiments] == ["a", "Default"]
+        experiments = self.store.search_experiments(view_type=ViewType.DELETED_ONLY)
+        assert [e.name for e in experiments] == ["b"]
+        experiments = self.store.search_experiments(view_type=ViewType.ALL)
+        assert [e.name for e in experiments] == ["b", "a", "Default"]
+
+    def test_search_experiments_filter_by_attribute(self):
+        self.initialize()
+        experiment_names = ["a", "ab", "Abc"]
+        self.create_experiments(experiment_names)
+
+        experiments = self.store.search_experiments(filter_string="name = 'a'")
+        assert [e.name for e in experiments] == ["a"]
+        experiments = self.store.search_experiments(filter_string="attribute.name = 'a'")
+        assert [e.name for e in experiments] == ["a"]
+        experiments = self.store.search_experiments(filter_string="attribute.`name` = 'a'")
+        assert [e.name for e in experiments] == ["a"]
+        experiments = self.store.search_experiments(filter_string="attribute.`name` != 'a'")
+        assert [e.name for e in experiments] == ["Abc", "ab", "Default"]
+        experiments = self.store.search_experiments(filter_string="name LIKE 'a%'")
+        assert [e.name for e in experiments] == ["ab", "a"]
+        experiments = self.store.search_experiments(filter_string="name ILIKE 'a%'")
+        assert [e.name for e in experiments] == ["Abc", "ab", "a"]
+        experiments = self.store.search_experiments(
+            filter_string="name ILIKE 'a%' AND name ILIKE '%b'"
+        )
+        assert [e.name for e in experiments] == ["ab"]
+
+    def test_search_experiments_filter_by_tag(self):
+        self.initialize()
+        experiments = [
+            ("exp1", [ExperimentTag("key", "value")]),
+            ("exp2", [ExperimentTag("key", "vaLue")]),
+            ("exp3", [ExperimentTag("k e y", "value")]),
+        ]
+        for name, tags in experiments:
+            self.store.create_experiment(name, tags=tags)
+
+        experiments = self.store.search_experiments(filter_string="tag.key = 'value'")
+        assert [e.name for e in experiments] == ["exp1"]
+        experiments = self.store.search_experiments(filter_string="tag.`k e y` = 'value'")
+        assert [e.name for e in experiments] == ["exp3"]
+        experiments = self.store.search_experiments(filter_string="tag.\"k e y\" = 'value'")
+        assert [e.name for e in experiments] == ["exp3"]
+        experiments = self.store.search_experiments(filter_string="tag.key != 'value'")
+        assert [e.name for e in experiments] == ["exp2"]
+        experiments = self.store.search_experiments(filter_string="tag.key LIKE 'val%'")
+        assert [e.name for e in experiments] == ["exp1"]
+        experiments = self.store.search_experiments(filter_string="tag.key LIKE '%Lue'")
+        assert [e.name for e in experiments] == ["exp2"]
+        experiments = self.store.search_experiments(filter_string="tag.key ILIKE '%alu%'")
+        assert [e.name for e in experiments] == ["exp2", "exp1"]
+        experiments = self.store.search_experiments(
+            filter_string="tag.key LIKE 'va%' AND tags.key LIKE '%Lue'"
+        )
+        assert [e.name for e in experiments] == ["exp2"]
+
+    def test_search_experiments_filter_by_attribute_and_tag(self):
+        self.initialize()
+        self.store.create_experiment(
+            "exp1", tags=[ExperimentTag("a", "1"), ExperimentTag("b", "2")]
+        )
+        self.store.create_experiment(
+            "exp2", tags=[ExperimentTag("a", "3"), ExperimentTag("b", "4")]
+        )
+        experiments = self.store.search_experiments(
+            filter_string="name ILIKE 'exp%' AND tag.a = '1'"
+        )
+        assert [e.name for e in experiments] == ["exp1"]
+
+    def test_search_experiments_order_by(self):
+        self.initialize()
+        experiment_names = ["x", "y", "z"]
+        self.create_experiments(experiment_names)
+
+        experiments = self.store.search_experiments(order_by=["name"])
+        assert [e.name for e in experiments] == ["Default", "x", "y", "z"]
+
+        experiments = self.store.search_experiments(order_by=["name ASC"])
+        assert [e.name for e in experiments] == ["Default", "x", "y", "z"]
+
+        experiments = self.store.search_experiments(order_by=["name DESC"])
+        assert [e.name for e in experiments] == ["z", "y", "x", "Default"]
+
+        experiments = self.store.search_experiments(order_by=["experiment_id DESC"])
+        assert [e.name for e in experiments] == ["z", "y", "x", "Default"]
+
+        experiments = self.store.search_experiments(order_by=["name", "experiment_id"])
+        assert [e.name for e in experiments] == ["Default", "x", "y", "z"]
+
+    def test_search_experiments_max_results(self):
+        self.initialize()
+        experiment_names = list(map(str, range(9)))
+        self.create_experiments(experiment_names)
+        reversed_experiment_names = experiment_names[::-1]
+
+        experiments = self.store.search_experiments()
+        assert [e.name for e in experiments] == reversed_experiment_names + ["Default"]
+        experiments = self.store.search_experiments(max_results=3)
+        assert [e.name for e in experiments] == reversed_experiment_names[:3]
+
+    def test_search_experiments_max_results_validation(self):
+        self.initialize()
+        with pytest.raises(MlflowException, match=r"It must be a positive integer, but got None"):
+            self.store.search_experiments(max_results=None)
+        with pytest.raises(MlflowException, match=r"It must be a positive integer, but got 0"):
+            self.store.search_experiments(max_results=0)
+        with pytest.raises(MlflowException, match=r"It must be at most \d+, but got 1000000"):
+            self.store.search_experiments(max_results=1_000_000)
+
+    def test_search_experiments_pagination(self):
+        self.initialize()
+        experiment_names = list(map(str, range(9)))
+        self.create_experiments(experiment_names)
+        reversed_experiment_names = experiment_names[::-1]
+
+        experiments = self.store.search_experiments(max_results=4)
+        assert [e.name for e in experiments] == reversed_experiment_names[:4]
+        assert experiments.token is not None
+
+        experiments = self.store.search_experiments(max_results=4, page_token=experiments.token)
+        assert [e.name for e in experiments] == reversed_experiment_names[4:8]
+        assert experiments.token is not None
+
+        experiments = self.store.search_experiments(max_results=4, page_token=experiments.token)
+        assert [e.name for e in experiments] == reversed_experiment_names[8:] + ["Default"]
+        assert experiments.token is None
 
     def _verify_experiment(self, fs, exp_id):
         exp = fs.get_experiment(exp_id)


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#6096

## What changes are proposed in this pull request?

Implement `FileStore.search_experiments`.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
