### PR TITLE
replaced all self.assertTrue with assert

### DIFF
--- a/tests/entities/test_run_status.py
+++ b/tests/entities/test_run_status.py
@@ -44,8 +44,8 @@ class TestRunStatus(unittest.TestCase):
             RunStatus.from_string("the IMPOSSIBLE status string")
 
     def test_is_terminated(self):
-        self.assertTrue(RunStatus.is_terminated(RunStatus.FAILED))
-        self.assertTrue(RunStatus.is_terminated(RunStatus.FINISHED))
-        self.assertTrue(RunStatus.is_terminated(RunStatus.KILLED))
-        self.assertFalse(RunStatus.is_terminated(RunStatus.SCHEDULED))
-        self.assertFalse(RunStatus.is_terminated(RunStatus.RUNNING))
+        assert (RunStatus.is_terminated(RunStatus.FAILED))
+        assert (RunStatus.is_terminated(RunStatus.FINISHED))
+        assert (RunStatus.is_terminated(RunStatus.KILLED))
+        assert not (RunStatus.is_terminated(RunStatus.SCHEDULED))
+        assert not (RunStatus.is_terminated(RunStatus.RUNNING))

--- a/tests/entities/test_run_status.py
+++ b/tests/entities/test_run_status.py
@@ -44,8 +44,8 @@ class TestRunStatus(unittest.TestCase):
             RunStatus.from_string("the IMPOSSIBLE status string")
 
     def test_is_terminated(self):
-        assert (RunStatus.is_terminated(RunStatus.FAILED))
-        assert (RunStatus.is_terminated(RunStatus.FINISHED))
-        assert (RunStatus.is_terminated(RunStatus.KILLED))
+        assert RunStatus.is_terminated(RunStatus.FAILED)
+        assert RunStatus.is_terminated(RunStatus.FINISHED)
+        assert RunStatus.is_terminated(RunStatus.KILLED)
         assert not RunStatus.is_terminated(RunStatus.SCHEDULED)
         assert not RunStatus.is_terminated(RunStatus.RUNNING)

--- a/tests/entities/test_run_status.py
+++ b/tests/entities/test_run_status.py
@@ -47,5 +47,5 @@ class TestRunStatus(unittest.TestCase):
         assert (RunStatus.is_terminated(RunStatus.FAILED))
         assert (RunStatus.is_terminated(RunStatus.FINISHED))
         assert (RunStatus.is_terminated(RunStatus.KILLED))
-        assert not (RunStatus.is_terminated(RunStatus.SCHEDULED))
-        assert not (RunStatus.is_terminated(RunStatus.RUNNING))
+        assert not RunStatus.is_terminated(RunStatus.SCHEDULED)
+        assert not RunStatus.is_terminated(RunStatus.RUNNING)

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -153,7 +153,7 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         fs = FileStore(self.test_root)
         for exp in fs.list_experiments():
             exp_id = exp.experiment_id
-            self.assertTrue(exp_id in self.experiments)
+            assert (exp_id in self.experiments)
             self.assertEqual(exp.name, self.exp_data[exp_id]["name"])
             self.assertEqual(exp.artifact_location, self.exp_data[exp_id]["artifact_location"])
 
@@ -478,9 +478,9 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
 
         # delete it
         fs.delete_experiment(exp_id)
-        self.assertTrue(exp_id not in self._extract_ids(fs.list_experiments(ViewType.ACTIVE_ONLY)))
-        self.assertTrue(exp_id in self._extract_ids(fs.list_experiments(ViewType.DELETED_ONLY)))
-        self.assertTrue(exp_id in self._extract_ids(fs.list_experiments(ViewType.ALL)))
+        assert (exp_id not in self._extract_ids(fs.list_experiments(ViewType.ACTIVE_ONLY)))
+        assert (exp_id in self._extract_ids(fs.list_experiments(ViewType.DELETED_ONLY)))
+        assert (exp_id in self._extract_ids(fs.list_experiments(ViewType.ALL)))
         self.assertEqual(fs.get_experiment(exp_id).lifecycle_stage, LifecycleStage.DELETED)
 
         # restore it
@@ -491,9 +491,9 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         restored_2 = fs.get_experiment_by_name(exp_name)
         self.assertEqual(restored_2.experiment_id, exp_id)
         self.assertEqual(restored_2.name, exp_name)
-        self.assertTrue(exp_id in self._extract_ids(fs.list_experiments(ViewType.ACTIVE_ONLY)))
-        self.assertTrue(exp_id not in self._extract_ids(fs.list_experiments(ViewType.DELETED_ONLY)))
-        self.assertTrue(exp_id in self._extract_ids(fs.list_experiments(ViewType.ALL)))
+        assert (exp_id in self._extract_ids(fs.list_experiments(ViewType.ACTIVE_ONLY)))
+        assert (exp_id not in self._extract_ids(fs.list_experiments(ViewType.DELETED_ONLY)))
+        assert (exp_id in self._extract_ids(fs.list_experiments(ViewType.ALL)))
         self.assertEqual(fs.get_experiment(exp_id).lifecycle_stage, LifecycleStage.ACTIVE)
 
     def test_rename_experiment(self):

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -153,7 +153,7 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         fs = FileStore(self.test_root)
         for exp in fs.list_experiments():
             exp_id = exp.experiment_id
-            assert (exp_id in self.experiments)
+            assert exp_id in self.experiments
             self.assertEqual(exp.name, self.exp_data[exp_id]["name"])
             self.assertEqual(exp.artifact_location, self.exp_data[exp_id]["artifact_location"])
 
@@ -478,9 +478,9 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
 
         # delete it
         fs.delete_experiment(exp_id)
-        assert (exp_id not in self._extract_ids(fs.list_experiments(ViewType.ACTIVE_ONLY)))
-        assert (exp_id in self._extract_ids(fs.list_experiments(ViewType.DELETED_ONLY)))
-        assert (exp_id in self._extract_ids(fs.list_experiments(ViewType.ALL)))
+        assert exp_id not in self._extract_ids(fs.list_experiments(ViewType.ACTIVE_ONLY))
+        assert exp_id in self._extract_ids(fs.list_experiments(ViewType.DELETED_ONLY))
+        assert exp_id in self._extract_ids(fs.list_experiments(ViewType.ALL))
         self.assertEqual(fs.get_experiment(exp_id).lifecycle_stage, LifecycleStage.DELETED)
 
         # restore it
@@ -491,9 +491,9 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         restored_2 = fs.get_experiment_by_name(exp_name)
         self.assertEqual(restored_2.experiment_id, exp_id)
         self.assertEqual(restored_2.name, exp_name)
-        assert (exp_id in self._extract_ids(fs.list_experiments(ViewType.ACTIVE_ONLY)))
-        assert (exp_id not in self._extract_ids(fs.list_experiments(ViewType.DELETED_ONLY)))
-        assert (exp_id in self._extract_ids(fs.list_experiments(ViewType.ALL)))
+        assert exp_id in self._extract_ids(fs.list_experiments(ViewType.ACTIVE_ONLY))
+        assert exp_id not in self._extract_ids(fs.list_experiments(ViewType.DELETED_ONLY))
+        assert exp_id in self._extract_ids(fs.list_experiments(ViewType.ALL))
         self.assertEqual(fs.get_experiment(exp_id).lifecycle_stage, LifecycleStage.ACTIVE)
 
     def test_rename_experiment(self):

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -271,8 +271,8 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         self.assertEqual(len(deleted_run_list), 2)
         for deleted_run in deleted_run_list:
             self.assertEqual(deleted_run.lifecycle_stage, entities.LifecycleStage.DELETED)
-            assert (deleted_run.experiment_id in experiment_id)
-            assert (deleted_run.run_id in run_ids)
+            assert deleted_run.experiment_id in experiment_id
+            assert deleted_run.run_id in run_ids
             with self.store.ManagedSessionMaker() as session:
                 assert self.store._get_run(session, deleted_run.run_id).deleted_time is not None
 
@@ -287,8 +287,8 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
             self.assertEqual(restored_run.lifecycle_stage, entities.LifecycleStage.ACTIVE)
             with self.store.ManagedSessionMaker() as session:
                 assert self.store._get_run(session, restored_run.run_id).deleted_time is None
-            assert (restored_run.experiment_id in experiment_id)
-            assert (restored_run.run_id in run_ids)
+            assert restored_run.experiment_id in experiment_id
+            assert restored_run.run_id in run_ids
 
     def test_get_experiment(self):
         name = "goku"
@@ -893,7 +893,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         self.store.log_metric(run.info.run_id, neg_inf_metric)
 
         run = self.store.get_run(run.info.run_id)
-        assert (tkey in run.data.metrics and run.data.metrics[tkey] == tval)
+        assert tkey in run.data.metrics and run.data.metrics[tkey] == tval
 
         # SQL store _get_run method returns full history of recorded metrics.
         # Should return duplicates as well
@@ -902,9 +902,9 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
             sql_run_metrics = self.store._get_run(session, run.info.run_id).metrics
             self.assertEqual(5, len(sql_run_metrics))
             self.assertEqual(4, len(run.data.metrics))
-            assert (math.isnan(run.data.metrics["NaN"]))
-            assert (run.data.metrics["PosInf"] == 1.7976931348623157e308)
-            assert (run.data.metrics["NegInf"] == -1.7976931348623157e308)
+            assert math.isnan(run.data.metrics["NaN"])
+            assert run.data.metrics["PosInf"] == 1.7976931348623157e308
+            assert run.data.metrics["NegInf"] == -1.7976931348623157e308
 
     def test_log_metric_concurrent_logging_succeeds(self):
         """
@@ -1021,7 +1021,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
 
         run = self.store.get_run(run.info.run_id)
         self.assertEqual(2, len(run.data.params))
-        assert (tkey in run.data.params and run.data.params[tkey] == tval)
+        assert tkey in run.data.params and run.data.params[tkey] == tval
 
     def test_log_param_uniqueness(self):
         run = self._run_factory()
@@ -1047,7 +1047,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
 
         run = self.store.get_run(run.info.run_id)
         self.assertEqual(2, len(run.data.params))
-        assert (tkey in run.data.params and run.data.params[tkey] == tval)
+        assert tkey in run.data.params and run.data.params[tkey] == tval
 
     def test_log_null_param(self):
         run = self._run_factory()
@@ -1083,27 +1083,27 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         new_tag = entities.RunTag("tag0", "value00000")
         self.store.set_experiment_tag(exp_id, tag)
         experiment = self.store.get_experiment(exp_id)
-        assert (experiment.tags["tag0"] == "value0")
+        assert experiment.tags["tag0"] == "value0"
         # test that updating a tag works
         self.store.set_experiment_tag(exp_id, new_tag)
         experiment = self.store.get_experiment(exp_id)
-        assert (experiment.tags["tag0"] == "value00000")
+        assert experiment.tags["tag0"] == "value00000"
         # test that setting a tag on 1 experiment does not impact another experiment.
         exp_id_2 = self._experiment_factory("setExperimentTagExp2")
         experiment2 = self.store.get_experiment(exp_id_2)
-        assert (len(experiment2.tags) == 0)
+        assert len(experiment2.tags) == 0
         # setting a tag on different experiments maintains different values across experiments
         different_tag = entities.RunTag("tag0", "differentValue")
         self.store.set_experiment_tag(exp_id_2, different_tag)
         experiment = self.store.get_experiment(exp_id)
-        assert (experiment.tags["tag0"] == "value00000")
+        assert experiment.tags["tag0"] == "value00000"
         experiment2 = self.store.get_experiment(exp_id_2)
-        assert (experiment2.tags["tag0"] == "differentValue")
+        assert experiment2.tags["tag0"] == "differentValue"
         # test can set multi-line tags
         multiLineTag = entities.ExperimentTag("multiline tag", "value2\nvalue2\nvalue2")
         self.store.set_experiment_tag(exp_id, multiLineTag)
         experiment = self.store.get_experiment(exp_id)
-        assert (experiment.tags["multiline tag"] == "value2\nvalue2\nvalue2")
+        assert experiment.tags["multiline tag"] == "value2\nvalue2\nvalue2"
         # test cannot set tags that are too long
         longTag = entities.ExperimentTag("longTagKey", "a" * 5001)
         with pytest.raises(MlflowException, match="exceeded length limit of 5000"):
@@ -1133,7 +1133,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         # test can set tags that are somewhat long
         self.store.set_tag(run.info.run_id, entities.RunTag("longTagKey", "a" * 4999))
         run = self.store.get_run(run.info.run_id)
-        assert (tkey in run.data.tags and run.data.tags[tkey] == new_val)
+        assert tkey in run.data.tags and run.data.tags[tkey] == new_val
 
     def test_delete_tag(self):
         run = self._run_factory()
@@ -1146,8 +1146,8 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         # delete a tag and check whether it is correctly deleted.
         self.store.delete_tag(run.info.run_id, k0)
         run = self.store.get_run(run.info.run_id)
-        assert (k0 not in run.data.tags)
-        assert (k1 in run.data.tags and run.data.tags[k1] == v1)
+        assert k0 not in run.data.tags
+        assert k1 in run.data.tags and run.data.tags[k1] == v1
 
         # test that deleting a tag works correctly with multiple runs having the same tag.
         run2 = self._run_factory(config=self._get_run_configs(run.info.experiment_id))
@@ -1156,8 +1156,8 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         self.store.delete_tag(run.info.run_id, k0)
         run = self.store.get_run(run.info.run_id)
         run2 = self.store.get_run(run2.info.run_id)
-        assert (k0 not in run.data.tags)
-        assert (k0 in run2.data.tags)
+        assert k0 not in run.data.tags
+        assert k0 in run2.data.tags
         # test that you cannot delete tags that don't exist.
         with pytest.raises(MlflowException, match="No tag with name"):
             self.store.delete_tag(run.info.run_id, "fakeTag")
@@ -1303,7 +1303,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         self.assertEqual(metric_obj.value, 34.0)
         self.assertEqual(metric_obj.timestamp, 85)
         self.assertEqual(metric_obj.step, 1)
-        assert ({("t1345", "tv44")} <= set(run.data.tags.items()))
+        assert {("t1345", "tv44")} <= set(run.data.tags.items())
 
     # Tests for Search API
     def _search(
@@ -2017,7 +2017,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         self.store._log_metrics(run.info.run_id, metrics)
 
         run = self.store.get_run(run.info.run_id)
-        assert (tkey in run.data.metrics and run.data.metrics[tkey] == tval)
+        assert tkey in run.data.metrics and run.data.metrics[tkey] == tval
 
         # SQL store _get_run method returns full history of recorded metrics.
         # Should return duplicates as well
@@ -2026,9 +2026,9 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
             sql_run_metrics = self.store._get_run(session, run.info.run_id).metrics
             self.assertEqual(5, len(sql_run_metrics))
             self.assertEqual(4, len(run.data.metrics))
-            assert (math.isnan(run.data.metrics["NaN"]))
-            assert (run.data.metrics["PosInf"] == 1.7976931348623157e308)
-            assert (run.data.metrics["NegInf"] == -1.7976931348623157e308)
+            assert math.isnan(run.data.metrics["NaN"])
+            assert run.data.metrics["PosInf"] == 1.7976931348623157e308
+            assert run.data.metrics["NegInf"] == -1.7976931348623157e308
 
     def test_log_batch_same_metric_repeated_single_req(self):
         run = self._run_factory()

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -271,8 +271,8 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         self.assertEqual(len(deleted_run_list), 2)
         for deleted_run in deleted_run_list:
             self.assertEqual(deleted_run.lifecycle_stage, entities.LifecycleStage.DELETED)
-            self.assertTrue(deleted_run.experiment_id in experiment_id)
-            self.assertTrue(deleted_run.run_id in run_ids)
+            assert (deleted_run.experiment_id in experiment_id)
+            assert (deleted_run.run_id in run_ids)
             with self.store.ManagedSessionMaker() as session:
                 assert self.store._get_run(session, deleted_run.run_id).deleted_time is not None
 
@@ -287,8 +287,8 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
             self.assertEqual(restored_run.lifecycle_stage, entities.LifecycleStage.ACTIVE)
             with self.store.ManagedSessionMaker() as session:
                 assert self.store._get_run(session, restored_run.run_id).deleted_time is None
-            self.assertTrue(restored_run.experiment_id in experiment_id)
-            self.assertTrue(restored_run.run_id in run_ids)
+            assert (restored_run.experiment_id in experiment_id)
+            assert (restored_run.run_id in run_ids)
 
     def test_get_experiment(self):
         name = "goku"
@@ -835,7 +835,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         with self.store.ManagedSessionMaker() as session:
             actual = session.query(models.SqlRun).filter_by(run_uuid=run.info.run_id).first()
             self.assertEqual(actual.lifecycle_stage, entities.LifecycleStage.DELETED)
-            self.assertTrue(
+            assert (
                 actual.deleted_time is not None
             )  # deleted time should be updated and thus not None anymore
 
@@ -893,7 +893,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         self.store.log_metric(run.info.run_id, neg_inf_metric)
 
         run = self.store.get_run(run.info.run_id)
-        self.assertTrue(tkey in run.data.metrics and run.data.metrics[tkey] == tval)
+        assert (tkey in run.data.metrics and run.data.metrics[tkey] == tval)
 
         # SQL store _get_run method returns full history of recorded metrics.
         # Should return duplicates as well
@@ -902,9 +902,9 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
             sql_run_metrics = self.store._get_run(session, run.info.run_id).metrics
             self.assertEqual(5, len(sql_run_metrics))
             self.assertEqual(4, len(run.data.metrics))
-            self.assertTrue(math.isnan(run.data.metrics["NaN"]))
-            self.assertTrue(run.data.metrics["PosInf"] == 1.7976931348623157e308)
-            self.assertTrue(run.data.metrics["NegInf"] == -1.7976931348623157e308)
+            assert (math.isnan(run.data.metrics["NaN"]))
+            assert (run.data.metrics["PosInf"] == 1.7976931348623157e308)
+            assert (run.data.metrics["NegInf"] == -1.7976931348623157e308)
 
     def test_log_metric_concurrent_logging_succeeds(self):
         """
@@ -1021,7 +1021,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
 
         run = self.store.get_run(run.info.run_id)
         self.assertEqual(2, len(run.data.params))
-        self.assertTrue(tkey in run.data.params and run.data.params[tkey] == tval)
+        assert (tkey in run.data.params and run.data.params[tkey] == tval)
 
     def test_log_param_uniqueness(self):
         run = self._run_factory()
@@ -1047,7 +1047,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
 
         run = self.store.get_run(run.info.run_id)
         self.assertEqual(2, len(run.data.params))
-        self.assertTrue(tkey in run.data.params and run.data.params[tkey] == tval)
+        assert (tkey in run.data.params and run.data.params[tkey] == tval)
 
     def test_log_null_param(self):
         run = self._run_factory()
@@ -1083,27 +1083,27 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         new_tag = entities.RunTag("tag0", "value00000")
         self.store.set_experiment_tag(exp_id, tag)
         experiment = self.store.get_experiment(exp_id)
-        self.assertTrue(experiment.tags["tag0"] == "value0")
+        assert (experiment.tags["tag0"] == "value0")
         # test that updating a tag works
         self.store.set_experiment_tag(exp_id, new_tag)
         experiment = self.store.get_experiment(exp_id)
-        self.assertTrue(experiment.tags["tag0"] == "value00000")
+        assert (experiment.tags["tag0"] == "value00000")
         # test that setting a tag on 1 experiment does not impact another experiment.
         exp_id_2 = self._experiment_factory("setExperimentTagExp2")
         experiment2 = self.store.get_experiment(exp_id_2)
-        self.assertTrue(len(experiment2.tags) == 0)
+        assert (len(experiment2.tags) == 0)
         # setting a tag on different experiments maintains different values across experiments
         different_tag = entities.RunTag("tag0", "differentValue")
         self.store.set_experiment_tag(exp_id_2, different_tag)
         experiment = self.store.get_experiment(exp_id)
-        self.assertTrue(experiment.tags["tag0"] == "value00000")
+        assert (experiment.tags["tag0"] == "value00000")
         experiment2 = self.store.get_experiment(exp_id_2)
-        self.assertTrue(experiment2.tags["tag0"] == "differentValue")
+        assert (experiment2.tags["tag0"] == "differentValue")
         # test can set multi-line tags
         multiLineTag = entities.ExperimentTag("multiline tag", "value2\nvalue2\nvalue2")
         self.store.set_experiment_tag(exp_id, multiLineTag)
         experiment = self.store.get_experiment(exp_id)
-        self.assertTrue(experiment.tags["multiline tag"] == "value2\nvalue2\nvalue2")
+        assert (experiment.tags["multiline tag"] == "value2\nvalue2\nvalue2")
         # test cannot set tags that are too long
         longTag = entities.ExperimentTag("longTagKey", "a" * 5001)
         with pytest.raises(MlflowException, match="exceeded length limit of 5000"):
@@ -1133,7 +1133,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         # test can set tags that are somewhat long
         self.store.set_tag(run.info.run_id, entities.RunTag("longTagKey", "a" * 4999))
         run = self.store.get_run(run.info.run_id)
-        self.assertTrue(tkey in run.data.tags and run.data.tags[tkey] == new_val)
+        assert (tkey in run.data.tags and run.data.tags[tkey] == new_val)
 
     def test_delete_tag(self):
         run = self._run_factory()
@@ -1146,8 +1146,8 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         # delete a tag and check whether it is correctly deleted.
         self.store.delete_tag(run.info.run_id, k0)
         run = self.store.get_run(run.info.run_id)
-        self.assertTrue(k0 not in run.data.tags)
-        self.assertTrue(k1 in run.data.tags and run.data.tags[k1] == v1)
+        assert (k0 not in run.data.tags)
+        assert (k1 in run.data.tags and run.data.tags[k1] == v1)
 
         # test that deleting a tag works correctly with multiple runs having the same tag.
         run2 = self._run_factory(config=self._get_run_configs(run.info.experiment_id))
@@ -1156,8 +1156,8 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         self.store.delete_tag(run.info.run_id, k0)
         run = self.store.get_run(run.info.run_id)
         run2 = self.store.get_run(run2.info.run_id)
-        self.assertTrue(k0 not in run.data.tags)
-        self.assertTrue(k0 in run2.data.tags)
+        assert (k0 not in run.data.tags)
+        assert (k0 in run2.data.tags)
         # test that you cannot delete tags that don't exist.
         with pytest.raises(MlflowException, match="No tag with name"):
             self.store.delete_tag(run.info.run_id, "fakeTag")
@@ -1303,7 +1303,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         self.assertEqual(metric_obj.value, 34.0)
         self.assertEqual(metric_obj.timestamp, 85)
         self.assertEqual(metric_obj.step, 1)
-        self.assertTrue({("t1345", "tv44")} <= set(run.data.tags.items()))
+        assert ({("t1345", "tv44")} <= set(run.data.tags.items()))
 
     # Tests for Search API
     def _search(
@@ -2017,7 +2017,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         self.store._log_metrics(run.info.run_id, metrics)
 
         run = self.store.get_run(run.info.run_id)
-        self.assertTrue(tkey in run.data.metrics and run.data.metrics[tkey] == tval)
+        assert (tkey in run.data.metrics and run.data.metrics[tkey] == tval)
 
         # SQL store _get_run method returns full history of recorded metrics.
         # Should return duplicates as well
@@ -2026,9 +2026,9 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
             sql_run_metrics = self.store._get_run(session, run.info.run_id).metrics
             self.assertEqual(5, len(sql_run_metrics))
             self.assertEqual(4, len(run.data.metrics))
-            self.assertTrue(math.isnan(run.data.metrics["NaN"]))
-            self.assertTrue(run.data.metrics["PosInf"] == 1.7976931348623157e308)
-            self.assertTrue(run.data.metrics["NegInf"] == -1.7976931348623157e308)
+            assert (math.isnan(run.data.metrics["NaN"]))
+            assert (run.data.metrics["PosInf"] == 1.7976931348623157e308)
+            assert (run.data.metrics["NegInf"] == -1.7976931348623157e308)
 
     def test_log_batch_same_metric_repeated_single_req(self):
         run = self._run_factory()


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
issue fixes #6566 

## What changes are proposed in this pull request?

replaced all `self.assertTrue` with `assert`

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
