### PR TITLE
Make `model_uri` optional for `mlflow models build-docker`

### DIFF
--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -193,7 +193,7 @@ def build_docker(model_uri, name, env_manager, mlflow_home, install_mlflow, enab
     If ``--model-uri`` is NOT specified:
 
     Builds a Docker image that can serve an arbitrary MLflow model. When launching a container with
-    the generated image, the model artifacts directory must be mounted as a volume into
+    the built image, the model artifacts directory must be mounted as a volume into
     the ``/opt/ml/model`` directory in the container as shown in the example below.
 
     .. code:: bash

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -192,9 +192,9 @@ def build_docker(model_uri, name, env_manager, mlflow_home, install_mlflow, enab
 
     If ``--model-uri`` is NOT specified:
 
-    Builds a Docker image that can serve an arbitrary MLflow model. When launching a container with
-    the built image, the model artifacts directory must be mounted as a volume into
-    the ``/opt/ml/model`` directory in the container as shown in the example below.
+    Builds a generic Docker image that can serve an arbitrary MLflow model. When launching
+    a container with the built image, the model artifacts directory must be mounted as a volume
+    into the ``/opt/ml/model`` directory in the container as shown in the example below.
 
     .. code:: bash
 

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -186,7 +186,7 @@ def build_docker(model_uri, name, env_manager, mlflow_home, install_mlflow, enab
 
         # Build a generic Docker image named 'my-image-name'
         mlflow models build-docker -n "my-image-name"
-        # Mount the model stored in /local/path/to/artifacts/model and serve it
+        # Mount the model stored in '/local/path/to/artifacts/model' and serve it
         docker run --rm -p 5001:8080 -v /local/path/to/artifacts/model:/opt/ml/model "my-image-name"
 
     .. warning::

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -168,7 +168,7 @@ def build_docker(model_uri, name, env_manager, mlflow_home, install_mlflow, enab
     python_function flavor. The container serves the model referenced by ``--model-uri``, if
     specified when ``build-docker`` is called. If ``--model-uri`` is not specified when build_docker
     is called, an MLflow Model directory must be mounted as a volume into the /opt/ml/model
-    directory in the container, as shown in the example below.
+    directory in the container.
 
     Building a Docker image with ``--model-uri``:
 
@@ -176,7 +176,7 @@ def build_docker(model_uri, name, env_manager, mlflow_home, install_mlflow, enab
 
         # Build a Docker image named 'my-image-name' that serves the model from run 'some-run-uuid'
         # at run-relative artifact path 'my-model'
-        mlflow models build-docker -m "runs:/some-run-uuid/my-model" -n "my-image-name"
+        mlflow models build-docker --model-uri "runs:/some-run-uuid/my-model" --name "my-image-name"
         # Serve the model
         docker run -p 5001:8080 "my-image-name"
 
@@ -185,7 +185,7 @@ def build_docker(model_uri, name, env_manager, mlflow_home, install_mlflow, enab
     .. code:: bash
 
         # Build a generic Docker image named 'my-image-name'
-        mlflow models build-docker -n "my-image-name"
+        mlflow models build-docker --name "my-image-name"
         # Mount the model stored in '/local/path/to/artifacts/model' and serve it
         docker run --rm -p 5001:8080 -v /local/path/to/artifacts/model:/opt/ml/model "my-image-name"
 

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -192,9 +192,10 @@ def build_docker(model_uri, name, env_manager, mlflow_home, install_mlflow, enab
 
     If ``--model-uri`` is NOT specified:
 
-    Builds a generic Docker image that can serve an arbitrary MLflow model. When launching
-    a container with the built image, the model artifacts directory must be mounted as a volume
-    into the ``/opt/ml/model`` directory in the container as shown in the example below.
+    Builds a generic Docker image that can serve an arbitrary MLflow model with the
+    'python_function' flavor. When launching a container with the built image, the model artifacts
+    directory must be mounted as a volume into the ``/opt/ml/model`` directory in the container
+    as shown in the example below.
 
     .. code:: bash
 

--- a/mlflow/models/flavor_backend_registry.py
+++ b/mlflow/models/flavor_backend_registry.py
@@ -13,6 +13,9 @@ def get_flavor_backend(model, build_docker=True, **kwargs):
     from mlflow.pyfunc.backend import PyFuncBackend
     from mlflow.rfunc.backend import RFuncBackend
 
+    if not model:
+        return pyfunc.FLAVOR_NAME, PyFuncBackend({}, **kwargs)
+
     _flavor_backends = {pyfunc.FLAVOR_NAME: PyFuncBackend, "crate": RFuncBackend}
     for flavor_name, flavor_config in model.flavors.items():
         if flavor_name in _flavor_backends:

--- a/mlflow/utils/cli_args.py
+++ b/mlflow/utils/cli_args.py
@@ -16,17 +16,28 @@ MODEL_PATH = click.option(
     "run-id or local filesystem path without run-id.",
 )
 
+_model_uri_help_string = (
+    "URI to the model. A local path, a 'runs:/' URI, or a"
+    " remote storage URI (e.g., an 's3://' URI). For more information"
+    " about supported remote URIs for model artifacts, see"
+    " https://mlflow.org/docs/latest/tracking.html#artifact-stores"
+)
+
+MODEL_URI_BUILD_DOCKER = click.option(
+    "--model-uri",
+    "-m",
+    metavar="URI",
+    default=None,
+    required=False,
+    help="[Optional] " + _model_uri_help_string,
+)
+
 MODEL_URI = click.option(
     "--model-uri",
     "-m",
-    default=None,
     metavar="URI",
     required=True,
-    help="URI to the model. A local path, a 'runs:/' URI, or a"
-    " remote storage URI (e.g., an 's3://' URI). For more information"
-    " about supported remote URIs for model artifacts, see"
-    " https://mlflow.org/docs/latest/tracking.html"
-    "#artifact-stores",
+    help=_model_uri_help_string,
 )
 
 MLFLOW_HOME = click.option(

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -87,14 +87,21 @@ def score_model_in_sagemaker_docker_container(
     return _evaluate_scoring_proc(proc, 5000, data, content_type, activity_polling_timeout_seconds)
 
 
-def pyfunc_build_image(model_uri, extra_args=None):
+def pyfunc_build_image(model_uri=None, extra_args=None):
     """
     Builds a docker image containing the specified model, returning the name of the image.
     :param model_uri: URI of model, e.g. runs:/some-run-id/run-relative/path/to/model
     :param extra_args: List of extra args to pass to `mlflow models build-docker` command
     """
     name = uuid.uuid4().hex
-    cmd = ["mlflow", "models", "build-docker", "-m", model_uri, "-n", name]
+    cmd = [
+        "mlflow",
+        "models",
+        "build-docker",
+        *(["-m", model_uri] if model_uri else []),
+        "-n",
+        name,
+    ]
     mlflow_home = os.environ.get("MLFLOW_HOME")
     if mlflow_home:
         cmd += ["--mlflow-home", mlflow_home]
@@ -119,7 +126,7 @@ def pyfunc_serve_from_docker_image(image_name, host_port, extra_args=None):
 
 
 def pyfunc_serve_from_docker_image_with_env_override(
-    image_name, host_port, gunicorn_opts, extra_args=None
+    image_name, host_port, gunicorn_opts, extra_args=None, extra_docker_run_options=None
 ):
     """
     Serves a model from a docker container, exposing it as an endpoint at the specified port
@@ -134,6 +141,7 @@ def pyfunc_serve_from_docker_image_with_env_override(
         "GUNICORN_CMD_ARGS=%s" % gunicorn_opts,
         "-p",
         "%s:8080" % host_port,
+        *(extra_docker_run_options or []),
         image_name,
     ]
     if extra_args is not None:

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -480,6 +480,22 @@ def test_build_docker_with_env_override(iris_data, sk_model, enable_mlserver):
     _validate_with_rest_endpoint(scoring_proc, host_port, df, x, sk_model, enable_mlserver)
 
 
+def test_build_docker_without_model_uri(iris_data, sk_model, tmp_path):
+    model_path = tmp_path.joinpath("model")
+    mlflow.sklearn.save_model(sk_model, model_path)
+    image_name = pyfunc_build_image(model_uri=None)
+    host_port = get_safe_port()
+    scoring_proc = pyfunc_serve_from_docker_image_with_env_override(
+        image_name,
+        host_port,
+        gunicorn_options,
+        extra_docker_run_options=["-v", f"{model_path}:/opt/ml/model"],
+    )
+    x = iris_data[0]
+    df = pd.DataFrame(x)
+    _validate_with_rest_endpoint(scoring_proc, host_port, df, x, sk_model)
+
+
 def _validate_with_rest_endpoint(scoring_proc, host_port, df, x, sk_model, enable_mlserver=False):
     with RestEndpoint(proc=scoring_proc, port=host_port) as endpoint:
         for content_type in [CONTENT_TYPE_JSON_SPLIT_ORIENTED, CONTENT_TYPE_CSV, CONTENT_TYPE_JSON]:


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Make `model_uri` optional for `mlflow models build-docker`. If `model_uri` is not specified, `mlflow models build-docker` generates an image that can serve an arbitrary MLflow model.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
