### PR TITLE
Log runtime pipeline config to MLflow

### DIFF
--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -37,6 +37,7 @@ _logger = logging.getLogger(__name__)
 
 
 class TrainStep(BaseStep):
+
     MODEL_ARTIFACT_RELATIVE_PATH = "model"
 
     def __init__(self, step_config, pipeline_root, pipeline_config=None):

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -37,11 +37,11 @@ _logger = logging.getLogger(__name__)
 
 
 class TrainStep(BaseStep):
-
     MODEL_ARTIFACT_RELATIVE_PATH = "model"
 
-    def __init__(self, step_config, pipeline_root):
+    def __init__(self, step_config, pipeline_root, pipeline_config=None):
         super().__init__(step_config, pipeline_root)
+        self.pipeline_config = pipeline_config
         self.tracking_config = TrackingConfig.from_dict(step_config)
         self.target_col = self.step_config.get("target_col")
         self.train_module_name, self.estimator_method_name = self.step_config[
@@ -151,7 +151,9 @@ class TrainStep(BaseStep):
 
             with open(os.path.join(output_directory, "run_id"), "w") as f:
                 f.write(run.info.run_id)
-            log_code_snapshot(self.pipeline_root, run.info.run_id)
+            log_code_snapshot(
+                self.pipeline_root, run.info.run_id, pipeline_config=self.pipeline_config
+            )
 
             eval_metrics = {}
             for dataset_name, dataset in {
@@ -451,7 +453,7 @@ class TrainStep(BaseStep):
                 "Config for train step is not found.", error_code=INVALID_PARAMETER_VALUE
             )
         step_config["target_col"] = pipeline_config.get("target_col")
-        return cls(step_config, pipeline_root)
+        return cls(step_config, pipeline_root, pipeline_config=pipeline_config)
 
     @property
     def name(self):

--- a/mlflow/pipelines/utils/tracking.py
+++ b/mlflow/pipelines/utils/tracking.py
@@ -27,7 +27,6 @@ from mlflow.utils.mlflow_tags import (
 
 _logger = logging.getLogger(__name__)
 
-
 TrackingConfigType = TypeVar("TrackingConfig")
 
 
@@ -242,8 +241,13 @@ def get_run_tags_env_vars(pipeline_root_path: str) -> Dict[str, str]:
 
 
 def log_code_snapshot(
-    pipeline_root: str, run_id: str, artifact_path: str = "pipeline_snapshot"
+    pipeline_root: str,
+    run_id: str,
+    artifact_path: str = "pipeline_snapshot",
+    pipeline_config: Dict[str, Any] = None,
 ) -> None:
+    import yaml
+
     """
     Logs a pipeline code snapshot as mlflow artifacts.
 
@@ -266,4 +270,9 @@ def log_code_snapshot(
                 tmp_path = tmpdir.joinpath(file_path.relative_to(pipeline_root))
                 tmp_path.parent.mkdir(exist_ok=True, parents=True)
                 shutil.copyfile(file_path, tmp_path)
+        if pipeline_config is not None:
+            tmp_path = tmpdir.joinpath("runtime/pipeline.yaml")
+            tmp_path.parent.mkdir(exist_ok=True, parents=True)
+            with open(tmp_path, mode="w+", encoding="utf-8") as config_file:
+                yaml.dump(pipeline_config, config_file)
         MlflowClient().log_artifacts(run_id, str(tmpdir), artifact_path=artifact_path)

--- a/mlflow/pipelines/utils/tracking.py
+++ b/mlflow/pipelines/utils/tracking.py
@@ -246,14 +246,13 @@ def log_code_snapshot(
     artifact_path: str = "pipeline_snapshot",
     pipeline_config: Dict[str, Any] = None,
 ) -> None:
-    import yaml
-
     """
     Logs a pipeline code snapshot as mlflow artifacts.
 
     :param pipeline_root_path: String file path to the directory where the pipeline is defined.
     :param run_id: Run ID to which the code snapshot is logged.
     :param artifact_path: Directory within the run's artifact director (default: "snapshots").
+    :param pipeline_config: Dict containing the full pipeline configuration at runtime.
     """
     with tempfile.TemporaryDirectory() as tmpdir:
         tmpdir = pathlib.Path(tmpdir)
@@ -271,8 +270,10 @@ def log_code_snapshot(
                 tmp_path.parent.mkdir(exist_ok=True, parents=True)
                 shutil.copyfile(file_path, tmp_path)
         if pipeline_config is not None:
+            import yaml
+
             tmp_path = tmpdir.joinpath("runtime/pipeline.yaml")
             tmp_path.parent.mkdir(exist_ok=True, parents=True)
-            with open(tmp_path, mode="w+", encoding="utf-8") as config_file:
+            with open(tmp_path, mode="w", encoding="utf-8") as config_file:
                 yaml.dump(pipeline_config, config_file)
         MlflowClient().log_artifacts(run_id, str(tmpdir), artifact_path=artifact_path)

--- a/tests/pipelines/test_tracking_utils.py
+++ b/tests/pipelines/test_tracking_utils.py
@@ -124,6 +124,7 @@ def test_log_code_snapshot(tmp_path: pathlib.Path):
         "requirements.txt",
         "profiles/local.yaml",
         "steps/train.py",
+        "runtime/pipeline.yaml",
     ]
     for f in files:
         path = tmp_path.joinpath(f)
@@ -131,8 +132,9 @@ def test_log_code_snapshot(tmp_path: pathlib.Path):
         path.write_text("")
 
     mlflow.set_experiment(experiment_id="0")
+    pipeline_config = {"name": "fake_config", "dict": {"key": 123}}
     with mlflow.start_run() as run:
-        log_code_snapshot(tmp_path, run.info.run_id)
+        log_code_snapshot(tmp_path, run.info.run_id, pipeline_config=pipeline_config)
         tracking_uri = mlflow.get_tracking_uri()
 
     artifacts = set(list_all_artifacts(tracking_uri, run.info.run_id))


### PR DESCRIPTION
Signed-off-by: Jin Zhang <jin.zhang@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs


## What changes are proposed in this pull request?

Added the full pipeline config at runtime as part of the pipeline_snapshot logged to MLflow.

## How is this patch tested?
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.


## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Full MLflow Pipeline configuration is now logged under `pipeline_snapshot/runtime/pipeline.yaml`.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
