### PR TITLE
Replace `unittest` assert methods (such as `assertEqual`) with a regular `assert`

### DIFF
--- a/tests/entities/model_registry/test_model_version.py
+++ b/tests/entities/model_registry/test_model_version.py
@@ -26,7 +26,7 @@ class TestModelVersion(unittest.TestCase):
         status_message,
         tags,
     ):
-        self.assertIsInstance(model_version, ModelVersion)
+        assert isinstance(model_version, ModelVersion)
         self.assertEqual(model_version.name, name)
         self.assertEqual(model_version.version, version)
         self.assertEqual(model_version.creation_timestamp, creation_timestamp)

--- a/tests/entities/model_registry/test_model_version.py
+++ b/tests/entities/model_registry/test_model_version.py
@@ -27,18 +27,18 @@ class TestModelVersion(unittest.TestCase):
         tags,
     ):
         assert isinstance(model_version, ModelVersion)
-        self.assertEqual(model_version.name, name)
-        self.assertEqual(model_version.version, version)
-        self.assertEqual(model_version.creation_timestamp, creation_timestamp)
-        self.assertEqual(model_version.last_updated_timestamp, last_updated_timestamp)
-        self.assertEqual(model_version.description, description)
-        self.assertEqual(model_version.user_id, user_id)
-        self.assertEqual(model_version.current_stage, current_stage)
-        self.assertEqual(model_version.source, source)
-        self.assertEqual(model_version.run_id, run_id)
-        self.assertEqual(model_version.status, status)
-        self.assertEqual(model_version.status_message, status_message)
-        self.assertEqual(model_version.tags, tags)
+        assert model_version.name == name
+        assert model_version.version == version
+        assert model_version.creation_timestamp == creation_timestamp
+        assert model_version.last_updated_timestamp == last_updated_timestamp
+        assert model_version.description == description
+        assert model_version.user_id == user_id
+        assert model_version.current_stage == current_stage
+        assert model_version.source == source
+        assert model_version.run_id == run_id
+        assert model_version.status == status
+        assert model_version.status_message == status_message
+        assert model_version.tags == tags
 
     def test_creation_and_hydration(self):
         name = random_str()
@@ -94,17 +94,15 @@ class TestModelVersion(unittest.TestCase):
             "tags": {tag.key: tag.value for tag in (tags or [])},
         }
         model_version_as_dict = dict(mvd)
-        self.assertEqual(model_version_as_dict, expected_dict)
+        assert model_version_as_dict == expected_dict
 
         proto = mvd.to_proto()
-        self.assertEqual(proto.name, name)
-        self.assertEqual(proto.version, "5")
-        self.assertEqual(proto.status, ModelVersionStatus.from_string("READY"))
-        self.assertEqual(proto.status_message, "Model version #5 is ready to use.")
-        self.assertEqual(set([tag.key for tag in proto.tags]), set(["key", "randomKey"]))
-        self.assertEqual(
-            set([tag.value for tag in proto.tags]), set(["value", "not a random value"])
-        )
+        assert proto.name == name
+        assert proto.version == "5"
+        assert proto.status == ModelVersionStatus.from_string("READY")
+        assert proto.status_message == "Model version #5 is ready to use."
+        assert set([tag.key for tag in proto.tags]) == set(["key", "randomKey"])
+        assert set([tag.value for tag in proto.tags]) == set(["value", "not a random value"])
         mvd_2 = ModelVersion.from_proto(proto)
         self._check(
             mvd_2,

--- a/tests/entities/model_registry/test_registered_model.py
+++ b/tests/entities/model_registry/test_registered_model.py
@@ -18,13 +18,13 @@ class TestRegisteredModel(unittest.TestCase):
         tags,
     ):
         assert isinstance(registered_model, RegisteredModel)
-        self.assertEqual(registered_model.name, name)
-        self.assertEqual(registered_model.creation_timestamp, creation_timestamp)
-        self.assertEqual(registered_model.last_updated_timestamp, last_updated_timestamp)
-        self.assertEqual(registered_model.description, description)
-        self.assertEqual(registered_model.last_updated_timestamp, last_updated_timestamp)
-        self.assertEqual(registered_model.latest_versions, latest_versions)
-        self.assertEqual(registered_model.tags, tags)
+        assert registered_model.name == name
+        assert registered_model.creation_timestamp == creation_timestamp
+        assert registered_model.last_updated_timestamp == last_updated_timestamp
+        assert registered_model.description == description
+        assert registered_model.last_updated_timestamp == last_updated_timestamp
+        assert registered_model.latest_versions == latest_versions
+        assert registered_model.tags == tags
 
     def test_creation_and_hydration(self):
         name = random_str()
@@ -40,13 +40,13 @@ class TestRegisteredModel(unittest.TestCase):
             "latest_versions": [],
             "tags": {},
         }
-        self.assertEqual(dict(rmd_1), as_dict)
+        assert dict(rmd_1) == as_dict
 
         proto = rmd_1.to_proto()
-        self.assertEqual(proto.name, name)
-        self.assertEqual(proto.creation_timestamp, 1)
-        self.assertEqual(proto.last_updated_timestamp, 2)
-        self.assertEqual(proto.description, description)
+        assert proto.name == name
+        assert proto.creation_timestamp == 1
+        assert proto.last_updated_timestamp == 2
+        assert proto.description == description
         rmd_2 = RegisteredModel.from_proto(proto)
         self._check(rmd_2, name, 1, 2, description, [], {})
         as_dict["tags"] = []
@@ -91,23 +91,21 @@ class TestRegisteredModel(unittest.TestCase):
         }
         rmd_1 = RegisteredModel.from_dictionary(as_dict)
         as_dict["tags"] = {}
-        self.assertEqual(dict(rmd_1), as_dict)
+        assert dict(rmd_1) == as_dict
 
         proto = rmd_1.to_proto()
-        self.assertEqual(proto.creation_timestamp, 1)
-        self.assertEqual(proto.last_updated_timestamp, 4000)
-        self.assertEqual(set([mvd.version for mvd in proto.latest_versions]), set(["1", "4"]))
-        self.assertEqual(set([mvd.name for mvd in proto.latest_versions]), set([name]))
-        self.assertEqual(
-            set([mvd.current_stage for mvd in proto.latest_versions]),
-            set(["Production", "Staging"]),
+        assert proto.creation_timestamp == 1
+        assert proto.last_updated_timestamp == 4000
+        assert set([mvd.version for mvd in proto.latest_versions]) == set(["1", "4"])
+        assert set([mvd.name for mvd in proto.latest_versions]) == set([name])
+        assert (
+            set([mvd.current_stage for mvd in proto.latest_versions])
+            == set(["Production", "Staging"]),
         )
-        self.assertEqual(
-            set([mvd.last_updated_timestamp for mvd in proto.latest_versions]), set([2000, 2002])
+        assert set([mvd.last_updated_timestamp for mvd in proto.latest_versions]) == set(
+            [2000, 2002]
         )
-        self.assertEqual(
-            set([mvd.creation_timestamp for mvd in proto.latest_versions]), set([1300, 1000])
-        )
+        assert set([mvd.creation_timestamp for mvd in proto.latest_versions]) == set([1300, 1000])
 
     def test_with_tags(self):
         name = random_str()
@@ -124,14 +122,12 @@ class TestRegisteredModel(unittest.TestCase):
         }
         rmd_1 = RegisteredModel.from_dictionary(as_dict)
         as_dict["tags"] = {tag.key: tag.value for tag in (tags or [])}
-        self.assertEqual(dict(rmd_1), as_dict)
+        assert dict(rmd_1) == as_dict
         proto = rmd_1.to_proto()
-        self.assertEqual(proto.creation_timestamp, 1)
-        self.assertEqual(proto.last_updated_timestamp, 4000)
-        self.assertEqual(set([tag.key for tag in proto.tags]), set(["key", "randomKey"]))
-        self.assertEqual(
-            set([tag.value for tag in proto.tags]), set(["value", "not a random value"])
-        )
+        assert proto.creation_timestamp == 1
+        assert proto.last_updated_timestamp == 4000
+        assert set([tag.key for tag in proto.tags]) == set(["key", "randomKey"])
+        assert set([tag.value for tag in proto.tags]) == set(["value", "not a random value"])
 
     def test_string_repr(self):
         rmd = RegisteredModel(

--- a/tests/entities/model_registry/test_registered_model.py
+++ b/tests/entities/model_registry/test_registered_model.py
@@ -17,7 +17,7 @@ class TestRegisteredModel(unittest.TestCase):
         latest_versions,
         tags,
     ):
-        self.assertIsInstance(registered_model, RegisteredModel)
+        assert isinstance(registered_model, RegisteredModel)
         self.assertEqual(registered_model.name, name)
         self.assertEqual(registered_model.creation_timestamp, creation_timestamp)
         self.assertEqual(registered_model.last_updated_timestamp, last_updated_timestamp)

--- a/tests/entities/test_experiment.py
+++ b/tests/entities/test_experiment.py
@@ -6,11 +6,11 @@ from tests.helper_functions import random_int, random_file
 
 class TestExperiment(unittest.TestCase):
     def _check(self, exp, exp_id, name, location, lifecyle_stage):
-        self.assertIsInstance(exp, Experiment)
-        self.assertEqual(exp.experiment_id, exp_id)
-        self.assertEqual(exp.name, name)
-        self.assertEqual(exp.artifact_location, location)
-        self.assertEqual(exp.lifecycle_stage, lifecyle_stage)
+        assert isinstance(exp, Experiment)
+        assert exp.experiment_id == exp_id
+        assert exp.name == name
+        assert exp.artifact_location == location
+        assert exp.lifecycle_stage == lifecyle_stage
 
     def test_creation_and_hydration(self):
         exp_id = str(random_int())
@@ -28,7 +28,7 @@ class TestExperiment(unittest.TestCase):
             "lifecycle_stage": lifecycle_stage,
             "tags": {},
         }
-        self.assertEqual(dict(exp), as_dict)
+        assert dict(exp) == as_dict
 
         proto = exp.to_proto()
         exp2 = Experiment.from_proto(proto)

--- a/tests/entities/test_file_info.py
+++ b/tests/entities/test_file_info.py
@@ -6,10 +6,10 @@ from tests.helper_functions import random_str, random_int
 
 class TestFileInfo(unittest.TestCase):
     def _check(self, fi, path, is_dir, size_in_bytes):
-        self.assertIsInstance(fi, FileInfo)
-        self.assertEqual(fi.path, path)
-        self.assertEqual(fi.is_dir, is_dir)
-        self.assertEqual(fi.file_size, size_in_bytes)
+        assert isinstance(fi, FileInfo)
+        assert fi.path == path
+        assert fi.is_dir == is_dir
+        assert fi.file_size == size_in_bytes
 
     def test_creation_and_hydration(self):
         path = random_str(random_int(10, 50))
@@ -19,7 +19,7 @@ class TestFileInfo(unittest.TestCase):
         self._check(fi1, path, is_dir, size_in_bytes)
 
         as_dict = {"path": path, "is_dir": is_dir, "file_size": size_in_bytes}
-        self.assertEqual(dict(fi1), as_dict)
+        assert dict(fi1) == as_dict
 
         proto = fi1.to_proto()
         fi2 = FileInfo.from_proto(proto)

--- a/tests/entities/test_param.py
+++ b/tests/entities/test_param.py
@@ -6,9 +6,9 @@ from tests.helper_functions import random_str, random_int
 
 class TestParam(unittest.TestCase):
     def _check(self, param, key, value):
-        self.assertIsInstance(param, Param)
-        self.assertEqual(param.key, key)
-        self.assertEqual(param.value, value)
+        assert isinstance(param, Param)
+        assert param.key == key
+        assert param.value == value
 
     def test_creation_and_hydration(self):
         key = random_str(random_int(10, 25))  # random string on size in range [10, 25]
@@ -18,7 +18,7 @@ class TestParam(unittest.TestCase):
         self._check(param, key, value)
 
         as_dict = {"key": key, "value": value}
-        self.assertEqual(dict(param), as_dict)
+        assert dict(param) == as_dict
 
         proto = param.to_proto()
         param2 = Param.from_proto(proto)

--- a/tests/entities/test_run.py
+++ b/tests/entities/test_run.py
@@ -51,9 +51,9 @@ class TestRun(TestRunInfo, TestRunData):
             "lifecycle_stage": lifecycle_stage,
             "artifact_uri": artifact_uri,
         }
-        self.assertEqual(
-            run1.to_dictionary(),
-            {
+        assert (
+            run1.to_dictionary()
+            == {
                 "info": expected_info_dict,
                 "data": {
                     "metrics": {m.key: m.value for m in metrics},
@@ -68,7 +68,7 @@ class TestRun(TestRunInfo, TestRunData):
         self._check_run(run2, run_info, metrics, params, tags)
 
         run3 = Run(run_info, None)
-        self.assertEqual(run3.to_dictionary(), {"info": expected_info_dict})
+        assert run3.to_dictionary() == {"info": expected_info_dict}
 
     def test_string_repr(self):
         run_info = RunInfo(

--- a/tests/entities/test_run_data.py
+++ b/tests/entities/test_run_data.py
@@ -23,7 +23,7 @@ class TestRunData(unittest.TestCase):
         assert tags_dict == {t.key: t.value for t in expected_tags}
 
     def _check(self, rd, metrics, params, tags):
-        self.assertIsInstance(rd, RunData)
+        assert isinstance(rd, RunData)
         self._check_metrics(rd._metric_objs, rd.metrics, metrics)
         self._check_params(rd.params, params)
         self._check_tags(rd.tags, tags)

--- a/tests/entities/test_run_data.py
+++ b/tests/entities/test_run_data.py
@@ -7,24 +7,20 @@ from tests.helper_functions import random_str, random_int
 
 class TestRunData(unittest.TestCase):
     def _check_metrics(self, metric_objs, metrics_dict, expected_metrics):
-        self.assertEqual(set([m.key for m in metric_objs]), set([m.key for m in expected_metrics]))
-        self.assertEqual(
-            set([m.value for m in metric_objs]), set([m.value for m in expected_metrics])
+        assert set([m.key for m in metric_objs]) == set([m.key for m in expected_metrics])
+        assert set([m.value for m in metric_objs]) == set([m.value for m in expected_metrics])
+        assert set([m.timestamp for m in metric_objs]) == set(
+            [m.timestamp for m in expected_metrics]
         )
-        self.assertEqual(
-            set([m.timestamp for m in metric_objs]), set([m.timestamp for m in expected_metrics])
-        )
-        self.assertEqual(
-            set([m.step for m in metric_objs]), set([m.step for m in expected_metrics])
-        )
+        assert set([m.step for m in metric_objs]) == set([m.step for m in expected_metrics])
         assert len(metrics_dict) == len(expected_metrics)
         assert metrics_dict == {m.key: m.value for m in expected_metrics}
 
     def _check_params(self, params_dict, expected_params):
-        self.assertEqual(params_dict, {p.key: p.value for p in expected_params})
+        assert params_dict == {p.key: p.value for p in expected_params}
 
     def _check_tags(self, tags_dict, expected_tags):
-        self.assertEqual(tags_dict, {t.key: t.value for t in expected_tags})
+        assert tags_dict == {t.key: t.value for t in expected_tags}
 
     def _check(self, rd, metrics, params, tags):
         self.assertIsInstance(rd, RunData)
@@ -56,7 +52,7 @@ class TestRunData(unittest.TestCase):
             "params": {p.key: p.value for p in params},
             "tags": {t.key: t.value for t in tags},
         }
-        self.assertEqual(dict(rd1), as_dict)
+        assert dict(rd1) == as_dict
         proto = rd1.to_proto()
         rd2 = RunData.from_proto(proto)
         self._check(rd2, metrics, params, tags)

--- a/tests/entities/test_run_info.py
+++ b/tests/entities/test_run_info.py
@@ -20,15 +20,15 @@ class TestRunInfo(unittest.TestCase):
         artifact_uri,
     ):
         assert isinstance(ri, RunInfo)
-        self.assertEqual(ri.run_uuid, run_id)
-        self.assertEqual(ri.run_id, run_id)
-        self.assertEqual(ri.experiment_id, experiment_id)
-        self.assertEqual(ri.user_id, user_id)
-        self.assertEqual(ri.status, status)
-        self.assertEqual(ri.start_time, start_time)
-        self.assertEqual(ri.end_time, end_time)
-        self.assertEqual(ri.lifecycle_stage, lifecycle_stage)
-        self.assertEqual(ri.artifact_uri, artifact_uri)
+        assert ri.run_uuid == run_id
+        assert ri.run_id == run_id
+        assert ri.experiment_id == experiment_id
+        assert ri.user_id == user_id
+        assert ri.status == status
+        assert ri.start_time == start_time
+        assert ri.end_time == end_time
+        assert ri.lifecycle_stage == lifecycle_stage
+        assert ri.artifact_uri == artifact_uri
 
     @staticmethod
     def _create():
@@ -97,7 +97,7 @@ class TestRunInfo(unittest.TestCase):
             "lifecycle_stage": lifecycle_stage,
             "artifact_uri": artifact_uri,
         }
-        self.assertEqual(dict(ri1), as_dict)
+        assert dict(ri1) == as_dict
 
         proto = ri1.to_proto()
         ri2 = RunInfo.from_proto(proto)
@@ -141,6 +141,6 @@ class TestRunInfo(unittest.TestCase):
         )
 
     def test_searchable_attributes(self):
-        self.assertSequenceEqual(
-            set(["status", "artifact_uri", "start_time"]), set(RunInfo.get_searchable_attributes())
+        assert set(["status", "artifact_uri", "start_time"]) == set(
+            RunInfo.get_searchable_attributes()
         )

--- a/tests/entities/test_run_info.py
+++ b/tests/entities/test_run_info.py
@@ -19,7 +19,7 @@ class TestRunInfo(unittest.TestCase):
         lifecycle_stage,
         artifact_uri,
     ):
-        self.assertIsInstance(ri, RunInfo)
+        assert isinstance(ri, RunInfo)
         self.assertEqual(ri.run_uuid, run_id)
         self.assertEqual(ri.run_id, run_id)
         self.assertEqual(ri.experiment_id, experiment_id)

--- a/tests/entities/test_run_status.py
+++ b/tests/entities/test_run_status.py
@@ -15,24 +15,24 @@ class TestRunStatus(unittest.TestCase):
                 RunStatus.KILLED,
             ]
         )
-        self.assertSequenceEqual(all_statuses, set(RunStatus.all_status()))
+        assert all_statuses == set(RunStatus.all_status())
 
     def test_status_mappings(self):
         # test enum to string mappings
-        self.assertEqual("RUNNING", RunStatus.to_string(RunStatus.RUNNING))
-        self.assertEqual(RunStatus.RUNNING, RunStatus.from_string("RUNNING"))
+        assert "RUNNING" == RunStatus.to_string(RunStatus.RUNNING)
+        assert RunStatus.RUNNING == RunStatus.from_string("RUNNING")
 
-        self.assertEqual("SCHEDULED", RunStatus.to_string(RunStatus.SCHEDULED))
-        self.assertEqual(RunStatus.SCHEDULED, RunStatus.from_string("SCHEDULED"))
+        assert "SCHEDULED" == RunStatus.to_string(RunStatus.SCHEDULED)
+        assert RunStatus.SCHEDULED == RunStatus.from_string("SCHEDULED")
 
-        self.assertEqual("FINISHED", RunStatus.to_string(RunStatus.FINISHED))
-        self.assertEqual(RunStatus.FINISHED, RunStatus.from_string("FINISHED"))
+        assert "FINISHED" == RunStatus.to_string(RunStatus.FINISHED)
+        assert RunStatus.FINISHED == RunStatus.from_string("FINISHED")
 
-        self.assertEqual("FAILED", RunStatus.to_string(RunStatus.FAILED))
-        self.assertEqual(RunStatus.FAILED, RunStatus.from_string("FAILED"))
+        assert "FAILED" == RunStatus.to_string(RunStatus.FAILED)
+        assert RunStatus.FAILED == RunStatus.from_string("FAILED")
 
-        self.assertEqual("KILLED", RunStatus.to_string(RunStatus.KILLED))
-        self.assertEqual(RunStatus.KILLED, RunStatus.from_string("KILLED"))
+        assert "KILLED" == RunStatus.to_string(RunStatus.KILLED)
+        assert RunStatus.KILLED == RunStatus.from_string("KILLED")
 
         with self.assertRaisesRegex(
             Exception, r"Could not get string corresponding to run status -120"
@@ -45,8 +45,8 @@ class TestRunStatus(unittest.TestCase):
             RunStatus.from_string("the IMPOSSIBLE status string")
 
     def test_is_terminated(self):
-        self.assertTrue(RunStatus.is_terminated(RunStatus.FAILED))
-        self.assertTrue(RunStatus.is_terminated(RunStatus.FINISHED))
-        self.assertTrue(RunStatus.is_terminated(RunStatus.KILLED))
-        self.assertFalse(RunStatus.is_terminated(RunStatus.SCHEDULED))
-        self.assertFalse(RunStatus.is_terminated(RunStatus.RUNNING))
+        assert RunStatus.is_terminated(RunStatus.FAILED)
+        assert RunStatus.is_terminated(RunStatus.FINISHED)
+        assert RunStatus.is_terminated(RunStatus.KILLED)
+        assert not RunStatus.is_terminated(RunStatus.SCHEDULED)
+        assert not RunStatus.is_terminated(RunStatus.RUNNING)

--- a/tests/store/db/test_utils.py
+++ b/tests/store/db/test_utils.py
@@ -50,7 +50,7 @@ class TestCreateSqlAlchemyEngineWithRetry(TestCase):
                         mock_create_sqlalchemy_engine.assert_called_once_with("mydb://host:port/")
                         mock_sqlalchemy_inspect.assert_called_once()
                         mock_sleep.assert_not_called()
-                        self.assertEqual(engine, "Engine")
+                        assert engine == "Engine"
 
     def test_create_sqlalchemy_engine_with_retry_success_after_third_call(self):
         with mock.patch.dict(os.environ, {}):
@@ -66,7 +66,7 @@ class TestCreateSqlAlchemyEngineWithRetry(TestCase):
                             mock_create_sqlalchemy_engine.mock_calls
                             == [mock.call("mydb://host:port/")] * 3
                         )
-                        self.assertEqual(engine, "Engine")
+                        assert engine == "Engine"
 
     def test_create_sqlalchemy_engine_with_retry_fail(self):
         with mock.patch.dict(os.environ, {}), mock.patch(

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -1137,8 +1137,8 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         ) as exception_context:
             self._search_registered_models(query, page_token="evilhax", max_results=1e15)
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
-        self.assertIn(
-            "Invalid value for request parameter max_results", exception_context.exception.message
+        assert (
+            "Invalid value for request parameter max_results" in exception_context.exception.message
         )
 
     def test_search_registered_model_order_by(self):

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -65,8 +65,8 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
     def test_create_registered_model(self):
         name = random_str() + "abCD"
         rm1 = self._rm_maker(name)
-        self.assertEqual(rm1.name, name)
-        self.assertEqual(rm1.description, None)
+        assert rm1.name == name
+        assert rm1.description == None
 
         # error on duplicate
         with self.assertRaisesRegex(
@@ -78,7 +78,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         # slightly different name is ok
         for name2 in [name + "extra", name.lower(), name.upper(), name + name]:
             rm2 = self._rm_maker(name2)
-            self.assertEqual(rm2.name, name2)
+            assert rm2.name == name2
 
         # test create model with tags
         name2 = random_str() + "tags"
@@ -88,20 +88,20 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         ]
         rm2 = self._rm_maker(name2, tags)
         rmd2 = self.store.get_registered_model(name2)
-        self.assertEqual(rm2.name, name2)
-        self.assertEqual(rm2.tags, {tag.key: tag.value for tag in tags})
-        self.assertEqual(rmd2.name, name2)
-        self.assertEqual(rmd2.tags, {tag.key: tag.value for tag in tags})
+        assert rm2.name == name2
+        assert rm2.tags == {tag.key: tag.value for tag in tags}
+        assert rmd2.name == name2
+        assert rmd2.tags == {tag.key: tag.value for tag in tags}
 
         # create with description
         name3 = random_str() + "-description"
         description = "the best model ever"
         rm3 = self._rm_maker(name3, description=description)
         rmd3 = self.store.get_registered_model(name3)
-        self.assertEqual(rm3.name, name3)
-        self.assertEqual(rm3.description, description)
-        self.assertEqual(rmd3.name, name3)
-        self.assertEqual(rmd3.description, description)
+        assert rm3.name == name3
+        assert rm3.description == description
+        assert rmd3.name == name3
+        assert rmd3.description == description
 
         # invalid model name will fail
         with self.assertRaisesRegex(
@@ -125,28 +125,28 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         with mock.patch("time.time") as mock_time:
             mock_time.return_value = 1234
             rm = self._rm_maker(name, tags)
-            self.assertEqual(rm.name, name)
+            assert rm.name == name
         rmd = self.store.get_registered_model(name=name)
-        self.assertEqual(rmd.name, name)
-        self.assertEqual(rmd.creation_timestamp, 1234000)
-        self.assertEqual(rmd.last_updated_timestamp, 1234000)
-        self.assertEqual(rmd.description, None)
-        self.assertEqual(rmd.latest_versions, [])
-        self.assertEqual(rmd.tags, {tag.key: tag.value for tag in tags})
+        assert rmd.name == name
+        assert rmd.creation_timestamp == 1234000
+        assert rmd.last_updated_timestamp == 1234000
+        assert rmd.description == None
+        assert rmd.latest_versions == []
+        assert rmd.tags == {tag.key: tag.value for tag in tags}
 
     def test_update_registered_model(self):
         name = "model_for_update_RM"
         rm1 = self._rm_maker(name)
         rmd1 = self.store.get_registered_model(name=name)
-        self.assertEqual(rm1.name, name)
-        self.assertEqual(rmd1.description, None)
+        assert rm1.name == name
+        assert rmd1.description == None
 
         # update description
         rm2 = self.store.update_registered_model(name=name, description="test model")
         rmd2 = self.store.get_registered_model(name=name)
-        self.assertEqual(rm2.name, "model_for_update_RM")
-        self.assertEqual(rmd2.name, "model_for_update_RM")
-        self.assertEqual(rmd2.description, "test model")
+        assert rm2.name == "model_for_update_RM"
+        assert rmd2.name == "model_for_update_RM"
+        assert rmd2.description == "test model"
 
     def test_rename_registered_model(self):
         original_name = "original name"
@@ -157,18 +157,18 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         rm = self.store.get_registered_model(original_name)
         mv1 = self.store.get_model_version(original_name, 1)
         mv2 = self.store.get_model_version(original_name, 2)
-        self.assertEqual(rm.name, original_name)
-        self.assertEqual(mv1.name, original_name)
-        self.assertEqual(mv2.name, original_name)
+        assert rm.name == original_name
+        assert mv1.name == original_name
+        assert mv2.name == original_name
 
         # test renaming registered model also updates its model versions
         self.store.rename_registered_model(original_name, new_name)
         rm = self.store.get_registered_model(new_name)
         mv1 = self.store.get_model_version(new_name, 1)
         mv2 = self.store.get_model_version(new_name, 2)
-        self.assertEqual(rm.name, new_name)
-        self.assertEqual(mv1.name, new_name)
-        self.assertEqual(mv2.name, new_name)
+        assert rm.name == new_name
+        assert mv1.name == new_name
+        assert mv2.name == new_name
 
         # test accessing the model with the old name will fail
         with self.assertRaisesRegex(
@@ -203,8 +203,8 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self._mv_maker(name)
         rm1 = self.store.get_registered_model(name=name)
         mv1 = self.store.get_model_version(name, 1)
-        self.assertEqual(rm1.name, name)
-        self.assertEqual(mv1.name, name)
+        assert rm1.name == name
+        assert mv1.name == name
 
         # delete model
         self.store.delete_registered_model(name=name)
@@ -246,25 +246,23 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
     def test_list_registered_model(self):
         self._rm_maker("A")
         registered_models = self.store.list_registered_models(max_results=10, page_token=None)
-        self.assertEqual(len(registered_models), 1)
-        self.assertEqual(registered_models[0].name, "A")
+        assert len(registered_models) == 1
+        assert registered_models[0].name == "A"
         assert isinstance(registered_models[0], RegisteredModel)
 
         self._rm_maker("B")
-        self.assertEqual(set(self._list_registered_models()), set(["A", "B"]))
+        assert set(self._list_registered_models()) == set(["A", "B"])
 
         self._rm_maker("BB")
         self._rm_maker("BA")
         self._rm_maker("AB")
         self._rm_maker("BBC")
-        self.assertEqual(
-            set(self._list_registered_models()), set(["A", "B", "BB", "BA", "AB", "BBC"])
-        )
+        assert set(self._list_registered_models()) == set(["A", "B", "BB", "BA", "AB", "BBC"])
 
         # list should not return deleted models
         self.store.delete_registered_model(name="BA")
         self.store.delete_registered_model(name="B")
-        self.assertEqual(set(self._list_registered_models()), set(["A", "BB", "AB", "BBC"]))
+        assert set(self._list_registered_models()) == set(["A", "BB", "AB", "BBC"])
 
     def test_list_registered_model_paginated_last_page(self):
         rms = [self._rm_maker("RM{:03}".format(i)).name for i in range(50)]
@@ -275,10 +273,10 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         returned_rms.extend(result)
         while result.token:
             result = self._list_registered_models(page_token=result.token, max_results=25)
-            self.assertEqual(len(result), 25)
+            assert len(result) == 25
             returned_rms.extend(result)
-        self.assertEqual(result.token, None)
-        self.assertEqual(set(rms), set(returned_rms))
+        assert result.token == None
+        assert set(rms) == set(returned_rms)
 
     def test_list_registered_model_paginated_returns_in_correct_order(self):
         rms = [self._rm_maker("RM{:03}".format(i)).name for i in range(50)]
@@ -286,21 +284,21 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         # test that pagination will return all valid results in sorted order
         # by name ascending
         result = self._list_registered_models(max_results=5)
-        self.assertNotEqual(result.token, None)
-        self.assertEqual(result, rms[0:5])
+        assert result.token != None
+        assert result == rms[0:5]
 
         result = self._list_registered_models(page_token=result.token, max_results=10)
-        self.assertNotEqual(result.token, None)
-        self.assertEqual(result, rms[5:15])
+        assert result.token != None
+        assert result == rms[5:15]
 
         result = self._list_registered_models(page_token=result.token, max_results=20)
-        self.assertNotEqual(result.token, None)
-        self.assertEqual(result, rms[15:35])
+        assert result.token != None
+        assert result == rms[15:35]
 
         result = self._list_registered_models(page_token=result.token, max_results=100)
         # assert that page token is None
-        self.assertEqual(result.token, None)
-        self.assertEqual(result, rms[35:])
+        assert result.token == None
+        assert result == rms[35:]
 
     def test_list_registered_model_paginated_errors(self):
         rms = [self._rm_maker("RM{:03}".format(i)).name for i in range(50)]
@@ -319,93 +317,81 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
         # list should not return deleted models
         self.store.delete_registered_model(name="RM{0:03}".format(0))
-        self.assertEqual(set(self._list_registered_models(max_results=100)), set(rms[1:]))
+        assert set(self._list_registered_models(max_results=100)) == set(rms[1:])
 
     def test_get_latest_versions(self):
         name = "test_for_latest_versions"
         self._rm_maker(name)
         rmd1 = self.store.get_registered_model(name=name)
-        self.assertEqual(rmd1.latest_versions, [])
+        assert rmd1.latest_versions == []
 
         mv1 = self._mv_maker(name)
-        self.assertEqual(mv1.version, 1)
+        assert mv1.version == 1
         rmd2 = self.store.get_registered_model(name=name)
-        self.assertEqual(self._extract_latest_by_stage(rmd2.latest_versions), {"None": 1})
+        assert self._extract_latest_by_stage(rmd2.latest_versions) == {"None": 1}
 
         # add a bunch more
         mv2 = self._mv_maker(name)
-        self.assertEqual(mv2.version, 2)
+        assert mv2.version == 2
         self.store.transition_model_version_stage(
             name=mv2.name, version=mv2.version, stage="Production", archive_existing_versions=False
         )
 
         mv3 = self._mv_maker(name)
-        self.assertEqual(mv3.version, 3)
+        assert mv3.version == 3
         self.store.transition_model_version_stage(
             name=mv3.name, version=mv3.version, stage="Production", archive_existing_versions=False
         )
         mv4 = self._mv_maker(name)
-        self.assertEqual(mv4.version, 4)
+        assert mv4.version == 4
         self.store.transition_model_version_stage(
             name=mv4.name, version=mv4.version, stage="Staging", archive_existing_versions=False
         )
 
         # test that correct latest versions are returned for each stage
         rmd4 = self.store.get_registered_model(name=name)
-        self.assertEqual(
-            self._extract_latest_by_stage(rmd4.latest_versions),
-            {"None": 1, "Production": 3, "Staging": 4},
-        )
-        self.assertEqual(
-            self._extract_latest_by_stage(self.store.get_latest_versions(name=name, stages=None)),
-            {"None": 1, "Production": 3, "Staging": 4},
-        )
-        self.assertEqual(
-            self._extract_latest_by_stage(self.store.get_latest_versions(name=name, stages=[])),
-            {"None": 1, "Production": 3, "Staging": 4},
-        )
-        self.assertEqual(
-            self._extract_latest_by_stage(
-                self.store.get_latest_versions(name=name, stages=["Production"])
-            ),
-            {"Production": 3},
-        )
-        self.assertEqual(
-            self._extract_latest_by_stage(
-                self.store.get_latest_versions(name=name, stages=["production"])
-            ),
-            {"Production": 3},
-        )  # The stages are case insensitive.
-        self.assertEqual(
-            self._extract_latest_by_stage(
-                self.store.get_latest_versions(name=name, stages=["pROduction"])
-            ),
-            {"Production": 3},
-        )  # The stages are case insensitive.
-        self.assertEqual(
-            self._extract_latest_by_stage(
-                self.store.get_latest_versions(name=name, stages=["None", "Production"])
-            ),
-            {"None": 1, "Production": 3},
-        )
+        assert self._extract_latest_by_stage(rmd4.latest_versions) == {
+            "None": 1,
+            "Production": 3,
+            "Staging": 4,
+        }
+        assert self._extract_latest_by_stage(
+            self.store.get_latest_versions(name=name, stages=None)
+        ) == {"None": 1, "Production": 3, "Staging": 4}
+        assert self._extract_latest_by_stage(
+            self.store.get_latest_versions(name=name, stages=[])
+        ) == {"None": 1, "Production": 3, "Staging": 4}
+        assert self._extract_latest_by_stage(
+            self.store.get_latest_versions(name=name, stages=["Production"])
+        ) == {"Production": 3}
+        assert self._extract_latest_by_stage(
+            self.store.get_latest_versions(name=name, stages=["production"])
+        ) == {
+            "Production": 3
+        }  # The stages are case insensitive.
+        assert self._extract_latest_by_stage(
+            self.store.get_latest_versions(name=name, stages=["pROduction"])
+        ) == {
+            "Production": 3
+        }  # The stages are case insensitive.
+        assert self._extract_latest_by_stage(
+            self.store.get_latest_versions(name=name, stages=["None", "Production"])
+        ) == {"None": 1, "Production": 3}
 
         # delete latest Production, and should point to previous one
         self.store.delete_model_version(name=mv3.name, version=mv3.version)
         rmd5 = self.store.get_registered_model(name=name)
-        self.assertEqual(
-            self._extract_latest_by_stage(rmd5.latest_versions),
-            {"None": 1, "Production": 2, "Staging": 4},
-        )
-        self.assertEqual(
-            self._extract_latest_by_stage(self.store.get_latest_versions(name=name, stages=None)),
-            {"None": 1, "Production": 2, "Staging": 4},
-        )
-        self.assertEqual(
-            self._extract_latest_by_stage(
-                self.store.get_latest_versions(name=name, stages=["Production"])
-            ),
-            {"Production": 2},
-        )
+        assert self._extract_latest_by_stage(rmd5.latest_versions) == {
+            "None": 1,
+            "Production": 2,
+            "Staging": 4,
+        }
+        assert self._extract_latest_by_stage(
+            self.store.get_latest_versions(name=name, stages=None)
+        ) == {"None": 1, "Production": 2, "Staging": 4}
+        assert self._extract_latest_by_stage(
+            self.store.get_latest_versions(name=name, stages=["Production"])
+        ) == {"Production": 2}
 
     def test_set_registered_model_tag(self):
         name1 = "SetRegisteredModelTag_TestMod"
@@ -420,17 +406,17 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self.store.set_registered_model_tag(name1, new_tag)
         rm1 = self.store.get_registered_model(name=name1)
         all_tags = initial_tags + [new_tag]
-        self.assertEqual(rm1.tags, {tag.key: tag.value for tag in all_tags})
+        assert rm1.tags == {tag.key: tag.value for tag in all_tags}
 
         # test overriding a tag with the same key
         overriding_tag = RegisteredModelTag("key", "overriding")
         self.store.set_registered_model_tag(name1, overriding_tag)
         all_tags = [tag for tag in all_tags if tag.key != "key"] + [overriding_tag]
         rm1 = self.store.get_registered_model(name=name1)
-        self.assertEqual(rm1.tags, {tag.key: tag.value for tag in all_tags})
+        assert rm1.tags == {tag.key: tag.value for tag in all_tags}
         # does not affect other models with the same key
         rm2 = self.store.get_registered_model(name=name2)
-        self.assertEqual(rm2.tags, {tag.key: tag.value for tag in initial_tags})
+        assert rm2.tags == {tag.key: tag.value for tag in initial_tags}
 
         # can not set tag on deleted (non-existed) registered model
         self.store.delete_registered_model(name1)
@@ -476,19 +462,19 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self.store.set_registered_model_tag(name1, new_tag)
         self.store.delete_registered_model_tag(name1, "randomTag")
         rm1 = self.store.get_registered_model(name=name1)
-        self.assertEqual(rm1.tags, {tag.key: tag.value for tag in initial_tags})
+        assert rm1.tags == {tag.key: tag.value for tag in initial_tags}
 
         # testing deleting a key does not affect other models with the same key
         self.store.delete_registered_model_tag(name1, "key")
         rm1 = self.store.get_registered_model(name=name1)
         rm2 = self.store.get_registered_model(name=name2)
-        self.assertEqual(rm1.tags, {"anotherKey": "some other value"})
-        self.assertEqual(rm2.tags, {tag.key: tag.value for tag in initial_tags})
+        assert rm1.tags == {"anotherKey": "some other value"}
+        assert rm2.tags == {tag.key: tag.value for tag in initial_tags}
 
         # delete tag that is already deleted does nothing
         self.store.delete_registered_model_tag(name1, "key")
         rm1 = self.store.get_registered_model(name=name1)
-        self.assertEqual(rm1.tags, {"anotherKey": "some other value"})
+        assert rm1.tags == {"anotherKey": "some other value"}
 
         # can not delete tag on deleted (non-existed) registered model
         self.store.delete_registered_model(name1)
@@ -517,91 +503,91 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         with mock.patch("time.time") as mock_time:
             mock_time.return_value = 456778
             mv1 = self._mv_maker(name, "a/b/CD", run_id)
-            self.assertEqual(mv1.name, name)
-            self.assertEqual(mv1.version, 1)
+            assert mv1.name == name
+            assert mv1.version == 1
 
         mvd1 = self.store.get_model_version(mv1.name, mv1.version)
-        self.assertEqual(mvd1.name, name)
-        self.assertEqual(mvd1.version, 1)
-        self.assertEqual(mvd1.current_stage, "None")
-        self.assertEqual(mvd1.creation_timestamp, 456778000)
-        self.assertEqual(mvd1.last_updated_timestamp, 456778000)
-        self.assertEqual(mvd1.description, None)
-        self.assertEqual(mvd1.source, "a/b/CD")
-        self.assertEqual(mvd1.run_id, run_id)
-        self.assertEqual(mvd1.status, "READY")
-        self.assertEqual(mvd1.status_message, None)
-        self.assertEqual(mvd1.tags, {})
+        assert mvd1.name == name
+        assert mvd1.version == 1
+        assert mvd1.current_stage == "None"
+        assert mvd1.creation_timestamp == 456778000
+        assert mvd1.last_updated_timestamp == 456778000
+        assert mvd1.description == None
+        assert mvd1.source == "a/b/CD"
+        assert mvd1.run_id == run_id
+        assert mvd1.status == "READY"
+        assert mvd1.status_message == None
+        assert mvd1.tags == {}
 
         # new model versions for same name autoincrement versions
         mv2 = self._mv_maker(name)
         mvd2 = self.store.get_model_version(name=mv2.name, version=mv2.version)
-        self.assertEqual(mv2.version, 2)
-        self.assertEqual(mvd2.version, 2)
+        assert mv2.version == 2
+        assert mvd2.version == 2
 
         # create model version with tags return model version entity with tags
         tags = [ModelVersionTag("key", "value"), ModelVersionTag("anotherKey", "some other value")]
         mv3 = self._mv_maker(name, tags=tags)
         mvd3 = self.store.get_model_version(name=mv3.name, version=mv3.version)
-        self.assertEqual(mv3.version, 3)
-        self.assertEqual(mv3.tags, {tag.key: tag.value for tag in tags})
-        self.assertEqual(mvd3.version, 3)
-        self.assertEqual(mvd3.tags, {tag.key: tag.value for tag in tags})
+        assert mv3.version == 3
+        assert mv3.tags == {tag.key: tag.value for tag in tags}
+        assert mvd3.version == 3
+        assert mvd3.tags == {tag.key: tag.value for tag in tags}
 
         # create model versions with runLink
         run_link = "http://localhost:3000/path/to/run/"
         mv4 = self._mv_maker(name, run_link=run_link)
         mvd4 = self.store.get_model_version(name, mv4.version)
-        self.assertEqual(mv4.version, 4)
-        self.assertEqual(mv4.run_link, run_link)
-        self.assertEqual(mvd4.version, 4)
-        self.assertEqual(mvd4.run_link, run_link)
+        assert mv4.version == 4
+        assert mv4.run_link == run_link
+        assert mvd4.version == 4
+        assert mvd4.run_link == run_link
 
         # create model version with description
         description = "the best model ever"
         mv5 = self._mv_maker(name, description=description)
         mvd5 = self.store.get_model_version(name, mv5.version)
-        self.assertEqual(mv5.version, 5)
-        self.assertEqual(mv5.description, description)
-        self.assertEqual(mvd5.version, 5)
-        self.assertEqual(mvd5.description, description)
+        assert mv5.version == 5
+        assert mv5.description == description
+        assert mvd5.version == 5
+        assert mvd5.description == description
 
         # create model version without runId
         mv6 = self._mv_maker(name, run_id=None)
         mvd6 = self.store.get_model_version(name, mv6.version)
-        self.assertEqual(mv6.version, 6)
-        self.assertEqual(mv6.run_id, None)
-        self.assertEqual(mvd6.version, 6)
-        self.assertEqual(mvd6.run_id, None)
+        assert mv6.version == 6
+        assert mv6.run_id == None
+        assert mvd6.version == 6
+        assert mvd6.run_id == None
 
     def test_update_model_version(self):
         name = "test_for_update_MV"
         self._rm_maker(name)
         mv1 = self._mv_maker(name)
         mvd1 = self.store.get_model_version(name=mv1.name, version=mv1.version)
-        self.assertEqual(mvd1.name, name)
-        self.assertEqual(mvd1.version, 1)
-        self.assertEqual(mvd1.current_stage, "None")
+        assert mvd1.name == name
+        assert mvd1.version == 1
+        assert mvd1.current_stage == "None"
 
         # update stage
         self.store.transition_model_version_stage(
             name=mv1.name, version=mv1.version, stage="Production", archive_existing_versions=False
         )
         mvd2 = self.store.get_model_version(name=mv1.name, version=mv1.version)
-        self.assertEqual(mvd2.name, name)
-        self.assertEqual(mvd2.version, 1)
-        self.assertEqual(mvd2.current_stage, "Production")
-        self.assertEqual(mvd2.description, None)
+        assert mvd2.name == name
+        assert mvd2.version == 1
+        assert mvd2.current_stage == "Production"
+        assert mvd2.description == None
 
         # update description
         self.store.update_model_version(
             name=mv1.name, version=mv1.version, description="test model version"
         )
         mvd3 = self.store.get_model_version(name=mv1.name, version=mv1.version)
-        self.assertEqual(mvd3.name, name)
-        self.assertEqual(mvd3.version, 1)
-        self.assertEqual(mvd3.current_stage, "Production")
-        self.assertEqual(mvd3.description, "test model version")
+        assert mvd3.name == name
+        assert mvd3.version == 1
+        assert mvd3.current_stage == "Production"
+        assert mvd3.description == "test model version"
 
         # only valid stages can be set
         with self.assertRaisesRegex(
@@ -623,7 +609,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
                 archive_existing_versions=False,
             )
             mvd5 = self.store.get_model_version(name=mv1.name, version=mv1.version)
-            self.assertEqual(mvd5.current_stage, "Staging")
+            assert mvd5.current_stage == "Staging"
 
     def test_transition_model_version_stage_when_archive_existing_versions_is_false(self):
         name = "model"
@@ -645,9 +631,9 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         mvd2 = self.store.get_model_version(name=name, version=mv2.version)
         mvd3 = self.store.get_model_version(name=name, version=mv3.version)
 
-        self.assertEqual(mvd1.current_stage, "Staging")
-        self.assertEqual(mvd2.current_stage, "Production")
-        self.assertEqual(mvd3.current_stage, "Staging")
+        assert mvd1.current_stage == "Staging"
+        assert mvd2.current_stage == "Production"
+        assert mvd3.current_stage == "Staging"
 
         self.store.transition_model_version_stage(name, mv3.version, "Production", False)
 
@@ -655,9 +641,9 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         mvd2 = self.store.get_model_version(name=name, version=mv2.version)
         mvd3 = self.store.get_model_version(name=name, version=mv3.version)
 
-        self.assertEqual(mvd1.current_stage, "Staging")
-        self.assertEqual(mvd2.current_stage, "Production")
-        self.assertEqual(mvd3.current_stage, "Production")
+        assert mvd1.current_stage == "Staging"
+        assert mvd2.current_stage == "Production"
+        assert mvd3.current_stage == "Production"
 
     def test_transition_model_version_stage_when_archive_existing_versions_is_true(self):
         name = "model"
@@ -685,10 +671,10 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         mvd2 = self.store.get_model_version(name=name, version=mv2.version)
         mvd3 = self.store.get_model_version(name=name, version=mv3.version)
 
-        self.assertEqual(mvd1.current_stage, "Archived")
-        self.assertEqual(mvd2.current_stage, "Production")
-        self.assertEqual(mvd3.current_stage, "Staging")
-        self.assertEqual(mvd1.last_updated_timestamp, mvd3.last_updated_timestamp)
+        assert mvd1.current_stage == "Archived"
+        assert mvd2.current_stage == "Production"
+        assert mvd3.current_stage == "Staging"
+        assert mvd1.last_updated_timestamp == mvd3.last_updated_timestamp
 
         self.store.transition_model_version_stage(name, mv3.version, "Production", True)
 
@@ -696,10 +682,10 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         mvd2 = self.store.get_model_version(name=name, version=mv2.version)
         mvd3 = self.store.get_model_version(name=name, version=mv3.version)
 
-        self.assertEqual(mvd1.current_stage, "Archived")
-        self.assertEqual(mvd2.current_stage, "Archived")
-        self.assertEqual(mvd3.current_stage, "Production")
-        self.assertEqual(mvd2.last_updated_timestamp, mvd3.last_updated_timestamp)
+        assert mvd1.current_stage == "Archived"
+        assert mvd2.current_stage == "Archived"
+        assert mvd3.current_stage == "Production"
+        assert mvd2.last_updated_timestamp == mvd3.last_updated_timestamp
 
         for uncanonical_stage_name in ["STAGING", "staging", "StAgInG"]:
             self.store.transition_model_version_stage(mv1.name, mv1.version, "Staging", False)
@@ -712,8 +698,8 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
 
             mvd1 = self.store.get_model_version(name=mv1.name, version=mv1.version)
             mvd2 = self.store.get_model_version(name=mv2.name, version=mv2.version)
-            self.assertEqual(mvd1.current_stage, "Archived")
-            self.assertEqual(mvd2.current_stage, "Staging")
+            assert mvd1.current_stage == "Archived"
+            assert mvd2.current_stage == "Staging"
 
     def test_delete_model_version(self):
         name = "test_for_delete_MV"
@@ -724,7 +710,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self._rm_maker(name)
         mv = self._mv_maker(name, tags=initial_tags)
         mvd = self.store.get_model_version(name=mv.name, version=mv.version)
-        self.assertEqual(mvd.name, name)
+        assert mvd.name == name
 
         self.store.delete_model_version(name=mv.name, version=mv.version)
 
@@ -757,18 +743,18 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self._rm_maker(name)
         mv = self._mv_maker(name, source=source, run_id=run_id, run_link=run_link)
         mvd = self.store.get_model_version(name=name, version=mv.version)
-        self.assertEqual(mvd.run_link, run_link)
-        self.assertEqual(mvd.run_id, run_id)
-        self.assertEqual(mvd.source, source)
+        assert mvd.run_link == run_link
+        assert mvd.run_id == run_id
+        assert mvd.source == source
         # delete the MV now
         self.store.delete_model_version(name, mv.version)
         # verify that the relevant fields are redacted
         mvd_deleted = self.store._get_sql_model_version_including_deleted(
             name=name, version=mv.version
         )
-        self.assertIn("REDACTED", mvd_deleted.run_link)
-        self.assertIn("REDACTED", mvd_deleted.source)
-        self.assertIn("REDACTED", mvd_deleted.run_id)
+        assert "REDACTED" in mvd_deleted.run_link
+        assert "REDACTED" in mvd_deleted.source
+        assert "REDACTED" in mvd_deleted.run_id
 
     def test_get_model_version_download_uri(self):
         name = "test_for_update_MV"
@@ -776,12 +762,13 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         source_path = "path/to/source"
         mv = self._mv_maker(name, source=source_path, run_id=uuid.uuid4().hex)
         mvd1 = self.store.get_model_version(name=mv.name, version=mv.version)
-        self.assertEqual(mvd1.name, name)
-        self.assertEqual(mvd1.source, source_path)
+        assert mvd1.name == name
+        assert mvd1.source == source_path
 
         # download location points to source
-        self.assertEqual(
-            self.store.get_model_version_download_uri(name=mv.name, version=mv.version), source_path
+        assert (
+            self.store.get_model_version_download_uri(name=mv.name, version=mv.version)
+            == source_path
         )
 
         # download URI does not change even if model version is updated
@@ -792,9 +779,10 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
             name=mv.name, version=mv.version, description="Test for Path"
         )
         mvd2 = self.store.get_model_version(name=mv.name, version=mv.version)
-        self.assertEqual(mvd2.source, source_path)
-        self.assertEqual(
-            self.store.get_model_version_download_uri(name=mv.name, version=mv.version), source_path
+        assert mvd2.source == source_path
+        assert (
+            self.store.get_model_version_download_uri(name=mv.name, version=mv.version)
+            == source_path
         )
 
         # cannot retrieve download URI for deleted model versions
@@ -813,37 +801,32 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         run_id_2 = uuid.uuid4().hex
         run_id_3 = uuid.uuid4().hex
         mv1 = self._mv_maker(name=name, source="A/B", run_id=run_id_1)
-        self.assertEqual(mv1.version, 1)
+        assert mv1.version == 1
         mv2 = self._mv_maker(name=name, source="A/C", run_id=run_id_2)
-        self.assertEqual(mv2.version, 2)
+        assert mv2.version == 2
         mv3 = self._mv_maker(name=name, source="A/D", run_id=run_id_2)
-        self.assertEqual(mv3.version, 3)
+        assert mv3.version == 3
         mv4 = self._mv_maker(name=name, source="A/D", run_id=run_id_3)
-        self.assertEqual(mv4.version, 4)
+        assert mv4.version == 4
 
         def search_versions(filter_string):
             return [mvd.version for mvd in self.store.search_model_versions(filter_string)]
 
         # search using name should return all 4 versions
-        self.assertEqual(set(search_versions("name='%s'" % name)), set([1, 2, 3, 4]))
+        assert set(search_versions("name='%s'" % name)) == set([1, 2, 3, 4])
 
         # search using run_id_1 should return version 1
-        self.assertEqual(set(search_versions("run_id='%s'" % run_id_1)), set([1]))
+        assert set(search_versions("run_id='%s'" % run_id_1)) == set([1])
 
         # search using run_id_2 should return versions 2 and 3
-        self.assertEqual(set(search_versions("run_id='%s'" % run_id_2)), set([2, 3]))
+        assert set(search_versions("run_id='%s'" % run_id_2)) == set([2, 3])
 
         # search using the IN operator should return all versions
-        self.assertEqual(
-            set(
-                search_versions(
-                    "run_id IN ('{run_id_1}','{run_id_2}')".format(
-                        run_id_1=run_id_1, run_id_2=run_id_2
-                    )
-                )
-            ),
-            set([1, 2, 3]),
-        )
+        assert set(
+            search_versions(
+                "run_id IN ('{run_id_1}','{run_id_2}')".format(run_id_1=run_id_1, run_id_2=run_id_2)
+            )
+        ) == set([1, 2, 3])
 
         # search using the IN operator with bad lists should return exceptions
         with self.assertRaisesRegex(
@@ -914,22 +897,22 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
         # search using source_path "A/D" should return version 3 and 4
-        self.assertEqual(set(search_versions("source_path = 'A/D'")), set([3, 4]))
+        assert set(search_versions("source_path = 'A/D'")) == set([3, 4])
 
         # search using source_path "A" should not return anything
-        self.assertEqual(len(search_versions("source_path = 'A'")), 0)
-        self.assertEqual(len(search_versions("source_path = 'A/'")), 0)
-        self.assertEqual(len(search_versions("source_path = ''")), 0)
+        assert len(search_versions("source_path = 'A'")) == 0
+        assert len(search_versions("source_path = 'A/'")) == 0
+        assert len(search_versions("source_path = ''")) == 0
 
         # delete mv4. search should not return version 4
         self.store.delete_model_version(name=mv4.name, version=mv4.version)
-        self.assertEqual(set(search_versions("")), set([1, 2, 3]))
+        assert set(search_versions("")) == set([1, 2, 3])
 
-        self.assertEqual(set(search_versions(None)), set([1, 2, 3]))
+        assert set(search_versions(None)) == set([1, 2, 3])
 
-        self.assertEqual(set(search_versions("name='%s'" % name)), set([1, 2, 3]))
+        assert set(search_versions("name='%s'" % name)) == set([1, 2, 3])
 
-        self.assertEqual(set(search_versions("source_path = 'A/D'")), set([3]))
+        assert set(search_versions("source_path = 'A/D'")) == set([3])
 
         self.store.transition_model_version_stage(
             name=mv1.name, version=mv1.version, stage="production", archive_existing_versions=False
@@ -967,66 +950,66 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
 
         # search with no filter should return all registered models
         rms, _ = self._search_registered_models(None)
-        self.assertEqual(rms, names)
+        assert rms == names
 
         # equality search using name should return exactly the 1 name
         rms, _ = self._search_registered_models("name='{}'".format(names[0]))
-        self.assertEqual(rms, [names[0]])
+        assert rms == [names[0]]
 
         # equality search using name that is not valid should return nothing
         rms, _ = self._search_registered_models("name='{}'".format(names[0] + "cats"))
-        self.assertEqual(rms, [])
+        assert rms == []
 
         # case-sensitive prefix search using LIKE should return all the RMs
         rms, _ = self._search_registered_models("name LIKE '{}%'".format(prefix))
-        self.assertEqual(rms, names)
+        assert rms == names
 
         # case-sensitive prefix search using LIKE with surrounding % should return all the RMs
         rms, _ = self._search_registered_models("name LIKE '%RM%'")
-        self.assertEqual(rms, names)
+        assert rms == names
 
         # case-sensitive prefix search using LIKE with surrounding % should return all the RMs
         # _e% matches test_for_search_ , so all RMs should match
         rms, _ = self._search_registered_models("name LIKE '_e%'")
-        self.assertEqual(rms, names)
+        assert rms == names
 
         # case-sensitive prefix search using LIKE should return just rm4
         rms, _ = self._search_registered_models("name LIKE '{}%'".format(prefix + "RM4A"))
-        self.assertEqual(rms, [names[4]])
+        assert rms == [names[4]]
 
         # case-sensitive prefix search using LIKE should return no models if no match
         rms, _ = self._search_registered_models("name LIKE '{}%'".format(prefix + "cats"))
-        self.assertEqual(rms, [])
+        assert rms == []
 
         # confirm that LIKE is not case-sensitive
         rms, _ = self._search_registered_models("name lIkE '%blah%'")
-        self.assertEqual(rms, [])
+        assert rms == []
 
         rms, _ = self._search_registered_models("name like '{}%'".format(prefix + "RM4A"))
-        self.assertEqual(rms, [names[4]])
+        assert rms == [names[4]]
 
         # case-insensitive prefix search using ILIKE should return both rm5 and rm6
         rms, _ = self._search_registered_models("name ILIKE '{}%'".format(prefix + "RM4A"))
-        self.assertEqual(rms, names[4:])
+        assert rms == names[4:]
 
         # case-insensitive postfix search with ILIKE
         rms, _ = self._search_registered_models("name ILIKE '%RM4a'")
-        self.assertEqual(rms, names[4:])
+        assert rms == names[4:]
 
         # case-insensitive prefix search using ILIKE should return both rm5 and rm6
         rms, _ = self._search_registered_models("name ILIKE '{}%'".format(prefix + "cats"))
-        self.assertEqual(rms, [])
+        assert rms == []
 
         # confirm that ILIKE is not case-sensitive
         rms, _ = self._search_registered_models("name iLike '%blah%'")
-        self.assertEqual(rms, [])
+        assert rms == []
 
         # confirm that ILIKE works for empty query
         rms, _ = self._search_registered_models("name iLike '%%'")
-        self.assertEqual(rms, names)
+        assert rms == names
 
         rms, _ = self._search_registered_models("name ilike '%RM4a'")
-        self.assertEqual(rms, names[4:])
+        assert rms == names[4:]
 
         # cannot search by invalid comparator types
         with self.assertRaisesRegex(
@@ -1058,30 +1041,31 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
 
         # delete last registered model. search should not return the first 5
         self.store.delete_registered_model(name=names[-1])
-        self.assertEqual(self._search_registered_models(None, max_results=1000), (names[:-1], None))
+        assert self._search_registered_models(None, max_results=1000) == (names[:-1], None)
 
         # equality search using name should return no names
-        self.assertEqual(self._search_registered_models("name='{}'".format(names[-1])), ([], None))
+        assert self._search_registered_models("name='{}'".format(names[-1])) == ([], None)
 
         # case-sensitive prefix search using LIKE should return all the RMs
-        self.assertEqual(
-            self._search_registered_models("name LIKE '{}%'".format(prefix)), (names[0:5], None)
+        assert self._search_registered_models("name LIKE '{}%'".format(prefix)) == (
+            names[0:5],
+            None,
         )
 
         # case-insensitive prefix search using ILIKE should return both rm5 and rm6
-        self.assertEqual(
-            self._search_registered_models("name ILIKE '{}%'".format(prefix + "RM4A")),
-            ([names[4]], None),
+        assert self._search_registered_models("name ILIKE '{}%'".format(prefix + "RM4A")) == (
+            [names[4]],
+            None,
         )
 
     def test_parse_search_registered_models_order_by(self):
         # test that "registered_models.name ASC" is returned by default
         parsed = SqlAlchemyStore._parse_search_registered_models_order_by([])
-        self.assertEqual([str(x) for x in parsed], ["registered_models.name ASC"])
+        assert [str(x) for x in parsed] == ["registered_models.name ASC"]
 
         # test that the given 'name' replaces the default one ('registered_models.name ASC')
         parsed = SqlAlchemyStore._parse_search_registered_models_order_by(["name DESC"])
-        self.assertEqual([str(x) for x in parsed], ["registered_models.name DESC"])
+        assert [str(x) for x in parsed] == ["registered_models.name DESC"]
 
         # test that an exception is raised when order_by contains duplicate fields
         msg = "`order_by` contains duplicate fields:"
@@ -1119,26 +1103,26 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         while token:
             result, token = self._search_registered_models(query, page_token=token, max_results=5)
             returned_rms.extend(result)
-        self.assertEqual(rms, returned_rms)
+        assert rms == returned_rms
 
         # test that pagination will return all valid results in sorted order
         # by name ascending
         result, token1 = self._search_registered_models(query, max_results=5)
-        self.assertNotEqual(token1, None)
-        self.assertEqual(result, rms[0:5])
+        assert token1 != None
+        assert result == rms[0:5]
 
         result, token2 = self._search_registered_models(query, page_token=token1, max_results=10)
-        self.assertNotEqual(token2, None)
-        self.assertEqual(result, rms[5:15])
+        assert token2 != None
+        assert result == rms[5:15]
 
         result, token3 = self._search_registered_models(query, page_token=token2, max_results=20)
-        self.assertNotEqual(token3, None)
-        self.assertEqual(result, rms[15:35])
+        assert token3 != None
+        assert result == rms[15:35]
 
         result, token4 = self._search_registered_models(query, page_token=token3, max_results=100)
         # assert that page token is None
-        self.assertEqual(token4, None)
-        self.assertEqual(result, rms[35:])
+        assert token4 == None
+        assert result == rms[35:]
 
         # test that providing a completely invalid page token throws
         with self.assertRaisesRegex(
@@ -1177,42 +1161,42 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
             )
             returned_rms.extend(result)
         # name descending should be the opposite order of the current order
-        self.assertEqual(rms[::-1], returned_rms)
+        assert rms[::-1] == returned_rms
         # last_updated_timestamp descending should have the newest RMs first
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=["last_updated_timestamp DESC"], max_results=100
         )
-        self.assertEqual(rms[::-1], result)
+        assert rms[::-1] == result
         # timestamp returns same result as last_updated_timestamp
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=["timestamp DESC"], max_results=100
         )
-        self.assertEqual(rms[::-1], result)
+        assert rms[::-1] == result
         # last_updated_timestamp ascending should have the oldest RMs first
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=["last_updated_timestamp ASC"], max_results=100
         )
-        self.assertEqual(rms, result)
+        assert rms == result
         # timestamp returns same result as last_updated_timestamp
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=["timestamp ASC"], max_results=100
         )
-        self.assertEqual(rms, result)
+        assert rms == result
         # timestamp returns same result as last_updated_timestamp
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=["timestamp"], max_results=100
         )
-        self.assertEqual(rms, result)
+        assert rms == result
         # name ascending should have the original order
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=["name ASC"], max_results=100
         )
-        self.assertEqual(rms, result)
+        assert rms == result
         # test that no ASC/DESC defaults to ASC
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=["last_updated_timestamp"], max_results=100
         )
-        self.assertEqual(rms, result)
+        assert rms == result
         with mock.patch("mlflow.store.model_registry.sqlalchemy_store.now", return_value=1):
             rm1 = self._rm_maker("MR1").name
             rm2 = self._rm_maker("MR2").name
@@ -1227,55 +1211,55 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
             order_by=["last_updated_timestamp ASC", "name DESC"],
             max_results=100,
         )
-        self.assertEqual([rm2, rm1, rm4, rm3], result)
+        assert [rm2 == rm1, rm4, rm3], result
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=["timestamp ASC", "name   DESC"], max_results=100
         )
-        self.assertEqual([rm2, rm1, rm4, rm3], result)
+        assert [rm2 == rm1, rm4, rm3], result
         # confirm that name ascending is the default, even if ties exist on other fields
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=[], max_results=100
         )
-        self.assertEqual([rm1, rm2, rm3, rm4], result)
+        assert [rm1 == rm2, rm3, rm4], result
         # test default tiebreak with descending timestamps
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=["last_updated_timestamp DESC"], max_results=100
         )
-        self.assertEqual([rm3, rm4, rm1, rm2], result)
+        assert [rm3 == rm4, rm1, rm2], result
         # test timestamp parsing
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=["timestamp\tASC"], max_results=100
         )
-        self.assertEqual([rm1, rm2, rm3, rm4], result)
+        assert [rm1 == rm2, rm3, rm4], result
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=["timestamp\r\rASC"], max_results=100
         )
-        self.assertEqual([rm1, rm2, rm3, rm4], result)
+        assert [rm1 == rm2, rm3, rm4], result
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=["timestamp\nASC"], max_results=100
         )
-        self.assertEqual([rm1, rm2, rm3, rm4], result)
+        assert [rm1 == rm2, rm3, rm4], result
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=["timestamp  ASC"], max_results=100
         )
-        self.assertEqual([rm1, rm2, rm3, rm4], result)
+        assert [rm1 == rm2, rm3, rm4], result
         # validate order by key is case-insensitive
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=["timestamp  asc"], max_results=100
         )
-        self.assertEqual([rm1, rm2, rm3, rm4], result)
+        assert [rm1 == rm2, rm3, rm4], result
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=["timestamp  aSC"], max_results=100
         )
-        self.assertEqual([rm1, rm2, rm3, rm4], result)
+        assert [rm1 == rm2, rm3, rm4], result
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=["timestamp  desc", "name desc"], max_results=100
         )
-        self.assertEqual([rm4, rm3, rm2, rm1], result)
+        assert [rm4 == rm3, rm2, rm1], result
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=["timestamp  deSc", "name deSc"], max_results=100
         )
-        self.assertEqual([rm4, rm3, rm2, rm1], result)
+        assert [rm4 == rm3, rm2, rm1], result
 
     def test_search_registered_model_order_by_errors(self):
         query = "name LIKE 'RM%'"
@@ -1321,19 +1305,19 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self.store.set_model_version_tag(name1, 1, new_tag)
         all_tags = initial_tags + [new_tag]
         rm1mv1 = self.store.get_model_version(name1, 1)
-        self.assertEqual(rm1mv1.tags, {tag.key: tag.value for tag in all_tags})
+        assert rm1mv1.tags == {tag.key: tag.value for tag in all_tags}
 
         # test overriding a tag with the same key
         overriding_tag = ModelVersionTag("key", "overriding")
         self.store.set_model_version_tag(name1, 1, overriding_tag)
         all_tags = [tag for tag in all_tags if tag.key != "key"] + [overriding_tag]
         rm1mv1 = self.store.get_model_version(name1, 1)
-        self.assertEqual(rm1mv1.tags, {tag.key: tag.value for tag in all_tags})
+        assert rm1mv1.tags == {tag.key: tag.value for tag in all_tags}
         # does not affect other model versions with the same key
         rm1mv2 = self.store.get_model_version(name1, 2)
         rm2mv1 = self.store.get_model_version(name2, 1)
-        self.assertEqual(rm1mv2.tags, {tag.key: tag.value for tag in initial_tags})
-        self.assertEqual(rm2mv1.tags, {tag.key: tag.value for tag in initial_tags})
+        assert rm1mv2.tags == {tag.key: tag.value for tag in initial_tags}
+        assert rm2mv1.tags == {tag.key: tag.value for tag in initial_tags}
 
         # can not set tag on deleted (non-existed) model version
         self.store.delete_model_version(name1, 2)
@@ -1392,21 +1376,21 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self.store.set_model_version_tag(name1, 1, new_tag)
         self.store.delete_model_version_tag(name1, 1, "randomTag")
         rm1mv1 = self.store.get_model_version(name1, 1)
-        self.assertEqual(rm1mv1.tags, {tag.key: tag.value for tag in initial_tags})
+        assert rm1mv1.tags == {tag.key: tag.value for tag in initial_tags}
 
         # testing deleting a key does not affect other model versions with the same key
         self.store.delete_model_version_tag(name1, 1, "key")
         rm1mv1 = self.store.get_model_version(name1, 1)
         rm1mv2 = self.store.get_model_version(name1, 2)
         rm2mv1 = self.store.get_model_version(name2, 1)
-        self.assertEqual(rm1mv1.tags, {"anotherKey": "some other value"})
-        self.assertEqual(rm1mv2.tags, {tag.key: tag.value for tag in initial_tags})
-        self.assertEqual(rm2mv1.tags, {tag.key: tag.value for tag in initial_tags})
+        assert rm1mv1.tags == {"anotherKey": "some other value"}
+        assert rm1mv2.tags == {tag.key: tag.value for tag in initial_tags}
+        assert rm2mv1.tags == {tag.key: tag.value for tag in initial_tags}
 
         # delete tag that is already deleted does nothing
         self.store.delete_model_version_tag(name1, 1, "key")
         rm1mv1 = self.store.get_model_version(name1, 1)
-        self.assertEqual(rm1mv1.tags, {"anotherKey": "some other value"})
+        assert rm1mv1.tags == {"anotherKey": "some other value"}
 
         # can not delete tag on deleted (non-existed) model version
         self.store.delete_model_version(name2, 1)

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -248,7 +248,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         registered_models = self.store.list_registered_models(max_results=10, page_token=None)
         self.assertEqual(len(registered_models), 1)
         self.assertEqual(registered_models[0].name, "A")
-        self.assertIsInstance(registered_models[0], RegisteredModel)
+        assert isinstance(registered_models[0], RegisteredModel)
 
         self._rm_maker("B")
         self.assertEqual(set(self._list_registered_models()), set(["A", "B"]))

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -766,7 +766,7 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         fs.set_tag(r2, RunTag("p_b", "ABC"))
 
         # test search returns both runs
-        assert sorted([r1, r2]) == sorted(
+        assert sorted([r1, r2]) == (
             self._search(fs, experiment_id, filter_str="tags.generic_tag = 'p_val'")
         )
         # test search returns appropriate run (same key different values per run)
@@ -774,10 +774,10 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         assert [r2] == self._search(fs, experiment_id, filter_str="tags.generic_2='another value'")
         assert [] == self._search(fs, experiment_id, filter_str="tags.generic_tag = 'wrong_val'")
         assert [] == self._search(fs, experiment_id, filter_str="tags.generic_tag != 'p_val'")
-        assert sorted([r1, r2]) == sorted(
+        assert sorted([r1, r2]) == (
             self._search(fs, experiment_id, filter_str="tags.generic_tag != 'wrong_val'")
         )
-        assert sorted([r1, r2]) == sorted(
+        assert sorted([r1, r2]) == (
             self._search(fs, experiment_id, filter_str="tags.generic_2 != 'wrong_val'")
         )
         assert [r1] == self._search(fs, experiment_id, filter_str="tags.p_a = 'abc'")

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -152,7 +152,7 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         fs = FileStore(self.test_root)
         for exp in fs.list_experiments():
             exp_id = exp.experiment_id
-            self.assertTrue(exp_id in self.experiments)
+            assert exp_id in self.experiments
             self.assertEqual(exp.name, self.exp_data[exp_id]["name"])
             self.assertEqual(exp.artifact_location, self.exp_data[exp_id]["artifact_location"])
 
@@ -454,9 +454,9 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
 
         # delete it
         fs.delete_experiment(exp_id)
-        self.assertTrue(exp_id not in self._extract_ids(fs.list_experiments(ViewType.ACTIVE_ONLY)))
-        self.assertTrue(exp_id in self._extract_ids(fs.list_experiments(ViewType.DELETED_ONLY)))
-        self.assertTrue(exp_id in self._extract_ids(fs.list_experiments(ViewType.ALL)))
+        assert exp_id not in self._extract_ids(fs.list_experiments(ViewType.ACTIVE_ONLY))
+        assert exp_id in self._extract_ids(fs.list_experiments(ViewType.DELETED_ONLY))
+        assert exp_id in self._extract_ids(fs.list_experiments(ViewType.ALL))
         self.assertEqual(fs.get_experiment(exp_id).lifecycle_stage, LifecycleStage.DELETED)
 
         # restore it
@@ -467,9 +467,9 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         restored_2 = fs.get_experiment_by_name(exp_name)
         self.assertEqual(restored_2.experiment_id, exp_id)
         self.assertEqual(restored_2.name, exp_name)
-        self.assertTrue(exp_id in self._extract_ids(fs.list_experiments(ViewType.ACTIVE_ONLY)))
-        self.assertTrue(exp_id not in self._extract_ids(fs.list_experiments(ViewType.DELETED_ONLY)))
-        self.assertTrue(exp_id in self._extract_ids(fs.list_experiments(ViewType.ALL)))
+        assert exp_id in self._extract_ids(fs.list_experiments(ViewType.ACTIVE_ONLY))
+        assert exp_id not in self._extract_ids(fs.list_experiments(ViewType.DELETED_ONLY))
+        assert exp_id in self._extract_ids(fs.list_experiments(ViewType.ALL))
         self.assertEqual(fs.get_experiment(exp_id).lifecycle_stage, LifecycleStage.ACTIVE)
 
     def test_rename_experiment(self):

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -812,8 +812,8 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         run.to_proto()
 
         # Verify attributes of the Python run entity
-        self.assertIsInstance(run.info, entities.RunInfo)
-        self.assertIsInstance(run.data, entities.RunData)
+        assert isinstance(run.info, entities.RunInfo)
+        assert isinstance(run.data, entities.RunData)
 
         self.assertEqual(run.data.metrics, {"my-metric": 3.4})
         self.assertEqual(run.data.params, {"my-param": "param-val"})

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -272,8 +272,8 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         self.assertEqual(len(deleted_run_list), 2)
         for deleted_run in deleted_run_list:
             self.assertEqual(deleted_run.lifecycle_stage, entities.LifecycleStage.DELETED)
-            self.assertTrue(deleted_run.experiment_id in experiment_id)
-            self.assertTrue(deleted_run.run_id in run_ids)
+            assert deleted_run.experiment_id in experiment_id
+            assert deleted_run.run_id in run_ids
 
         self.store.restore_experiment(experiment_id)
 
@@ -284,8 +284,8 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         self.assertEqual(len(restored_run_list), 2)
         for restored_run in restored_run_list:
             self.assertEqual(restored_run.lifecycle_stage, entities.LifecycleStage.ACTIVE)
-            self.assertTrue(restored_run.experiment_id in experiment_id)
-            self.assertTrue(restored_run.run_id in run_ids)
+            assert restored_run.experiment_id in experiment_id
+            assert restored_run.run_id in run_ids
 
     def test_get_experiment(self):
         name = "goku"
@@ -886,7 +886,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         self.store.log_metric(run.info.run_id, neg_inf_metric)
 
         run = self.store.get_run(run.info.run_id)
-        self.assertTrue(tkey in run.data.metrics and run.data.metrics[tkey] == tval)
+        assert tkey in run.data.metrics and run.data.metrics[tkey] == tval
 
         # SQL store _get_run method returns full history of recorded metrics.
         # Should return duplicates as well
@@ -895,9 +895,9 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
             sql_run_metrics = self.store._get_run(session, run.info.run_id).metrics
             self.assertEqual(5, len(sql_run_metrics))
             self.assertEqual(4, len(run.data.metrics))
-            self.assertTrue(math.isnan(run.data.metrics["NaN"]))
-            self.assertTrue(run.data.metrics["PosInf"] == 1.7976931348623157e308)
-            self.assertTrue(run.data.metrics["NegInf"] == -1.7976931348623157e308)
+            assert math.isnan(run.data.metrics["NaN"])
+            assert run.data.metrics["PosInf"] == 1.7976931348623157e308
+            assert run.data.metrics["NegInf"] == -1.7976931348623157e308
 
     def test_log_metric_concurrent_logging_succeeds(self):
         """
@@ -1015,7 +1015,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
 
         run = self.store.get_run(run.info.run_id)
         self.assertEqual(2, len(run.data.params))
-        self.assertTrue(tkey in run.data.params and run.data.params[tkey] == tval)
+        assert tkey in run.data.params and run.data.params[tkey] == tval
 
     def test_log_param_uniqueness(self):
         run = self._run_factory()
@@ -1041,7 +1041,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
 
         run = self.store.get_run(run.info.run_id)
         self.assertEqual(2, len(run.data.params))
-        self.assertTrue(tkey in run.data.params and run.data.params[tkey] == tval)
+        assert tkey in run.data.params and run.data.params[tkey] == tval
 
     def test_log_null_param(self):
         run = self._run_factory()
@@ -1066,27 +1066,27 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         new_tag = entities.RunTag("tag0", "value00000")
         self.store.set_experiment_tag(exp_id, tag)
         experiment = self.store.get_experiment(exp_id)
-        self.assertTrue(experiment.tags["tag0"] == "value0")
+        assert experiment.tags["tag0"] == "value0"
         # test that updating a tag works
         self.store.set_experiment_tag(exp_id, new_tag)
         experiment = self.store.get_experiment(exp_id)
-        self.assertTrue(experiment.tags["tag0"] == "value00000")
+        assert experiment.tags["tag0"] == "value00000"
         # test that setting a tag on 1 experiment does not impact another experiment.
         exp_id_2 = self._experiment_factory("setExperimentTagExp2")
         experiment2 = self.store.get_experiment(exp_id_2)
-        self.assertTrue(len(experiment2.tags) == 0)
+        assert len(experiment2.tags) == 0
         # setting a tag on different experiments maintains different values across experiments
         different_tag = entities.RunTag("tag0", "differentValue")
         self.store.set_experiment_tag(exp_id_2, different_tag)
         experiment = self.store.get_experiment(exp_id)
-        self.assertTrue(experiment.tags["tag0"] == "value00000")
+        assert experiment.tags["tag0"] == "value00000"
         experiment2 = self.store.get_experiment(exp_id_2)
-        self.assertTrue(experiment2.tags["tag0"] == "differentValue")
+        assert experiment2.tags["tag0"] == "differentValue"
         # test can set multi-line tags
         multiLineTag = entities.ExperimentTag("multiline tag", "value2\nvalue2\nvalue2")
         self.store.set_experiment_tag(exp_id, multiLineTag)
         experiment = self.store.get_experiment(exp_id)
-        self.assertTrue(experiment.tags["multiline tag"] == "value2\nvalue2\nvalue2")
+        assert experiment.tags["multiline tag"] == "value2\nvalue2\nvalue2"
         # test cannot set tags that are too long
         longTag = entities.ExperimentTag("longTagKey", "a" * 5001)
         with pytest.raises(MlflowException, match="exceeded length limit of 5000"):
@@ -1116,7 +1116,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         # test can set tags that are somewhat long
         self.store.set_tag(run.info.run_id, entities.RunTag("longTagKey", "a" * 4999))
         run = self.store.get_run(run.info.run_id)
-        self.assertTrue(tkey in run.data.tags and run.data.tags[tkey] == new_val)
+        assert tkey in run.data.tags and run.data.tags[tkey] == new_val
 
     def test_delete_tag(self):
         run = self._run_factory()
@@ -1129,8 +1129,8 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         # delete a tag and check whether it is correctly deleted.
         self.store.delete_tag(run.info.run_id, k0)
         run = self.store.get_run(run.info.run_id)
-        self.assertTrue(k0 not in run.data.tags)
-        self.assertTrue(k1 in run.data.tags and run.data.tags[k1] == v1)
+        assert k0 not in run.data.tags
+        assert k1 in run.data.tags and run.data.tags[k1] == v1
 
         # test that deleting a tag works correctly with multiple runs having the same tag.
         run2 = self._run_factory(config=self._get_run_configs(run.info.experiment_id))
@@ -1139,8 +1139,8 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         self.store.delete_tag(run.info.run_id, k0)
         run = self.store.get_run(run.info.run_id)
         run2 = self.store.get_run(run2.info.run_id)
-        self.assertTrue(k0 not in run.data.tags)
-        self.assertTrue(k0 in run2.data.tags)
+        assert k0 not in run.data.tags
+        assert k0 in run2.data.tags
         # test that you cannot delete tags that don't exist.
         with pytest.raises(MlflowException, match="No tag with name"):
             self.store.delete_tag(run.info.run_id, "fakeTag")
@@ -1283,7 +1283,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         self.assertEqual(metric_obj.value, 34.0)
         self.assertEqual(metric_obj.timestamp, 85)
         self.assertEqual(metric_obj.step, 1)
-        self.assertTrue(set([("t1345", "tv44")]) <= set(run.data.tags.items()))
+        assert set([("t1345", "tv44")]) <= set(run.data.tags.items())
 
     # Tests for Search API
     def _search(
@@ -2000,7 +2000,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         self.store._log_metrics(run.info.run_id, metrics)
 
         run = self.store.get_run(run.info.run_id)
-        self.assertTrue(tkey in run.data.metrics and run.data.metrics[tkey] == tval)
+        assert tkey in run.data.metrics and run.data.metrics[tkey] == tval
 
         # SQL store _get_run method returns full history of recorded metrics.
         # Should return duplicates as well
@@ -2009,9 +2009,9 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
             sql_run_metrics = self.store._get_run(session, run.info.run_id).metrics
             self.assertEqual(5, len(sql_run_metrics))
             self.assertEqual(4, len(run.data.metrics))
-            self.assertTrue(math.isnan(run.data.metrics["NaN"]))
-            self.assertTrue(run.data.metrics["PosInf"] == 1.7976931348623157e308)
-            self.assertTrue(run.data.metrics["NegInf"] == -1.7976931348623157e308)
+            assert math.isnan(run.data.metrics["NaN"])
+            assert run.data.metrics["PosInf"] == 1.7976931348623157e308
+            assert run.data.metrics["NegInf"] == -1.7976931348623157e308
 
     def test_log_batch_same_metric_repeated_single_req(self):
         run = self._run_factory()


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Replace `unittest` assert methods such as `assertEqual` with a regular `assert` to make use of pytest's rewritten assertion, which provides more detailed error information and helps debuggig.


Example:

```
# pytest's assert

    def test_1(self):
        a = {1, 2, 3}
        b = {1, 2}
>       assert a == b
E       AssertionError: assert {1, 2, 3} == {1, 2}
E         Extra items in the left set:
E         3
E         Full diff:
E         - {1, 2}
E         + {1, 2, 3}
E         ?      +++

tests/test_foo.py:8: AssertionError
______________________________________________________________________________________________________________________________________________ TestFoo.test_2 _______________________________________________________________________________________________________________________________________________

# assertEqual

    def test_2(self):
        a = {1, 2, 3}
        b = {1, 2}
>       self.assertEqual(a, b)
E       AssertionError: Items in the first set but not the second:
E       3
```

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
