### PR TITLE
Fix java model server compatibility with models containing databricks_runtime conf

### DIFF
--- a/mlflow/java/scoring/src/main/java/org/mlflow/models/Model.java
+++ b/mlflow/java/scoring/src/main/java/org/mlflow/models/Model.java
@@ -48,6 +48,9 @@ public class Model {
   @JsonProperty("mlflow_version")
   private String mlflowVersion;
 
+  @JsonProperty("databricks_runtime")
+  private String databricksRuntime;
+
   private String rootPath;
 
   /**
@@ -98,6 +101,14 @@ public class Model {
   /** @return The version of MLflow with which the model was saved */
   public Optional<String> getMlflowVersion() {
     return Optional.ofNullable(this.mlflowVersion);
+  }
+
+  /**
+   * @return If the model was trained on Databricks, the version the Databricks Runtime
+   * that was used to train the model
+   */
+  public Optional<String> getDatabricksRuntime() {
+    return Optional.ofNullable(this.databricksRuntime);
   }
 
   /** @return The path to the root directory of the MLflow model */

--- a/mlflow/java/scoring/src/test/java/org/mlflow/ModelTest.java
+++ b/mlflow/java/scoring/src/test/java/org/mlflow/ModelTest.java
@@ -50,6 +50,18 @@ public class ModelTest {
   }
 
   @Test
+  public void testModelIsLoadedCorrectlyWhenDatabricksRuntimeExists() {
+    String configPath = getClass().getResource("sample_model_root/MLmodel.with.databricks_runtime").getFile();
+    try {
+      Model model = Model.fromConfigPath(configPath);
+      Assert.assertTrue(model.getDatabricksRuntime().isPresent());
+    } catch (IOException e) {
+      e.printStackTrace();
+      Assert.fail("Encountered an exception while reading the model from a configuration path!");
+    }
+  }
+
+  @Test
   public void testModelIsLoadedFromYamlUsingRootPathCorrectly() {
     String rootPath = getClass().getResource("sample_model_root").getFile();
     try {

--- a/mlflow/java/scoring/src/test/resources/org/mlflow/models/sample_model_root/MLmodel.with.databricks_runtime
+++ b/mlflow/java/scoring/src/test/resources/org/mlflow/models/sample_model_root/MLmodel.with.databricks_runtime
@@ -1,0 +1,23 @@
+flavors:
+  mleap:
+    mleap_version: 0.8.1
+    model_data: mleap/model
+utc_time_created: '2018-08-10 18:34:28.720095'
+run_id: c228016dea284522882b657d91eeffa6
+artifact_path: model
+model_uuid: 4ab08bf9d91e4535bc2719f9210840c3
+mlflow_version: 1.25.0
+databricks_runtime: databricks_runtime: 11.0-cpu-ml-scala2.12
+signature:
+  inputs: '[{"name": "fixed acidity", "type": "double"}, {"name": "volatile acidity",
+    "type": "double"}, {"name": "citric acid", "type": "double"}, {"name": "residual
+    sugar", "type": "double"}, {"name": "chlorides", "type": "double"}, {"name": "free
+    sulfur dioxide", "type": "double"}, {"name": "total sulfur dioxide", "type": "double"},
+    {"name": "density", "type": "double"}, {"name": "pH", "type": "double"}, {"name":
+    "sulphates", "type": "double"}, {"name": "alcohol", "type": "double"}]'
+  outputs: '[{"name": null, "type": "double"}]'
+input_example: {
+  "type": "dataframe",
+  "format": "split",
+  "artifact_path": "input_example.json"
+}

--- a/mlflow/java/scoring/src/test/resources/org/mlflow/models/sample_model_root/MLmodel.with.databricks_runtime
+++ b/mlflow/java/scoring/src/test/resources/org/mlflow/models/sample_model_root/MLmodel.with.databricks_runtime
@@ -7,7 +7,7 @@ run_id: c228016dea284522882b657d91eeffa6
 artifact_path: model
 model_uuid: 4ab08bf9d91e4535bc2719f9210840c3
 mlflow_version: 1.25.0
-databricks_runtime: databricks_runtime: 11.0-cpu-ml-scala2.12
+databricks_runtime: 11.0-cpu-ml-scala2.12
 signature:
   inputs: '[{"name": "fixed acidity", "type": "double"}, {"name": "volatile acidity",
     "type": "double"}, {"name": "citric acid", "type": "double"}, {"name": "residual


### PR DESCRIPTION
Signed-off-by: dbczumar <corey.zumar@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

Fixes #6307 

## What changes are proposed in this pull request?

Fix java model server compatibility with models containing databricks_runtime conf

## How is this patch tested?

Added tests

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

Fix java model server compatibility with models containing databricks_runtime conf

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [X] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
