### PR TITLE
Deduplicate MlflowClient in MLflow docs, move to mlflow.client module

### DIFF
--- a/docs/source/model-registry.rst
+++ b/docs/source/model-registry.rst
@@ -135,7 +135,7 @@ For this method, you will need the ``run_id`` as part of the ``runs:URI`` argume
 If a registered model with the name doesn’t exist, the method registers a new model, creates Version 1, and returns a ModelVersion MLflow object.
 If a registered model with the name exists, the method creates a new model version and returns the version object.
 
-And finally, you can use the :meth:`~mlflow.MlflowClient.create_registered_model` to create a new registered model. If the model name exists,
+And finally, you can use the :meth:`~mlflow.client.MlflowClient.create_registered_model` to create a new registered model. If the model name exists,
 this method will throw an :class:`~mlflow.exceptions.MlflowException` because creating a new registered model requires a unique name.
 
 .. code-block:: py
@@ -213,7 +213,7 @@ After you have registered an MLflow model, you can serve the model as a service 
 Adding or Updating an MLflow Model Descriptions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-At any point in a model’s lifecycle development, you can update a model version's description using :meth:`~mlflow.MlflowClient.update_model_version`.
+At any point in a model’s lifecycle development, you can update a model version's description using :meth:`~mlflow.client.MlflowClient.update_model_version`.
 
 .. code-block:: py
 
@@ -227,7 +227,7 @@ At any point in a model’s lifecycle development, you can update a model versio
 Renaming an MLflow Model
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-As well as adding or updating a description of a specific version of the model, you can rename an existing registered model using :meth:`~mlflow.MlflowClient.rename_registered_model`.
+As well as adding or updating a description of a specific version of the model, you can rename an existing registered model using :meth:`~mlflow.client.MlflowClient.rename_registered_model`.
 
 .. code-block:: py
 
@@ -277,7 +277,7 @@ This outputs:
         'name': 'sk-learn-random-forest-reg-model'}
 
 With hundreds of models, it can be cumbersome to peruse the results returned from this call. A more efficient approach would be to search for a specific model name and list its version
-details using :meth:`~mlflow.MlflowClient.search_model_versions` method
+details using :meth:`~mlflow.client.MlflowClient.search_model_versions` method
 and provide a filter string such as ``"name='sk-learn-random-forest-reg-model'"``
 
 .. code-block:: py

--- a/docs/source/projects.rst
+++ b/docs/source/projects.rst
@@ -585,10 +585,10 @@ To avoid having to write parameters repeatedly, you can add default parameters i
 Building Multistep Workflows
 -----------------------------
 
-The :py:func:`mlflow.projects.run` API, combined with :py:mod:`mlflow.tracking`, makes it possible to build
+The :py:func:`mlflow.projects.run` API, combined with :py:mod:`mlflow.client`, makes it possible to build
 multi-step workflows with separate projects (or entry points in the same project) as the individual
 steps. Each call to :py:func:`mlflow.projects.run` returns a run object, that you can use with
-:py:mod:`mlflow.tracking` to determine when the run has ended and get its output artifacts. These artifacts
+:py:mod:`mlflow.client` to determine when the run has ended and get its output artifacts. These artifacts
 can then be passed into another step that takes ``path`` or ``uri`` parameters. You can coordinate
 all of the workflow in a single Python program that looks at the results of each step and decides
 what to submit next using custom code. Some example use cases for multi-step workflows include:

--- a/docs/source/python_api/mlflow.client.rst
+++ b/docs/source/python_api/mlflow.client.rst
@@ -1,9 +1,9 @@
 .. _mlflow.tracking:
 
-mlflow.tracking
+mlflow.client
 ===============
 
-.. automodule:: mlflow.tracking
+.. automodule:: mlflow.client
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/source/python_api/mlflow.rst
+++ b/docs/source/python_api/mlflow.rst
@@ -4,4 +4,4 @@ mlflow
 .. automodule:: mlflow
     :members:
     :undoc-members:
-
+    :exclude-members: MlflowClient

--- a/docs/source/search-experiments.rst
+++ b/docs/source/search-experiments.rst
@@ -3,7 +3,7 @@
 Search Experiments
 ==================
 
-:py:func:`mlflow.search_experiments` and :py:func:`mlflow.MlflowClient.search_experiments` support the same filter string syntax as :py:func:`mlflow.search_runs` and :py:func:`mlflow.MlflowClient.search_runs`, but the supported identifiers and comparators are different.
+:py:func:`mlflow.search_experiments` and :py:func:`MlflowClient.search_experiments() <mlflow.client.MlflowClient.search_experiments>` support the same filter string syntax as :py:func:`mlflow.search_runs` and :py:func:`MlflowClient.search_runs() <mlflow.client.MlflowClient.search_runs>`, but the supported identifiers and comparators are different.
 
 .. contents:: Table of Contents
   :local:

--- a/docs/source/search-runs.rst
+++ b/docs/source/search-runs.rst
@@ -145,7 +145,7 @@ multiple experiments, use one of the client APIs.
 Python
 ^^^^^^
 
-Use the :py:func:`mlflow.MlflowClient.search_runs` or :py:func:`mlflow.search_runs` API to
+Use the :py:func:`MlflowClient.search_runs() <mlflow.client.MlflowClient.search_runs>` or :py:func:`mlflow.search_runs` API to
 search programmatically. You can specify the list of columns to order by
 (for example, "metrics.rmse") in the ``order_by`` column. The column can contain an
 optional ``DESC`` or ``ASC`` value; the default is ``ASC``. The default ordering is to sort by

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -287,7 +287,7 @@ Logging Functions
 the URI can either be a HTTP/HTTPS URI for a remote server, a database connection string, or a
 local path to log data to a directory. The URI defaults to ``mlruns``.
 
-:py:func:`mlflow.tracking.get_tracking_uri` returns the current tracking URI.
+:py:func:`mlflow.get_tracking_uri` returns the current tracking URI.
 
 :py:func:`mlflow.create_experiment` creates a new experiment and returns its ID. Runs can be
 launched under the experiment by passing the experiment ID to ``mlflow.start_run``.
@@ -307,7 +307,7 @@ with no active run automatically starts a new one.
 currently active run, if any.
 **Note**: You cannot access currently-active run attributes
 (parameters, metrics, etc.) through the run returned by ``mlflow.active_run``. In order to access
-such attributes, use the :py:class:`mlflow.MlflowClient` as follows:
+such attributes, use the :py:class:`MlflowClient <mlflow.client.MlflowClient>` as follows:
 
 .. code-block:: py
 
@@ -722,7 +722,7 @@ Managing Experiments and Runs with the Tracking Service API
 -----------------------------------------------------------
 
 MLflow provides a more detailed Tracking Service API for managing experiments and runs directly,
-which is available through client SDK in the :py:mod:`mlflow.tracking` module.
+which is available through client SDK in the :py:mod:`mlflow.client` module.
 This makes it possible to query data about past runs, log additional information about them, create experiments,
 add tags to a run, and more.
 
@@ -740,7 +740,7 @@ add tags to a run, and more.
 Adding Tags to Runs
 ~~~~~~~~~~~~~~~~~~~
 
-The :py:func:`mlflow.MlflowClient.set_tag` function lets you add custom tags to runs. A tag can only have a single unique value mapped to it at a time. For example:
+The :py:func:`MlflowClient.set_tag() <mlflow.client.MlflowClient.set_tag>` function lets you add custom tags to runs. A tag can only have a single unique value mapped to it at a time. For example:
 
 .. code-block:: py
 

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -25,7 +25,7 @@ which automatically terminates the run at the end of the ``with`` block.
 The fluent tracking API is not currently threadsafe. Any concurrent callers to the tracking API must
 implement mutual exclusion manually.
 
-For a lower level API, see the :py:mod:`mlflow.tracking` module.
+For a lower level API, see the :py:mod:`mlflow.client` module.
 """
 from mlflow.version import VERSION as __version__  # pylint: disable=unused-import
 from mlflow.utils.logging_utils import _configure_mlflow_loggers
@@ -45,6 +45,7 @@ from mlflow import tracking
 import mlflow.models
 import mlflow.artifacts
 import mlflow.pipelines
+import mlflow.client
 
 # model flavors
 _model_flavors_supported = []
@@ -150,6 +151,7 @@ list_experiments = mlflow.tracking.fluent.list_experiments
 search_experiments = mlflow.tracking.fluent.search_experiments
 get_tracking_uri = tracking.get_tracking_uri
 get_registry_uri = tracking.get_registry_uri
+is_tracking_uri_set = tracking.is_tracking_uri_set
 create_experiment = mlflow.tracking.fluent.create_experiment
 set_experiment = mlflow.tracking.fluent.set_experiment
 log_params = mlflow.tracking.fluent.log_params
@@ -163,7 +165,7 @@ register_model = mlflow.tracking._model_registry.fluent.register_model
 autolog = mlflow.tracking.fluent.autolog
 evaluate = mlflow.models.evaluate
 last_active_run = mlflow.tracking.fluent.last_active_run
-MlflowClient = tracking.MlflowClient
+MlflowClient = mlflow.client.MlflowClient
 
 run = projects.run
 
@@ -191,6 +193,7 @@ __all__ = [
     "get_artifact_uri",
     "get_tracking_uri",
     "set_tracking_uri",
+    "is_tracking_uri_set",
     "get_experiment",
     "get_experiment_by_name",
     "list_experiments",

--- a/mlflow/client.py
+++ b/mlflow/client.py
@@ -1,0 +1,12 @@
+"""
+The ``mlflow.client`` module provides a Python CRUD interface to MLflow Experiments, Runs,
+Model Versions, and Registered Models. This is a lower level API that directly translates to MLflow
+`REST API <../rest-api.html>`_ calls.
+For a higher level API for managing an "active run", use the :py:mod:`mlflow` module.
+"""
+
+from mlflow.tracking.client import MlflowClient
+
+__all__ = [
+    "MlflowClient",
+]

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -402,7 +402,7 @@ def active_run() -> Optional[ActiveRun]:
 
     **Note**: You cannot access currently-active run attributes
     (parameters, metrics, etc.) through the run returned by ``mlflow.active_run``. In order
-    to access such attributes, use the :py:class:`mlflow.tracking.MlflowClient` as follows:
+    to access such attributes, use the :py:class:`mlflow.client.MlflowClient` as follows:
 
     .. code-block:: python
         :caption: Example

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -402,7 +402,7 @@ def active_run() -> Optional[ActiveRun]:
 
     **Note**: You cannot access currently-active run attributes
     (parameters, metrics, etc.) through the run returned by ``mlflow.active_run``. In order
-    to access such attributes, use the :py:class:`mlflow.MlflowClient` as follows:
+    to access such attributes, use the :py:class:`mlflow.tracking.MlflowClient` as follows:
 
     .. code-block:: python
         :caption: Example


### PR DESCRIPTION
Signed-off-by: dbczumar <corey.zumar@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

Deduplicate MlflowClient in MLflow docs, move client docs from `mlflow.tracking` to `mlflow.client`; `mlflow.tracking` is / was a strange place for this, since the client also includes Registry APIs.

## What changes are proposed in this pull request?

Deduplicate MlflowClient in MLflow docs

## How is this patch tested?

Docs tests, empirical inspection of rendered docs

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

Move documentation for the `MlflowClient` from `mlfflow.tracking` to `mlflow.client`.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [X] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
