### PR TITLE
Remove comments and empty lines in requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,15 @@ def package_files(directory):
     return paths
 
 
+def is_comment_or_empty(line):
+    stripped = line.strip()
+    return stripped == "" or stripped.startswith("#")
+
+
+def remove_comments_and_empty_lines(lines):
+    return [line for line in lines if not is_comment_or_empty(line)]
+
+
 # Prints out a set of paths (relative to the mlflow/ directory) of files in mlflow/server/js/build
 # to include in the wheel, e.g. "../mlflow/server/js/build/index.html"
 js_files = package_files("mlflow/server/js/build")
@@ -45,7 +54,7 @@ Model Registry, as well as support for Project execution against local backends
 and Databricks.
 """
 with open(os.path.join("requirements", "skinny-requirements.txt"), "r") as f:
-    SKINNY_REQUIREMENTS = f.readlines()
+    SKINNY_REQUIREMENTS = remove_comments_and_empty_lines(f.read().splitlines())
 
 
 """
@@ -55,7 +64,7 @@ Server & UI. It also adds project backends such as Docker and Kubernetes among
 other capabilities.
 """
 with open(os.path.join("requirements", "core-requirements.txt"), "r") as f:
-    CORE_REQUIREMENTS = SKINNY_REQUIREMENTS + f.readlines()
+    CORE_REQUIREMENTS = SKINNY_REQUIREMENTS + remove_comments_and_empty_lines(f.read().splitlines())
 
 _is_mlflow_skinny = bool(os.environ.get(_MLFLOW_SKINNY_ENV_VAR))
 logging.debug("{} env var is set: {}".format(_MLFLOW_SKINNY_ENV_VAR, _is_mlflow_skinny))


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

`SKINNY_REQUIREMENTS` and `CORe_REQUIREMENTS` in `setup.py` currently contain comments and empty lines. They should be removed.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

### Before

```
$ python setup.py -q dependencies
# This file is automatically generated by running the dev/generate_requirements.py script. Do not

# manually modify this file. Instead, modify the corresponding requirements YAML file and run the

# dev/generate_requirements.py script to regenerate this file.



click<9,>=7.0

cloudpickle<3

databricks-cli<1,>=0.8.7

entrypoints<1

gitpython<4,>=2.1.0

pyyaml<7,>=5.1

protobuf<5,>=3.12.0

pytz<2023

requests<3,>=2.17.3

packaging<22

importlib_metadata<5,>=3.7.0,!=4.7.0

sqlparse<1,>=0.3.1

# This file is automatically generated by running the dev/generate_requirements.py script. Do not

# manually modify this file. Instead, modify the corresponding requirements YAML file and run the

# dev/generate_requirements.py script to regenerate this file.



alembic<2

docker<6,>=4.0.0

Flask<3

numpy<2

scipy<2

pandas<2

prometheus-flask-exporter<1

querystring_parser<2

sqlalchemy<2,>=1.4.0

gunicorn<21; platform_system != 'Windows'

waitress<3; platform_system == 'Windows'
```

### After

```
$ python setup.py -q dependencies
click<9,>=7.0
cloudpickle<3
databricks-cli<1,>=0.8.7
entrypoints<1
gitpython<4,>=2.1.0
pyyaml<7,>=5.1
protobuf<5,>=3.12.0
pytz<2023
requests<3,>=2.17.3
packaging<22
importlib_metadata<5,>=3.7.0,!=4.7.0
sqlparse<1,>=0.3.1
alembic<2
docker<6,>=4.0.0
Flask<3
numpy<2
scipy<2
pandas<2
prometheus-flask-exporter<1
querystring_parser<2
sqlalchemy<2,>=1.4.0
gunicorn<21; platform_system != 'Windows'
waitress<3; platform_system == 'Windows'
```

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
