### PR TITLE
Use `pandas.testing.assert_frame_equal` instead of `pd.DataFrame.equals` for better debuggability

### DIFF
--- a/tests/lightgbm/test_lightgbm_autolog.py
+++ b/tests/lightgbm/test_lightgbm_autolog.py
@@ -531,7 +531,7 @@ def test_lgb_autolog_gets_input_example(bst_params):
 
     input_example = _read_example(model_conf, model_path)
 
-    assert input_example.equals(X[:5])
+    pd.testing.assert_frame_equal(input_example, (X[:5]))
 
     pyfunc_model = mlflow.pyfunc.load_model(os.path.join(run.info.artifact_uri, "model"))
 

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -770,8 +770,8 @@ def test_evaluate_custom_metric_success():
     # pylint: disable=unsupported-membership-test
     assert isinstance(res_artifacts_2, dict)
     assert "pred_target_abs_diff" in res_artifacts_2
-    assert res_artifacts_2["pred_target_abs_diff"].equals(
-        np.abs(eval_df["prediction"] - eval_df["target"])
+    pd.testing.assert_series_equal(
+        res_artifacts_2["pred_target_abs_diff"], np.abs(eval_df["prediction"] - eval_df["target"])
     )
 
     assert "example_dictionary_artifact" in res_artifacts_2
@@ -957,13 +957,15 @@ def test_custom_metric_logs_artifacts_from_paths(
     assert "test_csv_artifact" in result.artifacts
     assert "test_csv_artifact_on_data_breast_cancer_dataset.csv" in artifacts
     assert isinstance(result.artifacts["test_csv_artifact"], CsvEvaluationArtifact)
-    assert result.artifacts["test_csv_artifact"].content.equals(pd.DataFrame({"a": [1, 2, 3]}))
+    pd.testing.assert_frame_equal(
+        result.artifacts["test_csv_artifact"].content, pd.DataFrame({"a": [1, 2, 3]})
+    )
 
     assert "test_parquet_artifact" in result.artifacts
     assert "test_parquet_artifact_on_data_breast_cancer_dataset.parquet" in artifacts
     assert isinstance(result.artifacts["test_parquet_artifact"], ParquetEvaluationArtifact)
-    assert result.artifacts["test_parquet_artifact"].content.equals(
-        pd.DataFrame({"test": [1, 2, 3]})
+    pd.testing.assert_frame_equal(
+        result.artifacts["test_parquet_artifact"].content, pd.DataFrame({"test": [1, 2, 3]})
     )
 
     assert "test_text_artifact" in result.artifacts
@@ -1032,7 +1034,9 @@ def test_custom_metric_logs_artifacts_from_objects(
     assert "test_csv_artifact" in result.artifacts
     assert "test_csv_artifact_on_data_breast_cancer_dataset.csv" in artifacts
     assert isinstance(result.artifacts["test_csv_artifact"], CsvEvaluationArtifact)
-    assert result.artifacts["test_csv_artifact"].content.equals(pd.DataFrame({"a": [1, 2, 3]}))
+    pd.testing.assert_frame_equal(
+        result.artifacts["test_csv_artifact"].content, pd.DataFrame({"a": [1, 2, 3]})
+    )
 
     assert "test_json_text_artifact" in result.artifacts
     assert "test_json_text_artifact_on_data_breast_cancer_dataset.json" in artifacts

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -224,11 +224,11 @@ def test_model_log_with_input_example_succeeds():
 
         # date column will get deserialized into string
         input_example["d"] = input_example["d"].apply(lambda x: x.isoformat())
-        assert x.equals(input_example)
+        pd.testing.assert_frame_equal(x, input_example)
 
         loaded_example = loaded_model.load_input_example(local_path)
         assert isinstance(loaded_example, pd.DataFrame)
-        assert loaded_example.equals(input_example)
+        pd.testing.assert_frame_equal(loaded_example, input_example)
 
 
 def test_model_load_input_example_numpy():

--- a/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
+++ b/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
@@ -525,17 +525,21 @@ def test_column_schema_enforcement_no_col_names():
     test_data = [[1.0, 2.0, 3.0]]
 
     # Can call with just a list
-    assert pyfunc_model.predict(test_data).equals(pd.DataFrame(test_data))
+    pd.testing.assert_frame_equal(pyfunc_model.predict(test_data), pd.DataFrame(test_data))
 
     # Or can call with a DataFrame without column names
-    assert pyfunc_model.predict(pd.DataFrame(test_data)).equals(pd.DataFrame(test_data))
+    pd.testing.assert_frame_equal(
+        pyfunc_model.predict(pd.DataFrame(test_data)), pd.DataFrame(test_data)
+    )
 
     # # Or can call with a np.ndarray
-    assert pyfunc_model.predict(pd.DataFrame(test_data).values).equals(pd.DataFrame(test_data))
+    pd.testing.assert_frame_equal(
+        pyfunc_model.predict(pd.DataFrame(test_data).values), pd.DataFrame(test_data)
+    )
 
     # Or with column names!
     pdf = pd.DataFrame(data=test_data, columns=["a", "b", "c"])
-    assert pyfunc_model.predict(pdf).equals(pdf)
+    pd.testing.assert_frame_equal(pyfunc_model.predict(pdf), pdf)
 
     # Must provide the right number of arguments
     with pytest.raises(MlflowException, match="the provided value only has 2 inputs."):
@@ -551,7 +555,7 @@ def test_column_schema_enforcement_no_col_names():
 
     # 9. dictionaries of str -> list/nparray work
     d = {"a": [1.0], "b": [2.0], "c": [3.0]}
-    assert pyfunc_model.predict(d).equals(pd.DataFrame(d))
+    pd.testing.assert_frame_equal(pyfunc_model.predict(d), pd.DataFrame(d))
 
 
 def test_tensor_schema_enforcement_no_col_names():

--- a/tests/sagemaker/test_sagemaker_deployment_client.py
+++ b/tests/sagemaker/test_sagemaker_deployment_client.py
@@ -1372,7 +1372,7 @@ def test_predict_with_dataframe_input_output(sagemaker_deployment_client):
         result = sagemaker_deployment_client.predict("test", df)
 
         assert isinstance(result, pd.DataFrame)
-        assert result.equals(output_df)
+        pd.testing.assert_frame_equal(result, output_df)
 
 
 @mock_sagemaker_aws_services

--- a/tests/utils/test_proto_json_utils.py
+++ b/tests/utils/test_proto_json_utils.py
@@ -479,11 +479,11 @@ def test_dataframe_from_json():
     parsed = _dataframe_from_json(
         jsonable_df.to_json(orient="split"), pandas_orient="split", schema=schema
     )
-    assert parsed.equals(source)
+    pd.testing.assert_frame_equal(parsed, source)
     parsed = _dataframe_from_json(
         jsonable_df.to_json(orient="records"), pandas_orient="records", schema=schema
     )
-    assert parsed.equals(source)
+    pd.testing.assert_frame_equal(parsed, source)
     # try parsing with tensor schema
     tensor_schema = Schema(
         [
@@ -501,13 +501,13 @@ def test_dataframe_from_json():
     )
 
     # NB: tensor schema does not automatically decode base64 encoded bytes.
-    assert parsed.equals(jsonable_df)
+    pd.testing.assert_frame_equal(parsed, jsonable_df)
     parsed = _dataframe_from_json(
         jsonable_df.to_json(orient="records"), pandas_orient="records", schema=tensor_schema
     )
 
     # NB: tensor schema does not automatically decode base64 encoded bytes.
-    assert parsed.equals(jsonable_df)
+    pd.testing.assert_frame_equal(parsed, jsonable_df)
 
     # Test parse with TensorSchema with a single tensor
     tensor_schema = Schema([TensorSpec(np.dtype("float32"), [-1, 3])])
@@ -519,15 +519,17 @@ def test_dataframe_from_json():
         },
         columns=["a", "b", "c"],
     )
-    assert source.equals(
+    pd.testing.assert_frame_equal(
+        source,
         _dataframe_from_json(
             source.to_json(orient="split"), pandas_orient="split", schema=tensor_schema
-        )
+        ),
     )
-    assert source.equals(
+    pd.testing.assert_frame_equal(
+        source,
         _dataframe_from_json(
             source.to_json(orient="records"), pandas_orient="records", schema=tensor_schema
-        )
+        ),
     )
 
     schema = Schema([ColSpec("datetime", "datetime")])

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -435,7 +435,7 @@ def test_xgb_autolog_gets_input_example(bst_params):
 
     input_example = _read_example(model_conf, model_path)
 
-    assert input_example.equals(X[:5])
+    pd.testing.assert_frame_equal(input_example, X[:5])
 
     pyfunc_model = mlflow.pyfunc.load_model(os.path.join(run.info.artifact_uri, "model"))
 


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Use `pandas.testing.assert_frame_equal` instead of `pd.DataFrame.equals` for better debuggability.

`assert pdf.equals(other_pdf)` is difficult to debug:

```
>       assert parsed.equals(source)
E       AssertionError: assert False
E        +  where False = <bound method NDFrame.equals of    boolean string  float  double  integer  long           binary date_string\n0     Tru...     4     4      b'\x04\x05'  1996-03-02\n2     True      c    3.4     3.4        5     5          b'\x06'  2021-03-05>(   boolean string  float  double  integer  long           binary date_string\n0     True      a    1.2     1.2        3...      4     4      b'\x04\x05'  1996-03-02\n2     True      c    3.4     3.4        5     5          b'\x06'  2021-03-05)
E        +    where <bound method NDFrame.equals of    boolean string  float  double  integer  long           binary date_string\n0     Tru...     4     4      b'\x04\x05'  1996-03-02\n2     True      c    3.4     3.4        5     5          b'\x06'  2021-03-05> =    boolean string  float  double  integer  long           binary date_string\n0     True      a    1.2     1.2        3...      4     4      b'\x04\x05'  1996-03-02\n2     True      c    3.4     3.4        5     5          b'\x06'  2021-03-05.equals
```

https://github.com/mlflow/mlflow/runs/7449102950?check_suite_focus=true#step:10:249

`pd.testing.assert_frame_equal` tells us what's different:

```python
>>> import pandas as pd
>>> pd.testing.assert_frame_equal(pd.DataFrame({"a": [1, 2, 3]}), pd.DataFrame({"a": [1, 2]}))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.7/site-packages/pandas/_testing/asserters.py", line 1250, in assert_frame_equal
    obj, f"{obj} shape mismatch", f"{repr(left.shape)}", f"{repr(right.shape)}"
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.7/site-packages/pandas/_testing/asserters.py", line 665, in raise_assert_detail
    raise AssertionError(msg)
AssertionError: DataFrame are different

DataFrame shape mismatch
[left]:  (3, 1)
[right]: (2, 1)
```

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
