### PR TITLE
Update mlflowclient to implement java.io.closeable

### DIFF
--- a/mlflow/java/client/README.md
+++ b/mlflow/java/client/README.md
@@ -157,6 +157,7 @@ public class QuickStartDriver {
     // Get run details
     Run run = client.getRun(runId);
     System.out.println("GetRun: " + run);
+    client.close();
   }
 }
 ```

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -9,6 +9,7 @@ import org.mlflow.api.proto.ModelRegistry.*;
 import org.mlflow.api.proto.Service.*;
 import org.mlflow.tracking.creds.*;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.Serializable;
 import java.net.URI;
@@ -22,7 +23,7 @@ import java.util.stream.Collectors;
 /**
  * Client to an MLflow Tracking Sever.
  */
-public class MlflowClient implements Serializable {
+public class MlflowClient implements Serializable, Closeable {
   protected static final String DEFAULT_EXPERIMENT_ID = "0";
   private static final String DEFAULT_MODELS_ARTIFACT_REPOSITORY_SCHEME = "models";
 
@@ -881,4 +882,10 @@ public class MlflowClient implements Serializable {
       return downloadModelVersion(modelName, details.getVersion());
   }
 
+  /**
+   * Closes the MlflowClient and releases any associated resources.
+   */
+  public void close() {
+    this.httpCaller.close();
+  }
 }

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowHttpCaller.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowHttpCaller.java
@@ -11,7 +11,6 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
 
 import org.apache.http.HttpResponse;
-import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPatch;
@@ -21,6 +20,7 @@ import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
 import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.ssl.SSLContextBuilder;
 import org.apache.http.util.EntityUtils;
@@ -34,7 +34,7 @@ import org.mlflow.tracking.creds.MlflowHostCredsProvider;
 class MlflowHttpCaller {
   private static final Logger logger = LoggerFactory.getLogger(MlflowHttpCaller.class);
   private static final String BASE_API_PATH = "api/2.0/mlflow";
-  protected HttpClient httpClient;
+  protected CloseableHttpClient httpClient;
   private final MlflowHostCredsProvider hostCredsProvider;
   private final int maxRateLimitIntervalMillis;
   private final int rateLimitRetrySleepInitMillis;
@@ -75,7 +75,7 @@ class MlflowHttpCaller {
                    int maxRateLimitIntervalMs,
                    int rateLimitRetrySleepInitMs,
                    int maxRetryAttempts,
-                   HttpClient client) {
+                   CloseableHttpClient client) {
     this(
       hostCredsProvider, maxRateLimitIntervalMs, rateLimitRetrySleepInitMs, maxRetryAttempts);
     this.httpClient = client;
@@ -246,5 +246,15 @@ class MlflowHttpCaller {
     }
 
     this.httpClient = builder.build();
+  }
+
+  void close() {
+    if (httpClient != null) {
+      try {
+	  httpClient.close();
+      } catch(IOException e){
+	  logger.warn("Unable to close connection to mlflow backend", e);
+      }
+    }
   }
 }

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/samples/FluentExample.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/samples/FluentExample.java
@@ -56,5 +56,6 @@ public class FluentExample {
       run.endRun();
     }
     executor.shutdown();
+    mlflow.getClient().close();
   }
 }

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/samples/QuickStartDriver.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/samples/QuickStartDriver.java
@@ -46,6 +46,7 @@ public class QuickStartDriver {
     System.out.println("====== getExperiment by name");
     Optional<Experiment> exp3 = client.getExperimentByName(expName);
     System.out.println("getExperimentByName: " + exp3);
+    client.close();
   }
 
   void createRun(MlflowClient client, String expId) {

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/TestClientProvider.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/TestClientProvider.java
@@ -28,6 +28,8 @@ public class TestClientProvider {
 
   private Process serverProcess;
 
+  private MlflowClient client;
+
   /**
    * Intializes an MLflow client and, if necessary, a local MLflow server process as well.
    * Callers should always call {@link #cleanupClientAndServer()}.
@@ -40,7 +42,8 @@ public class TestClientProvider {
     String trackingUri = System.getenv("MLFLOW_TRACKING_URI");
     if (trackingUri != null) {
       logger.info("MLFLOW_TRACKING_URI was set, test will run against that server");
-      return new MlflowClient(trackingUri);
+      client = new MlflowClient(trackingUri);
+      return client;
     } else {
       Path tempDir = Files.createTempDirectory(getClass().getSimpleName());
       String mlruns = tempDir.resolve("mlruns").toString();
@@ -56,7 +59,8 @@ public class TestClientProvider {
     String trackingUri = System.getenv("MLFLOW_TRACKING_URI");
     if (trackingUri != null) {
       logger.info("MLFLOW_TRACKING_URI was set, test will run against that server");
-      return new MlflowClient(trackingUri);
+      client = new MlflowClient(trackingUri);
+      return client;
     } else {
       Path tempDir = Files.createTempDirectory(getClass().getSimpleName());
       String tempDBFile = tempDir.resolve("sqldb").toAbsolutePath().toString();
@@ -70,6 +74,9 @@ public class TestClientProvider {
    * not initialized successfully.
    */
   public void cleanupClientAndServer() throws InterruptedException {
+    if (client != null) {
+      client.close();
+    }
     if (serverProcess == null) {
       return;
     }
@@ -142,7 +149,8 @@ public class TestClientProvider {
         + MAX_SERVER_WAIT_TIME_MILLIS + " milliseconds.");
     }
 
-    return new MlflowClient("http://" + bindAddress + ":" + freePort);
+    client = new MlflowClient("http://" + bindAddress + ":" + freePort);
+    return client;
   }
 
   /** Launches a new daemon Thread to drain the given InputStream into the given OutputStream. */


### PR DESCRIPTION
Signed-off-by: Brian Barnes <brian.barnes@databricks.com>

## What changes are proposed in this pull request?

Updates MlflowClient to implement java.io.Closeable. This allows callers to close the client in order to avoid socket leaks.

I opted not to propagate the IOException through to the caller, it is a customer-facing API (simplicity is especially important) and it is unlikely the caller would be able to do anything productive with this information.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [x] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
