### PR TITLE
Raise clear error message when pipeline path contains a space

### DIFF
--- a/mlflow/pipelines/pipeline.py
+++ b/mlflow/pipelines/pipeline.py
@@ -239,6 +239,15 @@ class Pipeline:
             ) from None
 
         pipeline_root_path = get_pipeline_root_path()
+        if pipeline_root_path.contains(" "):
+            raise MlflowException(
+                message=(
+                    "Pipeline directory path cannot contain spaces. Please move or rename your"
+                    f" pipeline directory. Current path: {pipeline_root_path}",
+                ),
+                error_code=INVALID_PARAMETER_VALUE,
+            ) from None
+
         pipeline_config = get_pipeline_config(
             pipeline_root_path=pipeline_root_path, profile=profile
         )

--- a/mlflow/pipelines/pipeline.py
+++ b/mlflow/pipelines/pipeline.py
@@ -239,7 +239,7 @@ class Pipeline:
             ) from None
 
         pipeline_root_path = get_pipeline_root_path()
-        if pipeline_root_path.contains(" "):
+        if " " in pipeline_root_path:
             raise MlflowException(
                 message=(
                     "Pipeline directory path cannot contain spaces. Please move or rename your"

--- a/mlflow/pipelines/pipeline.py
+++ b/mlflow/pipelines/pipeline.py
@@ -243,7 +243,7 @@ class Pipeline:
             raise MlflowException(
                 message=(
                     "Pipeline directory path cannot contain spaces. Please move or rename your"
-                    f" pipeline directory. Current path: {pipeline_root_path}",
+                    f" pipeline directory. Current path: {pipeline_root_path}"
                 ),
                 error_code=INVALID_PARAMETER_VALUE,
             ) from None

--- a/tests/pipelines/test_pipeline.py
+++ b/tests/pipelines/test_pipeline.py
@@ -1,6 +1,6 @@
 import os
 import pathlib
-import shutil
+from distutils.dir_util import copy_tree
 
 import pandas as pd
 import pytest
@@ -60,12 +60,11 @@ def test_create_pipeline_fails_with_empty_profile_name(empty_profile):
 
 @pytest.mark.usefixtures("enter_pipeline_example_directory")
 def test_create_pipeline_fails_with_path_containing_space(tmp_path):
-    space_parent_dir = tmp_path / " space parent "
-    space_child_dir = space_parent_dir / "child"
-    os.makedirs(space_parent_dir)
-    shutil.copytree(os.getcwd(), space_child_dir)
+    space_path = tmp_path / " space parent " / "child"
+    os.makedirs(space_path)
+    copy_tree(os.getcwd(), str(space_path))
 
-    with chdir(space_child_dir), pytest.raises(
+    with chdir(space_path), pytest.raises(
         MlflowException, match="Pipeline directory path cannot contain spaces"
     ):
         Pipeline(profile="local")

--- a/tests/pipelines/test_pipeline.py
+++ b/tests/pipelines/test_pipeline.py
@@ -65,7 +65,9 @@ def test_create_pipeline_fails_with_path_containing_space(tmp_path):
     os.makedirs(space_parent_dir)
     shutil.copytree(os.getcwd(), space_child_dir)
 
-    with chdir(space_child_dir), pytest.raises(MlflowException, match="Pipeline directory path cannot contain spaces"):
+    with chdir(space_child_dir), pytest.raises(
+        MlflowException, match="Pipeline directory path cannot contain spaces"
+    ):
         Pipeline(profile="local")
 
 

--- a/tests/pipelines/test_pipeline.py
+++ b/tests/pipelines/test_pipeline.py
@@ -60,8 +60,10 @@ def test_create_pipeline_fails_with_empty_profile_name(empty_profile):
 
 @pytest.mark.usefixtures("enter_pipeline_example_directory")
 def test_create_pipeline_fails_with_path_containing_space(tmp_path):
-    space_path = tmp_path / " space parent " / "child"
-    os.makedirs(space_path)
+    space_parent = tmp_path / "space parent"
+    space_path = space_parent / "child"
+    os.makedirs(space_parent, exist_ok=True)
+    os.makedirs(space_path, exist_ok=True)
     copy_tree(os.getcwd(), str(space_path))
 
     with chdir(space_path), pytest.raises(


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

Addresses #6404

## What changes are proposed in this pull request?

Unfortunately, most implementations of Make do not support file paths with spaces, since spaces are syntactically used to separate Make targets. For example, this is a longstanding limitation in GNU Make: https://savannah.gnu.org/bugs/?712. To avoid confusing error behavior, as in #6404, this PR introduces a clear error message requesting that users move their pipeline directory to a path that does not contain spaces.

More drastic solutions include automatically copying or symlinking pipeline directory contents to a temporary directory, though this complicates the execution layer substantially. If users express a strong requirement for spaces in pipeline root paths, we can revisit this.

## How is this patch tested?

Unit test

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
