### PR TITLE
Series schema

### DIFF
--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -116,7 +116,10 @@ def _infer_schema(data: Any) -> Schema:
             )
         schema = Schema(res)
     elif isinstance(data, pd.Series):
-        schema = Schema([ColSpec(type=_infer_pandas_column(data))])
+        name = None
+        if hasattr(data, "name"):
+            name = data.name
+        schema = Schema([ColSpec(type=_infer_pandas_column(data), name=name)])
     elif isinstance(data, pd.DataFrame):
         schema = Schema(
             [ColSpec(type=_infer_pandas_column(data[col]), name=col) for col in data.columns]

--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -116,9 +116,7 @@ def _infer_schema(data: Any) -> Schema:
             )
         schema = Schema(res)
     elif isinstance(data, pd.Series):
-        name = None
-        if hasattr(data, "name"):
-            name = data.name
+        name = hasattr(data, "name", None)
         schema = Schema([ColSpec(type=_infer_pandas_column(data), name=name)])
     elif isinstance(data, pd.DataFrame):
         schema = Schema(

--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -116,7 +116,7 @@ def _infer_schema(data: Any) -> Schema:
             )
         schema = Schema(res)
     elif isinstance(data, pd.Series):
-        name = hasattr(data, "name", None)
+        name = getattr(data, "name", None)
         schema = Schema([ColSpec(type=_infer_pandas_column(data), name=name)])
     elif isinstance(data, pd.DataFrame):
         schema = Schema(

--- a/tests/types/test_schema.py
+++ b/tests/types/test_schema.py
@@ -226,6 +226,12 @@ def test_schema_inference_on_pandas_series():
         with pytest.raises(MlflowException, match="Unsupported numpy data type"):
             _infer_schema(pd.Series(np.array([1, 2, 3], dtype=np.float128)))
 
+    # test names
+    s = pd.Series([1, 2, 3])
+    if hasattr(s, "name"):
+        s.rename('test', inplace=True)
+        assert 'test' in _infer_schema(s).input_names()
+
 
 def test_get_tensor_shape(dict_of_ndarrays):
     assert all(-1 == _get_tensor_shape(tensor)[0] for tensor in dict_of_ndarrays.values())

--- a/tests/types/test_schema.py
+++ b/tests/types/test_schema.py
@@ -231,7 +231,7 @@ def test_schema_inference_on_pandas_series():
     if hasattr(s, "name"):
         s.rename("test", inplace=True)
         assert "test" in _infer_schema(s).input_names()
-        assert not "foo" in _infer_schema(s).input_names()
+        assert len(_infer_schema(s).input_names()) == 1
 
 
 def test_get_tensor_shape(dict_of_ndarrays):

--- a/tests/types/test_schema.py
+++ b/tests/types/test_schema.py
@@ -231,6 +231,7 @@ def test_schema_inference_on_pandas_series():
     if hasattr(s, "name"):
         s.rename('test', inplace=True)
         assert 'test' in _infer_schema(s).input_names()
+        assert not 'foo' in _infer_schema(s).input_names()
 
 
 def test_get_tensor_shape(dict_of_ndarrays):

--- a/tests/types/test_schema.py
+++ b/tests/types/test_schema.py
@@ -229,9 +229,9 @@ def test_schema_inference_on_pandas_series():
     # test names
     s = pd.Series([1, 2, 3])
     if hasattr(s, "name"):
-        s.rename('test', inplace=True)
-        assert 'test' in _infer_schema(s).input_names()
-        assert not 'foo' in _infer_schema(s).input_names()
+        s.rename("test", inplace=True)
+        assert "test" in _infer_schema(s).input_names()
+        assert not "foo" in _infer_schema(s).input_names()
 
 
 def test_get_tensor_shape(dict_of_ndarrays):


### PR DESCRIPTION
infer panda series name for ColSpec

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#6360

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

Added in getting name inference on a pandas series object

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

Wrote new pytest assertion to check for name attribute in `input_names` on a schema object. Check mlflow/tests/types/test_schema.py for change.

<img width="1417" alt="Screen Shot 2022-07-28 at 3 34 27 PM" src="https://user-images.githubusercontent.com/40377123/181632334-764371c9-2ade-46c9-9ef4-4c9d3f4c4572.png">
<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)


Refer to #6360

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
