### PR TITLE
check if xdg-open is available

### DIFF
--- a/mlflow/pipelines/utils/step.py
+++ b/mlflow/pipelines/utils/step.py
@@ -86,6 +86,7 @@ def display_html(html_data: str = None, html_file_path: str = None) -> None:
             _logger.info(f"Opening HTML file at: '{html_file_path}'")
             subprocess.run([open_tool, html_file_path], check=True)
 
+
 def get_pandas_data_profile(data_frame, title: str):
     """Returns a data profiling object over input data frame.
 

--- a/mlflow/pipelines/utils/step.py
+++ b/mlflow/pipelines/utils/step.py
@@ -78,9 +78,9 @@ def display_html(html_data: str = None, html_file_path: str = None) -> None:
 
         # Use xdg-open in Linux environment
         if shutil.which("xdg-open") is not None:
-            open_tool = "xdg-open"
+            open_tool = shutil.which("xdg-open")
         elif shutil.which("open") is not None:
-            open_tool = "open"
+            open_tool = shutil.which("open")
 
         if os.path.exists(html_file_path) and open_tool is not None:
             _logger.info(f"Opening HTML file at: '{html_file_path}'")

--- a/mlflow/pipelines/utils/step.py
+++ b/mlflow/pipelines/utils/step.py
@@ -81,6 +81,8 @@ def display_html(html_data: str = None, html_file_path: str = None) -> None:
             open_tool = shutil.which("xdg-open")
         elif shutil.which("open") is not None:
             open_tool = shutil.which("open")
+        else:
+            open_tool = None
 
         if os.path.exists(html_file_path) and open_tool is not None:
             _logger.info(f"Opening HTML file at: '{html_file_path}'")

--- a/mlflow/pipelines/utils/step.py
+++ b/mlflow/pipelines/utils/step.py
@@ -84,7 +84,13 @@ def display_html(html_data: str = None, html_file_path: str = None) -> None:
 
         if os.path.exists(html_file_path) and open_tool is not None:
             _logger.info(f"Opening HTML file at: '{html_file_path}'")
-            subprocess.run([open_tool, html_file_path], check=True)
+            try:
+                subprocess.run([open_tool, html_file_path], check=True)
+            except Exception as e:
+                _logger.warning(
+                    f"Encountered unexpected error opening the html page."
+                    f" The file may be manually accessed at {html_file_path}. Exception: {e}"
+                )
 
 
 def get_pandas_data_profile(data_frame, title: str):

--- a/mlflow/pipelines/utils/step.py
+++ b/mlflow/pipelines/utils/step.py
@@ -76,10 +76,15 @@ def display_html(html_data: str = None, html_file_path: str = None) -> None:
         import shutil
         import subprocess
 
-        if os.path.exists(html_file_path) and shutil.which("open") is not None:
-            _logger.info(f"Opening HTML file at: '{html_file_path}'")
-            subprocess.run(["open", html_file_path], check=True)
+        # Use xdg-open in Linux environment
+        if shutil.which("xdg-open") is not None:
+            open_tool = "xdg-open"
+        elif shutil.which("open") is not None:
+            open_tool = "open"
 
+        if os.path.exists(html_file_path) and open_tool is not None:
+            _logger.info(f"Opening HTML file at: '{html_file_path}'")
+            subprocess.run([open_tool, html_file_path], check=True)
 
 def get_pandas_data_profile(data_frame, title: str):
     """Returns a data profiling object over input data frame.


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs
Resolves #6324

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->


## What changes are proposed in this pull request?
Check if `xdg-open` is installed and utilize that instead of `open` for compatibility with Linux environments

(Please fill in changes proposed in this fix)

## How is this patch tested?

Manually tested by installing locally.

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes
Updated pipeline step command to utilize xdg-open for Linux environments

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
