### PR TITLE
Avoid logging model signatures in pyspark ML autologging if model input/output dataframe contains unsupported data types

### DIFF
--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -1015,7 +1015,7 @@ def autolog(
                             "Input dataframe contains unsupported spark data types: "
                             f"{unsupported_columns}. Model signature will not be logged."
                         )
-                    log_model_signatures = False
+                        log_model_signatures = False
 
                 input_example, signature = resolve_input_example_and_signature(
                     _get_input_example_as_pd_df,

--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -1027,7 +1027,7 @@ def autolog(
                     unsupported_columns = _get_columns_with_unsupported_data_type(input_df)
                     if unsupported_columns:
                         _logger.warning(
-                            "Input dataframe contains unsupported spark data types: "
+                            "Model input contains unsupported spark data types: "
                             f"{unsupported_columns}. Model signature will not be logged."
                         )
                         log_model_signatures = False

--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -1013,7 +1013,7 @@ def autolog(
                     if unsupported_columns:
                         _logger.warning(
                             "Input dataframe contains unsupported spark data types: "
-                            f"{unsupported_columns}. Model signatures will not be logged."
+                            f"{unsupported_columns}. Model signature will not be logged."
                         )
                     log_model_signatures = False
 

--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -890,7 +890,7 @@ def autolog(
 
                                     Currently, only scalar Spark data types are supported. If
                                     model inputs/outputs contain non-scalar Spark data types such
-                                    as vector, signatures are not logged.
+                                    as ``pyspark.ml.linalg.Vector``, signatures are not logged.
 
     **The default log model allowlist in mlflow**
         .. literalinclude:: ../../../mlflow/pyspark/ml/log_model_allowlist.txt

--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -1010,6 +1010,7 @@ def autolog(
                     model_output = spark_model.transform(input_slice_df).drop(
                         *input_slice_df.columns
                     )
+                    # TODO: Remove this once we support non-scalar spark data types
                     unsupported_columns = _get_columns_with_unsupported_data_type(model_output)
                     if unsupported_columns:
                         _logger.warning(
@@ -1022,6 +1023,7 @@ def autolog(
 
                     return infer_signature(input_example_slice, model_output)
 
+                # TODO: Remove this once we support non-scalar spark data types
                 nonlocal log_model_signatures
                 if log_model_signatures:
                     unsupported_columns = _get_columns_with_unsupported_data_type(input_df)

--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -886,6 +886,12 @@ def autolog(
                                  with spark ml pipeline/estimator artifacts during training.
                                  If ``False`` signatures are not logged.
 
+                                 .. warning::
+
+                                    Currently, only scalar Spark data types are supported. If
+                                    model inputs/outputs contain non-scalar Spark data types such
+                                    as vector, signatures are not logged.
+
     **The default log model allowlist in mlflow**
         .. literalinclude:: ../../../mlflow/pyspark/ml/log_model_allowlist.txt
            :language: text
@@ -1014,8 +1020,8 @@ def autolog(
                     unsupported_columns = _get_columns_with_unsupported_data_type(model_output)
                     if unsupported_columns:
                         _logger.warning(
-                            "Model output contains unsupported spark data types: "
-                            f"{unsupported_columns}. Output signature will not be logged."
+                            "Model outputs contain unsupported Spark data types: "
+                            f"{unsupported_columns}. Output schema is not be logged."
                         )
                         model_output = None
                     else:
@@ -1029,8 +1035,8 @@ def autolog(
                     unsupported_columns = _get_columns_with_unsupported_data_type(input_df)
                     if unsupported_columns:
                         _logger.warning(
-                            "Model input contains unsupported spark data types: "
-                            f"{unsupported_columns}. Model signature will not be logged."
+                            "Model inputs contain unsupported Spark data types: "
+                            f"{unsupported_columns}. Model signature is not logged."
                         )
                         log_model_signatures = False
 

--- a/mlflow/types/schema.py
+++ b/mlflow/types/schema.py
@@ -66,6 +66,10 @@ class DataType(Enum):
 
         return getattr(pyspark.sql.types, self._spark_type)()
 
+    @classmethod
+    def get_spark_types(cls):
+        return [dt.to_spark() for dt in cls._member_map_.values()]
+
 
 class ColSpec:
     """

--- a/tests/spark/autologging/ml/test_pyspark_ml_autologging.py
+++ b/tests/spark/autologging/ml/test_pyspark_ml_autologging.py
@@ -949,7 +949,13 @@ def _read_model_conf_as_dict(run):
         return yaml.load(f, Loader=yaml.FullLoader)
 
 
-def _assert_autolog_infers_model_signature_correctly(run, input_sig_spec, output_sig_spec=None):
+def _read_schema(schema_str):
+    if schema_str is None:
+        return None
+    return json.loads(schema_str)
+
+
+def _assert_autolog_infers_model_signature_correctly(run, input_sig_spec, output_sig_spec):
     data = _read_model_conf_as_dict(run)
     assert data is not None
     assert "signature" in data
@@ -957,9 +963,8 @@ def _assert_autolog_infers_model_signature_correctly(run, input_sig_spec, output
     assert signature is not None
     assert "inputs" in signature
     assert "outputs" in signature
-    assert json.loads(signature["inputs"]) == input_sig_spec
-    if output_sig_spec:
-        assert json.loads(signature["outputs"]) == output_sig_spec
+    assert _read_schema(signature["inputs"]) == input_sig_spec
+    assert _read_schema(signature["outputs"]) == output_sig_spec
 
 
 def test_autolog_input_example_with_estimator(spark_session, dataset_multinomial, lr):


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Prior to #6287, `_dataframe_from_json` ignored the input schema because of https://github.com/pandas-dev/pandas/issues/33205, and logging non-scalar spark data types (e.g. vector) as string for model signature didn't cause any issues, but it does now because all non-scalar columns are converted to string:

https://github.com/mlflow/mlflow/runs/7560797806?check_suite_focus=true#step:12:340

```
E               pyspark.sql.utils.IllegalArgumentException: requirement failed: Column features must be of type class org.apache.spark.ml.linalg.VectorUDT:struct<type:tinyint,size:int,indices:array<int>,values:array<double>> but was actually class org.apache.spark.sql.types.StringType$:string.
```

This PR made changes to avoid logging non-scalar data types as string. We can revert the changes once non-scalar Spark data types are supported for model signature.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed the issue where PySpark ML autologging incorrectly infers non-scalar Spark data types as strings.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
