### PR TITLE
Add run / model links to MLP train step card

### DIFF
--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -1,6 +1,7 @@
 import importlib
 import logging
 import os
+import re
 import sys
 import datetime
 
@@ -29,12 +30,16 @@ from mlflow.pipelines.utils.tracking import (
 from mlflow.projects.utils import get_databricks_env_vars
 from mlflow.tracking import MlflowClient
 from mlflow.tracking.fluent import _get_experiment_id
+from mlflow.utils.databricks_utils import get_databricks_run_url
 from mlflow.utils.mlflow_tags import MLFLOW_SOURCE_TYPE, MLFLOW_PIPELINE_TEMPLATE_NAME
 
 _logger = logging.getLogger(__name__)
 
 
 class TrainStep(BaseStep):
+
+    MODEL_ARTIFACT_RELATIVE_PATH = "model"
+
     def __init__(self, step_config, pipeline_root):
         super().__init__(step_config, pipeline_root)
         self.tracking_config = TrackingConfig.from_dict(step_config)
@@ -138,7 +143,7 @@ class TrainStep(BaseStep):
             output_model_path = get_step_output_path(
                 pipeline_root_path=self.pipeline_root,
                 step_name=self.name,
-                relative_path="model",
+                relative_path=TrainStep.MODEL_ARTIFACT_RELATIVE_PATH,
             )
             if os.path.exists(output_model_path) and os.path.isdir(output_model_path):
                 shutil.rmtree(output_model_path)
@@ -337,12 +342,42 @@ class TrainStep(BaseStep):
                 row_style, axis=1
             )
         )
+        # Tab 1: Run summary.
+        run_card_tab = card.add_tab(
+            "Run Summary",
+            "{{ RUN_ID }} " + "{{ MODEL_URI }}" + "{{ EXE_DURATION }}" + "{{ LAST_UPDATE_TIME }}",
+        )
+        run_url = get_databricks_run_url(
+            tracking_uri=mlflow.get_tracking_uri(),
+            run_id=run_id,
+        )
+        model_url = get_databricks_run_url(
+            tracking_uri=mlflow.get_tracking_uri(),
+            run_id=run_id,
+            artifact_path=re.sub(r"^.*?%s" % run_id, "", model_uri),
+        )
+
+        if run_url is not None:
+            run_card_tab.add_html(
+                "RUN_ID", f"<b>MLflow Run ID:</b> <a href={run_url}>{run_id}</a><br><br>"
+            )
+        else:
+            run_card_tab.add_markdown("RUN_ID", f"**MLflow Run ID:** `{run_id}`")
+
+        if model_url is not None:
+            run_card_tab.add_html(
+                "MODEL_URI", f"<b>MLflow Model URI:</b> <a href={model_url}>{model_uri}</a>"
+            )
+        else:
+            run_card_tab.add_markdown("MODEL_URI", f"**MLflow Model URI:** `{model_uri}`")
+
+        # Tab 2: Model performance summary metrics.
         card.add_tab(
             "Model Performance Summary Metrics",
             "<h3 class='section-title'>Summary Metrics</h3>{{ METRICS }} ",
         ).add_html("METRICS", metric_table_html)
 
-        # Tab 1: Prediction and error data profile.
+        # Tab 3: Prediction and error data profile.
         pred_and_error_df_profile = get_pandas_data_profile(
             pred_and_error_df.reset_index(drop=True),
             "Predictions and Errors (Validation Dataset)",
@@ -350,12 +385,12 @@ class TrainStep(BaseStep):
         card.add_tab("Profile of Predictions and Errors", "{{PROFILE}}").add_pandas_profile(
             "PROFILE", pred_and_error_df_profile
         )
-        # Tab 2: Model architecture.
+        # Tab 4: Model architecture.
         set_config(display="diagram")
         model_repr = estimator_html_repr(model)
         card.add_tab("Model Architecture", "{{MODEL_ARCH}}").add_html("MODEL_ARCH", model_repr)
 
-        # Tab 3: Inferred model (transformer + estimator) schema.
+        # Tab 5: Inferred model (transformer + estimator) schema.
         def render_schema(inputs, title):
             from mlflow.types import ColSpec
 
@@ -381,33 +416,20 @@ class TrainStep(BaseStep):
             '<div style="display: flex">{tables}</div>'.format(tables="\n".join(schema_tables)),
         )
 
-        # Tab 4: Examples with Largest Prediction Error
+        # Tab 6: Examples with Largest Prediction Error
         (
             card.add_tab(
                 "Training Examples with Largest Prediction Error", "{{ WORST_EXAMPLES_TABLE }}"
             ).add_html("WORST_EXAMPLES_TABLE", BaseCard.render_table(worst_examples_df))
         )
 
-        # Tab 5: Leaderboard
+        # Tab 7: Leaderboard
         if leaderboard_df is not None:
             (
                 card.add_tab("Leaderboard", "{{ LEADERBOARD_TABLE }}").add_html(
                     "LEADERBOARD_TABLE", BaseCard.render_table(leaderboard_df, hide_index=False)
                 )
             )
-
-        # Tab 6: Run summary.
-        (
-            card.add_tab(
-                "Run Summary",
-                "{{ RUN_ID }} "
-                + "{{ MODEL_URI }}"
-                + "{{ EXE_DURATION }}"
-                + "{{ LAST_UPDATE_TIME }}",
-            )
-            .add_markdown("RUN_ID", f"**MLflow Run ID:** `{run_id}`")
-            .add_markdown("MODEL_URI", f"**MLflow Model URI:** `{model_uri}`")
-        )
 
         return card
 

--- a/mlflow/projects/utils.py
+++ b/mlflow/projects/utils.py
@@ -362,4 +362,9 @@ def get_databricks_env_vars(tracking_uri):
         env_vars["DATABRICKS_TOKEN"] = config.token
     if config.ignore_tls_verification:
         env_vars["DATABRICKS_INSECURE"] = str(config.ignore_tls_verification)
+
+    workspace_info = databricks_utils.get_databricks_workspace_info_from_uri(tracking_uri)
+    if workspace_info is not None:
+        env_vars.update(workspace_info.to_environment())
+
     return env_vars

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -2,12 +2,13 @@ import functools
 import logging
 import os
 import subprocess
+from typing import Optional, TypeVar
 
+from databricks_cli.configure import provider
 from mlflow.exceptions import MlflowException
 from mlflow.utils.rest_utils import MlflowHostCreds
-from databricks_cli.configure import provider
 from mlflow.utils._spark_utils import _get_active_spark_session
-from mlflow.utils.uri import get_db_info_from_uri
+from mlflow.utils.uri import get_db_info_from_uri, is_databricks_uri
 
 _logger = logging.getLogger(__name__)
 
@@ -482,3 +483,150 @@ def is_running_in_ipython_environment():
         return get_ipython() is not None
     except (ImportError, ModuleNotFoundError):
         return False
+
+
+def get_databricks_run_url(tracking_uri: str, run_id: str, artifact_path=None) -> Optional[str]:
+    """
+    Obtains a Databricks URL corresponding to the specified MLflow Run, optionally referring
+    to an artifact within the run.
+
+    :param tracking_uri: The URI of the MLflow Tracking server containing the Run.
+    :param run_id: The ID of the MLflow Run for which to obtain a Databricks URL.
+    :param artifact_path: An optional relative artifact path within the Run to which the URL
+                          should refer.
+    :return: A Databricks URL corresponding to the specified MLflow Run
+             (and artifact path, if specified), or None if the MLflow Run does not belong to a
+             Databricks Workspace.
+    """
+    from mlflow.tracking.client import MlflowClient
+
+    try:
+        workspace_info = (
+            DatabricksWorkspaceInfo.from_environment()
+            or get_databricks_workspace_info_from_uri(tracking_uri)
+        )
+        if workspace_info is not None:
+            experiment_id = MlflowClient(tracking_uri).get_run(run_id).info.experiment_id
+            return _construct_databricks_run_url(
+                host=workspace_info.host,
+                experiment_id=experiment_id,
+                run_id=run_id,
+                workspace_id=workspace_info.workspace_id,
+                artifact_path=artifact_path,
+            )
+    except Exception:
+        return None
+
+
+def get_databricks_model_version_url(registry_uri: str, name: str, version: str) -> Optional[str]:
+    """
+    Obtains a Databricks URL corresponding to the specified Model Version.
+
+    :param tracking_uri: The URI of the Model Registry server containing the Model Version.
+    :param name: The name of the registered model containing the Model Version.
+    :param version: Version number of the Model Version.
+    :return: A Databricks URL corresponding to the specified Model Version, or None if the
+             Model Version does not belong to a Databricks Workspace.
+    """
+    try:
+        workspace_info = (
+            DatabricksWorkspaceInfo.from_environment()
+            or get_databricks_workspace_info_from_uri(registry_uri)
+        )
+        if workspace_info is not None:
+            return _construct_databricks_model_version_url(
+                host=workspace_info.host,
+                name=name,
+                version=version,
+                workspace_id=workspace_info.workspace_id,
+            )
+    except Exception as e:
+        return None
+
+
+DatabricksWorkspaceInfoType = TypeVar("DatabricksWorkspaceInfo", bound="DatabricksWorkspaceInfo")
+
+
+class DatabricksWorkspaceInfo:
+
+    WORKSPACE_HOST_ENV_VAR = "_DATABRICKS_WORKSPACE_HOST"
+    WORKSPACE_ID_ENV_VAR = "_DATABRICKS_WORKSPACE_ID"
+
+    def __init__(self, host: str, workspace_id: Optional[str] = None):
+        self.host = host
+        self.workspace_id = workspace_id
+
+    @classmethod
+    def from_environment(cls) -> Optional[DatabricksWorkspaceInfoType]:
+        if DatabricksWorkspaceInfo.WORKSPACE_HOST_ENV_VAR in os.environ:
+            return DatabricksWorkspaceInfo(
+                host=os.environ[DatabricksWorkspaceInfo.WORKSPACE_HOST_ENV_VAR],
+                workspace_id=os.environ.get(DatabricksWorkspaceInfo.WORKSPACE_ID_ENV_VAR),
+            )
+        else:
+            return None
+
+    def to_environment(self):
+        env = {
+            DatabricksWorkspaceInfo.WORKSPACE_HOST_ENV_VAR: self.host,
+        }
+        if self.workspace_id is not None:
+            env[DatabricksWorkspaceInfo.WORKSPACE_ID_ENV_VAR] = self.workspace_id
+
+        return env
+
+
+def get_databricks_workspace_info_from_uri(tracking_uri: str) -> Optional[DatabricksWorkspaceInfo]:
+    if not is_databricks_uri(tracking_uri):
+        return None
+
+    if is_databricks_default_tracking_uri(tracking_uri) and (
+        is_in_databricks_notebook() or is_in_databricks_job()
+    ):
+        workspace_host, workspace_id = get_workspace_info_from_dbutils()
+    else:
+        workspace_host, workspace_id = get_workspace_info_from_databricks_secrets(tracking_uri)
+        if not workspace_id:
+            _logger.info(
+                "No workspace ID specified; if your Databricks workspaces share the same"
+                " host URL, you may want to specify the workspace ID (along with the host"
+                " information in the secret manager) for run lineage tracking. For more"
+                " details on how to specify this information in the secret manager,"
+                " please refer to the Databricks MLflow documentation."
+            )
+
+    if workspace_host:
+        return DatabricksWorkspaceInfo(host=workspace_host, workspace_id=workspace_id)
+    else:
+        return None
+
+
+def _construct_databricks_run_url(
+    host: str,
+    experiment_id: str,
+    run_id: str,
+    workspace_id: Optional[str] = None,
+    artifact_path: Optional[str] = None,
+) -> str:
+    run_url = host
+    if workspace_id and workspace_id != "0":
+        run_url += "?o=" + str(workspace_id)
+
+    run_url += f"#mlflow/experiments/{experiment_id}/runs/{run_id}"
+
+    if artifact_path is not None:
+        run_url += f"/artifactPath/{artifact_path.lstrip('/')}"
+
+    return run_url
+
+
+def _construct_databricks_model_version_url(
+    host: str, name: str, version: str, workspace_id: Optional[str] = None
+) -> str:
+    model_version_url = host
+    if workspace_id and workspace_id != "0":
+        model_version_url += "?o=" + str(workspace_id)
+
+    model_version_url += f"#mlflow/models/{name}/{version}"
+
+    return model_version_url

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -540,7 +540,7 @@ def get_databricks_model_version_url(registry_uri: str, name: str, version: str)
                 version=version,
                 workspace_id=workspace_info.workspace_id,
             )
-    except Exception as e:
+    except Exception:
         return None
 
 

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -252,19 +252,6 @@ def is_databricks_model_registry_artifacts_uri(artifact_uri):
     return artifact_uri_path.startswith(_MODEL_REGISTRY_ARTIFACT_URI)
 
 
-def construct_run_url(hostname, experiment_id, run_id, workspace_id=None):
-    if not hostname or not experiment_id or not run_id:
-        raise MlflowException(
-            "Hostname, experiment ID, and run ID are all required to construct a run URL"
-        )
-    prefix = hostname
-    if workspace_id and workspace_id != "0":
-        prefix += "?o=" + workspace_id
-    return prefix + "#mlflow/experiments/{experiment_id}/runs/{run_id}".format(
-        experiment_id=experiment_id, run_id=run_id
-    )
-
-
 def is_valid_dbfs_uri(uri):
     parsed = urllib.parse.urlparse(uri)
     if parsed.scheme != "dbfs":

--- a/tests/pipelines/test_train_step.py
+++ b/tests/pipelines/test_train_step.py
@@ -82,6 +82,34 @@ def test_train_steps_writes_model_pkl_and_card(tmp_pipeline_root_path):
     assert (train_step_output_dir / "card.html").exists()
 
 
+def test_train_steps_writes_card_with_model_and_run_links_on_databricks(
+    monkeypatch, tmp_pipeline_root_path
+):
+    workspace_host = "https://dev.databricks.com"
+    workspace_id = 123456
+    workspace_url = f"{workspace_host}?o={workspace_id}"
+
+    monkeypatch.setenv("_DATABRICKS_WORKSPACE_HOST", workspace_host)
+    monkeypatch.setenv("_DATABRICKS_WORKSPACE_ID", workspace_id)
+    monkeypatch.setenv(_MLFLOW_PIPELINES_EXECUTION_DIRECTORY_ENV_VAR, str(tmp_pipeline_root_path))
+
+    train_step, train_step_output_dir = set_up_train_step(tmp_pipeline_root_path)
+    train_step._run(str(train_step_output_dir))
+
+    with open(train_step_output_dir / "run_id") as f:
+        run_id = f.read()
+
+    assert (train_step_output_dir / "card.html").exists()
+    with open(train_step_output_dir / "card.html", "r") as f:
+        step_card_content = f.read()
+
+    assert f"<a href={workspace_url}#mlflow/experiments/1/runs/{run_id}>" in step_card_content
+    assert (
+        f"<a href={workspace_url}#mlflow/experiments/1/runs/{run_id}/artifactPath/train/model>"
+        in step_card_content
+    )
+
+
 def test_train_steps_autologs(tmp_pipeline_root_path):
     with mock.patch.dict(
         os.environ, {_MLFLOW_PIPELINES_EXECUTION_DIRECTORY_ENV_VAR: str(tmp_pipeline_root_path)}

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -57,17 +57,13 @@ def mock_databricks_tracking_store():
                 RunInfo(self.run_id, self.experiment_id, "userid", "status", 0, 1, None), None
             )
 
-    prev_databricks_tracking_store = _tracking_store_registry.get_store_builder("databricks")
-    try:
-        mock_databricks_tracking_store = MockDatabricksTrackingStore(run_id, experiment_id)
-        _tracking_store_registry.register(
-            "databricks", lambda *args, **kwargs: mock_databricks_tracking_store
-        )
-        yield mock_databricks_tracking_store
-    finally:
-        _tracking_store_registry.register(
-            "databricks", lambda *args, **kwargs: prev_databricks_tracking_store
-        )
+    mock_tracking_store = MockDatabricksTrackingStore(run_id, experiment_id)
+
+    with mock.patch(
+        "mlflow.tracking._tracking_service.utils._tracking_store_registry.get_store",
+        return_value=mock_tracking_store,
+    ):
+        yield mock_tracking_store
 
 
 @pytest.fixture

--- a/tests/utils/test_uri.py
+++ b/tests/utils/test_uri.py
@@ -6,7 +6,6 @@ from mlflow.store.db.db_types import DATABASE_ENGINES
 from mlflow.utils.uri import (
     add_databricks_profile_info_to_artifact_uri,
     append_to_uri_path,
-    construct_run_url,
     extract_and_normalize_path,
     extract_db_type_from_uri,
     get_databricks_profile_uri_from_artifact_uri,

--- a/tests/utils/test_uri.py
+++ b/tests/utils/test_uri.py
@@ -80,58 +80,6 @@ def test_get_db_info_from_uri_errors_invalid_profile(server_uri):
         get_db_info_from_uri(server_uri)
 
 
-@pytest.mark.parametrize(
-    "hostname, experiment_id, run_id, workspace_id, result",
-    [
-        (
-            "https://www.databricks.com/",
-            "19201",
-            "2231",
-            "12211",
-            "https://www.databricks.com/?o=12211#mlflow/experiments/19201/runs/2231",
-        ),
-        (
-            "https://www.databricks.com/",
-            "19201",
-            "2231",
-            None,
-            "https://www.databricks.com/#mlflow/experiments/19201/runs/2231",
-        ),
-        (
-            "https://www.databricks.com/",
-            "19201",
-            "2231",
-            "0",
-            "https://www.databricks.com/#mlflow/experiments/19201/runs/2231",
-        ),
-        (
-            "https://www.databricks.com/",
-            "19201",
-            "2231",
-            "0",
-            "https://www.databricks.com/#mlflow/experiments/19201/runs/2231",
-        ),
-    ],
-)
-def test_construct_run_url(hostname, experiment_id, run_id, workspace_id, result):
-    assert construct_run_url(hostname, experiment_id, run_id, workspace_id) == result
-
-
-@pytest.mark.parametrize(
-    "hostname, experiment_id, run_id, workspace_id",
-    [
-        (None, "19201", "2231", "0"),
-        ("https://www.databricks.com/", None, "2231", "0"),
-        ("https://www.databricks.com/", "19201", None, "0"),
-    ],
-)
-def test_construct_run_url_errors(hostname, experiment_id, run_id, workspace_id):
-    with pytest.raises(
-        MlflowException, match="Hostname, experiment ID, and run ID are all required"
-    ):
-        construct_run_url(hostname, experiment_id, run_id, workspace_id)
-
-
 def test_uri_types():
     assert is_local_uri("mlruns")
     assert is_local_uri("./mlruns")


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## What changes are proposed in this pull request?

Add run / model links to MLP train step card on Databricks

## How is this patch tested?

- Unit tests
- Manually verified that card links appear on Databricks, preexisting text appears outside of Databricks

<img width="1407" alt="Screen Shot 2022-07-26 at 12 32 25 PM" src="https://user-images.githubusercontent.com/39497902/181098804-bec685f3-29b0-4a4d-bae6-7d918fbc15b7.png">

<img width="911" alt="Screen Shot 2022-07-26 at 12 32 21 PM" src="https://user-images.githubusercontent.com/39497902/181098853-f855b75a-2613-4f92-829c-1cd37613b1ca.png">

<img width="699" alt="Screen Shot 2022-07-26 at 12 32 05 PM" src="https://user-images.githubusercontent.com/39497902/181098926-76dbcb4a-da94-4ae0-af97-aaf8e4406c8f.png">

<img width="2301" alt="Screen Shot 2022-07-26 at 12 39 21 PM" src="https://user-images.githubusercontent.com/39497902/181098979-9f375efa-e2da-464d-b1a9-63a848572f5f.png">

<img width="1775" alt="Screen Shot 2022-07-26 at 12 39 16 PM" src="https://user-images.githubusercontent.com/39497902/181098938-453b0f06-7cf1-4047-a4b1-73be3ede0542.png">

<img width="1221" alt="Screen Shot 2022-07-26 at 12 39 27 PM" src="https://user-images.githubusercontent.com/39497902/181099005-0aac53b9-f6f4-44a8-b5a2-240fb8a80506.png">

- Verified that model registration source link remains correct:

Created "remote workspace" (still E2 Dogfood) secrets

```
$ databricks secrets create-scope --scope foo
$ databricks secrets put --scope foo --key bar-host
$ databricks secrets put --scope foo --key bar-token
$ databricks secrets put --scope foo --key bar-workspace-id
```

Registered a model using a run from the "remote workspace" and verified that the resulting run link is as expected:

<img width="1977" alt="Screen Shot 2022-07-26 at 1 15 50 PM" src="https://user-images.githubusercontent.com/39497902/181105365-155a29a7-5d80-44fe-8487-5dfa452a49a6.png">

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

Add run / model links to the train step card on Databricks.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
