### PR TITLE
Create setup-java action that uses Adopt OpenJDK 11 by default

### DIFF
--- a/.github/actions/setup-java/action.yml
+++ b/.github/actions/setup-java/action.yml
@@ -1,0 +1,20 @@
+name: 'setup-java'
+description: 'Set up Java'
+inputs:
+  java-version:
+    description: 'java-version'
+    default: 11
+    required: false
+
+  distribution:
+    description: 'distribution'
+    default: adopt
+    required: false
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/setup-java@v3
+      with:
+        java-version: ${{ inputs.java-version }}
+        distribution: ${{ inputs.distribution }}

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -113,7 +113,7 @@ jobs:
             java_version=11
           fi
           echo "::set-output name=version::$java_version"
-      - uses: actions/setup-java@v3
+      - uses: ./.github/actions/setup-java
         with:
           java-version: ${{ steps.get-java-version.outputs.version }}
           distribution: "adopt"

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -102,7 +102,7 @@ jobs:
         rm -rf "$AGENT_TOOLSDIRECTORY"
     - uses: ./.github/actions/setup-python
     - uses: ./.github/actions/setup-pyenv
-    - uses: actions/setup-java@v3
+    - uses: ./.github/actions/setup-java
       with:
         java-version: 11
         distribution: 'adopt'
@@ -160,11 +160,7 @@ jobs:
         repository: ${{ github.event.inputs.repository }}
         ref: ${{ github.event.inputs.ref }}
     - uses: ./.github/actions/setup-python
-    - name: Set up Java
-      uses: actions/setup-java@v3
-      with:
-        java-version: 11
-        distribution: 'adopt'
+    - uses: ./.github/actions/setup-java
     - name: Install dependencies
       run: |
         source ./dev/install-common-deps.sh
@@ -215,10 +211,7 @@ jobs:
           rm -rf "$AGENT_TOOLSDIRECTORY"
       - uses: ./.github/actions/setup-python
       - uses: ./.github/actions/setup-pyenv
-      - uses: actions/setup-java@v3
-        with:
-          java-version: 11
-          distribution: 'adopt'
+      - uses: ./.github/actions/setup-java
       - uses: ./.github/actions/cache-pip
       - name: Install dependencies
         env:
@@ -242,10 +235,7 @@ jobs:
           repository: ${{ github.event.inputs.repository }}
           ref: ${{ github.event.inputs.ref }}
       - uses: ./.github/actions/setup-python
-      - uses: actions/setup-java@v3
-        with:
-          java-version: 11
-          distribution: 'adopt'
+      - uses: ./.github/actions/setup-java
       - name: Install dependencies
         run: |
           source ./dev/install-common-deps.sh
@@ -315,10 +305,7 @@ jobs:
           submodules: recursive
       - uses: ./.github/actions/setup-python
       - uses: ./.github/actions/setup-pyenv
-      - uses: actions/setup-java@v3
-        with:
-          java-version: 11
-          distribution: 'adopt'
+      - uses: ./.github/actions/setup-java
       - name: Install dependencies
         run: |
           source ./dev/install-common-deps.sh
@@ -339,10 +326,7 @@ jobs:
           repository: ${{ github.event.inputs.repository }}
           ref: ${{ github.event.inputs.ref }}
       - uses: ./.github/actions/setup-python
-      - uses: actions/setup-java@v3
-        with:
-          java-version: 11
-          distribution: 'adopt'
+      - uses: ./.github/actions/setup-java
       - name: Install dependencies
         env:
           INSTALL_ML_DEPENDENCIES: true
@@ -364,10 +348,7 @@ jobs:
           ref: ${{ github.event.inputs.ref }}
       - uses: ./.github/actions/setup-python
       - uses: ./.github/actions/setup-pyenv
-      - uses: actions/setup-java@v3
-        with:
-          java-version: 11
-          distribution: 'adopt'
+      - uses: ./.github/actions/setup-java
       - name: Install python dependencies
         run: |
           pip install -r requirements/test-requirements.txt

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -33,10 +33,7 @@ jobs:
         submodules: recursive
         repository: ${{ github.event.inputs.repository }}
         ref: ${{ github.event.inputs.ref }}
-    - uses: actions/setup-java@v3
-      with:
-        java-version: 11
-        distribution: 'adopt'
+    - uses: ./.github/actions/setup-java
     - uses: r-lib/actions/setup-r@v2
     # This step dumps the current set of R dependencies and R version into files to be used
     # as a cache key when caching/restoring R dependencies.


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Create setup-java action that uses Adopt OpenJDK 11 by default to DRY GA configs.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
