### PR TITLE
Deprecate duplicate artifact download APIs

### DIFF
--- a/examples/mlflow_artifacts/example.py
+++ b/examples/mlflow_artifacts/example.py
@@ -4,6 +4,7 @@ from pprint import pprint
 
 import mlflow
 from mlflow.tracking import MlflowClient
+from mlflow.artifacts import download_artifacts
 
 
 def save_text(path, text):
@@ -37,8 +38,8 @@ def main():
     # Download artifacts
     client = MlflowClient()
     print("Downloading artifacts")
-    pprint(os.listdir(client.download_artifacts(run_id1, "")))
-    pprint(os.listdir(client.download_artifacts(run_id1, "dir")))
+    pprint(os.listdir(download_artifacts(run_id=run_id1, artifact_path="")))
+    pprint(os.listdir(download_artifacts(run_id=run_id1, artifact_path="dir")))
 
     # List artifacts
     print("Listing artifacts")

--- a/examples/pip_requirements/pip_requirements.py
+++ b/examples/pip_requirements/pip_requirements.py
@@ -10,6 +10,7 @@ from sklearn.datasets import load_iris
 import xgboost as xgb
 import mlflow
 from mlflow.tracking import MlflowClient
+from mlflow.artifacts import download_artifacts
 
 
 def read_lines(path):
@@ -19,11 +20,17 @@ def read_lines(path):
 
 def get_pip_requirements(run_id, artifact_path, return_constraints=False):
     client = MlflowClient()
-    req_path = client.download_artifacts(run_id, f"{artifact_path}/requirements.txt")
+    req_path = download_artifacts(
+        run_id=run_id,
+        artifact_path=f"{artifact_path}/requirements.txt"
+    )
     reqs = read_lines(req_path)
 
     if return_constraints:
-        con_path = client.download_artifacts(run_id, f"{artifact_path}/constraints.txt")
+        con_path = download_artifacts(
+            run_id=run_id,
+            artifact_path=f"{artifact_path}/constraints.txt"
+        )
         cons = read_lines(con_path)
         return set(reqs), set(cons)
 

--- a/examples/pip_requirements/pip_requirements.py
+++ b/examples/pip_requirements/pip_requirements.py
@@ -20,16 +20,12 @@ def read_lines(path):
 
 def get_pip_requirements(run_id, artifact_path, return_constraints=False):
     client = MlflowClient()
-    req_path = download_artifacts(
-        run_id=run_id,
-        artifact_path=f"{artifact_path}/requirements.txt"
-    )
+    req_path = download_artifacts(run_id=run_id, artifact_path=f"{artifact_path}/requirements.txt")
     reqs = read_lines(req_path)
 
     if return_constraints:
         con_path = download_artifacts(
-            run_id=run_id,
-            artifact_path=f"{artifact_path}/constraints.txt"
+            run_id=run_id, artifact_path=f"{artifact_path}/constraints.txt"
         )
         cons = read_lines(con_path)
         return set(reqs), set(cons)

--- a/examples/shap/binary_classification.py
+++ b/examples/shap/binary_classification.py
@@ -7,6 +7,7 @@ import shap
 
 import mlflow
 from mlflow.tracking import MlflowClient
+from mlflow.artifacts import download_artifacts
 
 
 # prepare training data
@@ -30,7 +31,7 @@ print("# artifacts:")
 print(artifacts)
 
 # load back the logged explanation
-dst_path = client.download_artifacts(run.info.run_id, artifact_path)
+dst_path = download_artifacts(run_id=run.info.run_id, artifact_path=artifact_path)
 base_values = np.load(os.path.join(dst_path, "base_values.npy"))
 shap_values = np.load(os.path.join(dst_path, "shap_values.npy"))
 

--- a/examples/shap/multiclass_classification.py
+++ b/examples/shap/multiclass_classification.py
@@ -7,6 +7,7 @@ import shap
 
 import mlflow
 from mlflow.tracking import MlflowClient
+from mlflow.artifacts import download_artifacts
 
 
 # prepare training data
@@ -29,7 +30,7 @@ print("# artifacts:")
 print(artifacts)
 
 # load back the logged explanation
-dst_path = client.download_artifacts(run.info.run_id, artifact_path)
+dst_path = download_artifacts(run_id=run.info.run_id, artifact_path=artifact_path)
 base_values = np.load(os.path.join(dst_path, "base_values.npy"))
 shap_values = np.load(os.path.join(dst_path, "shap_values.npy"))
 

--- a/examples/shap/regression.py
+++ b/examples/shap/regression.py
@@ -7,6 +7,7 @@ import shap
 
 import mlflow
 from mlflow.tracking import MlflowClient
+from mlflow.artifacts import download_artifacts
 
 
 # prepare training data
@@ -30,7 +31,7 @@ print("# artifacts:")
 print(artifacts)
 
 # load back the logged explanation
-dst_path = client.download_artifacts(run.info.run_id, artifact_path)
+dst_path = download_artifacts(run_id=run.info.run_id, artifact_path=artifact_path)
 base_values = np.load(os.path.join(dst_path, "base_values.npy"))
 shap_values = np.load(os.path.join(dst_path, "shap_values.npy"))
 

--- a/mlflow/artifacts/__init__.py
+++ b/mlflow/artifacts/__init__.py
@@ -8,7 +8,6 @@ from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.tracking import _get_store
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri, get_artifact_repository
-from mlflow.tracking._tracking_service.utils import _use_tracking_uri
 
 
 def download_artifacts(

--- a/mlflow/artifacts/__init__.py
+++ b/mlflow/artifacts/__init__.py
@@ -56,11 +56,7 @@ def download_artifacts(
 
     artifact_path = artifact_path if artifact_path is not None else ""
 
-    if tracking_uri is not None:
-        with _use_tracking_uri(tracking_uri):
-            store = _get_store()
-    else:
-        store = _get_store()
+    store = _get_store(store_uri=tracking_uri)
     artifact_uri = store.get_run(run_id).info.artifact_uri
     artifact_repo = get_artifact_repository(artifact_uri)
     artifact_location = artifact_repo.download_artifacts(artifact_path, dst_path=dst_path)

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -441,6 +441,22 @@ class TrackingServiceClient:
         """
         return self._get_artifact_repo(run_id).list_artifacts(path)
 
+    def download_artifacts(self, run_id, path, dst_path=None):
+        """
+        Download an artifact file or directory from a run to a local directory if applicable,
+        and return a local path for it.
+
+        :param run_id: The run to download artifacts from.
+        :param path: Relative source path to the desired artifact.
+        :param dst_path: Absolute path of the local filesystem destination directory to which to
+                         download the specified artifacts. This directory must already exist.
+                         If unspecified, the artifacts will either be downloaded to a new
+                         uniquely-named directory on the local filesystem or will be returned
+                         directly in the case of the LocalArtifactRepository.
+        :return: Local path of desired artifact.
+        """
+        return self._get_artifact_repo(run_id).download_artifacts(path, dst_path)
+
     def set_terminated(self, run_id, status=None, end_time=None):
         """Set a run's status to terminated.
 

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -441,22 +441,6 @@ class TrackingServiceClient:
         """
         return self._get_artifact_repo(run_id).list_artifacts(path)
 
-    def download_artifacts(self, run_id, path, dst_path=None):
-        """
-        Download an artifact file or directory from a run to a local directory if applicable,
-        and return a local path for it.
-
-        :param run_id: The run to download artifacts from.
-        :param path: Relative source path to the desired artifact.
-        :param dst_path: Absolute path of the local filesystem destination directory to which to
-                         download the specified artifacts. This directory must already exist.
-                         If unspecified, the artifacts will either be downloaded to a new
-                         uniquely-named directory on the local filesystem or will be returned
-                         directly in the case of the LocalArtifactRepository.
-        :return: Local path of desired artifact.
-        """
-        return self._get_artifact_repo(run_id).download_artifacts(path, dst_path)
-
     def set_terminated(self, run_id, status=None, end_time=None):
         """Set a run's status to terminated.
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -28,7 +28,7 @@ from mlflow.tracking._tracking_service import utils
 from mlflow.tracking._tracking_service.client import TrackingServiceClient
 from mlflow.tracking.artifact_utils import _upload_artifacts_to_databricks
 from mlflow.tracking.registry import UnsupportedModelRegistryStoreURIException
-from mlflow.utils.annotations import experimental
+from mlflow.utils.annotations import experimental, deprecated
 from mlflow.utils.databricks_utils import get_databricks_run_url
 from mlflow.utils.logging_utils import eprint
 from mlflow.utils.uri import is_databricks_uri
@@ -1482,6 +1482,53 @@ class MlflowClient:
             size: 5
         """
         return self._tracking_client.list_artifacts(run_id, path)
+
+    @deprecated("mlflow.artifacts.download_artifacts", "2.0")
+    def download_artifacts(self, run_id: str, path: str, dst_path: Optional[str] = None) -> str:
+        """
+        Download an artifact file or directory from a run to a local directory if applicable,
+        and return a local path for it.
+
+        :param run_id: The run to download artifacts from.
+        :param path: Relative source path to the desired artifact.
+        :param dst_path: Absolute path of the local filesystem destination directory to which to
+                         download the specified artifacts. This directory must already exist.
+                         If unspecified, the artifacts will either be downloaded to a new
+                         uniquely-named directory on the local filesystem or will be returned
+                         directly in the case of the LocalArtifactRepository.
+        :return: Local path of desired artifact.
+
+        .. code-block:: python
+            :caption: Example
+
+            import os
+            import mlflow
+            from mlflow import MlflowClient
+
+            features = "rooms, zipcode, median_price, school_rating, transport"
+            with open("features.txt", 'w') as f:
+                f.write(features)
+
+            # Log artifacts
+            with mlflow.start_run() as run:
+                mlflow.log_artifact("features.txt", artifact_path="features")
+
+            # Download artifacts
+            client = MlflowClient()
+            local_dir = "/tmp/artifact_downloads"
+            if not os.path.exists(local_dir):
+                os.mkdir(local_dir)
+            local_path = client.download_artifacts(run.info.run_id, "features", local_dir)
+            print("Artifacts downloaded in: {}".format(local_path))
+            print("Artifacts: {}".format(os.listdir(local_path)))
+
+        .. code-block:: text
+            :caption: Output
+
+            Artifacts downloaded in: /tmp/artifact_downloads/features
+            Artifacts: ['features.txt']
+        """
+        return self._tracking_client.download_artifacts(run_id, path, dst_path)
 
     def set_terminated(
         self, run_id: str, status: Optional[str] = None, end_time: Optional[int] = None

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1483,52 +1483,6 @@ class MlflowClient:
         """
         return self._tracking_client.list_artifacts(run_id, path)
 
-    def download_artifacts(self, run_id: str, path: str, dst_path: Optional[str] = None) -> str:
-        """
-        Download an artifact file or directory from a run to a local directory if applicable,
-        and return a local path for it.
-
-        :param run_id: The run to download artifacts from.
-        :param path: Relative source path to the desired artifact.
-        :param dst_path: Absolute path of the local filesystem destination directory to which to
-                         download the specified artifacts. This directory must already exist.
-                         If unspecified, the artifacts will either be downloaded to a new
-                         uniquely-named directory on the local filesystem or will be returned
-                         directly in the case of the LocalArtifactRepository.
-        :return: Local path of desired artifact.
-
-        .. code-block:: python
-            :caption: Example
-
-            import os
-            import mlflow
-            from mlflow import MlflowClient
-
-            features = "rooms, zipcode, median_price, school_rating, transport"
-            with open("features.txt", 'w') as f:
-                f.write(features)
-
-            # Log artifacts
-            with mlflow.start_run() as run:
-                mlflow.log_artifact("features.txt", artifact_path="features")
-
-            # Download artifacts
-            client = MlflowClient()
-            local_dir = "/tmp/artifact_downloads"
-            if not os.path.exists(local_dir):
-                os.mkdir(local_dir)
-            local_path = client.download_artifacts(run.info.run_id, "features", local_dir)
-            print("Artifacts downloaded in: {}".format(local_path))
-            print("Artifacts: {}".format(os.listdir(local_path)))
-
-        .. code-block:: text
-            :caption: Output
-
-            Artifacts downloaded in: /tmp/artifact_downloads/features
-            Artifacts: ['features.txt']
-        """
-        return self._tracking_client.download_artifacts(run_id, path, dst_path)
-
     def set_terminated(
         self, run_id: str, status: Optional[str] = None, end_time: Optional[int] = None
     ) -> None:

--- a/tests/tracking/test_mlflow_artifacts.py
+++ b/tests/tracking/test_mlflow_artifacts.py
@@ -10,6 +10,7 @@ import mlflow
 from mlflow import MlflowClient
 from tests.helper_functions import LOCALHOST, get_safe_port
 from tests.tracking.integration_test_utils import _await_server_up_or_die
+from mlflow.artifacts import download_artifacts
 
 
 def is_windows():
@@ -213,11 +214,10 @@ def test_download_artifacts(artifacts_server, tmpdir):
         mlflow.log_artifact(tmp_path_a)
         mlflow.log_artifact(tmp_path_b, "dir")
 
-    client = MlflowClient()
-    dest_path = client.download_artifacts(run.info.run_id, "")
+    dest_path = download_artifacts(run_id=run.info.run_id, artifact_path="")
     assert sorted(os.listdir(dest_path)) == ["a.txt", "dir"]
     assert read_file(os.path.join(dest_path, "a.txt")) == "0"
-    dest_path = client.download_artifacts(run.info.run_id, "dir")
+    dest_path = download_artifacts(run_id=run.info.run_id, artifact_path="dir")
     assert os.listdir(dest_path) == ["b.txt"]
     assert read_file(os.path.join(dest_path, "b.txt")) == "1"
 

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -656,7 +656,6 @@ def test_set_terminated_status(mlflow_client):
 
 
 def test_artifacts(mlflow_client, tmp_path):
-    mlflow.set_tracking_uri(mlflow_client.tracking_uri)
     experiment_id = mlflow_client.create_experiment("Art In Fact")
     experiment_info = mlflow_client.get_experiment(experiment_id)
     assert experiment_info.artifact_location.startswith(path_to_local_file_uri(str(tmp_path)))
@@ -679,11 +678,15 @@ def test_artifacts(mlflow_client, tmp_path):
     dir_artifacts_list = mlflow_client.list_artifacts(run_id, "dir")
     assert set([a.path for a in dir_artifacts_list]) == {"dir/my.file"}
 
-    all_artifacts = download_artifacts(run_id=run_id, artifact_path=".")
+    all_artifacts = download_artifacts(
+        run_id=run_id, artifact_path=".", tracking_uri=mlflow_client.tracking_uri
+    )
     assert open("%s/my.file" % all_artifacts, "r").read() == "Hello, World!"
     assert open("%s/dir/my.file" % all_artifacts, "r").read() == "Hello, World!"
 
-    dir_artifacts = download_artifacts(run_id=run_id, artifact_path="dir")
+    dir_artifacts = download_artifacts(
+        run_id=run_id, artifact_path="dir", tracking_uri=mlflow_client.tracking_uri
+    )
     assert open("%s/my.file" % dir_artifacts, "r").read() == "Hello, World!"
 
 

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -38,6 +38,7 @@ from tests.tracking.integration_test_utils import (
     _init_server,
     _send_rest_tracking_post_request,
 )
+from mlflow.artifacts import download_artifacts
 
 
 _logger = logging.getLogger(__name__)
@@ -677,11 +678,11 @@ def test_artifacts(mlflow_client, tmp_path):
     dir_artifacts_list = mlflow_client.list_artifacts(run_id, "dir")
     assert set([a.path for a in dir_artifacts_list]) == {"dir/my.file"}
 
-    all_artifacts = mlflow_client.download_artifacts(run_id, ".")
+    all_artifacts = download_artifacts(run_id=run_id, artifact_path=".")
     assert open("%s/my.file" % all_artifacts, "r").read() == "Hello, World!"
     assert open("%s/dir/my.file" % all_artifacts, "r").read() == "Hello, World!"
 
-    dir_artifacts = mlflow_client.download_artifacts(run_id, "dir")
+    dir_artifacts = download_artifacts(run_id=run_id, artifact_path="dir")
     assert open("%s/my.file" % dir_artifacts, "r").read() == "Hello, World!"
 
 

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -656,6 +656,7 @@ def test_set_terminated_status(mlflow_client):
 
 
 def test_artifacts(mlflow_client, tmp_path):
+    mlflow.set_tracking_uri(mlflow_client.tracking_uri)
     experiment_id = mlflow_client.create_experiment("Art In Fact")
     experiment_info = mlflow_client.get_experiment(experiment_id)
     assert experiment_info.artifact_location.startswith(path_to_local_file_uri(str(tmp_path)))


### PR DESCRIPTION
Signed-off-by: Weichen Xu <weichen.xu@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?


Deprecate duplicate artifact download APIs.

The following APIs are removed:
```
MlflowClient.download_artifacts
```


## How is this patch tested?

Unit tests.

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Deprecate duplicate artifact download API: `MlflowClient.download_artifacts`

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [x] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
