### PR TITLE
Add searchExperiments API to Java client, deprecate listExperiments

### DIFF
--- a/mlflow/java/client/README.md
+++ b/mlflow/java/client/README.md
@@ -54,7 +54,7 @@ RunInfo createRun(CreateRun request)
 List<RunInfo> listRunInfos(String experimentId)
 
 
-List<Experiment> listExperiments()
+List<Experiment> searchExperiments()
 GetExperiment.Response getExperiment(String experimentId)
 Optional<Experiment> getExperimentByName(String experimentName)
 long createExperiment(String experimentName)
@@ -117,8 +117,8 @@ public class QuickStartDriver {
     GetExperiment.Response exp = client.getExperiment(expId);
     System.out.println("getExperiment: " + exp);
 
-    System.out.println("====== listExperiments");
-    List<Experiment> exps = client.listExperiments();
+    System.out.println("====== searchExperiments");
+    List<Experiment> exps = client.searchExperiments();
     System.out.println("#experiments: " + exps.size());
     exps.forEach(e -> System.out.println("  Exp: " + e));
 

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/ExperimentsPage.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/ExperimentsPage.java
@@ -1,0 +1,88 @@
+package org.mlflow.tracking;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Optional;
+import org.mlflow.api.proto.Service.*;
+
+public class ExperimentsPage implements Page<Experiment> {
+
+  private final String token;
+  private final List<Experiment> experiments;
+
+  private final MlflowClient client;
+  private final String searchFilter;
+  private final ViewType experimentViewType;
+  private final List<String> orderBy;
+  private final int maxResults;
+
+  /**
+   * Creates a fixed size page of Experiments.
+   */
+  ExperimentsPage(List<Experiment> experiments,
+                  String token,
+                  String searchFilter,
+                  ViewType experimentViewType,
+                  int maxResults,
+                  List<String> orderBy,
+                  MlflowClient client) {
+    this.experiments = Collections.unmodifiableList(experiments);
+    this.token = token;
+    this.searchFilter = searchFilter;
+    this.experimentViewType = experimentViewType;
+    this.orderBy = orderBy;
+    this.maxResults = maxResults;
+    this.client = client;
+  }
+
+  /**
+   * @return The number of experiments in the page.
+   */
+  public int getPageSize() {
+    return this.experiments.size();
+  }
+
+  /**
+   * @return True if a token for the next page exists and isn't empty. Otherwise returns false.
+   */
+  public boolean hasNextPage() {
+    return this.token != null && this.token != "";
+  }
+
+  /**
+   * @return An optional with the token for the next page. 
+   * Empty if the token doesn't exist or is empty.
+   */
+  public Optional<String> getNextPageToken() {
+    if (this.hasNextPage()) {
+      return Optional.of(this.token);
+    } else {
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * @return The next page of experiments matching the search criteria.
+   * If there are no more pages, an {@link org.mlflow.tracking.EmptyPage} will be returned.
+   */
+  public Page<Experiment> getNextPage() {
+    if (this.hasNextPage()) {
+      return this.client.searchExperiments(this.searchFilter,
+                                           this.experimentViewType,
+                                           this.maxResults,
+                                           this.orderBy,
+                                           this.token);
+    } else {
+      return new EmptyPage();
+    }
+  }
+
+  /**
+   * @return An iterable over the experiments in this page.
+   */
+  public List<Experiment> getItems() {
+    return experiments;
+  }
+
+}

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -256,6 +256,82 @@ public class MlflowClient implements Serializable {
       searchFilter, runViewType, maxResults, orderBy, this);
   }
 
+  /**
+   * Return experiments that satisfy the search query.
+   *
+   * @param searchFilter SQL compatible search query string.
+   *                     Examples : "name = 'MyExperiment'", "tags.problem_type = 'iris_regression'"
+   *                     If null, the result will be equivalent to having an empty search filter.
+   * @param experimentViewType ViewType for expected experiments. One of
+   *                           (ACTIVE_ONLY, DELETED_ONLY, ALL). If null, only experiments with
+   *                           viewtype ACTIVE_ONLY will be searched.
+   * @param maxResults Maximum number of experiments desired in one page.
+   * @param orderBy List of properties to order by. Example: "metrics.acc DESC".
+   *
+   * @return A page of experiments that satisfy the search filter.
+   */
+  public ExperimentsPage searchExperiments(String searchFilter,
+                                           ViewType experimentViewType,
+                                           int maxResults,
+                                           List<String> orderBy) {
+    return searchExperiments(searchFilter, experimentViewType, maxResults, new ArrayList<>(), null);
+  }
+
+  /**
+   * Return up to the first 1000 experiments that satisfy the search query.
+   *
+   * @param searchFilter SQL compatible search query string.
+   *                     Examples : "name = 'MyExperiment'", "tags.problem_type = 'iris_regression'"
+   *                     If null, the result will be equivalent to having an empty search filter.
+   *
+   * @return A page of experiments that satisfy the search filter.
+   */
+  public ExperimentsPage searchExperiments(String searchFilter) {
+    return searchExperiments(searchFilter, null, 1000, new ArrayList<>(), null);
+  }
+
+  /**
+   * Return experiments that satisfy the search query.
+   *
+   * @param searchFilter SQL compatible search query string.
+   *                     Examples : "name = 'MyExperiment'", "tags.problem_type = 'iris_regression'"
+   *                     If null, the result will be equivalent to having an empty search filter.
+   * @param experimentViewType ViewType for expected experiments. One of
+   *                           (ACTIVE_ONLY, DELETED_ONLY, ALL). If null, only experiments with
+   *                           viewtype ACTIVE_ONLY will be searched.
+   * @param maxResults Maximum number of experiments desired in one page.
+   * @param orderBy List of properties to order by. Example: "metrics.acc DESC".
+   * @param pageToken String token specifying the next page of results. It should be obtained from
+   *             a call to {@link #searchExperiments(String)}.
+   *
+   * @return A page of experiments that satisfy the search filter.
+   */
+  public ExperimentsPage searchExperiments(String searchFilter,
+                                           ViewType experimentViewType,
+                                           int maxResults,
+                                           List<String> orderBy,
+                                           String pageToken) {
+    SearchExperiments.Builder builder = SearchExperiments.newBuilder()
+            .addAllOrderBy(orderBy)
+            .setMaxResults(maxResults);
+
+    if (searchFilter != null) {
+      builder.setFilter(searchFilter);
+    }
+    if (experimentViewType != null) {
+      builder.setViewType(experimentViewType);
+    }
+    if (pageToken != null) {
+      builder.setPageToken(pageToken);
+    }
+    SearchExperiments request = builder.build();
+    String ijson = mapper.toJson(request);
+    String ojson = sendPost("experiments/search", ijson);
+    SearchExperiments.Response response = mapper.toSearchExperimentsResponse(ojson);
+    return new ExperimentsPage(response.getExperimentsList(), response.getNextPageToken(),
+      searchFilter, experimentViewType, maxResults, orderBy, this);
+  }
+
   /** @return  A list of all experiments. */
   public List<Experiment> listExperiments() {
     return mapper.toListExperimentsResponse(httpCaller.get("experiments/list"))

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -260,7 +260,9 @@ public class MlflowClient implements Serializable {
    * Return experiments that satisfy the search query.
    *
    * @param searchFilter SQL compatible search query string.
-   *                     Examples : "name = 'MyExperiment'", "tags.problem_type = 'iris_regression'"
+   *                     Examples:
+   *                         - "attribute.name = 'MyExperiment'"
+   *                         - "tags.problem_type = 'iris_regression'"
    *                     If null, the result will be equivalent to having an empty search filter.
    * @param experimentViewType ViewType for expected experiments. One of
    *                           (ACTIVE_ONLY, DELETED_ONLY, ALL). If null, only experiments with
@@ -274,14 +276,16 @@ public class MlflowClient implements Serializable {
                                            ViewType experimentViewType,
                                            int maxResults,
                                            List<String> orderBy) {
-    return searchExperiments(searchFilter, experimentViewType, maxResults, new ArrayList<>(), null);
+    return searchExperiments(searchFilter, experimentViewType, maxResults, orderBy, null);
   }
 
   /**
    * Return up to the first 1000 experiments that satisfy the search query.
    *
    * @param searchFilter SQL compatible search query string.
-   *                     Examples : "name = 'MyExperiment'", "tags.problem_type = 'iris_regression'"
+   *                     Examples:
+   *                         - "attribute.name = 'MyExperiment'"
+   *                         - "tags.problem_type = 'iris_regression'"
    *                     If null, the result will be equivalent to having an empty search filter.
    *
    * @return A page of experiments that satisfy the search filter.
@@ -294,7 +298,9 @@ public class MlflowClient implements Serializable {
    * Return experiments that satisfy the search query.
    *
    * @param searchFilter SQL compatible search query string.
-   *                     Examples : "name = 'MyExperiment'", "tags.problem_type = 'iris_regression'"
+   *                     Examples:
+   *                         - "attribute.name = 'MyExperiment'"
+   *                         - "tags.problem_type = 'iris_regression'"
    *                     If null, the result will be equivalent to having an empty search filter.
    * @param experimentViewType ViewType for expected experiments. One of
    *                           (ACTIVE_ONLY, DELETED_ONLY, ALL). If null, only experiments with
@@ -320,6 +326,8 @@ public class MlflowClient implements Serializable {
     }
     if (experimentViewType != null) {
       builder.setViewType(experimentViewType);
+    } else {
+      builder.setViewType(ViewType.ACTIVE_ONLY);
     }
     if (pageToken != null) {
       builder.setPageToken(pageToken);

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -280,7 +280,16 @@ public class MlflowClient implements Serializable {
   }
 
   /**
-   * Return up to the first 1000 experiments that satisfy the search query.
+   * Return up to 1000 active experiments.
+   *
+   * @return A page of active experiments with up to 1000 items.
+   */
+  public ExperimentsPage searchExperiments() {
+    return searchExperiments("", null, 1000, new ArrayList<>(), null);
+  }
+
+  /**
+   * Return up to the first 1000 active experiments that satisfy the search query.
    *
    * @param searchFilter SQL compatible search query string.
    *                     Examples:
@@ -288,7 +297,7 @@ public class MlflowClient implements Serializable {
    *                         - "tags.problem_type = 'iris_regression'"
    *                     If null, the result will be equivalent to having an empty search filter.
    *
-   * @return A page of experiments that satisfy the search filter.
+   * @return A page of up to active 1000 experiments that satisfy the search filter.
    */
   public ExperimentsPage searchExperiments(String searchFilter) {
     return searchExperiments(searchFilter, null, 1000, new ArrayList<>(), null);
@@ -340,7 +349,12 @@ public class MlflowClient implements Serializable {
       searchFilter, experimentViewType, maxResults, orderBy, this);
   }
 
-  /** @return  A list of all experiments. */
+  /**
+   * @deprecated
+   * Use {@link #searchExperiments()} instead.
+   *
+   * @return  A list of all experiments.
+   */
   public List<Experiment> listExperiments() {
     return mapper.toListExperimentsResponse(httpCaller.get("experiments/list"))
       .getExperimentsList();

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowHttpCaller.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowHttpCaller.java
@@ -33,7 +33,7 @@ import org.mlflow.tracking.creds.MlflowHostCredsProvider;
 
 class MlflowHttpCaller {
   private static final Logger logger = LoggerFactory.getLogger(MlflowHttpCaller.class);
-  private static final String BASE_API_PATH = "api/2.0/preview/mlflow";
+  private static final String BASE_API_PATH = "api/2.0/mlflow";
   protected HttpClient httpClient;
   private final MlflowHostCredsProvider hostCredsProvider;
   private final int maxRateLimitIntervalMillis;

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowProtobufMapper.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowProtobufMapper.java
@@ -186,6 +186,12 @@ class MlflowProtobufMapper {
     return builder.build();
   }
 
+  SearchExperiments.Response toSearchExperimentsResponse(String json) {
+    SearchExperiments.Response.Builder builder = SearchExperiments.Response.newBuilder();
+    merge(json, builder);
+    return builder.build();
+  }
+
   ListExperiments.Response toListExperimentsResponse(String json) {
     ListExperiments.Response.Builder builder = ListExperiments.Response.newBuilder();
     merge(json, builder);

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/samples/QuickStartDriver.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/samples/QuickStartDriver.java
@@ -32,8 +32,8 @@ public class QuickStartDriver {
     GetExperiment.Response exp = client.getExperiment(expId);
     System.out.println("getExperiment: " + exp);
 
-    System.out.println("====== listExperiments");
-    List<Experiment> exps = client.listExperiments();
+    System.out.println("====== searchExperiments");
+    List<Experiment> exps = client.searchExperiments().getItems();
     System.out.println("#experiments: " + exps.size());
     exps.forEach(e -> System.out.println("  Exp: " + e));
 

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
@@ -152,7 +152,7 @@ public class MlflowClientTest {
 
   @Test
   public void searchExperimentsTest() {
-    List<Experiment> expsBefore = client.searchExperiments("").getItems();
+    List<Experiment> expsBefore = client.searchExperiments().getItems();
 
     String expName1 = createExperimentName();
     String expId1 = client.createExperiment(expName1);
@@ -168,7 +168,7 @@ public class MlflowClientTest {
     client.setExperimentTag(expId3, "test", "test");
     client.setExperimentTag(expId3, "expgroup", "group1");
 
-    List<Experiment> exps = client.searchExperiments("").getItems();
+    List<Experiment> exps = client.searchExperiments().getItems();
     Assert.assertEquals(exps.size(), 3 + expsBefore.size());
 
     String exp1Filter = String.format("attribute.name = '%s'", expName1);
@@ -225,6 +225,11 @@ public class MlflowClientTest {
     Assert.assertEquals(page2.getItems().get(0).getName(), orderedExpNames.get(1));
     Assert.assertEquals(page2.getItems().get(1).getName(), orderedExpNames.get(2));
     Assert.assertFalse(page2.getNextPageToken().isPresent());
+
+    ExperimentsPage nextPageFromPrevPage = (ExperimentsPage) page1.getNextPage();
+    Assert.assertEquals(nextPageFromPrevPage.getItems().size(), 1);
+    Assert.assertEquals(nextPageFromPrevPage.getItems().get(0).getName(), orderedExpNames.get(1));
+    Assert.assertTrue(nextPageFromPrevPage.getNextPageToken().isPresent());
   }
 
   @Test

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
@@ -6,6 +6,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -13,6 +14,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.Stack;
 import java.util.Vector;
+import java.util.stream.Collectors;
 
 import com.google.common.collect.Lists;
 import org.apache.commons.io.FileUtils;
@@ -152,122 +154,77 @@ public class MlflowClientTest {
   public void searchExperimentsTest() {
     List<Experiment> expsBefore = client.searchExperiments("").getItems();
 
-    String expName = createExperimentName();
-    String expId = client.createExperiment(expName);
+    String expName1 = createExperimentName();
+    String expId1 = client.createExperiment(expName1);
+    client.setExperimentTag(expId1, "test", "test");
+    client.setExperimentTag(expId1, "expgroup", "group1");
+
+    String expName2 = createExperimentName();
+    String expId2 = client.createExperiment(expName2);
+    client.setExperimentTag(expId2, "test", "test");
+
+    String expName3 = createExperimentName();
+    String expId3 = client.createExperiment(expName3);
+    client.setExperimentTag(expId3, "test", "test");
+    client.setExperimentTag(expId3, "expgroup", "group1");
 
     List<Experiment> exps = client.searchExperiments("").getItems();
-    Assert.assertEquals(exps.size(), 1 + expsBefore.size());
+    Assert.assertEquals(exps.size(), 3 + expsBefore.size());
 
-    // // Create exp 
-    // String expName = createExperimentName(); 
-    // String expId = client.createExperiment(expName); 
-    // logger.debug(">> TEST.0"); 
-    //
-    // // Create run 
-    // String user = System.getenv("USER"); 
-    // long startTime = System.currentTimeMillis(); 
-    // String sourceFile = "MyFile.java"; 
-    //
-    // RunInfo runCreated_1 = client.createRun(expId); 
-    // String runId_1 = runCreated_1.getRunUuid(); 
-    // logger.debug("runId=" + runId_1); 
-    //
-    // RunInfo runCreated_2 = client.createRun(expId); 
-    // String runId_2 = runCreated_2.getRunUuid(); 
-    // logger.debug("runId=" + runId_2); 
-    //
-    // // Log parameters 
-    // client.logParam(runId_1, "min_samples_leaf", MIN_SAMPLES_LEAF); 
-    // client.logParam(runId_2, "min_samples_leaf", MIN_SAMPLES_LEAF); 
-    //
-    // client.logParam(runId_1, "max_depth", "5"); 
-    // client.logParam(runId_2, "max_depth", "15"); 
-    //
-    // // Log metrics 
-    // client.logMetric(runId_1, "accuracy_score", 0.1); 
-    // client.logMetric(runId_1, "accuracy_score", 0.4); 
-    // client.logMetric(runId_2, "accuracy_score", 0.9); 
-    //
-    // // Log tag 
-    // client.setTag(runId_1, "user_email", USER_EMAIL); 
-    // client.setTag(runId_1, "test", "works"); 
-    // client.setTag(runId_2, "test", "also works"); 
-    //
-    // List<String> experimentIds = Arrays.asList(expId); 
-    //
-    // // metrics based searches 
-    // List<RunInfo> searchResult = client.searchRuns(experimentIds, "metrics.accuracy_score < 0"); 
-    // Assert.assertEquals(searchResult.size(), 0); 
-    //
-    // searchResult = client.searchRuns(experimentIds, "metrics.accuracy_score > 0"); 
-    // Assert.assertEquals(searchResult.size(), 2); 
-    //
-    // searchResult = client.searchRuns(experimentIds, "metrics.accuracy_score < 0.3"); 
-    // Assert.assertEquals(searchResult.size(), 0); 
-    //
-    // searchResult = client.searchRuns(experimentIds, "metrics.accuracy_score < 0.5"); 
-    // Assert.assertEquals(searchResult.get(0).getRunUuid(), runId_1); 
-    //
-    // searchResult = client.searchRuns(experimentIds, "metrics.accuracy_score > 0.5"); 
-    // Assert.assertEquals(searchResult.get(0).getRunUuid(), runId_2); 
-    //
-    // // parameter based searches 
-    // searchResult = client.searchRuns(experimentIds, 
-    //         "params.min_samples_leaf = '" + MIN_SAMPLES_LEAF + "'"); 
-    // Assert.assertEquals(searchResult.size(), 2); 
-    // searchResult = client.searchRuns(experimentIds, 
-    //         "params.min_samples_leaf != '" + MIN_SAMPLES_LEAF + "'"); 
-    // Assert.assertEquals(searchResult.size(), 0); 
-    // searchResult = client.searchRuns(experimentIds, "params.max_depth = '5'"); 
-    // Assert.assertEquals(searchResult.get(0).getRunUuid(), runId_1); 
-    //
-    // searchResult = client.searchRuns(experimentIds, "params.max_depth = '15'"); 
-    // Assert.assertEquals(searchResult.get(0).getRunUuid(), runId_2); 
-    //
-    // // tag based search 
-    // searchResult = client.searchRuns(experimentIds, "tag.user_email = '" + USER_EMAIL + "'"); 
-    // Assert.assertEquals(searchResult.get(0).getRunUuid(), runId_1); 
-    //
-    // searchResult = client.searchRuns(experimentIds, "tag.user_email != '" + USER_EMAIL + "'"); 
-    // Assert.assertEquals(searchResult.size(), 0); 
-    //
-    // searchResult = client.searchRuns(experimentIds, "tag.test = 'works'"); 
-    // Assert.assertEquals(searchResult.get(0).getRunUuid(), runId_1); 
-    //
-    // searchResult = client.searchRuns(experimentIds, "tag.test = 'also works'"); 
-    // Assert.assertEquals(searchResult.get(0).getRunUuid(), runId_2); 
-    //
-    // // Paged searchRuns 
-    //
-    // List<Run> searchRuns = Lists.newArrayList(client.searchRuns(experimentIds, "",  
-    //         ViewType.ACTIVE_ONLY, 1000, Lists.newArrayList("metrics.accuracy_score")).getItems()); 
-    // Assert.assertEquals(searchRuns.get(0).getInfo().getRunUuid(), runId_1); 
-    // Assert.assertEquals(searchRuns.get(1).getInfo().getRunUuid(), runId_2); 
-    //
-    // searchRuns = Lists.newArrayList(client.searchRuns(experimentIds, "", ViewType.ACTIVE_ONLY, 
-    //         1000, Lists.newArrayList("params.min_samples_leaf", "metrics.accuracy_score DESC")) 
-    //         .getItems()); 
-    // Assert.assertEquals(searchRuns.get(1).getInfo().getRunUuid(), runId_1); 
-    // Assert.assertEquals(searchRuns.get(0).getInfo().getRunUuid(), runId_2); 
-    //
-    // Page<Run> page = client.searchRuns(experimentIds, "", ViewType.ACTIVE_ONLY, 1000); 
-    // Assert.assertEquals(page.getPageSize(), 2); 
-    // Assert.assertEquals(page.hasNextPage(), false); 
-    // Assert.assertEquals(page.getNextPageToken(), Optional.empty()); 
-    //
-    // page = client.searchRuns(experimentIds, "", ViewType.ACTIVE_ONLY, 1); 
-    // Assert.assertEquals(page.getPageSize(), 1); 
-    // Assert.assertEquals(page.hasNextPage(), true); 
-    // Assert.assertNotEquals(page.getNextPageToken(), Optional.empty()); 
-    //
-    // Page<Run> page2 = page.getNextPage(); 
-    // Assert.assertEquals(page2.getPageSize(), 1); 
-    // Assert.assertEquals(page2.hasNextPage(), false); 
-    // Assert.assertEquals(page2.getNextPageToken(), Optional.empty()); 
-    //
-    // Page<Run> page3 = page2.getNextPage(); 
-    // Assert.assertEquals(page3.getPageSize(), 0); 
-    // Assert.assertEquals(page3.getNextPageToken(), Optional.empty()); 
+    String exp1Filter = String.format("attribute.name = '%s'", expName1);
+    List<Experiment> exps1 = client.searchExperiments(exp1Filter).getItems();
+    Assert.assertEquals(exps1.size(), 1);
+    Assert.assertEquals(exps1.get(0).getExperimentId(), expId1);
+
+    String exp2Filter = String.format("attribute.name = '%s'", expName2);
+    List<Experiment> exps2 = client.searchExperiments(exp2Filter).getItems();
+    Assert.assertEquals(exps2.size(), 1);
+    Assert.assertEquals(exps2.get(0).getExperimentId(), expId2);
+
+    String expGroupFilter = String.format("tags.expgroup = 'group1'");
+    List<Experiment> expGroup = client.searchExperiments(expGroupFilter).getItems();
+    Assert.assertEquals(
+      expGroup.stream().map(exp -> exp.getExperimentId()).collect(Collectors.toSet()),
+      new HashSet<>(Arrays.asList(expId1, expId3))
+    );
+
+    client.deleteExperiment(expId2);
+
+    List<Experiment> activeExps = client.searchExperiments("").getItems();
+    Set<String> activeExpIds = activeExps.stream().map(
+        exp -> exp.getExperimentId()
+    ).collect(Collectors.toSet());
+    Assert.assertTrue(activeExpIds.contains(expId1));
+    Assert.assertTrue(activeExpIds.contains(expId3));
+    Assert.assertFalse(activeExpIds.contains(expId2));
+
+    List<Experiment> deletedExps = client.searchExperiments(
+        "", ViewType.DELETED_ONLY, 10, new ArrayList<>()
+    ).getItems();
+    Assert.assertEquals(deletedExps.size(), 1);
+    Assert.assertEquals(deletedExps.get(0).getExperimentId(), expId2);
+
+    List<String> orderedExpNames = Arrays.asList(expName1, expName2, expName3);
+    Collections.sort(orderedExpNames);
+
+    ExperimentsPage page1 = client.searchExperiments(
+      "tags.test = 'test'", ViewType.ALL, 1, Arrays.asList("attribute.name")
+    );
+    Assert.assertEquals(page1.getItems().size(), 1);
+    Assert.assertEquals(page1.getItems().get(0).getName(), orderedExpNames.get(0));
+    Assert.assertTrue(page1.getNextPageToken().isPresent());
+
+    ExperimentsPage page2 = client.searchExperiments(
+      "tags.test = 'test'",
+      ViewType.ALL,
+      2,
+      Arrays.asList("attribute.name"),
+      page1.getNextPageToken().get()
+    );
+    Assert.assertEquals(page2.getItems().size(), 2);
+    Assert.assertEquals(page2.getItems().get(0).getName(), orderedExpNames.get(1));
+    Assert.assertEquals(page2.getItems().get(1).getName(), orderedExpNames.get(2));
+    Assert.assertFalse(page2.getNextPageToken().isPresent());
   }
 
   @Test

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
@@ -149,6 +149,128 @@ public class MlflowClientTest {
   }
 
   @Test
+  public void searchExperimentsTest() {
+    List<Experiment> expsBefore = client.searchExperiments("").getItems();
+
+    String expName = createExperimentName();
+    String expId = client.createExperiment(expName);
+
+    List<Experiment> exps = client.searchExperiments("").getItems();
+    Assert.assertEquals(exps.size(), 1 + expsBefore.size());
+
+    // // Create exp 
+    // String expName = createExperimentName(); 
+    // String expId = client.createExperiment(expName); 
+    // logger.debug(">> TEST.0"); 
+    //
+    // // Create run 
+    // String user = System.getenv("USER"); 
+    // long startTime = System.currentTimeMillis(); 
+    // String sourceFile = "MyFile.java"; 
+    //
+    // RunInfo runCreated_1 = client.createRun(expId); 
+    // String runId_1 = runCreated_1.getRunUuid(); 
+    // logger.debug("runId=" + runId_1); 
+    //
+    // RunInfo runCreated_2 = client.createRun(expId); 
+    // String runId_2 = runCreated_2.getRunUuid(); 
+    // logger.debug("runId=" + runId_2); 
+    //
+    // // Log parameters 
+    // client.logParam(runId_1, "min_samples_leaf", MIN_SAMPLES_LEAF); 
+    // client.logParam(runId_2, "min_samples_leaf", MIN_SAMPLES_LEAF); 
+    //
+    // client.logParam(runId_1, "max_depth", "5"); 
+    // client.logParam(runId_2, "max_depth", "15"); 
+    //
+    // // Log metrics 
+    // client.logMetric(runId_1, "accuracy_score", 0.1); 
+    // client.logMetric(runId_1, "accuracy_score", 0.4); 
+    // client.logMetric(runId_2, "accuracy_score", 0.9); 
+    //
+    // // Log tag 
+    // client.setTag(runId_1, "user_email", USER_EMAIL); 
+    // client.setTag(runId_1, "test", "works"); 
+    // client.setTag(runId_2, "test", "also works"); 
+    //
+    // List<String> experimentIds = Arrays.asList(expId); 
+    //
+    // // metrics based searches 
+    // List<RunInfo> searchResult = client.searchRuns(experimentIds, "metrics.accuracy_score < 0"); 
+    // Assert.assertEquals(searchResult.size(), 0); 
+    //
+    // searchResult = client.searchRuns(experimentIds, "metrics.accuracy_score > 0"); 
+    // Assert.assertEquals(searchResult.size(), 2); 
+    //
+    // searchResult = client.searchRuns(experimentIds, "metrics.accuracy_score < 0.3"); 
+    // Assert.assertEquals(searchResult.size(), 0); 
+    //
+    // searchResult = client.searchRuns(experimentIds, "metrics.accuracy_score < 0.5"); 
+    // Assert.assertEquals(searchResult.get(0).getRunUuid(), runId_1); 
+    //
+    // searchResult = client.searchRuns(experimentIds, "metrics.accuracy_score > 0.5"); 
+    // Assert.assertEquals(searchResult.get(0).getRunUuid(), runId_2); 
+    //
+    // // parameter based searches 
+    // searchResult = client.searchRuns(experimentIds, 
+    //         "params.min_samples_leaf = '" + MIN_SAMPLES_LEAF + "'"); 
+    // Assert.assertEquals(searchResult.size(), 2); 
+    // searchResult = client.searchRuns(experimentIds, 
+    //         "params.min_samples_leaf != '" + MIN_SAMPLES_LEAF + "'"); 
+    // Assert.assertEquals(searchResult.size(), 0); 
+    // searchResult = client.searchRuns(experimentIds, "params.max_depth = '5'"); 
+    // Assert.assertEquals(searchResult.get(0).getRunUuid(), runId_1); 
+    //
+    // searchResult = client.searchRuns(experimentIds, "params.max_depth = '15'"); 
+    // Assert.assertEquals(searchResult.get(0).getRunUuid(), runId_2); 
+    //
+    // // tag based search 
+    // searchResult = client.searchRuns(experimentIds, "tag.user_email = '" + USER_EMAIL + "'"); 
+    // Assert.assertEquals(searchResult.get(0).getRunUuid(), runId_1); 
+    //
+    // searchResult = client.searchRuns(experimentIds, "tag.user_email != '" + USER_EMAIL + "'"); 
+    // Assert.assertEquals(searchResult.size(), 0); 
+    //
+    // searchResult = client.searchRuns(experimentIds, "tag.test = 'works'"); 
+    // Assert.assertEquals(searchResult.get(0).getRunUuid(), runId_1); 
+    //
+    // searchResult = client.searchRuns(experimentIds, "tag.test = 'also works'"); 
+    // Assert.assertEquals(searchResult.get(0).getRunUuid(), runId_2); 
+    //
+    // // Paged searchRuns 
+    //
+    // List<Run> searchRuns = Lists.newArrayList(client.searchRuns(experimentIds, "",  
+    //         ViewType.ACTIVE_ONLY, 1000, Lists.newArrayList("metrics.accuracy_score")).getItems()); 
+    // Assert.assertEquals(searchRuns.get(0).getInfo().getRunUuid(), runId_1); 
+    // Assert.assertEquals(searchRuns.get(1).getInfo().getRunUuid(), runId_2); 
+    //
+    // searchRuns = Lists.newArrayList(client.searchRuns(experimentIds, "", ViewType.ACTIVE_ONLY, 
+    //         1000, Lists.newArrayList("params.min_samples_leaf", "metrics.accuracy_score DESC")) 
+    //         .getItems()); 
+    // Assert.assertEquals(searchRuns.get(1).getInfo().getRunUuid(), runId_1); 
+    // Assert.assertEquals(searchRuns.get(0).getInfo().getRunUuid(), runId_2); 
+    //
+    // Page<Run> page = client.searchRuns(experimentIds, "", ViewType.ACTIVE_ONLY, 1000); 
+    // Assert.assertEquals(page.getPageSize(), 2); 
+    // Assert.assertEquals(page.hasNextPage(), false); 
+    // Assert.assertEquals(page.getNextPageToken(), Optional.empty()); 
+    //
+    // page = client.searchRuns(experimentIds, "", ViewType.ACTIVE_ONLY, 1); 
+    // Assert.assertEquals(page.getPageSize(), 1); 
+    // Assert.assertEquals(page.hasNextPage(), true); 
+    // Assert.assertNotEquals(page.getNextPageToken(), Optional.empty()); 
+    //
+    // Page<Run> page2 = page.getNextPage(); 
+    // Assert.assertEquals(page2.getPageSize(), 1); 
+    // Assert.assertEquals(page2.hasNextPage(), false); 
+    // Assert.assertEquals(page2.getNextPageToken(), Optional.empty()); 
+    //
+    // Page<Run> page3 = page2.getNextPage(); 
+    // Assert.assertEquals(page3.getPageSize(), 0); 
+    // Assert.assertEquals(page3.getNextPageToken(), Optional.empty()); 
+  }
+
+  @Test
   public void addGetRun() {
     // Create exp
     String expName = createExperimentName();
@@ -403,7 +525,7 @@ public class MlflowClientTest {
     Assert.assertEquals(page2.getPageSize(), 1);
     Assert.assertEquals(page2.hasNextPage(), false);
     Assert.assertEquals(page2.getNextPageToken(), Optional.empty());
-    
+
     Page<Run> page3 = page2.getNextPage();
     Assert.assertEquals(page3.getPageSize(), 0);
     Assert.assertEquals(page3.getNextPageToken(), Optional.empty());


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## What changes are proposed in this pull request?

Add searchExperiments API to Java client, deprecate listExperiments

## How is this patch tested?

Added integration tests

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

Add searchExperiments API to Java client, deprecate listExperiments

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [X] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
