### PR TITLE
fix use-set-literal errors batch 3 (#mlflow-6535)

### DIFF
--- a/tests/lightgbm/test_lightgbm_autolog.py
+++ b/tests/lightgbm/test_lightgbm_autolog.py
@@ -170,15 +170,13 @@ def test_lgb_autolog_sklearn():
     client = MlflowClient()
     run = client.get_run(run.info.run_id)
     assert run.data.metrics.items() <= params.items()
-    artifacts = set(x.path for x in client.list_artifacts(run.info.run_id))
-    assert artifacts >= set(
-        [
-            "feature_importance_gain.png",
-            "feature_importance_gain.json",
-            "feature_importance_split.png",
-            "feature_importance_split.json",
-        ]
-    )
+    artifacts = {x.path for x in client.list_artifacts(run.info.run_id)}
+    assert artifacts >= {
+        "feature_importance_gain.png",
+        "feature_importance_gain.json",
+        "feature_importance_split.png",
+        "feature_importance_split.json",
+    }
     loaded_model = mlflow.lightgbm.load_model(model_uri)
     np.testing.assert_allclose(loaded_model.predict(X), model.predict(X))
 

--- a/tests/models/test_model_input_examples.py
+++ b/tests/models/test_model_input_examples.py
@@ -90,7 +90,7 @@ def test_input_examples(pandas_df_with_all_types, dict_of_ndarrays):
         filename = example.info["artifact_path"]
         with open(tmp.path(filename), "r") as f:
             data = json.load(f)
-            assert set(data.keys()) == set(("columns", "data"))
+            assert set(data.keys()) == {"columns", "data"}
         parsed_df = _dataframe_from_json(tmp.path(filename), schema=sig.inputs)
         assert (pandas_df_with_all_types == parsed_df).all().all()
         # the frame read without schema should match except for the binary values
@@ -175,7 +175,7 @@ def test_input_examples_with_nan(df_with_nan, dict_of_ndarrays_with_nans):
         filename = example.info["artifact_path"]
         with open(tmp.path(filename), "r") as f:
             data = json.load(f)
-            assert set(data.keys()) == set(("columns", "data"))
+            assert set(data.keys()) == {"columns", "data"}
         parsed_df = _dataframe_from_json(tmp.path(filename), schema=sig.inputs)
         # by definition of NaN, NaN == NaN is False but NaN != NaN is True
         assert (

--- a/tests/projects/test_project_spec.py
+++ b/tests/projects/test_project_spec.py
@@ -15,7 +15,7 @@ def test_project_get_entry_point():
     assert entry_point.name == "greeter"
     assert entry_point.command == "python greeter.py {greeting} {name}"
     # Validate parameters
-    assert set(entry_point.parameters.keys()) == set(["name", "greeting"])
+    assert set(entry_point.parameters.keys()) == {"name", "greeting"}
     name_param = entry_point.parameters["name"]
     assert name_param.type == "string"
     assert name_param.default is None


### PR DESCRIPTION
Signed-off-by: Evgenii Uvarov <evgenii.uvarov.post@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
https://github.com/mlflow/mlflow/issues/6535

## What changes are proposed in this pull request?

Fixed use-set-literal errors in:

- tests/lightgbm/test_lightgbm_autolog.py
- tests/models/test_model_input_examples.py
- tests/projects/test_project_spec.py

<br class="Apple-interchange-newline">

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
