### PR TITLE
Add environment variable for `echo` option in `create_engine`

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -45,7 +45,7 @@ class _BooleanEnvironmentVariable(_EnvironmentVariable):
 
     def __init__(self, name, default):
         # `default not in [True, False, None]` doesn't work because `1 in [True]`
-        # (or `0 == [False]`) returns True.
+        # (or `0 in [False]`) returns True.
         if not (default is True or default is False or default is None):
             raise ValueError(f"{name} default value must be one of [True, False, None]")
         super().__init__(name, bool, default)

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -15,7 +15,7 @@ class _EnvironmentVariable:
         self.default = default
 
     @property
-    def defined(self):
+    def is_defined(self):
         return self.name in os.environ
 
     def get(self):
@@ -44,15 +44,14 @@ class _BooleanEnvironmentVariable(_EnvironmentVariable):
     """
 
     def get(self):
-        if not self.defined:
+        if not self.is_defined:
             return self.default
 
         val = os.getenv(self.name)
         lowercased = val.lower()
-        if lowercased not in ["true", "false"]:
+        if lowercased not in ["true", "false", "1", "0"]:
             raise ValueError(
-                f"{self.name} value must be either 'true' or 'false' (case-insensitive), "
-                f"but got {val}"
+                f"{self.name} value must be one of ['true', 'false', '1', '0'], but got {val}"
             )
         return lowercased == "true"
 

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -14,6 +14,10 @@ class _EnvironmentVariable:
         self.type = type_
         self.default = default
 
+    @property
+    def defined(self):
+        return self.name in os.environ
+
     def get(self):
         """
         Reads the value of the environment variable if it exists and converts it to the desired
@@ -40,7 +44,7 @@ class _BooleanEnvironmentVariable(_EnvironmentVariable):
     """
 
     def get(self):
-        if self.name not in os.environ:
+        if not self.defined:
             return self.default
 
         val = os.getenv(self.name)
@@ -114,4 +118,6 @@ MLFLOW_SQLALCHEMYSTORE_MAX_OVERFLOW = _EnvironmentVariable(
 #: SQLAlchemy tracking store. See https://docs.sqlalchemy.org/en/14/core/engines.html#sqlalchemy.create_engine.params.echo
 #: for more information.
 #: (default: ``False``)
-MLFLOW_SQLALCHEMYSTORE_ECHO = _EnvironmentVariable("MLFLOW_SQLALCHEMYSTORE_ECHO", bool, False)
+MLFLOW_SQLALCHEMYSTORE_ECHO = _BooleanEnvironmentVariable(
+    "MLFLOW_SQLALCHEMYSTORE_ECHO", bool, False
+)

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -43,6 +43,13 @@ class _BooleanEnvironmentVariable(_EnvironmentVariable):
     Represents a boolean environment variable.
     """
 
+    def __init__(self, name, default):
+        # `default not in [True, False, None]` doesn't work because `1 in [True]`
+        # (or `0 == [False]`) returns True.
+        if not (default is True or default is False or default is None):
+            raise ValueError(f"{name} default value must be one of [True, False, None]")
+        super().__init__(name, bool, default)
+
     def get(self):
         if not self.is_defined:
             return self.default
@@ -51,9 +58,10 @@ class _BooleanEnvironmentVariable(_EnvironmentVariable):
         lowercased = val.lower()
         if lowercased not in ["true", "false", "1", "0"]:
             raise ValueError(
-                f"{self.name} value must be one of ['true', 'false', '1', '0'], but got {val}"
+                f"{self.name} value must be one of ['true', 'false', '1', '0'] (case-insensitive), "
+                f"but got {val}"
             )
-        return lowercased == "true"
+        return lowercased in ["true", "1"]
 
 
 #: Specify the maximum number of retries for MLflow http request
@@ -117,6 +125,4 @@ MLFLOW_SQLALCHEMYSTORE_MAX_OVERFLOW = _EnvironmentVariable(
 #: SQLAlchemy tracking store. See https://docs.sqlalchemy.org/en/14/core/engines.html#sqlalchemy.create_engine.params.echo
 #: for more information.
 #: (default: ``False``)
-MLFLOW_SQLALCHEMYSTORE_ECHO = _BooleanEnvironmentVariable(
-    "MLFLOW_SQLALCHEMYSTORE_ECHO", bool, False
-)
+MLFLOW_SQLALCHEMYSTORE_ECHO = _BooleanEnvironmentVariable("MLFLOW_SQLALCHEMYSTORE_ECHO", False)

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -34,6 +34,25 @@ class _EnvironmentVariable:
         return repr(self.name)
 
 
+class _BooleanEnvironmentVariable(_EnvironmentVariable):
+    """
+    Represents a boolean environment variable.
+    """
+
+    def get(self):
+        if self.name not in os.environ:
+            return self.default
+
+        val = os.getenv(self.name)
+        lowercased = val.lower()
+        if lowercased not in ["true", "false"]:
+            raise ValueError(
+                f"{self.name} value must be either 'true' or 'false' (case-insensitive), "
+                f"but got {val}"
+            )
+        return lowercased == "true"
+
+
 #: Specify the maximum number of retries for MLflow http request
 #: (default: ``5``)
 MLFLOW_HTTP_REQUEST_MAX_RETRIES = _EnvironmentVariable("MLFLOW_HTTP_REQUEST_MAX_RETRIES", int, 5)
@@ -90,3 +109,9 @@ MLFLOW_SQLALCHEMYSTORE_POOL_RECYCLE = _EnvironmentVariable(
 MLFLOW_SQLALCHEMYSTORE_MAX_OVERFLOW = _EnvironmentVariable(
     "MLFLOW_SQLALCHEMYSTORE_MAX_OVERFLOW", int, None
 )
+
+#: Specifies the ``echo`` parameter to use for ``sqlalchemy.create_engine`` in the
+#: SQLAlchemy tracking store. See https://docs.sqlalchemy.org/en/14/core/engines.html#sqlalchemy.create_engine.params.echo
+#: for more information.
+#: (default: ``False``)
+MLFLOW_SQLALCHEMYSTORE_ECHO = _EnvironmentVariable("MLFLOW_SQLALCHEMYSTORE_ECHO", bool, False)

--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -16,6 +16,7 @@ from mlflow.environment_variables import (
     MLFLOW_SQLALCHEMYSTORE_POOL_SIZE,
     MLFLOW_SQLALCHEMYSTORE_POOL_RECYCLE,
     MLFLOW_SQLALCHEMYSTORE_MAX_OVERFLOW,
+    MLFLOW_SQLALCHEMYSTORE_ECHO,
 )
 
 _logger = logging.getLogger(__name__)
@@ -183,6 +184,7 @@ def create_sqlalchemy_engine(db_uri):
     pool_size = MLFLOW_SQLALCHEMYSTORE_POOL_SIZE.get()
     pool_max_overflow = MLFLOW_SQLALCHEMYSTORE_MAX_OVERFLOW.get()
     pool_recycle = MLFLOW_SQLALCHEMYSTORE_POOL_RECYCLE.get()
+    echo = MLFLOW_SQLALCHEMYSTORE_ECHO.get()
     pool_kwargs = {}
     # Send argument only if they have been injected.
     # Some engine does not support them (for example sqllite)
@@ -192,6 +194,8 @@ def create_sqlalchemy_engine(db_uri):
         pool_kwargs["max_overflow"] = int(pool_max_overflow)
     if pool_recycle:
         pool_kwargs["pool_recycle"] = int(pool_recycle)
+    if echo:
+        pool_kwargs["echo"] = echo
     if pool_kwargs:
         _logger.info("Create SQLAlchemy engine with pool options %s", pool_kwargs)
     return sqlalchemy.create_engine(db_uri, pool_pre_ping=True, **pool_kwargs)

--- a/tests/store/db/test_utils.py
+++ b/tests/store/db/test_utils.py
@@ -11,7 +11,7 @@ def test_create_sqlalchemy_engine_inject_pool_options():
             "MLFLOW_SQLALCHEMYSTORE_POOL_SIZE": "2",
             "MLFLOW_SQLALCHEMYSTORE_POOL_RECYCLE": "3600",
             "MLFLOW_SQLALCHEMYSTORE_MAX_OVERFLOW": "4",
-            "MLFLOW_SQLALCHEMYSTORE_ECHO": "true",
+            "MLFLOW_SQLALCHEMYSTORE_ECHO": "TRUE",
         },
     ):
         with mock.patch("sqlalchemy.create_engine") as mock_create_engine:

--- a/tests/store/db/test_utils.py
+++ b/tests/store/db/test_utils.py
@@ -11,6 +11,7 @@ def test_create_sqlalchemy_engine_inject_pool_options():
             "MLFLOW_SQLALCHEMYSTORE_POOL_SIZE": "2",
             "MLFLOW_SQLALCHEMYSTORE_POOL_RECYCLE": "3600",
             "MLFLOW_SQLALCHEMYSTORE_MAX_OVERFLOW": "4",
+            "MLFLOW_SQLALCHEMYSTORE_ECHO": "true",
         },
     ):
         with mock.patch("sqlalchemy.create_engine") as mock_create_engine:
@@ -21,6 +22,7 @@ def test_create_sqlalchemy_engine_inject_pool_options():
                 pool_size=2,
                 pool_recycle=3600,
                 max_overflow=4,
+                echo=True,
             )
 
 

--- a/tests/test_environment_variables.py
+++ b/tests/test_environment_variables.py
@@ -1,0 +1,41 @@
+from mlflow.environment_variables import _BooleanEnvironmentVariable
+import pytest
+
+
+@pytest.mark.parametrize("value", [0, 1, "0", "1", "TRUE", "FALSE"])
+def test_boolean_environment_variable_invalid_default_value(value):
+    with pytest.raises(ValueError, match=r"must be one of \[True, False, None\]"):
+        _BooleanEnvironmentVariable("TEST_BOOLEAN_ENV_VAR", value)
+
+
+@pytest.mark.parametrize("value", [True, False, None])
+def test_boolean_environment_variable_valid_default_value(value):
+    assert _BooleanEnvironmentVariable("TEST_BOOLEAN_ENV_VAR", value).get() is value
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("TRUE", True),
+        ("true", True),
+        ("tRuE", True),
+        ("FALSE", False),
+        ("false", False),
+        ("FaLsE", False),
+        ("1", True),
+        ("0", False),
+    ],
+)
+def test_boolean_environment_variable_valid_value(monkeypatch, value, expected):
+    monkeypatch.setenv("TEST_BOOLEAN_ENV_VAR", value)
+    assert _BooleanEnvironmentVariable("TEST_BOOLEAN_ENV_VAR", None).get() is expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["bool", "10", "yes", "no"],
+)
+def test_boolean_environment_variable_invalid_value(monkeypatch, value):
+    monkeypatch.setenv("TEST_BOOLEAN_ENV_VAR", value)
+    with pytest.raises(ValueError, match=r"must be one of \['true', 'false', '1', '0'\]"):
+        _BooleanEnvironmentVariable("TEST_BOOLEAN_ENV_VAR", None).get()


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Add an environment variable to specify the `echo` option in `create_engine` to allow printing out SQL statements while developing a SQLAlchemy-related API.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

Ran the following command and it works as expected.

```
MLFLOW_SQLALCHEMYSTORE_ECHO=TRUE pytest tests/store/tracking/test_sqlalchemy_store.py -s
MLFLOW_SQLALCHEMYSTORE_ECHO=FALSE pytest tests/store/tracking/test_sqlalchemy_store.py -s
```

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
