### PR TITLE
Use `virtualenv` by default when restoring a model environment

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -197,6 +197,7 @@ jobs:
           repository: ${{ github.event.inputs.repository }}
           ref: ${{ github.event.inputs.ref }}
       - uses: ./.github/actions/setup-python
+      - uses: ./.github/actions/setup-pyenv
       - uses: ./.github/actions/setup-java
       - name: Install dependencies
         run: |

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -33,6 +33,11 @@ jobs:
         submodules: recursive
         repository: ${{ github.event.inputs.repository }}
         ref: ${{ github.event.inputs.ref }}
+    - uses: ./.github/actions/setup-python
+    - uses: ./.github/actions/setup-pyenv
+    - name: Install virtualenv
+      run: |
+        pip install virtualenv
     - uses: ./.github/actions/setup-java
     - uses: r-lib/actions/setup-r@v2
     # This step dumps the current set of R dependencies and R version into files to be used

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -64,7 +64,7 @@ def serve(
             "data": [[1, 2, 3], [4, 5, 6]]
         }'
     """
-    env_manager = env_manager or _EnvManager.CONDA
+    env_manager = env_manager or _EnvManager.VIRTUALENV
     return _get_flavor_backend(
         model_uri, env_manager=env_manager, workers=workers, install_mlflow=install_mlflow
     ).serve(
@@ -119,7 +119,7 @@ def predict(
     data formats accepted by this function, see the following documentation:
     https://www.mlflow.org/docs/latest/models.html#built-in-deployment-tools.
     """
-    env_manager = env_manager or _EnvManager.CONDA
+    env_manager = env_manager or _EnvManager.VIRTUALENV
     if content_type == "json" and json_format not in ("split", "records"):
         raise Exception("Unsupported json format '{}'.".format(json_format))
     return _get_flavor_backend(
@@ -149,7 +149,7 @@ def prepare_env(
     downloading dependencies or initializing a conda environment. After preparation,
     calling predict or serve should be fast.
     """
-    env_manager = env_manager or _EnvManager.CONDA
+    env_manager = env_manager or _EnvManager.VIRTUALENV
     return _get_flavor_backend(
         model_uri, env_manager=env_manager, install_mlflow=install_mlflow
     ).prepare_env(model_uri=model_uri)
@@ -205,7 +205,7 @@ def build_docker(model_uri, name, env_manager, mlflow_home, install_mlflow, enab
     See https://www.mlflow.org/docs/latest/python_api/mlflow.pyfunc.html for more information on the
     'python_function' flavor.
     """
-    env_manager = env_manager or _EnvManager.CONDA
+    env_manager = env_manager or _EnvManager.VIRTUALENV
     _get_flavor_backend(model_uri, docker_build=True, env_manager=env_manager).build_image(
         model_uri,
         name,

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -918,7 +918,7 @@ def _get_or_create_env_root_dir(should_use_nfs):
 _MLFLOW_SERVER_OUTPUT_TAIL_LINES_TO_KEEP = 200
 
 
-def spark_udf(spark, model_uri, result_type="double", env_manager=_EnvManager.VIRTUALENV):
+def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
     """
     A Spark UDF that can be used to invoke the Python function formatted model.
 
@@ -994,7 +994,7 @@ def spark_udf(spark, model_uri, result_type="double", env_manager=_EnvManager.VI
     :param env_manager: The environment manager to use in order to create the python environment
                         for model inference. Note that environment is only restored in the context
                         of the PySpark UDF; the software environment outside of the UDF is
-                        unaffected. Default value is ``virtualenv``, and the following values are
+                        unaffected. Default value is ``local``, and the following values are
                         supported:
 
                          - ``conda``: (Recommended) Use Conda to restore the software environment

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -918,7 +918,7 @@ def _get_or_create_env_root_dir(should_use_nfs):
 _MLFLOW_SERVER_OUTPUT_TAIL_LINES_TO_KEEP = 200
 
 
-def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
+def spark_udf(spark, model_uri, result_type="double", env_manager=_EnvManager.VIRTUALENV):
     """
     A Spark UDF that can be used to invoke the Python function formatted model.
 
@@ -994,13 +994,13 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
     :param env_manager: The environment manager to use in order to create the python environment
                         for model inference. Note that environment is only restored in the context
                         of the PySpark UDF; the software environment outside of the UDF is
-                        unaffected. Default value is ``local``, and the following values are
+                        unaffected. Default value is ``virtualenv``, and the following values are
                         supported:
 
-                         - ``conda``: (Recommended) Use Conda to restore the software environment
-                           that was used to train the model.
                          - ``virtualenv``: Use virtualenv to restore the python environment that
                            was used to train the model.
+                         - ``conda``: (Recommended) Use Conda to restore the software environment
+                           that was used to train the model.
                          - ``local``: Use the current Python environment for model inference, which
                            may differ from the environment used to train the model and may lead to
                            errors or invalid predictions.

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -918,7 +918,7 @@ def _get_or_create_env_root_dir(should_use_nfs):
 _MLFLOW_SERVER_OUTPUT_TAIL_LINES_TO_KEEP = 200
 
 
-def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
+def spark_udf(spark, model_uri, result_type="double", env_manager=_EnvManager.VIRTUALENV):
     """
     A Spark UDF that can be used to invoke the Python function formatted model.
 
@@ -994,7 +994,7 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
     :param env_manager: The environment manager to use in order to create the python environment
                         for model inference. Note that environment is only restored in the context
                         of the PySpark UDF; the software environment outside of the UDF is
-                        unaffected. Default value is ``local``, and the following values are
+                        unaffected. Default value is ``virtualenv``, and the following values are
                         supported:
 
                          - ``conda``: (Recommended) Use Conda to restore the software environment

--- a/mlflow/sagemaker/cli.py
+++ b/mlflow/sagemaker/cli.py
@@ -578,7 +578,7 @@ def build_and_push_container(build, push, container, env_manager, mlflow_home):
     The image is built locally and it requires Docker to run.
     The image is pushed to ECR under current active AWS account and to current active AWS region.
     """
-    env_manager = env_manager or em.CONDA
+    env_manager = env_manager or em.VIRTUALENV
     if not (build or push):
         click.echo("skipping both build and push, have nothing to do!")
     if build:

--- a/mlflow/utils/cli_args.py
+++ b/mlflow/utils/cli_args.py
@@ -121,7 +121,7 @@ environment manager. The following values are supported:
 - conda: use conda
 - virtualenv: use virtualenv (and pyenv for Python version management)
 
-If unspecified, default to conda.
+If unspecified, default to virtualenv.
 """,
 )
 

--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -1,7 +1,6 @@
 import yaml
 import os
 import logging
-import sys
 import re
 import hashlib
 
@@ -64,14 +63,10 @@ class _PythonEnv:
     @classmethod
     def current(cls):
         return cls(
-            python=cls._get_current_python(),
+            python=PYTHON_VERSION,
             build_dependencies=cls.get_current_build_dependencies(),
             dependencies=[f"-r {_REQUIREMENTS_FILE_NAME}"],
         )
-
-    @staticmethod
-    def _get_current_python():
-        return ".".join(map(str, sys.version_info[:3]))
 
     @staticmethod
     def _get_package_version(package_name):
@@ -159,10 +154,11 @@ class _PythonEnv:
                 )
 
         if python is None:
-            raise MlflowException(
-                f"Could not extract python version from {path}",
-                error_code=INVALID_PARAMETER_VALUE,
+            _logger.warning(
+                f"{path} does not include a python version specification. "
+                f"Using the current python version {PYTHON_VERSION}."
             )
+            python = PYTHON_VERSION
 
         if unmatched_dependencies:
             _logger.warning(

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -398,7 +398,7 @@ def test_prepare_env_fails(sk_model):
     with TempDir(chdr=True):
         with mlflow.start_run() as active_run:
             mlflow.sklearn.log_model(
-                sk_model, "model", conda_env={"dependencies": ["mlflow-does-not-exist-dep==abc"]}
+                sk_model, "model", pip_requirements=["does-not-exist-dep==abc"]
             )
             model_uri = "runs:/{run_id}/model".format(run_id=active_run.info.run_id)
 

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -133,7 +133,15 @@ def test_mlflow_is_not_installed_unless_specified():
         _mlflow_conda_env(path=os.path.join(fake_model_path, "conda.yaml"), install_mlflow=False)
         # The following should fail because there should be no mlflow in the env:
         p = subprocess.Popen(
-            ["mlflow", "models", "predict", "-m", fake_model_path],
+            [
+                "mlflow",
+                "models",
+                "predict",
+                "-m",
+                fake_model_path,
+                "--env-manager",
+                "conda",
+            ],
             stderr=subprocess.PIPE,
             cwd=tmp.path(""),
         )

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -225,7 +225,10 @@ def test_spark_udf_with_single_arg(spark):
         mlflow.pyfunc.log_model("model", python_model=TestModel())
 
         udf = mlflow.pyfunc.spark_udf(
-            spark, "runs:/{}/model".format(run.info.run_id), result_type=StringType()
+            spark,
+            "runs:/{}/model".format(run.info.run_id),
+            result_type=StringType(),
+            env_manager="conda",
         )
 
         data1 = spark.createDataFrame(pd.DataFrame({"a": [1], "b": [4]})).repartition(1)

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -219,7 +219,7 @@ def test_spark_udf_env_manager_predict_sklearn_model(spark, sklearn_model, model
 def test_spark_udf_with_single_arg(spark):
     class TestModel(PythonModel):
         def predict(self, context, model_input):
-            return [",".join(model_input.columns.tolist())] * len(model_input)
+            return [",".join(map(str, model_input.columns.tolist()))] * len(model_input)
 
     with mlflow.start_run() as run:
         mlflow.pyfunc.log_model("model", python_model=TestModel())

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -225,10 +225,7 @@ def test_spark_udf_with_single_arg(spark):
         mlflow.pyfunc.log_model("model", python_model=TestModel())
 
         udf = mlflow.pyfunc.spark_udf(
-            spark,
-            "runs:/{}/model".format(run.info.run_id),
-            result_type=StringType(),
-            env_manager="conda",
+            spark, "runs:/{}/model".format(run.info.run_id), result_type=StringType()
         )
 
         data1 = spark.createDataFrame(pd.DataFrame({"a": [1], "b": [4]})).repartition(1)

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -44,7 +44,9 @@ types = [np.int32, int, str, np.float32, np.double]
 def score_model_as_udf(model_uri, pandas_df, result_type="double"):
     spark = get_spark_session(pyspark.SparkConf())
     spark_df = spark.createDataFrame(pandas_df).coalesce(1)
-    pyfunc_udf = spark_udf(spark=spark, model_uri=model_uri, result_type=result_type)
+    pyfunc_udf = spark_udf(
+        spark=spark, model_uri=model_uri, result_type=result_type, env_manager="local"
+    )
     new_df = spark_df.withColumn("prediction", pyfunc_udf(*pandas_df.columns))
     return [x["prediction"] for x in new_df.collect()]
 
@@ -149,12 +151,12 @@ def test_spark_udf(spark, model_path):
                     expected = expected.astype(np.float32)
 
             expected = [list(row[1]) if is_array else row[1][0] for row in expected.iterrows()]
-            pyfunc_udf = spark_udf(spark, model_path, result_type=t)
+            pyfunc_udf = spark_udf(spark, model_path, result_type=t, env_manager="local")
             new_df = spark_df.withColumn("prediction", pyfunc_udf(*pandas_df.columns))
             actual = list(new_df.select("prediction").toPandas()["prediction"])
             assert expected == actual
             if not is_array:
-                pyfunc_udf = spark_udf(spark, model_path, result_type=tname)
+                pyfunc_udf = spark_udf(spark, model_path, result_type=tname, env_manager="local")
                 new_df = spark_df.withColumn("prediction", pyfunc_udf(*pandas_df.columns))
                 actual = list(new_df.select("prediction").toPandas()["prediction"])
                 assert expected == actual
@@ -254,7 +256,10 @@ def test_spark_udf_autofills_no_arguments(spark):
     with mlflow.start_run() as run:
         mlflow.pyfunc.log_model("model", python_model=TestModel(), signature=signature)
         udf = mlflow.pyfunc.spark_udf(
-            spark, "runs:/{}/model".format(run.info.run_id), result_type=ArrayType(StringType())
+            spark,
+            "runs:/{}/model".format(run.info.run_id),
+            result_type=ArrayType(StringType()),
+            env_manager="local",
         )
         res = good_data.withColumn("res", udf()).select("res").toPandas()
         assert res["res"][0] == ["a", "b", "c"]
@@ -314,7 +319,10 @@ def test_spark_udf_autofills_column_names_with_schema(spark):
     with mlflow.start_run() as run:
         mlflow.pyfunc.log_model("model", python_model=TestModel(), signature=signature)
         udf = mlflow.pyfunc.spark_udf(
-            spark, "runs:/{}/model".format(run.info.run_id), result_type=ArrayType(StringType())
+            spark,
+            "runs:/{}/model".format(run.info.run_id),
+            result_type=ArrayType(StringType()),
+            env_manager="local",
         )
         data = spark.createDataFrame(
             pd.DataFrame(
@@ -342,7 +350,10 @@ def test_spark_udf_with_datetime_columns(spark):
     with mlflow.start_run() as run:
         mlflow.pyfunc.log_model("model", python_model=TestModel(), signature=signature)
         udf = mlflow.pyfunc.spark_udf(
-            spark, "runs:/{}/model".format(run.info.run_id), result_type=ArrayType(StringType())
+            spark,
+            "runs:/{}/model".format(run.info.run_id),
+            result_type=ArrayType(StringType()),
+            env_manager="local",
         )
         data = spark.range(10).selectExpr(
             "current_timestamp() as timestamp", "current_date() as date"

--- a/tests/utils/test_python_env.py
+++ b/tests/utils/test_python_env.py
@@ -89,7 +89,7 @@ dependencies:
     assert python_env.dependencies == ["a", "b"]
 
 
-def test_from_conda_yaml_selects_current_python_version_if_conda_yaml_does_not_include_it(tmp_path):
+def test_from_conda_yaml_use_current_python_version_when_no_python_spec_in_conda_yaml(tmp_path):
     content = """
 name: example
 channels:

--- a/tests/utils/test_python_env.py
+++ b/tests/utils/test_python_env.py
@@ -2,6 +2,7 @@ import pytest
 from unittest import mock
 
 from mlflow.utils.environment import _PythonEnv
+from mlflow.utils import PYTHON_VERSION
 
 
 def test_constructor_argument_validation():
@@ -88,7 +89,7 @@ dependencies:
     assert python_env.dependencies == ["a", "b"]
 
 
-def test_from_conda_yaml_python_dependency_is_missing(tmp_path):
+def test_from_conda_yaml_selects_current_python_version_if_conda_yaml_does_not_include_it(tmp_path):
     content = """
 name: example
 channels:
@@ -101,8 +102,7 @@ dependencies:
 """
     yaml_path = tmp_path / "conda.yaml"
     yaml_path.write_text(content)
-    with pytest.raises(Exception, match="Could not extract python version"):
-        _PythonEnv.from_conda_yaml(yaml_path)
+    assert _PythonEnv.from_conda_yaml(yaml_path).python == PYTHON_VERSION
 
 
 def test_from_conda_yaml_invalid_python_comparator(tmp_path):


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Use `virtualenv` by default when restoring a model environment.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The default tool to restore a model environment has been changed to `virtualenv` from `conda`.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
