### PR TITLE
update to run profiles on the first 100 dataframe columns

### DIFF
--- a/mlflow/pipelines/utils/step.py
+++ b/mlflow/pipelines/utils/step.py
@@ -124,7 +124,7 @@ def get_pandas_data_profile(data_frame, title: str):
     max_cols = min(data_frame.columns.size, _MAX_PROFILE_COL_SIZE)
     max_rows = min(max(max_cells // max_cols, 1), _MAX_PROFILE_ROW_SIZE)
     truncated_df = data_frame.drop(columns=data_frame.columns[max_cols:]).sample(
-        n=max_rows, ignore_index=True, random_state=42
+        n=max_rows, ignore_index=True, random_state=42, replace=True
     )
     if (
         data_frame.size != max_cells

--- a/mlflow/pipelines/utils/step.py
+++ b/mlflow/pipelines/utils/step.py
@@ -122,14 +122,14 @@ def get_pandas_data_profile(data_frame, title: str):
 
     max_cells = min(data_frame.size, _MAX_PROFILE_CELL_SIZE)
     max_cols = min(data_frame.columns.size, _MAX_PROFILE_COL_SIZE)
-    max_rows = min(max(max_cells // max_cols, 1), _MAX_PROFILE_ROW_SIZE)
+    max_rows = min(max(max_cells // max_cols, 1), len(data_frame), _MAX_PROFILE_ROW_SIZE)
     truncated_df = data_frame.drop(columns=data_frame.columns[max_cols:]).sample(
-        n=max_rows, ignore_index=True, random_state=42, replace=True
+        n=max_rows, ignore_index=True, random_state=42
     )
     if (
-        data_frame.size != max_cells
-        or data_frame.columns.size != max_cols
-        or max(max_cells // max_cols, 1) != max_rows
+        max_cells == _MAX_PROFILE_CELL_SIZE
+        or max_cols == _MAX_PROFILE_COL_SIZE
+        or max_rows == _MAX_PROFILE_ROW_SIZE
     ):
         _logger.info(
             "Truncating the data frame for %s to %d cells, %d columns and %d rows",

--- a/mlflow/pipelines/utils/step.py
+++ b/mlflow/pipelines/utils/step.py
@@ -12,7 +12,7 @@ _logger = logging.getLogger(__name__)
 
 _MAX_PROFILE_CELL_SIZE = 10000000  # 10M Cells
 _MAX_PROFILE_ROW_SIZE = 1000000  # 1M Rows
-_MAX_PROFILE_COL_SIZE = 1000000  # 1M Cols
+_MAX_PROFILE_COL_SIZE = 100  # 100 Cols
 
 
 def get_merged_eval_metrics(eval_metrics: Dict[str, Dict], ordered_metric_names: List[str] = None):
@@ -126,6 +126,18 @@ def get_pandas_data_profile(data_frame, title: str):
     truncated_df = data_frame.drop(columns=data_frame.columns[max_cols:]).sample(
         n=max_rows, ignore_index=True, random_state=42
     )
+    if (
+        data_frame.size != max_cells
+        or data_frame.columns.size != max_cols
+        or max(max_cells // max_cols, 1) != max_rows
+    ):
+        _logger.info(
+            "Truncating the data frame for %s to %d cells, %d columns and %d rows",
+            title,
+            max_cells,
+            max_cols,
+            max_rows,
+        )
     return ProfileReport(
         truncated_df,
         title=title,

--- a/tests/pipelines/test_step_utils.py
+++ b/tests/pipelines/test_step_utils.py
@@ -78,6 +78,7 @@ def test_get_merged_eval_metrics_works(
         (DataFrame(np.arange(160).reshape(8, 20)), 10, 5, 9, 5, 2),
         (DataFrame(np.arange(160).reshape(8, 20)), 10, 5, 1, 5, 1),
         (DataFrame(np.arange(160).reshape(8, 20)), 10, 30, 1, 20, 1),
+        (DataFrame(np.arange(160).reshape(2, 80)), 80, 8, 10, 8, 2),
     ],
 )
 def test_get_data_profile_truncates_large_data_frame(


### PR DESCRIPTION
## What changes are proposed in this pull request?
Update to run profiles on the first 100 data frame columns

## How is this patch tested?
- [x] Verified running this notebook https://e2-dogfood.staging.cloud.databricks.com/?o=6051921418418893#notebook/584469380481482 to verify that it reduces the time before and after the change

Before:
<img width="2482" alt="image" src="https://user-images.githubusercontent.com/5621432/181111978-ea065441-c3a2-4fca-92bf-76b0620f62e4.png">

After:
![image](https://user-images.githubusercontent.com/5621432/181110143-6e7d68eb-657f-4985-8c77-bcfdb2263832.png)

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
