### PR TITLE
Integrate mlflowdbfs with mlflow python client

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -47,3 +47,7 @@ MLFLOW_HTTP_REQUEST_BACKOFF_FACTOR = _EnvironmentVariable(
 #: Specify timeout in seconds for MLflow http request
 #: (default: ``120``)
 MLFLOW_HTTP_REQUEST_TIMEOUT = _EnvironmentVariable("MLFLOW_HTTP_REQUEST_TIMEOUT", int, 120)
+
+#: Specify whether to disable model logging and loading via mlflowdbfs.
+#: (default: ``False``)
+_DISABLE_MLFLOWDBFS = _EnvironmentVariable("DISABLE_MLFLOWDBFS", str, "")

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -27,14 +27,17 @@ import uuid
 import yaml
 
 import mlflow
-from mlflow import pyfunc, mleap
+from mlflow import environment_variables, pyfunc, mleap
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model
 from mlflow.models.model import MLMODEL_FILE_NAME
 from mlflow.models.signature import ModelSignature
 from mlflow.models.utils import ModelInputExample, _save_example
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
-from mlflow.tracking.artifact_utils import _download_artifact_from_uri
+from mlflow.tracking.artifact_utils import (
+    _download_artifact_from_uri,
+    _get_root_uri_and_artifact_path,
+)
 from mlflow.utils.environment import (
     _mlflow_conda_env,
     _validate_env_arguments,
@@ -48,6 +51,7 @@ from mlflow.utils.environment import (
 )
 from mlflow.utils.requirements_utils import _get_pinned_requirement
 from mlflow.utils.docstring_utils import format_docstring, LOG_MODEL_PARAM_DOCS
+from mlflow.store.artifact.databricks_artifact_repo import DatabricksArtifactRepository
 from mlflow.store.artifact.runs_artifact_repo import RunsArtifactRepository
 from mlflow.store.artifact.models_artifact_repo import ModelsArtifactRepository
 from mlflow.utils.file_utils import TempDir, write_to
@@ -56,6 +60,8 @@ from mlflow.utils.uri import (
     append_to_uri_path,
     dbfs_hdfs_uri_to_fuse_path,
     is_valid_dbfs_uri,
+    is_databricks_acled_artifacts_uri,
+    get_databricks_profile_uri_from_artifact_uri,
 )
 from mlflow.utils import databricks_utils
 from mlflow.utils.model_utils import (
@@ -72,6 +78,7 @@ FLAVOR_NAME = "spark"
 # Default temporary directory on DFS. Used to write / read from Spark ML models.
 DFS_TMP = "/tmp/mlflow"
 _SPARK_MODEL_PATH_SUB = "sparkml"
+_MLFLOWDBFS_SCHEME = "mlflowdbfs"
 
 _logger = logging.getLogger(__name__)
 
@@ -199,7 +206,6 @@ def log_model(
         model = pipeline.fit(training)
         mlflow.spark.log_model(model, "spark-model")
     """
-    from py4j.protocol import Py4JError
 
     _validate_model(spark_model)
     from pyspark.ml import PipelineModel
@@ -208,12 +214,26 @@ def log_model(
         spark_model = PipelineModel([spark_model])
     run_id = mlflow.tracking.fluent._get_or_start_run().info.run_id
     run_root_artifact_uri = mlflow.get_artifact_uri()
+    if _should_use_mlflowdbfs(run_root_artifact_uri):
+        mlflowdbfs_path = _mlflowdbfs_path(run_id, artifact_path)
+        with databricks_utils.MlflowCredentialContext(
+            get_databricks_profile_uri_from_artifact_uri(run_root_artifact_uri)
+        ):
+            try:
+                spark_model.save(mlflowdbfs_path)
+            except Exception as e:
+                raise MlflowException("failed to save spark model via mlflowdbfs") from e
+
     # If the artifact URI is a local filesystem path, defer to Model.log() to persist the model,
     # since Spark may not be able to write directly to the driver's filesystem. For example,
     # writing to `file:/uri` will write to the local filesystem from each executor, which will
-    # be incorrect on multi-node clusters - to avoid such issues we just use the Model.log() path
-    # here.
-    if is_local_uri(run_root_artifact_uri):
+    # be incorrect on multi-node clusters.
+    # If the artifact URI is not a local filesystem path we attempt to write directly to the
+    # artifact repo via Spark. If this fails, we defer to Model.log().
+    elif is_local_uri(run_root_artifact_uri) or not _maybe_save_model(
+        spark_model,
+        append_to_uri_path(run_root_artifact_uri, artifact_path, _SPARK_MODEL_PATH_SUB),
+    ):
         return Model.log(
             artifact_path=artifact_path,
             flavor=mlflow.spark,
@@ -229,28 +249,6 @@ def log_model(
             pip_requirements=pip_requirements,
             extra_pip_requirements=extra_pip_requirements,
         )
-    model_dir = os.path.join(run_root_artifact_uri, artifact_path)
-    # Try to write directly to the artifact repo via Spark. If this fails, defer to Model.log()
-    # to persist the model
-    try:
-        spark_model.save(posixpath.join(model_dir, _SPARK_MODEL_PATH_SUB))
-    except Py4JError:
-        return Model.log(
-            artifact_path=artifact_path,
-            flavor=mlflow.spark,
-            spark_model=spark_model,
-            conda_env=conda_env,
-            code_paths=code_paths,
-            dfs_tmpdir=dfs_tmpdir,
-            sample_input=sample_input,
-            registered_model_name=registered_model_name,
-            signature=signature,
-            input_example=input_example,
-            await_registration_for=await_registration_for,
-            pip_requirements=pip_requirements,
-            extra_pip_requirements=extra_pip_requirements,
-        )
-
     # Otherwise, override the default model log behavior and save model directly to artifact repo
     mlflow_model = Model(artifact_path=artifact_path, run_id=run_id)
     with TempDir() as tmp:
@@ -278,6 +276,27 @@ def log_model(
 
 def _tmp_path(dfs_tmp):
     return posixpath.join(dfs_tmp, str(uuid.uuid4()))
+
+
+def _mlflowdbfs_path(run_id, artifact_path):
+    if artifact_path.startswith("/"):
+        raise MlflowException(
+            "artifact_path should be relative, found: {}".format(artifact_path),
+            INVALID_PARAMETER_VALUE,
+        )
+    return "{}:///artifacts?run_id={}&path=/{}".format(
+        _MLFLOWDBFS_SCHEME, run_id, posixpath.join(artifact_path, _SPARK_MODEL_PATH_SUB)
+    )
+
+
+def _maybe_save_model(spark_model, model_dir):
+    from py4j.protocol import Py4JError
+
+    try:
+        spark_model.save(posixpath.join(model_dir, _SPARK_MODEL_PATH_SUB))
+        return True
+    except Py4JError:
+        return False
 
 
 class _HadoopFileSystem:
@@ -321,6 +340,10 @@ class _HadoopFileSystem:
     @classmethod
     def _remote_path(cls, path):
         return cls._jvm().org.apache.hadoop.fs.Path(path)
+
+    @classmethod
+    def _stats(cls):
+        return cls._jvm().org.apache.hadoop.fs.FileSystem.getGlobalStorageStatistics()
 
     @classmethod
     def copy_to_local_file(cls, src, dst, remove_src):
@@ -384,6 +407,30 @@ class _HadoopFileSystem:
     @classmethod
     def delete(cls, path):
         cls._fs().delete(cls._remote_path(path), True)
+
+    @classmethod
+    def is_filesystem_available(cls, scheme):
+        return scheme in [stats.getScheme() for stats in cls._stats().iterator()]
+
+
+def _should_use_mlflowdbfs(root_uri):
+    # The `mlflowdbfs` scheme does not appear in the available schemes returned from
+    # the Hadoop FileSystem API until a read call has been issued.
+    from mlflow.utils._spark_utils import _get_active_spark_session
+
+    try:
+        _get_active_spark_session().read.load("mlflowdbfs:///artifact?run_id=foo&path=/bar")
+    except Exception:
+        # The load invocation is expected to throw an exception.
+        pass
+
+    return (
+        is_valid_dbfs_uri(root_uri)
+        and is_databricks_acled_artifacts_uri(root_uri)
+        and databricks_utils.is_in_databricks_runtime()
+        and environment_variables._DISABLE_MLFLOWDBFS.get() in ["", "False", "false"]
+        and _HadoopFileSystem.is_filesystem_available(_MLFLOWDBFS_SCHEME)
+    )
 
 
 def _save_model_metadata(
@@ -701,10 +748,25 @@ def load_model(model_uri, dfs_tmpdir=None):
         runs_uri = model_uri
         model_uri = ModelsArtifactRepository.get_underlying_uri(model_uri)
         _logger.info("'%s' resolved as '%s'", runs_uri, model_uri)
+    # This MUST be called prior to appending the model flavor to `model_uri` in order
+    # for `artifact_path` to take on the correct value for model loading via mlflowdbfs.
+    root_uri, artifact_path = _get_root_uri_and_artifact_path(model_uri)
+
     flavor_conf = _get_flavor_configuration_from_uri(model_uri, FLAVOR_NAME)
     model_uri = append_to_uri_path(model_uri, flavor_conf["model_data"])
     local_model_path = _download_artifact_from_uri(model_uri)
     _add_code_from_conf_to_system_path(local_model_path, flavor_conf)
+
+    if _should_use_mlflowdbfs(model_uri):
+        from pyspark.ml.pipeline import PipelineModel
+
+        mlflowdbfs_path = _mlflowdbfs_path(
+            DatabricksArtifactRepository._extract_run_id(model_uri), artifact_path
+        )
+        with databricks_utils.MlflowCredentialContext(
+            get_databricks_profile_uri_from_artifact_uri(root_uri)
+        ):
+            return PipelineModel.load(mlflowdbfs_path)
 
     return _load_model(
         model_uri=model_uri, dfs_tmpdir_base=dfs_tmpdir, local_model_path=local_model_path

--- a/mlflow/tracking/artifact_utils.py
+++ b/mlflow/tracking/artifact_utils.py
@@ -55,11 +55,10 @@ def get_artifact_uri(run_id, artifact_path=None, tracking_uri=None):
 
 # TODO: This would be much simpler if artifact_repo.download_artifacts could take the absolute path
 # or no path.
-def _download_artifact_from_uri(artifact_uri, output_path=None):
+def _get_root_uri_and_artifact_path(artifact_uri):
     """
-    :param artifact_uri: The *absolute* URI of the artifact to download.
-    :param output_path: The local filesystem path to which to download the artifact. If unspecified,
-                        a local output path will be created.
+    Parse the artifact_uri to get the root_uri and artifact_path.
+    :param artifact_uri: The *absolute* URI of the artifact.
     """
     if os.path.exists(artifact_uri):
         if os.name != "nt":
@@ -69,9 +68,7 @@ def _download_artifact_from_uri(artifact_uri, output_path=None):
             # resolve them (i.e., spaces converted to %20 within a file name or path listing)
             root_uri = os.path.dirname(artifact_uri)
             artifact_path = os.path.basename(artifact_uri)
-            return get_artifact_repository(artifact_uri=root_uri).download_artifacts(
-                artifact_path=artifact_path, dst_path=output_path
-            )
+            return root_uri, artifact_path
         else:  # if we're dealing with nt-based systems, we need to utilize pathname2url to encode.
             artifact_uri = path_to_local_file_uri(artifact_uri)
 
@@ -90,7 +87,16 @@ def _download_artifact_from_uri(artifact_uri, output_path=None):
         artifact_path = posixpath.basename(parsed_uri.path)
         parsed_uri = parsed_uri._replace(path=posixpath.dirname(parsed_uri.path))
         root_uri = prefix + urllib.parse.urlunparse(parsed_uri)
+    return root_uri, artifact_path
 
+
+def _download_artifact_from_uri(artifact_uri, output_path=None):
+    """
+    :param artifact_uri: The *absolute* URI of the artifact to download.
+    :param output_path: The local filesystem path to which to download the artifact. If unspecified,
+                        a local output path will be created.
+    """
+    root_uri, artifact_path = _get_root_uri_and_artifact_path(artifact_uri)
     return get_artifact_repository(artifact_uri=root_uri).download_artifacts(
         artifact_path=artifact_path, dst_path=output_path
     )

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -40,6 +40,27 @@ def _use_repl_context_if_available(name):
     return decorator
 
 
+class MlflowCredentialContext:
+    """Sets and clears credentials on a context using the provided profile URL."""
+
+    def __init__(self, databricks_profile_url):
+        self.databricks_profile_url = databricks_profile_url or "databricks"
+        self.db_utils = _get_dbutils()
+
+    def __enter__(self):
+        db_creds = get_databricks_host_creds(self.databricks_profile_url)
+        self.db_utils.notebook.entry_point.putMlflowProperties(
+            db_creds.host,
+            db_creds.ignore_tls_verification,
+            db_creds.token,
+            db_creds.username,
+            db_creds.password,
+        )
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        self.db_utils.notebook.entry_point.clearMlflowProperties()
+
+
 def _get_dbutils():
     try:
         import IPython


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR updates the `mlflow.spark.log_model` and `mlflow.spark.load_model` commands to use the `mlflowdbfs` scheme where appropriate. This provides a mechanism for users to load and log spark models to the DBFS without using the root mount, to which read access is unrestricted within an organization.

## How is this patch tested?

[This tutorial](https://docs.databricks.com/_static/notebooks/mlflow/mlflow-mleap-training.html) was executed on a databricks 12.x cluster, with mleap commands replaced with `mlflow.spark.log_model` and `mlflow.spark.load_model`

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

## Release Notes

In the databricks runtime Spark models are loaded/logged to DBFS outside the root mount by default. Users may disable this behavior by setting the `DISABLE_MLFLOWDBFS` environment variable.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.


### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [x] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
