### PR TITLE
Encode timestamp in batch inference with `mlflow.pyfunc.spark_udf`

### DIFF
--- a/examples/spark_udf/spark_udf_advanced.py
+++ b/examples/spark_udf/spark_udf_advanced.py
@@ -1,0 +1,72 @@
+import random
+from datetime import datetime
+from time import time
+
+import mlflow
+import pandas as pd
+from pyspark.sql import SparkSession
+from sklearn.datasets import load_iris
+from sklearn.neighbors import KNeighborsClassifier
+from sklearn.compose import ColumnTransformer
+from sklearn.preprocessing import FunctionTransformer
+from sklearn.pipeline import Pipeline
+
+
+def print_with_title(title, *args):
+    print(f"\n===== {title} =====\n")
+    for a in args:
+        print(a)
+
+
+def get_timestamped_iris():
+    X, y = load_iris(as_frame=True, return_X_y=True)
+    months = X.index.to_series() % 12 + 1
+    timestamp = pd.to_datetime(months.map("2022-{:02d}-01 02:03:04".format))
+    return X.assign(timestamp=timestamp.values), y
+
+
+def extract_month(df):
+    print_with_title("extract_month input", df.head(), df.dtypes)
+    transformed = df.assign(month=df["timestamp"].dt.month)
+    print_with_title("extract_month output", transformed.head(), transformed.dtypes)
+    return transformed
+
+
+def main():
+    X, y = get_timestamped_iris()
+    print_with_title("Ran input", X.head(30), X.dtypes)
+
+    signature = mlflow.models.infer_signature(X, y)
+    print_with_title("Signature", signature)
+
+    month_extractor = FunctionTransformer(extract_month, validate=False)
+    column_selector = ColumnTransformer(
+        [("selector", "passthrough", X.columns.drop("timestamp"))], remainder="drop"
+    )
+    model = Pipeline(
+        [
+            ("month_extractor", month_extractor),
+            ("column_selector", column_selector),
+            ("knn", KNeighborsClassifier()),
+        ]
+    )
+    model.fit(X, y)
+
+    with mlflow.start_run():
+        model_info = mlflow.sklearn.log_model(model, "model", signature=signature)
+
+    with SparkSession.builder.getOrCreate() as spark:
+        infer_spark_df = spark.createDataFrame(X)
+        print_with_title(
+            "Inference input",
+            infer_spark_df._jdf.showString(5, 1, False),
+            infer_spark_df._jdf.schema().treeString(),
+        )
+
+        pyfunc_udf = mlflow.pyfunc.spark_udf(spark, model_info.model_uri, env_manager="conda")
+        result = infer_spark_df.select(pyfunc_udf(*X.columns).alias("predictions")).toPandas()
+        print_with_title("Inference result", result)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/spark_udf/spark_udf_datetime.py
+++ b/examples/spark_udf/spark_udf_datetime.py
@@ -1,5 +1,7 @@
+import random
+import datetime
+
 import mlflow
-import pandas as pd
 from pyspark.sql import SparkSession
 from sklearn.datasets import load_iris
 from sklearn.neighbors import KNeighborsClassifier
@@ -23,10 +25,9 @@ def extract_month(df):
 
 def main():
     X, y = load_iris(as_frame=True, return_X_y=True)
-    # Add a datetime column
-    months = X.index.to_series() % 12 + 1
-    timestamp = pd.to_datetime(months.map("2022-{:02d}-01 02:03:04".format))
-    X = X.assign(timestamp=timestamp)
+    X = X.assign(
+        timestamp=[datetime.datetime(2022, random.randint(1, 12), 1) for _ in range(len(X))]
+    )
     print_with_title("Ran input", X.head(30), X.dtypes)
 
     signature = mlflow.models.infer_signature(X, y)

--- a/examples/spark_udf/spark_udf_datetime.py
+++ b/examples/spark_udf/spark_udf_datetime.py
@@ -26,7 +26,7 @@ def main():
     # Add a datetime column
     months = X.index.to_series() % 12 + 1
     timestamp = pd.to_datetime(months.map("2022-{:02d}-01 02:03:04".format))
-    X = X.assign(timestamp=timestamp), y
+    X = X.assign(timestamp=timestamp)
     print_with_title("Ran input", X.head(30), X.dtypes)
 
     signature = mlflow.models.infer_signature(X, y)
@@ -52,7 +52,7 @@ def main():
         infer_spark_df = spark.createDataFrame(X.sample(n=10, random_state=42))
         print_with_title(
             "Inference input",
-            infer_spark_df._jdf.showString(5, 1, False),
+            infer_spark_df._jdf.showString(5, 20, False),  # numRows, truncate, vertical
             infer_spark_df._jdf.schema().treeString(),
         )
 

--- a/mlflow/pyfunc/scoring_server/client.py
+++ b/mlflow/pyfunc/scoring_server/client.py
@@ -4,7 +4,7 @@ from mlflow.pyfunc import scoring_server
 import json
 import datetime
 
-# Extend `DateTimeEncoder` in https://stackoverflow.com/a/12126976 to support `pandas.TimeStamp`
+# Extended `DateTimeEncoder` in https://stackoverflow.com/a/12126976 to support `pandas.TimeStamp`
 class DateTimeEncoder(json.JSONEncoder):
     def default(self, o):
         import pandas as pd

--- a/mlflow/pyfunc/scoring_server/client.py
+++ b/mlflow/pyfunc/scoring_server/client.py
@@ -4,7 +4,7 @@ from mlflow.pyfunc import scoring_server
 import json
 import datetime
 
-# Extended `DateTimeEncoder` in https://stackoverflow.com/a/12126976 to support `pandas.TimeStamp`
+# Modified `DateTimeEncoder` in https://stackoverflow.com/a/12126976 to support `pandas.TimeStamp`
 class DateTimeEncoder(json.JSONEncoder):
     def default(self, o):
         import pandas as pd

--- a/mlflow/pyfunc/scoring_server/client.py
+++ b/mlflow/pyfunc/scoring_server/client.py
@@ -4,7 +4,7 @@ from mlflow.pyfunc import scoring_server
 import json
 import datetime
 
-# Modified `DateTimeEncoder` in https://stackoverflow.com/a/12126976 to support `pandas.TimeStamp`
+# Reference: https://stackoverflow.com/a/12126976
 class DateTimeEncoder(json.JSONEncoder):
     def default(self, o):
         import pandas as pd

--- a/mlflow/pyfunc/scoring_server/client.py
+++ b/mlflow/pyfunc/scoring_server/client.py
@@ -1,20 +1,9 @@
 import requests
 import time
-from mlflow.pyfunc import scoring_server
 import json
-import datetime
 
-# Reference: https://stackoverflow.com/a/12126976
-class DateTimeEncoder(json.JSONEncoder):
-    def default(self, o):
-        import pandas as pd
-
-        if isinstance(o, (datetime.datetime, datetime.date, datetime.time, pd.Timestamp)):
-            return o.isoformat()
-        elif isinstance(o, datetime.timedelta):
-            return (datetime.datetime.min + o).time().isoformat()
-
-        return super(DateTimeEncoder, self).default(o)
+from mlflow.pyfunc import scoring_server
+from mlflow.utils.proto_json_utils import _DateTimeEncoder
 
 
 class ScoringServerClient:
@@ -51,7 +40,7 @@ class ScoringServerClient:
         content_type = scoring_server.CONTENT_TYPE_JSON
         post_data = json.dumps(
             scoring_server._get_jsonable_obj(data, pandas_orient="split"),
-            cls=DateTimeEncoder,
+            cls=_DateTimeEncoder,
         )
 
         response = requests.post(

--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -220,7 +220,6 @@ def _dataframe_from_json(
                 dtypes = dict(zip(schema.input_names(), schema.numpy_types()))
         else:
             dtypes = dict(zip(schema.input_names(), schema.pandas_types()))
-
         df = pd.read_json(
             path_or_str,
             orient=pandas_orient,
@@ -356,3 +355,14 @@ def parse_tf_serving_input(inp_dict, schema=None):
             )
 
     return data
+
+
+# Reference: https://stackoverflow.com/a/12126976
+class _DateTimeEncoder(json.JSONEncoder):
+    def default(self, o):
+        import pandas as pd
+
+        if isinstance(o, (datetime.datetime, datetime.date, datetime.time, pd.Timestamp)):
+            return o.isoformat()
+
+        return super().default(o)

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -193,7 +193,7 @@ def test_mlflow_run_example(directory, params, tmpdir):
         ("evaluation", ["python", "evaluate_with_custom_metrics.py"]),
         ("evaluation", ["python", "evaluate_with_custom_metrics_comprehensive.py"]),
         ("diviner", ["python", "train.py"]),
-        ("spark_udf", ["python", "spark_udf_advanced.py"]),
+        ("spark_udf", ["python", "spark_udf_datetime.py"]),
     ],
 )
 def test_command_example(directory, command):

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -193,6 +193,7 @@ def test_mlflow_run_example(directory, params, tmpdir):
         ("evaluation", ["python", "evaluate_with_custom_metrics.py"]),
         ("evaluation", ["python", "evaluate_with_custom_metrics_comprehensive.py"]),
         ("diviner", ["python", "train.py"]),
+        ("spark_udf", ["python", "spark_udf_advanced.py"]),
     ],
 )
 def test_command_example(directory, command):

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -518,6 +518,6 @@ def test_spark_udf_datetime_conversion_using_model_schema(spark):
 
     inference_sample = X.sample(n=10, random_state=42)
     infer_spark_df = spark.createDataFrame(inference_sample)
-    pyfunc_udf = mlflow.pyfunc.spark_udf(spark, model_info.model_uri, env_manager="virtualenv")
+    pyfunc_udf = mlflow.pyfunc.spark_udf(spark, model_info.model_uri, env_manager="conda")
     result = infer_spark_df.select(pyfunc_udf(*X.columns).alias("predictions")).toPandas()
     np.testing.assert_almost_equal(result.to_numpy().squeeze(), model.predict(inference_sample))

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -490,7 +490,7 @@ def test_spark_udf_embedded_model_server_killed_when_job_canceled(
         client.ping()
 
 
-def test_spark_udf_datetime_conversion_using_model_schema(spark):
+def test_spark_udf_datetime_with_model_schema(spark):
     X, y = datasets.load_iris(as_frame=True, return_X_y=True)
     # Add a datetime column
     months = X.index.to_series() % 12 + 1
@@ -523,9 +523,9 @@ def test_spark_udf_datetime_conversion_using_model_schema(spark):
     np.testing.assert_almost_equal(result.to_numpy().squeeze(), model.predict(inference_sample))
 
 
-def test_spark_udf_string_datetime(spark):
+def test_spark_udf_string_datetime_with_model_schema(spark):
     X, y = datasets.load_iris(as_frame=True, return_X_y=True)
-    # Add a datetime column
+    # Add a string datetime column
     months = X.index.to_series() % 12 + 1
     string_timestamp = months.map("2022-{:02d}-01 02:03:04".format)
     X = X.assign(timestamp=string_timestamp)

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -27,6 +27,9 @@ from mlflow.types import Schema, ColSpec
 import sklearn.datasets as datasets
 from collections import namedtuple
 from sklearn.neighbors import KNeighborsClassifier
+from sklearn.compose import ColumnTransformer
+from sklearn.preprocessing import FunctionTransformer
+from sklearn.pipeline import Pipeline
 
 from pyspark.sql.functions import pandas_udf
 from pyspark.sql.functions import col, struct
@@ -485,3 +488,36 @@ def test_spark_udf_embedded_model_server_killed_when_job_canceled(
     # assert ping failed, i.e. the server process is killed successfully.
     with pytest.raises(Exception):  # pylint: disable=pytest-raises-without-match
         client.ping()
+
+
+def test_spark_udf_datetime_conversion_using_model_schema(spark):
+    X, y = datasets.load_iris(as_frame=True, return_X_y=True)
+    # Add a datetime column
+    months = X.index.to_series() % 12 + 1
+    timestamp = pd.to_datetime(months.map("2022-{:02d}-01 02:03:04".format))
+    X = X.assign(timestamp=timestamp)
+
+    month_extractor = FunctionTransformer(
+        lambda df: df.assign(month=df["timestamp"].dt.month), validate=False
+    )
+    timestamp_remover = ColumnTransformer(
+        [("selector", "passthrough", X.columns.drop("timestamp"))], remainder="drop"
+    )
+    model = Pipeline(
+        [
+            ("month_extractor", month_extractor),
+            ("timestamp_remover", timestamp_remover),
+            ("knn", KNeighborsClassifier()),
+        ]
+    )
+    model.fit(X, y)
+
+    with mlflow.start_run():
+        signature = mlflow.models.infer_signature(X, y)
+        model_info = mlflow.sklearn.log_model(model, "model", signature=signature)
+
+    inference_sample = X.sample(n=10, random_state=42)
+    infer_spark_df = spark.createDataFrame(inference_sample)
+    pyfunc_udf = mlflow.pyfunc.spark_udf(spark, model_info.model_uri, env_manager="virtualenv")
+    result = infer_spark_df.select(pyfunc_udf(*X.columns).alias("predictions")).toPandas()
+    np.testing.assert_almost_equal(result.to_numpy().squeeze(), model.predict(inference_sample))

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -494,7 +494,6 @@ def test_spark_udf_embedded_model_server_killed_when_job_canceled(
 
 def test_spark_udf_datetime_with_model_schema(spark):
     X, y = datasets.load_iris(as_frame=True, return_X_y=True)
-    # Add a datetime column
     X = X.assign(
         timestamp=[datetime.datetime(2022, random.randint(1, 12), 1) for _ in range(len(X))]
     )
@@ -528,10 +527,7 @@ def test_spark_udf_datetime_with_model_schema(spark):
 
 def test_spark_udf_string_datetime_with_model_schema(spark):
     X, y = datasets.load_iris(as_frame=True, return_X_y=True)
-    # Add a string datetime column
-    months = X.index.to_series() % 12 + 1
-    string_timestamp = months.map("2022-{:02d}-01 02:03:04".format)
-    X = X.assign(timestamp=string_timestamp)
+    X = X.assign(timestamp=["2022-{:02d}-01".format(random.randint(1, 12)) for _ in range(len(X))])
 
     month_extractor = FunctionTransformer(
         lambda df: df.assign(month=df["timestamp"].str.extract(r"^2022-0?(\d{1,2})-").astype(int)),

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -492,12 +492,12 @@ def test_spark_udf_embedded_model_server_killed_when_job_canceled(
         client.ping()
 
 
-@pytest.mark.parametrize("datetime_type", [pd.Timestamp, datetime.datetime, datetime.date])
-def test_spark_udf_datetime_with_model_schema(spark, datetime_type):
+def test_spark_udf_datetime_with_model_schema(spark):
     X, y = datasets.load_iris(as_frame=True, return_X_y=True)
     # Add a datetime column
-    timestamp = pd.Series(datetime_type(2022, random.randint(1, 12), 1) for _ in range(len(X)))
-    X = X.assign(timestamp=timestamp)
+    X = X.assign(
+        timestamp=[datetime.datetime(2022, random.randint(1, 12), 1) for _ in range(len(X))]
+    )
 
     month_extractor = FunctionTransformer(
         lambda df: df.assign(month=df["timestamp"].map(lambda d: d.month)), validate=False

--- a/tests/utils/test_proto_json_utils.py
+++ b/tests/utils/test_proto_json_utils.py
@@ -474,7 +474,6 @@ def test_dataframe_from_json():
             ColSpec("long", "long"),
             ColSpec("binary", "binary"),
             ColSpec("string", "date_string"),
-            ColSpec("datetime", "datetime"),
         ]
     )
     parsed = _dataframe_from_json(
@@ -531,22 +530,9 @@ def test_dataframe_from_json():
         )
     )
 
-    schema = Schema(
-        [
-            ColSpec("datetime", "datetime"),
-        ]
-    )
-
+    schema = Schema([ColSpec("datetime", "datetime")])
     parsed = _dataframe_from_json(
-        """
-{
-  "datetime": [
-    "2022-01-01T00:00:00",
-    "2022-01-02T03:04:05",
-    "00:00:00"
-  ]
-}
-""",
+        '{"datetime": ["2022-01-01T00:00:00", "2022-01-02T03:04:05", "00:00:00"]}',
         pandas_orient="records",
         schema=schema,
     )


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
Fixes #6211

## What changes are proposed in this pull request?

Encode datetime data before sending it to the server to fix #6211.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
