### PR TITLE
Make URLs clickable in the MLflow Tracking UI

### DIFF
--- a/mlflow/server/js/src/common/utils/Utils.js
+++ b/mlflow/server/js/src/common/utils/Utils.js
@@ -1063,6 +1063,15 @@ class Utils {
     }
     return `./#${route}`; // issue-2213 use relative path in case there is a url prefix
   }
+
+  static isValidHttpUrl(str) {
+    try {
+      const url = new URL(str);
+      return url.protocol === 'http:' || url.protocol === 'https:';
+    } catch (err) {
+      return false;
+    }
+  }
 }
 
 export default Utils;

--- a/mlflow/server/js/src/common/utils/Utils.js
+++ b/mlflow/server/js/src/common/utils/Utils.js
@@ -1065,6 +1065,7 @@ class Utils {
   }
 
   static isValidHttpUrl(str) {
+    // The URL() constructor will throw on invalid URL
     try {
       const url = new URL(str);
       return url.protocol === 'http:' || url.protocol === 'https:';

--- a/mlflow/server/js/src/common/utils/Utils.test.js
+++ b/mlflow/server/js/src/common/utils/Utils.test.js
@@ -902,5 +902,7 @@ test('isValidHttpUrl', () => {
   expect(Utils.isValidHttpUrl('some other text https://some_url.com/')).toEqual(false);
   expect(Utils.isValidHttpUrl('fualksdhjakjsdh')).toEqual(false);
   expect(Utils.isValidHttpUrl('#')).toEqual(false);
+  // disable no-script-url rule to test that javascript protocol is not seen as valid url
+  /* eslint-disable no-script-url*/
   expect(Utils.isValidHttpUrl('javascript:void(0)')).toEqual(false);
 });

--- a/mlflow/server/js/src/common/utils/Utils.test.js
+++ b/mlflow/server/js/src/common/utils/Utils.test.js
@@ -891,3 +891,16 @@ test('concatAndGroupArraysById', () => {
     { id: 123, year: 2020 },
   ]);
 });
+
+test('isValidHttpUrl', () => {
+  expect(Utils.isValidHttpUrl('not_a_url')).toEqual(false);
+  expect(Utils.isValidHttpUrl('https://some_url.com')).toEqual(true);
+  expect(Utils.isValidHttpUrl('https://some_url.com/?with=query_param')).toEqual(true);
+  expect(Utils.isValidHttpUrl('http://some_url.com/')).toEqual(true);
+  expect(Utils.isValidHttpUrl('http:/localhost')).toEqual(true);
+  expect(Utils.isValidHttpUrl('http:/a')).toEqual(true);
+  expect(Utils.isValidHttpUrl('some other text https://some_url.com/')).toEqual(false);
+  expect(Utils.isValidHttpUrl('fualksdhjakjsdh')).toEqual(false);
+  expect(Utils.isValidHttpUrl('#')).toEqual(false);
+  expect(Utils.isValidHttpUrl('javascript:void(0)')).toEqual(false);
+});

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.js
@@ -91,6 +91,7 @@ export class ExperimentRunsTableMultiColumnView2Impl extends React.Component {
     versionCellRenderer: VersionCellRenderer,
     modelsCellRenderer: ModelsCellRenderer,
     dateCellRenderer: DateCellRenderer,
+    tagCellRenderer: TagCellRenderer,
     agColumnHeader: RunsTableCustomHeader,
     loadingOverlayComponent: Spinner,
     noRowsOverlayComponent: ExperimentRunsTableEmptyOverlay,
@@ -323,6 +324,7 @@ export class ExperimentRunsTableMultiColumnView2Impl extends React.Component {
           headerName: tagKey,
           headerTooltip: tagKey,
           field: `${TAG_PREFIX}-${tagKey}`,
+          cellRenderer: 'tagCellRenderer',
           ...(i >= MAX_TAG_COLS ? { columnGroupShow: 'open' } : null),
         })),
       },
@@ -800,3 +802,17 @@ const styles = {
 };
 
 ModelsCellRenderer.propTypes = { value: PropTypes.object };
+
+export function TagCellRenderer(props) {
+  const tagValue = props.value;
+
+  return Utils.isValidHttpUrl(tagValue) ? (
+    <a href={tagValue} target='_blank' rel='noreferrer'>
+      {tagValue}
+    </a>
+  ) : (
+    tagValue
+  );
+}
+
+TagCellRenderer.propTypes = { value: PropTypes.string };

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.test.js
@@ -411,9 +411,19 @@ describe('ExperimentRunsTableMultiColumnView2', () => {
   });
 
   test('should render tag that is a valid http(s) as clickable link', () => {
-    expect(TagCellRenderer({value: "https://some_url.com"})).toEqual(<a href="https://some_url.com" target="_blank" rel="noreferrer">https://some_url.com</a>);
-    expect(TagCellRenderer({value: "http://some_url.com"})).toEqual(<a href="http://some_url.com" target="_blank" rel="noreferrer">http://some_url.com</a>);
-    expect(TagCellRenderer({value: "some text"})).toEqual("some text");
-    expect(TagCellRenderer({value: "some text https://some_url.com"})).toEqual("some text https://some_url.com");
-  })
+    expect(TagCellRenderer({ value: 'https://some_url.com' })).toEqual(
+      <a href='https://some_url.com' target='_blank' rel='noreferrer'>
+        https://some_url.com
+      </a>,
+    );
+    expect(TagCellRenderer({ value: 'http://some_url.com' })).toEqual(
+      <a href='http://some_url.com' target='_blank' rel='noreferrer'>
+        http://some_url.com
+      </a>,
+    );
+    expect(TagCellRenderer({ value: 'some text' })).toEqual('some text');
+    expect(TagCellRenderer({ value: 'some text https://some_url.com' })).toEqual(
+      'some text https://some_url.com',
+    );
+  });
 });

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.test.js
@@ -3,6 +3,7 @@ import { shallow } from 'enzyme';
 import {
   ExperimentRunsTableMultiColumnView2Impl,
   ModelsCellRenderer,
+  TagCellRenderer,
 } from './ExperimentRunsTableMultiColumnView2';
 import { COLUMN_TYPES, ATTRIBUTE_COLUMN_LABELS } from '../constants';
 import { MemoryRouter as Router } from 'react-router-dom';
@@ -408,4 +409,11 @@ describe('ExperimentRunsTableMultiColumnView2', () => {
     expect(tagColumnNames).toEqual(expectedTagColumnNames);
     expect(setColumnDefsSpy).toHaveBeenCalledTimes(1);
   });
+
+  test('should render tag that is a valid http(s) as clickable link', () => {
+    expect(TagCellRenderer({value: "https://some_url.com"})).toEqual(<a href="https://some_url.com" target="_blank" rel="noreferrer">https://some_url.com</a>);
+    expect(TagCellRenderer({value: "http://some_url.com"})).toEqual(<a href="http://some_url.com" target="_blank" rel="noreferrer">http://some_url.com</a>);
+    expect(TagCellRenderer({value: "some text"})).toEqual("some text");
+    expect(TagCellRenderer({value: "some text https://some_url.com"})).toEqual("some text https://some_url.com");
+  })
 });


### PR DESCRIPTION
Signed-off-by: Marijn Valk <marijncv@hotmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
close #3908 

## What changes are proposed in this pull request?

This PR makes tags that are valid URLs clickable in the MLflow tracking UI by wrapping them in an anchor tag.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

https://user-images.githubusercontent.com/9256667/185806108-b29816f0-1330-428c-8d19-80112bc2ae56.mov

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Made valid URL clickable in the MLflow tracking UI

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
