### PR TITLE
Fix regression in pandas type inference behavior for scoring server

### DIFF
--- a/mlflow/types/schema.py
+++ b/mlflow/types/schema.py
@@ -2,7 +2,6 @@ import json
 from enum import Enum
 
 import numpy as np
-import pandas as pd
 import string
 from typing import Dict, Any, List, Union, Optional
 

--- a/mlflow/types/schema.py
+++ b/mlflow/types/schema.py
@@ -9,13 +9,6 @@ from typing import Dict, Any, List, Union, Optional
 from mlflow.exceptions import MlflowException
 
 
-def _pandas_string_type():
-    try:
-        return pd.StringDtype()
-    except AttributeError:
-        return object
-
-
 class DataType(Enum):
     """
     MLflow data types.
@@ -43,7 +36,7 @@ class DataType(Enum):
     """32b floating point numbers. """
     double = (5, np.dtype("float64"), "DoubleType")
     """64b floating point numbers. """
-    string = (6, np.dtype("str"), "StringType", _pandas_string_type())
+    string = (6, np.dtype("str"), "StringType", object)
     """Text data."""
     binary = (7, np.dtype("bytes"), "BinaryType", object)
     """Sequence of raw bytes."""

--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -227,9 +227,6 @@ def _dataframe_from_json(
             precise_float=precise_float,
             convert_dates=False,
         )
-        # In pandas < 1.4, `pandas.read_json` ignores non-numpy dtypes:
-        # https://github.com/pandas-dev/pandas/issues/33205
-        df = df.astype(dtypes)
         if not schema.is_tensor_spec():
             actual_cols = set(df.columns)
             for type_, name in zip(schema.input_types(), schema.input_names()):

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -224,13 +224,11 @@ def test_model_log_with_input_example_succeeds():
 
         # date column will get deserialized into string
         input_example["d"] = input_example["d"].apply(lambda x: x.isoformat())
-        pd.testing.assert_frame_equal(x, input_example.astype({"b": "string", "d": "string"}))
+        pd.testing.assert_frame_equal(x, input_example)
 
         loaded_example = loaded_model.load_input_example(local_path)
         assert isinstance(loaded_example, pd.DataFrame)
-        pd.testing.assert_frame_equal(
-            loaded_example, input_example.astype({"b": "string", "d": "string"})
-        )
+        pd.testing.assert_frame_equal(loaded_example, input_example)
 
 
 def test_model_load_input_example_numpy():

--- a/tests/pyfunc/test_scoring_server.py
+++ b/tests/pyfunc/test_scoring_server.py
@@ -474,8 +474,8 @@ def test_parse_with_schema(pandas_df_with_all_types):
     # The same goes for floats:
     assert df["bad_float"].dtype == np.float32
     assert all(df["bad_float"] == np.array([1.1, 9007199254740992, 3.3], dtype=np.float32))
-    # String is forced:
-    assert all(df["bad_string"] == np.array([1, 2, 3], dtype=str))
+    # However bad string is recognized as int64:
+    assert all(df["bad_string"] == np.array([1, 2, 3], dtype=object))
 
     # Boolean is forced - zero and empty string is false, everything else is true:
     assert df["bad_boolean"].dtype == bool
@@ -546,7 +546,8 @@ def test_serving_model_with_schema(pandas_df_with_all_types):
         response_json = json.loads(response.content)
 
         # objects are not converted to pandas Strings at the moment
-        assert response_json == [[k, str(v)] for k, v in pandas_df_with_all_types.dtypes.items()]
+        expected_types = {**pandas_df_with_all_types.dtypes, "string": np.dtype(object)}
+        assert response_json == [[k, str(v)] for k, v in expected_types.items()]
         response = pyfunc_serve_and_score_model(
             model_uri="runs:/{}/model".format(run.info.run_id),
             data=json.dumps(pandas_df_with_all_types.to_dict(orient="records"), cls=NumpyEncoder),
@@ -554,7 +555,7 @@ def test_serving_model_with_schema(pandas_df_with_all_types):
             extra_args=["--env-manager", "local"],
         )
         response_json = json.loads(response.content)
-        assert response_json == [[k, str(v)] for k, v in pandas_df_with_all_types.dtypes.items()]
+        assert response_json == [[k, str(v)] for k, v in expected_types.items()]
 
 
 def test_split_oriented_json_to_numpy_array():

--- a/tests/utils/test_proto_json_utils.py
+++ b/tests/utils/test_proto_json_utils.py
@@ -479,15 +479,11 @@ def test_dataframe_from_json():
     parsed = _dataframe_from_json(
         jsonable_df.to_json(orient="split"), pandas_orient="split", schema=schema
     )
-    pd.testing.assert_frame_equal(
-        parsed, source.astype({"string": "string", "date_string": "string"})
-    )
+    pd.testing.assert_frame_equal(parsed, source)
     parsed = _dataframe_from_json(
         jsonable_df.to_json(orient="records"), pandas_orient="records", schema=schema
     )
-    pd.testing.assert_frame_equal(
-        parsed, source.astype({"string": "string", "date_string": "string"})
-    )
+    pd.testing.assert_frame_equal(parsed, source)
     # try parsing with tensor schema
     tensor_schema = Schema(
         [
@@ -505,13 +501,13 @@ def test_dataframe_from_json():
     )
 
     # NB: tensor schema does not automatically decode base64 encoded bytes.
-    pd.testing.assert_frame_equal(parsed, jsonable_df.astype({"binary": bytes}))
+    pd.testing.assert_frame_equal(parsed, jsonable_df)
     parsed = _dataframe_from_json(
         jsonable_df.to_json(orient="records"), pandas_orient="records", schema=tensor_schema
     )
 
     # NB: tensor schema does not automatically decode base64 encoded bytes.
-    pd.testing.assert_frame_equal(parsed, jsonable_df.astype({"binary": bytes}))
+    pd.testing.assert_frame_equal(parsed, jsonable_df)
 
     # Test parse with TensorSchema with a single tensor
     tensor_schema = Schema([TensorSpec(np.dtype("float32"), [-1, 3])])


### PR DESCRIPTION
Signed-off-by: dbczumar <corey.zumar@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

Fixes a regression caused by https://github.com/mlflow/mlflow/pull/6287 that caused coercion of inputs to pandas types.

## What changes are proposed in this pull request?

Fix regression in pandas type inference behavior for scoring server.

## How is this patch tested?

Reverted unit tests to behavior prior to https://github.com/mlflow/mlflow/pull/6287/files#diff-5bf4b1bc0b3499b52dd643e44054f4e7410d5e549fb7673ce0c45757f74ff11c, confirmed they pass.

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [X] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
