### PR TITLE
Allow logging of NA parameter values

### DIFF
--- a/mlflow/R/mlflow/R/tracking-runs.R
+++ b/mlflow/R/mlflow/R/tracking-runs.R
@@ -258,13 +258,14 @@ mlflow_log_param <- function(key, value, run_id = NULL, client = NULL) {
   c(client, run_id) %<-% resolve_client_and_run_id(client, run_id)
 
   key <- cast_string(key)
-  value <- cast_string(value)
+  value <- cast_string(value, allow_na = TRUE)
+  value <- ifelse(is.na(value), "NA", value)
 
   data <- list(
     run_uuid = run_id,
     run_id = run_id,
     key = key,
-    value = cast_string(value)
+    value = value
   )
   mlflow_rest("runs", "log-parameter", client = client, verb = "POST", data = data)
   mlflow_register_tracking_event("log_param", data)

--- a/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
+++ b/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
@@ -136,6 +136,8 @@ test_that("logging functionality", {
 
   mlflow_set_tag("tag_key", "tag_value")
   mlflow_log_param("param_key", "param_value")
+  mlflow_log_param("na", NA)
+  mlflow_log_param("nan", NaN)
 
   run <- mlflow_get_run()
   metrics <- run$metrics[[1]]
@@ -148,8 +150,8 @@ test_that("logging functionality", {
   run_id <- run$run_uuid
   tags <- run$tags[[1]]
   expect_identical("tag_value", tags$value[tags$key == "tag_key"])
-  expect_identical(run$params[[1]]$key, "param_key")
-  expect_identical(run$params[[1]]$value, "param_value")
+  expect_setequal(run$params[[1]]$key, c("na", "nan", "param_key"))
+  expect_setequal(run$params[[1]]$value, c("NA", "NaN", "param_value"))
 
   mlflow_delete_tag("tag_key", run_id)
   run <- mlflow_get_run()


### PR DESCRIPTION
## What changes are proposed in this pull request?

Some parameters for models can be `NA`, for example `period` within
`stats::arima()`. This PR allows for that.

## How is this patch tested?

- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

## Does this PR change the documentation?

- [x] No.

## Release Notes

### Is this a user-facing change?

- [x] No.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [x] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
