### PR TITLE
Supporting to add registry URI for multi workspace support to register model to a different workspace

### DIFF
--- a/mlflow/pipelines/steps/register.py
+++ b/mlflow/pipelines/steps/register.py
@@ -38,6 +38,7 @@ class RegisterStep(BaseStep):
             )
         self.register_model_name = self.step_config["model_name"]
         self.allow_non_validated_model = self.step_config.get("allow_non_validated_model", False)
+        self.registry_uri = self.step_config.get("registry_uri", None)
 
     def _run(self, output_directory):
         apply_pipeline_tracking_config(self.tracking_config)
@@ -66,6 +67,8 @@ class RegisterStep(BaseStep):
             self.model_uri = "runs:/{run_id}/{artifact_path}".format(
                 run_id=run_id, artifact_path=artifact_path
             )
+            if self.registry_uri:
+                mlflow.set_registry_uri(self.registry_uri)
             self.model_details = mlflow.register_model(
                 model_uri=self.model_uri,
                 name=self.register_model_name,

--- a/tests/pipelines/test_register_step.py
+++ b/tests/pipelines/test_register_step.py
@@ -54,6 +54,7 @@ steps:
         threshold: 1_000_000
   register:
     model_name: "demo_model"
+    registry_uri: "sqlite:////tmp/registry.db"
     {allow_non_validated_model}
 metrics:
   custom:
@@ -92,6 +93,7 @@ def weighted_mean_squared_error(eval_df, builtin_metrics):
     assert model_validation_status_path.exists()
     expected_status = "REJECTED" if mae_threshold < 0 else "VALIDATED"
     assert model_validation_status_path.read_text() == expected_status
+    assert mlflow.get_registry_uri() == "sqlite:////tmp/registry.db"
     assert len(mlflow.tracking.MlflowClient().list_registered_models()) == (
         1 if expected_status == "VALIDATED" else 0
     )


### PR DESCRIPTION
## What changes are proposed in this pull request?
Supporting to add registry URI for multi workspace support to register model to a different workspace

## How is this patch tested?
- [x] Added test to make sure that `set_registry_uri` was called

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
