### PR TITLE
Add Pipelines step option to skip step profiling

### DIFF
--- a/mlflow/pipelines/steps/ingest/__init__.py
+++ b/mlflow/pipelines/steps/ingest/__init__.py
@@ -39,7 +39,7 @@ class IngestStep(BaseStep):
         super().__init__(step_config, pipeline_root)
 
         dataset_format = step_config.get("format")
-        self.disable_profiling = step_config.get("disable_profiling", False)
+        self.skip_data_profiling = step_config.get("skip_data_profiling", False)
         if not dataset_format:
             raise MlflowException(
                 message=(
@@ -75,7 +75,7 @@ class IngestStep(BaseStep):
 
         ingested_df = read_parquet_as_pandas_df(data_parquet_path=dataset_dst_path)
         ingested_dataset_profile = None
-        if not self.disable_profiling:
+        if not self.skip_data_profiling:
             _logger.info("Profiling ingested dataset")
             ingested_dataset_profile = get_pandas_data_profile(
                 ingested_df, "Profile of Ingested Dataset"
@@ -130,7 +130,7 @@ class IngestStep(BaseStep):
             )
 
         card = BaseCard(self.pipeline_name, self.name)
-        if not self.disable_profiling:
+        if not self.skip_data_profiling:
             (  # Tab #1 -- Ingested dataset profile.
                 card.add_tab("Data Profile", "{{PROFILE}}").add_pandas_profile(
                     "PROFILE", ingested_dataset_profile

--- a/mlflow/pipelines/steps/ingest/__init__.py
+++ b/mlflow/pipelines/steps/ingest/__init__.py
@@ -39,7 +39,7 @@ class IngestStep(BaseStep):
         super().__init__(step_config, pipeline_root)
 
         dataset_format = step_config.get("format")
-        self.disable_profiling = step_config.get("disable_profiler", False)
+        self.disable_profiling = step_config.get("disable_profiling", False)
         if not dataset_format:
             raise MlflowException(
                 message=(

--- a/mlflow/pipelines/steps/ingest/__init__.py
+++ b/mlflow/pipelines/steps/ingest/__init__.py
@@ -39,6 +39,7 @@ class IngestStep(BaseStep):
         super().__init__(step_config, pipeline_root)
 
         dataset_format = step_config.get("format")
+        self.disable_profiling = step_config.get("disable_profiler", False)
         if not dataset_format:
             raise MlflowException(
                 message=(
@@ -72,17 +73,20 @@ class IngestStep(BaseStep):
         )
         _logger.info("Successfully stored data in parquet format at '%s'", dataset_dst_path)
 
-        _logger.info("Profiling ingested dataset")
         ingested_df = read_parquet_as_pandas_df(data_parquet_path=dataset_dst_path)
-        ingested_dataset_profile = get_pandas_data_profile(
-            ingested_df, "Profile of Ingested Dataset"
-        )
+        ingested_dataset_profile = None
+        if not self.disable_profiling:
+            _logger.info("Profiling ingested dataset")
+            ingested_dataset_profile = get_pandas_data_profile(
+                ingested_df, "Profile of Ingested Dataset"
+            )
+            dataset_profile_path = os.path.join(
+                output_directory, IngestStep._DATASET_PROFILE_OUTPUT_NAME
+            )
+            ingested_dataset_profile.to_file(output_file=dataset_profile_path)
+            _logger.info(f"Wrote dataset profile to '{dataset_profile_path}'")
+
         schema = pd.io.json.build_table_schema(ingested_df, index=False)
-        dataset_profile_path = os.path.join(
-            output_directory, IngestStep._DATASET_PROFILE_OUTPUT_NAME
-        )
-        ingested_dataset_profile.to_file(output_file=dataset_profile_path)
-        _logger.info(f"Wrote dataset profile to '{dataset_profile_path}'")
 
         step_card = self._build_step_card(
             ingested_dataset_profile=ingested_dataset_profile,
@@ -126,11 +130,12 @@ class IngestStep(BaseStep):
             )
 
         card = BaseCard(self.pipeline_name, self.name)
-        (  # Tab #1 -- Ingested dataset profile.
-            card.add_tab("Data Profile", "{{PROFILE}}").add_pandas_profile(
-                "PROFILE", ingested_dataset_profile
+        if not self.disable_profiling:
+            (  # Tab #1 -- Ingested dataset profile.
+                card.add_tab("Data Profile", "{{PROFILE}}").add_pandas_profile(
+                    "PROFILE", ingested_dataset_profile
+                )
             )
-        )
         # Tab #2 -- Ingested dataset schema.
         schema_html = BaseCard.render_table(schema["fields"])
         card.add_tab("Data Schema", "{{SCHEMA}}").add_html("SCHEMA", schema_html)
@@ -164,9 +169,11 @@ class IngestStep(BaseStep):
                 message="The `data` section of pipeline.yaml must be specified",
                 error_code=INVALID_PARAMETER_VALUE,
             )
+        data_config = pipeline_config["data"]
+        ingest_config = pipeline_config.get("steps", {}).get("ingest", {})
 
         return cls(
-            step_config=pipeline_config["data"],
+            step_config={**data_config, **ingest_config},
             pipeline_root=pipeline_root,
         )
 

--- a/mlflow/pipelines/steps/split.py
+++ b/mlflow/pipelines/steps/split.py
@@ -92,7 +92,7 @@ class SplitStep(BaseStep):
         self.num_dropped_rows = None
 
         self.target_col = self.step_config.get("target_col")
-        self.disable_profiling = self.step_config.get("disable_profiling", False)
+        self.skip_data_profiling = self.step_config.get("skip_data_profiling", False)
         if self.target_col is None:
             raise MlflowException(
                 "Missing target_col config in pipeline config.",
@@ -115,7 +115,7 @@ class SplitStep(BaseStep):
         # Build card
         card = BaseCard(self.pipeline_name, self.name)
 
-        if not self.disable_profiling:
+        if not self.skip_data_profiling:
             # Build profiles for input dataset, and train / validation / test splits
             train_profile = get_pandas_data_profile(
                 train_df.reset_index(drop=True),

--- a/mlflow/pipelines/steps/split.py
+++ b/mlflow/pipelines/steps/split.py
@@ -92,7 +92,7 @@ class SplitStep(BaseStep):
         self.num_dropped_rows = None
 
         self.target_col = self.step_config.get("target_col")
-        self.disable_profiling = self.step_config.get("disable_profiling")
+        self.disable_profiling = self.step_config.get("disable_profiling", False)
         if self.target_col is None:
             raise MlflowException(
                 "Missing target_col config in pipeline config.",

--- a/mlflow/pipelines/steps/split.py
+++ b/mlflow/pipelines/steps/split.py
@@ -92,6 +92,7 @@ class SplitStep(BaseStep):
         self.num_dropped_rows = None
 
         self.target_col = self.step_config.get("target_col")
+        self.disable_profiling = self.step_config.get("disable_profiling")
         if self.target_col is None:
             raise MlflowException(
                 "Missing target_col config in pipeline config.",
@@ -111,32 +112,35 @@ class SplitStep(BaseStep):
         self.split_ratios = split_ratios
 
     def _build_profiles_and_card(self, train_df, validation_df, test_df) -> BaseCard:
-        # Build profiles for input dataset, and train / validation / test splits
-        train_profile = get_pandas_data_profile(
-            train_df.reset_index(drop=True),
-            "Profile of Train Dataset",
-        )
-        validation_profile = get_pandas_data_profile(
-            validation_df.reset_index(drop=True),
-            "Profile of Validation Dataset",
-        )
-        test_profile = get_pandas_data_profile(
-            test_df.reset_index(drop=True),
-            "Profile of Test Dataset",
-        )
-
         # Build card
         card = BaseCard(self.pipeline_name, self.name)
-        # Tab #1 - #3: data profiles for train/validation and test.
-        card.add_tab("Data Profile (Train)", "{{PROFILE}}").add_pandas_profile(
-            "PROFILE", train_profile
-        )
-        card.add_tab("Data Profile (Validation)", "{{PROFILE}}").add_pandas_profile(
-            "PROFILE", validation_profile
-        )
-        card.add_tab("Data Profile (Test)", "{{PROFILE}}").add_pandas_profile(
-            "PROFILE", test_profile
-        )
+
+        if not self.disable_profiling:
+            # Build profiles for input dataset, and train / validation / test splits
+            train_profile = get_pandas_data_profile(
+                train_df.reset_index(drop=True),
+                "Profile of Train Dataset",
+            )
+            validation_profile = get_pandas_data_profile(
+                validation_df.reset_index(drop=True),
+                "Profile of Validation Dataset",
+            )
+            test_profile = get_pandas_data_profile(
+                test_df.reset_index(drop=True),
+                "Profile of Test Dataset",
+            )
+
+            # Tab #1 - #3: data profiles for train/validation and test.
+            card.add_tab("Data Profile (Train)", "{{PROFILE}}").add_pandas_profile(
+                "PROFILE", train_profile
+            )
+            card.add_tab("Data Profile (Validation)", "{{PROFILE}}").add_pandas_profile(
+                "PROFILE", validation_profile
+            )
+            card.add_tab("Data Profile (Test)", "{{PROFILE}}").add_pandas_profile(
+                "PROFILE", test_profile
+            )
+
         # Tab #4: run summary.
         (
             card.add_tab(

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -45,7 +45,7 @@ class TrainStep(BaseStep):
         self.pipeline_config = pipeline_config
         self.tracking_config = TrackingConfig.from_dict(step_config)
         self.target_col = self.step_config.get("target_col")
-        self.disable_profiling = self.step_config.get("disable_profiling", False)
+        self.skip_data_profiling = self.step_config.get("skip_data_profiling", False)
         self.train_module_name, self.estimator_method_name = self.step_config[
             "estimator_method"
         ].rsplit(".", 1)
@@ -353,7 +353,7 @@ class TrainStep(BaseStep):
             "<h3 class='section-title'>Summary Metrics</h3>{{ METRICS }} ",
         ).add_html("METRICS", metric_table_html)
 
-        if not self.disable_profiling:
+        if not self.skip_data_profiling:
             # Tab 2: Prediction and error data profile.
             pred_and_error_df_profile = get_pandas_data_profile(
                 pred_and_error_df.reset_index(drop=True),

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -45,6 +45,7 @@ class TrainStep(BaseStep):
         self.pipeline_config = pipeline_config
         self.tracking_config = TrackingConfig.from_dict(step_config)
         self.target_col = self.step_config.get("target_col")
+        self.disable_profiling = self.step_config.get("disable_profiling", False)
         self.train_module_name, self.estimator_method_name = self.step_config[
             "estimator_method"
         ].rsplit(".", 1)
@@ -352,14 +353,15 @@ class TrainStep(BaseStep):
             "<h3 class='section-title'>Summary Metrics</h3>{{ METRICS }} ",
         ).add_html("METRICS", metric_table_html)
 
-        # Tab 2: Prediction and error data profile.
-        pred_and_error_df_profile = get_pandas_data_profile(
-            pred_and_error_df.reset_index(drop=True),
-            "Predictions and Errors (Validation Dataset)",
-        )
-        card.add_tab("Profile of Predictions and Errors", "{{PROFILE}}").add_pandas_profile(
-            "PROFILE", pred_and_error_df_profile
-        )
+        if not self.disable_profiling:
+            # Tab 2: Prediction and error data profile.
+            pred_and_error_df_profile = get_pandas_data_profile(
+                pred_and_error_df.reset_index(drop=True),
+                "Predictions and Errors (Validation Dataset)",
+            )
+            card.add_tab("Profile of Predictions and Errors", "{{PROFILE}}").add_pandas_profile(
+                "PROFILE", pred_and_error_df_profile
+            )
         # Tab 3: Model architecture.
         set_config(display="diagram")
         model_repr = estimator_html_repr(model)

--- a/mlflow/pipelines/steps/transform.py
+++ b/mlflow/pipelines/steps/transform.py
@@ -50,7 +50,7 @@ class TransformStep(BaseStep):
         self.run_end_time = None
         self.execution_duration = None
         self.target_col = self.step_config.get("target_col")
-        self.disable_profiling = self.step_config.get("disable_profiling", False)
+        self.skip_data_profiling = self.step_config.get("skip_data_profiling", False)
         (self.transformer_module_name, self.transformer_method_name,) = self.step_config[
             "transformer_method"
         ].rsplit(".", 1)
@@ -125,7 +125,7 @@ class TransformStep(BaseStep):
         # Build card
         card = BaseCard(self.pipeline_name, self.name)
 
-        if not self.disable_profiling:
+        if not self.skip_data_profiling:
             # Tab 1 and 2: build profiles for train_transformed, validation_transformed
             train_transformed_profile = get_pandas_data_profile(
                 train_transformed,

--- a/mlflow/pipelines/steps/transform.py
+++ b/mlflow/pipelines/steps/transform.py
@@ -50,6 +50,7 @@ class TransformStep(BaseStep):
         self.run_end_time = None
         self.execution_duration = None
         self.target_col = self.step_config.get("target_col")
+        self.disable_profiling = self.step_config.get("disable_profiling", False)
         (self.transformer_module_name, self.transformer_method_name,) = self.step_config[
             "transformer_method"
         ].rsplit(".", 1)
@@ -124,21 +125,22 @@ class TransformStep(BaseStep):
         # Build card
         card = BaseCard(self.pipeline_name, self.name)
 
-        # Tab 1 and 2: build profiles for train_transformed, validation_transformed
-        train_transformed_profile = get_pandas_data_profile(
-            train_transformed,
-            "Profile of Train Transformed Dataset",
-        )
-        validation_transformed_profile = get_pandas_data_profile(
-            validation_transformed,
-            "Profile of Validation Transformed Dataset",
-        )
-        card.add_tab("Data Profile (Train Transformed)", "{{PROFILE}}").add_pandas_profile(
-            "PROFILE", train_transformed_profile
-        )
-        card.add_tab("Data Profile (Validation Transformed)", "{{PROFILE}}").add_pandas_profile(
-            "PROFILE", validation_transformed_profile
-        )
+        if not self.disable_profiling:
+            # Tab 1 and 2: build profiles for train_transformed, validation_transformed
+            train_transformed_profile = get_pandas_data_profile(
+                train_transformed,
+                "Profile of Train Transformed Dataset",
+            )
+            validation_transformed_profile = get_pandas_data_profile(
+                validation_transformed,
+                "Profile of Validation Transformed Dataset",
+            )
+            card.add_tab("Data Profile (Train Transformed)", "{{PROFILE}}").add_pandas_profile(
+                "PROFILE", train_transformed_profile
+            )
+            card.add_tab("Data Profile (Validation Transformed)", "{{PROFILE}}").add_pandas_profile(
+                "PROFILE", validation_transformed_profile
+            )
 
         # Tab 3: transformer diagram
         from sklearn.utils import estimator_html_repr

--- a/tests/pipelines/test_ingest_step.py
+++ b/tests/pipelines/test_ingest_step.py
@@ -647,7 +647,7 @@ def test_ingest_skips_profiling_when_specified(pandas_df, tmp_path):
                     "format": "parquet",
                     "location": str(dataset_path),
                 },
-                "steps": {"ingest": {"disable_profiling": True}},
+                "steps": {"ingest": {"skip_data_profiling": True}},
             },
             pipeline_root=os.getcwd(),
         ).run(output_directory=tmp_path)

--- a/tests/pipelines/test_ingest_step.py
+++ b/tests/pipelines/test_ingest_step.py
@@ -633,3 +633,31 @@ def test_ingest_throws_when_dataset_files_have_wrong_format(pandas_df, tmp_path)
             },
             pipeline_root=os.getcwd(),
         ).run(output_directory=tmp_path)
+
+
+@pytest.mark.usefixtures("enter_test_pipeline_directory")
+def test_ingest_skips_profiling_when_specified(pandas_df, tmp_path):
+    dataset_path = tmp_path / "df.parquet"
+    pandas_df.to_parquet(dataset_path)
+
+    with mock.patch("mlflow.pipelines.utils.step.get_pandas_data_profile") as mock_profiling:
+        IngestStep.from_pipeline_config(
+            pipeline_config={
+                "data": {
+                    "format": "parquet",
+                    "location": str(dataset_path),
+                },
+                "steps": {
+                    "ingest": {
+                        "disable_profiling": True
+                    }
+                }
+            },
+            pipeline_root=os.getcwd(),
+        ).run(output_directory=tmp_path)
+
+    expected_step_card_path = os.path.join(tmp_path, "card.html")
+    with open(expected_step_card_path, "r") as f:
+        step_card_html_content = f.read()
+    assert "Profile of Ingested Dataset" not in step_card_html_content
+    mock_profiling.assert_not_called()

--- a/tests/pipelines/test_ingest_step.py
+++ b/tests/pipelines/test_ingest_step.py
@@ -647,11 +647,7 @@ def test_ingest_skips_profiling_when_specified(pandas_df, tmp_path):
                     "format": "parquet",
                     "location": str(dataset_path),
                 },
-                "steps": {
-                    "ingest": {
-                        "disable_profiling": True
-                    }
-                }
+                "steps": {"ingest": {"disable_profiling": True}},
             },
             pipeline_root=os.getcwd(),
         ).run(output_directory=tmp_path)

--- a/tests/pipelines/test_split_step.py
+++ b/tests/pipelines/test_split_step.py
@@ -147,8 +147,11 @@ def test_split_step_skips_profiling_when_specified(tmp_path):
 
     with mock.patch.dict(
         os.environ, {_MLFLOW_PIPELINES_EXECUTION_DIRECTORY_ENV_VAR: str(tmp_path)}
-    ), mock.patch("mlflow.pipelines.utils.step.get_pandas_data_profile") as mock_profiling,\
-            mock.patch("mlflow.pipelines.step.get_pipeline_name", return_value="fake_name"):
+    ), mock.patch(
+        "mlflow.pipelines.utils.step.get_pandas_data_profile"
+    ) as mock_profiling, mock.patch(
+        "mlflow.pipelines.step.get_pipeline_name", return_value="fake_name"
+    ):
         split_step = SplitStep({"target_col": "y", "disable_profiling": True}, "fake_root")
         split_step._run(str(split_output_dir))
 

--- a/tests/pipelines/test_split_step.py
+++ b/tests/pipelines/test_split_step.py
@@ -152,7 +152,7 @@ def test_split_step_skips_profiling_when_specified(tmp_path):
     ) as mock_profiling, mock.patch(
         "mlflow.pipelines.step.get_pipeline_name", return_value="fake_name"
     ):
-        split_step = SplitStep({"target_col": "y", "disable_profiling": True}, "fake_root")
+        split_step = SplitStep({"target_col": "y", "skip_data_profiling": True}, "fake_root")
         split_step._run(str(split_output_dir))
 
     mock_profiling.assert_not_called()


### PR DESCRIPTION
Signed-off-by: apurva-koti <apurva.koti@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## What changes are proposed in this pull request?

Add step-level configs for skipping data profiling.
If option is enabled, we skip the pandas profiling part of the `_run` method and accordingly leave it out of the step card.


## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

Manual testing:
- Confirmed profiling logs are not visible in the output. ✅ 
- Confirmed profiling does not appear as a tab in the step card. ✅ 
- Runtime is faster. ✅ 
Before for split:
```
Run duration (s): 8.83
```
After for split:
```
Run duration (s): 0.231
```

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

A `skip_data_profiling` option has been added to applicable MLflow Pipelines steps (ingest, step, transform and train).

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
