### PR TITLE
Jasperhg90feat pipeline yaml arg

### DIFF
--- a/mlflow/pipelines/cli.py
+++ b/mlflow/pipelines/cli.py
@@ -19,6 +19,18 @@ _CLI_ARG_PIPELINE_PROFILE = click.option(
 )
 
 
+_CLI_ARG_PIPELINE_FILE_NAME = click.option(
+    "--pipeline_file_name",
+    type=click.STRING,
+    default="pipeline.yaml",
+    required=False,
+    help=(
+        "The name of the pipeline YAML file to use. If not provided, will default to" +
+        " 'pipeline.yaml'"
+    ),    
+)
+
+
 @click.group("pipelines")
 def commands():
     """
@@ -37,13 +49,14 @@ def commands():
     help="The name of the pipeline step to run.",
 )
 @_CLI_ARG_PIPELINE_PROFILE
+@_CLI_ARG_PIPELINE_FILE_NAME
 @experimental("command")
-def run(step, profile):
+def run(step, profile, pipeline_file_name):
     """
     Run the full pipeline, or run a particular pipeline step if specified, producing
     outputs and displaying a summary of results upon completion.
     """
-    Pipeline(profile=profile).run(step)
+    Pipeline(profile=profile, pipeline_file_name=pipeline_file_name).run(step)
 
 
 @commands.command(
@@ -61,14 +74,15 @@ def run(step, profile):
     help="The name of the pipeline step for which to remove cached outputs.",
 )
 @_CLI_ARG_PIPELINE_PROFILE
+@_CLI_ARG_PIPELINE_FILE_NAME
 @experimental("command")
-def clean(step, profile):
+def clean(step, profile, pipeline_file_name):
     """
     Remove all pipeline outputs from the cache, or remove the cached outputs of a particular
     pipeline step if specified. After cached outputs are cleaned for a particular step, the step
     will be re-executed in its entirety the next time it is run.
     """
-    Pipeline(profile=profile).clean(step)
+    Pipeline(profile=profile, pipeline_file_name=pipeline_file_name).clean(step)
 
 
 @commands.command(
@@ -85,11 +99,12 @@ def clean(step, profile):
     help="The name of the pipeline step to inspect.",
 )
 @_CLI_ARG_PIPELINE_PROFILE
+@_CLI_ARG_PIPELINE_FILE_NAME
 @experimental("command")
-def inspect(step, profile):
+def inspect(step, profile, pipeline_file_name):
     """
     Display a visual overview of the pipeline graph, or display a summary of results from a
     particular pipeline step if specified. If the specified step has not been executed,
     nothing is displayed.
     """
-    Pipeline(profile=profile).inspect(step)
+    Pipeline(profile=profile, pipeline_file_name=pipeline_file_name).inspect(step)

--- a/mlflow/pipelines/pipeline.py
+++ b/mlflow/pipelines/pipeline.py
@@ -29,7 +29,7 @@ class _BasePipeline:
     """
 
     @experimental
-    def __init__(self, pipeline_root_path: str, profile: str, pipeline_name: str = "pipeline.yaml") -> None:
+    def __init__(self, pipeline_root_path: str, profile: str, pipeline_file_name: str = "pipeline.yaml") -> None:
         """
         Pipeline base class.
 
@@ -44,7 +44,7 @@ class _BasePipeline:
         """
         self._pipeline_root_path = pipeline_root_path
         self._profile = profile
-        self._pipeline_name = pipeline_name
+        self._pipeline_file_name = pipeline_file_name
         self._name = get_pipeline_name(pipeline_root_path)
         self._steps = self._resolve_pipeline_steps()
 
@@ -209,7 +209,7 @@ class Pipeline:
     """
 
     @experimental
-    def __new__(cls, profile: str, pipeline_name: str = "pipeline.yaml") -> RegressionPipeline:
+    def __new__(cls, profile: str, pipeline_file_name: str = "pipeline.yaml") -> RegressionPipeline:
         """
         Creates an instance of an MLflow Pipeline for a particular ML problem or MLOps task based
         on the current working directory and supplied configuration. The current working directory
@@ -220,7 +220,7 @@ class Pipeline:
                         task-specific pipeline. Profiles customize the configuration of
                         one or more pipeline steps, and pipeline executions with different profiles
                         often produce different results.
-        :param pipeline_name: The name of the pipeline file. If none is provided, pipeline.yaml will 
+        :param pipeline_file_name: The name of the pipeline file. If none is provided, pipeline.yaml will 
                               be used.
         :return: A pipeline for a particular ML problem or MLOps task. For example, an instance of
                  :py:class:`RegressionPipeline
@@ -245,7 +245,7 @@ class Pipeline:
 
         pipeline_root_path = get_pipeline_root_path()
         pipeline_config = get_pipeline_config(
-            pipeline_root_path=pipeline_root_path, profile=profile, pipeline_name=pipeline_name
+            pipeline_root_path=pipeline_root_path, profile=profile, pipeline_file_name=pipeline_file_name
         )
         template = pipeline_config.get("template")
         if template is None:

--- a/mlflow/pipelines/pipeline.py
+++ b/mlflow/pipelines/pipeline.py
@@ -44,6 +44,7 @@ class _BasePipeline:
         """
         self._pipeline_root_path = pipeline_root_path
         self._profile = profile
+        self._pipeline_name = pipeline_name
         self._name = get_pipeline_name(pipeline_root_path)
         self._steps = self._resolve_pipeline_steps()
 
@@ -208,7 +209,7 @@ class Pipeline:
     """
 
     @experimental
-    def __new__(cls, profile: str) -> RegressionPipeline:
+    def __new__(cls, profile: str, pipeline_name: str = "pipeline.yaml") -> RegressionPipeline:
         """
         Creates an instance of an MLflow Pipeline for a particular ML problem or MLOps task based
         on the current working directory and supplied configuration. The current working directory
@@ -219,6 +220,8 @@ class Pipeline:
                         task-specific pipeline. Profiles customize the configuration of
                         one or more pipeline steps, and pipeline executions with different profiles
                         often produce different results.
+        :param pipeline_name: The name of the pipeline file. If none is provided, pipeline.yaml will 
+                              be used.
         :return: A pipeline for a particular ML problem or MLOps task. For example, an instance of
                  :py:class:`RegressionPipeline
                  <mlflow.pipelines.regression.v1.pipeline.RegressionPipeline>`

--- a/mlflow/pipelines/pipeline.py
+++ b/mlflow/pipelines/pipeline.py
@@ -17,7 +17,7 @@ from mlflow.pipelines.utils.step import display_html
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, INTERNAL_ERROR, BAD_REQUEST
 from mlflow.utils.annotations import experimental
 from mlflow.utils.class_utils import _get_class_from_string
-from typing import List
+from typing import List, Optional
 
 _logger = logging.getLogger(__name__)
 
@@ -206,7 +206,7 @@ class Pipeline:
     """
 
     @experimental
-    def __new__(cls, profile: str) -> RegressionPipeline:
+    def __new__(cls, profile: str, pipeline_name: Optional[str] = None) -> RegressionPipeline:
         """
         Creates an instance of an MLflow Pipeline for a particular ML problem or MLOps task based
         on the current working directory and supplied configuration. The current working directory
@@ -217,6 +217,8 @@ class Pipeline:
                         task-specific pipeline. Profiles customize the configuration of
                         one or more pipeline steps, and pipeline executions with different profiles
                         often produce different results.
+        :param pipeline_name: The name of the pipeline file. If none is provided, pipeline.yaml will 
+                              be used.
         :return: A pipeline for a particular ML problem or MLOps task. For example, an instance of
                  :py:class:`RegressionPipeline
                  <mlflow.pipelines.regression.v1.pipeline.RegressionPipeline>`
@@ -240,7 +242,7 @@ class Pipeline:
 
         pipeline_root_path = get_pipeline_root_path()
         pipeline_config = get_pipeline_config(
-            pipeline_root_path=pipeline_root_path, profile=profile
+            pipeline_root_path=pipeline_root_path, profile=profile, pipeline_name=pipeline_name
         )
         template = pipeline_config.get("template")
         if template is None:

--- a/mlflow/pipelines/pipeline.py
+++ b/mlflow/pipelines/pipeline.py
@@ -29,7 +29,7 @@ class _BasePipeline:
     """
 
     @experimental
-    def __init__(self, pipeline_root_path: str, profile: str) -> None:
+    def __init__(self, pipeline_root_path: str, profile: str, pipeline_name: str = "pipeline.yaml") -> None:
         """
         Pipeline base class.
 
@@ -39,6 +39,8 @@ class _BasePipeline:
         :param profile: String specifying the profile name, with which
                         {pipeline_root_path}/profiles/{profile}.yaml is read and merged with
                         pipeline.yaml to generate the configuration to run the pipeline.
+        :param pipeline_name: The name of the pipeline file. If none is provided, pipeline.yaml will 
+                              be used.
         """
         self._pipeline_root_path = pipeline_root_path
         self._profile = profile
@@ -206,7 +208,7 @@ class Pipeline:
     """
 
     @experimental
-    def __new__(cls, profile: str, pipeline_name: Optional[str] = None) -> RegressionPipeline:
+    def __new__(cls, profile: str) -> RegressionPipeline:
         """
         Creates an instance of an MLflow Pipeline for a particular ML problem or MLOps task based
         on the current working directory and supplied configuration. The current working directory
@@ -217,8 +219,6 @@ class Pipeline:
                         task-specific pipeline. Profiles customize the configuration of
                         one or more pipeline steps, and pipeline executions with different profiles
                         often produce different results.
-        :param pipeline_name: The name of the pipeline file. If none is provided, pipeline.yaml will 
-                              be used.
         :return: A pipeline for a particular ML problem or MLOps task. For example, an instance of
                  :py:class:`RegressionPipeline
                  <mlflow.pipelines.regression.v1.pipeline.RegressionPipeline>`

--- a/mlflow/pipelines/utils/__init__.py
+++ b/mlflow/pipelines/utils/__init__.py
@@ -15,7 +15,7 @@ _PIPELINE_PROFILE_ENV_VAR = "MLFLOW_PIPELINES_PROFILE"
 _logger = logging.getLogger(__name__)
 
 
-def get_pipeline_name(pipeline_root_path: str = None) -> str:
+def get_pipeline_name(pipeline_root_path: str = None, pipeline_name: str = None) -> str:
     """
     Obtains the name of the specified pipeline or of the pipeline corresponding to the current
     working directory.
@@ -28,25 +28,30 @@ def get_pipeline_name(pipeline_root_path: str = None) -> str:
                              working directory does not correspond to a pipeline.
     :return: The name of the specified pipeline.
     """
-    pipeline_root_path = pipeline_root_path or get_pipeline_root_path()
+    pipeline_root_path = pipeline_root_path or get_pipeline_root_path(pipeline_name=pipeline_name)
     _verify_is_pipeline_root_directory(pipeline_root_path=pipeline_root_path)
     return os.path.basename(pipeline_root_path)
 
 
-def get_pipeline_config(pipeline_root_path: str = None, profile: str = None) -> Dict[str, Any]:
+def get_pipeline_config(pipeline_root_path: str = None, profile: str = None, pipeline_name: str = None) -> Dict[str, Any]:
     """
     Obtains a dictionary representation of the configuration for the specified pipeline.
 
     :param pipeline_root_path: The absolute path of the pipeline root directory on the local
                                filesystem. If unspecified, the pipeline root directory is
                                resolved from the current working directory, and an
+    :param pipeline_name: The filename of the pipeline to load. If None is provided,
+                          pipeline.yaml will be used.
     :raises MlflowException: If the specified ``pipeline_root_path`` is not a pipeline root
                              directory or if ``pipeline_root_path`` is ``None`` and the current
                              working directory does not correspond to a pipeline.
     :return: The configuration of the specified pipeline.
     """
-    pipeline_root_path = pipeline_root_path or get_pipeline_root_path()
+    pipeline_root_path = pipeline_root_path or get_pipeline_root_path(pipeline_name)
     _verify_is_pipeline_root_directory(pipeline_root_path=pipeline_root_path)
+
+    if pipeline_name is None:
+        pipeline_name = _PIPELINE_CONFIG_FILE_NAME
     try:
         if profile:
             profile_file_path = os.path.join(
@@ -59,10 +64,10 @@ def get_pipeline_config(pipeline_root_path: str = None, profile: str = None) -> 
                     error_code=INVALID_PARAMETER_VALUE,
                 )
             return render_and_merge_yaml(
-                pipeline_root_path, _PIPELINE_CONFIG_FILE_NAME, profile_file_path
+                pipeline_root_path, pipeline_name, profile_file_path
             )
         else:
-            return read_yaml(pipeline_root_path, _PIPELINE_CONFIG_FILE_NAME)
+            return read_yaml(pipeline_root_path, pipeline_name)
     except MlflowException:
         raise
     except Exception as e:
@@ -75,12 +80,14 @@ def get_pipeline_config(pipeline_root_path: str = None, profile: str = None) -> 
         ) from e
 
 
-def get_pipeline_root_path() -> str:
+def get_pipeline_root_path(pipeline_name: str = None) -> str:
     """
     Obtains the path of the pipeline corresponding to the current working directory, throwing an
     ``MlflowException`` if the current working directory does not reside within a pipeline
     directory.
 
+    :param pipeline_name: The filename of the pipeline to check for. If None is provided,
+                          pipeline.yaml will be used.
     :return: The absolute path of the pipeline root directory on the local filesystem.
     """
     # In the release version of MLflow Pipelines, each pipeline will be its own git repository.
@@ -89,9 +96,10 @@ def get_pipeline_root_path() -> str:
     # development purposes finds the first `pipeline.yaml` file by traversing up the directory
     # tree, while the release version will find the pipeline repository root (commented out below)
     curr_dir_path = pathlib.Path.cwd()
-
+    if pipeline_name is None:
+        pipeline_name = _PIPELINE_CONFIG_FILE_NAME
     while True:
-        pipeline_yaml_path_to_check = curr_dir_path / _PIPELINE_CONFIG_FILE_NAME
+        pipeline_yaml_path_to_check = curr_dir_path / pipeline_name
         if pipeline_yaml_path_to_check.exists():
             return str(curr_dir_path.resolve())
         elif curr_dir_path != curr_dir_path.parent:
@@ -100,7 +108,7 @@ def get_pipeline_root_path() -> str:
             # If curr_dir_path == curr_dir_path.parent,
             # we have reached the root directory without finding
             # the desired pipeline.yaml file
-            raise MlflowException(f"Failed to find {_PIPELINE_CONFIG_FILE_NAME}!")
+            raise MlflowException(f"Failed to find {pipeline_name}!")
 
 
 def get_default_profile() -> str:
@@ -113,7 +121,7 @@ def get_default_profile() -> str:
     return "databricks" if is_in_databricks_runtime() else "local"
 
 
-def _verify_is_pipeline_root_directory(pipeline_root_path: str) -> str:
+def _verify_is_pipeline_root_directory(pipeline_root_path: str, pipeline_name: str = None) -> str:
     """
     Verifies that the specified local filesystem path is the path of a pipeline root directory.
 
@@ -122,8 +130,10 @@ def _verify_is_pipeline_root_directory(pipeline_root_path: str) -> str:
     :raises MlflowException: If the specified ``pipeline_root_path`` is not a pipeline root
                              directory.
     """
-    pipeline_yaml_path = os.path.join(pipeline_root_path, _PIPELINE_CONFIG_FILE_NAME)
+    if pipeline_name is None:
+        pipeline_name = _PIPELINE_CONFIG_FILE_NAME
+    pipeline_yaml_path = os.path.join(pipeline_root_path, pipeline_name)
     if not os.path.exists(pipeline_yaml_path):
         raise MlflowException(
-            f"Failed to find {_PIPELINE_CONFIG_FILE_NAME} in {pipeline_yaml_path}!"
+            f"Failed to find {pipeline_name} in {pipeline_yaml_path}!"
         )

--- a/mlflow/pipelines/utils/__init__.py
+++ b/mlflow/pipelines/utils/__init__.py
@@ -23,6 +23,8 @@ def get_pipeline_name(pipeline_root_path: str = None, pipeline_name: str = None)
     :param pipeline_root_path: The absolute path of the pipeline root directory on the local
                                filesystem. If unspecified, the pipeline root directory is
                                resolved from the current working directory.
+    :param pipeline_name: The filename of the pipeline to load. If None is provided,
+                          pipeline.yaml will be used.
     :raises MlflowException: If the specified ``pipeline_root_path`` is not a pipeline root
                              directory or if ``pipeline_root_path`` is ``None`` and the current
                              working directory does not correspond to a pipeline.

--- a/tests/pipelines/test_pipeline.py
+++ b/tests/pipelines/test_pipeline.py
@@ -56,6 +56,17 @@ def test_create_pipeline_fails_with_empty_profile_name(empty_profile):
 
 
 @pytest.mark.usefixtures("enter_pipeline_example_directory")
+def test_create_pipeline_custom_yaml_file_works():
+    p = Pipeline(profile="local", pipeline_file_name="pipeline_train.yaml")
+
+
+@pytest.mark.usefixtures("enter_pipeline_example_directory")
+def test_create_pipeline_custom_yaml_file_fails():
+    with pytest.raises(MlflowException, match="Yaml file"):
+        p = Pipeline(profile="local", pipeline_file_name="pipeline_inference.yaml")
+
+
+@pytest.mark.usefixtures("enter_pipeline_example_directory")
 @pytest.mark.parametrize("custom_execution_directory", [None, "custom"])
 def test_pipelines_execution_directory_is_managed_as_expected(
     custom_execution_directory, enter_pipeline_example_directory, tmp_path

--- a/tests/pipelines/test_pipeline.py
+++ b/tests/pipelines/test_pipeline.py
@@ -57,7 +57,7 @@ def test_create_pipeline_fails_with_empty_profile_name(empty_profile):
 
 @pytest.mark.usefixtures("enter_pipeline_example_directory")
 def test_create_pipeline_custom_yaml_file_works():
-    p = Pipeline(profile="local", pipeline_file_name="pipeline_train.yaml")
+    p = Pipeline(profile="local", pipeline_file_name="pipeline.yaml")
 
 
 @pytest.mark.usefixtures("enter_pipeline_example_directory")


### PR DESCRIPTION
## Related Issues/PRs

This PR closes #6209. 

## What changes are proposed in this pull request?

This PR adds a 'pipeline_yaml_file' input argument for MLFlow pipelines such that the user can specify which pipeline should be used in case that there are multiple pipelines in the same directory. The input argument defaults to 'pipeline.yaml'. We also added this to the CLI.

## How is this patch tested?

We added the default pipeline name to an [existing test](https://github.com/JasperHG90/mlflow/blob/master/tests/pipelines/test_pipeline.py#L58-L66) and added a test that should fail because it is looking for a pipeline that does not exist.

## Does this PR change the documentation?

No.

## Release Notes

### Is this a user-facing change?

Yes. Users can pass the name of their pipeline to the `Pipeline` class. Previously, this was not possible.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components

- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes