### PR TITLE
Fix step card display breakage in Jupyter notebooks

### DIFF
--- a/mlflow/pipelines/step.py
+++ b/mlflow/pipelines/step.py
@@ -147,7 +147,7 @@ class BaseStep(metaclass=abc.ABCMeta):
 
         card = BaseCard.load(card_path)
         card_html_path = os.path.join(output_directory, CARD_HTML_NAME)
-        display_html(html_data=card.to_html(), html_file_path=card_html_path)
+        display_html(html_data=card.to_html())
 
     @experimental
     @abc.abstractmethod

--- a/mlflow/pipelines/step.py
+++ b/mlflow/pipelines/step.py
@@ -147,7 +147,7 @@ class BaseStep(metaclass=abc.ABCMeta):
 
         card = BaseCard.load(card_path)
         card_html_path = os.path.join(output_directory, CARD_HTML_NAME)
-        display_html(html_data=card.to_html())
+        display_html(html_data=card.to_html(), html_file_path=card_html_path)
 
     @experimental
     @abc.abstractmethod

--- a/mlflow/pipelines/utils/step.py
+++ b/mlflow/pipelines/utils/step.py
@@ -62,6 +62,8 @@ def display_html(html_data: str = None, html_file_path: str = None) -> None:
     if is_running_in_ipython_environment():
         from IPython.display import display as ip_display, HTML
 
+        html_file_path = html_file_path if html_data is None else None
+
         if is_in_databricks_runtime():
             # Patch IPython display with Databricks display before showing the HTML.
             import IPython.core.display as icd


### PR DESCRIPTION
Signed-off-by: apurva-koti <apurva.koti@databricks.com>
## What changes are proposed in this pull request?

Hide the `html_file_path` argument when `display_html` is being used in a renderer for the step card in Pipelines' `inspect` function.
This fixes an issue in Jupyter notebooks where one cell displaying a step's card would prevent another cell from doing so, due to both cells displaying the same HTML with the same tab element classname suffixes and causing a JS conflict.

By removing this argument, we direct IPython to display the cards using the freshly rendered card HTML, which would contain newly seeded classname suffixes.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

Before:
<img width="1109" alt="image" src="https://user-images.githubusercontent.com/51172624/182257654-dd5bcc90-28d8-4a94-85c4-0b2d8f9dc753.png">

After:
<img width="1128" alt="image" src="https://user-images.githubusercontent.com/51172624/182257717-c224dd24-e8a7-41e3-8ae4-fcff158f5a1b.png">


<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
