### PR TITLE
Add arguments to `install-common-deps.sh` and remove environment variables to control dependencies

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -68,10 +68,8 @@ jobs:
 
     - name: Install dependencies
       if: ${{ github.event_name == 'schedule' || steps.check-diff.outputs.examples_changed == 'true' }}
-      env:
-        INSTALL_ML_DEPENDENCIES: true
       run: |
-        source ./dev/install-common-deps.sh
+        source ./dev/install-common-deps.sh --ml
 
     - name: Run example tests
       if: ${{ github.event_name == 'schedule' || steps.check-diff.outputs.examples_changed == 'true' }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -52,10 +52,8 @@ jobs:
         echo "::add-matcher::.github/workflows/matchers/pylint.json"
         echo "::add-matcher::.github/workflows/matchers/black.json"
     - name: Install dependencies
-      env:
-        INSTALL_ML_DEPENDENCIES: true
       run: |
-        source ./dev/install-common-deps.sh
+        source ./dev/install-common-deps.sh --ml
         pip install -r requirements/lint-requirements.txt
     - name: Test custom pylint-plugins
       run : |
@@ -78,11 +76,8 @@ jobs:
         ref: ${{ github.event.inputs.ref }}
     - uses: ./.github/actions/setup-python
     - name: Install dependencies
-      env:
-        INSTALL_SKINNY_PYTHON_DEPS: true
-        MLFLOW_SKINNY: true
       run: |
-        source ./dev/install-common-deps.sh
+        source ./dev/install-common-deps.sh --skinny
     - name: Run tests
       run: |
         ./dev/run-python-skinny-tests.sh
@@ -108,10 +103,8 @@ jobs:
         distribution: 'adopt'
     - uses: ./.github/actions/cache-pip
     - name: Install dependencies
-      env:
-        INSTALL_ML_DEPENDENCIES: true
       run: |
-        source ./dev/install-common-deps.sh
+        source ./dev/install-common-deps.sh --ml
     - name: Run tests
       env:
         # Fix for https://github.com/mlflow/mlflow/issues/4229
@@ -221,10 +214,8 @@ jobs:
           distribution: 'adopt'
       - uses: ./.github/actions/cache-pip
       - name: Install dependencies
-        env:
-          INSTALL_ML_DEPENDENCIES: true
         run: |
-          source ./dev/install-common-deps.sh
+          source ./dev/install-common-deps.sh --ml
       - name: Run tests
         env:
           SPARK_LOCAL_IP: 127.0.0.1
@@ -265,9 +256,6 @@ jobs:
           submodules: recursive
       - uses: ./.github/actions/setup-python
       - name: Install dependencies
-        env:
-          INSTALL_SMALL_PYTHON_DEPS: true
-          INSTALL_LARGE_PYTHON_DEPS: false
         run: |
           source ./dev/install-common-deps.sh
           pip install -e .[pipelines]
@@ -344,10 +332,8 @@ jobs:
           java-version: 11
           distribution: 'adopt'
       - name: Install dependencies
-        env:
-          INSTALL_ML_DEPENDENCIES: true
         run: |
-          source ./dev/install-common-deps.sh
+          source ./dev/install-common-deps.sh --ml
       - name: Run tests
         env:
           SPARK_LOCAL_IP: 127.0.0.1

--- a/dev/install-common-deps.sh
+++ b/dev/install-common-deps.sh
@@ -48,7 +48,7 @@ pip install --upgrade pip wheel
 pip --version
 
 if [[ "$SKINNY" == "true" ]]; then
-  pip install . --upgrade
+  MLFLOW_SKINNY=true pip install . --upgrade
 else
   pip install .[extras] --upgrade
 fi

--- a/dev/install-common-deps.sh
+++ b/dev/install-common-deps.sh
@@ -12,6 +12,33 @@ function retry-with-backoff() {
     return 1
 }
 
+while :
+do
+  case "$1" in
+    # Install skinny dependencies
+    --skinny)
+      SKINNY="true"
+      shift
+      ;;
+    # Install ML dependencies
+    --ml)
+      ML="true"
+      shift
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      echo "Error: unknown option: $1" >&2
+      exit 1
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
 # Cleanup apt repository to make room for tests.
 sudo apt clean
 df -h
@@ -20,7 +47,7 @@ python --version
 pip install --upgrade pip wheel
 pip --version
 
-if [[ "$MLFLOW_SKINNY" == "true" ]]; then
+if [[ "$SKINNY" == "true" ]]; then
   pip install . --upgrade
 else
   pip install .[extras] --upgrade
@@ -29,12 +56,12 @@ export MLFLOW_HOME=$(pwd)
 
 req_files=""
 # Install Python test dependencies only if we're running Python tests
-if [[ "$INSTALL_SKINNY_PYTHON_DEPS" == "true" ]]; then
+if [[ "$SKINNY" == "true" ]]; then
   req_files+=" -r requirements/skinny-test-requirements.txt"
 else
   req_files+=" -r requirements/test-requirements.txt"
 fi
-if [[ "$INSTALL_ML_DEPENDENCIES" == "true" ]]; then
+if [[ "$ML" == "true" ]]; then
   req_files+=" -r requirements/extra-ml-requirements.txt"
 fi
 


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Add arguments to `install-common-deps.sh` and remove environment variables to control dependencies in GA config YAMLs.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
