### PR TITLE
Fix filestore data loss on failed write & mitigate read / write race condition

### DIFF
--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -993,7 +993,8 @@ class FileStore(AbstractStore):
         """
         tmp_file_path = None
         try:
-            _, tmp_file_path = tempfile.mkstemp(suffix="file.yaml")
+            tmp_file_fd, tmp_file_path = tempfile.mkstemp(suffix="file.yaml")
+            os.close(tmp_file_fd)
             write_yaml(
                 root=get_parent_dir(tmp_file_path),
                 file_name=os.path.basename(tmp_file_path),

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -331,6 +331,26 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         with safe_edit_yaml(root_dir, "meta.yaml", self._experiment_id_edit_func):
             self._verify_experiment(fs, exp_id)
 
+    def test_get_experiment_retries_for_transient_empty_yaml_read(self):
+        fs = FileStore(self.test_root)
+        exp_name = random_str()
+        exp_id = fs.create_experiment(exp_name)
+
+        mock_empty_call_count = 0
+
+        def mock_read_yaml(*args, **kwargs):
+            nonlocal mock_empty_call_count
+            if mock_empty_call_count < 2:
+                mock_empty_call_count += 1
+                return None
+            else:
+                return read_yaml(*args, **kwargs)
+
+        with mock.patch("mlflow.store.tracking.file_store.read_yaml", mock_read_yaml):
+            fetched_experiment = fs.get_experiment(exp_id)
+            assert fetched_experiment.experiment_id == exp_id
+            assert fetched_experiment.name == exp_name
+
     def test_get_experiment_by_name(self):
         fs = FileStore(self.test_root)
         for exp_id in self.experiments:
@@ -642,6 +662,25 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
             runs = self.exp_data[exp_id]["runs"]
             for run_id in runs:
                 self._verify_run(fs, run_id)
+
+    def test_get_run_retries_for_transient_empty_yaml_read(self):
+        fs = FileStore(self.test_root)
+        run = self._create_run(fs)
+
+        mock_empty_call_count = 0
+
+        def mock_read_yaml(*args, **kwargs):
+            nonlocal mock_empty_call_count
+            if mock_empty_call_count < 2:
+                mock_empty_call_count += 1
+                return None
+            else:
+                return read_yaml(*args, **kwargs)
+
+        with mock.patch("mlflow.store.tracking.file_store.read_yaml", mock_read_yaml):
+            fetched_run = fs.get_run(run.info.run_id)
+            assert fetched_run.info.run_id == run.info.run_id
+            assert fetched_run.info.artifact_uri == run.info.artifact_uri
 
     def test_get_run_int_experiment_id_backcompat(self):
         fs = FileStore(self.test_root)

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -338,7 +338,7 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
 
         mock_empty_call_count = 0
 
-        def mock_read_yaml(*args, **kwargs):
+        def mock_read_yaml_impl(*args, **kwargs):
             nonlocal mock_empty_call_count
             if mock_empty_call_count < 2:
                 mock_empty_call_count += 1
@@ -346,10 +346,13 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
             else:
                 return read_yaml(*args, **kwargs)
 
-        with mock.patch("mlflow.store.tracking.file_store.read_yaml", mock_read_yaml):
+        with mock.patch(
+            "mlflow.store.tracking.file_store.read_yaml", side_effect=mock_read_yaml_impl
+        ) as mock_read_yaml:
             fetched_experiment = fs.get_experiment(exp_id)
             assert fetched_experiment.experiment_id == exp_id
             assert fetched_experiment.name == exp_name
+            assert mock_read_yaml.call_count == 3
 
     def test_get_experiment_by_name(self):
         fs = FileStore(self.test_root)
@@ -669,7 +672,7 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
 
         mock_empty_call_count = 0
 
-        def mock_read_yaml(*args, **kwargs):
+        def mock_read_yaml_impl(*args, **kwargs):
             nonlocal mock_empty_call_count
             if mock_empty_call_count < 2:
                 mock_empty_call_count += 1
@@ -677,10 +680,13 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
             else:
                 return read_yaml(*args, **kwargs)
 
-        with mock.patch("mlflow.store.tracking.file_store.read_yaml", mock_read_yaml):
+        with mock.patch(
+            "mlflow.store.tracking.file_store.read_yaml", side_effect=mock_read_yaml_impl
+        ) as mock_read_yaml:
             fetched_run = fs.get_run(run.info.run_id)
             assert fetched_run.info.run_id == run.info.run_id
             assert fetched_run.info.artifact_uri == run.info.artifact_uri
+            assert mock_read_yaml.call_count == 3
 
     def test_get_run_int_experiment_id_backcompat(self):
         fs = FileStore(self.test_root)


### PR DESCRIPTION
Signed-off-by: dbczumar <corey.zumar@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

Fixes #6339 

## What changes are proposed in this pull request?

Fix filestore data loss on failed write & mitigate read / write race condition by changing overwrites to a "move on write" strategy and adding retries with backoff for empty reads.

## How is this patch tested?

Unit tests

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

Fix a bug in FileStore that caused run and experiment metadata to be lost in the event of a failed metadata update.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
