### PR TITLE
Fix inefficient relative time computation for metric plot

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/MetricsPlotView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/MetricsPlotView.js
@@ -65,7 +65,7 @@ export class MetricsPlotView extends React.Component {
     return legend;
   };
 
-  static getXsForLineChart(history, xAxis) {
+  static getXValuesForLineChart(history, xAxis) {
     switch (xAxis) {
       case X_AXIS_STEP:
         return history.map(({ step }) => step);

--- a/mlflow/server/js/src/experiment-tracking/components/MetricsPlotView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/MetricsPlotView.js
@@ -65,13 +65,17 @@ export class MetricsPlotView extends React.Component {
     return legend;
   };
 
-  static parseTimestamp = (timestamp, history, xAxis) => {
-    if (xAxis === X_AXIS_RELATIVE) {
-      const minTimestamp = _.minBy(history, 'timestamp').timestamp;
-      return (timestamp - minTimestamp) / 1000;
+  static getXsForLineChart(history, xAxis) {
+    switch (xAxis) {
+      case X_AXIS_STEP:
+        return history.map(({ step }) => step);
+      case X_AXIS_RELATIVE:
+        const { timestamp: minTimestamp } = _.minBy(history, 'timestamp');
+        return history.map(({ timestamp }) => (timestamp - minTimestamp) / 1000);
+      default:
+        return history.map(({ timestamp }) => Utils.formatTimestamp(timestamp));
     }
-    return Utils.formatTimestamp(timestamp);
-  };
+  }
 
   getPlotPropsForLineChart = () => {
     const { metrics, xAxis, showPoint, lineSmoothness, isComparing, deselectedCurves } = this.props;
@@ -92,12 +96,7 @@ export class MetricsPlotView extends React.Component {
         : 'legendonly';
       return {
         name: MetricsPlotView.getLineLegend(metricKey, runDisplayName, isComparing),
-        x: history.map((entry) => {
-          if (xAxis === X_AXIS_STEP) {
-            return entry.step;
-          }
-          return MetricsPlotView.parseTimestamp(entry.timestamp, history, xAxis);
-        }),
+        x: MetricsPlotView.getXValuesForLineChart(history, xAxis),
         y: isSingleHistory ? historyValues : EMA(historyValues, lineSmoothness),
         text: historyValues.map((value) => (isNaN(value) ? value : value.toFixed(5))),
         type: 'scattergl',

--- a/mlflow/server/js/src/experiment-tracking/components/MetricsPlotView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/MetricsPlotView.js
@@ -65,11 +65,11 @@ export class MetricsPlotView extends React.Component {
     return legend;
   };
 
-  static getXValuesForLineChart(history, xAxis) {
+  static getXValuesForLineChart(history, xAxisType) {
     if (history.length === 0) {
       return [];
     }
-    switch (xAxis) {
+    switch (xAxisType) {
       case X_AXIS_STEP:
         return history.map(({ step }) => step);
       case X_AXIS_RELATIVE: {

--- a/mlflow/server/js/src/experiment-tracking/components/MetricsPlotView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/MetricsPlotView.js
@@ -66,6 +66,9 @@ export class MetricsPlotView extends React.Component {
   };
 
   static getXValuesForLineChart(history, xAxis) {
+    if (history.length === 0) {
+      return [];
+    }
     switch (xAxis) {
       case X_AXIS_STEP:
         return history.map(({ step }) => step);
@@ -73,7 +76,7 @@ export class MetricsPlotView extends React.Component {
         const { timestamp: minTimestamp } = _.minBy(history, 'timestamp');
         return history.map(({ timestamp }) => (timestamp - minTimestamp) / 1000);
       }
-      default:
+      default: // X_AXIS_WALL
         return history.map(({ timestamp }) => Utils.formatTimestamp(timestamp));
     }
   }

--- a/mlflow/server/js/src/experiment-tracking/components/MetricsPlotView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/MetricsPlotView.js
@@ -69,9 +69,10 @@ export class MetricsPlotView extends React.Component {
     switch (xAxis) {
       case X_AXIS_STEP:
         return history.map(({ step }) => step);
-      case X_AXIS_RELATIVE:
+      case X_AXIS_RELATIVE: {
         const { timestamp: minTimestamp } = _.minBy(history, 'timestamp');
         return history.map(({ timestamp }) => (timestamp - minTimestamp) / 1000);
+      }
       default:
         return history.map(({ timestamp }) => Utils.formatTimestamp(timestamp));
     }

--- a/mlflow/server/js/src/experiment-tracking/components/MetricsPlotView.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/MetricsPlotView.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { MetricsPlotView } from './MetricsPlotView';
-import { X_AXIS_RELATIVE, X_AXIS_WALL } from './MetricsPlotControls';
+import { X_AXIS_STEP, X_AXIS_RELATIVE, X_AXIS_WALL } from './MetricsPlotControls';
 import { CHART_TYPE_BAR, CHART_TYPE_LINE } from './MetricsPlotPanel';
 import Utils from '../../common/utils/Utils';
 import { LazyPlot } from './LazyPlot';
@@ -594,16 +594,25 @@ describe('unit tests', () => {
     expect(MetricsPlotView.getLineLegend('metric_1', 'Run abc', false)).toBe('metric_1');
   });
 
-  test('parseTimestamp()', () => {
+  test('getXValuesForLineChart()', () => {
     const timestamp = 1556662044000;
+    const anotherTimestamp = timestamp + 5000;
     const timestampStr = Utils.formatTimestamp(timestamp);
-    const history = [{ timestamp: 1556662043000 }];
-    // convert to step when axis is Time (Relative)
-    expect(MetricsPlotView.parseTimestamp(timestamp, history, X_AXIS_RELATIVE)).toBe(1);
+    const anotherTimestampStr = Utils.formatTimestamp(anotherTimestamp);
+    const history = [
+      { step: 0, timestamp },
+      { step: 1, timestamp: anotherTimestamp },
+    ];
+    // convert to step when axis is Step
+    expect(MetricsPlotView.getXValuesForLineChart(history, X_AXIS_STEP)).toEqual([0, 1]);
+    // convert to relative time in seconds when axis is Time (Relative)
+    expect(MetricsPlotView.getXValuesForLineChart(history, X_AXIS_RELATIVE)).toEqual([0, 5]);
     // convert to date time string when axis is Time (Wall)
-    expect(MetricsPlotView.parseTimestamp(timestamp, history, X_AXIS_WALL)).toBe(timestampStr);
+    expect(MetricsPlotView.getXValuesForLineChart(history, X_AXIS_WALL)).toEqual([
+      timestampStr,
+      anotherTimestampStr,
+    ]);
   });
-
   test('should disable both plotly logo and the link to plotly studio', () => {
     wrapper = shallow(<MetricsPlotView {...minimalPropsForBarChart} />);
     const plot = wrapper.find(LazyPlot);


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
Fix #6332

## What changes are proposed in this pull request?

As discovered in https://github.com/mlflow/mlflow/issues/6332#issuecomment-1196376829, relative time computation for the metric plot is inefficient because the minimum time is computed in each step. This PR fixes it.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

See https://github.com/mlflow/mlflow/issues/6332#issuecomment-1196405481.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
