### PR TITLE
Don't use mlflowdbfs if dbutils is unavailable

### DIFF
--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -427,7 +427,7 @@ def _should_use_mlflowdbfs(root_uri):
         return False
 
     try:
-        mlflow.databricks_utils._get_dbutils()
+        databricks_utils._get_dbutils()
     except Exception:
         # If dbutils is unavailable, indicate that mlflowdbfs is unavailable
         # because usage of mlflowdbfs depends on dbutils

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -426,6 +426,13 @@ def _should_use_mlflowdbfs(root_uri):
     ):
         return False
 
+    try:
+        mlflow.databricks_utils._get_dbutils()
+    except Exception:
+        # If dbutils is unavailable, indicate that mlflowdbfs is unavailable
+        # because usage of mlflowdbfs depends on dbutils
+        return False
+
     mlflowdbfs_read_exception_str = None
     try:
         _get_active_spark_session().read.load("mlflowdbfs:///artifact?run_id=foo&path=/bar")

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -645,7 +645,8 @@ def test_model_is_recorded_when_using_direct_save(spark_model_iris):
         "db_runtime_version",
         "mlflowdbfs_disabled",
         "mlflowdbfs_available",
-        "dbutils_available,expectedURI",
+        "dbutils_available",
+        "expectedURI",
     ),
     [
         (

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -640,12 +640,13 @@ def test_model_is_recorded_when_using_direct_save(spark_model_iris):
 
 
 @pytest.mark.parametrize(
-    "artifact_uri, db_runtime_version,mlflowdbfs_disabled,mlflowdbfs_available,expectedURI",
+    "artifact_uri, db_runtime_version,mlflowdbfs_disabled,mlflowdbfs_available,dbutils_available,expectedURI",
     [
         (
             "dbfs:/databricks/mlflow-tracking/a/b",
             "12.0",
             "",
+            True,
             True,
             "mlflowdbfs:///artifacts?run_id={}&path=/model/sparkml",
         ),
@@ -654,19 +655,30 @@ def test_model_is_recorded_when_using_direct_save(spark_model_iris):
             "12.0",
             "false",
             True,
+            True,
             "mlflowdbfs:///artifacts?run_id={}&path=/model/sparkml",
+        ),
+        (
+            "dbfs:/databricks/mlflow-tracking/a/b",
+            "12.0",
+            "false",
+            True,
+            False,
+            "dbfs:/databricks/mlflow-tracking/a/b/model/sparkml/sparkml",
         ),
         (
             "dbfs:/databricks/mlflow-tracking/a/b",
             "12.0",
             "",
             False,
+            True,
             "dbfs:/databricks/mlflow-tracking/a/b/model/sparkml/sparkml",
         ),
         (
             "dbfs:/databricks/mlflow-tracking/a/b",
             "",
             "",
+            True,
             True,
             "dbfs:/databricks/mlflow-tracking/a/b/model/sparkml/sparkml",
         ),
@@ -675,10 +687,11 @@ def test_model_is_recorded_when_using_direct_save(spark_model_iris):
             "12.0",
             "true",
             True,
+            True,
             "dbfs:/databricks/mlflow-tracking/a/b/model/sparkml/sparkml",
         ),
-        ("dbfs:/root/a/b", "12.0", "", True, "dbfs:/root/a/b/model/sparkml/sparkml"),
-        ("s3://mybucket/a/b", "12.0", "", True, "s3://mybucket/a/b/model/sparkml/sparkml"),
+        ("dbfs:/root/a/b", "12.0", "", True, True, "dbfs:/root/a/b/model/sparkml/sparkml"),
+        ("s3://mybucket/a/b", "12.0", "", True, True, "s3://mybucket/a/b/model/sparkml/sparkml"),
     ],
 )
 def test_model_logged_via_mlflowdbfs_when_appropriate(
@@ -688,6 +701,7 @@ def test_model_logged_via_mlflowdbfs_when_appropriate(
     db_runtime_version,
     mlflowdbfs_disabled,
     mlflowdbfs_available,
+    dbutils_available,
     expectedURI,
 ):
     def mock_spark_session_load(path):
@@ -697,6 +711,22 @@ def test_model_logged_via_mlflowdbfs_when_appropriate(
     mock_read_spark_session = mock.Mock()
     mock_read_spark_session.load = mock_spark_session_load
 
+    from mlflow.utils.databricks_utils import _get_dbutils as og_getdbutils
+
+    def mock_get_dbutils():
+        import inspect
+
+        # _get_dbutils is called during run creation and model logging; to avoid breaking run
+        # creation, we only mock the output if _get_dbutils is called during spark model logging
+        caller_fn_name = inspect.stack()[1].function
+        if caller_fn_name == "_should_use_mlflowdbfs":
+            if dbutils_available:
+                return mock.Mock()
+            else:
+                raise Exception("dbutils not available")
+        else:
+            return og_getdbutils()
+
     with mock.patch(
         "mlflow.utils._spark_utils._get_active_spark_session",
         return_value=mock_spark_session,
@@ -705,6 +735,9 @@ def test_model_logged_via_mlflowdbfs_when_appropriate(
         return_value=mlflowdbfs_available,
     ), mock.patch(
         "mlflow.utils.databricks_utils.MlflowCredentialContext", autospec=True
+    ), mock.patch(
+        "mlflow.utils.databricks_utils._get_dbutils",
+        mock_get_dbutils,
     ), mock.patch.object(
         spark_model_iris.model, "save"
     ) as mock_save:
@@ -731,6 +764,19 @@ def test_model_logging_uses_mlflowdbfs_if_appropriate_when_hdfs_check_fails(
     mock_spark_session = mock.Mock()
     mock_spark_session.read = mock_read_spark_session
 
+    from mlflow.utils.databricks_utils import _get_dbutils as og_getdbutils
+
+    def mock_get_dbutils():
+        import inspect
+
+        # _get_dbutils is called during run creation and model logging; to avoid breaking run
+        # creation, we only mock the output if _get_dbutils is called during spark model logging
+        caller_fn_name = inspect.stack()[1].function
+        if caller_fn_name == "_should_use_mlflowdbfs":
+            return mock.Mock()
+        else:
+            return og_getdbutils()
+
     with mock.patch(
         "mlflow.utils._spark_utils._get_active_spark_session",
         return_value=mock_spark_session,
@@ -742,6 +788,9 @@ def test_model_logging_uses_mlflowdbfs_if_appropriate_when_hdfs_check_fails(
         side_effect=Exception("MlflowDbfsClient operation failed!"),
     ), mock.patch(
         "mlflow.utils.databricks_utils.MlflowCredentialContext", autospec=True
+    ), mock.patch(
+        "mlflow.utils.databricks_utils._get_dbutils",
+        mock_get_dbutils,
     ), mock.patch.object(
         spark_model_iris.model, "save"
     ) as mock_save:

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -640,7 +640,13 @@ def test_model_is_recorded_when_using_direct_save(spark_model_iris):
 
 
 @pytest.mark.parametrize(
-    "artifact_uri, db_runtime_version,mlflowdbfs_disabled,mlflowdbfs_available,dbutils_available,expectedURI",
+    (
+        "artifact_uri",
+        "db_runtime_version",
+        "mlflowdbfs_disabled",
+        "mlflowdbfs_available",
+        "dbutils_available,expectedURI",
+    ),
     [
         (
             "dbfs:/databricks/mlflow-tracking/a/b",


### PR DESCRIPTION
Signed-off-by: dbczumar <corey.zumar@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## What changes are proposed in this pull request?

Don't use mlflowdbfs if dbutils is unavailable

## How is this patch tested?

Tests are WIP

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
