### PR TITLE
fix final batch of use-set-literal errors #6535

### DIFF
--- a/pylint_plugins/set_checker.py
+++ b/pylint_plugins/set_checker.py
@@ -1,32 +1,6 @@
-import os
-
 import astroid
 from pylint.interfaces import IAstroidChecker
 from pylint.checkers import BaseChecker
-
-
-IGNORED_FILES = set(
-    map(
-        os.path.abspath,
-        [
-            ##### Instructions #####
-            # 1. Select the file you would like to work on.
-            # 2. Remove the file from the list.
-            # 3. Run `pylint <the file>`.
-            # 4. Fix lint errors.
-            # 5. File a PR.
-            "tests/lightgbm/test_lightgbm_autolog.py",
-            "tests/models/test_model_input_examples.py",
-            "tests/projects/test_project_spec.py",
-            "tests/pyfunc/test_model_export_with_loader_module_and_data_path.py",
-            "tests/store/artifact/test_databricks_artifact_repo.py",
-            "tests/store/artifact/test_ftp_artifact_repo.py",
-            "tests/tensorflow/test_tensorflow2_autolog.py",
-            "tests/utils/test_requirements_utils.py",
-            "tests/xgboost/test_xgboost_autolog.py",
-        ],
-    )
-)
 
 
 class SetChecker(BaseChecker):
@@ -45,8 +19,6 @@ class SetChecker(BaseChecker):
     priority = -1
 
     def visit_call(self, node: astroid.Call):
-        if node.root().file in IGNORED_FILES:
-            return
         if (
             node.func.as_string() == "set"
             and node.args

--- a/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
+++ b/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
@@ -551,7 +551,7 @@ def test_column_schema_enforcement_no_col_names():
 
     # Can only provide data type that can be converted to dataframe...
     with pytest.raises(MlflowException, match="Expected input to be DataFrame or list. Found: set"):
-        pyfunc_model.predict(set([1, 2, 3]))
+        pyfunc_model.predict({1, 2, 3})
 
     # 9. dictionaries of str -> list/nparray work
     d = {"a": [1.0], "b": [2.0], "c": [3.0]}

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -548,9 +548,7 @@ class TestDatabricksArtifactRepository:
             call_endpoint_mock.side_effect = list_artifact_paginated_response_protos
             message_mock.return_value = None
             artifacts = databricks_artifact_repo.list_artifacts()
-            assert set(["a.txt", "b", "c.txt", "d", "e.txt", "f"]) == {
-                file.path for file in artifacts
-            }
+            assert {"a.txt", "b", "c.txt", "d", "e.txt", "f"} == {file.path for file in artifacts}
             calls = [
                 mock.call(ListArtifacts(run_id=MOCK_RUN_ID, path="")),
                 mock.call(ListArtifacts(run_id=MOCK_RUN_ID, path="", page_token="2")),

--- a/tests/store/artifact/test_ftp_artifact_repo.py
+++ b/tests/store/artifact/test_ftp_artifact_repo.py
@@ -229,7 +229,7 @@ def test_log_artifacts(artifact_path, ftp_mock, tmpdir):
     call_mock = MagicMock(return_value=ftp_mock)
     repo.get_ftp_client.return_value = MagicMock(__enter__=call_mock)
 
-    dirs_created = set([dest_path_root])
+    dirs_created = {dest_path_root}
     files_created = set()
     cwd_history = ["/"]
 
@@ -272,24 +272,21 @@ def test_log_artifacts(artifact_path, ftp_mock, tmpdir):
     dest_path = (
         dest_path_root if artifact_path is None else posixpath.join(dest_path_root, artifact_path)
     )
-    dirs_expected = set(
-        [
-            dest_path,
-            posixpath.join(dest_path, "empty1"),
-            posixpath.join(dest_path, "subsubdir"),
-            posixpath.join(dest_path, "subsubdir", "empty2"),
-        ]
-    )
-    files_expected = set(
-        [
-            posixpath.join(dest_path, "a.txt"),
-            posixpath.join(dest_path, "b.txt"),
-            posixpath.join(dest_path, "c.txt"),
-            posixpath.join(dest_path, "subsubdir/aa.txt"),
-            posixpath.join(dest_path, "subsubdir/bb.txt"),
-            posixpath.join(dest_path, "subsubdir/cc.txt"),
-        ]
-    )
+    dirs_expected = {
+        dest_path,
+        posixpath.join(dest_path, "empty1"),
+        posixpath.join(dest_path, "subsubdir"),
+        posixpath.join(dest_path, "subsubdir", "empty2"),
+    }
+
+    files_expected = {
+        posixpath.join(dest_path, "a.txt"),
+        posixpath.join(dest_path, "b.txt"),
+        posixpath.join(dest_path, "c.txt"),
+        posixpath.join(dest_path, "subsubdir/aa.txt"),
+        posixpath.join(dest_path, "subsubdir/bb.txt"),
+        posixpath.join(dest_path, "subsubdir/cc.txt"),
+    }
 
     for dirs_expected_i in dirs_expected.copy():
         if dirs_expected_i != dest_path_root:

--- a/tests/utils/test_requirements_utils.py
+++ b/tests/utils/test_requirements_utils.py
@@ -309,7 +309,7 @@ def test_infer_requirements_does_not_print_warning_for_recognized_packages():
         return_value=["sklearn"],
     ), mock.patch(
         "mlflow.utils.requirements_utils._PYPI_PACKAGE_INDEX",
-        _PyPIPackageIndex(date="2022-01-01", package_names=set(["scikit-learn"])),
+        _PyPIPackageIndex(date="2022-01-01", package_names={"scikit-learn"}),
     ), mock.patch(
         "mlflow.utils.requirements_utils._logger.warning"
     ) as mock_warning:

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -188,8 +188,8 @@ def test_xgb_autolog_sklearn():
     client = MlflowClient()
     run = client.get_run(run.info.run_id)
     assert run.data.metrics.items() <= params.items()
-    artifacts = set(x.path for x in client.list_artifacts(run.info.run_id))
-    assert artifacts >= set(["feature_importance_weight.png", "feature_importance_weight.json"])
+    artifacts = {x.path for x in client.list_artifacts(run.info.run_id)}
+    assert artifacts >= {"feature_importance_weight.png", "feature_importance_weight.json"}
     loaded_model = mlflow.xgboost.load_model(model_uri)
     np.testing.assert_allclose(loaded_model.predict(X), model.predict(X))
 


### PR DESCRIPTION
Signed-off-by: Daniel Gibbons <daniel.gibbons04@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
Fix #6535

## What changes are proposed in this pull request?

Fixed use-set-literal errors in:
- `tests/pyfunc/test_model_export_with_loader_module_and_data_path.py`
- `tests/store/artifact/test_databricks_artifact_repo.py`
- `tests/store/artifact/test_ftp_artifact_repo.py`
- `tests/utils/test_requirements_utils.py`
- `tests/xgboost/test_xgboost_autolog.py`

and removed redundant code related to `IGNORED_FILES` in `pylint_plugins/set_checker.py`

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
