### PR TITLE
Require that deployments predict / explain CLI invocations specify either deployment name or endpoint

### DIFF
--- a/mlflow/deployments/cli.py
+++ b/mlflow/deployments/cli.py
@@ -288,8 +288,15 @@ def predictions_to_json(raw_predictions, output):
 
 
 @commands.command("predict")
-@click.option("--name", "name", help="Name of the deployment. Exactly one of --name or --endpoint must be specified.")
-@click.option("--endpoint", help="Name of the endpoint. Exactly one of --name or --endpoint must be specified.")
+@click.option(
+    "--name",
+    "name",
+    help="Name of the deployment. Exactly one of --name or --endpoint must be specified.",
+)
+@click.option(
+    "--endpoint",
+    help="Name of the endpoint. Exactly one of --name or --endpoint must be specified.",
+)
 @target_details
 @parse_input
 @parse_output
@@ -318,8 +325,15 @@ def predict(target, name, input_path, output_path, endpoint):
 
 
 @commands.command("explain")
-@click.option("--name", "name", help="Name of the deployment. Exactly one of --name or --endpoint must be specified.")
-@click.option("--endpoint", help="Name of the endpoint. Exactly one of --name or --endpoint must be specified.")
+@click.option(
+    "--name",
+    "name",
+    help="Name of the deployment. Exactly one of --name or --endpoint must be specified.",
+)
+@click.option(
+    "--endpoint",
+    help="Name of the endpoint. Exactly one of --name or --endpoint must be specified.",
+)
 @target_details
 @parse_input
 @parse_output

--- a/mlflow/deployments/cli.py
+++ b/mlflow/deployments/cli.py
@@ -300,7 +300,7 @@ def predict(target, name, input_path, output_path, endpoint):
     import pandas as pd
 
     if (name, endpoint).count(None) != 1:
-        raise click.UsageError("Must specify exactly one of --name or --endpoint")
+        raise click.UsageError("Must specify exactly one of --name or --endpoint.")
 
     df = pd.read_json(input_path)
     client = interface.get_deploy_client(target)
@@ -337,7 +337,7 @@ def explain(target, name, input_path, output_path, endpoint):
     import pandas as pd
 
     if (name, endpoint).count(None) != 1:
-        raise click.UsageError("Must specify exactly one of --name or --endpoint")
+        raise click.UsageError("Must specify exactly one of --name or --endpoint.")
 
     df = pd.read_json(input_path)
     client = interface.get_deploy_client(target)

--- a/mlflow/deployments/cli.py
+++ b/mlflow/deployments/cli.py
@@ -161,7 +161,7 @@ def create_deployment(flavor, model_uri, target, name, config, endpoint):
     " about supported remote URIs for model artifacts, see"
     " https://mlflow.org/docs/latest/tracking.html"
     "#artifact-stores",
-)  # optional model_uri
+)
 @click.option(
     "--flavor",
     "-f",
@@ -288,8 +288,8 @@ def predictions_to_json(raw_predictions, output):
 
 
 @commands.command("predict")
-@optional_endpoint_param
-@optional_deployment_name
+@click.option("--name", "name", help="Name of the deployment. Exactly one of --name or --endpoint must be specified.")
+@click.option("--endpoint", help="Name of the endpoint. Exactly one of --name or --endpoint must be specified.")
 @target_details
 @parse_input
 @parse_output
@@ -298,6 +298,9 @@ def predict(target, name, input_path, output_path, endpoint):
     Predict the results for the deployed model for the given input(s)
     """
     import pandas as pd
+
+    if (name, endpoint).count(None) != 1:
+        raise click.UsageError("Must specify exactly one of --name or --endpoint")
 
     df = pd.read_json(input_path)
     client = interface.get_deploy_client(target)
@@ -315,8 +318,8 @@ def predict(target, name, input_path, output_path, endpoint):
 
 
 @commands.command("explain")
-@optional_endpoint_param
-@optional_deployment_name
+@click.option("--name", "name", help="Name of the deployment. Exactly one of --name or --endpoint must be specified.")
+@click.option("--endpoint", help="Name of the endpoint. Exactly one of --name or --endpoint must be specified.")
 @target_details
 @parse_input
 @parse_output
@@ -332,6 +335,9 @@ def explain(target, name, input_path, output_path, endpoint):
     https://www.mlflow.org/docs/latest/models.html#built-in-deployment-tools
     """
     import pandas as pd
+
+    if (name, endpoint).count(None) != 1:
+        raise click.UsageError("Must specify exactly one of --name or --endpoint")
 
     df = pd.read_json(input_path)
     client = interface.get_deploy_client(target)


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

Fix #6173

## What changes are proposed in this pull request?

Require that deployments predict / explain CLI invocations specify either deployment name or endpoint

## How is this patch tested?

Manual verification

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

Require that `mlflow deployments predict / explain` invocations specify a deployment name or endpoint.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [X] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
