### PR TITLE
Migrate pipeline tests to mlflow github actions

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -230,51 +230,6 @@ jobs:
           export MLFLOW_HOME=$(pwd)
           pytest tests/models
 
-  pipelines:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: recursive
-      - uses: ./.github/actions/setup-python
-      - name: Install dependencies
-        run: |
-          source ./dev/install-common-deps.sh
-          pip install -e .[pipelines]
-          # TODO: Unpin once Delta supports Spark 3.3 (https://github.com/delta-io/delta/issues/1217)
-          pip install 'pyspark<3.3'
-      - name: Run tests
-        run: |
-          export MLFLOW_HOME=$(pwd)
-          pytest tests/pipelines
-
-  pipelines-windows:
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: recursive
-      - uses: ./.github/actions/setup-python
-      - name: Install python dependencies
-        run: |
-          pip install -r requirements/test-requirements.txt
-          pip install --no-dependencies tests/resources/mlflow-test-plugin
-          pip install -e .[extras]
-          pip install -e .[pipelines]
-          # TODO: Unpin once Delta supports Spark 3.3 (https://github.com/delta-io/delta/issues/1217)
-          pip install 'pyspark<3.3'
-      - name: Download Hadoop winutils for Spark
-        run: |
-          git clone https://github.com/cdarlint/winutils
-      - name: Run tests
-        run: |
-          # Set Hadoop environment variables required for testing Spark integrations on Windows
-          export HADOOP_HOME=`realpath winutils/hadoop-3.2.2`
-          export PATH=$PATH:$HADOOP_HOME/bin
-          # Run pipelines tests
-          export MLFLOW_HOME=$(pwd)
-          pytest tests/pipelines
-
   pyfunc:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pipeline-template.yml
+++ b/.github/workflows/pipeline-template.yml
@@ -1,0 +1,91 @@
+name: Pipeline template tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: >
+          [Optional] Repository name with owner. For example, mlflow/mlp-regression-template.
+        required: true
+        default: "mlflow/mlp-regression-template"
+      ref:
+        description: >
+          [Optional] The branch, tag or SHA to checkout. When checking out the repository that
+           triggered a workflow, this defaults to the reference or SHA for that event. Otherwise,
+           uses the default branch.
+        required: false
+        default: ""
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
+  cancel-in-progress: true
+
+# Use `bash --noprofile --norc -exo pipefail` by default for all `run` steps in this workflow:
+# https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#defaultsrun
+defaults:
+  run:
+    shell: bash --noprofile --norc -exo pipefail {0}
+
+env:
+  # Note miniconda is pre-installed in the virtual environments for GitHub Actions:
+  # https://github.com/actions/virtual-environments/blob/main/images/linux/scripts/installers/miniconda.sh
+  MLFLOW_CONDA_HOME: /usr/share/miniconda
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/checkout@v3
+      with:
+        path: ${{ github.event.inputs.repository }}
+        repository: ${{ github.event.inputs.repository }}
+        ref: ${{ github.event.inputs.ref }}
+    - uses: ./.github/actions/setup-python
+    - uses: ./.github/actions/cache-pip
+    - name: Add problem matchers
+      run: |
+        echo "::add-matcher::.github/workflows/matchers/pylint.json"
+        echo "::add-matcher::.github/workflows/matchers/black.json"
+    - name: Install dependencies
+      run: |
+        pip install -r ${{ github.event.inputs.repository }}/.github/workflows/scripts/lint-requirements.txt
+    - name: Run lint checks
+      run: |
+        cd ${{ github.event.inputs.repository }} && .github/workflows/scripts/lint.sh
+  pipeline:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+        with:
+          path: ${{ github.event.inputs.repository }}
+          repository: ${{ github.event.inputs.repository }}
+          ref: ${{ github.event.inputs.ref }}
+      - uses: ./.github/actions/setup-python
+      - name: Install dependencies
+        run: |
+          pip install -e .[pipelines]
+          pip install -r ${{ github.event.inputs.repository }}/requirements.txt
+          pip install -r ${{ github.event.inputs.repository }}/.github/workflows/scripts/test-requirements.txt
+      - name: Run tests
+        run: |
+          cd ${{ github.event.inputs.repository }} && pytest tests
+  pipeline-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+        with:
+          path: ${{ github.event.inputs.repository }}
+          repository: ${{ github.event.inputs.repository }}
+          ref: ${{ github.event.inputs.ref }}
+      - uses: actions/setup-python
+      - name: Install dependencies
+        run: |
+          pip install -e .[pipelines]
+          pip install -r ${{ github.event.inputs.repository }}/requirements.txt
+          pip install -r ${{ github.event.inputs.repository }}/.github/workflows/scripts/test-requirements.txt
+      - name: Run tests
+        run: |
+          cd ${{ github.event.inputs.repository }} &&  pytest tests

--- a/.github/workflows/pipeline-template.yml
+++ b/.github/workflows/pipeline-template.yml
@@ -17,7 +17,7 @@ on:
         default: ""
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 # Use `bash --noprofile --norc -exo pipefail` by default for all `run` steps in this workflow:
@@ -49,10 +49,10 @@ jobs:
         echo "::add-matcher::.github/workflows/matchers/black.json"
     - name: Install dependencies
       run: |
-        pip install -r ${{ github.event.inputs.repository }}/.github/workflows/scripts/lint-requirements.txt
+        pip install -r ${{ github.event.inputs.repository }}/requirements/lint-requirements.txt
     - name: Run lint checks
       run: |
-        cd ${{ github.event.inputs.repository }} && .github/workflows/scripts/lint.sh
+        cd ${{ github.event.inputs.repository }} && ../../dev/lint.sh
   pipeline:
     runs-on: ubuntu-latest
     steps:
@@ -67,10 +67,12 @@ jobs:
         run: |
           pip install -e .[pipelines]
           pip install -r ${{ github.event.inputs.repository }}/requirements.txt
-          pip install -r ${{ github.event.inputs.repository }}/.github/workflows/scripts/test-requirements.txt
+          pip install -r ${{ github.event.inputs.repository }}/requirements/test-requirements.txt
+          # This dependency is needed pytest.ini uses pytest-cov
+          pip install pytest-cov
       - name: Run tests
         run: |
-          cd ${{ github.event.inputs.repository }} && pytest tests
+          cd ${{ github.event.inputs.repository }} && pytest tests --rootdir .
   pipeline-windows:
     runs-on: windows-latest
     steps:
@@ -80,12 +82,14 @@ jobs:
           path: ${{ github.event.inputs.repository }}
           repository: ${{ github.event.inputs.repository }}
           ref: ${{ github.event.inputs.ref }}
-      - uses: actions/setup-python
+      - uses: ./.github/actions/setup-python
       - name: Install dependencies
         run: |
           pip install -e .[pipelines]
           pip install -r ${{ github.event.inputs.repository }}/requirements.txt
-          pip install -r ${{ github.event.inputs.repository }}/.github/workflows/scripts/test-requirements.txt
+          pip install -r ${{ github.event.inputs.repository }}/requirements/test-requirements.txt
+          # This dependency is needed pytest.ini uses pytest-cov
+          pip install pytest-cov
       - name: Run tests
         run: |
-          cd ${{ github.event.inputs.repository }} &&  pytest tests
+          cd ${{ github.event.inputs.repository }} &&  pytest tests --rootdir .

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,13 +1,19 @@
 name: Pipeline tests
 
 on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - branch-[0-9]+.[0-9]+
   workflow_dispatch:
     inputs:
       repository:
         description: >
-          [Optional] Repository name with owner. For example, mlflow/mlp-regression-template.
-        required: true
-        default: "mlflow/mlp-regression-template"
+          [Optional] Repository name with owner. For example, mlflow/mlflow.
+           Defaults to the repository that triggered a workflow.
+        required: false
+        default: ""
       ref:
         description: >
           [Optional] The branch, tag or SHA to checkout. When checking out the repository that
@@ -17,7 +23,7 @@ on:
         default: ""
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 # Use `bash --noprofile --norc -exo pipefail` by default for all `run` steps in this workflow:
@@ -30,62 +36,50 @@ env:
   # Note miniconda is pre-installed in the virtual environments for GitHub Actions:
   # https://github.com/actions/virtual-environments/blob/main/images/linux/scripts/installers/miniconda.sh
   MLFLOW_CONDA_HOME: /usr/share/miniconda
+  SPARK_LOCAL_IP: localhost
 
 jobs:
-  lint:
+  pipelines:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/checkout@v3
-      with:
-        path: ${{ github.event.inputs.repository }}
-        repository: ${{ github.event.inputs.repository }}
-        ref: ${{ github.event.inputs.ref }}
-    - uses: ./.github/actions/setup-python
-    - uses: ./.github/actions/cache-pip
-    - name: Add problem matchers
-      run: |
-        echo "::add-matcher::.github/workflows/matchers/pylint.json"
-        echo "::add-matcher::.github/workflows/matchers/black.json"
-    - name: Install dependencies
-      run: |
-        pip install -r ${{ github.event.inputs.repository }}/.github/workflows/scripts/lint-requirements.txt
-    - name: Run lint checks
-      run: |
-        cd ${{ github.event.inputs.repository }} && .github/workflows/scripts/lint.sh
-  pipeline:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
       - uses: actions/checkout@v3
         with:
-          path: ${{ github.event.inputs.repository }}
-          repository: ${{ github.event.inputs.repository }}
-          ref: ${{ github.event.inputs.ref }}
+          submodules: recursive
       - uses: ./.github/actions/setup-python
       - name: Install dependencies
         run: |
+          source ./dev/install-common-deps.sh
           pip install -e .[pipelines]
-          pip install -r ${{ github.event.inputs.repository }}/requirements.txt
-          pip install -r ${{ github.event.inputs.repository }}/.github/workflows/scripts/test-requirements.txt
+          # TODO: Unpin once Delta supports Spark 3.3 (https://github.com/delta-io/delta/issues/1217)
+          pip install 'pyspark<3.3'
       - name: Run tests
         run: |
-          cd ${{ github.event.inputs.repository }} && pytest tests
-  test-pipeline-windows:
+          export MLFLOW_HOME=$(pwd)
+          pytest tests/pipelines
+
+  pipelines-windows:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/checkout@v3
         with:
-          path: ${{ github.event.inputs.repository }}
-          repository: ${{ github.event.inputs.repository }}
-          ref: ${{ github.event.inputs.ref }}
-      - uses: actions/setup-python
-      - name: Install dependencies
+          submodules: recursive
+      - uses: ./.github/actions/setup-python
+      - name: Install python dependencies
         run: |
+          pip install -r requirements/test-requirements.txt
+          pip install --no-dependencies tests/resources/mlflow-test-plugin
+          pip install -e .[extras]
           pip install -e .[pipelines]
-          pip install -r ${{ github.event.inputs.repository }}/requirements.txt
-          pip install -r ${{ github.event.inputs.repository }}/.github/workflows/scripts/test-requirements.txt
+          # TODO: Unpin once Delta supports Spark 3.3 (https://github.com/delta-io/delta/issues/1217)
+          pip install 'pyspark<3.3'
+      - name: Download Hadoop winutils for Spark
+        run: |
+          git clone https://github.com/cdarlint/winutils
       - name: Run tests
         run: |
-          cd ${{ github.event.inputs.repository }} &&  pytest tests
+          # Set Hadoop environment variables required for testing Spark integrations on Windows
+          export HADOOP_HOME=`realpath winutils/hadoop-3.2.2`
+          export PATH=$PATH:$HADOOP_HOME/bin
+          # Run pipelines tests
+          export MLFLOW_HOME=$(pwd)
+          pytest tests/pipelines

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,0 +1,116 @@
+name: Pipeline tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: >
+          [Optional] Repository name with owner. For example, mlflow/mlp-regression-template.
+        required: true
+        default: "mlflow/mlp-regression-template"
+      ref:
+        description: >
+          [Optional] The branch, tag or SHA to checkout. When checking out the repository that
+           triggered a workflow, this defaults to the reference or SHA for that event. Otherwise,
+           uses the default branch.
+        required: false
+        default: ""
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
+  cancel-in-progress: true
+
+# Use `bash --noprofile --norc -exo pipefail` by default for all `run` steps in this workflow:
+# https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#defaultsrun
+defaults:
+  run:
+    shell: bash --noprofile --norc -exo pipefail {0}
+
+env:
+  # Note miniconda is pre-installed in the virtual environments for GitHub Actions:
+  # https://github.com/actions/virtual-environments/blob/main/images/linux/scripts/installers/miniconda.sh
+  MLFLOW_CONDA_HOME: /usr/share/miniconda
+
+jobs:
+  test-pipeline:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        path: mlflow
+    - name: Check mlflow
+      run: |
+        cd mlflow && ls . && pwd
+    - uses: actions/checkout@v3
+      with:
+        path: ${{ github.event.inputs.repository }}
+        repository: ${{ github.event.inputs.repository }}
+        ref: ${{ github.event.inputs.ref }}
+    # - uses: ./.github/actions/setup-python
+    # - uses: ./.github/actions/cache-pip
+    - name: Check mlp-repo
+      run: |
+        cd  ${{ github.event.inputs.repository }} && ls . && pwd
+  lint-pipeline:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/checkout@v3
+      with:
+        path: ${{ github.event.inputs.repository }}
+        repository: ${{ github.event.inputs.repository }}
+        ref: ${{ github.event.inputs.ref }}
+    - uses: ./.github/actions/setup-python
+      with:
+        python-version: "3.7"
+    - uses: ./.github/actions/cache-pip
+    - name: Add problem matchers
+      run: |
+        echo "::add-matcher::.github/workflows/matchers/pylint.json"
+        echo "::add-matcher::.github/workflows/matchers/black.json"
+    - name: Install dependencies
+      run: |
+        pip install -r requirements/lint-requirements.txt
+    - name: Run lint checks
+      run: |
+        cd ${{ github.event.inputs.repository }} && ../.././dev/lint.sh
+  regression_pipelines:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+        with:
+          path: ${{ github.event.inputs.repository }}
+          repository: ${{ github.event.inputs.repository }}
+          ref: ${{ github.event.inputs.ref }}
+      - uses: ./.github/actions/setup-python
+        with:
+          python-version: "3.7"
+      - name: Install dependencies
+        run: |
+          pip install -r ${{ github.event.inputs.repository }}/requirements.txt
+          pip install -e .[pipelines]
+          pip install -r requirements/test-requirements.txt
+      - name: Run tests
+        run: |
+          cd ${{ github.event.inputs.repository }} && pytest tests
+  regression_pipelines-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+        with:
+          path: ${{ github.event.inputs.repository }}
+          repository: ${{ github.event.inputs.repository }}
+          ref: ${{ github.event.inputs.ref }}
+      - uses: actions/setup-python
+        with:
+          python-version: "3.7"
+      - name: Install dependencies
+        run: |
+          pip install -r ${{ github.event.inputs.repository }}/requirements.txt
+          pip install -e .[pipelines]
+          pip install -r requirements/test-requirements.txt
+      - name: Run tests
+        run: |
+          cd ${{ github.event.inputs.repository }} &&  pytest tests

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -32,26 +32,7 @@ env:
   MLFLOW_CONDA_HOME: /usr/share/miniconda
 
 jobs:
-  test-pipeline:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        path: mlflow
-    - name: Check mlflow
-      run: |
-        cd mlflow && ls . && pwd
-    - uses: actions/checkout@v3
-      with:
-        path: ${{ github.event.inputs.repository }}
-        repository: ${{ github.event.inputs.repository }}
-        ref: ${{ github.event.inputs.ref }}
-    # - uses: ./.github/actions/setup-python
-    # - uses: ./.github/actions/cache-pip
-    - name: Check mlp-repo
-      run: |
-        cd  ${{ github.event.inputs.repository }} && ls . && pwd
-  lint-pipeline:
+  lint:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -61,8 +42,6 @@ jobs:
         repository: ${{ github.event.inputs.repository }}
         ref: ${{ github.event.inputs.ref }}
     - uses: ./.github/actions/setup-python
-      with:
-        python-version: "3.7"
     - uses: ./.github/actions/cache-pip
     - name: Add problem matchers
       run: |
@@ -70,11 +49,11 @@ jobs:
         echo "::add-matcher::.github/workflows/matchers/black.json"
     - name: Install dependencies
       run: |
-        pip install -r requirements/lint-requirements.txt
+        pip install -r ${{ github.event.inputs.repository }}/.github/workflows/scripts/lint-requirements.txt
     - name: Run lint checks
       run: |
-        cd ${{ github.event.inputs.repository }} && ../.././dev/lint.sh
-  regression_pipelines:
+        cd ${{ github.event.inputs.repository }} && .github/workflows/scripts/lint.sh
+  pipeline:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -84,17 +63,15 @@ jobs:
           repository: ${{ github.event.inputs.repository }}
           ref: ${{ github.event.inputs.ref }}
       - uses: ./.github/actions/setup-python
-        with:
-          python-version: "3.7"
       - name: Install dependencies
         run: |
-          pip install -r ${{ github.event.inputs.repository }}/requirements.txt
           pip install -e .[pipelines]
-          pip install -r requirements/test-requirements.txt
+          pip install -r ${{ github.event.inputs.repository }}/requirements.txt
+          pip install -r ${{ github.event.inputs.repository }}/.github/workflows/scripts/test-requirements.txt
       - name: Run tests
         run: |
           cd ${{ github.event.inputs.repository }} && pytest tests
-  regression_pipelines-windows:
+  test-pipeline-windows:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
@@ -104,13 +81,11 @@ jobs:
           repository: ${{ github.event.inputs.repository }}
           ref: ${{ github.event.inputs.ref }}
       - uses: actions/setup-python
-        with:
-          python-version: "3.7"
       - name: Install dependencies
         run: |
-          pip install -r ${{ github.event.inputs.repository }}/requirements.txt
           pip install -e .[pipelines]
-          pip install -r requirements/test-requirements.txt
+          pip install -r ${{ github.event.inputs.repository }}/requirements.txt
+          pip install -r ${{ github.event.inputs.repository }}/.github/workflows/scripts/test-requirements.txt
       - name: Run tests
         run: |
           cd ${{ github.event.inputs.repository }} &&  pytest tests

--- a/dev/lint.sh
+++ b/dev/lint.sh
@@ -16,8 +16,10 @@ fi
 echo -e "\n========== pylint ==========\n"
 pylint $(git ls-files | grep '\.py$')
 
-echo -e "\n========== rstcheck ==========\n"
-rstcheck README.rst
+if [[ -f "README.rst" ]]; then
+  echo -e "\n========== rstcheck ==========\n"
+  rstcheck README.rst
+fi
 
 if [[ "$err" != "0" ]]; then
   echo -e "\nOne of the previous steps failed, check above"

--- a/payload.json
+++ b/payload.json
@@ -1,6 +1,0 @@
-{
-  "inputs": {
-    "repository": "mlflow/mlp-regression-template",
-    "ref": "refs/heads/main"
-  }
-}

--- a/payload.json
+++ b/payload.json
@@ -1,0 +1,6 @@
+{
+  "inputs": {
+    "repository": "mlflow/mlp-regression-template",
+    "ref": "refs/heads/main"
+  }
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?
Migrate pipeline tests to mlflow github actions

## How is this patch tested?
- [x] act -j regression_pipelines -e payload.json -s GITHUB_TOKEN=
```
[Pipeline tests/test-regression_pipelines]   ✅  Success - Install dependencies
[Pipeline tests/test-regression_pipelines] ⭐  Run Run tests
[Pipeline tests/test-regression_pipelines]   🐳  docker exec cmd=[bash --noprofile --norc -exo pipefail /var/run/act/workflow/4] user= workdir=
| + cd mlflow/mlp-regression-template
| + pytest tests
| ============================= test session starts ==============================
| platform linux -- Python 3.7.12, pytest-7.1.2, pluggy-1.0.0 -- /opt/hostedtoolcache/Python/3.7.12/x64/bin/python
| cachedir: .pytest_cache
| rootdir: /Users/Sunish.Sheth/workspace/databricks/mlflow, configfile: pytest.ini
| plugins: localserver-0.5.0, cov-3.0.0
collected 6 items                                                              
| 
| tests/ingest_test.py::test_ingest_function_reads_csv_correctly PASSED    [ 16%]
| tests/split_test.py::test_post_split_fn_returns_datasets_with_correct_spec PASSED [ 33%]
| tests/split_test.py::test_post_split_fn_returns_non_empty_datasets PASSED [ 50%]
| tests/train_test.py::test_train_fn_returns_object_with_correct_spec PASSED [ 66%]
| tests/train_test.py::test_train_fn_passes_check_estimator PASSED         [ 83%]
| tests/transform_test.py::test_tranform_fn_returns_object_with_correct_spec PASSED [100%]/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/coverage/inorout.py:519: CoverageWarning: Module ./mlflow was never imported. (module-not-imported)
|   self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
| /opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/coverage/control.py:794: CoverageWarning: No data was collected. (no-data-collected)
|   self._warn("No data was collected.", slug="no-data-collected")
| WARNING: Failed to generate report: No data to report.
| 
| /opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/pytest_cov/plugin.py:294: CovReportWarning: Failed to generate report: No data to report.
| 
|   self.cov_controller.finish()
| 
| 
| =============================== warnings summary ===============================
| mlflow/mlp-regression-template/tests/train_test.py::test_train_fn_passes_check_estimator
|   /opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/sklearn/utils/estimator_checks.py:586: SkipTestWarning: Skipping check_sample_weights_invariance for SGDRegressor: zero sample_weight is not equivalent to removing samples
|     warnings.warn(str(exception), SkipTestWarning)
| 
| -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
| 
| ---------- coverage: platform linux, python 3.7.12-final-0 -----------
| 
| ============================= slowest 10 durations =============================
| 0.21s call     mlflow/mlp-regression-template/tests/train_test.py::test_train_fn_passes_check_estimator
| 0.04s setup    mlflow/mlp-regression-template/tests/ingest_test.py::test_ingest_function_reads_csv_correctly
| 0.02s call     mlflow/mlp-regression-template/tests/split_test.py::test_post_split_fn_returns_non_empty_datasets
| 0.02s call     mlflow/mlp-regression-template/tests/split_test.py::test_post_split_fn_returns_datasets_with_correct_spec
| 0.01s setup    mlflow/mlp-regression-template/tests/split_test.py::test_post_split_fn_returns_datasets_with_correct_spec
| 0.01s call     mlflow/mlp-regression-template/tests/ingest_test.py::test_ingest_function_reads_csv_correctly
| 
| (4 durations < 0.005s hidden.  Use -vv to show these durations.)
| ========================= 6 passed, 1 warning in 1.54s =========================
```
- [x] act -j regression_pipelines_windows -e payload.json -s GITHUB_TOKEN=
- [x] act -j lint -e payload.json -s GITHUB_TOKEN=
```
[Pipeline tests/lint-pipeline]   ✅  Success - Install dependencies
[Pipeline tests/lint-pipeline] ⭐  Run Run lint checks
[Pipeline tests/lint-pipeline]   🐳  docker exec cmd=[bash --noprofile --norc -exo pipefail /var/run/act/workflow/6] user= workdir=
| + cd mlflow/mlp-regression-template
| + .github/workflows/scripts/lint.sh
| 
| ========== black ==========
| 
| Skipping .ipynb files as Jupyter dependencies are not installed.
| You can fix this by running ``pip install black[jupyter]``
| All done! ✨ 🍰 ✨
| 12 files would be left unchanged.
| 
| ========== pylint ==========
| 
| 
| ------------------------------------
| Your code has been rated at 10.00/10
| 
[Pipeline tests/lint-pipeline]   ✅  Success - Run lint checks
```

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
