### PR TITLE
Augment predict step to use model name for register step

### DIFF
--- a/mlflow/pipelines/steps/predict.py
+++ b/mlflow/pipelines/steps/predict.py
@@ -139,9 +139,9 @@ class PredictStep(BaseStep):
                 model_name = register_config["model_name"]
             except KeyError:
                 raise MlflowException(
-                    "No model specified for batch scoring: register step does not have "
-                    "`model_name` configuration key and predict step does not have `model_uri` "
-                    "configuration key.",
+                    "No model specified for batch scoring: predict step does not have `model_uri` "
+                    "configuration key and register step does not have `model_name` configuration "
+                    " key.",
                     error_code=INVALID_PARAMETER_VALUE,
                 )
             else:

--- a/mlflow/pipelines/steps/predict.py
+++ b/mlflow/pipelines/steps/predict.py
@@ -133,6 +133,17 @@ class PredictStep(BaseStep):
                 "Invalid `output_format` in predict step configuration.",
                 error_code=INVALID_PARAMETER_VALUE,
             )
+        if "model_uri" not in step_config:
+            try:
+                register_config = pipeline_config["steps"]["predict"]
+                model_name = register_config["model_name"]
+            except KeyError:
+                raise MlflowException(
+                    "No model specified for batch scoring: register step does not have `model_name` "
+                    "configuration key and predict step does not have `model_uri` configuration key."
+                )
+            else:
+                step_config["model_uri"] = f"models:/{model_name}/latest"
         return cls(step_config, pipeline_root)
 
     @property

--- a/mlflow/pipelines/steps/predict.py
+++ b/mlflow/pipelines/steps/predict.py
@@ -135,12 +135,14 @@ class PredictStep(BaseStep):
             )
         if "model_uri" not in step_config:
             try:
-                register_config = pipeline_config["steps"]["predict"]
+                register_config = pipeline_config["steps"]["register"]
                 model_name = register_config["model_name"]
             except KeyError:
                 raise MlflowException(
-                    "No model specified for batch scoring: register step does not have `model_name` "
-                    "configuration key and predict step does not have `model_uri` configuration key."
+                    "No model specified for batch scoring: register step does not have "
+                    "`model_name` configuration key and predict step does not have `model_uri` "
+                    "configuration key.",
+                    error_code=INVALID_PARAMETER_VALUE,
                 )
             else:
                 step_config["model_uri"] = f"models:/{model_name}/latest"

--- a/mlflow/pipelines/steps/split.py
+++ b/mlflow/pipelines/steps/split.py
@@ -142,7 +142,6 @@ class SplitStep(BaseStep):
             card.add_tab(
                 "Run Summary",
                 """
-                {{ SCHEMA_LOCATION }}
                 {{ TRAIN_SPLIT_NUM_ROWS }}
                 {{ VALIDATION_SPLIT_NUM_ROWS }}
                 {{ TEST_SPLIT_NUM_ROWS }}

--- a/tests/pipelines/test_predict_step.py
+++ b/tests/pipelines/test_predict_step.py
@@ -9,7 +9,7 @@ from sklearn.datasets import load_diabetes
 
 from mlflow.exceptions import MlflowException
 from mlflow.pipelines.utils import _PIPELINE_CONFIG_FILE_NAME
-from mlflow.pipelines.steps.predict import PredictStep
+from mlflow.pipelines.steps.predict import PredictStep, _SCORED_OUTPUT_FILE_NAME
 
 # pylint: disable=unused-import
 from tests.pipelines.helper_functions import (
@@ -101,7 +101,12 @@ def test_predict_step_runs(
     )
     predict_step._run(str(predict_step_output_dir))
 
-    prediction_assertions(predict_step_output_dir, "parquet", "scored", spark_session)
+    # Test internal predict step output artifact
+    artifact_file_name, artifact_file_extension = _SCORED_OUTPUT_FILE_NAME.split(".")
+    prediction_assertions(
+        predict_step_output_dir, artifact_file_extension, artifact_file_name, spark_session
+    )
+    # Test user specified output
     prediction_assertions(predict_step_output_dir, "parquet", "output", spark_session)
 
 

--- a/tests/pipelines/test_predict_step.py
+++ b/tests/pipelines/test_predict_step.py
@@ -215,3 +215,36 @@ def test_predict_throws_when_improperly_configured():
             },
             pipeline_root=os.getcwd(),
         )
+
+
+@pytest.mark.usefixtures("enter_test_pipeline_directory")
+def test_predict_throws_when_model_unspecified():
+    pipeline_config = {
+        "steps": {
+            "predict": {
+                "output_format": "parquet",
+                "output_location": "random/path",
+            }
+        }
+    }
+    with pytest.raises(MlflowException, match="No model specified for batch scoring"):
+        PredictStep.from_pipeline_config(
+            pipeline_config=pipeline_config,
+            pipeline_root=os.getcwd(),
+        )
+
+    pipeline_config_register = {
+        "steps": {
+            "predict": {
+                "output_format": "parquet",
+                "output_location": "random/path",
+            },
+            "register": {
+                "model_name": "taxi_fare_regressor",
+            },
+        }
+    }
+    PredictStep.from_pipeline_config(
+        pipeline_config=pipeline_config_register,
+        pipeline_root=os.getcwd(),
+    )

--- a/tests/pipelines/test_predict_step.py
+++ b/tests/pipelines/test_predict_step.py
@@ -274,7 +274,7 @@ def test_predict_throws_when_improperly_configured():
 
 
 @pytest.mark.usefixtures("enter_test_pipeline_directory")
-def test_predict_throws_when_model_is_unspecified():
+def test_predict_throws_when_no_model_is_specified():
     pipeline_config = {
         "steps": {
             "predict": {


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

## What changes are proposed in this pull request?

This PR adds functionality to the predict step to rely on the `model_name` configuration key of the register step when no `model_uri` key is specified.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
