### PR TITLE
Use localhost instead of 127.0.0.1 at `SPARK_LOCAL_IP` in GA builds

### DIFF
--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -165,7 +165,7 @@ jobs:
       - name: Run tests
         env:
           MLFLOW_CONDA_HOME: /usr/share/miniconda
-          SPARK_LOCAL_IP: 127.0.0.1
+          SPARK_LOCAL_IP: localhost
           PACKAGE_VERSION: ${{ matrix.version }}
         run: |
           ${{ matrix.run }}

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -76,7 +76,7 @@ jobs:
     - name: Run example tests
       if: ${{ github.event_name == 'schedule' || steps.check-diff.outputs.examples_changed == 'true' }}
       env:
-        SPARK_LOCAL_IP: 127.0.0.1
+        SPARK_LOCAL_IP: localhost
       run: |
         pytest tests/examples --durations=30
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -36,6 +36,7 @@ env:
   # Note miniconda is pre-installed in the virtual environments for GitHub Actions:
   # https://github.com/actions/virtual-environments/blob/main/images/linux/scripts/installers/miniconda.sh
   MLFLOW_CONDA_HOME: /usr/share/miniconda
+  SPARK_LOCAL_IP: localhost
 
 jobs:
   lint:
@@ -113,9 +114,6 @@ jobs:
       run: |
         source ./dev/install-common-deps.sh
     - name: Run tests
-      env:
-        # Fix for https://github.com/mlflow/mlflow/issues/4229
-        SPARK_LOCAL_IP: 127.0.0.1
       run: |
         # Establish SSH to localhost for test_sftp_artifact_repo.py
         ssh-keygen -t rsa -N '' -f ~/.ssh/id_rsa
@@ -169,8 +167,6 @@ jobs:
       run: |
         source ./dev/install-common-deps.sh
     - name: Run tests
-      env:
-        SPARK_LOCAL_IP: 127.0.0.1
       run: |
         cd mlflow/java
         mvn clean package -q
@@ -226,8 +222,6 @@ jobs:
         run: |
           source ./dev/install-common-deps.sh
       - name: Run tests
-        env:
-          SPARK_LOCAL_IP: 127.0.0.1
         run: |
           ./dev/run-python-flavor-tests.sh;
 
@@ -251,8 +245,6 @@ jobs:
           source ./dev/install-common-deps.sh
           pip install pyspark
       - name: Run tests
-        env:
-          SPARK_LOCAL_IP: 127.0.0.1
         run: |
           export MLFLOW_HOME=$(pwd)
           pytest tests/models
@@ -324,8 +316,6 @@ jobs:
           source ./dev/install-common-deps.sh
           pip install keras tensorflow pyspark
       - name: Run tests
-        env:
-          SPARK_LOCAL_IP: 127.0.0.1
         run: |
           export MLFLOW_HOME=$(pwd)
           pytest --durations=30 tests/pyfunc
@@ -349,8 +339,6 @@ jobs:
         run: |
           source ./dev/install-common-deps.sh
       - name: Run tests
-        env:
-          SPARK_LOCAL_IP: 127.0.0.1
         run: |
           ./dev/run-python-sagemaker-tests.sh;
 


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Applies the same change as https://github.com/apache/spark/pull/32102.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
