### PR TITLE
Allow specifying mlflow command line args as env variables.

### DIFF
--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -244,6 +244,7 @@ def _validate_server_args(gunicorn_opts=None, workers=None, waitress_opts=None):
 @cli.command()
 @click.option(
     "--backend-store-uri",
+    envvar="MLFLOW_BACKEND_STORE_URI",
     metavar="PATH",
     default=DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH,
     help="URI to which to persist experiment and run data. Acceptable URIs are "
@@ -254,6 +255,7 @@ def _validate_server_args(gunicorn_opts=None, workers=None, waitress_opts=None):
 )
 @click.option(
     "--registry-store-uri",
+    envvar="MLFLOW_REGISTRY_STORE_URI",
     metavar="URI",
     default=None,
     help="URI to which to persist registered models. Acceptable URIs are "
@@ -262,6 +264,7 @@ def _validate_server_args(gunicorn_opts=None, workers=None, waitress_opts=None):
 )
 @click.option(
     "--default-artifact-root",
+    envvar="MLFLOW_DEFAULT_ARTIFACT_ROOT",
     metavar="URI",
     default=None,
     help="Directory in which to store artifacts for any new experiments created. For tracking "
@@ -352,6 +355,7 @@ def _validate_static_prefix(ctx, param, value):  # pylint: disable=unused-argume
 @cli.command()
 @click.option(
     "--backend-store-uri",
+    envvar="MLFLOW_BACKEND_STORE_URI",
     metavar="PATH",
     default=DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH,
     help="URI to which to persist experiment and run data. Acceptable URIs are "
@@ -362,6 +366,7 @@ def _validate_static_prefix(ctx, param, value):  # pylint: disable=unused-argume
 )
 @click.option(
     "--registry-store-uri",
+    envvar="MLFLOW_REGISTRY_STORE_URI",
     metavar="URI",
     default=None,
     help="URI to which to persist registered models. Acceptable URIs are "
@@ -370,6 +375,7 @@ def _validate_static_prefix(ctx, param, value):  # pylint: disable=unused-argume
 )
 @click.option(
     "--default-artifact-root",
+    envvar="MLFLOW_DEFAULT_ARTIFACT_ROOT",
     metavar="URI",
     default=None,
     help="Directory in which to store artifacts for any new experiments created. For tracking "
@@ -383,6 +389,7 @@ def _validate_static_prefix(ctx, param, value):  # pylint: disable=unused-argume
 @cli_args.SERVE_ARTIFACTS
 @click.option(
     "--artifacts-only",
+    envvar="MLFLOW_ARTIFACTS_ONLY",
     is_flag=True,
     default=False,
     help="If specified, configures the mlflow server to be used only for proxied artifact serving. "
@@ -397,12 +404,14 @@ def _validate_static_prefix(ctx, param, value):  # pylint: disable=unused-argume
 @cli_args.WORKERS
 @click.option(
     "--static-prefix",
+    envvar="MLFLOW_STATIC_PREFIX",
     default=None,
     callback=_validate_static_prefix,
     help="A prefix which will be prepended to the path of all static paths.",
 )
 @click.option(
     "--gunicorn-opts",
+    envvar="MLFLOW_GUNICORN_OPTS",
     default=None,
     help="Additional command line options forwarded to gunicorn processes.",
 )
@@ -411,6 +420,7 @@ def _validate_static_prefix(ctx, param, value):  # pylint: disable=unused-argume
 )
 @click.option(
     "--expose-prometheus",
+    envvar="MLFLOW_EXPOSE_PROMETHEUS",
     default=None,
     help="Path to the directory where metrics will be stored. If the directory "
     "doesn't exist, it will be created. "

--- a/mlflow/utils/cli_args.py
+++ b/mlflow/utils/cli_args.py
@@ -139,6 +139,7 @@ INSTALL_MLFLOW = click.option(
 HOST = click.option(
     "--host",
     "-h",
+    envvar="MLFLOW_HOST",
     metavar="HOST",
     default="127.0.0.1",
     help="The network address to listen on (default: 127.0.0.1). "
@@ -146,7 +147,13 @@ HOST = click.option(
     "server from other machines.",
 )
 
-PORT = click.option("--port", "-p", default=5000, help="The port to listen on (default: 5000).")
+PORT = click.option(
+    "--port",
+    "-p",
+    envvar="MLFLOW_PORT",
+    default=5000,
+    help="The port to listen on (default: 5000).",
+)
 
 TIMEOUT = click.option(
     "--timeout", "-t", help="Timeout in seconds to serve a request (default: 60)."
@@ -156,6 +163,7 @@ TIMEOUT = click.option(
 WORKERS = click.option(
     "--workers",
     "-w",
+    envvar="MLFLOW_WORKERS",
     default=None,
     help="Number of gunicorn worker processes to handle requests (default: 4).",
 )
@@ -169,6 +177,7 @@ ENABLE_MLSERVER = click.option(
 
 ARTIFACTS_DESTINATION = click.option(
     "--artifacts-destination",
+    envvar="MLFLOW_ARTIFACTS_DESTINATION",
     metavar="URI",
     default="./mlartifacts",
     help=(
@@ -181,6 +190,7 @@ ARTIFACTS_DESTINATION = click.option(
 
 SERVE_ARTIFACTS = click.option(
     "--serve-artifacts",
+    envvar="MLFLOW_SERVE_ARTIFACTS",
     is_flag=True,
     default=False,
     help="If specified, enables serving of artifact uploads, downloads, and list requests "


### PR DESCRIPTION
Signed-off-by: Phil Xiaojun Hu <phil@cnphil.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
Close #3122 

## What changes are proposed in this pull request?

Allow the following flags to be read from environment variables:

* MLFLOW_BACKEND_STORE_URI
* MLFLOW_DEFAULT_ARTIFACT_ROOT
* MLFLOW_ARTIFACTS_DESTINATION
* MLFLOW_SERVE_ARTIFACTS
* MLFLOW_HOST
* MLFLOW_PORT

## How is this patch tested?

Some help/guidance wanted:
- Ran `pytest tests/test_cli.py`, all tests pass except for `tests/test_cli.py::test_mlflow_models_serve[True]` which seems to be stuck in an infinite loop, is this expected? (The test also fails on master/HEAD for me, so probably unrelated to the PR)
- Manually tested by running `mlflow server` with the added env variables, seems to work.
- Also please give some guidance on whether this PR deserves its own test case in test_cli.py.

- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

## Does this PR change the documentation?

Please also give some guidance on whether this PR needs a docs change.

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

mlflow server configurations can also be specified in environment variables.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
