### PR TITLE
adding examples for tags in create_experiment and start_run

### DIFF
--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -581,6 +581,7 @@ class MlflowClient:
 
         .. code-block:: python
             :caption: Example
+
             from pathlib import Path
             from mlflow import MlflowClient
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -581,14 +581,14 @@ class MlflowClient:
 
         .. code-block:: python
             :caption: Example
-
+            from pathlib import Path
             from mlflow import MlflowClient
 
             # Create an experiment with a name that is unique and case sensitive.
             client = MlflowClient()
             experiment_id = client.create_experiment(
                 "Social NLP Experiments",
-                artifact_location="file:///absolute-path/mlruns",
+                artifact_location=Path.cwd().joinpath("mlruns").as_uri(),
                 tags={"version": "v1", "priority": "P1"},
             )
             client.set_experiment_tag(experiment_id, "nlp.framework", "Spark NLP")
@@ -606,8 +606,8 @@ class MlflowClient:
 
             Name: Social NLP Experiments
             Experiment_id: 1
-            Artifact Location: file:///.../mlruns/1
-            Tags: {'nlp.framework': 'Spark NLP'}
+            Artifact Location: file:///.../mlruns
+            Tags: {'version': 'v1', 'priority': 'P1', 'nlp.framework': 'Spark NLP'}
             Lifecycle_stage: active
         """
         return self._tracking_client.create_experiment(name, artifact_location, tags)

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -586,7 +586,11 @@ class MlflowClient:
 
             # Create an experiment with a name that is unique and case sensitive.
             client = MlflowClient()
-            experiment_id = client.create_experiment("Social NLP Experiments")
+            experiment_id = client.create_experiment(
+                "Social NLP Experiments",
+                artifact_location="file:///absolute-path/mlruns",
+                tags={"version": "v1", "priority": "P1"},
+            )
             client.set_experiment_tag(experiment_id, "nlp.framework", "Spark NLP")
 
             # Fetch experiment metadata information

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -244,7 +244,7 @@ def start_run(
         print("child run:")
         print("run_id : {}".format(child_run.info.run_id))
         print("--")
-        print("Child runs of parent run_id: {}".format(parent_run.info.run_id))
+        print("Child runs of parent run")
 
         # Search all child runs with a parent id
         query = "tags.mlflow.parentRunId = '{}'".format(parent_run.info.run_id)

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -244,11 +244,11 @@ def start_run(
         print("child run:")
         print("run_id : {}".format(child_run.info.run_id))
         print("--")
-        print("child runs of parent run")
 
         # Search all child runs with a parent id
         query = "tags.mlflow.parentRunId = '{}'".format(parent_run.info.run_id)
         results = mlflow.search_runs(filter_string=query)
+        print("child runs:")
         print(results[["run_id", "params.child", "tags.mlflow.runName"]])
 
     .. code-block:: text

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -247,7 +247,7 @@ def start_run(
 
         # Search all child runs with a parent id
         query = "tags.mlflow.parentRunId = '{}'".format(parent_run.info.run_id)
-        results = mlflow.search_runs(filter_string=query)
+        results = mlflow.search_runs(experiment_ids=[experiment_id], filter_string=query)
         print("child runs:")
         print(results[["run_id", "params.child", "tags.mlflow.runName"]])
 

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -244,7 +244,7 @@ def start_run(
         print("child run:")
         print("run_id : {}".format(child_run.info.run_id))
         print("--")
-        print("Child runs of parent run")
+        print("child runs of parent run")
 
         # Search all child runs with a parent id
         query = "tags.mlflow.parentRunId = '{}'".format(parent_run.info.run_id)

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -223,13 +223,13 @@ def start_run(
             run_name="PARENT_RUN",
             experiment_id=experiment_id,
             tags={"version": "v1", "priority": "P1"},
-            description="starting a parent for experiment {}".format(experiment_id),
+            description="parent",
         ) as parent_run:
             mlflow.log_param("parent", "yes")
             with mlflow.start_run(
                 run_name="CHILD_RUN",
                 experiment_id=experiment_id,
-                description="child run of parent run: {}".format(parent_run.info.run_id),
+                description="child",
                 nested=True,
             ) as child_run:
                 mlflow.log_param("child", "yes")
@@ -1212,7 +1212,7 @@ def create_experiment(
         Name: Social NLP Experiments
         Experiment_id: 1
         Artifact Location: file:///.../mlruns
-        Tags: {'version': 'v1', 'priority': 'P1', 'nlp.framework': 'Spark NLP'}
+        Tags: {'version': 'v1', 'priority': 'P1'}
         Lifecycle_stage: active
     """
     return MlflowClient().create_experiment(name, artifact_location, tags)

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -234,9 +234,17 @@ def start_run(
             ) as child_run:
                 mlflow.log_param("child", "yes")
 
-        print("parent run_id: {}".format(parent_run.info.run_id))
-        print("child run_id : {}".format(child_run.info.run_id))
+        print("parent run:")
+
+        print("run_id: {}".format(parent_run.info.run_id))
+        print("description: {}".format(parent_run.data.tags.get("mlflow.note.content")))
+        print("version tag value: {}".format(parent_run.data.tags.get("version")))
+        print("priority tag value: {}".format(parent_run.data.tags.get("priority")))
         print("--")
+        print("child run:")
+        print("run_id : {}".format(child_run.info.run_id))
+        print("--")
+        print("Child runs of parent run_id: {}".format(parent_run.info.run_id))
 
         # Search all child runs with a parent id
         query = "tags.mlflow.parentRunId = '{}'".format(parent_run.info.run_id)
@@ -246,11 +254,19 @@ def start_run(
     .. code-block:: text
         :caption: Output
 
-        parent run_id: 5ec0e7ae18f54c2694ffb48c2fccf25c
-        child run_id : 78b3b0d264b44cd29e8dc389749bb4be
+        parent run:
+        run_id: 8979459433a24a52ab3be87a229a9cdf
+        description: starting a parent for experiment 7
+        version tag value: v1
+        priority tag value: P1
+        --
+        child run:
+        run_id : 7d175204675e40328e46d9a6a5a7ee6a
+        --
+        Child runs of parent run_id: 8979459433a24a52ab3be87a229a9cdf
         --
                                      run_id params.child tags.mlflow.runName
-        0  78b3b0d264b44cd29e8dc389749bb4be          yes           CHILD_RUN
+        0  7d175204675e40328e46d9a6a5a7ee6a          yes           CHILD_RUN
     """
     global _active_run_stack
     _validate_experiment_id_type(experiment_id)
@@ -1175,11 +1191,12 @@ def create_experiment(
         :caption: Example
 
         import mlflow
+        from pathlib import Path
 
         # Create an experiment name, which must be unique and case sensitive
         experiment_id = mlflow.create_experiment(
             "Social NLP Experiments",
-            artifact_location="file:///absolute-path/mlruns",
+            artifact_location=Path.cwd().joinpath("mlruns").as_uri(),
             tags={"version": "v1", "priority": "P1"},
         )
         experiment = mlflow.get_experiment(experiment_id)
@@ -1194,8 +1211,8 @@ def create_experiment(
 
         Name: Social NLP Experiments
         Experiment_id: 1
-        Artifact Location: file:///.../mlruns/1
-        Tags= {}
+        Artifact Location: file:///.../mlruns
+        Tags: {'version': 'v1', 'priority': 'P1', 'nlp.framework': 'Spark NLP'}
         Lifecycle_stage: active
     """
     return MlflowClient().create_experiment(name, artifact_location, tags)

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -218,9 +218,20 @@ def start_run(
         import mlflow
 
         # Create nested runs
-        with mlflow.start_run(run_name='PARENT_RUN') as parent_run:
+        experiment_id = mlflow.create_experiment("experiment1")
+        with mlflow.start_run(
+            run_name="PARENT_RUN",
+            experiment_id=experiment_id,
+            tags={"version": "v1", "priority": "P1"},
+            description="starting a parent for experiment {}".format(experiment_id),
+        ) as parent_run:
             mlflow.log_param("parent", "yes")
-            with mlflow.start_run(run_name='CHILD_RUN', nested=True) as child_run:
+            with mlflow.start_run(
+                run_name="CHILD_RUN",
+                experiment_id=experiment_id,
+                description="child run of parent run: {}".format(parent_run.info.run_id),
+                nested=True,
+            ) as child_run:
                 mlflow.log_param("child", "yes")
 
         print("parent run_id: {}".format(parent_run.info.run_id))
@@ -1166,7 +1177,11 @@ def create_experiment(
         import mlflow
 
         # Create an experiment name, which must be unique and case sensitive
-        experiment_id = mlflow.create_experiment("Social NLP Experiments")
+        experiment_id = mlflow.create_experiment(
+            "Social NLP Experiments",
+            artifact_location="file:///absolute-path/mlruns",
+            tags={"version": "v1", "priority": "P1"},
+        )
         experiment = mlflow.get_experiment(experiment_id)
         print("Name: {}".format(experiment.name))
         print("Experiment_id: {}".format(experiment.experiment_id))

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -263,8 +263,7 @@ def start_run(
         child run:
         run_id : 7d175204675e40328e46d9a6a5a7ee6a
         --
-        Child runs of parent run_id: 8979459433a24a52ab3be87a229a9cdf
-        --
+        child runs:
                                      run_id params.child tags.mlflow.runName
         0  7d175204675e40328e46d9a6a5a7ee6a          yes           CHILD_RUN
     """

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -241,9 +241,6 @@ def start_run(
         print("version tag value: {}".format(parent_run.data.tags.get("version")))
         print("priority tag value: {}".format(parent_run.data.tags.get("priority")))
         print("--")
-        print("child run:")
-        print("run_id : {}".format(child_run.info.run_id))
-        print("--")
 
         # Search all child runs with a parent id
         query = "tags.mlflow.parentRunId = '{}'".format(parent_run.info.run_id)
@@ -259,9 +256,6 @@ def start_run(
         description: starting a parent for experiment 7
         version tag value: v1
         priority tag value: P1
-        --
-        child run:
-        run_id : 7d175204675e40328e46d9a6a5a7ee6a
         --
         child runs:
                                      run_id params.child tags.mlflow.runName


### PR DESCRIPTION
## Related Issues/PRs

closes #6101 

## What changes are proposed in this pull request?
expanded examples for `create_experiment` and `start_run` to have tags, descriptions

## How is this patch tested?

- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.


## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [x] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
