### PR TITLE
[Model Validation] Finishing touches and documentation

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -1269,9 +1269,9 @@ You can also use the :py:func:`mlflow.evaluate()` API to perform some checks on 
 generated during model evaluation to validate the quality of your model. By specifying a 
 ``validation_thresholds`` dictionary mapping metric names to :py:class:`mlflow.models.MetricThreshold` 
 objects, you can specify value thresholds that your model's evaluation metrics must exceed as well 
-as absolute and relative gains your model must have in comparison to evaluations metrics for a 
+as absolute and relative gains your model must have in comparison to a specified
 ``baseline_model``. If you model fails to clear specified thresholds, :py:func:`mlflow.evaluate()` 
-will throw a `ModelValidationFailedException` detailing why your model failed validation.
+will throw a `ModelValidationFailedException` detailing why.
 
 .. code-block:: py
 
@@ -1320,8 +1320,8 @@ will throw a `ModelValidationFailedException` detailing why your model failed va
             baseline_model=baseline_model_uri,
         )
 
-Refer to :py:class:`mlflow.models.MetricThreshold` to see details on how the thresholds checks are 
-calculated. For a more comprehensive model validation example, refer to `this example from the MLflow GitHub Repository
+Refer to :py:class:`mlflow.models.MetricThreshold` to see details on how the thresholds are specified
+and checked. For a more comprehensive model validation example, refer to `this example from the MLflow GitHub Repository
 <https://github.com/mlflow/mlflow/blob/master/examples/evaluation/evaluate_with_model_validation.py>`_.
 
 Additional information about model evaluation behaviors and outputs is available in the

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -1271,7 +1271,7 @@ generated during model evaluation to validate the quality of your model. By spec
 objects, you can specify value thresholds that your model's evaluation metrics must exceed as well 
 as absolute and relative gains your model must have in comparison to a specified
 ``baseline_model``. If your model fails to clear specified thresholds, :py:func:`mlflow.evaluate()` 
-will throw a ``ModelValidationFailedException`` detailing why.
+will throw a ``ModelValidationFailedException`` detailing the validation failure.
 
 .. code-block:: py
 

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -1321,7 +1321,7 @@ will throw a ``ModelValidationFailedException`` detailing the validation failure
         )
 
 Refer to :py:class:`mlflow.models.MetricThreshold` to see details on how the thresholds are specified
-and checked. For a more comprehensive demonstration on how to use perform model validation, refer to 
+and checked. For a more comprehensive demonstration on how to use :py:func:`mlflow.evaluate()` to perform model validation, refer to 
 `the Model Validation example from the MLflow GitHub Repository
 <https://github.com/mlflow/mlflow/blob/master/examples/evaluation/evaluate_with_model_validation.py>`_.
 

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -1321,7 +1321,8 @@ will throw a `ModelValidationFailedException` detailing why.
         )
 
 Refer to :py:class:`mlflow.models.MetricThreshold` to see details on how the thresholds are specified
-and checked. For a more comprehensive model validation example, refer to `this example from the MLflow GitHub Repository
+and checked. For a more comprehensive demonstration on how to use perform model validation, refer to 
+`the Model Validation example from the MLflow GitHub Repository
 <https://github.com/mlflow/mlflow/blob/master/examples/evaluation/evaluate_with_model_validation.py>`_.
 
 Additional information about model evaluation behaviors and outputs is available in the

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -1270,7 +1270,7 @@ generated during model evaluation to validate the quality of your model. By spec
 ``validation_thresholds`` dictionary mapping metric names to :py:class:`mlflow.models.MetricThreshold` 
 objects, you can specify value thresholds that your model's evaluation metrics must exceed as well 
 as absolute and relative gains your model must have in comparison to a specified
-``baseline_model``. If you model fails to clear specified thresholds, :py:func:`mlflow.evaluate()` 
+``baseline_model``. If your model fails to clear specified thresholds, :py:func:`mlflow.evaluate()` 
 will throw a ``ModelValidationFailedException`` detailing why.
 
 .. code-block:: py

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -1271,7 +1271,7 @@ generated during model evaluation to validate the quality of your model. By spec
 objects, you can specify value thresholds that your model's evaluation metrics must exceed as well 
 as absolute and relative gains your model must have in comparison to a specified
 ``baseline_model``. If you model fails to clear specified thresholds, :py:func:`mlflow.evaluate()` 
-will throw a `ModelValidationFailedException` detailing why.
+will throw a ``ModelValidationFailedException`` detailing why.
 
 .. code-block:: py
 

--- a/examples/evaluation/README.md
+++ b/examples/evaluation/README.md
@@ -13,6 +13,8 @@ specified dataset using builtin default evaluator, and log resulting metrics & a
   model with a custom metric function on dataset loaded by `sklearn.datasets.fetch_california_housing`
 - Example `evaluate_with_custom_metrics_comprehensive.py` evaluates a scikit-learn `LinearRegression` model
   with a comprehensive list of custom metric functions on dataset loaded by `sklearn.datasets.fetch_california_housing`
+- Example `evaluate_with_model_validation.py` evaluates a candidate xgboost `XGBClassifier` model
+  on dataset loaded by `shap.datasets.adult` and validates that the resulting metrics clear specified thresholds.
 
 #### Prerequisites
 
@@ -30,4 +32,5 @@ python evaluate_on_multiclass_classifier.py
 python evaluate_on_regressor.py
 python evaluate_with_custom_metrics.py
 python evaluate_with_custom_metrics_comprehensive.py
+python evaluate_with_model_vaidation.py
 ```

--- a/examples/evaluation/README.md
+++ b/examples/evaluation/README.md
@@ -1,6 +1,6 @@
 ### MLflow evaluation Examples
 
-The examples in this directory illustrate how you can use the `mlflow.evaluate` API. Specifically,
+The examples in this directory demonstrate how to use the `mlflow.evaluate()` API. Specifically,
 they show how to evaluate a PyFunc model on a specified dataset using the builtin default evaluator 
 and specified custom metrics, where the resulting metrics & artifacts are logged to MLflow Tracking. 
 They also show how to specify validation thresholds for the resulting metrics to validate the quality 

--- a/examples/evaluation/README.md
+++ b/examples/evaluation/README.md
@@ -1,7 +1,10 @@
 ### MLflow evaluation Examples
 
-The examples in this directory illustrate how you can use the `mlflow.evaluate` API to evaluate a PyFunc model on the
-specified dataset using builtin default evaluator, and log resulting metrics & artifacts to MLflow Tracking.
+The examples in this directory illustrate how you can use the `mlflow.evaluate` API. Specifically,
+they show how to evaluate a PyFunc model on a specified dataset using the builtin default evaluator 
+and specified custom metrics, where the resulting metrics & artifacts are logged to MLflow Tracking. 
+They also show how to specify validation thresholds for the resulting metrics to validate the quality 
+of your model. See full list of examples below:
 
 - Example `evaluate_on_binary_classifier.py` evaluates an xgboost `XGBClassifier` model on dataset loaded by
   `shap.datasets.adult`.
@@ -13,8 +16,9 @@ specified dataset using builtin default evaluator, and log resulting metrics & a
   model with a custom metric function on dataset loaded by `sklearn.datasets.fetch_california_housing`
 - Example `evaluate_with_custom_metrics_comprehensive.py` evaluates a scikit-learn `LinearRegression` model
   with a comprehensive list of custom metric functions on dataset loaded by `sklearn.datasets.fetch_california_housing`
-- Example `evaluate_with_model_validation.py` evaluates a candidate xgboost `XGBClassifier` model
-  on dataset loaded by `shap.datasets.adult` and validates that the resulting metrics clear specified thresholds.
+- Example `evaluate_with_model_validation.py` trains both a candidate xgboost `XGBClassifier` model 
+  and a baseline `DummyClassifier` model on dataset loaded by `shap.datasets.adult`. Then, it validates
+  the candidate model against specified thresholds on both builtin and custom metrics and the dummy model.
 
 #### Prerequisites
 

--- a/examples/evaluation/evaluate_with_model_validation.py
+++ b/examples/evaluation/evaluate_with_model_validation.py
@@ -44,7 +44,7 @@ thresholds = {
         min_relative_change=0.05,  # accuracy should be at least 5 percent greater than baseline model accuracy
         higher_is_better=True,
     ),
-    # Specify threshold for custom metirc
+    # Specify threshold for custom metric
     "double_positive": MetricThreshold(
         threshold=1e5, higher_is_better=False  # double_positive should be <=1e5
     ),
@@ -52,6 +52,9 @@ thresholds = {
 
 with mlflow.start_run() as run:
     candidate_model_uri = mlflow.sklearn.log_model(candidate_model, "candidate_model").model_uri
+    # Note: in most model validation use-cases the baseline model should instead be a previously
+    # trained model (such as the current production model), specified directly in the
+    # mlflow.evaluate() call via model URI.
     baseline_model_uri = mlflow.sklearn.log_model(baseline_model, "baseline_model").model_uri
 
     try:

--- a/examples/evaluation/evaluate_with_model_validation.py
+++ b/examples/evaluation/evaluate_with_model_validation.py
@@ -1,0 +1,72 @@
+import xgboost
+import shap
+from sklearn.model_selection import train_test_split
+from sklearn.dummy import DummyClassifier
+import mlflow
+from mlflow.models import MetricThreshold
+from mlflow.models.evaluation.validation import ModelValidationFailedException
+
+# load UCI Adult Data Set; segment it into training and test sets
+X, y = shap.datasets.adult()
+X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.33, random_state=42)
+
+# train a candidate XGBoost model
+candidate_model = xgboost.XGBClassifier().fit(X_train, y_train)
+
+# train a baseline dummy model
+baseline_model = DummyClassifier(strategy="uniform").fit(X_train, y_train)
+
+# construct an evaluation dataset from the test set
+eval_data = X_test
+eval_data["label"] = y_test
+
+# Define a custom metric to evaluate against
+def double_positive(_, builtin_metrics):
+    return {
+        "double_positive": builtin_metrics["true_positives"] * 2,
+    }
+
+
+# Define criteria for model to be validated against
+thresholds = {
+    # Specify metric value threshold
+    "precision": MetricThreshold(threshold=0.7, higher_is_better=True),  # precision should be >=0.7
+    # Specify model comparison thresholds
+    "recall": MetricThreshold(
+        min_absolute_change=0.1,  # recall should be at least 0.1 greater than baseline model recall
+        min_relative_change=0.1,  # recall should be at least 10 percent greater than baseline model recall
+        higher_is_better=True,
+    ),
+    # Specify both metric value and model comparison thresholds
+    "accuracy": MetricThreshold(
+        threshold=0.8,  # accuracy should be >=0.8
+        min_absolute_change=0.05,  # accuracy should be at least 0.05 greater than baseline model accuracy
+        min_relative_change=0.05,  # accuracy should be at least 5 percent greater than baseline model accuracy
+        higher_is_better=True,
+    ),
+    # Specify threshold for custom metirc
+    "double_positive": MetricThreshold(
+        threshold=1e5, higher_is_better=False  # double_positive should be <=1e5
+    ),
+}
+
+with mlflow.start_run() as run:
+    candidate_model_uri = mlflow.sklearn.log_model(candidate_model, "candidate_model").model_uri
+    baseline_model_uri = mlflow.sklearn.log_model(baseline_model, "baseline_model").model_uri
+
+    try:
+        mlflow.evaluate(
+            candidate_model_uri,
+            eval_data,
+            targets="label",
+            model_type="classifier",
+            dataset_name="adult",
+            validation_thresholds=thresholds,
+            custom_metrics=[double_positive],
+            baseline_model=baseline_model_uri,
+        )
+    except ModelValidationFailedException as e:
+        print("Model failed to pass validation criteria! See detailed error message:")
+        print(e)
+    else:
+        print("Model passed validation criteria!")

--- a/examples/evaluation/evaluate_with_model_validation.py
+++ b/examples/evaluation/evaluate_with_model_validation.py
@@ -61,6 +61,7 @@ with mlflow.start_run() as run:
             targets="label",
             model_type="classifier",
             dataset_name="adult",
+            evaluators=["default"],
             validation_thresholds=thresholds,
             custom_metrics=[double_positive],
             baseline_model=baseline_model_uri,

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -1089,21 +1089,22 @@ def evaluate(
                                              .. code-block:: python
                                                  :caption: Example of Model Validation
 
+                                                 from mlflow.models import MetricThreshold
+
                                                  thresholds = {
-                                                     # Metric Value Threshold
+                                                     # Metric value thresholds
                                                      "f1_score": MetricThreshold(
                                                          threshold=0.8,
                                                          higher_is_better=True
                                                      ),
-                                                     # Model Comparison: min_absolute_change
-                                                     # and min_relative_change
+                                                     # Model comparison thresholds
                                                      "log_loss": MetricThreshold(
                                                          min_absolute_change=0.05,
                                                          min_relative_change=0.1,
                                                          higher_is_better=False
                                                      ),
-                                                     # Both Metric Value Threshold
-                                                     # and Model Comparison
+                                                     # Both metric value and model comparison \
+thresholds
                                                      "accuarcy": MetricThreshold(
                                                          threshold=0.8,
                                                          min_absolute_change=0.09,

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -706,7 +706,7 @@ def _validate(validation_thresholds, candidate_metrics, baseline_metrics=None):
         comparator_fn = operator.__ge__ if metric_threshold.higher_is_better else operator.__le__
 
         if metric_threshold.threshold is not None:
-            # metric threshold failed
+            # metric threshold fails
             # - if not (metric_value >= threshold) for higher is better
             # - if not (metric_value <= threshold) for lower is better
             validation_result.threshold_failed = not comparator_fn(
@@ -720,7 +720,7 @@ def _validate(validation_thresholds, candidate_metrics, baseline_metrics=None):
             continue
 
         if metric_threshold.min_absolute_change is not None:
-            # metric comparsion aboslute change failed
+            # metric comparsion aboslute change fails
             # - if not (metric_value >= baseline + min_absolute_change) for higher is better
             # - if not (metric_value <= baseline - min_absolute_change) for lower is better
             if metric_threshold.higher_is_better:
@@ -735,7 +735,18 @@ def _validate(validation_thresholds, candidate_metrics, baseline_metrics=None):
                 )
 
         if metric_threshold.min_relative_change is not None:
-            # metric comparsion relative change failed
+            # If baseline metric value equals 0, fallback to simple comparison check
+            if baseline_metric_value == 0:
+                _logger.warning(
+                    f"Relative model comparison is not possible for metric {metric_name} "
+                    "as baseline value is 0. Falling back to simple comparison check."
+                )
+                validation_result.min_relative_change_failed = not comparator_fn(
+                    Decimal(candidate_metric_value),
+                    Decimal(baseline_metric_value),
+                )
+                continue
+            # metric comparsion relative change fails
             # - if (metric_value - baseline) / baseline < min_relative_change for higher is better
             # - if (baseline - metric_value) / baseline < min_relative_change for lower is better
             if metric_threshold.higher_is_better:
@@ -1077,7 +1088,7 @@ def evaluate(
                                              :py:class:`mlflow.models.MetricThreshold` used for
                                              model validation. Each metric name must either be the
                                              name of a builtin metric or the name of a custom
-                                             metric defined in the``custom_metrics`` parameter.
+                                             metric defined in the ``custom_metrics`` parameter.
 
                                              .. code-block:: python
                                                  :caption: Example of Model Validation
@@ -1143,14 +1154,15 @@ def evaluate(
         baseline_model = mlflow.pyfunc.load_model(baseline_model)
     elif baseline_model is not None:
         raise MlflowException(
-            message="The baseline model argument must be a string URI referring to an MLflow model",
+            message="The baseline model argument must be a string URI referring to an "
+            "MLflow model.",
             error_code=INVALID_PARAMETER_VALUE,
         )
     elif _model_validation_contains_model_comparison(validation_thresholds):
         raise MlflowException(
-            message="The baseline model argument must be a string URI referring to "
-            "an MLflow model when model comparison thresholds  "
-            "(min_absolute_change, min_relative_change) are specified.",
+            message="The baseline model argument is None. The baseline model must be specified "
+            "when model comparison thresholds (min_absolute_change, min_relative_change) "
+            "are specified.",
             error_code=INVALID_PARAMETER_VALUE,
         )
 

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -738,8 +738,9 @@ def _validate(validation_thresholds, candidate_metrics, baseline_metrics=None):
             # If baseline metric value equals 0, fallback to simple comparison check
             if baseline_metric_value == 0:
                 _logger.warning(
-                    f"Relative model comparison is not possible for metric {metric_name} "
-                    "as baseline value is 0. Falling back to simple comparison check."
+                    f"Cannot perform relative model comparison for metric {metric_name} as "
+                    "baseline metric value is 0. Falling back to simple comparison: verifying "
+                    "that candidate metric value is better than the baseline metric value."
                 )
                 validation_result.min_relative_change_failed = not comparator_fn(
                     Decimal(candidate_metric_value),

--- a/mlflow/models/evaluation/validation.py
+++ b/mlflow/models/evaluation/validation.py
@@ -37,7 +37,7 @@ class MetricThreshold:
                                   threshold falls back performing a simple verification that the
                                   candidate metric value is better than the baseline metric value,
                                   i.e. metric value >= baseline model metric value + 1e-10 if higher
-                                  is better metric value <= baseline model metric value - 1e-10 if
+                                  is better; metric value <= baseline model metric value - 1e-10 if
                                   lower is better.
 
     :param higher_is_better: A required boolean representing whether higher value is

--- a/mlflow/models/evaluation/validation.py
+++ b/mlflow/models/evaluation/validation.py
@@ -33,6 +33,9 @@ class MetricThreshold:
                                   >= baseline model metric value * (1 + min_relative_change)
                                 - Otherwise, metric value has to be
                                   <= baseline model metric value * (1 - min_relative_change)
+                                - Note that if the baseline model metric value is equal to 0, the
+                                  threshold falls back to a minimum absolute change threshold of
+                                  min_absolute_change 0.
 
     :param higher_is_better: A required boolean representing whether higher value is
                              better for the metric.

--- a/mlflow/models/evaluation/validation.py
+++ b/mlflow/models/evaluation/validation.py
@@ -14,7 +14,7 @@ class MetricThreshold:
                       - Otherwise, the metric value has to be <= threshold to pass the validation.
 
     :param min_absolute_change: (Optional) A positive number representing the minimum absolute
-                                change required for candidate model to pass the comparison with
+                                change required for candidate model to pass validation with
                                 the baseline model.
 
                                 - If higher is better for the metric, metric value has to be

--- a/mlflow/models/evaluation/validation.py
+++ b/mlflow/models/evaluation/validation.py
@@ -1,5 +1,5 @@
 from mlflow.exceptions import MlflowException
-from mlflow.protos.databricks_pb2 import BAD_REQUEST
+from mlflow.protos.databricks_pb2 import BAD_REQUEST, INVALID_PARAMETER_VALUE
 
 
 class MetricThreshold:
@@ -13,9 +13,9 @@ class MetricThreshold:
                         >= threshold to pass validation.
                       - Otherwise, the metric value has to be <= threshold to pass the validation.
 
-    :param min_absolute_change: (Optional) A positive floating point number representing the
-                                minimum absolute change required for candidate model to
-                                pass the comparison with the baseline model.
+    :param min_absolute_change: (Optional) A positive number representing the minimum absolute
+                                change required for candidate model to pass the comparison with
+                                the baseline model.
 
                                 - If higher is better for the metric, metric value has to be
                                   >= baseline model metric value + min_absolute_change
@@ -48,55 +48,64 @@ class MetricThreshold:
         min_relative_change=None,
         higher_is_better=None,
     ):
+        if threshold is not None and not type(threshold) in {int, float}:
+            raise MetricThresholdClassException("`threshold` parameter must be a number.")
+        if min_absolute_change is not None and (
+            not type(min_absolute_change) in {int, float} or min_absolute_change <= 0
+        ):
+            raise MetricThresholdClassException(
+                "`min_absolute_change` parameter must be a positive number."
+            )
+        if min_relative_change is not None:
+            if not isinstance(min_relative_change, float):
+                raise MetricThresholdClassException(
+                    "`min_relative_change` parameter must be a floating point number."
+                )
+            if min_relative_change < 0 or min_relative_change > 1:
+                raise MetricThresholdClassException(
+                    "`min_relative_change` parameter must be between 0 and 1."
+                )
+        if higher_is_better is None:
+            raise MetricThresholdClassException("`higher_is_better` parameter must be defined.")
+        if not isinstance(higher_is_better, bool):
+            raise MetricThresholdClassException("`higher_is_better` parameter must be a boolean.")
         self._threshold = threshold
         self._min_absolute_change = min_absolute_change
         self._min_relative_change = min_relative_change
         self._higher_is_better = higher_is_better
-        if self._min_relative_change is not None and (
-            self._min_relative_change < 0 or self._min_relative_change > 1
-        ):
-            raise ValueError("The min_relative_change argument must be in [0, 1]")
-        if self._higher_is_better is None or not isinstance(self._higher_is_better, bool):
-            raise ValueError(
-                "The higher_is_better argument must be present and \
-                a bool indicating whether higher value is preferred"
-            )
 
     @property
     def threshold(self):
         """
-        Value threshold.
-        :rtype: float
+        Value of the threshold.
         """
         return self._threshold
 
     @property
     def min_absolute_change(self):
         """
-        Minimum absolute change required to pass model comparison with baseline model
-        :rtype: float
+        Value of the minimum absolute change required to pass model comparison with baseline model.
         """
         return self._min_absolute_change
 
     @property
     def min_relative_change(self):
         """
-        Minimum relative change required to pass model comparison wwith baseline model
-        :rtype: float
+        Float value of the minimum relative change required to pass model comparison with
+        baseline model.
         """
         return self._min_relative_change
 
     @property
     def higher_is_better(self):
         """
-        Whether higher value is better for the metric.
-        :rtype: bool
+        Boolean value representing whether higher value is better for the metric.
         """
         return self._higher_is_better
 
     def is_empty(self):
         """
-        Return True if there is no threshold specified, False otherwise.
+        Returns True if there is no threshold specified, False otherwise.
         """
         return (
             self._threshold is None
@@ -106,7 +115,7 @@ class MetricThreshold:
 
     def __str__(self):
         """
-        Return a human-readable string consisting of all specified thresholds.
+        Returns a human-readable string consisting of all specified thresholds.
         """
         threshold_strs = []
         if self._threshold is not None:
@@ -121,6 +130,12 @@ class MetricThreshold:
             else:
                 threshold_strs.append("Lower value is better.")
         return " ".join(threshold_strs)
+
+
+class MetricThresholdClassException(MlflowException):
+    def __init__(self, _message, **kwargs):
+        message = "Could not instantiate MetricThreshold class: " + _message
+        super().__init__(message, error_code=INVALID_PARAMETER_VALUE, **kwargs)
 
 
 class _MetricValidationResult:

--- a/mlflow/models/evaluation/validation.py
+++ b/mlflow/models/evaluation/validation.py
@@ -34,8 +34,8 @@ class MetricThreshold:
                                 - Otherwise, metric value has to be
                                   <= baseline model metric value * (1 - min_relative_change)
                                 - Note that if the baseline model metric value is equal to 0, the
-                                  threshold falls back to a minimum absolute change threshold of
-                                  min_absolute_change 0.
+                                  threshold falls back performing a simple verification that the
+                                  candidate metric value is better than the baseline metric value.
 
     :param higher_is_better: A required boolean representing whether higher value is
                              better for the metric.

--- a/mlflow/models/evaluation/validation.py
+++ b/mlflow/models/evaluation/validation.py
@@ -72,6 +72,8 @@ class MetricThreshold:
             raise MetricThresholdClassException("`higher_is_better` parameter must be defined.")
         if not isinstance(higher_is_better, bool):
             raise MetricThresholdClassException("`higher_is_better` parameter must be a boolean.")
+        if threshold is None and min_absolute_change is None and min_relative_change is None:
+            raise MetricThresholdClassException("no threshold was specified.")
         self._threshold = threshold
         self._min_absolute_change = min_absolute_change
         self._min_relative_change = min_relative_change
@@ -105,16 +107,6 @@ class MetricThreshold:
         Boolean value representing whether higher value is better for the metric.
         """
         return self._higher_is_better
-
-    def is_empty(self):
-        """
-        Returns True if there is no threshold specified, False otherwise.
-        """
-        return (
-            self._threshold is None
-            and self._min_absolute_change is None
-            and self._min_relative_change is None
-        )
 
     def __str__(self):
         """
@@ -173,7 +165,7 @@ class _MetricValidationResult:
 
     def __str__(self):
         """
-        Return a human-readable string representing the validation result for the metric.
+        Returns a human-readable string representing the validation result for the metric.
         """
         if self.is_success():
             return f"Metric {self.metric_name} passed the validation."

--- a/mlflow/models/evaluation/validation.py
+++ b/mlflow/models/evaluation/validation.py
@@ -35,7 +35,10 @@ class MetricThreshold:
                                   <= baseline model metric value * (1 - min_relative_change)
                                 - Note that if the baseline model metric value is equal to 0, the
                                   threshold falls back performing a simple verification that the
-                                  candidate metric value is better than the baseline metric value.
+                                  candidate metric value is better than the baseline metric value,
+                                  i.e. metric value >= baseline model metric value + 1e-10 if higher
+                                  is better metric value <= baseline model metric value - 1e-10 if
+                                  lower is better.
 
     :param higher_is_better: A required boolean representing whether higher value is
                              better for the metric.
@@ -144,8 +147,10 @@ class _MetricValidationResult:
     Not user facing, used for organizing metric failures and generating failure message
     more conveniently.
     :param metric_name: String representing the metric name
+    :param candidate_metric_value: value of metric for candidate model
     :param metric_threshold: :py:class: `MetricThreshold<mlflow.models.validation.MetricThreshold>`
                              The MetricThreshold for the metric.
+    :param baseline_metric_value: value of metric for baseline model
     """
 
     missing_candidate = False

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -192,6 +192,7 @@ def test_mlflow_run_example(directory, params, tmpdir):
         ("evaluation", ["python", "evaluate_on_regressor.py"]),
         ("evaluation", ["python", "evaluate_with_custom_metrics.py"]),
         ("evaluation", ["python", "evaluate_with_custom_metrics_comprehensive.py"]),
+        ("evaluation", ["python", "evaluate_with_model_validation.py"]),
         ("diviner", ["python", "train.py"]),
         ("spark_udf", ["python", "spark_udf_datetime.py"]),
         ("pyfunc", ["python", "train.py"]),

--- a/tests/models/test_evaluation.py
+++ b/tests/models/test_evaluation.py
@@ -355,10 +355,6 @@ def baseline_model_uri(request):
         return mlflow.pyfunc.load_model(model_uri)
     if request.param == "invalid_model_uri":
         return "invalid_uri"
-    if request.param == "bool":
-        return True
-    if request.param == "int":
-        return 0
     return None
 
 

--- a/tests/models/test_evaluation.py
+++ b/tests/models/test_evaluation.py
@@ -312,6 +312,31 @@ def get_svm_model_url():
 
 
 @pytest.fixture
+def iris_pandas_df_dataset():
+    X, y = get_iris()
+    eval_X, eval_y = X[0::3], y[0::3]
+    data = pd.DataFrame(
+        {
+            "f1": eval_X[:, 0],
+            "f2": eval_X[:, 1],
+            "f3": eval_X[:, 2],
+            "f4": eval_X[:, 3],
+            "y": eval_y,
+        }
+    )
+    return EvaluationDataset(data=data, targets="y", name="iris_pandas_df_dataset")
+
+
+@pytest.fixture
+def iris_pandas_df_num_cols_dataset():
+    X, y = get_iris()
+    eval_X, eval_y = X[0::3], y[0::3]
+    data = pd.DataFrame(eval_X)
+    data["y"] = eval_y
+    return EvaluationDataset(data=data, targets="y", name="iris_pandas_df_num_cols_dataset")
+
+
+@pytest.fixture
 def baseline_model_uri(request):
     if request.param == "linear_regressor_model_uri":
         return get_linear_regressor_model_uri()
@@ -574,22 +599,6 @@ def test_gen_md5_for_arraylike_obj():
 
     list4 = list0[:10] + [99] + list0[10:]
     assert get_md5(list3) == get_md5(list4)
-
-
-@pytest.fixture
-def iris_pandas_df_dataset():
-    X, y = get_iris()
-    eval_X, eval_y = X[0::3], y[0::3]
-    data = pd.DataFrame(
-        {
-            "f1": eval_X[:, 0],
-            "f2": eval_X[:, 1],
-            "f3": eval_X[:, 2],
-            "f4": eval_X[:, 3],
-            "y": eval_y,
-        }
-    )
-    return EvaluationDataset(data=data, targets="y", name="iris_pandas_df_dataset")
 
 
 def test_dataset_hash(

--- a/tests/models/test_validation.py
+++ b/tests/models/test_validation.py
@@ -703,6 +703,26 @@ def min_relative_change_threshold_test_spec(request):
             {},
         )
 
+    if request.param == "baseline_metric_value_equals_0_succeeds":
+        threshold = MetricThreshold(min_relative_change=0.1, higher_is_better=True)
+        return (
+            {"metric_1": 1e-10},
+            {"metric_1": 0},
+            {"metric_1": threshold},
+            {"metric_1": _MetricValidationResult("metric_1", 0.8, threshold, 0.7)},
+        )
+
+    if request.param == "baseline_metric_value_equals_0_fails":
+        metric_1_threshold = MetricThreshold(min_relative_change=0.1, higher_is_better=True)
+        metric_1_result = _MetricValidationResult("metric_1", 0, metric_1_threshold, 0)
+        metric_1_result.min_relative_change_failed = True
+        return (
+            {"metric_1": 0},
+            {"metric_1": 0},
+            {"metric_1": metric_1_threshold},
+            {"metric_1": metric_1_result},
+        )
+
 
 @pytest.mark.parametrize(
     "min_relative_change_threshold_test_spec",
@@ -712,6 +732,7 @@ def min_relative_change_threshold_test_spec(request):
         ("single_metric_not_satisfied_lower_better"),
         ("multiple_metrics_not_satisfied_lower_better"),
         ("missing_baseline_metric"),
+        ("baseline_metric_value_equals_0_fails"),
     ],
     indirect=["min_relative_change_threshold_test_spec"],
 )
@@ -766,6 +787,7 @@ def test_validation_model_comparison_relative_threshold_should_fail(
         ("single_metric_satisfied_lower_better"),
         ("equality_boundary"),
         ("multiple_metrics_all_satisfied"),
+        ("baseline_metric_value_equals_0_succeeds"),
     ],
     indirect=["min_relative_change_threshold_test_spec"],
 )

--- a/tests/models/test_validation.py
+++ b/tests/models/test_validation.py
@@ -70,6 +70,11 @@ def metric_threshold_class_test_spec(request):
     elif request.param == "higher_is_better_is_not_bool":
         class_params["higher_is_better"] = 1
         expected_failure_message = "`higher_is_better` parameter must be a boolean."
+    elif request.param == "no_threshold":
+        class_params["threshold"] = None
+        class_params["min_absolute_change"] = None
+        class_params["min_relative_change"] = None
+        expected_failure_message = "no threshold was specified."
 
     return (class_params, expected_failure_message)
 
@@ -84,6 +89,7 @@ def metric_threshold_class_test_spec(request):
         ("min_relative_change_is_not_between_0_and_1"),
         ("higher_is_better_is_not_defined"),
         ("higher_is_better_is_not_bool"),
+        ("no_threshold"),
     ],
     indirect=["metric_threshold_class_test_spec"],
 )

--- a/tests/models/test_validation.py
+++ b/tests/models/test_validation.py
@@ -863,19 +863,16 @@ def test_validation_missing_baseline_model(
     with mock.patch.object(
         _model_evaluation_registry, "_registry", {"test_evaluator1": MockEvaluator}
     ):
-        evaluator1_config = {}
-        evaluator1_return_value = EvaluationResult(
-            metrics=metrics, artifacts={}, baseline_model_metrics=baseline_model_metrics
-        )
-        expected_failure_message = ""
-        with mock.patch.object(
-            MockEvaluator, "can_evaluate", return_value=True
-        ) as _, mock.patch.object(
-            MockEvaluator, "evaluate", return_value=evaluator1_return_value
-        ) as _:
+        with mock.patch.object(MockEvaluator, "can_evaluate", return_value=True), mock.patch.object(
+            MockEvaluator,
+            "evaluate",
+            return_value=EvaluationResult(
+                metrics=metrics, artifacts={}, baseline_model_metrics=baseline_model_metrics
+            ),
+        ):
             with pytest.raises(
                 MlflowException,
-                match=expected_failure_message,
+                match="The baseline model must be specified",
             ):
                 evaluate(
                     multiclass_logistic_regressor_model_uri,
@@ -884,7 +881,7 @@ def test_validation_missing_baseline_model(
                     targets=iris_dataset._constructor_args["targets"],
                     dataset_name=iris_dataset.name,
                     evaluators="test_evaluator1",
-                    evaluator_config=evaluator1_config,
+                    evaluator_config={},
                     validation_thresholds=validation_thresholds,
-                    baseline_model=multiclass_logistic_regressor_model_uri,
+                    baseline_model=None,
                 )


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

#xxx

## What changes are proposed in this pull request?

Here are the changes included in this PR:
* Created failure message for missing `baseline_model` parameter and added corresponding tests.
* Built a way to handle the case when baseline metric values equals 0 and added corresponding tests.
* Added parameter checks to MetricThreshold class instantiation and added corresponding tests.
* Polished doc strings and comments.
* Added model validation documentation and examples.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

I verified locally that the doc strings are built as expected.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
