### PR TITLE
Add `MLFLOW_SQLALCHEMYSTORE_POOL_RECYCLE` flag

### DIFF
--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -1090,6 +1090,8 @@ You can inject some `SQLAlchemy connection pooling options <https://docs.sqlalch
 +-----------------------------------------+-----------------------------+
 | ``MLFLOW_SQLALCHEMYSTORE_POOL_SIZE``    | ``pool_size``               |
 +-----------------------------------------+-----------------------------+
+| ``MLFLOW_SQLALCHEMYSTORE_POOL_RECYCLE`` | ``pool_recycle``            |
++-----------------------------------------+-----------------------------+
 | ``MLFLOW_SQLALCHEMYSTORE_MAX_OVERFLOW`` | ``max_overflow``            |
 +-----------------------------------------+-----------------------------+
 

--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -16,6 +16,7 @@ from mlflow.store.db.db_types import SQLITE
 _logger = logging.getLogger(__name__)
 
 MLFLOW_SQLALCHEMYSTORE_POOL_SIZE = "MLFLOW_SQLALCHEMYSTORE_POOL_SIZE"
+MLFLOW_SQLALCHEMYSTORE_POOL_RECYCLE = "MLFLOW_SQLALCHEMYSTORE_POOL_RECYCLE"
 MLFLOW_SQLALCHEMYSTORE_MAX_OVERFLOW = "MLFLOW_SQLALCHEMYSTORE_MAX_OVERFLOW"
 MAX_RETRY_COUNT = 15
 
@@ -179,6 +180,7 @@ def create_sqlalchemy_engine_with_retry(db_uri):
 def create_sqlalchemy_engine(db_uri):
     pool_size = os.environ.get(MLFLOW_SQLALCHEMYSTORE_POOL_SIZE)
     pool_max_overflow = os.environ.get(MLFLOW_SQLALCHEMYSTORE_MAX_OVERFLOW)
+    pool_recycle = os.environ.get(MLFLOW_SQLALCHEMYSTORE_POOL_RECYCLE)
     pool_kwargs = {}
     # Send argument only if they have been injected.
     # Some engine does not support them (for example sqllite)
@@ -186,6 +188,8 @@ def create_sqlalchemy_engine(db_uri):
         pool_kwargs["pool_size"] = int(pool_size)
     if pool_max_overflow:
         pool_kwargs["max_overflow"] = int(pool_max_overflow)
+    if pool_recycle:
+        pool_kwargs["pool_recycle"] = int(pool_recycle)
     if pool_kwargs:
         _logger.info("Create SQLAlchemy engine with pool options %s", pool_kwargs)
     return sqlalchemy.create_engine(db_uri, pool_pre_ping=True, **pool_kwargs)

--- a/tests/store/db/test_utils.py
+++ b/tests/store/db/test_utils.py
@@ -7,12 +7,20 @@ from mlflow.store.db import utils
 def test_create_sqlalchemy_engine_inject_pool_options():
     with mock.patch.dict(
         os.environ,
-        {"MLFLOW_SQLALCHEMYSTORE_POOL_SIZE": "2", "MLFLOW_SQLALCHEMYSTORE_MAX_OVERFLOW": "4"},
+        {
+            "MLFLOW_SQLALCHEMYSTORE_POOL_SIZE": "2",
+            "MLFLOW_SQLALCHEMYSTORE_POOL_RECYCLE": "3600",
+            "MLFLOW_SQLALCHEMYSTORE_MAX_OVERFLOW": "4",
+        },
     ):
         with mock.patch("sqlalchemy.create_engine") as mock_create_engine:
             utils.create_sqlalchemy_engine("mydb://host:port/")
             mock_create_engine.assert_called_once_with(
-                "mydb://host:port/", pool_pre_ping=True, pool_size=2, max_overflow=4
+                "mydb://host:port/",
+                pool_pre_ping=True,
+                pool_size=2,
+                pool_recycle=3600,
+                max_overflow=4,
             )
 
 


### PR DESCRIPTION
## Related Issues/PRs

Some MySQL databases timeout connections if they are not used. If an MLFlow server uses such a database, but nobody is using the MLFlow application for the duration of the timeout, the database connection can be dropped, breaking the application. 

The following errors are observed in logs during such situations:

```
ERROR mlflow.server: Exception on /api/2.0/mlflow/experiments/get-by-name [GET]
Traceback (most recent call last):
  File "/.../lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 3280, in _wrap_pool_connect
    return fn()
  File "/.../lib/python3.8/site-packages/sqlalchemy/pool/base.py", line 310, in connect
    return _ConnectionFairy._checkout(self)
  File "/.../lib/python3.8/site-packages/sqlalchemy/pool/base.py", line 901, in _checkout
    result = pool._dialect.do_ping(fairy.dbapi_connection)
  File "/.../lib/python3.8/site-packages/sqlalchemy/dialects/mysql/mysqldb.py", line 183, in do_ping
    dbapi_connection.ping(False)
MySQLdb._exceptions.OperationalError: (4031, 'The client was disconnected by the server because of inactivity. See wait_timeout and interactive_timeout for configuring this behavior.')

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/.../lib/python3.8/site-packages/mlflow/store/db/utils.py", line 79, in make_managed_session
    yield session
  File "/.../lib/python3.8/site-packages/mlflow/store/tracking/sqlalchemy_store.py", line 393, in get_experiment_by_name
    session.query(SqlExperiment)
  File "/.../lib/python3.8/site-packages/sqlalchemy/orm/query.py", line 2845, in one_or_none
    return self._iter().one_or_none()
  File "/.../lib/python3.8/site-packages/sqlalchemy/orm/query.py", line 2903, in _iter
    result = self.session.execute(
  File "/.../lib/python3.8/site-packages/sqlalchemy/orm/session.py", line 1695, in execute
    conn = self._connection_for_bind(bind)
  File "/.../lib/python3.8/site-packages/sqlalchemy/orm/session.py", line 1536, in _connection_for_bind
    return self._transaction._connection_for_bind(
  File "/.../lib/python3.8/site-packages/sqlalchemy/orm/session.py", line 747, in _connection_for_bind
    conn = bind.connect()
  File "/.../lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 3234, in connect
    return self._connection_cls(self, close_with_result=close_with_result)
  File "/.../lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 96, in __init__
    else engine.raw_connection()
  File "/.../lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 3313, in raw_connection
    return self._wrap_pool_connect(self.pool.connect, _connection)
  File "/.../lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 3283, in _wrap_pool_connect
    Connection._handle_dbapi_exception_noconnection(
  File "/.../lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 2117, in _handle_dbapi_exception_noconnection
    util.raise_(
  File "/.../lib/python3.8/site-packages/sqlalchemy/util/compat.py", line 207, in raise_
    raise exception
  File "/.../lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 3280, in _wrap_pool_connect
    return fn()
  File "/.../lib/python3.8/site-packages/sqlalchemy/pool/base.py", line 310, in connect
    return _ConnectionFairy._checkout(self)
  File "/.../lib/python3.8/site-packages/sqlalchemy/pool/base.py", line 901, in _checkout
    result = pool._dialect.do_ping(fairy.dbapi_connection)
  File "/.../lib/python3.8/site-packages/sqlalchemy/dialects/mysql/mysqldb.py", line 183, in do_ping
    dbapi_connection.ping(False)
sqlalchemy.exc.OperationalError: (MySQLdb._exceptions.OperationalError) (4031, 'The client was disconnected by the server because of inactivity. See wait_timeout and interactive_timeout for configuring this behavior.')
(Background on this error at: https://sqlalche.me/e/14/e3q8)
```

```
Exception during reset or similar
Traceback (most recent call last):
  File "/.../lib/python3.8/site-packages/sqlalchemy/pool/base.py", line 739, in _finalize_fairy
    fairy._reset(pool)
  File "/.../lib/python3.8/site-packages/sqlalchemy/pool/base.py", line 988, in _reset
    pool._dialect.do_rollback(self)
  File "/.../lib/python3.8/site-packages/sqlalchemy/engine/default.py", line 682, in do_rollback
    dbapi_connection.rollback()
MySQLdb._exceptions.OperationalError: (4031, 'The client was disconnected by the server because of inactivity. See wait_timeout and interactive_timeout for configuring this behavior.')
```

The solution to this problem is to use SQLAlchemy's [connection pool recycling](https://docs.sqlalchemy.org/en/14/core/pooling.html#setting-pool-recycle), which prevents the pool from using a particular connection which has passed a certain age.


## What changes are proposed in this pull request?

Add a runtime environment flag `MLFLOW_SQLALCHEMYSTORE_POOL_RECYCLE` which can be used to pass a `pool_recycle` value to SQLAlchemy's `create_engine` function.

More information:
https://docs.sqlalchemy.org/en/14/core/pooling.html#setting-pool-recycle


`MLFLOW_SQLALCHEMYSTORE_POOL_RECYCLE` flag works in the same way as previously defined `MLFLOW_SQLALCHEMYSTORE_POOL_SIZE` and `MLFLOW_SQLALCHEMYSTORE_MAX_OVERFLOW`.


## How is this patch tested?

The change was tested in our production environment and solves the issue described above.

Added the new flag to appropriate unit test.

- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.


## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [x] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
