### PR TITLE
Move prometheus client dependency to `extras`

### DIFF
--- a/requirements/core-requirements.txt
+++ b/requirements/core-requirements.txt
@@ -8,7 +8,6 @@ Flask<3
 numpy<2
 scipy<2
 pandas<2
-prometheus-flask-exporter<1
 querystring_parser<2
 sqlalchemy<2,>=1.4.0
 gunicorn<21; platform_system != 'Windows'

--- a/requirements/core-requirements.yaml
+++ b/requirements/core-requirements.yaml
@@ -28,10 +28,6 @@ pandas:
   pip_release: pandas
   max_major_version: 1
 
-prometheus-flask-exporter:
-  pip_release: prometheus-flask-exporter
-  max_major_version: 0
-
 querystring_parser:
   pip_release: querystring_parser
   max_major_version: 1

--- a/setup.py
+++ b/setup.py
@@ -145,6 +145,9 @@ setup(
             "mlserver>=0.5.3",
             "mlserver-mlflow>=0.5.3",
             "virtualenv",
+            # Required for exporting metrics from the MLflow server to Prometheus
+            # as part of the MLflow server monitoring add-on
+            "prometheus-flask-exporter",
         ],
         "pipelines": [
             "scikit-learn>=1.0",


### PR DESCRIPTION
Signed-off-by: dbczumar <corey.zumar@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## What changes are proposed in this pull request?

Move prometheus client dependency to `extras`

## How is this patch tested?

Existing tests

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

Move prometheus client dependency to `extras`

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [X] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [X] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
