### PR TITLE
Predict Step: output format and location, env restoration

### DIFF
--- a/mlflow/pipelines/batch_scoring/v1/dag_help_strings.py
+++ b/mlflow/pipelines/batch_scoring/v1/dag_help_strings.py
@@ -24,10 +24,9 @@ steps:
   preprocessing:
     preprocess_method: steps.preprocessing.process_data
   predict:
-    model_name: "taxi_fare_regressor"
-    model_stage: "Production"
-    output_location: {{OUTPUT_PATH}}
-    output_format: "parquet"
+    model_uri: "models:/taxi_fare_regressor/Production"
+    output_format: {{OUTPUT_DATA_FORMAT|default('parquet')}}
+    output_path: "{{OUTPUT_DATA_LOCATION}}"
 """
 )
 
@@ -92,9 +91,8 @@ PREDICT_STEP = format_help_string(
     """The 'predict' step applies the specified model against the cleaned dataset produced by the 'preprocessing' step. An example pipeline.yaml 'predict' step definition is shown below.
 steps:
   predict:
-    model_name: "taxi_fare_regressor"
-    version: 11
-    output_path: "{{OUTPUT_DATA_PATH}}"
+    model_uri: "models:/taxi_fare_regressor/Production"
     output_format: {{OUTPUT_DATA_FORMAT|default('parquet')}}
+    output_location: "{{OUTPUT_DATA_LOCATION}}"
 """
 )

--- a/mlflow/pipelines/batch_scoring/v1/dag_help_strings.py
+++ b/mlflow/pipelines/batch_scoring/v1/dag_help_strings.py
@@ -26,7 +26,7 @@ steps:
   predict:
     model_uri: "models:/taxi_fare_regressor/Production"
     output_format: {{OUTPUT_DATA_FORMAT|default('parquet')}}
-    output_path: "{{OUTPUT_DATA_LOCATION}}"
+    output_location: "{{OUTPUT_DATA_LOCATION}}"
 """
 )
 

--- a/mlflow/pipelines/steps/predict.py
+++ b/mlflow/pipelines/steps/predict.py
@@ -59,7 +59,8 @@ class PredictStep(BaseStep):
 
         # score dataset
         model_uri = self.step_config["model_uri"]
-        predict = mlflow.pyfunc.spark_udf(spark, model_uri)
+        env_manager = "local" if "_disable_env_restoration" in self.step_config else "conda"
+        predict = mlflow.pyfunc.spark_udf(spark, model_uri, env_manager=env_manager)
         scored_sdf = input_sdf.withColumn("prediction", predict(struct(*input_sdf.columns)))
 
         # save predictions

--- a/mlflow/pipelines/steps/predict.py
+++ b/mlflow/pipelines/steps/predict.py
@@ -65,25 +65,11 @@ class PredictStep(BaseStep):
         # save predictions
         output_format = self.step_config["output_format"]
         if output_format == "parquet" or output_format == "delta":
-            try:
-                scored_sdf.coalesce(1).write.format(output_format).save(
-                    self.step_config["output_location"]
-                )
-            except KeyError:
-                raise MlflowException(
-                    f'Output format "{output_format}" requires configuration" \
-                    " key `output_location`.',
-                    error_code=INVALID_PARAMETER_VALUE,
-                )
+            scored_sdf.coalesce(1).write.format(output_format).save(
+                self.step_config["output_location"]
+            )
         else:
-            try:
-                scored_sdf.write.format("delta").saveAsTable(self.step_config["output_table"])
-            except KeyError:
-                raise MlflowException(
-                    'Output format "table" requires configuration key `output_table`.',
-                    error_code=INVALID_PARAMETER_VALUE,
-                )
-
+            scored_sdf.write.format("delta").saveAsTable(self.step_config["output_location"])
         # predict step artifacts
         scored_pdf = scored_sdf.toPandas()
         scored_pdf.to_parquet(os.path.join(output_directory, "scored.parquet"), engine="pyarrow")
@@ -100,7 +86,7 @@ class PredictStep(BaseStep):
             raise MlflowException(
                 "Config for predict step is not found.", error_code=INVALID_PARAMETER_VALUE
             )
-        required_configuration_keys = ["model_uri", "output_format"]
+        required_configuration_keys = ["model_uri", "output_format", "output_location"]
         for key in required_configuration_keys:
             if key not in step_config:
                 raise MlflowException(

--- a/mlflow/pipelines/steps/predict.py
+++ b/mlflow/pipelines/steps/predict.py
@@ -63,6 +63,7 @@ class PredictStep(BaseStep):
         scored_sdf = input_sdf.withColumn("prediction", predict(struct(*input_sdf.columns)))
 
         # save predictions
+        # note: the current output writing logic allows no overwrites
         output_format = self.step_config["output_format"]
         if output_format == "parquet" or output_format == "delta":
             scored_sdf.coalesce(1).write.format(output_format).save(
@@ -70,6 +71,7 @@ class PredictStep(BaseStep):
             )
         else:
             scored_sdf.write.format("delta").saveAsTable(self.step_config["output_location"])
+
         # predict step artifacts
         scored_pdf = scored_sdf.toPandas()
         scored_pdf.to_parquet(os.path.join(output_directory, "scored.parquet"), engine="pyarrow")

--- a/tests/pipelines/test_predict_step.py
+++ b/tests/pipelines/test_predict_step.py
@@ -38,7 +38,7 @@ def spark_session():
     session.stop()
 
 
-def dataframe_assertions(output_dir: Path, output_format: str, output_name: str, spark):
+def prediction_assertions(output_dir: Path, output_format: str, output_name: str, spark):
     if output_format == "table":
         sdf = spark.table(output_name)
         df = sdf.toPandas()
@@ -100,8 +100,8 @@ def test_predict_step_runs(
     )
     predict_step._run(str(predict_step_output_dir))
 
-    dataframe_assertions(predict_step_output_dir, "parquet", "scored", spark_session)
-    dataframe_assertions(predict_step_output_dir, "parquet", "output", spark_session)
+    prediction_assertions(predict_step_output_dir, "parquet", "scored", spark_session)
+    prediction_assertions(predict_step_output_dir, "parquet", "output", spark_session)
 
 
 @pytest.mark.parametrize("output_format", ["parquet", "delta", "table"])
@@ -124,7 +124,7 @@ def test_predict_step_output_formats(
         )
     predict_step = PredictStep.from_pipeline_config(pipeline_config, str(tmp_pipeline_root_path))
     predict_step._run(str(predict_step_output_dir))
-    dataframe_assertions(predict_step_output_dir, output_format, output_name, spark_session)
+    prediction_assertions(predict_step_output_dir, output_format, output_name, spark_session)
 
 
 @pytest.mark.usefixtures("enter_test_pipeline_directory")

--- a/tests/pipelines/test_predict_step.py
+++ b/tests/pipelines/test_predict_step.py
@@ -93,6 +93,7 @@ def test_predict_step_runs(
                     "model_uri": model_uri,
                     "output_format": "parquet",
                     "output_location": str(predict_step_output_dir.joinpath("output.parquet")),
+                    "_disable_env_restoration": True,
                 }
             }
         },
@@ -113,7 +114,13 @@ def test_predict_step_output_formats(
     model_uri = train_log_and_register_model(rm_name, is_dummy=True)
 
     pipeline_config = {
-        "steps": {"predict": {"model_uri": model_uri, "output_format": output_format}}
+        "steps": {
+            "predict": {
+                "model_uri": model_uri,
+                "output_format": output_format,
+                "_disable_env_restoration": True,
+            }
+        }
     }
     if output_format == "table":
         pipeline_config["steps"]["predict"]["output_location"] = output_name

--- a/tests/pipelines/test_predict_step.py
+++ b/tests/pipelines/test_predict_step.py
@@ -7,7 +7,6 @@ from pyspark.sql import SparkSession
 from sklearn.datasets import load_diabetes
 
 from mlflow.exceptions import MlflowException
-from mlflow.utils.file_utils import read_yaml
 from mlflow.pipelines.utils import _PIPELINE_CONFIG_FILE_NAME
 from mlflow.pipelines.steps.predict import PredictStep
 from mlflow.pipelines.steps.preprocessing import _PREPROCESSED_OUTPUT_FILE_NAME
@@ -39,50 +38,93 @@ def spark_session():
     session.stop()
 
 
+def dataframe_assertions(output_dir: Path, output_format: str, output_name: str, spark):
+    if output_format == "table":
+        sdf = spark.table(output_name)
+        df = sdf.toPandas()
+    else:
+        file_name = "{}.{}".format(output_name, output_format)
+        (output_dir / file_name).exists()
+        df = pd.read_parquet(output_dir / file_name)
+    assert "prediction" in df
+    assert (df.prediction == 42).all()
+
+
+# Sets up predict step run and returns output directory
 @pytest.fixture(autouse=True)
-def predict_input(tmp_pipeline_exec_path: Path):
+def predict_step_output_dir(tmp_pipeline_root_path: Path, tmp_pipeline_exec_path: Path):
     proprocessing_step_output_dir = tmp_pipeline_exec_path.joinpath(
         "steps", "preprocessing", "outputs"
     )
     proprocessing_step_output_dir.mkdir(parents=True)
     X, _ = load_diabetes(as_frame=True, return_X_y=True)
     X.to_parquet(proprocessing_step_output_dir.joinpath(_PREPROCESSED_OUTPUT_FILE_NAME))
-
-
-@pytest.mark.parametrize("register_model", [True, False])
-def test_predict_step_run(
-    tmp_pipeline_root_path: Path, tmp_pipeline_exec_path: Path, register_model: Boolean
-):
-    if register_model:
-        rm_name = "model_" + get_random_id()
-        model_uri = train_log_and_register_model(rm_name)
-    else:
-        run_id, _ = train_and_log_model()
-        model_uri = "runs:/{run_id}/{artifact_path}".format(
-            run_id=run_id, artifact_path="train/model"
-        )
-
+    predict_step_output_dir = tmp_pipeline_exec_path.joinpath("steps", "predict", "outputs")
+    predict_step_output_dir.mkdir(parents=True)
     pipeline_yaml = tmp_pipeline_root_path.joinpath(_PIPELINE_CONFIG_FILE_NAME)
     pipeline_yaml.write_text(
         """
 template: "batch_scoring/v1"
-steps:
-  predict:
-    model_uri: {model_uri}
-    output_format: parquet
-""".format(
-            model_uri=model_uri,
-        )
+"""
     )
-    pipeline_config = read_yaml(tmp_pipeline_root_path, _PIPELINE_CONFIG_FILE_NAME)
-    predict_step_output_dir = tmp_pipeline_exec_path.joinpath("steps", "predict", "outputs")
-    predict_step_output_dir.mkdir(parents=True)
+    return predict_step_output_dir
 
-    predict_step = PredictStep.from_pipeline_config(pipeline_config, str(tmp_pipeline_root_path))
+
+@pytest.mark.parametrize("register_model", [True, False])
+def test_predict_step_runs(
+    tmp_pipeline_root_path: Path,
+    predict_step_output_dir: Path,
+    spark_session,
+    register_model: Boolean,
+):
+    if register_model:
+        rm_name = "model_" + get_random_id()
+        model_uri = train_log_and_register_model(rm_name, is_dummy=True)
+    else:
+        run_id, _ = train_and_log_model(is_dummy=True)
+        model_uri = "runs:/{run_id}/{artifact_path}".format(
+            run_id=run_id, artifact_path="train/model"
+        )
+
+    predict_step = PredictStep.from_pipeline_config(
+        {
+            "steps": {
+                "predict": {
+                    "model_uri": model_uri,
+                    "output_format": "parquet",
+                    "output_location": str(predict_step_output_dir.joinpath("output.parquet")),
+                }
+            }
+        },
+        str(tmp_pipeline_root_path),
+    )
     predict_step._run(str(predict_step_output_dir))
 
-    (predict_step_output_dir / "scored.parquet").exists()
-    assert "prediction" in pd.read_parquet(predict_step_output_dir / "scored.parquet")
+    dataframe_assertions(predict_step_output_dir, "parquet", "scored", spark_session)
+    dataframe_assertions(predict_step_output_dir, "parquet", "output", spark_session)
+
+
+@pytest.mark.parametrize("output_format", ["parquet", "delta", "table"])
+def test_predict_step_output_formats(
+    tmp_pipeline_root_path: Path, predict_step_output_dir: Path, spark_session, output_format: str
+):
+    rm_name = "model_" + get_random_id()
+    output_name = "output_" + get_random_id()
+    model_uri = train_log_and_register_model(rm_name, is_dummy=True)
+
+    pipeline_config = {
+        "steps": {"predict": {"model_uri": model_uri, "output_format": output_format}}
+    }
+    if output_format == "table":
+        pipeline_config["steps"]["predict"]["output_table"] = output_name
+    else:
+        file_name = "{}.{}".format(output_name, output_format)
+        pipeline_config["steps"]["predict"]["output_location"] = str(
+            predict_step_output_dir / file_name
+        )
+    predict_step = PredictStep.from_pipeline_config(pipeline_config, str(tmp_pipeline_root_path))
+    predict_step._run(str(predict_step_output_dir))
+    dataframe_assertions(predict_step_output_dir, output_format, output_name, spark_session)
 
 
 @pytest.mark.usefixtures("enter_test_pipeline_directory")


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs
#xxx

## What changes are proposed in this pull request?

This PR
* Builds the functionality to write prediction data to user specified formats and locations.
* Augments the unit tests to verify the prediction results.
* Adds environment restoration to the Spark UDF
* Disables this environment restoration during testing because it adds two plus minutes to the test module runtime (50 seconds to 3 minutes and 10 seconds).

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
