### PR TITLE
Fix `!=` operator for MySQL

### DIFF
--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -110,7 +110,7 @@ class SearchUtils:
         # Use non-binary ahead of binary comparison for runtime performance
         # Use non-binary ahead of binary comparison for runtime performance
         def case_sensitive_mysql_eq(value):
-            return sa.text(f"{col} = :value AND BINARY {col} = :value").bindparams(
+            return sa.text(f"({col} = :value AND BINARY {col} = :value)").bindparams(
                 sa.bindparam("value", value=value, unique=True)
             )
 
@@ -120,7 +120,7 @@ class SearchUtils:
             )
 
         def case_sensitive_mysql_like(value):
-            return sa.text(f"{col} LIKE :value AND BINARY {col} LIKE :value").bindparams(
+            return sa.text(f"({col} LIKE :value AND BINARY {col} LIKE :value)").bindparams(
                 sa.bindparam("value", value=value, unique=True)
             )
 

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -115,7 +115,7 @@ class SearchUtils:
             )
 
         def case_sensitive_mysql_ne(value):
-            return sa.text(f"{col} != :value OR BINARY {col} != :value").bindparams(
+            return sa.text(f"({col} != :value OR BINARY {col} != :value)").bindparams(
                 sa.bindparam("value", value=value, unique=True)
             )
 

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -410,29 +410,31 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
 
     def test_search_experiments_filter_by_tag(self):
         experiments = [
-            ("exp1", [ExperimentTag("key", "value")]),
-            ("exp2", [ExperimentTag("key", "vaLue")]),
-            ("exp3", [ExperimentTag("k e y", "value")]),
+            ("exp1", [ExperimentTag("key1", "value"), ExperimentTag("key2", "value")]),
+            ("exp2", [ExperimentTag("key1", "vaLue"), ExperimentTag("key2", "vaLue")]),
+            ("exp3", [ExperimentTag("k e y 1", "value")]),
         ]
         for name, tags in experiments:
             self.store.create_experiment(name, tags=tags)
 
-        experiments = self.store.search_experiments(filter_string="tag.key = 'value'")
+        experiments = self.store.search_experiments(filter_string="tag.key1 = 'value'")
         assert [e.name for e in experiments] == ["exp1"]
-        experiments = self.store.search_experiments(filter_string="tag.`k e y` = 'value'")
+        experiments = self.store.search_experiments(filter_string="tag.`k e y 1` = 'value'")
         assert [e.name for e in experiments] == ["exp3"]
-        experiments = self.store.search_experiments(filter_string="tag.\"k e y\" = 'value'")
+        experiments = self.store.search_experiments(filter_string="tag.\"k e y 1\" = 'value'")
         assert [e.name for e in experiments] == ["exp3"]
-        experiments = self.store.search_experiments(filter_string="tag.key != 'value'")
+        experiments = self.store.search_experiments(filter_string="tag.key1 != 'value'")
         assert [e.name for e in experiments] == ["exp2"]
-        experiments = self.store.search_experiments(filter_string="tag.key LIKE 'val%'")
+        experiments = self.store.search_experiments(filter_string="tag.key1 != 'VALUE'")
+        assert [e.name for e in experiments] == ["exp2", "exp1"]
+        experiments = self.store.search_experiments(filter_string="tag.key1 LIKE 'val%'")
         assert [e.name for e in experiments] == ["exp1"]
-        experiments = self.store.search_experiments(filter_string="tag.key LIKE '%Lue'")
+        experiments = self.store.search_experiments(filter_string="tag.key1 LIKE '%Lue'")
         assert [e.name for e in experiments] == ["exp2"]
-        experiments = self.store.search_experiments(filter_string="tag.key ILIKE '%alu%'")
+        experiments = self.store.search_experiments(filter_string="tag.key1 ILIKE '%alu%'")
         assert [e.name for e in experiments] == ["exp2", "exp1"]
         experiments = self.store.search_experiments(
-            filter_string="tag.key LIKE 'va%' AND tags.key LIKE '%Lue'"
+            filter_string="tag.key1 LIKE 'va%' AND tag.key2 LIKE '%Lue'"
         )
         assert [e.name for e in experiments] == ["exp2"]
         experiments = self.store.search_experiments(filter_string="tag.KEY = 'value'")


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Fix the `!=` operator for MySQL.

### Comparison of SQL generated by `case_sensitive_mysql_ne`:

`filter_string="tag.key1 != 'value'"` generates a SQL like this:

Before

```
WHERE experiment_tags.key = %s AND BINARY experiment_tags.key = %s AND experiment_tags.value != %s OR BINARY experiment_tags.value != %s
```

After

```
WHERE experiment_tags.key = %s AND BINARY experiment_tags.key = %s AND (experiment_tags.value != %s OR BINARY experiment_tags.value != %s)
```

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [x] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
