### PR TITLE
Avoid using assertions at top level in `mlflow/models/docker_utils.py`

### DIFF
--- a/mlflow/models/docker_utils.py
+++ b/mlflow/models/docker_utils.py
@@ -68,8 +68,8 @@ def _get_maven_proxy():
         return " ".join(maven_proxy_options)
 
     return " ".join(
-        maven_proxy_options
-        + (
+        (
+            *maven_proxy_options,
             f"-Dhttp.proxyUser={parsed_http_proxy.username}",
             f"-Dhttp.proxyPassword={parsed_http_proxy.password}",
         )

--- a/mlflow/models/docker_utils.py
+++ b/mlflow/models/docker_utils.py
@@ -49,13 +49,11 @@ def _get_maven_proxy():
     # or PROTOCOL://HOSTNAME:PORT
     parsed_http_proxy = urlparse(http_proxy)
     assert parsed_http_proxy.hostname is not None, "Invalid `http_proxy` hostname."
-    assert isinstance(parsed_http_proxy.port, int), f"Invalid proxy port: {parsed_http_proxy.port}"
+    assert parsed_http_proxy.port is not None, f"Invalid proxy port: {parsed_http_proxy.port}"
 
     parsed_https_proxy = urlparse(https_proxy)
     assert parsed_https_proxy.hostname is not None, "Invalid `https_proxy` hostname."
-    assert isinstance(
-        parsed_https_proxy.port, int
-    ), f"Invalid proxy port: {parsed_https_proxy.port}"
+    assert parsed_https_proxy.port is not None, f"Invalid proxy port: {parsed_https_proxy.port}"
 
     maven_proxy_options = (
         "-DproxySet=true",


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#6120

## What changes are proposed in this pull request?

- Fix a bug discovered in https://github.com/conda-forge/mlflow-feedstock/pull/100.
- Avoid using assertions at top level in `mlflow/models/docker_utils.py`

https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=551407&view=logs&j=171a126d-c574-5c8c-1269-ff3b989e923d&t=1183ba29-a0b5-5324-8463-2a49ace9e213&l=2795

```
Traceback (most recent call last):
  File "D:\bld\mlflow-split_1660550110647\test_tmp\run_test.py", line 29, in <module>
    import mlflow.sagemaker
  File "D:\bld\mlflow-split_1660550110647\_test_env\lib\site-packages\mlflow\sagemaker\__init__.py", line 24, in <module>
    from mlflow.models.container import SUPPORTED_FLAVORS as SUPPORTED_DEPLOYMENT_FLAVORS
  File "D:\bld\mlflow-split_1660550110647\_test_env\lib\site-packages\mlflow\models\container\__init__.py", line 23, in <module>
    from mlflow.models.docker_utils import DISABLE_ENV_CREATION
  File "D:\bld\mlflow-split_1660550110647\_test_env\lib\site-packages\mlflow\models\docker_utils.py", line 46, in <module>
    assert parsed_http_proxy.hostname is not None, "Invalid `http_proxy` hostname."
AssertionError: Invalid `http_proxy` hostname.
```

We might need to make a patch release to unblock https://github.com/conda-forge/mlflow-feedstock/pull/100.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

Existing tests

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
