### PR TITLE
Improve `deprecated` decorator

### DIFF
--- a/mlflow/utils/annotations.py
+++ b/mlflow/utils/annotations.py
@@ -41,8 +41,8 @@ def deprecated(alternative=None, since=None, impact=None):
         since_str = " since %s" % since if since else ""
         impact_str = impact if impact else "This method will be removed in a future release."
 
-        notice = "``{function_name}`` is deprecated{since_string}. {impact}".format(
-            function_name=".".join([func.__module__, func.__name__]),
+        notice = "``{qual_function_name}`` is deprecated{since_string}. {impact}".format(
+            qual_function_name=".".join([func.__module__, func.__qualname__]),
             since_string=since_str,
             impact=impact_str,
         )
@@ -51,7 +51,7 @@ def deprecated(alternative=None, since=None, impact=None):
 
         @wraps(func)
         def deprecated_func(*args, **kwargs):
-            warnings.warn(notice, category=DeprecationWarning, stacklevel=2)
+            warnings.warn(notice, category=FutureWarning, stacklevel=2)
             return func(*args, **kwargs)
 
         if func.__doc__ is not None:

--- a/tests/utils/test_annotations.py
+++ b/tests/utils/test_annotations.py
@@ -1,0 +1,35 @@
+import re
+
+import pytest
+from mlflow.utils.annotations import deprecated
+
+
+class MyClass:
+    @deprecated()
+    def method(self):
+        """
+        Returns 0
+        """
+        return 0
+
+
+@deprecated()
+def function():
+    """
+    Returns 1
+    """
+    return 1
+
+
+def test_deprecated_method():
+    msg = "``tests.utils.test_annotations.MyClass.method`` is deprecated"
+    with pytest.warns(FutureWarning, match=re.escape(msg)):
+        assert MyClass().method() == 0
+    assert msg in MyClass.method.__doc__
+
+
+def test_deprecated_function():
+    msg = "``tests.utils.test_annotations.function`` is deprecated"
+    with pytest.warns(FutureWarning, match=re.escape(msg)):
+        assert function() == 1
+    assert msg in function.__doc__


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Makes the following updates:

1. Raise `FutureWarning` (intended to be seen by application end users) instead of `DeprecationWarning` (intended to be seen by other Python developers and hidden when triggered by imported application, library or framework modules). See https://docs.python.org/3/whatsnew/3.7.html#whatsnew37-pep565 for more information.
2. Use the `__qualname__` attribute instead of `__name__` so that the decorator can be applied to a method.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
3. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
