### PR TITLE
Add `use-set-literal` rule for better performace

### DIFF
--- a/pylint_plugins/__init__.py
+++ b/pylint_plugins/__init__.py
@@ -1,9 +1,11 @@
 from .pytest_raises_checker import PytestRaisesChecker
 from .print_function import PrintFunction
 from .unittest_assert_raises import UnittestAssertRaises
+from .set_checker import SetChecker
 
 
 def register(linter):
     linter.register_checker(PytestRaisesChecker(linter))
     linter.register_checker(PrintFunction(linter))
     linter.register_checker(UnittestAssertRaises(linter))
+    linter.register_checker(SetChecker(linter))

--- a/pylint_plugins/set_checker.py
+++ b/pylint_plugins/set_checker.py
@@ -1,0 +1,70 @@
+import os
+
+import astroid
+from pylint.interfaces import IAstroidChecker
+from pylint.checkers import BaseChecker
+
+
+IGNORED_FILES = set(
+    map(
+        os.path.abspath,
+        [
+            ##### Instructions #####
+            # 1. Select the file you would like to work on.
+            # 2. Remove the file.
+            # 3. Run `pylint <the file>`.
+            # 4. Fix lint errors.
+            # 5. File a PR.
+            "mlflow/azure/client.py",
+            "mlflow/entities/lifecycle_stage.py",
+            "mlflow/entities/run_status.py",
+            "mlflow/server/handlers.py",
+            "mlflow/tracking/fluent.py",
+            "mlflow/utils/autologging_utils/safety.py",
+            "mlflow/utils/search_utils.py",
+            "tests/autologging/test_autologging_behaviors_unit.py",
+            "tests/entities/model_registry/test_model_version.py",
+            "tests/entities/model_registry/test_registered_model.py",
+            "tests/entities/test_run_info.py",
+            "tests/entities/test_run_status.py",
+            "tests/lightgbm/test_lightgbm_autolog.py",
+            "tests/models/test_model_input_examples.py",
+            "tests/projects/test_project_spec.py",
+            "tests/pyfunc/test_model_export_with_loader_module_and_data_path.py",
+            "tests/store/artifact/test_databricks_artifact_repo.py",
+            "tests/store/artifact/test_ftp_artifact_repo.py",
+            "tests/store/model_registry/test_sqlalchemy_store.py",
+            "tests/store/tracking/test_sqlalchemy_store.py",
+            "tests/tensorflow/test_tensorflow2_autolog.py",
+            "tests/tracking/test_model_registry.py",
+            "tests/utils/test_requirements_utils.py",
+            "tests/xgboost/test_xgboost_autolog.py",
+        ],
+    )
+)
+
+
+class SetChecker(BaseChecker):
+    __implements__ = IAstroidChecker
+
+    name = "set-checker"
+    USE_SET_LITERAL = "use-set-literal"
+    msgs = {
+        "W0005": (
+            "Use set literal (e.g. `{'a', 'b'}`) instead of using `set()` on transient list or "
+            "tuple (e.g. `set(['a', 'b'])`)",
+            USE_SET_LITERAL,
+            "Use set literal",
+        ),
+    }
+    priority = -1
+
+    def visit_call(self, node: astroid.Call):
+        if node.root().file in IGNORED_FILES:
+            return
+        if (
+            node.func.as_string() == "set"
+            and node.args
+            and isinstance(node.args[0], (astroid.List, astroid.Tuple))
+        ):
+            self.add_message(SetChecker.USE_SET_LITERAL, node=node)

--- a/pylint_plugins/tests/test_set_checker.py
+++ b/pylint_plugins/tests/test_set_checker.py
@@ -1,0 +1,34 @@
+import pytest
+import astroid
+from pylint.testutils import MessageTest
+from pylint.testutils import CheckerTestCase
+
+from pylint_plugins import SetChecker
+
+
+@pytest.fixture(scope="module")
+def test_case():
+    class TestSetChecker(CheckerTestCase):
+        CHECKER_CLASS = SetChecker
+
+    test_case = TestSetChecker()
+    test_case.setup_method()
+    return test_case
+
+
+def test_use_set_literal(test_case):
+    node = astroid.extract_node("set(['a', 'b'])")
+    with test_case.assertAddsMessages(
+        MessageTest(test_case.CHECKER_CLASS.USE_SET_LITERAL, node=node, line=1, col_offset=0)
+    ):
+        test_case.walk(node)
+
+    node = astroid.extract_node("set(('a', 'b'))")
+    with test_case.assertAddsMessages(
+        MessageTest(test_case.CHECKER_CLASS.USE_SET_LITERAL, node=node, line=1, col_offset=0)
+    ):
+        test_case.walk(node)
+
+    node = astroid.extract_node("set([x for x in range(3)])")
+    with test_case.assertNoMessages():
+        test_case.walk(node)

--- a/pylint_plugins/tests/test_set_checker.py
+++ b/pylint_plugins/tests/test_set_checker.py
@@ -32,3 +32,7 @@ def test_use_set_literal(test_case):
     node = astroid.extract_node("set([x for x in range(3)])")
     with test_case.assertNoMessages():
         test_case.walk(node)
+
+    node = astroid.extract_node("set(numbers)")
+    with test_case.assertNoMessages():
+        test_case.walk(node)


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Add a pylint rule to prevent using `set()` on a transient `tuple` or `list` for better performance and consistency.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
