### PR TITLE
Enable `super-with-arguments` rule for pylint 

### DIFF
--- a/examples/paddle/train_high_level_api.py
+++ b/examples/paddle/train_high_level_api.py
@@ -8,7 +8,7 @@ eval_dataset = paddle.text.datasets.UCIHousing(mode="test")
 
 class UCIHousing(paddle.nn.Layer):
     def __init__(self):
-        super(UCIHousing, self).__init__()
+        super().__init__()
         self.fc_ = paddle.nn.Linear(13, 1, None)
 
     def forward(self, inputs):

--- a/examples/paddle/train_low_level_api.py
+++ b/examples/paddle/train_low_level_api.py
@@ -27,7 +27,7 @@ def load_data():
 
 class Regressor(paddle.nn.Layer):
     def __init__(self):
-        super(Regressor, self).__init__()
+        super().__init__()
 
         self.fc = Linear(in_features=13, out_features=1)
 

--- a/examples/pytorch/BertNewsClassification/bert_classification.py
+++ b/examples/pytorch/BertNewsClassification/bert_classification.py
@@ -59,7 +59,7 @@ class NewsDataset(IterDataPipe):
         :param num_samples: number of samples to load
         :param dataset: Dataset type - 20newsgroups or ag_news
         """
-        super(NewsDataset, self).__init__()
+        super().__init__()
         self.source = source
         self.start = 0
         self.tokenizer = tokenizer
@@ -109,7 +109,7 @@ class BertDataModule(pl.LightningDataModule):
         """
         Initialization of inherited lightning data module
         """
-        super(BertDataModule, self).__init__()
+        super().__init__()
         self.PRE_TRAINED_MODEL_NAME = "bert-base-uncased"
         self.train_dataset = None
         self.val_dataset = None
@@ -258,7 +258,7 @@ class BertNewsClassifier(pl.LightningModule):
         """
         Initializes the network, optimizer and scheduler
         """
-        super(BertNewsClassifier, self).__init__()
+        super().__init__()
         self.PRE_TRAINED_MODEL_NAME = "bert-base-uncased"
         self.bert_model = BertModel.from_pretrained(self.PRE_TRAINED_MODEL_NAME)
         for param in self.bert_model.parameters():

--- a/examples/pytorch/IterativePruning/mnist.py
+++ b/examples/pytorch/IterativePruning/mnist.py
@@ -27,7 +27,7 @@ class MNISTDataModule(pl.LightningDataModule):
         """
         Initialization of inherited lightning data module
         """
-        super(MNISTDataModule, self).__init__()
+        super().__init__()
         self.df_train = None
         self.df_val = None
         self.df_test = None
@@ -92,7 +92,7 @@ class LightningMNISTClassifier(pl.LightningModule):
         """
         Initializes the network
         """
-        super(LightningMNISTClassifier, self).__init__()
+        super().__init__()
 
         # mnist images are (1, 28, 28) (channels, width, height)
         self.optimizer = None

--- a/examples/pytorch/MNIST/mnist_autolog_example.py
+++ b/examples/pytorch/MNIST/mnist_autolog_example.py
@@ -32,7 +32,7 @@ class MNISTDataModule(pl.LightningDataModule):
         """
         Initialization of inherited lightning data module
         """
-        super(MNISTDataModule, self).__init__()
+        super().__init__()
         self.df_train = None
         self.df_val = None
         self.df_test = None
@@ -97,7 +97,7 @@ class LightningMNISTClassifier(pl.LightningModule):
         """
         Initializes the network
         """
-        super(LightningMNISTClassifier, self).__init__()
+        super().__init__()
 
         # mnist images are (1, 28, 28) (channels, width, height)
         self.optimizer = None

--- a/examples/pytorch/torchscript/IrisClassification/iris_classification.py
+++ b/examples/pytorch/torchscript/IrisClassification/iris_classification.py
@@ -12,7 +12,7 @@ import mlflow.pytorch
 
 class IrisClassifier(nn.Module):
     def __init__(self):
-        super(IrisClassifier, self).__init__()
+        super().__init__()
         self.fc1 = nn.Linear(4, 10)
         self.fc2 = nn.Linear(10, 10)
         self.fc3 = nn.Linear(10, 3)

--- a/examples/pytorch/torchscript/MNIST/mnist_torchscript.py
+++ b/examples/pytorch/torchscript/MNIST/mnist_torchscript.py
@@ -15,7 +15,7 @@ import mlflow.pytorch
 
 class Net(nn.Module):
     def __init__(self):
-        super(Net, self).__init__()
+        super().__init__()
         self.conv1 = nn.Conv2d(1, 32, 3, 1)
         self.conv2 = nn.Conv2d(32, 64, 3, 1)
         self.dropout1 = nn.Dropout(0.25)

--- a/mlflow/paddle/__init__.py
+++ b/mlflow/paddle/__init__.py
@@ -152,7 +152,7 @@ def save_model(
         class Regressor(paddle.nn.Layer):
 
             def __init__(self):
-                super(Regressor, self).__init__()
+                super().__init__()
 
                 self.fc = Linear(in_features=13, out_features=1)
 

--- a/mlflow/pipelines/steps/register.py
+++ b/mlflow/pipelines/steps/register.py
@@ -23,7 +23,7 @@ _logger = logging.getLogger(__name__)
 
 class RegisterStep(BaseStep):
     def __init__(self, step_config: Dict[str, Any], pipeline_root: str):
-        super(RegisterStep, self).__init__(step_config, pipeline_root)
+        super().__init__(step_config, pipeline_root)
         self.tracking_config = TrackingConfig.from_dict(step_config)
         self.num_dropped_rows = None
         self.model_uri = None

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -239,7 +239,7 @@ def log_model(
 
         class LinearNNModel(torch.nn.Module):
             def __init__(self):
-                super(LinearNNModel, self).__init__()
+                super().__init__()
                 self.linear = torch.nn.Linear(1, 1)  # One in and one out
 
             def forward(self, x):
@@ -956,7 +956,7 @@ def autolog(
 
         class MNISTModel(pl.LightningModule):
             def __init__(self):
-                super(MNISTModel, self).__init__()
+                super().__init__()
                 self.l1 = torch.nn.Linear(28 * 28, 10)
 
             def forward(self, x):

--- a/pylintrc
+++ b/pylintrc
@@ -173,7 +173,8 @@ disable=print-statement,
 # it should appear only once). See also the "--disable" option for examples.
 enable=c-extension-no-member,
        line-too-long,
-       use-a-generator
+       use-a-generator,
+       super-with-arguments
 
 
 [REPORTS]


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

Close #6270

## What changes are proposed in this pull request?

Changes to include `super-with-arguments` rule in pylintrc.

## How is this patch tested?

- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
