### PR TITLE
Tag based registered model search and model version search

### DIFF
--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -364,7 +364,7 @@ class SqlAlchemyStore(AbstractStore):
         for f in parsed_filters:
             type_ = f["type"]
             key = f["key"]
-            comparator = f["comparator"]
+            comparator = f["comparator"].upper()
             value = f["value"]
             if type_ == "attribute":
                 if key not in ("name",):
@@ -383,8 +383,7 @@ class SqlAlchemyStore(AbstractStore):
             elif type_ == "tag":
                 if comparator not in ("=", "!=", "LIKE", "ILIKE"):
                     raise MlflowException.invalid_parameter_value(
-                        f"Invalid comparator for tag: {comparator}",
-                        error_code=INVALID_PARAMETER_VALUE,
+                        f"Invalid comparator for tag: {comparator}"
                     )
                 val_filter = SearchUtils.get_sql_filter_ops(
                     SqlRegisteredModelTag.value, comparator, dialect
@@ -410,7 +409,7 @@ class SqlAlchemyStore(AbstractStore):
         for f in parsed_filters:
             type_ = f["type"]
             key = f["key"]
-            comparator = f["comparator"]
+            comparator = f["comparator"].upper()
             value = f["value"]
             if type_ == "attribute":
                 if key not in ("name", "source_path", "run_id"):
@@ -435,7 +434,6 @@ class SqlAlchemyStore(AbstractStore):
                 if comparator not in ("=", "!=", "LIKE", "ILIKE"):
                     raise MlflowException.invalid_parameter_value(
                         f"Invalid comparator for tag: {comparator}",
-                        error_code=INVALID_PARAMETER_VALUE,
                     )
                 val_filter = SearchUtils.get_sql_filter_ops(
                     SqlModelVersionTag.value, comparator, dialect

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -427,7 +427,7 @@ class SqlAlchemyStore(AbstractStore):
                 if comparator == "IN":
                     # Note: Here the run_id values in databases contains only lower case letters,
                     # so we already filter out comparison values containing upper case letters
-                    # in `SearchModelUtils._get_values`. This address MYSQL IN clause case
+                    # in `SearchModelUtils._get_values`. This addresses MySQL IN clause case
                     # in-sensitive issue.
                     f = attr.in_(value)
                 else:

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -425,7 +425,10 @@ class SqlAlchemyStore(AbstractStore):
                     )
                 attr = getattr(SqlModelVersion, "source" if key == "source_path" else key)
                 if comparator == "IN":
-                    # TODO: Make it case sensitive in MYSQL
+                    # Note: Here the run_id values in databases contains only lower case letters,
+                    # so we already filter out comparison values containing upper case letters
+                    # in `SearchModelUtils._get_values`. This address MYSQL IN clause case
+                    # in-sensitive issue.
                     f = attr.in_(value)
                 else:
                     f = SearchUtils.get_sql_filter_ops(attr, comparator, dialect)(value)

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -2,6 +2,9 @@ import time
 
 import logging
 import sqlalchemy
+from functools import reduce
+
+from sqlalchemy.future import select
 
 from mlflow.entities.model_registry.model_version_stages import (
     get_canonical_stage,
@@ -62,8 +65,7 @@ def _get_search_model_versions_filter_clauses(parsed_filters, dialect):
         "\"source_path = '<source_path>'\" " \
         'or "run_id = \'<run_id>\' or "run_id IN (<run_ids>)" ' \
         'or \"tags.<tag key>\" comparison filter ' \
-        'or "AND" expression composed of the above filters.' \
-        f"Invalid filter string: {filter_string}"
+        'or "AND" expression composed of the above filters.'
     attribute_filters = []
     non_attribute_filters = []
     for f in parsed_filters:
@@ -78,7 +80,7 @@ def _get_search_model_versions_filter_clauses(parsed_filters, dialect):
                 raise MlflowException(
                     "Model Registry search filter only supports the equality(=) "
                     "comparator and the IN operator "
-                    "for the run_id parameter. Input filter string: %s" % filter_string,
+                    "for the run_id parameter.",
                     error_code=INVALID_PARAMETER_VALUE,
                 )
             attr = getattr(SqlModelVersion, key)

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -462,7 +462,7 @@ class SqlAlchemyStore(AbstractStore):
                 )
 
         mv_query = select(SqlModelVersion).filter(*attribute_filters)
-        if attribute_filters:
+        if tag_filters:
             tag_filter_query = (
                 select(SqlModelVersionTag.name, SqlModelVersionTag.version)
                 .filter(sqlalchemy.or_(*tag_filters))

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -78,7 +78,7 @@ def _get_search_model_versions_filter_clauses(parsed_filters, dialect):
                     f"Invalid comparator for attribute: {comparator}",
                     error_code=INVALID_PARAMETER_VALUE,
                 )
-            attr = getattr(SqlModelVersion, key)
+            attr = getattr(SqlModelVersion, "source" if key == "source_path" else key)
             if comparator == "IN":
                 # TODO: Make it case sensitive in MYSQL
                 f = attr.in_(value)

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -847,7 +847,7 @@ class SqlAlchemyStore(AbstractStore):
                               condition either name of model like ``name = 'model_name'`` or
                               ``run_id = '...'``.
         :return: PagedList of :py:class:`mlflow.entities.model_registry.ModelVersion`
-                 objects.
+                 objects. The order of returned records is descending order of last updated time.
         """
         parsed_filters = SearchModelUtils.parse_search_filter(filter_string)
 
@@ -858,7 +858,7 @@ class SqlAlchemyStore(AbstractStore):
         with self.ManagedSessionMaker() as session:
             stmt = filter_query.options(*self._get_eager_model_version_query_options()).filter(
                 SqlModelVersion.current_stage != STAGE_DELETED_INTERNAL
-            )
+            ).order_by(SqlModelVersion.last_updated_time.desc())
             sql_model_versions = session.execute(stmt).scalars(SqlModelVersion).all()
             model_versions = [mv.to_mlflow_entity() for mv in sql_model_versions]
             return PagedList(model_versions, None)

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -352,7 +352,7 @@ class SqlAlchemyStore(AbstractStore):
             )
             if page_token:
                 query = query.offset(offset)
-            sql_registered_models = session.execute(query).scalars(SqlModelVersion).all()
+            sql_registered_models = session.execute(query).scalars(SqlRegisteredModel).all()
             next_page_token = compute_next_token(len(sql_registered_models))
             rm_entities = [rm.to_mlflow_entity() for rm in sql_registered_models][:max_results]
             return PagedList(rm_entities, next_page_token)

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -822,12 +822,10 @@ class SqlAlchemyStore(AbstractStore):
         )
 
         with self.ManagedSessionMaker() as session:
-            attribute_filters.append(SqlModelVersion.current_stage != STAGE_DELETED_INTERNAL)
-
             stmt = (
                 reduce(lambda s, f: s.join(f), non_attribute_filters, select(SqlModelVersion))
                 .options(*self._get_eager_model_version_query_options())
-                .filter(*attribute_filters)
+                .filter(*attribute_filters, SqlModelVersion.current_stage != STAGE_DELETED_INTERNAL)
             )
             sql_model_versions = session.execute(stmt).scalars(SqlModelVersion).all()
             model_versions = [mv.to_mlflow_entity() for mv in sql_model_versions]

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -389,7 +389,9 @@ class SqlAlchemyStore(AbstractStore):
                 val_filter = SearchUtils.get_sql_filter_ops(
                     SqlRegisteredModelTag.value, comparator, dialect
                 )(value)
-                key_filter = SqlRegisteredModelTag.key == key
+                key_filter = SearchUtils.get_sql_filter_ops(
+                    SqlRegisteredModelTag.key, '=', dialect
+                )(key)
                 non_attribute_filters.append(
                     select(SqlRegisteredModelTag).filter(key_filter, val_filter).subquery()
                 )
@@ -438,7 +440,9 @@ class SqlAlchemyStore(AbstractStore):
                 val_filter = SearchUtils.get_sql_filter_ops(
                     SqlModelVersionTag.value, comparator, dialect
                 )(value)
-                key_filter = SqlModelVersionTag.key == key
+                key_filter = SearchUtils.get_sql_filter_ops(
+                    SqlModelVersionTag.key, '=', dialect
+                )(key)
                 non_attribute_filters.append(
                     select(SqlModelVersionTag).filter(key_filter, val_filter).subquery()
                 )

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -439,9 +439,9 @@ class SqlAlchemyStore(AbstractStore):
                     )
                 attr = getattr(SqlModelVersion, "source" if key == "source_path" else key)
                 if comparator == "IN":
-                    # Note: Here the run_id values in databases contains only lower case letters,
+                    # Note: Here the run_id values in databases contain only lower case letters,
                     # so we already filter out comparison values containing upper case letters
-                    # in `SearchModelUtils._get_values`. This addresses MySQL IN clause case
+                    # in `SearchModelUtils._get_value`. This addresses MySQL IN clause case
                     # in-sensitive issue.
                     f = attr.in_(value)
                 else:
@@ -845,7 +845,7 @@ class SqlAlchemyStore(AbstractStore):
                               condition either name of model like ``name = 'model_name'`` or
                               ``run_id = '...'``.
         :return: PagedList of :py:class:`mlflow.entities.model_registry.ModelVersion`
-                 objects. The order of returned records is descending order of last updated time.
+                 objects sorted by last updated time in descending order.
         """
         parsed_filters = SearchModelUtils.parse_search_filter(filter_string)
 

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -364,7 +364,7 @@ class SqlAlchemyStore(AbstractStore):
         for f in parsed_filters:
             type_ = f["type"]
             key = f["key"]
-            comparator = f["comparator"].upper()
+            comparator = f["comparator"]
             value = f["value"]
             if type_ == "attribute":
                 if key not in ("name",):
@@ -409,7 +409,7 @@ class SqlAlchemyStore(AbstractStore):
         for f in parsed_filters:
             type_ = f["type"]
             key = f["key"]
-            comparator = f["comparator"].upper()
+            comparator = f["comparator"]
             value = f["value"]
             if type_ == "attribute":
                 if key not in ("name", "source_path", "run_id"):

--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -66,7 +66,7 @@ class AbstractStore:
               - ``=``: Equal to.
               - ``!=``: Not equal to.
               - ``LIKE``: Case-sensitive pattern match.
-              - ``ILIKE``: Case-insensitive sensitive pattern match.
+              - ``ILIKE``: Case-insensitive pattern match.
 
             Logical operators
               - ``AND``: Combines two sub-queries and returns True if both of them are True.

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -513,8 +513,8 @@ class SqlAlchemyStore(AbstractStore):
             self._check_experiment_is_active(experiment)
 
             # Note: we need to ensure the generated "run_id" only contains digits and lower
-            # case letters, because some query filters contains "IN" clause, and in MYSQL the
-            # "IN" clause is case in-sensitive, we use a trick that filter out comparison values
+            # case letters, because some query filters contain "IN" clause, and in MYSQL the
+            # "IN" clause is case-insensitive, we use a trick that filters out comparison values
             # containing upper case letters when parsing "IN" clause inside query filter.
             run_id = uuid.uuid4().hex
             artifact_location = append_to_uri_path(

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -512,6 +512,10 @@ class SqlAlchemyStore(AbstractStore):
             experiment = self.get_experiment(experiment_id)
             self._check_experiment_is_active(experiment)
 
+            # Note: we need to ensure the generated "run_id" only contains digits and lower
+            # case letters, because some query filters contains "IN" clause, and in MYSQL the
+            # "IN" clause is case in-sensitive, we use a trick that filter out comparison values
+            # containing upper case letters when parsing "IN" clause inside query filter.
             run_id = uuid.uuid4().hex
             artifact_location = append_to_uri_path(
                 experiment.artifact_location, run_id, SqlAlchemyStore.ARTIFACTS_FOLDER_NAME

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -184,7 +184,7 @@ class TrackingServiceClient:
               - ``=``: Equal to.
               - ``!=``: Not equal to.
               - ``LIKE``: Case-sensitive pattern match.
-              - ``ILIKE``: Case-insensitive sensitive pattern match.
+              - ``ILIKE``: Case-insensitive pattern match.
 
             Logical operators
               - ``AND``: Combines two sub-queries and returns True if both of them are True.

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1990,13 +1990,14 @@ class MlflowClient:
         """
         Search for registered models in backend that satisfy the filter criteria.
 
-        :param filter_string: Filter query string (e.g., ``"name = 'a_model_name'"``),
+        :param filter_string: Filter query string
+            (e.g., ``"name = 'a_model_name' and tag.key = 'value1'"``),
             defaults to searching for all registered models. The following identifiers, comparators,
             and logical operators are supported.
 
             Identifiers
               - ``name``: registered model name.
-              - ``tags.<tag_key>``: registered model tag. If ``tag_key`` contains paces, it must be
+              - ``tags.<tag_key>``: registered model tag. If ``tag_key`` contains spaces, it must be
                 wrapped with backticks (e.g., ``"tags.`extra key`"``).
 
             Comparators
@@ -2694,7 +2695,8 @@ class MlflowClient:
         """
         Search for model versions in backend that satisfy the filter criteria.
 
-        :param filter_string: Filter query string (e.g., ``"name = 'a_model_name'"``),
+        :param filter_string: Filter query string
+            (e.g., ``"name = 'a_model_name' and tag.key = 'value1'"``),
             defaults to searching for all model versions. The following identifiers, comparators,
             and logical operators are supported.
 
@@ -2702,7 +2704,7 @@ class MlflowClient:
               - ``name``: model name.
               - ``source_path``: model version source path.
               - ``run_id``: The id of the mlflow run that generates the model version.
-              - ``tags.<tag_key>``: model version tag. If ``tag_key`` contains paces, it must be
+              - ``tags.<tag_key>``: model version tag. If ``tag_key`` contains spaces, it must be
                 wrapped with backticks (e.g., ``"tags.`extra key`"``).
 
             Comparators

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -426,7 +426,7 @@ class MlflowClient:
               - ``=``: Equal to.
               - ``!=``: Not equal to.
               - ``LIKE``: Case-sensitive pattern match.
-              - ``ILIKE``: Case-insensitive sensitive pattern match.
+              - ``ILIKE``: Case-insensitive pattern match.
 
             Logical operators
               - ``AND``: Combines two sub-queries and returns True if both of them are True.
@@ -2003,7 +2003,7 @@ class MlflowClient:
               - ``=``: Equal to.
               - ``!=``: Not equal to.
               - ``LIKE``: Case-sensitive pattern match.
-              - ``ILIKE``: Case-insensitive sensitive pattern match.
+              - ``ILIKE``: Case-insensitive pattern match.
 
             Logical operators
               - ``AND``: Combines two sub-queries and returns True if both of them are True.
@@ -2709,7 +2709,7 @@ class MlflowClient:
               - ``=``: Equal to.
               - ``!=``: Not equal to.
               - ``LIKE``: Case-sensitive pattern match.
-              - ``ILIKE``: Case-insensitive sensitive pattern match.
+              - ``ILIKE``: Case-insensitive pattern match.
               - ``IN``: In a value list. Only ``run_id`` identifier supports ``IN`` comparator.
 
             Logical operators

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1990,12 +1990,24 @@ class MlflowClient:
         """
         Search for registered models in backend that satisfy the filter criteria.
 
-        :param filter_string: Filter query string, defaults to searching all registered
-                models. Currently, it supports only a single filter condition as the name
-                of the model, for example, ``name = 'model_name'`` or a search expression
-                to match a pattern in the registered model name.
-                For example, ``name LIKE 'Boston%'`` (case sensitive) or
-                ``name ILIKE '%boston%'`` (case insensitive).
+        :param filter_string: Filter query string (e.g., ``"name = 'a_model_name'"``),
+            defaults to searching for all registered models. The following identifiers, comparators,
+            and logical operators are supported.
+
+            Identifiers
+              - ``name``: registered model name.
+              - ``tags.<tag_key>``: registered model tag. If ``tag_key`` contains paces, it must be
+                wrapped with backticks (e.g., ``"tags.`extra key`"``).
+
+            Comparators
+              - ``=``: Equal to.
+              - ``!=``: Not equal to.
+              - ``LIKE``: Case-sensitive pattern match.
+              - ``ILIKE``: Case-insensitive sensitive pattern match.
+
+            Logical operators
+              - ``AND``: Combines two sub-queries and returns True if both of them are True.
+
         :param max_results: Maximum number of registered models desired.
         :param order_by: List of column names with ASC|DESC annotation, to be used for ordering
                          matching search results.
@@ -2682,9 +2694,27 @@ class MlflowClient:
         """
         Search for model versions in backend that satisfy the filter criteria.
 
-        :param filter_string: A filter string expression. Currently, it supports a single filter
-                              condition either a name of model like ``name = 'model_name'`` or
-                              ``run_id = '...'``.
+        :param filter_string: Filter query string (e.g., ``"name = 'a_model_name'"``),
+            defaults to searching for all model versions. The following identifiers, comparators,
+            and logical operators are supported.
+
+            Identifiers
+              - ``name``: model name.
+              - ``source_path``: model version source path.
+              - ``run_id``: The id of the mlflow run that generates the model version.
+              - ``tags.<tag_key>``: model version tag. If ``tag_key`` contains paces, it must be
+                wrapped with backticks (e.g., ``"tags.`extra key`"``).
+
+            Comparators
+              - ``=``: Equal to.
+              - ``!=``: Not equal to.
+              - ``LIKE``: Case-sensitive pattern match.
+              - ``ILIKE``: Case-insensitive sensitive pattern match.
+              - ``IN``: In a value list. Only ``run_id`` identifier supports ``IN`` comparator.
+
+            Logical operators
+              - ``AND``: Combines two sub-queries and returns True if both of them are True.
+
         :return: PagedList of :py:class:`mlflow.entities.model_registry.ModelVersion` objects.
 
         .. code-block:: python

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1090,7 +1090,7 @@ def search_experiments(
           - ``=``: Equal to.
           - ``!=``: Not equal to.
           - ``LIKE``: Case-sensitive pattern match.
-          - ``ILIKE``: Case-insensitive sensitive pattern match.
+          - ``ILIKE``: Case-insensitive pattern match.
 
         Logical operators
           - ``AND``: Combines two sub-queries and returns True if both of them are True.

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -102,7 +102,7 @@ class SearchUtils:
         import sqlalchemy as sa
 
         # Use case-sensitive collation for MSSQL
-        if dialect == MYSQL:
+        if dialect == MSSQL:
             column = column.collate("Japanese_Bushu_Kakusu_100_CS_AS_KS_WS")
 
         # Use non-binary ahead of binary comparison for runtime performance

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -993,7 +993,7 @@ class SearchModelUtils(SearchUtils):
                 run_id_list = cls._parse_list_from_sql_token(token)
                 # Because MySQL IN clause is case-insensitive, but all run_ids only contains lower case
                 # letters, so that we filter out run_ids containing upper case letters here.
-                run_id_list = [run_id for run_id in run_id_list if run_id.lower() == run_id]
+                run_id_list = [run_id for run_id in run_id_list if run_id.islower()]
                 return run_id_list
             else:
                 raise MlflowException(

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -1002,11 +1002,7 @@ class SearchModelUtils(SearchUtils):
 
     @classmethod
     def _invalid_statement_token_search_model_registry(cls, token):
-        if isinstance(token, Comparison):
-            return False
-        elif isinstance(token, Identifier):
-            return False
-        elif isinstance(token, Parenthesis):
+        if isinstance(token, (Comparison, Identifier, Parenthesis)):
             return False
         elif token.is_whitespace:
             return False

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -928,7 +928,9 @@ class SearchExperimentsUtils(SearchUtils):
 class SearchModelUtils(SearchUtils):
     @classmethod
     def _process_statement(cls, statement):
-        invalids = list(filter(cls._invalid_statement_token_search_model_registry, statement.tokens))
+        invalids = list(
+            filter(cls._invalid_statement_token_search_model_registry, statement.tokens)
+        )
         if len(invalids) > 0:
             invalid_clauses = ", ".join(map(str, invalids))
             raise MlflowException.invalid_parameter_value(
@@ -950,8 +952,9 @@ class SearchModelUtils(SearchUtils):
                     f"Invalid entity type '{entity_type}'. "
                     f"Valid entity types are {valid_entity_types}"
                 )
-            identifier = cls._TAG_IDENTIFIER if entity_type in ("tag", "tags") \
-                else cls._ATTRIBUTE_IDENTIFIER
+            identifier = (
+                cls._TAG_IDENTIFIER if entity_type in ("tag", "tags") else cls._ATTRIBUTE_IDENTIFIER
+            )
 
         key = cls._trim_backticks(cls._strip_quotes(key))
         return {"type": identifier, "key": key}
@@ -990,9 +993,7 @@ class SearchModelUtils(SearchUtils):
                 run_id_list = cls._parse_list_from_sql_token(token)
                 # Because MYSQL IN clause is case in-sensitive, but all run_ids only contains lower case
                 # letters, so that we filter out run_ids containing upper case letters here.
-                run_id_list = [
-                    run_id for run_id in run_id_list if run_id.lower() == run_id
-                ]
+                run_id_list = [run_id for run_id in run_id_list if run_id.lower() == run_id]
                 return run_id_list
             else:
                 raise MlflowException(

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -1051,7 +1051,13 @@ class SearchModelUtils(SearchUtils):
                         "Only run_id attribute support compare with a list of quoted string values.",
                         error_code=INVALID_PARAMETER_VALUE,
                     )
-                return cls._parse_list_from_sql_token(token)
+                run_id_list = cls._parse_list_from_sql_token(token)
+                # Because MYSQL IN clause is case in-sensitive, but all run_ids only contains lower case
+                # letters, so that we filter out run_ids containing upper case letters here.
+                run_id_list = [
+                    run_id for run_id in run_id_list if run_id.lower() == run_id
+                ]
+                return run_id_list
             else:
                 raise MlflowException(
                     "Expected a quoted string value or a list of quoted string values for "

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -1026,7 +1026,7 @@ class SearchModelUtils(SearchUtils):
         cls._validate_comparison(stripped_comparison)
         left, comparator, right = stripped_comparison
         comp = cls._get_identifier(left.value)
-        comp["comparator"] = comparator.value
+        comp["comparator"] = comparator.value.upper()
         comp["value"] = cls._get_value(comp.get("type"), comp.get("key"), right)
         return comp
 

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -991,7 +991,7 @@ class SearchModelUtils(SearchUtils):
                         error_code=INVALID_PARAMETER_VALUE,
                     )
                 run_id_list = cls._parse_list_from_sql_token(token)
-                # Because MYSQL IN clause is case in-sensitive, but all run_ids only contains lower case
+                # Because MySQL IN clause is case-insensitive, but all run_ids only contains lower case
                 # letters, so that we filter out run_ids containing upper case letters here.
                 run_id_list = [run_id for run_id in run_id_list if run_id.lower() == run_id]
                 return run_id_list
@@ -1005,7 +1005,8 @@ class SearchModelUtils(SearchUtils):
             # Expected to be either "param" or "metric".
             raise MlflowException(
                 "Invalid identifier type. Expected one of "
-                "{}.".format([cls._ATTRIBUTE_IDENTIFIER, cls._TAG_IDENTIFIER])
+                "{}.".format([cls._ATTRIBUTE_IDENTIFIER, cls._TAG_IDENTIFIER]),
+                error_code=INVALID_PARAMETER_VALUE,
             )
 
     @classmethod

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -939,7 +939,7 @@ class SearchModelUtils(SearchUtils):
         return [cls._get_comparison(t) for t in statement.tokens if isinstance(t, Comparison)]
 
     @classmethod
-    def _get_identifier(cls, identifier):
+    def _get_model_search_identifier(cls, identifier):
         tokens = identifier.split(".", maxsplit=1)
         if len(tokens) == 1:
             key = tokens[0]
@@ -964,7 +964,7 @@ class SearchModelUtils(SearchUtils):
         stripped_comparison = [token for token in comparison.tokens if not token.is_whitespace]
         cls._validate_comparison(stripped_comparison)
         left, comparator, right = stripped_comparison
-        comp = cls._get_identifier(left.value)
+        comp = cls._get_model_search_identifier(left.value)
         comp["comparator"] = comparator.value.upper()
         comp["value"] = cls._get_value(comp.get("type"), comp.get("key"), right)
         return comp
@@ -987,12 +987,13 @@ class SearchModelUtils(SearchUtils):
                 cls._check_valid_identifier_list(token)
                 if key != "run_id":
                     raise MlflowException(
-                        "Only run_id attribute support compare with a list of quoted string values.",
+                        "Only run_id attribute support compare with a list of quoted string "
+                        "values.",
                         error_code=INVALID_PARAMETER_VALUE,
                     )
                 run_id_list = cls._parse_list_from_sql_token(token)
-                # Because MySQL IN clause is case-insensitive, but all run_ids only contains lower case
-                # letters, so that we filter out run_ids containing upper case letters here.
+                # Because MySQL IN clause is case-insensitive, but all run_ids only contains lower
+                # case letters, so that we filter out run_ids containing upper case letters here.
                 run_id_list = [run_id for run_id in run_id_list if run_id.islower()]
                 return run_id_list
             else:

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -110,7 +110,7 @@ class SearchUtils:
         # Use non-binary ahead of binary comparison for runtime performance
         # Use non-binary ahead of binary comparison for runtime performance
         def case_sensitive_mysql_eq(value):
-            return sa.text(f"{col} = :value AND BINARY {col} = :value").bindparams(
+            return sa.text(f"({col} = :value AND BINARY {col} = :value)").bindparams(
                 sa.bindparam("value", value=value, unique=True)
             )
 
@@ -120,7 +120,7 @@ class SearchUtils:
             )
 
         def case_sensitive_mysql_like(value):
-            return sa.text(f"{col} LIKE :value AND BINARY {col} LIKE :value").bindparams(
+            return sa.text(f"({col} LIKE :value AND BINARY {col} LIKE :value)").bindparams(
                 sa.bindparam("value", value=value, unique=True)
             )
 

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -992,7 +992,7 @@ class SearchModelUtils(SearchUtils):
                         error_code=INVALID_PARAMETER_VALUE,
                     )
                 run_id_list = cls._parse_list_from_sql_token(token)
-                # Because MySQL IN clause is case-insensitive, but all run_ids only contains lower
+                # Because MySQL IN clause is case-insensitive, but all run_ids only contain lower
                 # case letters, so that we filter out run_ids containing upper case letters here.
                 run_id_list = [run_id for run_id in run_id_list if run_id.islower()]
                 return run_id_list

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -115,7 +115,7 @@ class SearchUtils:
             )
 
         def case_sensitive_mysql_ne(value):
-            return sa.text(f"{col} != :value OR BINARY {col} != :value").bindparams(
+            return sa.text(f"({col} != :value OR BINARY {col} != :value)").bindparams(
                 sa.bindparam("value", value=value, unique=True)
             )
 

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -987,3 +987,16 @@ class SearchExperimentsUtils(SearchUtils):
     @classmethod
     def sort(cls, experiments, order_by_list):  # pylint: disable=arguments-renamed
         return sorted(experiments, key=cls._get_sort_key(order_by_list))
+
+
+class SearchModelVersionsUtils(SearchUtils):
+
+    @classmethod
+    def _process_statement(cls, statement):
+        invalids = list(filter(cls._invalid_statement_token_search_model_registry, statement.tokens))
+        if len(invalids) > 0:
+            invalid_clauses = ", ".join(map(str, invalids))
+            raise MlflowException.invalid_parameter_value(
+                "Invalid clause(s) in filter string: %s" % invalid_clauses
+            )
+        return [cls._get_comparison(t) for t in statement.tokens if isinstance(t, Comparison)]

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -1053,11 +1053,16 @@ class SearchModelVersionsUtils(SearchUtils):
                 return cls._strip_quotes(token.value, expect_quoted_value=True)
             elif isinstance(token, Parenthesis):
                 cls._check_valid_identifier_list(token)
+                if key != "run_id":
+                    raise MlflowException(
+                        "Only run_id attribute support compare with a list of quoted string values.",
+                        error_code = INVALID_PARAMETER_VALUE,
+                    )
                 return cls._parse_list_from_sql_token(token)
             else:
                 raise MlflowException(
-                    "Expected a quoted string value for attributes. "
-                    "Got value {value}".format(value=token.value),
+                    "Expected a quoted string value or a list of quoted string values for "
+                    "attributes. Got value {value}".format(value=token.value),
                     error_code=INVALID_PARAMETER_VALUE,
                 )
         else:

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -1019,6 +1019,10 @@ class SearchModelUtils(SearchUtils):
         elif token.match(ttype=TokenType.Operator.Comparison, values=["IN"]):
             # `IN` is a comparison token in sqlparse >= 0.4.0:
             # https://github.com/andialbrecht/sqlparse/pull/567
+            if token.value == "IN":
+                # This case it represent the IN filter parsed failed.
+                # e.g. "run_id IN"
+                return True
             return False
         else:
             return True

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -102,7 +102,7 @@ class SearchUtils:
         import sqlalchemy as sa
 
         # Use case-sensitive collation for MSSQL
-        if dialect == MSSQL:
+        if dialect == MYSQL:
             column = column.collate("Japanese_Bushu_Kakusu_100_CS_AS_KS_WS")
 
         # Use non-binary ahead of binary comparison for runtime performance

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -970,19 +970,19 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         def search_versions(filter_string):
             return [mvd.version for mvd in self.store.search_model_versions(filter_string)]
 
-        self.assertEqual(set(search_versions(f"name='{name}' and tag.t2 = 'xyz'")), {1})
-        self.assertEqual(set(search_versions(f"name='wrong_name' and tag.t2 = 'xyz'")), set())
-        self.assertEqual(set(search_versions(f"name='{name}' and tag.`t2` = 'xyz'")), {1})
-        self.assertEqual(set(search_versions(f"name='{name}' and tag.t3 = 'xyz'")), set())
-        self.assertEqual(set(search_versions(f"name='{name}' and tag.t2 != 'xy'")), {1, 2})
-        self.assertEqual(set(search_versions(f"name='{name}' and tag.t2 LIKE 'xy%'")), {1})
-        self.assertEqual(set(search_versions(f"name='{name}' and tag.t2 LIKE 'xY%'")), set())
-        self.assertEqual(set(search_versions(f"name='{name}' and tag.t2 ILIKE 'xY%'")), {1})
-        self.assertEqual(set(search_versions(f"name='{name}' and tag.t2 LIKE 'x%'")), {1, 2})
-        self.assertEqual(set(search_versions(f"name='{name}' and tag.T2 = 'xyz'")), set())
-        self.assertEqual(set(search_versions(f"name='{name}' and tag.t1 = 'abc' and tag.t2 = 'xyz'")), {1})
-        self.assertEqual(set(search_versions(f"name='{name}' and tag.t1 = 'abc' and tag.t2 LIKE 'x%'")), {1, 2})
-        self.assertEqual(set(search_versions(f"name='{name}' and tag.t1 = 'abc' and tag.t2 LIKE 'y%'")), set())
+        self.assertEqual(set(search_versions(f"name = '{name}' and tag.t2 = 'xyz'")), {1})
+        self.assertEqual(set(search_versions(f"name = 'wrong_name' and tag.t2 = 'xyz'")), set())
+        self.assertEqual(set(search_versions(f"name = '{name}' and tag.`t2` = 'xyz'")), {1})
+        self.assertEqual(set(search_versions(f"name = '{name}' and tag.t3 = 'xyz'")), set())
+        self.assertEqual(set(search_versions(f"name = '{name}' and tag.t2 != 'xy'")), {1, 2})
+        self.assertEqual(set(search_versions(f"name = '{name}' and tag.t2 LIKE 'xy%'")), {1})
+        self.assertEqual(set(search_versions(f"name = '{name}' and tag.t2 LIKE 'xY%'")), set())
+        self.assertEqual(set(search_versions(f"name = '{name}' and tag.t2 ILIKE 'xY%'")), {1})
+        self.assertEqual(set(search_versions(f"name = '{name}' and tag.t2 LIKE 'x%'")), {1, 2})
+        self.assertEqual(set(search_versions(f"name = '{name}' and tag.T2 = 'xyz'")), set())
+        self.assertEqual(set(search_versions(f"name = '{name}' and tag.t1 = 'abc' and tag.t2 = 'xyz'")), {1})
+        self.assertEqual(set(search_versions(f"name = '{name}' and tag.t1 = 'abc' and tag.t2 LIKE 'x%'")), {1, 2})
+        self.assertEqual(set(search_versions(f"name = '{name}' and tag.t1 = 'abc' and tag.t2 LIKE 'y%'")), set())
 
     def _search_registered_models(
         self, filter_string, max_results=10, order_by=None, page_token=None
@@ -1127,10 +1127,10 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self._rm_maker(name1, tags1)
         self._rm_maker(name2, tags2)
 
-        rms, _ = self._search_registered_models(f"tag.t3='XYZ'")
+        rms, _ = self._search_registered_models(f"tag.t3 = 'XYZ'")
         self.assertEqual(set(rms), {name2})
 
-        rms, _ = self._search_registered_models(f"name = '{name1}' and tag.t1='abc'")
+        rms, _ = self._search_registered_models(f"name = '{name1}' and tag.t1 = 'abc'")
         self.assertEqual(set(rms), {name1})
 
         rms, _ = self._search_registered_models(f"tag.t1 LIKE 'ab%'")
@@ -1139,10 +1139,10 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         rms, _ = self._search_registered_models(f"tag.t1 LIKE 'ab%' AND tag.t2 LIKE 'xy%'")
         self.assertEqual(set(rms), {name1, name2})
 
-        rms, _ = self._search_registered_models(f"tag.t3='XYz'")
+        rms, _ = self._search_registered_models(f"tag.t3 = 'XYz'")
         self.assertEqual(set(rms), set())
 
-        rms, _ = self._search_registered_models(f"tag.T3='XYZ'")
+        rms, _ = self._search_registered_models(f"tag.T3 = 'XYZ'")
         self.assertEqual(set(rms), set())
 
         rms, _ = self._search_registered_models(f"tag.t1 != 'abc'")

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -888,6 +888,16 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
             search_versions("run_id IN (1,2,3)")
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
+        self.assertEqual(
+            set(search_versions(f"run_id LIKE '{run_id_2[:30]}%'")),
+            set([2, 3]),
+        )
+
+        self.assertEqual(
+            set(search_versions(f"run_id ILIKE '{run_id_2[:30].upper()}%'")),
+            set([2, 3]),
+        )
+
         # search using the IN operator with empty lists should return exceptions
         with self.assertRaisesRegex(
             MlflowException,
@@ -1002,19 +1012,19 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
 
         assert search_versions(f"name = '{name}' and tag.t2 = 'xyz'") == [1]
         assert search_versions("name = 'wrong_name' and tag.t2 = 'xyz'") == []
-        assert search_versions(f"name = '{name}' and tag.`t2` = 'xyz'") == [1]
-        assert search_versions(f"name = '{name}' and tag.t3 = 'xyz'") == []
-        assert search_versions(f"name = '{name}' and tag.t2 != 'xy'") == [2, 1]
-        assert search_versions(f"name = '{name}' and tag.t2 LIKE 'xy%'") == [1]
-        assert search_versions(f"name = '{name}' and tag.t2 LIKE 'xY%'") == []
-        assert search_versions(f"name = '{name}' and tag.t2 ILIKE 'xY%'") == [1]
-        assert search_versions(f"name = '{name}' and tag.t2 LIKE 'x%'") == [2, 1]
-        assert search_versions(f"name = '{name}' and tag.T2 = 'xyz'") == []
-        assert search_versions(f"name = '{name}' and tag.t1 = 'abc' and tag.t2 = 'xyz'") == [1]
-        assert search_versions(f"name = '{name}' and tag.t1 = 'abc' and tag.t2 LIKE 'x%'") == [2, 1]
-        assert search_versions(f"name = '{name}' and tag.t1 = 'abc' and tag.t2 LIKE 'y%'") == []
+        assert search_versions("tag.`t2` = 'xyz'") == [1]
+        assert search_versions("tag.t3 = 'xyz'") == []
+        assert search_versions("tag.t2 != 'xy'") == [2, 1]
+        assert search_versions("tag.t2 LIKE 'xy%'") == [1]
+        assert search_versions("tag.t2 LIKE 'xY%'") == []
+        assert search_versions("tag.t2 ILIKE 'xY%'") == [1]
+        assert search_versions("tag.t2 LIKE 'x%'") == [2, 1]
+        assert search_versions("tag.T2 = 'xyz'") == []
+        assert search_versions("tag.t1 = 'abc' and tag.t2 = 'xyz'") == [1]
+        assert search_versions("tag.t1 = 'abc' and tag.t2 LIKE 'x%'") == [2, 1]
+        assert search_versions("tag.t1 = 'abc' and tag.t2 LIKE 'y%'") == []
         # test filter with duplicated keys
-        assert search_versions(f"name = '{name}' and tag.t2 like 'x%' and tag.t2 != 'xyz'") == [2]
+        assert search_versions("tag.t2 like 'x%' and tag.t2 != 'xyz'") == [2]
 
     def _search_registered_models(
         self, filter_string, max_results=10, order_by=None, page_token=None

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -900,10 +900,11 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
             search_versions("run_id IN (")
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
-        # TODO: fix
-        # with self.assertRaisesRegex(MlflowException, r"Invalid filter '.+'") as exception_context:
-        #    search_versions("run_id IN")
-        # assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+        with self.assertRaisesRegex(
+                MlflowException, r"Invalid clause\(s\) in filter string"
+        ) as exception_context:
+            search_versions("run_id IN")
+        assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
         with self.assertRaisesRegex(
             MlflowException,

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -876,6 +876,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
             search_versions("run_id IN (")
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
+        # TODO: fix
         # with self.assertRaisesRegex(MlflowException, r"Invalid filter '.+'") as exception_context:
         #     search_versions("run_id IN")
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -994,28 +994,28 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         def search_versions(filter_string):
             return [mvd.version for mvd in self.store.search_model_versions(filter_string)]
 
-        self.assertEqual(set(search_versions(f"name = '{name}' and tag.t2 = 'xyz'")), {1})
-        self.assertEqual(set(search_versions(f"name = 'wrong_name' and tag.t2 = 'xyz'")), set())
-        self.assertEqual(set(search_versions(f"name = '{name}' and tag.`t2` = 'xyz'")), {1})
-        self.assertEqual(set(search_versions(f"name = '{name}' and tag.t3 = 'xyz'")), set())
-        self.assertEqual(set(search_versions(f"name = '{name}' and tag.t2 != 'xy'")), {1, 2})
-        self.assertEqual(set(search_versions(f"name = '{name}' and tag.t2 LIKE 'xy%'")), {1})
-        self.assertEqual(set(search_versions(f"name = '{name}' and tag.t2 LIKE 'xY%'")), set())
-        self.assertEqual(set(search_versions(f"name = '{name}' and tag.t2 ILIKE 'xY%'")), {1})
-        self.assertEqual(set(search_versions(f"name = '{name}' and tag.t2 LIKE 'x%'")), {1, 2})
-        self.assertEqual(set(search_versions(f"name = '{name}' and tag.T2 = 'xyz'")), set())
+        self.assertEqual(search_versions(f"name = '{name}' and tag.t2 = 'xyz'"), [1])
+        self.assertEqual(search_versions(f"name = 'wrong_name' and tag.t2 = 'xyz'"), [])
+        self.assertEqual(search_versions(f"name = '{name}' and tag.`t2` = 'xyz'"), [1])
+        self.assertEqual(search_versions(f"name = '{name}' and tag.t3 = 'xyz'"), [])
+        self.assertEqual(search_versions(f"name = '{name}' and tag.t2 != 'xy'"), [2, 1])
+        self.assertEqual(search_versions(f"name = '{name}' and tag.t2 LIKE 'xy%'"), [1])
+        self.assertEqual(search_versions(f"name = '{name}' and tag.t2 LIKE 'xY%'"), [])
+        self.assertEqual(search_versions(f"name = '{name}' and tag.t2 ILIKE 'xY%'"), [1])
+        self.assertEqual(search_versions(f"name = '{name}' and tag.t2 LIKE 'x%'"), [2, 1])
+        self.assertEqual(search_versions(f"name = '{name}' and tag.T2 = 'xyz'"), [])
         self.assertEqual(
-            set(search_versions(f"name = '{name}' and tag.t1 = 'abc' and tag.t2 = 'xyz'")), {1}
+            search_versions(f"name = '{name}' and tag.t1 = 'abc' and tag.t2 = 'xyz'"), [1]
         )
         self.assertEqual(
-            set(search_versions(f"name = '{name}' and tag.t1 = 'abc' and tag.t2 LIKE 'x%'")), {1, 2}
+            search_versions(f"name = '{name}' and tag.t1 = 'abc' and tag.t2 LIKE 'x%'"), [2, 1]
         )
         self.assertEqual(
-            set(search_versions(f"name = '{name}' and tag.t1 = 'abc' and tag.t2 LIKE 'y%'")), set()
+            search_versions(f"name = '{name}' and tag.t1 = 'abc' and tag.t2 LIKE 'y%'"), []
         )
         # test filter with duplicated keys
         self.assertEqual(
-            set(search_versions(f"name = '{name}' and tag.t2 like 'x%' and tag.t2 != 'xyz'")), {2}
+            search_versions(f"name = '{name}' and tag.t2 like 'x%' and tag.t2 != 'xyz'"), [2]
         )
 
     def _search_registered_models(

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -1162,29 +1162,29 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self._rm_maker(name2, tags2)
 
         rms, _ = self._search_registered_models(f"tag.t3 = 'XYZ'")
-        self.assertEqual(set(rms), {name2})
+        self.assertEqual(rms, [name2])
 
         rms, _ = self._search_registered_models(f"name = '{name1}' and tag.t1 = 'abc'")
-        self.assertEqual(set(rms), {name1})
+        self.assertEqual(rms, [name1])
 
         rms, _ = self._search_registered_models(f"tag.t1 LIKE 'ab%'")
-        self.assertEqual(set(rms), {name1, name2})
+        self.assertEqual(rms, [name1, name2])
 
         rms, _ = self._search_registered_models(f"tag.t1 LIKE 'ab%' AND tag.t2 LIKE 'xy%'")
-        self.assertEqual(set(rms), {name1, name2})
+        self.assertEqual(rms, [name1, name2])
 
         rms, _ = self._search_registered_models(f"tag.t3 = 'XYz'")
-        self.assertEqual(set(rms), set())
+        self.assertEqual(rms, [])
 
         rms, _ = self._search_registered_models(f"tag.T3 = 'XYZ'")
-        self.assertEqual(set(rms), set())
+        self.assertEqual(rms, [])
 
         rms, _ = self._search_registered_models(f"tag.t1 != 'abc'")
-        self.assertEqual(set(rms), {name2})
+        self.assertEqual(rms, [name2])
 
         # test filter with duplicated keys
         rms, _ = self._search_registered_models(f"tag.t1 != 'abcd' and tag.t1 LIKE 'ab%'")
-        self.assertEqual(set(rms), {name1})
+        self.assertEqual(rms, [name1])
 
     def test_parse_search_registered_models_order_by(self):
         # test that "registered_models.name ASC" is returned by default

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -908,7 +908,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
         with self.assertRaisesRegex(
-                MlflowException, r"Invalid clause\(s\) in filter string"
+            MlflowException, r"Invalid clause\(s\) in filter string"
         ) as exception_context:
             search_versions("run_id IN")
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
@@ -982,41 +982,33 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
             run_id=run_id_1,
             tags=[ModelVersionTag("t1", "abc"), ModelVersionTag("t2", "xyz")],
         )
-        self.assertEqual(mv1.version, 1)
+        assert mv1.version == 1
         mv2 = self._mv_maker(
             name=name,
             source="A/C",
             run_id=run_id_2,
             tags=[ModelVersionTag("t1", "abc"), ModelVersionTag("t2", "x123")],
         )
-        self.assertEqual(mv2.version, 2)
+        assert mv2.version == 2
 
         def search_versions(filter_string):
             return [mvd.version for mvd in self.store.search_model_versions(filter_string)]
 
-        self.assertEqual(search_versions(f"name = '{name}' and tag.t2 = 'xyz'"), [1])
-        self.assertEqual(search_versions(f"name = 'wrong_name' and tag.t2 = 'xyz'"), [])
-        self.assertEqual(search_versions(f"name = '{name}' and tag.`t2` = 'xyz'"), [1])
-        self.assertEqual(search_versions(f"name = '{name}' and tag.t3 = 'xyz'"), [])
-        self.assertEqual(search_versions(f"name = '{name}' and tag.t2 != 'xy'"), [2, 1])
-        self.assertEqual(search_versions(f"name = '{name}' and tag.t2 LIKE 'xy%'"), [1])
-        self.assertEqual(search_versions(f"name = '{name}' and tag.t2 LIKE 'xY%'"), [])
-        self.assertEqual(search_versions(f"name = '{name}' and tag.t2 ILIKE 'xY%'"), [1])
-        self.assertEqual(search_versions(f"name = '{name}' and tag.t2 LIKE 'x%'"), [2, 1])
-        self.assertEqual(search_versions(f"name = '{name}' and tag.T2 = 'xyz'"), [])
-        self.assertEqual(
-            search_versions(f"name = '{name}' and tag.t1 = 'abc' and tag.t2 = 'xyz'"), [1]
-        )
-        self.assertEqual(
-            search_versions(f"name = '{name}' and tag.t1 = 'abc' and tag.t2 LIKE 'x%'"), [2, 1]
-        )
-        self.assertEqual(
-            search_versions(f"name = '{name}' and tag.t1 = 'abc' and tag.t2 LIKE 'y%'"), []
-        )
+        assert search_versions(f"name = '{name}' and tag.t2 = 'xyz'") == [1]
+        assert search_versions(f"name = 'wrong_name' and tag.t2 = 'xyz'") == []
+        assert search_versions(f"name = '{name}' and tag.`t2` = 'xyz'") == [1]
+        assert search_versions(f"name = '{name}' and tag.t3 = 'xyz'") == []
+        assert search_versions(f"name = '{name}' and tag.t2 != 'xy'") == [2, 1]
+        assert search_versions(f"name = '{name}' and tag.t2 LIKE 'xy%'") == [1]
+        assert search_versions(f"name = '{name}' and tag.t2 LIKE 'xY%'") == []
+        assert search_versions(f"name = '{name}' and tag.t2 ILIKE 'xY%'") == [1]
+        assert search_versions(f"name = '{name}' and tag.t2 LIKE 'x%'") == [2, 1]
+        assert search_versions(f"name = '{name}' and tag.T2 = 'xyz'") == []
+        assert search_versions(f"name = '{name}' and tag.t1 = 'abc' and tag.t2 = 'xyz'") == [1]
+        assert search_versions(f"name = '{name}' and tag.t1 = 'abc' and tag.t2 LIKE 'x%'") == [2, 1]
+        assert search_versions(f"name = '{name}' and tag.t1 = 'abc' and tag.t2 LIKE 'y%'") == []
         # test filter with duplicated keys
-        self.assertEqual(
-            search_versions(f"name = '{name}' and tag.t2 like 'x%' and tag.t2 != 'xyz'"), [2]
-        )
+        search_versions(f"name = '{name}' and tag.t2 like 'x%' and tag.t2 != 'xyz'") == [2]
 
     def _search_registered_models(
         self, filter_string, max_results=10, order_by=None, page_token=None
@@ -1162,29 +1154,29 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self._rm_maker(name2, tags2)
 
         rms, _ = self._search_registered_models(f"tag.t3 = 'XYZ'")
-        self.assertEqual(rms, [name2])
+        assert rms == [name2]
 
         rms, _ = self._search_registered_models(f"name = '{name1}' and tag.t1 = 'abc'")
-        self.assertEqual(rms, [name1])
+        assert rms == [name1]
 
         rms, _ = self._search_registered_models(f"tag.t1 LIKE 'ab%'")
-        self.assertEqual(rms, [name1, name2])
+        assert rms == [name1, name2]
 
         rms, _ = self._search_registered_models(f"tag.t1 LIKE 'ab%' AND tag.t2 LIKE 'xy%'")
-        self.assertEqual(rms, [name1, name2])
+        assert rms == [name1, name2]
 
         rms, _ = self._search_registered_models(f"tag.t3 = 'XYz'")
-        self.assertEqual(rms, [])
+        assert rms == []
 
         rms, _ = self._search_registered_models(f"tag.T3 = 'XYZ'")
-        self.assertEqual(rms, [])
+        assert rms == []
 
         rms, _ = self._search_registered_models(f"tag.t1 != 'abc'")
-        self.assertEqual(rms, [name2])
+        assert rms == [name2]
 
         # test filter with duplicated keys
         rms, _ = self._search_registered_models(f"tag.t1 != 'abcd' and tag.t1 LIKE 'ab%'")
-        self.assertEqual(rms, [name1])
+        assert rms == [name1]
 
     def test_parse_search_registered_models_order_by(self):
         # test that "registered_models.name ASC" is returned by default

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -1008,7 +1008,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         assert search_versions(f"name = '{name}' and tag.t1 = 'abc' and tag.t2 LIKE 'x%'") == [2, 1]
         assert search_versions(f"name = '{name}' and tag.t1 = 'abc' and tag.t2 LIKE 'y%'") == []
         # test filter with duplicated keys
-        search_versions(f"name = '{name}' and tag.t2 like 'x%' and tag.t2 != 'xyz'") == [2]
+        assert search_versions(f"name = '{name}' and tag.t2 like 'x%' and tag.t2 != 'xyz'") == [2]
 
     def _search_registered_models(
         self, filter_string, max_results=10, order_by=None, page_token=None

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -961,19 +961,6 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         assert mvds[0].source == "A/B"
         assert mvds[0].description == "Online prediction model!"
 
-    def test_search_model_versions_in_clause_mysql_case_sensitive(self):
-        from mlflow.utils.search_utils import SearchModelUtils
-        from mlflow.store.db.db_types import MYSQL
-        run_id1 = uuid.uuid4().hex
-        run_id2 = uuid.uuid4().hex
-        filter_str = f"run_id IN ('{run_id1.upper()}','{run_id2}')"
-        parsed_filter = SearchModelUtils.parse_search_filter(filter_str)
-        attr_filters, _ = SqlAlchemyStore._get_search_model_versions_filter_clauses(parsed_filter, MYSQL)
-        self.assertEqual(
-            attr_filters[0].right.effective_value,
-            [run_id2]
-        )
-
     def test_search_model_versions_by_tag(self):
         # create some model versions
         name = "test_for_search_MV_by_tag"

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -966,19 +966,19 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         def search_versions(filter_string):
             return [mvd.version for mvd in self.store.search_model_versions(filter_string)]
 
-        self.assertEqual(set(search_versions(f"name='{name}' and tag.t2='xyz'")), {1})
-        self.assertEqual(set(search_versions(f"name='wrong_name' and tag.t2='xyz'")), set())
-        self.assertEqual(set(search_versions(f"name='{name}' and tag.`t2`='xyz'")), {1})
-        self.assertEqual(set(search_versions(f"name='{name}' and tag.t3='xyz'")), set())
-        self.assertEqual(set(search_versions(f"name='{name}' and tag.t2!='xy'")), {1, 2})
+        self.assertEqual(set(search_versions(f"name='{name}' and tag.t2 = 'xyz'")), {1})
+        self.assertEqual(set(search_versions(f"name='wrong_name' and tag.t2 = 'xyz'")), set())
+        self.assertEqual(set(search_versions(f"name='{name}' and tag.`t2` = 'xyz'")), {1})
+        self.assertEqual(set(search_versions(f"name='{name}' and tag.t3 = 'xyz'")), set())
+        self.assertEqual(set(search_versions(f"name='{name}' and tag.t2 != 'xy'")), {1, 2})
         self.assertEqual(set(search_versions(f"name='{name}' and tag.t2 LIKE 'xy%'")), {1})
         self.assertEqual(set(search_versions(f"name='{name}' and tag.t2 LIKE 'xY%'")), set())
         self.assertEqual(set(search_versions(f"name='{name}' and tag.t2 ILIKE 'xY%'")), {1})
         self.assertEqual(set(search_versions(f"name='{name}' and tag.t2 LIKE 'x%'")), {1, 2})
-        self.assertEqual(set(search_versions(f"name='{name}' and tag.T2='xyz'")), set())
-        self.assertEqual(set(search_versions(f"name='{name}' and tag.t1='abc' and tag.t2='xyz'")), {1})
-        self.assertEqual(set(search_versions(f"name='{name}' and tag.t1='abc' and tag.t2 LIKE 'x%'")), {1, 2})
-        self.assertEqual(set(search_versions(f"name='{name}' and tag.t1='abc' and tag.t2 LIKE 'y%'")), set())
+        self.assertEqual(set(search_versions(f"name='{name}' and tag.T2 = 'xyz'")), set())
+        self.assertEqual(set(search_versions(f"name='{name}' and tag.t1 = 'abc' and tag.t2 = 'xyz'")), {1})
+        self.assertEqual(set(search_versions(f"name='{name}' and tag.t1 = 'abc' and tag.t2 LIKE 'x%'")), {1, 2})
+        self.assertEqual(set(search_versions(f"name='{name}' and tag.t1 = 'abc' and tag.t2 LIKE 'y%'")), set())
 
     def _search_registered_models(
         self, filter_string, max_results=10, order_by=None, page_token=None

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -902,7 +902,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
 
         # TODO: fix
         # with self.assertRaisesRegex(MlflowException, r"Invalid filter '.+'") as exception_context:
-        #     search_versions("run_id IN")
+        #    search_versions("run_id IN")
         # assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
         with self.assertRaisesRegex(

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -914,6 +914,12 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
         with self.assertRaisesRegex(
+            MlflowException, r"Invalid clause\(s\) in filter string"
+        ) as exception_context:
+            search_versions("name LIKE")
+        assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+
+        with self.assertRaisesRegex(
             MlflowException,
             (
                 r"While parsing a list in the query, "
@@ -1161,6 +1167,9 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         assert rms == [name1]
 
         rms, _ = self._search_registered_models("tag.t1 LIKE 'ab%'")
+        assert rms == [name1, name2]
+
+        rms, _ = self._search_registered_models("tag.t1 ILIKE 'aB%'")
         assert rms == [name1, name2]
 
         rms, _ = self._search_registered_models("tag.t1 LIKE 'ab%' AND tag.t2 LIKE 'xy%'")

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -969,13 +969,17 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         run_id_2 = uuid.uuid4().hex
 
         mv1 = self._mv_maker(
-            name=name, source="A/B", run_id=run_id_1,
-            tags=[ModelVersionTag("t1", "abc"), ModelVersionTag("t2", "xyz")]
+            name=name,
+            source="A/B",
+            run_id=run_id_1,
+            tags=[ModelVersionTag("t1", "abc"), ModelVersionTag("t2", "xyz")],
         )
         self.assertEqual(mv1.version, 1)
         mv2 = self._mv_maker(
-            name=name, source="A/C", run_id=run_id_2,
-            tags=[ModelVersionTag("t1", "abc"), ModelVersionTag("t2", "x123")]
+            name=name,
+            source="A/C",
+            run_id=run_id_2,
+            tags=[ModelVersionTag("t1", "abc"), ModelVersionTag("t2", "x123")],
         )
         self.assertEqual(mv2.version, 2)
 
@@ -992,9 +996,15 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self.assertEqual(set(search_versions(f"name = '{name}' and tag.t2 ILIKE 'xY%'")), {1})
         self.assertEqual(set(search_versions(f"name = '{name}' and tag.t2 LIKE 'x%'")), {1, 2})
         self.assertEqual(set(search_versions(f"name = '{name}' and tag.T2 = 'xyz'")), set())
-        self.assertEqual(set(search_versions(f"name = '{name}' and tag.t1 = 'abc' and tag.t2 = 'xyz'")), {1})
-        self.assertEqual(set(search_versions(f"name = '{name}' and tag.t1 = 'abc' and tag.t2 LIKE 'x%'")), {1, 2})
-        self.assertEqual(set(search_versions(f"name = '{name}' and tag.t1 = 'abc' and tag.t2 LIKE 'y%'")), set())
+        self.assertEqual(
+            set(search_versions(f"name = '{name}' and tag.t1 = 'abc' and tag.t2 = 'xyz'")), {1}
+        )
+        self.assertEqual(
+            set(search_versions(f"name = '{name}' and tag.t1 = 'abc' and tag.t2 LIKE 'x%'")), {1, 2}
+        )
+        self.assertEqual(
+            set(search_versions(f"name = '{name}' and tag.t1 = 'abc' and tag.t2 LIKE 'y%'")), set()
+        )
 
     def _search_registered_models(
         self, filter_string, max_results=10, order_by=None, page_token=None
@@ -1080,7 +1090,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         # cannot search by invalid comparator types
         with self.assertRaisesRegex(
             MlflowException,
-            r"Parameter value is either not quoted or unidentified quote types used for string value something"
+            r"Parameter value is either not quoted or unidentified quote types used for string value something",
         ) as exception_context:
             self._search_registered_models("name!=something")
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -844,7 +844,15 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
             ),
             set([1, 2, 3]),
         )
-
+        # search the IN operator is case sensitive.
+        self.assertEqual(
+            set(
+                search_versions(
+                    f"run_id IN ('{run_id_1.upper()}','{run_id_2}')"
+                )
+            ),
+            set([2, 3]),
+        )
         # search using the IN operator with bad lists should return exceptions
         with self.assertRaisesRegex(
             MlflowException,
@@ -879,7 +887,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         # TODO: fix
         # with self.assertRaisesRegex(MlflowException, r"Invalid filter '.+'") as exception_context:
         #     search_versions("run_id IN")
-        assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+        # assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
         with self.assertRaisesRegex(
             MlflowException,

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -995,7 +995,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
             return [mvd.version for mvd in self.store.search_model_versions(filter_string)]
 
         assert search_versions(f"name = '{name}' and tag.t2 = 'xyz'") == [1]
-        assert search_versions(f"name = 'wrong_name' and tag.t2 = 'xyz'") == []
+        assert search_versions("name = 'wrong_name' and tag.t2 = 'xyz'") == []
         assert search_versions(f"name = '{name}' and tag.`t2` = 'xyz'") == [1]
         assert search_versions(f"name = '{name}' and tag.t3 = 'xyz'") == []
         assert search_versions(f"name = '{name}' and tag.t2 != 'xy'") == [2, 1]
@@ -1094,7 +1094,8 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         # cannot search by invalid comparator types
         with self.assertRaisesRegex(
             MlflowException,
-            r"Parameter value is either not quoted or unidentified quote types used for string value something",
+            "Parameter value is either not quoted or unidentified quote types used for string "
+            "value something",
         ) as exception_context:
             self._search_registered_models("name!=something")
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
@@ -1153,29 +1154,29 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self._rm_maker(name1, tags1)
         self._rm_maker(name2, tags2)
 
-        rms, _ = self._search_registered_models(f"tag.t3 = 'XYZ'")
+        rms, _ = self._search_registered_models("tag.t3 = 'XYZ'")
         assert rms == [name2]
 
         rms, _ = self._search_registered_models(f"name = '{name1}' and tag.t1 = 'abc'")
         assert rms == [name1]
 
-        rms, _ = self._search_registered_models(f"tag.t1 LIKE 'ab%'")
+        rms, _ = self._search_registered_models("tag.t1 LIKE 'ab%'")
         assert rms == [name1, name2]
 
-        rms, _ = self._search_registered_models(f"tag.t1 LIKE 'ab%' AND tag.t2 LIKE 'xy%'")
+        rms, _ = self._search_registered_models("tag.t1 LIKE 'ab%' AND tag.t2 LIKE 'xy%'")
         assert rms == [name1, name2]
 
-        rms, _ = self._search_registered_models(f"tag.t3 = 'XYz'")
+        rms, _ = self._search_registered_models("tag.t3 = 'XYz'")
         assert rms == []
 
-        rms, _ = self._search_registered_models(f"tag.T3 = 'XYZ'")
+        rms, _ = self._search_registered_models("tag.T3 = 'XYZ'")
         assert rms == []
 
-        rms, _ = self._search_registered_models(f"tag.t1 != 'abc'")
+        rms, _ = self._search_registered_models("tag.t1 != 'abc'")
         assert rms == [name2]
 
         # test filter with duplicated keys
-        rms, _ = self._search_registered_models(f"tag.t1 != 'abcd' and tag.t1 LIKE 'ab%'")
+        rms, _ = self._search_registered_models("tag.t1 != 'abcd' and tag.t1 LIKE 'ab%'")
         assert rms == [name1]
 
     def test_parse_search_registered_models_order_by(self):

--- a/tests/tracking/test_model_registry.py
+++ b/tests/tracking/test_model_registry.py
@@ -382,7 +382,7 @@ def test_create_and_query_model_version_flow(mlflow_client, backend_store_uri):
     mv3 = mlflow_client.create_model_version(name, "another_path/to/model", "run_id_2")
     assert mv3.version == "3"
     assert [mvd1] == mlflow_client.search_model_versions("source_path = 'path/to/model'")
-    assert [mvd1, mvd2] == mlflow_client.search_model_versions("run_id = 'run_id_1'")
+    assert [mvd2, mvd1] == mlflow_client.search_model_versions("run_id = 'run_id_1'")
 
     assert "path/to/model" == mlflow_client.get_model_version_download_uri(name, "1")
 


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
https://github.com/mlflow/mlflow/issues/6095

## What changes are proposed in this pull request?

Tag based registered model search and model version search.

Testing code:

```python
import mlflow
mlflow.tracking.set_tracking_uri("...")

client = mlflow.tracking.MlflowClient()

result1 = client.search_registered_models(
    filter_string="name='sk-learn-random-forest-reg-model' and tag.axaxb iLike '123XXy'"
)

result2 = client.search_model_versions(filter_string="name = 'sk-learn-random-forest-reg-model' and tags.kk1 ILIKE '%abc%'")
```

## How is this patch tested?

Unit tests


## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
