### PR TITLE
Validate metric value in `FileStore.log_metric`

### DIFF
--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
@@ -175,7 +175,7 @@ public class MlflowClientTest {
     client.logMetric(runId, "zero_one_loss", ZERO_ONE_LOSS);
     client.logMetric(runId, "multi_log_default_step_ts", 2.0);
     client.logMetric(runId, "multi_log_default_step_ts", -1.0);
-    client.logMetric(runId, "multi_log_specified_step_ts", 1.0, -1000, 1);
+    client.logMetric(runId, "multi_log_specified_step_ts", 1.0, 1000, 1);
     client.logMetric(runId, "multi_log_specified_step_ts", 2.0, 2000, -5);
     client.logMetric(runId, "multi_log_specified_step_ts", -3.0, 3000, 4);
     client.logMetric(runId, "multi_log_specified_step_ts", 4.0, 2999, 4);

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
@@ -456,7 +456,7 @@ public class MlflowClientTest {
     List<Metric> multiSpecifiedMetricHistory = client.getMetricHistory(
       runId, "multi_log_specified_step_ts");
     assertMetricHistory(multiSpecifiedMetricHistory, "multi_log_specified_step_ts",
-      Arrays.asList(1.0, 2.0, -3.0, 4.0), Arrays.asList(-1000L, 2000L, 3000L, 2999L),
+      Arrays.asList(1.0, 2.0, -3.0, 4.0), Arrays.asList(1000L, 2000L, 3000L, 2999L),
       Arrays.asList(1L, -5L, 4L, 4L));
 
     List<RunTag> tags = run.getData().getTagsList();

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -36,6 +36,7 @@ from mlflow.store.tracking import (
 from mlflow.store.tracking.abstract_store import AbstractStore
 from mlflow.store.entities.paged_list import PagedList
 from mlflow.utils.validation import (
+    _validate_metric,
     _validate_metric_name,
     _validate_param_name,
     _validate_run_id,
@@ -815,7 +816,7 @@ class FileStore(AbstractStore):
 
     def log_metric(self, run_id, metric):
         _validate_run_id(run_id)
-        _validate_metric_name(metric.key)
+        _validate_metric(metric.key, metric.value, metric.timestamp, metric.step)
         run_info = self._get_run_info(run_id)
         check_run_is_active(run_info)
         self._log_run_metric(run_info, metric)

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -110,7 +110,7 @@ def _is_numeric(value):
 
 def _validate_metric(key, value, timestamp, step):
     """
-    Check that a param with the specified key, value, timestamp is valid and raise an exception if
+    Check that a metric with the specified key, value, timestamp is valid and raise an exception if
     it isn't.
     """
     _validate_metric_name(key)

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -110,8 +110,8 @@ def _is_numeric(value):
 
 def _validate_metric(key, value, timestamp, step):
     """
-    Check that a metric with the specified key, value, timestamp is valid and raise an exception if
-    it isn't.
+    Check that a metric with the specified key, value, timestamp, and step is valid and raise an
+    exception if it isn't.
     """
     _validate_metric_name(key)
     # value must be a Number

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -698,6 +698,12 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         assert metric_obj.timestamp == 50
         assert metric_obj.value == 20
 
+    def test_log_metric_with_non_numeric_value_raises_exception(self):
+        fs = FileStore(self.test_root)
+        run_id = self._create_run(fs).info.run_id
+        with pytest.raises(MlflowException, match=r"Got invalid value string for metric"):
+            fs.log_metric(run_id, Metric("test", "string", 0, 0))
+
     def test_get_all_metrics(self):
         fs = FileStore(self.test_root)
         for exp_id in self.experiments:


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

`FileStore.log_metric` should validate that a metric value is numeric, but it actually doesn't. For example, `python -c "import mlflow; mlflow.log_metric('a', 'b')"` doesn't throw an exception.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
