### PR TITLE
[Model Validation] Disable logging metrics and artifacts for baseline model evaluation

### DIFF
--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -160,7 +160,7 @@ class EvaluationResult:
     @property
     def baseline_model_metrics(self) -> Dict[str, Any]:
         """
-        A dictionary mapping scalar metric names to scalar metric values for baseline model
+        A dictionary mapping scalar metric names to scalar metric values for the baseline model
         """
         return self._baseline_model_metrics
 

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -519,9 +519,9 @@ class ModelEvaluator(metaclass=ABCMeta):
         :param kwargs: For forwards compatibility, a placeholder for additional arguments that
                        may be added to the evaluation interface in the future.
         :param baseline_model: (Optional) A string URI referring to a MLflow model with the pyfunc
-                                          flavor as baseline model to be compared with the
-                                          candidate model for model validation.
-                                          (pyfunc model instance is not allowed)
+                                          flavor as a baseline model to be compared with the
+                                          candidate model (specified by the `model` param) for model
+                                          validation. (pyfunc model instance is not allowed)
         :return: A tuple of :py:class:`mlflow.models.EvaluationResult` instance containing
                  evaluation results for candidate model and baseline model (if provided else None).
         """

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -491,6 +491,8 @@ class ModelEvaluator(metaclass=ABCMeta):
         :param evaluator_config: A dictionary of additional configurations for
                                  the evaluator.
         :param custom_metrics: A list of callable custom metric functions.
+        :param is_baseline_model: A boolean indicating whether the evaulation is for baseline model.
+           For baseline model, no artifact will be generated and no metric will be logged.
         :param kwargs: For forwards compatibility, a placeholder for additional arguments that
                        may be added to the evaluation interface in the future.
         :return: An :py:class:`mlflow.models.EvaluationResult` instance containing

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -315,7 +315,8 @@ class EvaluationDataset:
 
             if len(self._features_data) != len(self._labels_data):
                 raise MlflowException(
-                    message="The input features example rows must be the same length with labels array.",
+                    message="The input features example rows must be the same length "
+                    "with labels array.",
                     erorr_code=INVALID_PARAMETER_VALUE,
                 )
 
@@ -517,9 +518,9 @@ class ModelEvaluator(metaclass=ABCMeta):
         :param custom_metrics: A list of callable custom metric functions.
         :param kwargs: For forwards compatibility, a placeholder for additional arguments that
                        may be added to the evaluation interface in the future.
-        :param baseline_model: (Optional) A string URI referring to a MLflow model as baseline model
-                                          to be compared with the candidate model
-                                          for model validation.
+        :param baseline_model: (Optional) A string URI referring to a MLflow model with the pyfunc
+                                          flavor as baseline model to be compared with the
+                                          candidate model for model validation.
                                           (pyfunc model instance is not allowed)
         :return: A tuple of :py:class:`mlflow.models.EvaluationResult` instance containing
                  evaluation results for candidate model and baseline model (if provided else None).
@@ -600,8 +601,8 @@ def _normalize_evaluators_and_evaluator_config_args(
     elif isinstance(evaluators, str):
         if not (evaluator_config is None or isinstance(evaluator_config, dict)):
             raise MlflowException(
-                message="If `evaluators` argument is the name of an evaluator, evaluator_config must be "
-                "None or a dict containing config items for the evaluator.",
+                message="If `evaluators` argument is the name of an evaluator, evaluator_config"
+                " must be None or a dict containing config items for the evaluator.",
                 error_code=INVALID_PARAMETER_VALUE,
             )
         evaluator_name_list = [evaluators]
@@ -1008,7 +1009,7 @@ def evaluate(
             return evaluate_result
 
         # TODO: Add Model Validation here
-        if baseline_model:
+        if baseline_model and validation_thresholds:
             pass
 
         return evaluate_result

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -507,7 +507,9 @@ class ModelEvaluator(metaclass=ABCMeta):
         """
         The abstract API to log metrics and artifacts, and return evaluation results.
 
-        :param model: A pyfunc model instance.
+        :param model: A pyfunc model instance, used as the candidate_model
+                      to be compared with baseline_model (specified by the `baseline_model` param)
+                      for model validation.
         :param model_type: A string describing the model type
                            (e.g., ``"regressor"``, ``"classifier"``, …).
         :param dataset: An instance of `mlflow.models.evaluation.base._EvaluationDataset`
@@ -812,7 +814,9 @@ def evaluate(
         - The evaluation dataset label values must be numeric or boolean, all feature values
           must be numeric, and each feature column must only contain scalar values.
 
-    :param model: A pyfunc model instance, or a URI referring to such a model.
+    :param model: A pyfunc model instance, or a URI referring to such a model, as
+                  the candidate_model to be compared with baseline_model
+                  (specified by the `baseline_model` param) for model validation.
 
     :param data: One of the following:
 
@@ -952,9 +956,10 @@ def evaluate(
                                              model validation.
                                              Metric name must be one of the builtin metric's name or
                                              name of a custom metric in custom_metrics argument.
-    :param baseline_model: (Optional) A string URI referring to a MLflow model as baseline model
-                                      to be compared with the candidate model for model validation.
-                                      (pyfunc model instance is not allowed)
+    :param baseline_model: (Optional) A string URI referring to a MLflow model with the pyfunc
+                                      flavor as a baseline model to be compared with the
+                                      candidate model (specified by the `model` param) for model
+                                      validation. (pyfunc model instance is not allowed)
 
     :return: An :py:class:`mlflow.models.EvaluationResult` instance containing
              evaluation results.

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -911,7 +911,10 @@ def evaluate(
                                        evaluators,
                                        custom_metrics=[squared_diff_plus_one, scatter_plot],
                                    )
-    :param validation_thresholds: (Optional) An array of MetricThreshold used for model validation.
+    :param validation_thresholds: (Optional) A dictionary of name to MetricThreshold used for
+                                             model validation.
+                                             Metric name must be one of the builtin metric's name or
+                                             name of a custom metric in custom_metrics argument.
     :param baseline_model: (Optional) A string URI referring to a MLflow model as baseline model
                                       to be compared with the candidate model for model validation.
                                       (pyfunc model instance is not allowed)

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -468,7 +468,16 @@ class ModelEvaluator(metaclass=ABCMeta):
 
     @abstractmethod
     def evaluate(
-        self, *, model, model_type, dataset, run_id, evaluator_config, custom_metrics=None, **kwargs
+        self,
+        *,
+        model,
+        model_type,
+        dataset,
+        run_id,
+        evaluator_config,
+        custom_metrics=None,
+        is_baseline_model=False,
+        **kwargs,
     ):
         """
         The abstract API to log metrics and artifacts, and return evaluation results.
@@ -607,6 +616,7 @@ def _evaluate(
     evaluator_name_list,
     evaluator_name_to_conf_map,
     custom_metrics,
+    is_baseline_model,
 ):
     """
     The public API "evaluate" will verify argument first, and then pass normalized arguments
@@ -641,6 +651,7 @@ def _evaluate(
                 run_id=run_id,
                 evaluator_config=config,
                 custom_metrics=custom_metrics,
+                is_baseline_model=is_baseline_model,
             )
             eval_results.append(result)
 
@@ -932,4 +943,5 @@ def evaluate(
             evaluator_name_list=evaluator_name_list,
             evaluator_name_to_conf_map=evaluator_name_to_conf_map,
             custom_metrics=custom_metrics,
+            is_baseline_model=False,
         )

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -21,7 +21,6 @@ import urllib
 import pathlib
 from collections import OrderedDict
 from abc import ABCMeta, abstractmethod
-import copy
 
 
 _logger = logging.getLogger(__name__)
@@ -614,29 +613,6 @@ def _get_last_failed_evaluator():
     This can be used to check which evaluator fail when `evaluate` API fail.
     """
     return _last_failed_evaluator
-
-
-def _is_eval_for_baseline_model(evaluator_name_to_conf_map):
-    """
-    Helper function to determining whether the evaluation is for baseline model
-    based on evaluator_name_to_conf_map; evaluation for baseline model should set
-    is_baseline_model set to True for evaluation_config for all evaluators.
-    """
-    if not evaluator_name_to_conf_map or not evaluator_name_to_conf_map.values:
-        return False
-    for config in evaluator_name_to_conf_map.values():
-        if not config or not config.get("is_baseline_model", False):
-            return False
-    return True
-
-
-def _add_is_baseline_model_flag_to_eval_config(evaluator_name_to_conf_map):
-    evaluator_name_to_conf_map_with_baseline_flag = copy.deepcopy(evaluator_name_to_conf_map)
-    for name in evaluator_name_to_conf_map_with_baseline_flag.keys():
-        if evaluator_name_to_conf_map_with_baseline_flag[name] is None:
-            evaluator_name_to_conf_map_with_baseline_flag[name] = {}
-        evaluator_name_to_conf_map_with_baseline_flag[name].update({"is_baseline_model": True})
-    return evaluator_name_to_conf_map_with_baseline_flag
 
 
 def _evaluate(

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -94,7 +94,7 @@ class EvaluationResult:
     def __init__(self, metrics, artifacts, baseline_model_metrics=None):
         self._metrics = metrics
         self._artifacts = artifacts
-        self._baseline_model_metrics = baseline_model_metrics
+        self._baseline_model_metrics = baseline_model_metrics if baseline_model_metrics else dict()
 
     @classmethod
     def load(cls, path):
@@ -160,7 +160,7 @@ class EvaluationResult:
     @property
     def baseline_model_metrics(self) -> Dict[str, Any]:
         """
-        A dictionary mapping scalar metric names to scalar metric values for baseline model
+        A dictionary mapping scalar metric names to scalar metric values for the baseline model
         """
         return self._baseline_model_metrics
 
@@ -522,8 +522,9 @@ class ModelEvaluator(metaclass=ABCMeta):
                                           flavor as baseline model to be compared with the
                                           candidate model for model validation.
                                           (pyfunc model instance is not allowed)
-        :return: A tuple of :py:class:`mlflow.models.EvaluationResult` instance containing
-                 evaluation results for candidate model and baseline model (if provided else None).
+        :return: :py:class:`mlflow.models.EvaluationResult` instance containing
+                 evaluation metrics for candidate model and baseline model and artifacts for
+                 candidate model.
         """
         raise NotImplementedError()
 
@@ -698,10 +699,7 @@ def _evaluate(
             erorr_code=INVALID_PARAMETER_VALUE,
         )
 
-    if baseline_model:
-        merged_eval_result = EvaluationResult(dict(), dict(), dict())
-    else:
-        merged_eval_result = EvaluationResult(dict(), dict())
+    merged_eval_result = EvaluationResult(dict(), dict(), dict())
 
     for eval_result in eval_results:
         if not eval_result:

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -962,7 +962,7 @@ def evaluate(
                                       validation. (pyfunc model instance is not allowed)
 
     :return: An :py:class:`mlflow.models.EvaluationResult` instance containing
-             evaluation results.
+             metrics of candidate model and baseline model, and artifacts of candidate model.
     """
     from mlflow.pyfunc import PyFuncModel
 

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -633,7 +633,8 @@ def _evaluate(
 
     client = MlflowClient()
     model_uuid = model.metadata.model_uuid
-    dataset._log_dataset_tag(client, run_id, model_uuid)
+    if not is_baseline_model:
+        dataset._log_dataset_tag(client, run_id, model_uuid)
 
     eval_results = []
     for evaluator_name in evaluator_name_list:

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -998,7 +998,6 @@ class DefaultEvaluator(ModelEvaluator):
         run_id,
         evaluator_config,
         custom_metrics=None,
-        is_baseline_model=False,
         **kwargs,
     ):
         import matplotlib
@@ -1015,7 +1014,7 @@ class DefaultEvaluator(ModelEvaluator):
             self.dataset_name = dataset.name
             self.feature_names = dataset.feature_names
             self.custom_metrics = custom_metrics
-            self.is_baseline_model = is_baseline_model
+            self.is_baseline_model = self.evaluator_config.get("is_baseline_model", False)
 
             model_loader_module, raw_model = _extract_raw_model(model)
             predict_fn, predict_proba_fn = _extract_predict_fn(model, raw_model)

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -710,7 +710,7 @@ class DefaultEvaluator(ModelEvaluator):
 
             self.metrics["precision_recall_auc"] = self.pr_curve.auc
 
-    def _log_multiclass_classifier(self):
+    def _log_multiclass_classifier_artifacts(self):
         per_class_metrics_collection_df = _get_classifier_per_class_metrics_collection_df(
             self.y, self.y_pred, self.label_list
         )
@@ -760,7 +760,7 @@ class DefaultEvaluator(ModelEvaluator):
 
         self._log_pandas_df_artifact(per_class_metrics_collection_df, "per_class_metrics")
 
-    def _log_binary_classifier(self):
+    def _log_binary_classifier_artifacts(self):
         from mlflow.models.evaluation.lift_curve import plot_lift_curve
 
         if self.y_probs is not None:
@@ -985,9 +985,9 @@ class DefaultEvaluator(ModelEvaluator):
         """
         if self.model_type == "classifier":
             if self.is_binomial:
-                self._log_binary_classifier()
+                self._log_binary_classifier_artifacts()
             else:
-                self._log_multiclass_classifier()
+                self._log_multiclass_classifier_artifacts()
             self._log_confusion_matrix()
         self._log_metrics()
         self._log_model_explainability()

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1067,9 +1067,7 @@ class DefaultEvaluator(ModelEvaluator):
         if evaluator_config.get("_disable_candidate_model", False):
             evaluation_result = EvaluationResult(metrics=dict(), artifacts=dict())
         else:
-            evaluation_result = self._evaluate(
-                model, is_baseline_model=evaluator_config.get("_disable_candidate_model", False)
-            )
+            evaluation_result = self._evaluate(model, is_baseline_model=False)
 
         if not baseline_model:
             return evaluation_result

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1065,7 +1065,7 @@ class DefaultEvaluator(ModelEvaluator):
             )
 
         evaluation_result = self._evaluate(
-            model, is_baseline_model=evaluator_config.get("is_baseline_model", False)
+            model, is_baseline_model=evaluator_config.get("disable_candidate_model", False)
         )
 
         if not baseline_model:

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -920,7 +920,7 @@ class DefaultEvaluator(ModelEvaluator):
 
     def _generate_model_predictions(self):
         """
-        Helper methof for generating model predictions
+        Helper method for generating model predictions
         """
         if self.model_type == "classifier":
             self.label_list = np.unique(self.y)

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1064,9 +1064,12 @@ class DefaultEvaluator(ModelEvaluator):
                 f"verify that you set the `model_type` and `dataset` arguments correctly."
             )
 
-        evaluation_result = self._evaluate(
-            model, is_baseline_model=evaluator_config.get("disable_candidate_model", False)
-        )
+        if evaluator_config.get("_disable_candidate_model", False):
+            evaluation_result = EvaluationResult(metrics=dict(), artifacts=dict())
+        else:
+            evaluation_result = self._evaluate(
+                model, is_baseline_model=evaluator_config.get("_disable_candidate_model", False)
+            )
 
         if not baseline_model:
             return evaluation_result

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -857,7 +857,7 @@ class DefaultEvaluator(ModelEvaluator):
         artifact._load(artifact_file_local_path)
         return artifact
 
-    def _evaluate_custom_metrics_and_log_produced_artifacts(self, disable_logging=False):
+    def _evaluate_custom_metrics_and_log_produced_artifacts(self, log_to_mlflow_tracking=True):
         if self.custom_metrics is None:
             return
         builtin_metrics = copy.deepcopy(self.metrics)
@@ -878,7 +878,7 @@ class DefaultEvaluator(ModelEvaluator):
                     copy.deepcopy(builtin_metrics),
                 )
                 self.metrics.update(metric_results)
-                if artifact_results is not None and not disable_logging:
+                if artifact_results is not None and log_to_mlflow_tracking:
                     for artifact_name, raw_artifact in artifact_results.items():
                         self.artifacts[artifact_name] = self._log_custom_metric_artifact(
                             artifact_name,
@@ -1028,7 +1028,7 @@ class DefaultEvaluator(ModelEvaluator):
                 self._generate_model_predictions()
                 self._compute_builtin_metrics()
                 self._evaluate_custom_metrics_and_log_produced_artifacts(
-                    disable_logging=is_baseline_model
+                    log_to_mlflow_tracking=not is_baseline_model
                 )
                 if not is_baseline_model:
                     self._log_metrics_and_artifacts()

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -447,8 +447,6 @@ class DefaultEvaluator(ModelEvaluator):
         do_plot,
         artifact_name,
     ):
-        if self.is_baseline_model:
-            return
         import matplotlib.pyplot as pyplot
 
         artifact_file_name = _gen_log_key(artifact_name, self.dataset_name) + ".png"
@@ -467,8 +465,6 @@ class DefaultEvaluator(ModelEvaluator):
         self.artifacts[artifact_name] = artifact
 
     def _log_pandas_df_artifact(self, pandas_df, artifact_name):
-        if self.is_baseline_model:
-            return
         artifact_file_name = _gen_log_key(artifact_name, self.dataset_name) + ".csv"
         artifact_file_local_path = self.temp_dir.path(artifact_file_name)
         pandas_df.to_csv(artifact_file_local_path, index=False)
@@ -506,9 +502,10 @@ class DefaultEvaluator(ModelEvaluator):
 
         algorithm = self.evaluator_config.get("explainability_algorithm", None)
         if algorithm is not None and algorithm not in _SUPPORTED_SHAP_ALGORITHMS:
-            raise ValueError(
-                f"Specified explainer algorithm {algorithm} is unsupported. Currently only "
-                f"support {','.join(_SUPPORTED_SHAP_ALGORITHMS)} algorithms."
+            raise MlflowException(
+                message=f"Specified explainer algorithm {algorithm} is unsupported. Currently only "
+                f"support {','.join(_SUPPORTED_SHAP_ALGORITHMS)} algorithms.",
+                error_code=INVALID_PARAMETER_VALUE,
             )
 
         if algorithm != "kernel":
@@ -693,11 +690,9 @@ class DefaultEvaluator(ModelEvaluator):
                 )
                 _logger.debug("", exc_info=True)
 
-    def _log_binary_classifier(self):
-        self.metrics.update(_get_classifier_per_class_metrics(self.y, self.y_pred))
-
+    def _compute_roc_and_pr_curve(self):
         if self.y_probs is not None:
-            roc_curve = _gen_classifier_curve(
+            self.roc_curve = _gen_classifier_curve(
                 is_binomial=True,
                 y=self.y,
                 y_probs=self.y_prob,
@@ -705,13 +700,8 @@ class DefaultEvaluator(ModelEvaluator):
                 curve_type="roc",
             )
 
-            def plot_roc_curve():
-                roc_curve.plot_fn(**roc_curve.plot_fn_args)
-
-            self._log_image_artifact(plot_roc_curve, "roc_curve_plot")
-            self.metrics["roc_auc"] = roc_curve.auc
-
-            pr_curve = _gen_classifier_curve(
+            self.metrics["roc_auc"] = self.roc_curve.auc
+            self.pr_curve = _gen_classifier_curve(
                 is_binomial=True,
                 y=self.y,
                 y_probs=self.y_prob,
@@ -719,11 +709,7 @@ class DefaultEvaluator(ModelEvaluator):
                 curve_type="pr",
             )
 
-            def plot_pr_curve():
-                pr_curve.plot_fn(**pr_curve.plot_fn_args)
-
-            self._log_image_artifact(plot_pr_curve, "precision_recall_curve_plot")
-            self.metrics["precision_recall_auc"] = pr_curve.auc
+            self.metrics["precision_recall_auc"] = self.pr_curve.auc
 
     def _log_multiclass_classifier(self):
         per_class_metrics_collection_df = _get_classifier_per_class_metrics_collection_df(
@@ -774,6 +760,26 @@ class DefaultEvaluator(ModelEvaluator):
             per_class_metrics_collection_df["precision_recall_auc"] = pr_curve.auc
 
         self._log_pandas_df_artifact(per_class_metrics_collection_df, "per_class_metrics")
+
+    def _log_binary_classifier(self):
+        from mlflow.models.evaluation.lift_curve import plot_lift_curve
+
+        if self.y_probs is not None:
+
+            def plot_roc_curve():
+                self.roc_curve.plot_fn(**self.roc_curve.plot_fn_args)
+
+            self._log_image_artifact(plot_roc_curve, "roc_curve_plot")
+
+            def plot_pr_curve():
+                self.pr_curve.plot_fn(**self.pr_curve.plot_fn_args)
+
+            self._log_image_artifact(plot_pr_curve, "precision_recall_curve_plot")
+
+            self._log_image_artifact(
+                lambda: plot_lift_curve(self.y, self.y_probs),
+                "lift_curve_plot",
+            )
 
     def _log_custom_metric_artifact(self, artifact_name, raw_artifact, custom_metric_tuple):
         """
@@ -852,7 +858,7 @@ class DefaultEvaluator(ModelEvaluator):
         artifact._load(artifact_file_local_path)
         return artifact
 
-    def _evaluate_custom_metrics_and_log_produced_artifacts(self):
+    def _evaluate_custom_metrics_and_log_produced_artifacts(self, disable_logging=False):
         if self.custom_metrics is None:
             return
         builtin_metrics = copy.deepcopy(self.metrics)
@@ -873,7 +879,7 @@ class DefaultEvaluator(ModelEvaluator):
                     copy.deepcopy(builtin_metrics),
                 )
                 self.metrics.update(metric_results)
-                if artifact_results is not None and not self.is_baseline_model:
+                if artifact_results is not None and not disable_logging:
                     for artifact_name, raw_artifact in artifact_results.items():
                         self.artifacts[artifact_name] = self._log_custom_metric_artifact(
                             artifact_name,
@@ -881,78 +887,7 @@ class DefaultEvaluator(ModelEvaluator):
                             custom_metric_tuple,
                         )
 
-    def _log_and_return_evaluation_result(self):
-        """
-        This function logs all of the produced metrics and artifacts (including custom metrics)
-        along with model explainability. Then, returns an instance of EvaluationResult.
-        :return:
-        """
-        self._evaluate_custom_metrics_and_log_produced_artifacts()
-        if not self.is_baseline_model:
-            self._log_metrics()
-            self._log_model_explainability()
-        return EvaluationResult(self.metrics, self.artifacts)
-
-    def _evaluate_classifier(self):
-        from mlflow.models.evaluation.lift_curve import plot_lift_curve
-
-        self.label_list = np.unique(self.y)
-        self.num_classes = len(self.label_list)
-
-        self.y_pred = self.predict_fn(self.X.copy_to_avoid_mutation())
-        self.is_binomial = self.num_classes <= 2
-
-        if self.is_binomial:
-            if list(self.label_list) not in [[0, 1], [-1, 1]]:
-                raise ValueError(
-                    "Binary classifier evaluation dataset positive class label must be 1 or True, "
-                    "negative class label must be 0 or -1 or False, and dataset must contains "
-                    "both positive and negative examples."
-                )
-            _logger.info(
-                "The evaluation dataset is inferred as binary dataset, positive label is "
-                f"{self.label_list[1]}, negative label is {self.label_list[0]}."
-            )
-        else:
-            _logger.info(
-                "The evaluation dataset is inferred as multiclass dataset, number of classes "
-                f"is inferred as {self.num_classes}"
-            )
-
-        if self.predict_proba_fn is not None:
-            self.y_probs = self.predict_proba_fn(self.X.copy_to_avoid_mutation())
-            if self.is_binomial:
-                self.y_prob = self.y_probs[:, 1]
-            else:
-                self.y_prob = None
-        else:
-            self.y_probs = None
-            self.y_prob = None
-
-        self.metrics.update(
-            _get_classifier_global_metrics(
-                self.is_binomial,
-                self.y,
-                self.y_pred,
-                self.y_probs,
-                self.label_list,
-            )
-        )
-        self._evaluate_sklearn_model_score_if_scorable()
-
-        if self.is_binomial:
-            self._log_binary_classifier()
-        else:
-            self._log_multiclass_classifier()
-
-        if self.is_binomial and self.y_probs is not None:
-            self._log_image_artifact(
-                lambda: plot_lift_curve(self.y, self.y_probs),
-                "lift_curve_plot",
-            )
-        # Skip confusion matrix for baseline model evaluation
-        if self.is_baseline_model:
-            return self._log_and_return_evaluation_result()
+    def _log_confusion_matrix(self):
         # normalize the confusion matrix, keep consistent with sklearn autologging.
         confusion_matrix = sk_metrics.confusion_matrix(
             self.y, self.y_pred, labels=self.label_list, normalize="true"
@@ -979,15 +914,72 @@ class DefaultEvaluator(ModelEvaluator):
                 plot_confusion_matrix,
                 "confusion_matrix",
             )
+        return
 
-        return self._log_and_return_evaluation_result()
+    def _generate_model_predictions(self):
+        if self.model_type == "classifier":
+            self.label_list = np.unique(self.y)
+            self.num_classes = len(self.label_list)
 
-    def _evaluate_regressor(self):
-        self.y_pred = self.model.predict(self.X.copy_to_avoid_mutation())
-        self.metrics.update(_get_regressor_metrics(self.y, self.y_pred))
+            self.y_pred = self.predict_fn(self.X.copy_to_avoid_mutation())
+            self.is_binomial = self.num_classes <= 2
+
+            if self.is_binomial:
+                if list(self.label_list) not in [[0, 1], [-1, 1]]:
+                    raise ValueError(
+                        "Binary classifier evaluation dataset positive class label must be 1 or"
+                        " True, negative class label must be 0 or -1 or False, and dataset"
+                        " must contains both positive and negative examples."
+                    )
+                _logger.info(
+                    "The evaluation dataset is inferred as binary dataset, positive label is "
+                    f"{self.label_list[1]}, negative label is {self.label_list[0]}."
+                )
+            else:
+                _logger.info(
+                    "The evaluation dataset is inferred as multiclass dataset, number of classes "
+                    f"is inferred as {self.num_classes}"
+                )
+
+            if self.predict_proba_fn is not None:
+                self.y_probs = self.predict_proba_fn(self.X.copy_to_avoid_mutation())
+                if self.is_binomial:
+                    self.y_prob = self.y_probs[:, 1]
+                else:
+                    self.y_prob = None
+            else:
+                self.y_probs = None
+                self.y_prob = None
+        elif self.model_type == "regressor":
+            self.y_pred = self.model.predict(self.X.copy_to_avoid_mutation())
+
+    def _compute_metrics(self):
         self._evaluate_sklearn_model_score_if_scorable()
+        if self.model_type == "classifier":
+            self.metrics.update(
+                _get_classifier_global_metrics(
+                    self.is_binomial,
+                    self.y,
+                    self.y_pred,
+                    self.y_probs,
+                    self.label_list,
+                )
+            )
+            if self.is_binomial:
+                self.metrics.update(_get_classifier_per_class_metrics(self.y, self.y_pred))
+                self._compute_roc_and_pr_curve()
+        elif self.model_type == "regressor":
+            self.metrics.update(_get_regressor_metrics(self.y, self.y_pred))
 
-        return self._log_and_return_evaluation_result()
+    def _log_metrics_and_artifacts(self):
+        if self.model_type == "classifier":
+            if self.is_binomial:
+                self._log_binary_classifier()
+            else:
+                self._log_multiclass_classifier()
+            self._log_confusion_matrix()
+        self._log_metrics()
+        self._log_model_explainability()
 
     def _evaluate(
         self,
@@ -1016,13 +1008,20 @@ class DefaultEvaluator(ModelEvaluator):
             self.baseline_metrics = dict()
             self.artifacts = {}
 
+            if self.model_type not in ["classifier", "regressor"]:
+                raise MlflowException(
+                    message=f"Unsupported model type {self.model_type}",
+                    erorr_code=INVALID_PARAMETER_VALUE,
+                )
             with mlflow.utils.autologging_utils.disable_autologging():
-                if self.model_type == "classifier":
-                    return self._evaluate_classifier()
-                elif self.model_type == "regressor":
-                    return self._evaluate_regressor()
-                else:
-                    raise ValueError(f"Unsupported model type {self.model_type}")
+                self._generate_model_predictions()
+                self._compute_metrics()
+                self._evaluate_custom_metrics_and_log_produced_artifacts(
+                    disable_logging=is_baseline_model
+                )
+                if not is_baseline_model:
+                    self._log_metrics_and_artifacts()
+                return EvaluationResult(metrics=self.metrics, artifacts=self.artifacts)
 
     def evaluate(
         self,
@@ -1059,10 +1058,15 @@ class DefaultEvaluator(ModelEvaluator):
         )
 
         if not baseline_model:
-            return evaluation_result, None
+            return evaluation_result
 
-        baseline_model_evaluation_result = self._evaluate(baseline_model, is_baseline_model=True)
-        return evaluation_result, baseline_model_evaluation_result
+        baseline_evaluation_result = self._evaluate(baseline_model, is_baseline_model=True)
+
+        return EvaluationResult(
+            metrics=evaluation_result.metrics,
+            artifacts=evaluation_result.artifacts,
+            baseline_model_metrics=baseline_evaluation_result.metrics,
+        )
 
     @property
     def X(self) -> pd.DataFrame:

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -989,15 +989,10 @@ class DefaultEvaluator(ModelEvaluator):
 
         return self._log_and_return_evaluation_result()
 
-    def evaluate(
+    def _evaluate(
         self,
-        *,
         model: "mlflow.pyfunc.PyFuncModel",
-        model_type,
-        dataset,
-        run_id,
-        evaluator_config,
-        custom_metrics=None,
+        is_baseline_model=False,
         **kwargs,
     ):
         import matplotlib
@@ -1007,14 +1002,7 @@ class DefaultEvaluator(ModelEvaluator):
 
             self.temp_dir = temp_dir
             self.model = model
-            self.model_type = model_type
-            self.dataset = dataset
-            self.run_id = run_id
-            self.evaluator_config = evaluator_config
-            self.dataset_name = dataset.name
-            self.feature_names = dataset.feature_names
-            self.custom_metrics = custom_metrics
-            self.is_baseline_model = self.evaluator_config.get("is_baseline_model", False)
+            self.is_baseline_model = is_baseline_model
 
             model_loader_module, raw_model = _extract_raw_model(model)
             predict_fn, predict_proba_fn = _extract_predict_fn(model, raw_model)
@@ -1024,26 +1012,57 @@ class DefaultEvaluator(ModelEvaluator):
             self.predict_fn = predict_fn
             self.predict_proba_fn = predict_proba_fn
 
-            self.y = dataset.labels_data
             self.metrics = dict()
+            self.baseline_metrics = dict()
             self.artifacts = {}
 
-            inferred_model_type = _infer_model_type_by_labels(self.y)
-
-            if inferred_model_type is not None and model_type != inferred_model_type:
-                _logger.warning(
-                    f"According to the evaluation dataset label values, the model type looks like "
-                    f"{inferred_model_type}, but you specified model type {model_type}. Please "
-                    f"verify that you set the `model_type` and `dataset` arguments correctly."
-                )
-
             with mlflow.utils.autologging_utils.disable_autologging():
-                if model_type == "classifier":
+                if self.model_type == "classifier":
                     return self._evaluate_classifier()
-                elif model_type == "regressor":
+                elif self.model_type == "regressor":
                     return self._evaluate_regressor()
                 else:
-                    raise ValueError(f"Unsupported model type {model_type}")
+                    raise ValueError(f"Unsupported model type {self.model_type}")
+
+    def evaluate(
+        self,
+        *,
+        model: "mlflow.pyfunc.PyFuncModel",
+        model_type,
+        dataset,
+        run_id,
+        evaluator_config,
+        custom_metrics=None,
+        baseline_model=None,
+        **kwargs,
+    ):
+        self.dataset = dataset
+        self.run_id = run_id
+        self.model_type = model_type
+        self.evaluator_config = evaluator_config
+        self.dataset_name = dataset.name
+        self.feature_names = dataset.feature_names
+        self.custom_metrics = custom_metrics
+        self.y = dataset.labels_data
+
+        inferred_model_type = _infer_model_type_by_labels(self.y)
+
+        if inferred_model_type is not None and model_type != inferred_model_type:
+            _logger.warning(
+                f"According to the evaluation dataset label values, the model type looks like "
+                f"{inferred_model_type}, but you specified model type {model_type}. Please "
+                f"verify that you set the `model_type` and `dataset` arguments correctly."
+            )
+
+        evaluation_result = self._evaluate(
+            model, is_baseline_model=evaluator_config.get("is_baseline_model", False)
+        )
+
+        if not baseline_model:
+            return evaluation_result, None
+
+        baseline_model_evaluation_result = self._evaluate(baseline_model, is_baseline_model=True)
+        return evaluation_result, baseline_model_evaluation_result
 
     @property
     def X(self) -> pd.DataFrame:

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -960,7 +960,7 @@ class DefaultEvaluator(ModelEvaluator):
 
     def _compute_builtin_metrics(self):
         """
-        Helper method for computing builtin metrics for self.model, update results to self.metrics
+        Helper method for computing builtin metrics
         """
         self._evaluate_sklearn_model_score_if_scorable()
         if self.model_type == "classifier":

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -461,6 +461,7 @@ class DefaultEvaluator(ModelEvaluator):
         finally:
             pyplot.close(pyplot.gcf())
 
+        mlflow.log_artifact(artifact_file_local_path)
         artifact = ImageEvaluationArtifact(uri=mlflow.get_artifact_uri(artifact_file_name))
         artifact._load(artifact_file_local_path)
         self.artifacts[artifact_name] = artifact

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -630,6 +630,11 @@ class PyFuncModel:
             data = _enforce_schema(data, input_schema)
         return self._model_impl.predict(data)
 
+    def __eq__(self, other):
+        if not isinstance(other, PyFuncModel):
+            return False
+        return self._model_meta == other._model_meta
+
     @property
     def metadata(self):
         """Model metadata."""

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -127,12 +127,21 @@ def evaluate_model_helper(
             targets=targets,
             dataset_name=dataset_name,
             evaluators="default",
+            evaluator_config=evaluator_config,
         )
 
 
 def metrics_check_helper(
     metrics, result, expected_metrics, dataset_log_key, test_is_baseline_model_flag
 ):
+    """
+    Helper function for unit tests for evaluation and validation for check metrics:
+        - if test_is_baseline_model_flag:
+            Check if no metric is logged.
+        - Othwerise
+            Check if logged metrics are expected.
+        Check if returned metrics are expected.
+    """
     if test_is_baseline_model_flag:
         assert metrics == {}
     for metric_key in expected_metrics:
@@ -152,8 +161,16 @@ def artifacts_check_helper(
     expected_artifacts_keys,
     test_is_baseline_model_flag,
 ):
+    """
+    Helper function for unit tests for evaluation and validation for check artifacts:
+        - if test_is_baseline_model_flag:
+            Check if no artifacts is logged and no artifacts returned.
+        - Otherwise
+            Check if logged artfacts and returned artfacts are expected.
+    """
     if test_is_baseline_model_flag:
         assert logged_artifacts == []
+        assert result_artifacts == {}
 
     else:
         assert set(logged_artifacts) == expected_artifacts

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -106,22 +106,6 @@ def evaluate_model_helper(
     )
 
 
-def check_metrics_are_expected_for_candidate_model_evaluation(
-    logged_metrics, result_metrics, expected_metrics, dataset_log_key
-):
-    """
-    Helper function for checking metrics of evaluation of model
-     - Meetrics should be logged and returned as expected
-    """
-    for metric_key in expected_metrics:
-        assert np.isclose(
-            expected_metrics[metric_key],
-            logged_metrics[metric_key + dataset_log_key],
-            rtol=1e-3,
-        )
-        assert np.isclose(expected_metrics[metric_key], result_metrics[metric_key], rtol=1e-3)
-
-
 def check_metrics_not_logged_for_baseline_model_evaluation(
     logged_metrics, result_metrics, expected_metrics
 ):
@@ -133,20 +117,6 @@ def check_metrics_not_logged_for_baseline_model_evaluation(
     assert logged_metrics == {}
     for metric_key in expected_metrics:
         assert np.isclose(expected_metrics[metric_key], result_metrics[metric_key], rtol=1e-3)
-
-
-def check_artifacts_are_expected_for_candidate_model_evaluation(
-    logged_artifacts,
-    result_artifacts,
-    expected_artifacts,
-    expected_artifacts_keys,
-):
-    """
-    Helper function for unit tests for checking artifacts of evaluation of candidate model
-        - Artifacts should be logged and returned as expected
-    """
-    assert set(logged_artifacts) == expected_artifacts
-    assert result_artifacts.keys() == expected_artifacts_keys
 
 
 def check_artifacts_are_not_generated_for_baseline_model_evaluation(
@@ -201,27 +171,23 @@ def test_regressor_evaluation(
         {**diabetes_dataset._metadata, "model": model.metadata.model_uuid}
     ]
 
-    check_metrics_are_expected_for_candidate_model_evaluation(
-        expected_metrics=expected_metrics,
-        result_metrics=result.metrics,
-        logged_metrics=metrics,
-        dataset_log_key="_on_data_diabetes_dataset",
-    )
+    for metric_key in expected_metrics:
+        assert np.isclose(
+            expected_metrics[metric_key],
+            metrics[metric_key + "_on_data_diabetes_dataset"],
+            rtol=1e-3,
+        )
+        assert np.isclose(expected_metrics[metric_key], result.metrics[metric_key], rtol=1e-3)
 
-    check_artifacts_are_expected_for_candidate_model_evaluation(
-        logged_artifacts=artifacts,
-        result_artifacts=result.artifacts,
-        expected_artifacts={
-            "shap_beeswarm_plot_on_data_diabetes_dataset.png",
-            "shap_feature_importance_plot_on_data_diabetes_dataset.png",
-            "shap_summary_plot_on_data_diabetes_dataset.png",
-        },
-        expected_artifacts_keys={
-            "shap_beeswarm_plot",
-            "shap_feature_importance_plot",
-            "shap_summary_plot",
-        },
-    )
+    assert json.loads(tags["mlflow.datasets"]) == [
+        {**diabetes_dataset._metadata, "model": model.metadata.model_uuid}
+    ]
+
+    assert set(artifacts) == {
+        "shap_beeswarm_plot_on_data_diabetes_dataset.png",
+        "shap_feature_importance_plot_on_data_diabetes_dataset.png",
+        "shap_summary_plot_on_data_diabetes_dataset.png",
+    }
 
 
 def test_regressor_evaluation_disable_logging_metrics_and_artifacts(
@@ -321,40 +287,35 @@ def test_multi_classifier_evaluation(
         iris_dataset.features_data, iris_dataset.labels_data
     )
 
-    check_metrics_are_expected_for_candidate_model_evaluation(
-        expected_metrics=expected_metrics,
-        result_metrics=result.metrics,
-        logged_metrics=metrics,
-        dataset_log_key="_on_data_iris_dataset",
-    )
+    for metric_key in expected_metrics:
+        assert np.isclose(
+            expected_metrics[metric_key], metrics[metric_key + "_on_data_iris_dataset"], rtol=1e-3
+        )
+        assert np.isclose(expected_metrics[metric_key], result.metrics[metric_key], rtol=1e-3)
 
     assert json.loads(tags["mlflow.datasets"]) == [
         {**iris_dataset._metadata, "model": model.metadata.model_uuid}
     ]
 
-    check_artifacts_are_expected_for_candidate_model_evaluation(
-        logged_artifacts=artifacts,
-        result_artifacts=result.artifacts,
-        expected_artifacts={
-            "shap_beeswarm_plot_on_data_iris_dataset.png",
-            "per_class_metrics_on_data_iris_dataset.csv",
-            "roc_curve_plot_on_data_iris_dataset.png",
-            "precision_recall_curve_plot_on_data_iris_dataset.png",
-            "shap_feature_importance_plot_on_data_iris_dataset.png",
-            "explainer_on_data_iris_dataset",
-            "confusion_matrix_on_data_iris_dataset.png",
-            "shap_summary_plot_on_data_iris_dataset.png",
-        },
-        expected_artifacts_keys={
-            "per_class_metrics",
-            "roc_curve_plot",
-            "precision_recall_curve_plot",
-            "confusion_matrix",
-            "shap_beeswarm_plot",
-            "shap_summary_plot",
-            "shap_feature_importance_plot",
-        },
-    )
+    assert set(artifacts) == {
+        "shap_beeswarm_plot_on_data_iris_dataset.png",
+        "per_class_metrics_on_data_iris_dataset.csv",
+        "roc_curve_plot_on_data_iris_dataset.png",
+        "precision_recall_curve_plot_on_data_iris_dataset.png",
+        "shap_feature_importance_plot_on_data_iris_dataset.png",
+        "explainer_on_data_iris_dataset",
+        "confusion_matrix_on_data_iris_dataset.png",
+        "shap_summary_plot_on_data_iris_dataset.png",
+    }
+    assert result.artifacts.keys() == {
+        "per_class_metrics",
+        "roc_curve_plot",
+        "precision_recall_curve_plot",
+        "confusion_matrix",
+        "shap_beeswarm_plot",
+        "shap_summary_plot",
+        "shap_feature_importance_plot",
+    }
 
 
 def test_multi_classifier_evaluation_disable_logging_metrics_and_artifacts(
@@ -442,39 +403,36 @@ def test_bin_classifier_evaluation(
         breast_cancer_dataset.features_data, breast_cancer_dataset.labels_data
     )
 
-    check_metrics_are_expected_for_candidate_model_evaluation(
-        expected_metrics=expected_metrics,
-        result_metrics=result.metrics,
-        logged_metrics=metrics,
-        dataset_log_key="_on_data_breast_cancer_dataset",
-    )
+    for metric_key in expected_metrics:
+        assert np.isclose(
+            expected_metrics[metric_key],
+            metrics[metric_key + "_on_data_breast_cancer_dataset"],
+            rtol=1e-3,
+        )
+        assert np.isclose(expected_metrics[metric_key], result.metrics[metric_key], rtol=1e-3)
 
     assert json.loads(tags["mlflow.datasets"]) == [
         {**breast_cancer_dataset._metadata, "model": model.metadata.model_uuid}
     ]
 
-    check_artifacts_are_expected_for_candidate_model_evaluation(
-        logged_artifacts=artifacts,
-        result_artifacts=result.artifacts,
-        expected_artifacts={
-            "shap_feature_importance_plot_on_data_breast_cancer_dataset.png",
-            "lift_curve_plot_on_data_breast_cancer_dataset.png",
-            "shap_beeswarm_plot_on_data_breast_cancer_dataset.png",
-            "precision_recall_curve_plot_on_data_breast_cancer_dataset.png",
-            "confusion_matrix_on_data_breast_cancer_dataset.png",
-            "shap_summary_plot_on_data_breast_cancer_dataset.png",
-            "roc_curve_plot_on_data_breast_cancer_dataset.png",
-        },
-        expected_artifacts_keys={
-            "roc_curve_plot",
-            "precision_recall_curve_plot",
-            "lift_curve_plot",
-            "confusion_matrix",
-            "shap_beeswarm_plot",
-            "shap_summary_plot",
-            "shap_feature_importance_plot",
-        },
-    )
+    assert set(artifacts) == {
+        "shap_feature_importance_plot_on_data_breast_cancer_dataset.png",
+        "lift_curve_plot_on_data_breast_cancer_dataset.png",
+        "shap_beeswarm_plot_on_data_breast_cancer_dataset.png",
+        "precision_recall_curve_plot_on_data_breast_cancer_dataset.png",
+        "confusion_matrix_on_data_breast_cancer_dataset.png",
+        "shap_summary_plot_on_data_breast_cancer_dataset.png",
+        "roc_curve_plot_on_data_breast_cancer_dataset.png",
+    }
+    assert result.artifacts.keys() == {
+        "roc_curve_plot",
+        "precision_recall_curve_plot",
+        "lift_curve_plot",
+        "confusion_matrix",
+        "shap_beeswarm_plot",
+        "shap_summary_plot",
+        "shap_feature_importance_plot",
+    }
 
 
 def test_bin_classifier_evaluation_disable_logging_metrics_and_artifacts(
@@ -557,23 +515,22 @@ def test_spark_regressor_model_evaluation(
 
     expected_metrics = _get_regressor_metrics(y, y_pred)
 
-    check_metrics_are_expected_for_candidate_model_evaluation(
-        expected_metrics=expected_metrics,
-        result_metrics=result.metrics,
-        logged_metrics=metrics,
-        dataset_log_key="_on_data_diabetes_spark_dataset",
-    )
+    for metric_key in expected_metrics:
+        assert np.isclose(
+            expected_metrics[metric_key],
+            metrics[metric_key + "_on_data_diabetes_spark_dataset"],
+            rtol=1e-3,
+        )
+        assert np.isclose(expected_metrics[metric_key], result.metrics[metric_key], rtol=1e-3)
+
+    model = mlflow.pyfunc.load_model(spark_linear_regressor_model_uri)
 
     assert json.loads(tags["mlflow.datasets"]) == [
         {**diabetes_spark_dataset._metadata, "model": model.metadata.model_uuid}
     ]
 
-    check_artifacts_are_expected_for_candidate_model_evaluation(
-        logged_artifacts=artifacts,
-        result_artifacts=result.artifacts,
-        expected_artifacts=set(),
-        expected_artifacts_keys=set(),
-    )
+    assert set(artifacts) == set()
+    assert result.artifacts == {}
 
 
 def test_spark_regressor_model_evaluation_disable_logging_metrics_and_artifacts(
@@ -651,33 +608,30 @@ def test_svm_classifier_evaluation(svm_model_uri, breast_cancer_dataset, baselin
         breast_cancer_dataset.features_data, breast_cancer_dataset.labels_data
     )
 
-    check_metrics_are_expected_for_candidate_model_evaluation(
-        expected_metrics=expected_metrics,
-        result_metrics=result.metrics,
-        logged_metrics=metrics,
-        dataset_log_key="_on_data_breast_cancer_dataset",
-    )
+    for metric_key in expected_metrics:
+        assert np.isclose(
+            expected_metrics[metric_key],
+            metrics[metric_key + "_on_data_breast_cancer_dataset"],
+            rtol=1e-3,
+        )
+        assert np.isclose(expected_metrics[metric_key], result.metrics[metric_key], rtol=1e-3)
 
     assert json.loads(tags["mlflow.datasets"]) == [
         {**breast_cancer_dataset._metadata, "model": model.metadata.model_uuid}
     ]
 
-    check_artifacts_are_expected_for_candidate_model_evaluation(
-        logged_artifacts=artifacts,
-        result_artifacts=result.artifacts,
-        expected_artifacts={
-            "confusion_matrix_on_data_breast_cancer_dataset.png",
-            "shap_feature_importance_plot_on_data_breast_cancer_dataset.png",
-            "shap_beeswarm_plot_on_data_breast_cancer_dataset.png",
-            "shap_summary_plot_on_data_breast_cancer_dataset.png",
-        },
-        expected_artifacts_keys={
-            "confusion_matrix",
-            "shap_beeswarm_plot",
-            "shap_summary_plot",
-            "shap_feature_importance_plot",
-        },
-    )
+    assert set(artifacts) == {
+        "confusion_matrix_on_data_breast_cancer_dataset.png",
+        "shap_feature_importance_plot_on_data_breast_cancer_dataset.png",
+        "shap_beeswarm_plot_on_data_breast_cancer_dataset.png",
+        "shap_summary_plot_on_data_breast_cancer_dataset.png",
+    }
+    assert result.artifacts.keys() == {
+        "confusion_matrix",
+        "shap_beeswarm_plot",
+        "shap_summary_plot",
+        "shap_feature_importance_plot",
+    }
 
 
 def test_svm_classifier_evaluation_disable_logging_metrics_and_artifacts(

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -83,20 +83,22 @@ def evaluate_model_helper(
     """
     Helper function for testing MLflow.evaluate
     To test if evaluation for baseline model does not log metrics and artifacts;
-    we set "is_baseline_model" to true for the evaluator_config so that the
+    we set "disable_candidate_model" to true for the evaluator_config so that the
     DefaultEvaluator will evaluate only the baseline_model with logging
     disabled. This code path is only for testing purposes.
     """
     if eval_baseline_model_only:
         if not evaluator_config:
-            evaluator_config = {"is_baseline_model": True}
+            evaluator_config = {"disable_candidate_model": True}
         elif not evaluators or evaluators == "default":
-            evaluator_config.update({"is_baseline_model": True})
+            evaluator_config.update({"disable_candidate_model": True})
         else:
             for config in evaluator_config.values():
-                config.update({"is_baseline_model": True})
+                config.update({"disable_candidate_model": True})
 
     return evaluate(
+        # Disable candidate model and evaluate baseline model only
+        # If eval_baseline_model_only is set to True
         model=baseline_model if eval_baseline_model_only else model,
         data=data,
         model_type=model_type,
@@ -104,6 +106,8 @@ def evaluate_model_helper(
         dataset_name=dataset_name,
         evaluators=evaluators,
         evaluator_config=evaluator_config,
+        # Disable candidate model and evaluate baseline model only
+        # If eval_baseline_model_only is set to True
         baseline_model=None if eval_baseline_model_only else baseline_model,
     )
 

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -89,26 +89,22 @@ def evaluate_model_helper(
     """
     if eval_baseline_model_only:
         if not evaluator_config:
-            evaluator_config = {"disable_candidate_model": True}
+            evaluator_config = {"_disable_candidate_model": True}
         elif not evaluators or evaluators == "default":
-            evaluator_config.update({"disable_candidate_model": True})
+            evaluator_config.update({"_disable_candidate_model": True})
         else:
             for config in evaluator_config.values():
-                config.update({"disable_candidate_model": True})
+                config.update({"_disable_candidate_model": True})
 
     return evaluate(
-        # Disable candidate model and evaluate baseline model only
-        # If eval_baseline_model_only is set to True
-        model=baseline_model if eval_baseline_model_only else model,
+        model=model,
         data=data,
         model_type=model_type,
         targets=targets,
         dataset_name=dataset_name,
         evaluators=evaluators,
         evaluator_config=evaluator_config,
-        # Disable candidate model and evaluate baseline model only
-        # If eval_baseline_model_only is set to True
-        baseline_model=None if eval_baseline_model_only else baseline_model,
+        baseline_model=baseline_model,
     )
 
 
@@ -218,7 +214,7 @@ def test_regressor_evaluation_disable_logging_metrics_and_artifacts(
             eval_baseline_model_only=True,
         )
 
-    _, metrics, tags, artifacts = get_run_data(run.info.run_id)
+    _, logged_metrics, tags, artifacts = get_run_data(run.info.run_id)
 
     model = mlflow.pyfunc.load_model(linear_regressor_model_uri)
 
@@ -232,8 +228,8 @@ def test_regressor_evaluation_disable_logging_metrics_and_artifacts(
 
     check_metrics_not_logged_for_baseline_model_evaluation(
         expected_metrics=expected_metrics,
-        result_metrics=result.metrics,
-        logged_metrics=metrics,
+        result_metrics=result.baseline_model_metrics,
+        logged_metrics=logged_metrics,
     )
 
     assert "mlflow.datassets" not in tags
@@ -346,7 +342,7 @@ def test_multi_classifier_evaluation_disable_logging_metrics_and_artifacts(
             eval_baseline_model_only=True,
         )
 
-    _, metrics, tags, artifacts = get_run_data(run.info.run_id)
+    _, logged_metrics, tags, artifacts = get_run_data(run.info.run_id)
 
     model = mlflow.pyfunc.load_model(multiclass_logistic_regressor_model_uri)
 
@@ -363,8 +359,8 @@ def test_multi_classifier_evaluation_disable_logging_metrics_and_artifacts(
 
     check_metrics_not_logged_for_baseline_model_evaluation(
         expected_metrics=expected_metrics,
-        result_metrics=result.metrics,
-        logged_metrics=metrics,
+        result_metrics=result.baseline_model_metrics,
+        logged_metrics=logged_metrics,
     )
 
     assert "mlflow.datassets" not in tags
@@ -463,7 +459,7 @@ def test_bin_classifier_evaluation_disable_logging_metrics_and_artifacts(
             eval_baseline_model_only=True,
         )
 
-    _, metrics, tags, artifacts = get_run_data(run.info.run_id)
+    _, logged_metrics, tags, artifacts = get_run_data(run.info.run_id)
 
     model = mlflow.pyfunc.load_model(binary_logistic_regressor_model_uri)
 
@@ -480,8 +476,8 @@ def test_bin_classifier_evaluation_disable_logging_metrics_and_artifacts(
 
     check_metrics_not_logged_for_baseline_model_evaluation(
         expected_metrics=expected_metrics,
-        result_metrics=result.metrics,
-        logged_metrics=metrics,
+        result_metrics=result.baseline_model_metrics,
+        logged_metrics=logged_metrics,
     )
 
     assert "mlflow.datassets" not in tags
@@ -561,7 +557,7 @@ def test_spark_regressor_model_evaluation_disable_logging_metrics_and_artifacts(
             eval_baseline_model_only=True,
         )
 
-    _, metrics, tags, artifacts = get_run_data(run.info.run_id)
+    _, logged_metrics, tags, artifacts = get_run_data(run.info.run_id)
 
     model = mlflow.pyfunc.load_model(spark_linear_regressor_model_uri)
 
@@ -573,8 +569,8 @@ def test_spark_regressor_model_evaluation_disable_logging_metrics_and_artifacts(
 
     check_metrics_not_logged_for_baseline_model_evaluation(
         expected_metrics=expected_metrics,
-        result_metrics=result.metrics,
-        logged_metrics=metrics,
+        result_metrics=result.baseline_model_metrics,
+        logged_metrics=logged_metrics,
     )
 
     assert "mlflow.datassets" not in tags
@@ -661,7 +657,7 @@ def test_svm_classifier_evaluation_disable_logging_metrics_and_artifacts(
             eval_baseline_model_only=True,
         )
 
-    _, metrics, tags, artifacts = get_run_data(run.info.run_id)
+    _, logged_metrics, tags, artifacts = get_run_data(run.info.run_id)
 
     model = mlflow.pyfunc.load_model(svm_model_uri)
 
@@ -677,8 +673,8 @@ def test_svm_classifier_evaluation_disable_logging_metrics_and_artifacts(
 
     check_metrics_not_logged_for_baseline_model_evaluation(
         expected_metrics=expected_metrics,
-        result_metrics=result.metrics,
-        logged_metrics=metrics,
+        result_metrics=result.baseline_model_metrics,
+        logged_metrics=logged_metrics,
     )
 
     assert "mlflow.datassets" not in tags

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -77,7 +77,7 @@ def evaluate_model_helper(
     dataset_name=None,
     evaluators=None,
     evaluator_config=None,
-    is_baseline_model=None,
+    eval_baseline_model_only=False,
 ):
 
     """
@@ -85,7 +85,7 @@ def evaluate_model_helper(
     To test if evaluation for baseline model does not log metrics and artifacts;
     we set "is_baseline_model" to true for all evaluator_config
     """
-    if is_baseline_model:
+    if eval_baseline_model_only:
         if not evaluator_config:
             evaluator_config = {"is_baseline_model": True}
         elif not evaluators or evaluators == "default":
@@ -95,75 +95,82 @@ def evaluate_model_helper(
                 config.update({"is_baseline_model": True})
 
     return evaluate(
-        model=baseline_model if is_baseline_model else model,
+        model=baseline_model if eval_baseline_model_only else model,
         data=data,
         model_type=model_type,
         targets=targets,
         dataset_name=dataset_name,
         evaluators=evaluators,
         evaluator_config=evaluator_config,
+        baseline_model=None if eval_baseline_model_only else baseline_model,
     )
 
 
-def metrics_check_helper(
-    logged_metrics, result_metrics, expected_metrics, dataset_log_key, test_is_baseline_model_flag
+def check_metrics_are_expected_for_candidate_model_evaluation(
+    logged_metrics, result_metrics, expected_metrics, dataset_log_key
 ):
     """
-    Helper function for unit tests for evaluation and validation for check metrics:
-        - if test_is_baseline_model_flag:
-            Check if no metric is logged.
-        - Othwerise
-            Check if logged metrics are expected.
-        Check if returned metrics are expected.
+    Helper function for checking metrics of evaluation of model
+     - Meetrics should be logged and returned as expected
     """
-    if test_is_baseline_model_flag:
-        assert logged_metrics == {}
     for metric_key in expected_metrics:
-        if not test_is_baseline_model_flag:
-            assert np.isclose(
-                expected_metrics[metric_key],
-                logged_metrics[metric_key + dataset_log_key],
-                rtol=1e-3,
-            )
+        assert np.isclose(
+            expected_metrics[metric_key],
+            logged_metrics[metric_key + dataset_log_key],
+            rtol=1e-3,
+        )
         assert np.isclose(expected_metrics[metric_key], result_metrics[metric_key], rtol=1e-3)
 
 
-def artifacts_check_helper(
+def check_metrics_not_logged_for_baseline_model_evaluation(
+    logged_metrics, result_metrics, expected_metrics
+):
+    """
+    Helper function for checking metrics of evaluation of baseline_model
+     - Metrics should not be logged
+     - Meetrics should be returned as expected
+    """
+    assert logged_metrics == {}
+    for metric_key in expected_metrics:
+        assert np.isclose(expected_metrics[metric_key], result_metrics[metric_key], rtol=1e-3)
+
+
+def check_artifacts_are_expected_for_candidate_model_evaluation(
     logged_artifacts,
     result_artifacts,
     expected_artifacts,
     expected_artifacts_keys,
-    test_is_baseline_model_flag,
 ):
     """
-    Helper function for unit tests for evaluation and validation for check artifacts:
-        - if test_is_baseline_model_flag:
-            Check if no artifacts is logged and no artifacts returned.
-        - Otherwise
-            Check if logged artfacts and returned artfacts are expected.
+    Helper function for unit tests for checking artifacts of evaluation of candidate model
+        - Artifacts should be logged and returned as expected
     """
-    if test_is_baseline_model_flag:
-        assert logged_artifacts == []
-        assert result_artifacts == {}
+    assert set(logged_artifacts) == expected_artifacts
+    assert result_artifacts.keys() == expected_artifacts_keys
 
-    else:
-        assert set(logged_artifacts) == expected_artifacts
-        assert result_artifacts.keys() == expected_artifacts_keys
+
+def check_artifacts_are_not_generated_for_baseline_model_evaluation(
+    logged_artifacts, result_artifacts
+):
+    """
+    Helper function for unit tests for checking artifacts of evaluation of baseline model
+        - No Artifact is returned nor logged
+    """
+    assert logged_artifacts == []
+    assert result_artifacts == {}
 
 
 @pytest.mark.parametrize(
-    "test_is_baseline_model_flag, baseline_model_uri",
+    "baseline_model_uri",
     [
-        (False, "None"),
-        (False, "linear_regressor_model_uri"),
-        (True, "linear_regressor_model_uri"),
+        ("None"),
+        ("linear_regressor_model_uri"),
     ],
     indirect=["baseline_model_uri"],
 )
 def test_regressor_evaluation(
     linear_regressor_model_uri,
     diabetes_dataset,
-    test_is_baseline_model_flag,
     baseline_model_uri,
 ):
     with mlflow.start_run() as run:
@@ -175,13 +182,12 @@ def test_regressor_evaluation(
             targets=diabetes_dataset._constructor_args["targets"],
             dataset_name=diabetes_dataset.name,
             evaluators="default",
-            is_baseline_model=test_is_baseline_model_flag,
+            eval_baseline_model_only=False,
         )
 
     _, metrics, tags, artifacts = get_run_data(run.info.run_id)
 
-    model_uri = baseline_model_uri if test_is_baseline_model_flag else linear_regressor_model_uri
-    model = mlflow.pyfunc.load_model(model_uri)
+    model = mlflow.pyfunc.load_model(linear_regressor_model_uri)
 
     y = diabetes_dataset.labels_data
     y_pred = model.predict(diabetes_dataset.features_data)
@@ -191,20 +197,18 @@ def test_regressor_evaluation(
         diabetes_dataset.features_data, diabetes_dataset.labels_data
     )
 
-    metrics_check_helper(
+    assert json.loads(tags["mlflow.datasets"]) == [
+        {**diabetes_dataset._metadata, "model": model.metadata.model_uuid}
+    ]
+
+    check_metrics_are_expected_for_candidate_model_evaluation(
         expected_metrics=expected_metrics,
         result_metrics=result.metrics,
         logged_metrics=metrics,
         dataset_log_key="_on_data_diabetes_dataset",
-        test_is_baseline_model_flag=test_is_baseline_model_flag,
     )
 
-    if not test_is_baseline_model_flag:
-        assert json.loads(tags["mlflow.datasets"]) == [
-            {**diabetes_dataset._metadata, "model": model.metadata.model_uuid}
-        ]
-
-    artifacts_check_helper(
+    check_artifacts_are_expected_for_candidate_model_evaluation(
         logged_artifacts=artifacts,
         result_artifacts=result.artifacts,
         expected_artifacts={
@@ -217,7 +221,48 @@ def test_regressor_evaluation(
             "shap_feature_importance_plot",
             "shap_summary_plot",
         },
-        test_is_baseline_model_flag=test_is_baseline_model_flag,
+    )
+
+
+def test_regressor_evaluation_disable_logging_metrics_and_artifacts(
+    linear_regressor_model_uri,
+    diabetes_dataset,
+):
+    with mlflow.start_run() as run:
+        result = evaluate_model_helper(
+            linear_regressor_model_uri,
+            linear_regressor_model_uri,
+            diabetes_dataset._constructor_args["data"],
+            model_type="regressor",
+            targets=diabetes_dataset._constructor_args["targets"],
+            dataset_name=diabetes_dataset.name,
+            evaluators="default",
+            eval_baseline_model_only=True,
+        )
+
+    _, metrics, tags, artifacts = get_run_data(run.info.run_id)
+
+    model = mlflow.pyfunc.load_model(linear_regressor_model_uri)
+
+    y = diabetes_dataset.labels_data
+    y_pred = model.predict(diabetes_dataset.features_data)
+
+    expected_metrics = _get_regressor_metrics(y, y_pred)
+    expected_metrics["score"] = model._model_impl.score(
+        diabetes_dataset.features_data, diabetes_dataset.labels_data
+    )
+
+    check_metrics_not_logged_for_baseline_model_evaluation(
+        expected_metrics=expected_metrics,
+        result_metrics=result.metrics,
+        logged_metrics=metrics,
+    )
+
+    assert "mlflow.datassets" not in tags
+
+    check_artifacts_are_not_generated_for_baseline_model_evaluation(
+        logged_artifacts=artifacts,
+        result_artifacts=result.artifacts,
     )
 
 
@@ -237,18 +282,16 @@ def test_regressor_evaluation_with_int_targets(
 
 
 @pytest.mark.parametrize(
-    "test_is_baseline_model_flag, baseline_model_uri",
+    "baseline_model_uri",
     [
-        (False, "None"),
-        (False, "multiclass_logistic_regressor_baseline_model_uri_4"),
-        (True, "multiclass_logistic_regressor_baseline_model_uri_4"),
+        ("None"),
+        ("multiclass_logistic_regressor_baseline_model_uri_4"),
     ],
     indirect=["baseline_model_uri"],
 )
 def test_multi_classifier_evaluation(
     multiclass_logistic_regressor_model_uri,
     iris_dataset,
-    test_is_baseline_model_flag,
     baseline_model_uri,
 ):
     with mlflow.start_run() as run:
@@ -260,17 +303,12 @@ def test_multi_classifier_evaluation(
             targets=iris_dataset._constructor_args["targets"],
             dataset_name=iris_dataset.name,
             evaluators="default",
-            is_baseline_model=test_is_baseline_model_flag,
+            eval_baseline_model_only=False,
         )
 
     _, metrics, tags, artifacts = get_run_data(run.info.run_id)
 
-    model_uri = (
-        baseline_model_uri
-        if test_is_baseline_model_flag
-        else multiclass_logistic_regressor_model_uri
-    )
-    model = mlflow.pyfunc.load_model(model_uri)
+    model = mlflow.pyfunc.load_model(multiclass_logistic_regressor_model_uri)
 
     _, raw_model = _extract_raw_model(model)
     predict_fn, predict_proba_fn = _extract_predict_fn(model, raw_model)
@@ -283,20 +321,18 @@ def test_multi_classifier_evaluation(
         iris_dataset.features_data, iris_dataset.labels_data
     )
 
-    metrics_check_helper(
+    check_metrics_are_expected_for_candidate_model_evaluation(
         expected_metrics=expected_metrics,
         result_metrics=result.metrics,
         logged_metrics=metrics,
         dataset_log_key="_on_data_iris_dataset",
-        test_is_baseline_model_flag=test_is_baseline_model_flag,
     )
 
-    if not test_is_baseline_model_flag:
-        assert json.loads(tags["mlflow.datasets"]) == [
-            {**iris_dataset._metadata, "model": model.metadata.model_uuid}
-        ]
+    assert json.loads(tags["mlflow.datasets"]) == [
+        {**iris_dataset._metadata, "model": model.metadata.model_uuid}
+    ]
 
-    artifacts_check_helper(
+    check_artifacts_are_expected_for_candidate_model_evaluation(
         logged_artifacts=artifacts,
         result_artifacts=result.artifacts,
         expected_artifacts={
@@ -318,23 +354,65 @@ def test_multi_classifier_evaluation(
             "shap_summary_plot",
             "shap_feature_importance_plot",
         },
-        test_is_baseline_model_flag=test_is_baseline_model_flag,
+    )
+
+
+def test_multi_classifier_evaluation_disable_logging_metrics_and_artifacts(
+    multiclass_logistic_regressor_model_uri,
+    iris_dataset,
+):
+    with mlflow.start_run() as run:
+        result = evaluate_model_helper(
+            multiclass_logistic_regressor_model_uri,
+            multiclass_logistic_regressor_model_uri,
+            iris_dataset._constructor_args["data"],
+            model_type="classifier",
+            targets=iris_dataset._constructor_args["targets"],
+            dataset_name=iris_dataset.name,
+            evaluators="default",
+            eval_baseline_model_only=True,
+        )
+
+    _, metrics, tags, artifacts = get_run_data(run.info.run_id)
+
+    model = mlflow.pyfunc.load_model(multiclass_logistic_regressor_model_uri)
+
+    _, raw_model = _extract_raw_model(model)
+    predict_fn, predict_proba_fn = _extract_predict_fn(model, raw_model)
+    y = iris_dataset.labels_data
+    y_pred = predict_fn(iris_dataset.features_data)
+    y_probs = predict_proba_fn(iris_dataset.features_data)
+
+    expected_metrics = _get_classifier_global_metrics(False, y, y_pred, y_probs, labels=None)
+    expected_metrics["score"] = model._model_impl.score(
+        iris_dataset.features_data, iris_dataset.labels_data
+    )
+
+    check_metrics_not_logged_for_baseline_model_evaluation(
+        expected_metrics=expected_metrics,
+        result_metrics=result.metrics,
+        logged_metrics=metrics,
+    )
+
+    assert "mlflow.datassets" not in tags
+
+    check_artifacts_are_not_generated_for_baseline_model_evaluation(
+        logged_artifacts=artifacts,
+        result_artifacts=result.artifacts,
     )
 
 
 @pytest.mark.parametrize(
-    "test_is_baseline_model_flag, baseline_model_uri",
+    "baseline_model_uri",
     [
-        (False, "None"),
-        (False, "binary_logistic_regressor_model_uri"),
-        (True, "binary_logistic_regressor_model_uri"),
+        ("None"),
+        ("binary_logistic_regressor_model_uri"),
     ],
     indirect=["baseline_model_uri"],
 )
 def test_bin_classifier_evaluation(
     binary_logistic_regressor_model_uri,
     breast_cancer_dataset,
-    test_is_baseline_model_flag,
     baseline_model_uri,
 ):
     with mlflow.start_run() as run:
@@ -346,15 +424,12 @@ def test_bin_classifier_evaluation(
             targets=breast_cancer_dataset._constructor_args["targets"],
             dataset_name=breast_cancer_dataset.name,
             evaluators="default",
-            is_baseline_model=test_is_baseline_model_flag,
+            eval_baseline_model_only=False,
         )
 
     _, metrics, tags, artifacts = get_run_data(run.info.run_id)
 
-    model_uri = (
-        baseline_model_uri if test_is_baseline_model_flag else binary_logistic_regressor_model_uri
-    )
-    model = mlflow.pyfunc.load_model(model_uri)
+    model = mlflow.pyfunc.load_model(binary_logistic_regressor_model_uri)
 
     _, raw_model = _extract_raw_model(model)
     predict_fn, predict_proba_fn = _extract_predict_fn(model, raw_model)
@@ -367,20 +442,18 @@ def test_bin_classifier_evaluation(
         breast_cancer_dataset.features_data, breast_cancer_dataset.labels_data
     )
 
-    metrics_check_helper(
+    check_metrics_are_expected_for_candidate_model_evaluation(
         expected_metrics=expected_metrics,
         result_metrics=result.metrics,
         logged_metrics=metrics,
         dataset_log_key="_on_data_breast_cancer_dataset",
-        test_is_baseline_model_flag=test_is_baseline_model_flag,
     )
 
-    if not test_is_baseline_model_flag:
-        assert json.loads(tags["mlflow.datasets"]) == [
-            {**breast_cancer_dataset._metadata, "model": model.metadata.model_uuid}
-        ]
+    assert json.loads(tags["mlflow.datasets"]) == [
+        {**breast_cancer_dataset._metadata, "model": model.metadata.model_uuid}
+    ]
 
-    artifacts_check_helper(
+    check_artifacts_are_expected_for_candidate_model_evaluation(
         logged_artifacts=artifacts,
         result_artifacts=result.artifacts,
         expected_artifacts={
@@ -401,23 +474,65 @@ def test_bin_classifier_evaluation(
             "shap_summary_plot",
             "shap_feature_importance_plot",
         },
-        test_is_baseline_model_flag=test_is_baseline_model_flag,
+    )
+
+
+def test_bin_classifier_evaluation_disable_logging_metrics_and_artifacts(
+    binary_logistic_regressor_model_uri,
+    breast_cancer_dataset,
+):
+    with mlflow.start_run() as run:
+        result = evaluate_model_helper(
+            binary_logistic_regressor_model_uri,
+            binary_logistic_regressor_model_uri,
+            breast_cancer_dataset._constructor_args["data"],
+            model_type="classifier",
+            targets=breast_cancer_dataset._constructor_args["targets"],
+            dataset_name=breast_cancer_dataset.name,
+            evaluators="default",
+            eval_baseline_model_only=True,
+        )
+
+    _, metrics, tags, artifacts = get_run_data(run.info.run_id)
+
+    model = mlflow.pyfunc.load_model(binary_logistic_regressor_model_uri)
+
+    _, raw_model = _extract_raw_model(model)
+    predict_fn, predict_proba_fn = _extract_predict_fn(model, raw_model)
+    y = breast_cancer_dataset.labels_data
+    y_pred = predict_fn(breast_cancer_dataset.features_data)
+    y_probs = predict_proba_fn(breast_cancer_dataset.features_data)
+
+    expected_metrics = _get_classifier_global_metrics(True, y, y_pred, y_probs, labels=None)
+    expected_metrics["score"] = model._model_impl.score(
+        breast_cancer_dataset.features_data, breast_cancer_dataset.labels_data
+    )
+
+    check_metrics_not_logged_for_baseline_model_evaluation(
+        expected_metrics=expected_metrics,
+        result_metrics=result.metrics,
+        logged_metrics=metrics,
+    )
+
+    assert "mlflow.datassets" not in tags
+
+    check_artifacts_are_not_generated_for_baseline_model_evaluation(
+        logged_artifacts=artifacts,
+        result_artifacts=result.artifacts,
     )
 
 
 @pytest.mark.parametrize(
-    "test_is_baseline_model_flag, baseline_model_uri",
+    "baseline_model_uri",
     [
-        (False, "None"),
-        (False, "spark_linear_regressor_model_uri"),
-        (True, "spark_linear_regressor_model_uri"),
+        ("None"),
+        ("spark_linear_regressor_model_uri"),
     ],
     indirect=["baseline_model_uri"],
 )
 def test_spark_regressor_model_evaluation(
     spark_linear_regressor_model_uri,
     diabetes_spark_dataset,
-    test_is_baseline_model_flag,
     baseline_model_uri,
 ):
     with mlflow.start_run() as run:
@@ -429,15 +544,12 @@ def test_spark_regressor_model_evaluation(
             targets=diabetes_spark_dataset._constructor_args["targets"],
             dataset_name=diabetes_spark_dataset.name,
             evaluators="default",
-            is_baseline_model=test_is_baseline_model_flag,
+            eval_baseline_model_only=False,
         )
 
     _, metrics, tags, artifacts = get_run_data(run.info.run_id)
 
-    model_uri = (
-        baseline_model_uri if test_is_baseline_model_flag else spark_linear_regressor_model_uri
-    )
-    model = mlflow.pyfunc.load_model(model_uri)
+    model = mlflow.pyfunc.load_model(spark_linear_regressor_model_uri)
 
     X = diabetes_spark_dataset.features_data
     y = diabetes_spark_dataset.labels_data
@@ -445,40 +557,74 @@ def test_spark_regressor_model_evaluation(
 
     expected_metrics = _get_regressor_metrics(y, y_pred)
 
-    metrics_check_helper(
+    check_metrics_are_expected_for_candidate_model_evaluation(
         expected_metrics=expected_metrics,
         result_metrics=result.metrics,
         logged_metrics=metrics,
         dataset_log_key="_on_data_diabetes_spark_dataset",
-        test_is_baseline_model_flag=test_is_baseline_model_flag,
     )
 
-    if not test_is_baseline_model_flag:
-        assert json.loads(tags["mlflow.datasets"]) == [
-            {**diabetes_spark_dataset._metadata, "model": model.metadata.model_uuid}
-        ]
+    assert json.loads(tags["mlflow.datasets"]) == [
+        {**diabetes_spark_dataset._metadata, "model": model.metadata.model_uuid}
+    ]
 
-    artifacts_check_helper(
+    check_artifacts_are_expected_for_candidate_model_evaluation(
         logged_artifacts=artifacts,
         result_artifacts=result.artifacts,
         expected_artifacts=set(),
         expected_artifacts_keys=set(),
-        test_is_baseline_model_flag=test_is_baseline_model_flag,
+    )
+
+
+def test_spark_regressor_model_evaluation_disable_logging_metrics_and_artifacts(
+    spark_linear_regressor_model_uri,
+    diabetes_spark_dataset,
+):
+    with mlflow.start_run() as run:
+        result = evaluate_model_helper(
+            spark_linear_regressor_model_uri,
+            spark_linear_regressor_model_uri,
+            diabetes_spark_dataset._constructor_args["data"],
+            model_type="regressor",
+            targets=diabetes_spark_dataset._constructor_args["targets"],
+            dataset_name=diabetes_spark_dataset.name,
+            evaluators="default",
+            eval_baseline_model_only=True,
+        )
+
+    _, metrics, tags, artifacts = get_run_data(run.info.run_id)
+
+    model = mlflow.pyfunc.load_model(spark_linear_regressor_model_uri)
+
+    X = diabetes_spark_dataset.features_data
+    y = diabetes_spark_dataset.labels_data
+    y_pred = model.predict(X)
+
+    expected_metrics = _get_regressor_metrics(y, y_pred)
+
+    check_metrics_not_logged_for_baseline_model_evaluation(
+        expected_metrics=expected_metrics,
+        result_metrics=result.metrics,
+        logged_metrics=metrics,
+    )
+
+    assert "mlflow.datassets" not in tags
+
+    check_artifacts_are_not_generated_for_baseline_model_evaluation(
+        logged_artifacts=artifacts,
+        result_artifacts=result.artifacts,
     )
 
 
 @pytest.mark.parametrize(
-    "test_is_baseline_model_flag, baseline_model_uri",
+    "baseline_model_uri",
     [
-        (False, "None"),
-        (False, "svm_model_uri"),
-        (True, "svm_model_uri"),
+        ("None"),
+        ("svm_model_uri"),
     ],
     indirect=["baseline_model_uri"],
 )
-def test_svm_classifier_evaluation(
-    svm_model_uri, breast_cancer_dataset, test_is_baseline_model_flag, baseline_model_uri
-):
+def test_svm_classifier_evaluation(svm_model_uri, breast_cancer_dataset, baseline_model_uri):
     with mlflow.start_run() as run:
         result = evaluate_model_helper(
             svm_model_uri,
@@ -488,13 +634,12 @@ def test_svm_classifier_evaluation(
             targets=breast_cancer_dataset._constructor_args["targets"],
             dataset_name=breast_cancer_dataset.name,
             evaluators="default",
-            is_baseline_model=test_is_baseline_model_flag,
+            eval_baseline_model_only=False,
         )
 
     _, metrics, tags, artifacts = get_run_data(run.info.run_id)
 
-    model_uri = baseline_model_uri if test_is_baseline_model_flag else svm_model_uri
-    model = mlflow.pyfunc.load_model(model_uri)
+    model = mlflow.pyfunc.load_model(svm_model_uri)
 
     _, raw_model = _extract_raw_model(model)
     predict_fn, _ = _extract_predict_fn(model, raw_model)
@@ -506,20 +651,18 @@ def test_svm_classifier_evaluation(
         breast_cancer_dataset.features_data, breast_cancer_dataset.labels_data
     )
 
-    metrics_check_helper(
+    check_metrics_are_expected_for_candidate_model_evaluation(
         expected_metrics=expected_metrics,
         result_metrics=result.metrics,
         logged_metrics=metrics,
         dataset_log_key="_on_data_breast_cancer_dataset",
-        test_is_baseline_model_flag=test_is_baseline_model_flag,
     )
 
-    if not test_is_baseline_model_flag:
-        assert json.loads(tags["mlflow.datasets"]) == [
-            {**breast_cancer_dataset._metadata, "model": model.metadata.model_uuid}
-        ]
+    assert json.loads(tags["mlflow.datasets"]) == [
+        {**breast_cancer_dataset._metadata, "model": model.metadata.model_uuid}
+    ]
 
-    artifacts_check_helper(
+    check_artifacts_are_expected_for_candidate_model_evaluation(
         logged_artifacts=artifacts,
         result_artifacts=result.artifacts,
         expected_artifacts={
@@ -534,21 +677,62 @@ def test_svm_classifier_evaluation(
             "shap_summary_plot",
             "shap_feature_importance_plot",
         },
-        test_is_baseline_model_flag=test_is_baseline_model_flag,
+    )
+
+
+def test_svm_classifier_evaluation_disable_logging_metrics_and_artifacts(
+    svm_model_uri, breast_cancer_dataset
+):
+    with mlflow.start_run() as run:
+        result = evaluate_model_helper(
+            svm_model_uri,
+            svm_model_uri,
+            breast_cancer_dataset._constructor_args["data"],
+            model_type="classifier",
+            targets=breast_cancer_dataset._constructor_args["targets"],
+            dataset_name=breast_cancer_dataset.name,
+            evaluators="default",
+            eval_baseline_model_only=True,
+        )
+
+    _, metrics, tags, artifacts = get_run_data(run.info.run_id)
+
+    model = mlflow.pyfunc.load_model(svm_model_uri)
+
+    _, raw_model = _extract_raw_model(model)
+    predict_fn, _ = _extract_predict_fn(model, raw_model)
+    y = breast_cancer_dataset.labels_data
+    y_pred = predict_fn(breast_cancer_dataset.features_data)
+
+    expected_metrics = _get_classifier_global_metrics(True, y, y_pred, None, labels=None)
+    expected_metrics["score"] = model._model_impl.score(
+        breast_cancer_dataset.features_data, breast_cancer_dataset.labels_data
+    )
+
+    check_metrics_not_logged_for_baseline_model_evaluation(
+        expected_metrics=expected_metrics,
+        result_metrics=result.metrics,
+        logged_metrics=metrics,
+    )
+
+    assert "mlflow.datassets" not in tags
+
+    check_artifacts_are_not_generated_for_baseline_model_evaluation(
+        logged_artifacts=artifacts,
+        result_artifacts=result.artifacts,
     )
 
 
 @pytest.mark.parametrize(
-    "test_is_baseline_model_flag, baseline_model_uri",
+    "baseline_model_uri",
     [
-        (False, "None"),
-        (False, "pipeline_model_uri"),
-        (True, "pipeline_model_uri"),
+        ("None"),
+        ("pipeline_model_uri"),
     ],
     indirect=["baseline_model_uri"],
 )
 def test_pipeline_model_kernel_explainer_on_categorical_features(
-    pipeline_model_uri, test_is_baseline_model_flag, baseline_model_uri
+    pipeline_model_uri, baseline_model_uri
 ):
     from mlflow.models.evaluation._shap_patch import _PatchedKernelExplainer
 
@@ -563,24 +747,20 @@ def test_pipeline_model_kernel_explainer_on_categorical_features(
             dataset_name="pipeline_model_dataset",
             evaluators="default",
             evaluator_config={"explainability_algorithm": "kernel"},
-            is_baseline_model=test_is_baseline_model_flag,
+            eval_baseline_model_only=False,
         )
     run_data = get_run_data(run.info.run_id)
-    if test_is_baseline_model_flag:
-        assert run_data.artifacts == []
-    else:
-        assert {
-            "shap_beeswarm_plot_on_data_pipeline_model_dataset.png",
-            "shap_feature_importance_plot_on_data_pipeline_model_dataset.png",
-            "shap_summary_plot_on_data_pipeline_model_dataset.png",
-            "explainer_on_data_pipeline_model_dataset",
-        }.issubset(run_data.artifacts)
+    assert {
+        "shap_beeswarm_plot_on_data_pipeline_model_dataset.png",
+        "shap_feature_importance_plot_on_data_pipeline_model_dataset.png",
+        "shap_summary_plot_on_data_pipeline_model_dataset.png",
+        "explainer_on_data_pipeline_model_dataset",
+    }.issubset(run_data.artifacts)
 
-    if not test_is_baseline_model_flag:
-        explainer = mlflow.shap.load_explainer(
-            f"runs:/{run.info.run_id}/explainer_on_data_pipeline_model_dataset"
-        )
-        assert isinstance(explainer, _PatchedKernelExplainer)
+    explainer = mlflow.shap.load_explainer(
+        f"runs:/{run.info.run_id}/explainer_on_data_pipeline_model_dataset"
+    )
+    assert isinstance(explainer, _PatchedKernelExplainer)
 
 
 def test_compute_df_mode_or_mean():

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -114,7 +114,7 @@ def check_metrics_not_logged_for_baseline_model_evaluation(
     """
     Helper function for checking metrics of evaluation of baseline_model
      - Metrics should not be logged
-     - Meetrics should be returned as expected
+     - Metrics should be returned in EvaluationResult as expected
     """
     assert logged_metrics == {}
     for metric_key in expected_metrics:

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -83,7 +83,9 @@ def evaluate_model_helper(
     """
     Helper function for testing MLflow.evaluate
     To test if evaluation for baseline model does not log metrics and artifacts;
-    we set "is_baseline_model" to true for all evaluator_config
+    we set "is_baseline_model" to true for the evaluator_config so that the
+    DefaultEvaluator will evaluate only the baseline_model with logging
+    disabled. This code path is only for testing purposes.
     """
     if eval_baseline_model_only:
         if not evaluator_config:

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -189,6 +189,12 @@ def test_regressor_evaluation(
         "shap_summary_plot_on_data_diabetes_dataset.png",
     }
 
+    assert result.artifacts.keys() == {
+        "shap_beeswarm_plot",
+        "shap_feature_importance_plot",
+        "shap_summary_plot",
+    }
+
 
 def test_regressor_evaluation_disable_logging_metrics_and_artifacts(
     linear_regressor_model_uri,

--- a/tests/models/test_evaluation.py
+++ b/tests/models/test_evaluation.py
@@ -271,6 +271,10 @@ def multiclass_logistic_regressor_model_uri_by_max_iter(max_iter):
 
 @pytest.fixture
 def binary_logistic_regressor_model_uri():
+    return get_binary_logistic_regressor_model_uri()
+
+
+def get_binary_logistic_regressor_model_uri():
     X, y = get_breast_cancer_dataset()
     clf = sklearn.linear_model.LogisticRegression()
     clf.fit(X, y)
@@ -315,6 +319,8 @@ def iris_pandas_df_dataset():
 def baseline_model_uri(request):
     if request.param == "linear_regressor_model_uri":
         return get_linear_regressor_model_uri()
+    if request.param == "binary_logistic_regressor_model_uri":
+        return get_binary_logistic_regressor_model_uri()
     if request.param == "multiclass_logistic_regressor_baseline_model_uri_4":
         return multiclass_logistic_regressor_model_uri_by_max_iter(max_iter=4)
     if request.param == "pyfunc":

--- a/tests/models/test_evaluation.py
+++ b/tests/models/test_evaluation.py
@@ -176,6 +176,10 @@ def get_pipeline_model_dataset():
 
 @pytest.fixture
 def pipeline_model_uri():
+    return get_pipeline_modlel_uri()
+
+
+def get_pipeline_modlel_uri():
     """
     Create a pipeline model that transforms and trains on the dataset returned by
     `get_pipeline_model_dataset`. The pipeline model imputes the missing values in
@@ -234,6 +238,10 @@ def get_linear_regressor_model_uri():
 
 @pytest.fixture
 def spark_linear_regressor_model_uri():
+    return get_spark_linear_regressor_model_uri()
+
+
+def get_spark_linear_regressor_model_uri():
     spark_df = get_diabetes_spark_dataset()
     reg = SparkLinearRegression()
     spark_reg_model = reg.fit(spark_df)
@@ -288,6 +296,10 @@ def get_binary_logistic_regressor_model_uri():
 
 @pytest.fixture
 def svm_model_uri():
+    return get_svm_model_url()
+
+
+def get_svm_model_url():
     X, y = get_breast_cancer_dataset()
     clf = sklearn.svm.LinearSVC()
     clf.fit(X, y)
@@ -321,6 +333,12 @@ def baseline_model_uri(request):
         return get_linear_regressor_model_uri()
     if request.param == "binary_logistic_regressor_model_uri":
         return get_binary_logistic_regressor_model_uri()
+    if request.param == "spark_linear_regressor_model_uri":
+        return get_spark_linear_regressor_model_uri()
+    if request.param == "pipeline_model_uri":
+        return get_pipeline_modlel_uri()
+    if request.param == "svm_model_uri":
+        return get_svm_model_url()
     if request.param == "multiclass_logistic_regressor_baseline_model_uri_4":
         return multiclass_logistic_regressor_model_uri_by_max_iter(max_iter=4)
     if request.param == "pyfunc":

--- a/tests/models/test_evaluation.py
+++ b/tests/models/test_evaluation.py
@@ -342,9 +342,14 @@ def baseline_model_uri(request):
     if request.param == "multiclass_logistic_regressor_baseline_model_uri_4":
         return multiclass_logistic_regressor_model_uri_by_max_iter(max_iter=4)
     if request.param == "pyfunc":
-        return lambda x: x
-    if request.param == "invalid":
+        model_uri = multiclass_logistic_regressor_model_uri_by_max_iter(max_iter=4)
+        return mlflow.pyfunc.load_model(model_uri)
+    if request.param == "invalid_model_uri":
         return "invalid_uri"
+    if request.param == "bool":
+        return True
+    if request.param == "int":
+        return 0
     return None
 
 
@@ -726,9 +731,12 @@ def test_evaluator_evaluation_interface(multiclass_logistic_regressor_model_uri,
         _model_evaluation_registry, "_registry", {"test_evaluator1": FakeEvauator1}
     ):
         evaluator1_config = {"eval1_confg_a": 3, "eval1_confg_b": 4}
-        evaluator1_return_value = EvaluationResult(
-            metrics={"m1": 5, "m2": 6},
-            artifacts={"a1": FakeArtifact1(uri="uri1"), "a2": FakeArtifact2(uri="uri2")},
+        evaluator1_return_value = (
+            EvaluationResult(
+                metrics={"m1": 5, "m2": 6},
+                artifacts={"a1": FakeArtifact1(uri="uri1"), "a2": FakeArtifact2(uri="uri2")},
+            ),
+            None,
         )
         with mock.patch.object(
             FakeEvauator1, "can_evaluate", return_value=False
@@ -769,9 +777,10 @@ def test_evaluator_evaluation_interface(multiclass_logistic_regressor_model_uri,
                     evaluators="test_evaluator1",
                     evaluator_config=evaluator1_config,
                     custom_metrics=None,
+                    baseline_model=None,
                 )
-                assert eval1_result.metrics == evaluator1_return_value.metrics
-                assert eval1_result.artifacts == evaluator1_return_value.artifacts
+                assert eval1_result.metrics == evaluator1_return_value[0].metrics
+                assert eval1_result.artifacts == evaluator1_return_value[0].artifacts
 
                 mock_can_evaluate.assert_called_once_with(
                     model_type="classifier", evaluator_config=evaluator1_config
@@ -783,142 +792,50 @@ def test_evaluator_evaluation_interface(multiclass_logistic_regressor_model_uri,
                     run_id=run.info.run_id,
                     evaluator_config=evaluator1_config,
                     custom_metrics=None,
+                    baseline_model=None,
                 )
 
 
 @pytest.mark.parametrize(
-    "baseline_model_uri,expected_error,valid_baseline_model_uri",
+    "baseline_model_uri, expected_error",
     [
-        ("None", None, False),
-        ("multiclass_logistic_regressor_baseline_model_uri_4", None, True),
         (
             "pyfunc",
             pytest.raises(
                 ValueError,
-                match="The baseline model argument must be a string "
-                + "URI referring to an MLflow model",
+                match=(
+                    "The baseline model argument must be a string URI "
+                    + "referring to an MLflow model"
+                ),
             ),
-            False,
         ),
         (
-            "invalid",
+            "invalid_model_uri",
             pytest.raises(OSError, match="No such file or directory: 'invalid_uri'"),
-            False,
         ),
     ],
     indirect=["baseline_model_uri"],
 )
-def test_evaluator_validation_interface(
-    multiclass_logistic_regressor_model_uri,
-    iris_dataset,
-    baseline_model_uri,
-    expected_error,
-    valid_baseline_model_uri,
+def test_model_validation_interface_invalid_baseline_model_should_throw(
+    multiclass_logistic_regressor_model_uri, iris_dataset, baseline_model_uri, expected_error
 ):
     with mock.patch.object(
         _model_evaluation_registry, "_registry", {"test_evaluator1": FakeEvauator1}
     ):
         evaluator1_config = {"config": True}
-        evaluator1_return_value = EvaluationResult(metrics={}, artifacts={})
-        if baseline_model_uri:
-            evaluator1_config_baseline = dict(evaluator1_config)
-            evaluator1_config_baseline.update({"is_baseline_model": True})
-        with mock.patch.object(
-            FakeEvauator1, "can_evaluate", return_value=True
-        ) as mock_can_evaluate, mock.patch.object(
-            FakeEvauator1, "evaluate", return_value=evaluator1_return_value
-        ) as mock_evaluate:
-            classifier_model = mlflow.pyfunc.load_model(multiclass_logistic_regressor_model_uri)
-            baseline_model = None
-            with mlflow.start_run() as run:
-                if valid_baseline_model_uri:
-                    # If baseline_model is a valid uri, MLflow.evaluate will call evaluator.evaluate
-                    # two times, one time for candidate model, one time for baseline model.
-                    eval1_result = evaluate(
-                        classifier_model,
-                        iris_dataset._constructor_args["data"],
-                        model_type="classifier",
-                        targets=iris_dataset._constructor_args["targets"],
-                        dataset_name=iris_dataset.name,
-                        evaluators="test_evaluator1",
-                        evaluator_config=evaluator1_config,
-                        custom_metrics=None,
-                        baseline_model=baseline_model_uri,
-                    )
-
-                    mock_can_evaluate.assert_has_calls(
-                        [
-                            mock.call(model_type="classifier", evaluator_config=evaluator1_config),
-                            mock.call(
-                                model_type="classifier", evaluator_config=evaluator1_config_baseline
-                            ),
-                        ]
-                    )
-                    baseline_model = mlflow.pyfunc.load_model(baseline_model_uri)
-                    mock_evaluate.assert_has_calls(
-                        [
-                            mock.call(
-                                model=classifier_model,
-                                model_type="classifier",
-                                dataset=iris_dataset,
-                                run_id=run.info.run_id,
-                                evaluator_config=evaluator1_config,
-                                custom_metrics=None,
-                            ),
-                            mock.call(
-                                model=baseline_model,
-                                dataset=iris_dataset,
-                                model_type="classifier",
-                                run_id=run.info.run_id,
-                                evaluator_config=evaluator1_config_baseline,
-                                custom_metrics=None,
-                            ),
-                        ]
-                    )
-                elif baseline_model_uri is not None:
-                    # If baseline_model is present but not valid; there are two cases:
-                    # - baseline_model is not string, should throw ValueError
-                    # - baseline_model is not valid uri, should throw OSError
-                    with expected_error:
-                        eval1_result = evaluate(
-                            classifier_model,
-                            iris_dataset._constructor_args["data"],
-                            model_type="classifier",
-                            targets=iris_dataset._constructor_args["targets"],
-                            dataset_name=iris_dataset.name,
-                            evaluators="test_evaluator1",
-                            evaluator_config=evaluator1_config,
-                            custom_metrics=None,
-                            baseline_model=baseline_model_uri,
-                        )
-                else:
-                    # If baseline_model is not present; evaluate should call evaluator.evaluate
-                    # only one time; for baseline model.
-                    eval1_result = evaluate(
-                        classifier_model,
-                        iris_dataset._constructor_args["data"],
-                        model_type="classifier",
-                        targets=iris_dataset._constructor_args["targets"],
-                        dataset_name=iris_dataset.name,
-                        evaluators="test_evaluator1",
-                        evaluator_config=evaluator1_config,
-                        custom_metrics=None,
-                        baseline_model=baseline_model_uri,
-                    )
-                    assert eval1_result.metrics == evaluator1_return_value.metrics
-                    assert eval1_result.artifacts == evaluator1_return_value.artifacts
-
-                    mock_can_evaluate.assert_called_once_with(
-                        model_type="classifier", evaluator_config=evaluator1_config
-                    )
-                    mock_evaluate.assert_called_once_with(
-                        model=classifier_model,
-                        model_type="classifier",
-                        dataset=iris_dataset,
-                        run_id=run.info.run_id,
-                        evaluator_config=evaluator1_config,
-                        custom_metrics=None,
-                    )
+        classifier_model = mlflow.pyfunc.load_model(multiclass_logistic_regressor_model_uri)
+        with expected_error:
+            evaluate(
+                classifier_model,
+                iris_dataset._constructor_args["data"],
+                model_type="classifier",
+                targets=iris_dataset._constructor_args["targets"],
+                dataset_name=iris_dataset.name,
+                evaluators="test_evaluator1",
+                evaluator_config=evaluator1_config,
+                custom_metrics=None,
+                baseline_model=baseline_model_uri,
+            )
 
 
 @pytest.mark.parametrize(
@@ -936,27 +853,27 @@ def test_evaluate_with_multi_evaluators(
     ):
         evaluator1_config = {"eval1_confg": 3}
         evaluator2_config = {"eval2_confg": 4}
-        evaluator1_config_baseline = None
-        evaluator2_config_baseline = None
-        if baseline_model_uri:
-            evaluator1_config_baseline = dict(evaluator1_config)
-            evaluator1_config_baseline.update({"is_baseline_model": True})
-            evaluator2_config_baseline = dict(evaluator2_config)
-            evaluator2_config_baseline.update({"is_baseline_model": True})
-        evaluator1_return_value = EvaluationResult(
-            metrics={"m1": 5}, artifacts={"a1": FakeArtifact1(uri="uri1")}
+        evaluator1_return_value = (
+            EvaluationResult(metrics={"m1": 5}, artifacts={"a1": FakeArtifact1(uri="uri1")}),
+            None,
         )
-        evaluator2_return_value = EvaluationResult(
-            metrics={"m2": 6}, artifacts={"a2": FakeArtifact2(uri="uri2")}
+        evaluator2_return_value = (
+            EvaluationResult(metrics={"m2": 6}, artifacts={"a2": FakeArtifact2(uri="uri2")}),
+            None,
         )
 
-        get_call_arg = lambda model, evaluator_config: {
+        baseline_model = (
+            mlflow.pyfunc.load_model(baseline_model_uri) if baseline_model_uri else None
+        )
+
+        get_evaluate_call_arg = lambda model, evaluator_config: {
             "model": model,
             "model_type": "classifier",
             "dataset": iris_dataset,
             "run_id": run.info.run_id,
             "evaluator_config": evaluator_config,
             "custom_metrics": None,
+            "baseline_model": baseline_model,
         }
         # evaluators = None is the case evaluators unspecified, it should fetch all registered
         # evaluators, and the evaluation results should equal to the case of
@@ -972,9 +889,6 @@ def test_evaluate_with_multi_evaluators(
                 FakeEvauator2, "evaluate", return_value=evaluator2_return_value
             ) as mock_evaluate2:
                 classifier_model = mlflow.pyfunc.load_model(multiclass_logistic_regressor_model_uri)
-                baseline_model = (
-                    mlflow.pyfunc.load_model(baseline_model_uri) if baseline_model_uri else None
-                )
                 with mlflow.start_run() as run:
                     eval_result = evaluate(
                         classifier_model,
@@ -990,67 +904,26 @@ def test_evaluate_with_multi_evaluators(
                         baseline_model=baseline_model_uri,
                     )
                     assert eval_result.metrics == {
-                        **evaluator1_return_value.metrics,
-                        **evaluator2_return_value.metrics,
+                        **evaluator1_return_value[0].metrics,
+                        **evaluator2_return_value[0].metrics,
                     }
                     assert eval_result.artifacts == {
-                        **evaluator1_return_value.artifacts,
-                        **evaluator2_return_value.artifacts,
+                        **evaluator1_return_value[0].artifacts,
+                        **evaluator2_return_value[0].artifacts,
                     }
-                    if not baseline_model_uri:
-                        mock_can_evaluate1.assert_called_once_with(
-                            model_type="classifier", evaluator_config=evaluator1_config
-                        )
-                        mock_evaluate1.assert_called_once_with(
-                            **get_call_arg(classifier_model, evaluator1_config)
-                        )
-                        mock_can_evaluate2.assert_called_once_with(
-                            model_type="classifier",
-                            evaluator_config=evaluator2_config,
-                        )
-                        mock_evaluate2.assert_called_once_with(
-                            **get_call_arg(classifier_model, evaluator2_config)
-                        )
-                    else:
-                        mock_can_evaluate1.assert_has_calls(
-                            [
-                                mock.call(
-                                    model_type="classifier", evaluator_config=evaluator1_config
-                                ),
-                                mock.call(
-                                    model_type="classifier",
-                                    evaluator_config=evaluator1_config_baseline,
-                                ),
-                            ]
-                        )
-                        mock_evaluate1.assert_has_calls(
-                            [
-                                mock.call(**get_call_arg(classifier_model, evaluator1_config)),
-                                mock.call(
-                                    **get_call_arg(baseline_model, evaluator1_config_baseline)
-                                ),
-                            ]
-                        )
-                        mock_can_evaluate2.assert_has_calls(
-                            [
-                                mock.call(
-                                    model_type="classifier",
-                                    evaluator_config=evaluator2_config,
-                                ),
-                                mock.call(
-                                    model_type="classifier",
-                                    evaluator_config=evaluator2_config_baseline,
-                                ),
-                            ]
-                        )
-                        mock_evaluate2.assert_has_calls(
-                            [
-                                mock.call(**get_call_arg(classifier_model, evaluator2_config)),
-                                mock.call(
-                                    **get_call_arg(baseline_model, evaluator2_config_baseline)
-                                ),
-                            ]
-                        )
+                    mock_can_evaluate1.assert_called_once_with(
+                        model_type="classifier", evaluator_config=evaluator1_config
+                    )
+                    mock_evaluate1.assert_called_once_with(
+                        **get_evaluate_call_arg(classifier_model, evaluator1_config)
+                    )
+                    mock_can_evaluate2.assert_called_once_with(
+                        model_type="classifier",
+                        evaluator_config=evaluator2_config,
+                    )
+                    mock_evaluate2.assert_called_once_with(
+                        **get_evaluate_call_arg(classifier_model, evaluator2_config)
+                    )
 
 
 def test_start_run_or_reuse_active_run():

--- a/tests/models/test_evaluation.py
+++ b/tests/models/test_evaluation.py
@@ -796,8 +796,8 @@ def test_evaluator_evaluation_interface(multiclass_logistic_regressor_model_uri,
             "pyfunc",
             pytest.raises(
                 ValueError,
-                match="The baseline model argument must "
-                + "be a string URI referring to an MLflow model",
+                match="The baseline model argument must \
+                be a string URI referring to an MLflow model",
             ),
             False,
         ),

--- a/tests/models/test_evaluation.py
+++ b/tests/models/test_evaluation.py
@@ -710,6 +710,7 @@ def test_evaluator_interface(multiclass_logistic_regressor_model_uri, iris_datas
                     run_id=run.info.run_id,
                     evaluator_config=evaluator1_config,
                     custom_metrics=None,
+                    is_baseline_model=False
                 )
 
 

--- a/tests/models/test_evaluation.py
+++ b/tests/models/test_evaluation.py
@@ -710,7 +710,7 @@ def test_evaluator_interface(multiclass_logistic_regressor_model_uri, iris_datas
                     run_id=run.info.run_id,
                     evaluator_config=evaluator1_config,
                     custom_metrics=None,
-                    is_baseline_model=False
+                    is_baseline_model=False,
                 )
 
 
@@ -774,6 +774,7 @@ def test_evaluate_with_multi_evaluators(multiclass_logistic_regressor_model_uri,
                         run_id=run.info.run_id,
                         evaluator_config=evaluator1_config,
                         custom_metrics=None,
+                        is_baseline_model=False,
                     )
                     mock_can_evaluate2.assert_called_once_with(
                         model_type="classifier",
@@ -786,6 +787,7 @@ def test_evaluate_with_multi_evaluators(multiclass_logistic_regressor_model_uri,
                         run_id=run.info.run_id,
                         evaluator_config=evaluator2_config,
                         custom_metrics=None,
+                        is_baseline_model=False,
                     )
 
 

--- a/tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_evaluator.py
+++ b/tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_evaluator.py
@@ -58,6 +58,7 @@ class DummyEvaluator(ModelEvaluator):
             metrics = {"accuracy_score": accuracy_score}
             if not self.is_baseline_model:
                 self._log_metrics(run_id, metrics, dataset.name)
+            if not self.is_baseline_model:
                 confusion_matrix = sk_metrics.confusion_matrix(y, y_pred)
                 confusion_matrix_artifact_name = f"confusion_matrix_on_{dataset.name}"
                 confusion_matrix_artifact = Array2DEvaluationArtifact(

--- a/tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_evaluator.py
+++ b/tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_evaluator.py
@@ -23,6 +23,7 @@ class Array2DEvaluationArtifact(EvaluationArtifact):
         return pdf.to_numpy()
 
 
+# pylint: disable=attribute-defined-outside-init
 class DummyEvaluator(ModelEvaluator):
     is_baseline_model = False
     # pylint: disable=unused-argument
@@ -43,70 +44,90 @@ class DummyEvaluator(ModelEvaluator):
             ],
         )
 
-    # pylint: disable=unused-argument
-    def evaluate(
-        self, *, model, model_type, dataset, run_id, evaluator_config, **kwargs
-    ) -> EvaluationResult:
-        self.is_baseline_model = evaluator_config.get("is_baseline_model", False)
-        client = MlflowClient()
-        X = dataset.features_data
-        y = dataset.labels_data
-        y_pred = model.predict(X)
-        if model_type == "classifier":
-            accuracy_score = sk_metrics.accuracy_score(y, y_pred)
+    def _evaluate(self, y_pred, is_baseline_model=False):
+        if self.model_type == "classifier":
+            accuracy_score = sk_metrics.accuracy_score(self.y, y_pred)
 
             metrics = {"accuracy_score": accuracy_score}
             artifacts = {}
-            if not self.is_baseline_model:
-                self._log_metrics(run_id, metrics, dataset.name)
-                confusion_matrix = sk_metrics.confusion_matrix(y, y_pred)
-                confusion_matrix_artifact_name = f"confusion_matrix_on_{dataset.name}"
+            if not is_baseline_model:
+                self._log_metrics(self.run_id, metrics, self.dataset.name)
+                confusion_matrix = sk_metrics.confusion_matrix(self.y, y_pred)
+                confusion_matrix_artifact_name = f"confusion_matrix_on_{self.dataset.name}"
                 confusion_matrix_artifact = Array2DEvaluationArtifact(
-                    uri=get_artifact_uri(run_id, confusion_matrix_artifact_name + ".csv"),
+                    uri=get_artifact_uri(self.run_id, confusion_matrix_artifact_name + ".csv"),
                     content=confusion_matrix,
                 )
                 confusion_matrix_csv_buff = io.StringIO()
                 confusion_matrix_artifact._save(confusion_matrix_csv_buff)
                 if not self.is_baseline_model:
-                    client.log_text(
-                        run_id,
+                    self.client.log_text(
+                        self.run_id,
                         confusion_matrix_csv_buff.getvalue(),
                         confusion_matrix_artifact_name + ".csv",
                     )
 
                 confusion_matrix_figure = sk_metrics.ConfusionMatrixDisplay.from_predictions(
-                    y, y_pred
+                    self.y, y_pred
                 ).figure_
                 img_buf = io.BytesIO()
                 confusion_matrix_figure.savefig(img_buf)
                 img_buf.seek(0)
                 confusion_matrix_image = Image.open(img_buf)
 
-                confusion_matrix_image_artifact_name = f"confusion_matrix_image_on_{dataset.name}"
+                confusion_matrix_image_artifact_name = (
+                    f"confusion_matrix_image_on_{self.dataset.name}"
+                )
                 confusion_matrix_image_artifact = ImageEvaluationArtifact(
-                    uri=get_artifact_uri(run_id, confusion_matrix_image_artifact_name + ".png"),
+                    uri=get_artifact_uri(
+                        self.run_id, confusion_matrix_image_artifact_name + ".png"
+                    ),
                     content=confusion_matrix_image,
                 )
                 confusion_matrix_image_artifact._save(confusion_matrix_image_artifact_name + ".png")
-                client.log_image(
-                    run_id, confusion_matrix_image, confusion_matrix_image_artifact_name + ".png"
+                self.client.log_image(
+                    self.run_id,
+                    confusion_matrix_image,
+                    confusion_matrix_image_artifact_name + ".png",
                 )
 
                 artifacts = {
                     confusion_matrix_artifact_name: confusion_matrix_artifact,
                     confusion_matrix_image_artifact_name: confusion_matrix_image_artifact,
                 }
-        elif model_type == "regressor":
-            mean_absolute_error = sk_metrics.mean_absolute_error(y, y_pred)
-            mean_squared_error = sk_metrics.mean_squared_error(y, y_pred)
+        elif self.model_type == "regressor":
+            mean_absolute_error = sk_metrics.mean_absolute_error(self.y, y_pred)
+            mean_squared_error = sk_metrics.mean_squared_error(self.y, y_pred)
             metrics = {
                 "mean_absolute_error": mean_absolute_error,
                 "mean_squared_error": mean_squared_error,
             }
             if not self.is_baseline_model:
-                self._log_metrics(run_id, metrics, dataset.name)
+                self._log_metrics(self.run_id, metrics, self.dataset.name)
             artifacts = {}
         else:
-            raise ValueError(f"Unsupported model type {model_type}")
+            raise ValueError(f"Unsupported model type {self.model_type}")
 
         return EvaluationResult(metrics=metrics, artifacts=artifacts)
+
+    # pylint: disable=unused-argument
+    def evaluate(
+        self, *, model, model_type, dataset, run_id, evaluator_config, baseline_model=None, **kwargs
+    ):
+        self.model_type = model_type
+        self.client = MlflowClient()
+        self.dataset = dataset
+        self.run_id = run_id
+        self.X = dataset.features_data
+        self.y = dataset.labels_data
+        y_pred = model.predict(self.X)
+        eval_result = self._evaluate(
+            y_pred, is_baseline_model=evaluator_config.get("is_baseline_model", False)
+        )
+
+        if not baseline_model:
+            return (eval_result, None)
+
+        y_pred_baseline = baseline_model.predict(self.X)
+        baseline_model_eval_result = self._evaluate(y_pred_baseline, is_baseline_model=True)
+        return (eval_result, baseline_model_eval_result)

--- a/tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_evaluator.py
+++ b/tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_evaluator.py
@@ -58,44 +58,43 @@ class DummyEvaluator(ModelEvaluator):
             metrics = {"accuracy_score": accuracy_score}
             if not self.is_baseline_model:
                 self._log_metrics(run_id, metrics, dataset.name)
-            confusion_matrix = sk_metrics.confusion_matrix(y, y_pred)
-            confusion_matrix_artifact_name = f"confusion_matrix_on_{dataset.name}"
-            confusion_matrix_artifact = Array2DEvaluationArtifact(
-                uri=get_artifact_uri(run_id, confusion_matrix_artifact_name + ".csv"),
-                content=confusion_matrix,
-            )
-            confusion_matrix_csv_buff = io.StringIO()
-            confusion_matrix_artifact._save(confusion_matrix_csv_buff)
-            if not self.is_baseline_model:
-                client.log_text(
-                    run_id,
-                    confusion_matrix_csv_buff.getvalue(),
-                    confusion_matrix_artifact_name + ".csv",
+                confusion_matrix = sk_metrics.confusion_matrix(y, y_pred)
+                confusion_matrix_artifact_name = f"confusion_matrix_on_{dataset.name}"
+                confusion_matrix_artifact = Array2DEvaluationArtifact(
+                    uri=get_artifact_uri(run_id, confusion_matrix_artifact_name + ".csv"),
+                    content=confusion_matrix,
                 )
+                confusion_matrix_csv_buff = io.StringIO()
+                confusion_matrix_artifact._save(confusion_matrix_csv_buff)
+                if not self.is_baseline_model:
+                    client.log_text(
+                        run_id,
+                        confusion_matrix_csv_buff.getvalue(),
+                        confusion_matrix_artifact_name + ".csv",
+                    )
 
-            confusion_matrix_figure = sk_metrics.ConfusionMatrixDisplay.from_predictions(
-                y, y_pred
-            ).figure_
-            img_buf = io.BytesIO()
-            confusion_matrix_figure.savefig(img_buf)
-            img_buf.seek(0)
-            confusion_matrix_image = Image.open(img_buf)
+                confusion_matrix_figure = sk_metrics.ConfusionMatrixDisplay.from_predictions(
+                    y, y_pred
+                ).figure_
+                img_buf = io.BytesIO()
+                confusion_matrix_figure.savefig(img_buf)
+                img_buf.seek(0)
+                confusion_matrix_image = Image.open(img_buf)
 
-            confusion_matrix_image_artifact_name = f"confusion_matrix_image_on_{dataset.name}"
-            confusion_matrix_image_artifact = ImageEvaluationArtifact(
-                uri=get_artifact_uri(run_id, confusion_matrix_image_artifact_name + ".png"),
-                content=confusion_matrix_image,
-            )
-            confusion_matrix_image_artifact._save(confusion_matrix_image_artifact_name + ".png")
-            if not self.is_baseline_model:
+                confusion_matrix_image_artifact_name = f"confusion_matrix_image_on_{dataset.name}"
+                confusion_matrix_image_artifact = ImageEvaluationArtifact(
+                    uri=get_artifact_uri(run_id, confusion_matrix_image_artifact_name + ".png"),
+                    content=confusion_matrix_image,
+                )
+                confusion_matrix_image_artifact._save(confusion_matrix_image_artifact_name + ".png")
                 client.log_image(
                     run_id, confusion_matrix_image, confusion_matrix_image_artifact_name + ".png"
                 )
 
-            artifacts = {
-                confusion_matrix_artifact_name: confusion_matrix_artifact,
-                confusion_matrix_image_artifact_name: confusion_matrix_image_artifact,
-            }
+                artifacts = {
+                    confusion_matrix_artifact_name: confusion_matrix_artifact,
+                    confusion_matrix_image_artifact_name: confusion_matrix_image_artifact,
+                }
         elif model_type == "regressor":
             mean_absolute_error = sk_metrics.mean_absolute_error(y, y_pred)
             mean_squared_error = sk_metrics.mean_squared_error(y, y_pred)

--- a/tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_evaluator.py
+++ b/tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_evaluator.py
@@ -45,9 +45,9 @@ class DummyEvaluator(ModelEvaluator):
 
     # pylint: disable=unused-argument
     def evaluate(
-        self, *, model, model_type, dataset, run_id, evaluator_config, is_baseline_model, **kwargs
+        self, *, model, model_type, dataset, run_id, evaluator_config, **kwargs
     ) -> EvaluationResult:
-        self.is_baseline_model = is_baseline_model
+        self.is_baseline_model = evaluator_config.get("is_baseline_model", False)
         client = MlflowClient()
         X = dataset.features_data
         y = dataset.labels_data

--- a/tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_evaluator.py
+++ b/tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_evaluator.py
@@ -56,6 +56,7 @@ class DummyEvaluator(ModelEvaluator):
             accuracy_score = sk_metrics.accuracy_score(y, y_pred)
 
             metrics = {"accuracy_score": accuracy_score}
+            artifacts = {}
             if not self.is_baseline_model:
                 self._log_metrics(run_id, metrics, dataset.name)
             if not self.is_baseline_model:

--- a/tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_evaluator.py
+++ b/tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_evaluator.py
@@ -25,7 +25,6 @@ class Array2DEvaluationArtifact(EvaluationArtifact):
 
 # pylint: disable=attribute-defined-outside-init
 class DummyEvaluator(ModelEvaluator):
-    is_baseline_model = False
     # pylint: disable=unused-argument
     def can_evaluate(self, *, model_type, evaluator_config, **kwargs):
         return model_type in ["classifier", "regressor"]
@@ -60,7 +59,7 @@ class DummyEvaluator(ModelEvaluator):
                 )
                 confusion_matrix_csv_buff = io.StringIO()
                 confusion_matrix_artifact._save(confusion_matrix_csv_buff)
-                if not self.is_baseline_model:
+                if not is_baseline_model:
                     self.client.log_text(
                         self.run_id,
                         confusion_matrix_csv_buff.getvalue(),
@@ -102,7 +101,7 @@ class DummyEvaluator(ModelEvaluator):
                 "mean_absolute_error": mean_absolute_error,
                 "mean_squared_error": mean_squared_error,
             }
-            if not self.is_baseline_model:
+            if not is_baseline_model:
                 self._log_metrics(self.run_id, metrics, self.dataset.name)
             artifacts = {}
         else:
@@ -121,9 +120,7 @@ class DummyEvaluator(ModelEvaluator):
         self.X = dataset.features_data
         self.y = dataset.labels_data
         y_pred = model.predict(self.X)
-        eval_result = self._evaluate(
-            y_pred, is_baseline_model=evaluator_config.get("is_baseline_model", False)
-        )
+        eval_result = self._evaluate(y_pred, is_baseline_model=False)
 
         if not baseline_model:
             return eval_result

--- a/tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_evaluator.py
+++ b/tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_evaluator.py
@@ -126,8 +126,12 @@ class DummyEvaluator(ModelEvaluator):
         )
 
         if not baseline_model:
-            return (eval_result, None)
+            return eval_result
 
         y_pred_baseline = baseline_model.predict(self.X)
         baseline_model_eval_result = self._evaluate(y_pred_baseline, is_baseline_model=True)
-        return (eval_result, baseline_model_eval_result)
+        return EvaluationResult(
+            metrics=eval_result.metrics,
+            artifacts=eval_result.artifacts,
+            baseline_model_metrics=baseline_model_eval_result.metrics,
+        )

--- a/tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_evaluator.py
+++ b/tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_evaluator.py
@@ -59,7 +59,6 @@ class DummyEvaluator(ModelEvaluator):
             artifacts = {}
             if not self.is_baseline_model:
                 self._log_metrics(run_id, metrics, dataset.name)
-            if not self.is_baseline_model:
                 confusion_matrix = sk_metrics.confusion_matrix(y, y_pred)
                 confusion_matrix_artifact_name = f"confusion_matrix_on_{dataset.name}"
                 confusion_matrix_artifact = Array2DEvaluationArtifact(


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

Model Validation - ML-23673 and ML-23676

## What changes are proposed in this pull request?
- Add baseline_model and validation_thresholds argument to MLflow.evaluate API.
- Add evaluation of baseline models during model validation.
- Add `is_baseline_model` flag to `evaluator_config` for disabling logging metrics and disable generating and logging artifacts for evaluation of baseline model during model validation.


## How is this patch tested?
Added unit tests for
- Parametrizing the existing unit tests for testing if evaluation has the same behavior for candidate model during model validation.
- If evaluation of candidate model with is_baseline_model flag set disables logging metrics and generating artifacts works for.
  - Linear Regressor
  - Binary classifier
  - Multiclass classifier
  - Spark Linear Regressor
  - SVM model
  - Pipeline model
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
