### PR TITLE
Skipping the transform step by using Functional transformer

### DIFF
--- a/mlflow/pipelines/steps/transform.py
+++ b/mlflow/pipelines/steps/transform.py
@@ -74,10 +74,18 @@ class TransformStep(BaseStep):
         validation_df = pd.read_parquet(validation_data_path)
 
         sys.path.append(self.pipeline_root)
+
+        def get_identity_transformer():
+            from sklearn.pipeline import Pipeline
+            from sklearn.preprocessing import FunctionTransformer
+
+            return Pipeline(steps=[("identity", FunctionTransformer())])
+
         transformer_fn = getattr(
             importlib.import_module(self.transformer_module_name), self.transformer_method_name
         )
         transformer = transformer_fn()
+        transformer = transformer if transformer else get_identity_transformer()
         transformer.fit(train_df.drop(columns=[self.target_col]))
 
         def transform_dataset(dataset):

--- a/tests/pipelines/test_transform_step.py
+++ b/tests/pipelines/test_transform_step.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pandas as pd
 
 import mlflow
+from mlflow import MlflowClient
 from mlflow.utils.file_utils import read_yaml
 from mlflow.pipelines.utils.execution import _MLFLOW_PIPELINES_EXECUTION_DIRECTORY_ENV_VAR
 from mlflow.pipelines.utils import _PIPELINE_CONFIG_FILE_NAME
@@ -16,7 +17,7 @@ from tests.pipelines.helper_functions import tmp_pipeline_root_path
 # pylint: enable=unused-import
 
 # Sets up the transform step and returns the constructed TransformStep instance and step output dir
-def set_up_transform_step(pipeline_root: Path):
+def set_up_transform_step(pipeline_root: Path, transform_user_module):
     split_step_output_dir = pipeline_root.joinpath("steps", "split", "outputs")
     split_step_output_dir.mkdir(parents=True)
 
@@ -35,33 +36,59 @@ def set_up_transform_step(pipeline_root: Path):
     dataset.to_parquet(str(split_step_output_dir / "train.parquet"))
 
     pipeline_yaml = pipeline_root.joinpath(_PIPELINE_CONFIG_FILE_NAME)
+    experiment_name = "demo"
+    MlflowClient().create_experiment(experiment_name)
+
     pipeline_yaml.write_text(
         """
         template: "regression/v1"
         target_col: "y"
         experiment:
-          name: "demo"
+          name: {experiment_name}
           tracking_uri: {tracking_uri}
         steps:
           transform:
-            transformer_method: sklearn.preprocessing.StandardScaler
+            transformer_method: {transform_user_module}
         """.format(
-            tracking_uri=mlflow.get_tracking_uri()
+            tracking_uri=mlflow.get_tracking_uri(),
+            experiment_name=experiment_name,
+            transform_user_module=transform_user_module,
         )
     )
     pipeline_config = read_yaml(pipeline_root, _PIPELINE_CONFIG_FILE_NAME)
     transform_step = TransformStep.from_pipeline_config(pipeline_config, str(pipeline_root))
-    return transform_step, transform_step_output_dir
+    return transform_step, transform_step_output_dir, split_step_output_dir
 
 
 def test_transform_step_writes_onehot_encoded_dataframe_and_transformer_pkl(tmp_pipeline_root_path):
     with mock.patch.dict(
         os.environ, {_MLFLOW_PIPELINES_EXECUTION_DIRECTORY_ENV_VAR: str(tmp_pipeline_root_path)}
     ):
-        transform_step, transform_step_output_dir = set_up_transform_step(tmp_pipeline_root_path)
+        transform_step, transform_step_output_dir, _ = set_up_transform_step(
+            tmp_pipeline_root_path, "sklearn.preprocessing.StandardScaler"
+        )
         transform_step._run(str(transform_step_output_dir))
 
     assert os.path.exists(transform_step_output_dir / "transformed_training_data.parquet")
     transformed = pd.read_parquet(transform_step_output_dir / "transformed_training_data.parquet")
     assert len(transformed.columns) == 3
+    assert os.path.exists(transform_step_output_dir / "transformer.pkl")
+
+
+def test_transform_empty_step(tmp_pipeline_root_path):
+    with mock.patch.dict(
+        os.environ, {_MLFLOW_PIPELINES_EXECUTION_DIRECTORY_ENV_VAR: str(tmp_pipeline_root_path)}
+    ), mock.patch("steps.transform.transformer_fn", return_value=None):
+        transform_step, transform_step_output_dir, split_step_output_dir = set_up_transform_step(
+            tmp_pipeline_root_path, "steps.transform.transformer_fn"
+        )
+        transform_step._run(str(transform_step_output_dir))
+
+    assert os.path.exists(transform_step_output_dir / "transformed_training_data.parquet")
+    train_transformed = pd.read_parquet(
+        transform_step_output_dir / "transformed_training_data.parquet"
+    )
+    train_split = pd.read_parquet(split_step_output_dir / "train.parquet")
+
+    assert train_transformed.equals(train_split) == True
     assert os.path.exists(transform_step_output_dir / "transformer.pkl")


### PR DESCRIPTION
## What changes are proposed in this pull request?
Skipping the transform step by using Functional transformer

## How is this patch tested?
- [x] Test added
- [x] Step card generated correctly.
<img width="1791" alt="Screen Shot 2022-07-28 at 4 23 42 PM" src="https://user-images.githubusercontent.com/5621432/181653337-7324063b-a4fa-4cab-8f90-170b5ac12a77.png">

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
