### PR TITLE
[2.0] Add searchExperiments API to Java client

### DIFF
--- a/mlflow/java/client/README.md
+++ b/mlflow/java/client/README.md
@@ -54,7 +54,7 @@ RunInfo createRun(CreateRun request)
 List<RunInfo> listRunInfos(String experimentId)
 
 
-List<Experiment> listExperiments()
+List<Experiment> searchExperiments()
 GetExperiment.Response getExperiment(String experimentId)
 Optional<Experiment> getExperimentByName(String experimentName)
 long createExperiment(String experimentName)
@@ -117,8 +117,8 @@ public class QuickStartDriver {
     GetExperiment.Response exp = client.getExperiment(expId);
     System.out.println("getExperiment: " + exp);
 
-    System.out.println("====== listExperiments");
-    List<Experiment> exps = client.listExperiments();
+    System.out.println("====== searchExperiments");
+    List<Experiment> exps = client.searchExperiments();
     System.out.println("#experiments: " + exps.size());
     exps.forEach(e -> System.out.println("  Exp: " + e));
 

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/ExperimentsPage.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/ExperimentsPage.java
@@ -1,0 +1,88 @@
+package org.mlflow.tracking;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Optional;
+import org.mlflow.api.proto.Service.*;
+
+public class ExperimentsPage implements Page<Experiment> {
+
+  private final String token;
+  private final List<Experiment> experiments;
+
+  private final MlflowClient client;
+  private final String searchFilter;
+  private final ViewType experimentViewType;
+  private final List<String> orderBy;
+  private final int maxResults;
+
+  /**
+   * Creates a fixed size page of Experiments.
+   */
+  ExperimentsPage(List<Experiment> experiments,
+                  String token,
+                  String searchFilter,
+                  ViewType experimentViewType,
+                  int maxResults,
+                  List<String> orderBy,
+                  MlflowClient client) {
+    this.experiments = Collections.unmodifiableList(experiments);
+    this.token = token;
+    this.searchFilter = searchFilter;
+    this.experimentViewType = experimentViewType;
+    this.orderBy = orderBy;
+    this.maxResults = maxResults;
+    this.client = client;
+  }
+
+  /**
+   * @return The number of experiments in the page.
+   */
+  public int getPageSize() {
+    return this.experiments.size();
+  }
+
+  /**
+   * @return True if a token for the next page exists and isn't empty. Otherwise returns false.
+   */
+  public boolean hasNextPage() {
+    return this.token != null && this.token != "";
+  }
+
+  /**
+   * @return An optional with the token for the next page. 
+   * Empty if the token doesn't exist or is empty.
+   */
+  public Optional<String> getNextPageToken() {
+    if (this.hasNextPage()) {
+      return Optional.of(this.token);
+    } else {
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * @return The next page of experiments matching the search criteria.
+   * If there are no more pages, an {@link org.mlflow.tracking.EmptyPage} will be returned.
+   */
+  public Page<Experiment> getNextPage() {
+    if (this.hasNextPage()) {
+      return this.client.searchExperiments(this.searchFilter,
+                                           this.experimentViewType,
+                                           this.maxResults,
+                                           this.orderBy,
+                                           this.token);
+    } else {
+      return new EmptyPage();
+    }
+  }
+
+  /**
+   * @return An iterable over the experiments in this page.
+   */
+  public List<Experiment> getItems() {
+    return experiments;
+  }
+
+}

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowHttpCaller.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowHttpCaller.java
@@ -33,7 +33,7 @@ import org.mlflow.tracking.creds.MlflowHostCredsProvider;
 
 class MlflowHttpCaller {
   private static final Logger logger = LoggerFactory.getLogger(MlflowHttpCaller.class);
-  private static final String BASE_API_PATH = "api/2.0/preview/mlflow";
+  private static final String BASE_API_PATH = "api/2.0/mlflow";
   protected HttpClient httpClient;
   private final MlflowHostCredsProvider hostCredsProvider;
   private final int maxRateLimitIntervalMillis;

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowProtobufMapper.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowProtobufMapper.java
@@ -186,6 +186,12 @@ class MlflowProtobufMapper {
     return builder.build();
   }
 
+  SearchExperiments.Response toSearchExperimentsResponse(String json) {
+    SearchExperiments.Response.Builder builder = SearchExperiments.Response.newBuilder();
+    merge(json, builder);
+    return builder.build();
+  }
+
   ListExperiments.Response toListExperimentsResponse(String json) {
     ListExperiments.Response.Builder builder = ListExperiments.Response.newBuilder();
     merge(json, builder);

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/samples/QuickStartDriver.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/samples/QuickStartDriver.java
@@ -32,8 +32,8 @@ public class QuickStartDriver {
     GetExperiment.Response exp = client.getExperiment(expId);
     System.out.println("getExperiment: " + exp);
 
-    System.out.println("====== listExperiments");
-    List<Experiment> exps = client.listExperiments();
+    System.out.println("====== searchExperiments");
+    List<Experiment> exps = client.searchExperiments().getItems();
     System.out.println("#experiments: " + exps.size());
     exps.forEach(e -> System.out.println("  Exp: " + e));
 

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
@@ -6,6 +6,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -13,6 +14,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.Stack;
 import java.util.Vector;
+import java.util.stream.Collectors;
 
 import com.google.common.collect.Lists;
 import org.apache.commons.io.FileUtils;
@@ -146,6 +148,88 @@ public class MlflowClientTest {
 
     GetExperiment.Response expGet = client.getExperiment(expId);
     Assert.assertEquals(expGet.getExperiment(), expList);
+  }
+
+  @Test
+  public void searchExperimentsTest() {
+    List<Experiment> expsBefore = client.searchExperiments().getItems();
+
+    String expName1 = createExperimentName();
+    String expId1 = client.createExperiment(expName1);
+    client.setExperimentTag(expId1, "test", "test");
+    client.setExperimentTag(expId1, "expgroup", "group1");
+
+    String expName2 = createExperimentName();
+    String expId2 = client.createExperiment(expName2);
+    client.setExperimentTag(expId2, "test", "test");
+
+    String expName3 = createExperimentName();
+    String expId3 = client.createExperiment(expName3);
+    client.setExperimentTag(expId3, "test", "test");
+    client.setExperimentTag(expId3, "expgroup", "group1");
+
+    List<Experiment> exps = client.searchExperiments().getItems();
+    Assert.assertEquals(exps.size(), 3 + expsBefore.size());
+
+    String exp1Filter = String.format("attribute.name = '%s'", expName1);
+    List<Experiment> exps1 = client.searchExperiments(exp1Filter).getItems();
+    Assert.assertEquals(exps1.size(), 1);
+    Assert.assertEquals(exps1.get(0).getExperimentId(), expId1);
+
+    String exp2Filter = String.format("attribute.name = '%s'", expName2);
+    List<Experiment> exps2 = client.searchExperiments(exp2Filter).getItems();
+    Assert.assertEquals(exps2.size(), 1);
+    Assert.assertEquals(exps2.get(0).getExperimentId(), expId2);
+
+    String expGroupFilter = String.format("tags.expgroup = 'group1'");
+    List<Experiment> expGroup = client.searchExperiments(expGroupFilter).getItems();
+    Assert.assertEquals(
+      expGroup.stream().map(exp -> exp.getExperimentId()).collect(Collectors.toSet()),
+      new HashSet<>(Arrays.asList(expId1, expId3))
+    );
+
+    client.deleteExperiment(expId2);
+
+    List<Experiment> activeExps = client.searchExperiments("").getItems();
+    Set<String> activeExpIds = activeExps.stream().map(
+        exp -> exp.getExperimentId()
+    ).collect(Collectors.toSet());
+    Assert.assertTrue(activeExpIds.contains(expId1));
+    Assert.assertTrue(activeExpIds.contains(expId3));
+    Assert.assertFalse(activeExpIds.contains(expId2));
+
+    List<Experiment> deletedExps = client.searchExperiments(
+        "", ViewType.DELETED_ONLY, 10, new ArrayList<>()
+    ).getItems();
+    Assert.assertEquals(deletedExps.size(), 1);
+    Assert.assertEquals(deletedExps.get(0).getExperimentId(), expId2);
+
+    List<String> orderedExpNames = Arrays.asList(expName1, expName2, expName3);
+    Collections.sort(orderedExpNames);
+
+    ExperimentsPage page1 = client.searchExperiments(
+      "tags.test = 'test'", ViewType.ALL, 1, Arrays.asList("attribute.name")
+    );
+    Assert.assertEquals(page1.getItems().size(), 1);
+    Assert.assertEquals(page1.getItems().get(0).getName(), orderedExpNames.get(0));
+    Assert.assertTrue(page1.getNextPageToken().isPresent());
+
+    ExperimentsPage page2 = client.searchExperiments(
+      "tags.test = 'test'",
+      ViewType.ALL,
+      2,
+      Arrays.asList("attribute.name"),
+      page1.getNextPageToken().get()
+    );
+    Assert.assertEquals(page2.getItems().size(), 2);
+    Assert.assertEquals(page2.getItems().get(0).getName(), orderedExpNames.get(1));
+    Assert.assertEquals(page2.getItems().get(1).getName(), orderedExpNames.get(2));
+    Assert.assertFalse(page2.getNextPageToken().isPresent());
+
+    ExperimentsPage nextPageFromPrevPage = (ExperimentsPage) page1.getNextPage();
+    Assert.assertEquals(nextPageFromPrevPage.getItems().size(), 1);
+    Assert.assertEquals(nextPageFromPrevPage.getItems().get(0).getName(), orderedExpNames.get(1));
+    Assert.assertTrue(nextPageFromPrevPage.getNextPageToken().isPresent());
   }
 
   @Test
@@ -403,7 +487,7 @@ public class MlflowClientTest {
     Assert.assertEquals(page2.getPageSize(), 1);
     Assert.assertEquals(page2.hasNextPage(), false);
     Assert.assertEquals(page2.getNextPageToken(), Optional.empty());
-    
+
     Page<Run> page3 = page2.getNextPage();
     Assert.assertEquals(page3.getPageSize(), 0);
     Assert.assertEquals(page3.getNextPageToken(), Optional.empty());


### PR DESCRIPTION
Signed-off-by: dbczumar <corey.zumar@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## What changes are proposed in this pull request?

Add searchExperiments API to Java client

## How is this patch tested?

Added integration tests

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

Add searchExperiments API to Java client

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [X] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
