### PR TITLE
Added a custom filter from_json to render_and_merge_yaml

### DIFF
--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -222,6 +222,14 @@ def render_and_merge_yaml(root, template_name, context_name):
     j2_env = jinja2.Environment(
         loader=jinja2.FileSystemLoader(root, encoding=ENCODING), undefined=jinja2.StrictUndefined
     )
+
+    def from_json(input_var):
+        import json
+
+        with open(input_var, mode="r", encoding="utf-8") as f:
+            return json.load(f)
+
+    j2_env.filters["from_json"] = from_json
     source = j2_env.get_template(template_name).render(context_dict)
     rendered_template_dict = yaml.load(source, Loader=UniqueKeyLoader)
     return merge_dicts(rendered_template_dict, context_dict)

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -62,6 +62,13 @@ def test_yaml_read_and_write(tmpdir):
 
 
 def test_render_and_merge_yaml(tmpdir):
+    import json
+
+    json_file = tmpdir / random_file("yaml")
+    extra_config = {"key": 123}
+    with open(json_file, "w") as f:
+        json.dump(extra_config, f)
+
     template_yaml_file = random_file("yaml")
     with open(tmpdir / template_yaml_file, "w") as f:
         f.write(
@@ -75,6 +82,7 @@ def test_render_and_merge_yaml(tmpdir):
             test_2: {{ TEST_VAR_1 }}
             test_3: {{ TEST_VAR_2 }}
             """
+            + f"test_4: {{{{ '{json_file}' | from_json }}}}"
         )
 
     data = {"MY_MLFLOW_SERVER": "./mlruns", "TEST_VAR_1": ["a", 1.2], "TEST_VAR_2": {"a": 2}}
@@ -90,6 +98,7 @@ def test_render_and_merge_yaml(tmpdir):
         "test_1": [1, 2, 3],
         "test_2": ["a", 1.2],
         "test_3": {"a": 2},
+        "test_4": extra_config,
     }
 
     assert result == expected

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -98,7 +98,7 @@ def test_render_and_merge_yaml(tmpdir):
         "test_1": [1, 2, 3],
         "test_2": ["a", 1.2],
         "test_3": {"a": 2},
-        "test_4": extra_config,
+        "test_4": 123,
     }
 
     assert result == expected

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -82,7 +82,7 @@ def test_render_and_merge_yaml(tmpdir):
             test_2: {{ TEST_VAR_1 }}
             test_3: {{ TEST_VAR_2 }}
             """
-            + f"test_4: {{{{ ('{json_file}' | from_json)['key'] }}}}"
+            + r"test_4: {{{{ ('{0}' | from_json)['key'] }}}}".format(json_file)
         )
 
     data = {"MY_MLFLOW_SERVER": "./mlruns", "TEST_VAR_1": ["a", 1.2], "TEST_VAR_2": {"a": 2}}

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -82,7 +82,7 @@ def test_render_and_merge_yaml(tmpdir):
             test_2: {{ TEST_VAR_1 }}
             test_3: {{ TEST_VAR_2 }}
             """
-            + f"test_4: {{{{ '{json_file}' | from_json }}["key"]}}"
+            + f"test_4: {{{{ ('{json_file}' | from_json)['key'] }}}}"
         )
 
     data = {"MY_MLFLOW_SERVER": "./mlruns", "TEST_VAR_1": ["a", 1.2], "TEST_VAR_2": {"a": 2}}

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -64,7 +64,7 @@ def test_yaml_read_and_write(tmpdir):
 def test_render_and_merge_yaml(tmpdir):
     import json
 
-    json_file = tmpdir / random_file("yaml")
+    json_file = tmpdir / random_file("json")
     extra_config = {"key": 123}
     with open(json_file, "w") as f:
         json.dump(extra_config, f)

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -82,7 +82,7 @@ def test_render_and_merge_yaml(tmpdir):
             test_2: {{ TEST_VAR_1 }}
             test_3: {{ TEST_VAR_2 }}
             """
-            + f"test_4: {{{{ '{json_file}' | from_json }}}}"
+            + f"test_4: {{{{ '{json_file}' | from_json }}["key"]}}"
         )
 
     data = {"MY_MLFLOW_SERVER": "./mlruns", "TEST_VAR_1": ["a", 1.2], "TEST_VAR_2": {"a": 2}}

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -64,9 +64,9 @@ def test_yaml_read_and_write(tmpdir):
 def test_render_and_merge_yaml(tmpdir):
     import json
 
-    json_file = tmpdir / random_file("json")
+    json_file = random_file("json")
     extra_config = {"key": 123}
-    with open(json_file, "w") as f:
+    with open(tmpdir / json_file, "w") as f:
         json.dump(extra_config, f)
 
     template_yaml_file = random_file("yaml")
@@ -89,7 +89,8 @@ def test_render_and_merge_yaml(tmpdir):
     context_yaml_file = random_file("yaml")
     file_utils.write_yaml(str(tmpdir), context_yaml_file, data)
 
-    result = file_utils.render_and_merge_yaml(tmpdir, template_yaml_file, context_yaml_file)
+    with tmpdir.as_cwd():
+        result = file_utils.render_and_merge_yaml(tmpdir, template_yaml_file, context_yaml_file)
     expected = {
         "MY_MLFLOW_SERVER": "./mlruns",
         "TEST_VAR_1": ["a", 1.2],
@@ -100,7 +101,6 @@ def test_render_and_merge_yaml(tmpdir):
         "test_3": {"a": 2},
         "test_4": 123,
     }
-
     assert result == expected
 
 


### PR DESCRIPTION
Signed-off-by: Jin Zhang <jin.zhang@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs
This PR addresses https://github.com/mlflow/mlflow/issues/6204

## What changes are proposed in this pull request?
To support loading extra configs from a JSON file, added a custom filter to Jinjia2 here.

## How is this patch tested?
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Users can reference an external JSON file in Pipeline config YAML file with `from_json` syntax.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
