### PR TITLE
[CLI] [FR] Add new CLI command for generating Dockerfile (issue #6532)

### DIFF
--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -35,15 +35,15 @@ def commands():
 @cli_args.INSTALL_MLFLOW
 @cli_args.ENABLE_MLSERVER
 def serve(
-    model_uri,
-    port,
-    host,
-    timeout,
-    workers,
-    no_conda,  # pylint: disable=unused-argument
-    env_manager=None,
-    install_mlflow=False,
-    enable_mlserver=False,
+        model_uri,
+        port,
+        host,
+        timeout,
+        workers,
+        no_conda,  # pylint: disable=unused-argument
+        env_manager=None,
+        install_mlflow=False,
+        enable_mlserver=False,
 ):
     """
     Serve a model saved with MLflow by launching a webserver on the specified host and port.
@@ -94,25 +94,25 @@ def serve(
     "-j",
     default="split",
     help="Only applies if the content type is 'json'. Specify how the data is encoded.  "
-    "Can be one of {'split', 'records'} mirroring the behavior of Pandas orient "
-    "attribute. The default is 'split' which expects dict like data: "
-    "{'index' -> [index], 'columns' -> [columns], 'data' -> [values]}, "
-    "where index  is optional. For more information see "
-    "https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_json"
-    ".html",
+         "Can be one of {'split', 'records'} mirroring the behavior of Pandas orient "
+         "attribute. The default is 'split' which expects dict like data: "
+         "{'index' -> [index], 'columns' -> [columns], 'data' -> [values]}, "
+         "where index  is optional. For more information see "
+         "https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_json"
+         ".html",
 )
 @cli_args.NO_CONDA
 @cli_args.ENV_MANAGER
 @cli_args.INSTALL_MLFLOW
 def predict(
-    model_uri,
-    input_path,
-    output_path,
-    content_type,
-    json_format,
-    no_conda,  # pylint: disable=unused-argument
-    env_manager,
-    install_mlflow,
+        model_uri,
+        input_path,
+        output_path,
+        content_type,
+        json_format,
+        no_conda,  # pylint: disable=unused-argument
+        env_manager,
+        install_mlflow,
 ):
     """
     Generate predictions in json format using a saved MLflow model. For information about the input
@@ -139,10 +139,10 @@ def predict(
 @cli_args.ENV_MANAGER
 @cli_args.INSTALL_MLFLOW
 def prepare_env(
-    model_uri,
-    no_conda,  # pylint: disable=unused-argument
-    env_manager,
-    install_mlflow,
+        model_uri,
+        no_conda,  # pylint: disable=unused-argument
+        env_manager,
+        install_mlflow,
 ):
     """
     Performs any preparation necessary to predict or serve the model, for example
@@ -157,12 +157,15 @@ def prepare_env(
 
 @commands.command("generate-dockerfile")
 @cli_args.MODEL_URI_BUILD_DOCKER
-@click.option("--filename", "-f", default="Dockerfile", help="file name for the resulting Dockerfile")
+@click.option("--output-directory",
+              "-d",
+              default="generate-dockerfile-output",
+              help="output directory for generating dockerfile")
 @cli_args.ENV_MANAGER
 @cli_args.MLFLOW_HOME
 @cli_args.INSTALL_MLFLOW
 @cli_args.ENABLE_MLSERVER
-def generate_dockerfile(model_uri, filename, env_manager, mlflow_home, install_mlflow, enable_mlserver):
+def generate_dockerfile(model_uri, output_directory, env_manager, mlflow_home, install_mlflow, enable_mlserver):
     """
     Generates a dockerfile whose default entrypoint serves an MLflow model at port 8080, using the
     python_function flavor.
@@ -174,11 +177,12 @@ def generate_dockerfile(model_uri, filename, env_manager, mlflow_home, install_m
     backend = _get_flavor_backend(model_uri, docker_build=True, env_manager=env_manager)
     backend.generate_dockerfile(
         model_uri,
-        filename,
+        output_directory,
         mlflow_home=mlflow_home,
         install_mlflow=install_mlflow,
         enable_mlserver=enable_mlserver,
     )
+
 
 @commands.command("build-docker")
 @cli_args.MODEL_URI_BUILD_DOCKER

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -160,7 +160,7 @@ def prepare_env(
 @click.option(
     "--output-directory",
     "-d",
-    default="generate-dockerfile-output",
+    default="mlflow-dockerfile",
     help="output directory for generating dockerfile",
 )
 @cli_args.ENV_MANAGER

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -176,6 +176,10 @@ def generate_dockerfile(
     directory, along with the model (if specified). This Dockerfile defines an image that is
     equivalent to the one produced by ``mlflow models build-docker``.
     """
+    _logger.info("Generating Dockerfile", extra={
+        "model_uri": model_uri,
+        "output directory": output_directory
+    })
     env_manager = env_manager or _EnvManager.CONDA
     backend = _get_flavor_backend(model_uri, docker_build=True, env_manager=env_manager)
     if backend.can_build_image():
@@ -186,6 +190,7 @@ def generate_dockerfile(
             install_mlflow=install_mlflow,
             enable_mlserver=enable_mlserver,
         )
+        _logger.info("Generated Dockerfile in directory %s", output_directory)
     else:
         _logger.error(
             "Cannot build docker image for selected backend",

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -157,15 +157,19 @@ def prepare_env(
 
 @commands.command("generate-dockerfile")
 @cli_args.MODEL_URI_BUILD_DOCKER
-@click.option("--output-directory",
-              "-d",
-              default="generate-dockerfile-output",
-              help="output directory for generating dockerfile")
+@click.option(
+    "--output-directory",
+    "-d",
+    default="generate-dockerfile-output",
+    help="output directory for generating dockerfile",
+)
 @cli_args.ENV_MANAGER
 @cli_args.MLFLOW_HOME
 @cli_args.INSTALL_MLFLOW
 @cli_args.ENABLE_MLSERVER
-def generate_dockerfile(model_uri, output_directory, env_manager, mlflow_home, install_mlflow, enable_mlserver):
+def generate_dockerfile(
+    model_uri, output_directory, env_manager, mlflow_home, install_mlflow, enable_mlserver
+):
     """
     Generates a directory with dockerfile whose default entrypoint serves an MLflow model at port 8080, using the
     python_function flavor.
@@ -184,7 +188,10 @@ def generate_dockerfile(model_uri, output_directory, env_manager, mlflow_home, i
             enable_mlserver=enable_mlserver,
         )
     else:
-        _logger.error("Cannot build docker image for selected backend", extra={"backend": backend.__class__.__name__})
+        _logger.error(
+            "Cannot build docker image for selected backend",
+            extra={"backend": backend.__class__.__name__},
+        )
         raise NotImplementedError("Cannot build docker image for selected backend")
 
 
@@ -250,7 +257,10 @@ def build_docker(model_uri, name, env_manager, mlflow_home, install_mlflow, enab
             enable_mlserver=enable_mlserver,
         )
     else:
-        _logger.error("Cannot build docker image for selected backend", extra={"backend": backend.__class__.__name__})
+        _logger.error(
+            "Cannot build docker image for selected backend",
+            extra={"backend": backend.__class__.__name__},
+        )
         raise NotImplementedError("Cannot build docker image for selected backend")
 
 

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -161,7 +161,7 @@ def prepare_env(
     "--output-directory",
     "-d",
     default="mlflow-dockerfile",
-    help="output directory for generating dockerfile",
+    help="Output directory where the generated Dockerfile is stored.",
 )
 @cli_args.ENV_MANAGER
 @cli_args.MLFLOW_HOME

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -155,6 +155,31 @@ def prepare_env(
     ).prepare_env(model_uri=model_uri)
 
 
+@commands.command("generate-dockerfile")
+@cli_args.MODEL_URI_BUILD_DOCKER
+@click.option("--filename", "-f", default="Dockerfile", help="file name for the resulting Dockerfile")
+@cli_args.ENV_MANAGER
+@cli_args.MLFLOW_HOME
+@cli_args.INSTALL_MLFLOW
+@cli_args.ENABLE_MLSERVER
+def generate_dockerfile(model_uri, filename, env_manager, mlflow_home, install_mlflow, enable_mlserver):
+    """
+    Generates a dockerfile whose default entrypoint serves an MLflow model at port 8080, using the
+    python_function flavor.
+
+    Essentially, it generates a dockerfile, which would've been the base for the docker image in `build_docker`
+    function
+    """
+    env_manager = env_manager or _EnvManager.CONDA
+    backend = _get_flavor_backend(model_uri, docker_build=True, env_manager=env_manager)
+    backend.generate_dockerfile(
+        model_uri,
+        filename,
+        mlflow_home=mlflow_home,
+        install_mlflow=install_mlflow,
+        enable_mlserver=enable_mlserver,
+    )
+
 @commands.command("build-docker")
 @cli_args.MODEL_URI_BUILD_DOCKER
 @click.option("--name", "-n", default="mlflow-pyfunc-servable", help="Name to use for built image")

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -167,9 +167,10 @@ def prepare_env(
 @cli_args.ENABLE_MLSERVER
 def generate_dockerfile(model_uri, output_directory, env_manager, mlflow_home, install_mlflow, enable_mlserver):
     """
-    Generates a dockerfile whose default entrypoint serves an MLflow model at port 8080, using the
+    Generates a directory with dockerfile whose default entrypoint serves an MLflow model at port 8080, using the
     python_function flavor.
-
+    Function accepts a directory path and not just a dockerfile path because if model is specified --- it will generate
+    additional folder with model files inside aforementioned directory
     This dockerfile defines an image that is equivalent to the one produced by ``mlflow models build-docker``
     """
     env_manager = env_manager or _EnvManager.CONDA

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -171,11 +171,10 @@ def generate_dockerfile(
     model_uri, output_directory, env_manager, mlflow_home, install_mlflow, enable_mlserver
 ):
     """
-    Generates a directory with dockerfile whose default entrypoint serves an MLflow model at port
-    8080, using the python_function flavor. Function accepts a directory path and not just a
-    dockerfile path because if model is specified --- it will generate additional folder with
-    model files inside aforementioned directory This dockerfile defines an image that is
-    equivalent to the one produced by ``mlflow models build-docker``
+    Generates a directory with Dockerfile whose default entrypoint serves an MLflow model at port
+    8080 using the python_function flavor. The generated Dockerfile is written to the specified output
+    directory, along with the model (if specified). This Dockerfile defines an image that is
+    equivalent to the one produced by ``mlflow models build-docker``.
     """
     env_manager = env_manager or _EnvManager.CONDA
     backend = _get_flavor_backend(model_uri, docker_build=True, env_manager=env_manager)

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -35,15 +35,15 @@ def commands():
 @cli_args.INSTALL_MLFLOW
 @cli_args.ENABLE_MLSERVER
 def serve(
-        model_uri,
-        port,
-        host,
-        timeout,
-        workers,
-        no_conda,  # pylint: disable=unused-argument
-        env_manager=None,
-        install_mlflow=False,
-        enable_mlserver=False,
+    model_uri,
+    port,
+    host,
+    timeout,
+    workers,
+    no_conda,  # pylint: disable=unused-argument
+    env_manager=None,
+    install_mlflow=False,
+    enable_mlserver=False,
 ):
     """
     Serve a model saved with MLflow by launching a webserver on the specified host and port.
@@ -94,25 +94,25 @@ def serve(
     "-j",
     default="split",
     help="Only applies if the content type is 'json'. Specify how the data is encoded.  "
-         "Can be one of {'split', 'records'} mirroring the behavior of Pandas orient "
-         "attribute. The default is 'split' which expects dict like data: "
-         "{'index' -> [index], 'columns' -> [columns], 'data' -> [values]}, "
-         "where index  is optional. For more information see "
-         "https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_json"
-         ".html",
+    "Can be one of {'split', 'records'} mirroring the behavior of Pandas orient "
+    "attribute. The default is 'split' which expects dict like data: "
+    "{'index' -> [index], 'columns' -> [columns], 'data' -> [values]}, "
+    "where index  is optional. For more information see "
+    "https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_json"
+    ".html",
 )
 @cli_args.NO_CONDA
 @cli_args.ENV_MANAGER
 @cli_args.INSTALL_MLFLOW
 def predict(
-        model_uri,
-        input_path,
-        output_path,
-        content_type,
-        json_format,
-        no_conda,  # pylint: disable=unused-argument
-        env_manager,
-        install_mlflow,
+    model_uri,
+    input_path,
+    output_path,
+    content_type,
+    json_format,
+    no_conda,  # pylint: disable=unused-argument
+    env_manager,
+    install_mlflow,
 ):
     """
     Generate predictions in json format using a saved MLflow model. For information about the input
@@ -139,10 +139,10 @@ def predict(
 @cli_args.ENV_MANAGER
 @cli_args.INSTALL_MLFLOW
 def prepare_env(
-        model_uri,
-        no_conda,  # pylint: disable=unused-argument
-        env_manager,
-        install_mlflow,
+    model_uri,
+    no_conda,  # pylint: disable=unused-argument
+    env_manager,
+    install_mlflow,
 ):
     """
     Performs any preparation necessary to predict or serve the model, for example

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -171,11 +171,11 @@ def generate_dockerfile(
     model_uri, output_directory, env_manager, mlflow_home, install_mlflow, enable_mlserver
 ):
     """
-    Generates a directory with dockerfile whose default entrypoint serves an MLflow model at port 8080, using the
-    python_function flavor.
-    Function accepts a directory path and not just a dockerfile path because if model is specified --- it will generate
-    additional folder with model files inside aforementioned directory
-    This dockerfile defines an image that is equivalent to the one produced by ``mlflow models build-docker``
+    Generates a directory with dockerfile whose default entrypoint serves an MLflow model at port
+    8080, using the python_function flavor. Function accepts a directory path and not just a
+    dockerfile path because if model is specified --- it will generate additional folder with
+    model files inside aforementioned directory This dockerfile defines an image that is
+    equivalent to the one produced by ``mlflow models build-docker``
     """
     env_manager = env_manager or _EnvManager.CONDA
     backend = _get_flavor_backend(model_uri, docker_build=True, env_manager=env_manager)

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -172,9 +172,9 @@ def generate_dockerfile(
 ):
     """
     Generates a directory with Dockerfile whose default entrypoint serves an MLflow model at port
-    8080 using the python_function flavor. The generated Dockerfile is written to the specified output
-    directory, along with the model (if specified). This Dockerfile defines an image that is
-    equivalent to the one produced by ``mlflow models build-docker``.
+    8080 using the python_function flavor. The generated Dockerfile is written to the specified
+    output directory, along with the model (if specified). This Dockerfile defines an image that
+    is equivalent to the one produced by ``mlflow models build-docker``.
     """
     if model_uri:
         _logger.info("Generating Dockerfile for model %s", model_uri)

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -179,7 +179,7 @@ def generate_dockerfile(
     if model_uri:
         _logger.info("Generating Dockerfile for model %s", model_uri)
     else:
-        _logger.info("Generating Dockerfile for unspecified model")
+        _logger.info("Generating Dockerfile")
     env_manager = env_manager or _EnvManager.CONDA
     backend = _get_flavor_backend(model_uri, docker_build=True, env_manager=env_manager)
     if backend.can_build_image():

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -170,8 +170,7 @@ def generate_dockerfile(model_uri, output_directory, env_manager, mlflow_home, i
     Generates a dockerfile whose default entrypoint serves an MLflow model at port 8080, using the
     python_function flavor.
 
-    Essentially, it generates a dockerfile, which would've been the base for the docker image in `build_docker`
-    function
+    This dockerfile defines an image that is equivalent to the one produced by ``mlflow models build-docker``
     """
     env_manager = env_manager or _EnvManager.CONDA
     backend = _get_flavor_backend(model_uri, docker_build=True, env_manager=env_manager)

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -176,10 +176,10 @@ def generate_dockerfile(
     directory, along with the model (if specified). This Dockerfile defines an image that is
     equivalent to the one produced by ``mlflow models build-docker``.
     """
-    _logger.info("Generating Dockerfile", extra={
-        "model_uri": model_uri,
-        "output directory": output_directory
-    })
+    if model_uri:
+        _logger.info("Generating Dockerfile for model %s", model_uri)
+    else:
+        _logger.info("Generating Dockerfile for unspecified model")
     env_manager = env_manager or _EnvManager.CONDA
     backend = _get_flavor_backend(model_uri, docker_build=True, env_manager=env_manager)
     if backend.can_build_image():

--- a/mlflow/models/docker_utils.py
+++ b/mlflow/models/docker_utils.py
@@ -153,11 +153,7 @@ def _get_mlflow_install_step(dockerfile_context_dir, mlflow_home):
 
 
 def _generate_dockerfile_content(
-        setup_miniconda,
-        setup_pyenv_and_virtualenv,
-        install_mlflow,
-        custom_setup_steps,
-        entrypoint
+    setup_miniconda, setup_pyenv_and_virtualenv, install_mlflow, custom_setup_steps, entrypoint
 ):
     """
     Generates a Dockerfile that can be used to build a docker image, that serves ML model

--- a/mlflow/models/docker_utils.py
+++ b/mlflow/models/docker_utils.py
@@ -152,8 +152,43 @@ def _get_mlflow_install_step(dockerfile_context_dir, mlflow_home):
         ).format(version=mlflow.version.VERSION, maven_proxy=maven_proxy)
 
 
+def _generate_dockerfile_raw(
+        setup_miniconda,
+        setup_pyenv_and_virtualenv,
+        install_mlflow,
+        custom_setup_steps,
+        entrypoint
+):
+    """
+    Generates a Dockerfile that can be used to build a docker image, that serves ML model
+    stored and tracked in MLflow.
+
+    It has `_raw` suffix because it just takes string parameters containing docker imperatives and has no logic
+    whatsoever. It will be more convenient if a more sophisticated function with some boolean flags would be called
+    `generate_dockerfile` while this function being a backend of sorts for such function.
+
+    :param setup_miniconda: Docker instructions related to set up miniconda. If used at all, variable `SETUP_MINICONDA`
+        provides a working template for instructions. Should be either an empty string or `SETUP_MINICONDA`-based
+        instructions
+    :param setup_pyenv_and_virtualenv: Docker instructions related to set up pyenv and virtualenv.
+        If used at all, variable `SETUP_PYENV_AND_VIRTUALENV` provides a working template for instructions.
+        Should be either an empty string or `SETUP_PYENV_AND_VIRTUALENV`-based
+        :param install_mlflow: Docker instruction for installing MLflow in given Docker context dir and optional source
+        directory
+    :param custom_setup_steps: Docker instructions for any customizations in the resulting Dockerfile
+    :param entrypoint: String containing ENTRYPOINT directive for docker image
+    """
+    return _DOCKERFILE_TEMPLATE.format(
+        setup_miniconda=setup_miniconda,
+        setup_pyenv_and_virtualenv=setup_pyenv_and_virtualenv,
+        install_mlflow=install_mlflow,
+        custom_setup_steps=custom_setup_steps,
+        entrypoint=entrypoint,
+    )
+
+
 def _build_image(
-    image_name, entrypoint, env_manager, mlflow_home=None, custom_setup_steps_hook=None
+        image_name, entrypoint, env_manager, mlflow_home=None, custom_setup_steps_hook=None
 ):
     """
     Build an MLflow Docker image that can be used to serve a
@@ -181,7 +216,7 @@ def _build_image(
         custom_setup_steps = custom_setup_steps_hook(cwd) if custom_setup_steps_hook else ""
         with open(os.path.join(cwd, "Dockerfile"), "w") as f:
             f.write(
-                _DOCKERFILE_TEMPLATE.format(
+                _generate_dockerfile_raw(
                     setup_miniconda=setup_miniconda,
                     setup_pyenv_and_virtualenv=setup_pyenv_and_virtualenv,
                     install_mlflow=install_mlflow,

--- a/mlflow/models/docker_utils.py
+++ b/mlflow/models/docker_utils.py
@@ -160,19 +160,19 @@ def _generate_dockerfile_content(
     stored and tracked in MLflow.
 
     It just takes string parameters containing docker imperatives and has no logic
-    whatsoever. It will be more convenient if a more sophisticated function with some boolean flags would be called
-    `generate_dockerfile` while this function being a backend of sorts for such function.
+    whatsoever. It will be more convenient if a more sophisticated function
+    with some boolean flags would be called `generate_dockerfile`
+    while this function being a backend of sorts for such function.
 
-    :param setup_miniconda: Docker instructions related to set up miniconda. If used at all, variable `SETUP_MINICONDA`
-        provides a working template for instructions. Should be either an empty string or `SETUP_MINICONDA`-based
-        instructions
-    :param setup_pyenv_and_virtualenv: Docker instructions related to set up pyenv and virtualenv.
-        If used at all, variable `SETUP_PYENV_AND_VIRTUALENV` provides a working template for instructions.
-        Should be either an empty string or `SETUP_PYENV_AND_VIRTUALENV`-based
-        :param install_mlflow: Docker instruction for installing MLflow in given Docker context dir and optional source
-        directory
-    :param custom_setup_steps: Docker instructions for any customizations in the resulting Dockerfile
-    :param entrypoint: String containing ENTRYPOINT directive for docker image
+    :param setup_miniconda: Docker instructions related to set up miniconda. If used at all,
+    variable `SETUP_MINICONDA` provides a working template for instructions. Should be either an
+    empty string or `SETUP_MINICONDA`-based instructions :param setup_pyenv_and_virtualenv:
+    Docker instructions related to set up pyenv and virtualenv. If used at all, variable
+    `SETUP_PYENV_AND_VIRTUALENV` provides a working template for instructions. Should be either
+    an empty string or `SETUP_PYENV_AND_VIRTUALENV`-based :param install_mlflow: Docker
+    instruction for installing MLflow in given Docker context dir and optional source directory
+    :param custom_setup_steps: Docker instructions for any customizations in the resulting
+    Dockerfile :param entrypoint: String containing ENTRYPOINT directive for docker image
     """
     return _DOCKERFILE_TEMPLATE.format(
         setup_miniconda=setup_miniconda,

--- a/mlflow/models/docker_utils.py
+++ b/mlflow/models/docker_utils.py
@@ -188,7 +188,7 @@ def _generate_dockerfile_raw(
 
 
 def _build_image(
-        image_name, entrypoint, env_manager, mlflow_home=None, custom_setup_steps_hook=None
+    image_name, entrypoint, env_manager, mlflow_home=None, custom_setup_steps_hook=None
 ):
     """
     Build an MLflow Docker image that can be used to serve a

--- a/mlflow/models/docker_utils.py
+++ b/mlflow/models/docker_utils.py
@@ -152,7 +152,7 @@ def _get_mlflow_install_step(dockerfile_context_dir, mlflow_home):
         ).format(version=mlflow.version.VERSION, maven_proxy=maven_proxy)
 
 
-def _generate_dockerfile_raw(
+def _generate_dockerfile_content(
         setup_miniconda,
         setup_pyenv_and_virtualenv,
         install_mlflow,
@@ -163,7 +163,7 @@ def _generate_dockerfile_raw(
     Generates a Dockerfile that can be used to build a docker image, that serves ML model
     stored and tracked in MLflow.
 
-    It has `_raw` suffix because it just takes string parameters containing docker imperatives and has no logic
+    It just takes string parameters containing docker imperatives and has no logic
     whatsoever. It will be more convenient if a more sophisticated function with some boolean flags would be called
     `generate_dockerfile` while this function being a backend of sorts for such function.
 
@@ -216,7 +216,7 @@ def _build_image(
         custom_setup_steps = custom_setup_steps_hook(cwd) if custom_setup_steps_hook else ""
         with open(os.path.join(cwd, "Dockerfile"), "w") as f:
             f.write(
-                _generate_dockerfile_raw(
+                _generate_dockerfile_content(
                     setup_miniconda=setup_miniconda,
                     setup_pyenv_and_virtualenv=setup_pyenv_and_virtualenv,
                     install_mlflow=install_mlflow,

--- a/mlflow/models/flavor_backend.py
+++ b/mlflow/models/flavor_backend.py
@@ -74,12 +74,7 @@ class FlavorBackend:
         raise NotImplementedError
 
     def generate_dockerfile(
-            self,
-            model_uri,
-            output_path,
-            install_mlflow,
-            mlflow_home,
-            enable_mlserver
+        self, model_uri, output_path, install_mlflow, mlflow_home, enable_mlserver
     ):
         raise NotImplementedError
 

--- a/mlflow/models/flavor_backend.py
+++ b/mlflow/models/flavor_backend.py
@@ -71,6 +71,21 @@ class FlavorBackend:
         pass
 
     @abstractmethod
+    def build_image(self, model_uri, image_name, install_mlflow, mlflow_home, enable_mlserver):
+        raise NotImplementedError
+
+    @abstractmethod
+    def generate_dockerfile(
+            self,
+            model_uri,
+            output_path,
+            install_mlflow,
+            mlflow_home,
+            enable_mlserver
+    ):
+        raise NotImplementedError
+
+    @abstractmethod
     def can_score_model(self):
         """
         Check whether this flavor backend can be deployed in the current environment.

--- a/mlflow/models/flavor_backend.py
+++ b/mlflow/models/flavor_backend.py
@@ -70,11 +70,9 @@ class FlavorBackend:
         """
         pass
 
-    @abstractmethod
     def build_image(self, model_uri, image_name, install_mlflow, mlflow_home, enable_mlserver):
         raise NotImplementedError
 
-    @abstractmethod
     def generate_dockerfile(
             self,
             model_uri,

--- a/mlflow/models/flavor_backend.py
+++ b/mlflow/models/flavor_backend.py
@@ -70,9 +70,11 @@ class FlavorBackend:
         """
         pass
 
+    @abstractmethod
     def build_image(self, model_uri, image_name, install_mlflow, mlflow_home, enable_mlserver):
         raise NotImplementedError
 
+    @abstractmethod
     def generate_dockerfile(
         self, model_uri, output_path, install_mlflow, mlflow_home, enable_mlserver
     ):

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -320,11 +320,7 @@ class PyFuncBackend(FlavorBackend):
         _logger.debug("Created all folders in path", extra={"output_directory": output_path})
         install_mlflow = _get_mlflow_install_step(output_path, mlflow_home)
 
-        custom_setup_steps = ()
-        if model_uri:
-            custom_setup_steps = copy_model_into_container(output_path)
-        else:
-            custom_setup_steps = ""
+        custom_setup_steps = copy_model_into_container(output_path)
 
         dockerfile_text = _generate_dockerfile_content(
             setup_miniconda=setup_miniconda,

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -30,7 +30,6 @@ from mlflow.utils.virtualenv import (
     _execute_in_virtualenv,
     _get_pip_install_mlflow,
 )
-from mlflow.utils import env_manager as em
 
 from mlflow.version import VERSION
 
@@ -309,7 +308,7 @@ class PyFuncBackend(FlavorBackend):
 
         mlflow_home = os.path.abspath(mlflow_home) if mlflow_home else None
 
-        is_conda = self._env_manager == em.CONDA
+        is_conda = self._env_manager == _EnvManager.CONDA
         setup_miniconda = SETUP_MINICONDA if is_conda else ""
         setup_pyenv_and_virtualenv = "" if is_conda else SETUP_PYENV_AND_VIRTUALENV
 

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -9,8 +9,14 @@ import warnings
 from pathlib import Path
 
 from mlflow.models import FlavorBackend
-from mlflow.models.docker_utils import _build_image, _generate_dockerfile_content, DISABLE_ENV_CREATION, SETUP_MINICONDA, \
-    SETUP_PYENV_AND_VIRTUALENV, _get_mlflow_install_step
+from mlflow.models.docker_utils import (
+    _build_image,
+    _generate_dockerfile_content,
+    DISABLE_ENV_CREATION,
+    SETUP_MINICONDA,
+    SETUP_PYENV_AND_VIRTUALENV,
+    _get_mlflow_install_step,
+)
 from mlflow.models.container import ENABLE_MLSERVER
 from mlflow.pyfunc import ENV, scoring_server, mlserver
 
@@ -287,10 +293,19 @@ class PyFuncBackend(FlavorBackend):
             return False
 
     def generate_dockerfile(
-            self, model_uri, output_directory="generate_dockerfile_output", install_mlflow=False, mlflow_home=None, enable_mlserver=False
+        self,
+        model_uri,
+        output_directory="generate_dockerfile_output",
+        install_mlflow=False,
+        mlflow_home=None,
+        enable_mlserver=False,
     ):
-        copy_model_into_container = self.copy_model_into_container_wrapper(model_uri, install_mlflow, enable_mlserver)
-        pyfunc_entrypoint = _pyfunc_entrypoint(self._env_manager, model_uri, install_mlflow, enable_mlserver)
+        copy_model_into_container = self.copy_model_into_container_wrapper(
+            model_uri, install_mlflow, enable_mlserver
+        )
+        pyfunc_entrypoint = _pyfunc_entrypoint(
+            self._env_manager, model_uri, install_mlflow, enable_mlserver
+        )
 
         mlflow_home = os.path.abspath(mlflow_home) if mlflow_home else None
 
@@ -303,13 +318,15 @@ class PyFuncBackend(FlavorBackend):
         _logger.debug("Created all folders in path", extra={"output_directory": output_directory})
         install_mlflow = _get_mlflow_install_step(output_directory, mlflow_home)
 
-        custom_setup_steps = copy_model_into_container(output_directory) if copy_model_into_container else ""
+        custom_setup_steps = (
+            copy_model_into_container(output_directory) if copy_model_into_container else ""
+        )
         dockerfile_text = _generate_dockerfile_content(
             setup_miniconda=setup_miniconda,
             setup_pyenv_and_virtualenv=setup_pyenv_and_virtualenv,
             install_mlflow=install_mlflow,
             custom_setup_steps=custom_setup_steps,
-            entrypoint=pyfunc_entrypoint
+            entrypoint=pyfunc_entrypoint,
         )
         _logger.debug("generated dockerfile text", extra={"dockerfile": dockerfile_text})
 
@@ -319,8 +336,12 @@ class PyFuncBackend(FlavorBackend):
     def build_image(
         self, model_uri, image_name, install_mlflow=False, mlflow_home=None, enable_mlserver=False
     ):
-        copy_model_into_container = self.copy_model_into_container_wrapper(model_uri, install_mlflow, enable_mlserver)
-        pyfunc_entrypoint = _pyfunc_entrypoint(self._env_manager, model_uri, install_mlflow, enable_mlserver)
+        copy_model_into_container = self.copy_model_into_container_wrapper(
+            model_uri, install_mlflow, enable_mlserver
+        )
+        pyfunc_entrypoint = _pyfunc_entrypoint(
+            self._env_manager, model_uri, install_mlflow, enable_mlserver
+        )
         _build_image(
             image_name=image_name,
             mlflow_home=mlflow_home,
@@ -382,12 +403,12 @@ def _pyfunc_entrypoint(env_manager, model_uri, install_mlflow, enable_mlserver):
                 "from mlflow.models import container as C",
                 "from mlflow.models.container import _install_pyfunc_deps",
                 (
-                        "_install_pyfunc_deps("
-                        + '"/opt/ml/model", '
-                        + f"install_mlflow={install_mlflow}, "
-                        + f"enable_mlserver={enable_mlserver}, "
-                        + f'env_manager="{env_manager}"'
-                        + ")"
+                    "_install_pyfunc_deps("
+                    + '"/opt/ml/model", '
+                    + f"install_mlflow={install_mlflow}, "
+                    + f"enable_mlserver={enable_mlserver}, "
+                    + f'env_manager="{env_manager}"'
+                    + ")"
                 ),
                 'C._serve("{env_manager}")'.format(env_manager=env_manager),
             ]

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -9,7 +9,7 @@ import warnings
 from pathlib import Path
 
 from mlflow.models import FlavorBackend
-from mlflow.models.docker_utils import _build_image, _generate_dockerfile_raw, DISABLE_ENV_CREATION, SETUP_MINICONDA, \
+from mlflow.models.docker_utils import _build_image, _generate_dockerfile_content, DISABLE_ENV_CREATION, SETUP_MINICONDA, \
     SETUP_PYENV_AND_VIRTUALENV, _get_mlflow_install_step
 from mlflow.models.container import ENABLE_MLSERVER
 from mlflow.pyfunc import ENV, scoring_server, mlserver
@@ -304,7 +304,7 @@ class PyFuncBackend(FlavorBackend):
         install_mlflow = _get_mlflow_install_step(output_directory, mlflow_home)
 
         custom_setup_steps = copy_model_into_container(output_directory) if copy_model_into_container else ""
-        dockerfile_text = _generate_dockerfile_raw(
+        dockerfile_text = _generate_dockerfile_content(
             setup_miniconda=setup_miniconda,
             setup_pyenv_and_virtualenv=setup_pyenv_and_virtualenv,
             install_mlflow=install_mlflow,

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -39,13 +39,13 @@ class PyFuncBackend(FlavorBackend):
     """
 
     def __init__(
-            self,
-            config,
-            workers=1,
-            env_manager=_EnvManager.CONDA,
-            install_mlflow=False,
-            env_root_dir=None,
-            **kwargs,
+        self,
+        config,
+        workers=1,
+        env_manager=_EnvManager.CONDA,
+        install_mlflow=False,
+        env_root_dir=None,
+        **kwargs,
     ):
         """
         :param env_root_dir: Root path for conda env. If None, use Conda's default environments
@@ -317,7 +317,7 @@ class PyFuncBackend(FlavorBackend):
             dockerfile.write(dockerfile_text)
 
     def build_image(
-            self, model_uri, image_name, install_mlflow=False, mlflow_home=None, enable_mlserver=False
+        self, model_uri, image_name, install_mlflow=False, mlflow_home=None, enable_mlserver=False
     ):
         copy_model_into_container = self.copy_model_into_container_wrapper(model_uri, install_mlflow, enable_mlserver)
         pyfunc_entrypoint = _pyfunc_entrypoint(self._env_manager, model_uri, install_mlflow, enable_mlserver)
@@ -338,17 +338,17 @@ class PyFuncBackend(FlavorBackend):
             if model_uri:
                 model_path = _download_artifact_from_uri(model_uri, output_path=model_cwd)
                 return """
-                         COPY {model_dir} /opt/ml/model
-                         RUN python -c \
-                         'from mlflow.models.container import _install_pyfunc_deps;\
-                         _install_pyfunc_deps(\
-                             "/opt/ml/model", \
-                             install_mlflow={install_mlflow}, \
-                             enable_mlserver={enable_mlserver}, \
-                             env_manager="{env_manager}")'
-                         ENV {disable_env}="true"
-                         ENV {ENABLE_MLSERVER}={enable_mlserver}
-                         """.format(
+                    COPY {model_dir} /opt/ml/model
+                    RUN python -c \
+                    'from mlflow.models.container import _install_pyfunc_deps;\
+                    _install_pyfunc_deps(\
+                         "/opt/ml/model", \
+                         install_mlflow={install_mlflow}, \
+                         enable_mlserver={enable_mlserver}, \
+                         env_manager="{env_manager}")'
+                    ENV {disable_env}="true"
+                    ENV {ENABLE_MLSERVER}={enable_mlserver}
+                    """.format(
                     disable_env=DISABLE_ENV_CREATION,
                     model_dir=str(posixpath.join("model_dir", os.path.basename(model_path))),
                     install_mlflow=repr(install_mlflow),
@@ -358,9 +358,9 @@ class PyFuncBackend(FlavorBackend):
                 )
             else:
                 return """
-                         ENV {disable_env}="true"
-                         ENV {ENABLE_MLSERVER}={enable_mlserver}
-                         """.format(
+                    ENV {disable_env}="true"
+                    ENV {ENABLE_MLSERVER}={enable_mlserver}
+                    """.format(
                     disable_env=DISABLE_ENV_CREATION,
                     ENABLE_MLSERVER=ENABLE_MLSERVER,
                     enable_mlserver=repr(enable_mlserver),
@@ -400,15 +400,15 @@ def _pyfunc_entrypoint(env_manager, model_uri, install_mlflow, enable_mlserver):
 
 
 def _execute_in_conda_env(
-        conda_env_name,
-        command,
-        install_mlflow,
-        command_env=None,
-        synchronous=True,
-        preexec_fn=None,
-        stdout=None,
-        stderr=None,
-        env_root_dir=None,
+    conda_env_name,
+    command,
+    install_mlflow,
+    command_env=None,
+    synchronous=True,
+    preexec_fn=None,
+    stdout=None,
+    stderr=None,
+    env_root_dir=None,
 ):
     """
     :param conda_env_path conda: conda environment file path

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -295,7 +295,7 @@ class PyFuncBackend(FlavorBackend):
     def generate_dockerfile(
         self,
         model_uri,
-        output_directory="generate_dockerfile_output",
+        output_directory="mlflow-dockerfile",
         install_mlflow=False,
         mlflow_home=None,
         enable_mlserver=False,

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -4,9 +4,7 @@ import pathlib
 import subprocess
 import posixpath
 import sys
-import tempfile
 import warnings
-from pathlib import Path
 
 from mlflow.models import FlavorBackend
 from mlflow.models.docker_utils import (

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -321,7 +321,7 @@ class PyFuncBackend(FlavorBackend):
         install_mlflow = _get_mlflow_install_step(output_path, mlflow_home)
 
         custom_setup_steps = ()
-        if copy_model_into_container:
+        if model_uri:
             custom_setup_steps = copy_model_into_container(output_path)
         else:
             custom_setup_steps = ""

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -292,7 +292,7 @@ class PyFuncBackend(FlavorBackend):
     def generate_dockerfile(
         self,
         model_uri,
-        output_directory="mlflow-dockerfile",
+        output_path="mlflow-dockerfile",
         install_mlflow=False,
         mlflow_home=None,
         enable_mlserver=False,
@@ -310,13 +310,13 @@ class PyFuncBackend(FlavorBackend):
         setup_miniconda = SETUP_MINICONDA if is_conda else ""
         setup_pyenv_and_virtualenv = "" if is_conda else SETUP_PYENV_AND_VIRTUALENV
 
-        os.makedirs(output_directory, exist_ok=True)
+        os.makedirs(output_path, exist_ok=True)
 
-        _logger.debug("Created all folders in path", extra={"output_directory": output_directory})
-        install_mlflow = _get_mlflow_install_step(output_directory, mlflow_home)
+        _logger.debug("Created all folders in path", extra={"output_directory": output_path})
+        install_mlflow = _get_mlflow_install_step(output_path, mlflow_home)
 
         custom_setup_steps = (
-            copy_model_into_container(output_directory) if copy_model_into_container else ""
+            copy_model_into_container(output_path) if copy_model_into_container else ""
         )
         dockerfile_text = _generate_dockerfile_content(
             setup_miniconda=setup_miniconda,
@@ -327,7 +327,7 @@ class PyFuncBackend(FlavorBackend):
         )
         _logger.debug("generated dockerfile text", extra={"dockerfile": dockerfile_text})
 
-        with open(os.path.join(output_directory, "Dockerfile"), "w") as dockerfile:
+        with open(os.path.join(output_path, "Dockerfile"), "w") as dockerfile:
             dockerfile.write(dockerfile_text)
 
     def build_image(
@@ -349,7 +349,8 @@ class PyFuncBackend(FlavorBackend):
 
     def copy_model_into_container_wrapper(self, model_uri, install_mlflow, enable_mlserver):
         def copy_model_into_container(dockerfile_context_dir):
-            # This function have to be included in another, since `_build_image` function in `docker_utils` accepts only
+            # This function have to be included in another,
+            # since `_build_image` function in `docker_utils` accepts only
             # single-argument function like this
             model_cwd = os.path.join(dockerfile_context_dir, "model_dir")
             pathlib.Path(model_cwd).mkdir(parents=True, exist_ok=True)

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -342,10 +342,10 @@ class PyFuncBackend(FlavorBackend):
                     RUN python -c \
                     'from mlflow.models.container import _install_pyfunc_deps;\
                     _install_pyfunc_deps(\
-                         "/opt/ml/model", \
-                         install_mlflow={install_mlflow}, \
-                         enable_mlserver={enable_mlserver}, \
-                         env_manager="{env_manager}")'
+                        "/opt/ml/model", \
+                        install_mlflow={install_mlflow}, \
+                        enable_mlserver={enable_mlserver}, \
+                        env_manager="{env_manager}")'
                     ENV {disable_env}="true"
                     ENV {ENABLE_MLSERVER}={enable_mlserver}
                     """.format(

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -307,17 +307,25 @@ class PyFuncBackend(FlavorBackend):
         mlflow_home = os.path.abspath(mlflow_home) if mlflow_home else None
 
         is_conda = self._env_manager == _EnvManager.CONDA
-        setup_miniconda = SETUP_MINICONDA if is_conda else ""
-        setup_pyenv_and_virtualenv = "" if is_conda else SETUP_PYENV_AND_VIRTUALENV
+        setup_miniconda = ""
+        setup_pyenv_and_virtualenv = ""
+
+        if is_conda:
+            setup_miniconda = SETUP_MINICONDA
+        else:
+            setup_pyenv_and_virtualenv = SETUP_PYENV_AND_VIRTUALENV
 
         os.makedirs(output_path, exist_ok=True)
 
         _logger.debug("Created all folders in path", extra={"output_directory": output_path})
         install_mlflow = _get_mlflow_install_step(output_path, mlflow_home)
 
-        custom_setup_steps = (
-            copy_model_into_container(output_path) if copy_model_into_container else ""
-        )
+        custom_setup_steps = ()
+        if copy_model_into_container:
+            custom_setup_steps = copy_model_into_container(output_path)
+        else:
+            custom_setup_steps = ""
+
         dockerfile_text = _generate_dockerfile_content(
             setup_miniconda=setup_miniconda,
             setup_pyenv_and_virtualenv=setup_pyenv_and_virtualenv,

--- a/mlflow/rfunc/backend.py
+++ b/mlflow/rfunc/backend.py
@@ -13,6 +13,14 @@ class RFuncBackend(FlavorBackend):
     Predict and serve locally models with 'crate' flavor.
     """
 
+    def build_image(self, model_uri, image_name, install_mlflow, mlflow_home, enable_mlserver):
+        pass
+
+    def generate_dockerfile(
+        self, model_uri, output_path, install_mlflow, mlflow_home, enable_mlserver
+    ):
+        pass
+
     version_pattern = re.compile(r"version ([0-9]+\.[0-9]+\.[0-9]+)")
 
     def predict(self, model_uri, input_path, output_path, content_type, json_format):

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -86,13 +86,13 @@ def score_model_in_sagemaker_docker_container(
     return _evaluate_scoring_proc(proc, 5000, data, content_type, activity_polling_timeout_seconds)
 
 
-def pyfunc_generate_dockerfile(model_uri=None, extra_args=None):
+def pyfunc_generate_dockerfile(output_directory, model_uri=None, extra_args=None):
     """
-    Builds a dockerfile for the specified model, returning the path of the dockerfile.
+    Builds a dockerfile for the specified model.
     :param model_uri: URI of model, e.g. runs:/some-run-id/run-relative/path/to/model
     :param extra_args: List of extra args to pass to `mlflow models build-docker` command
+    :param output_directory: Output directory to generate Dockerfile and model artifacts
     """
-    output_directory = ".dockerfile-output-{}".format(uuid.uuid4().hex)
     cmd = [
         "mlflow",
         "models",
@@ -107,7 +107,6 @@ def pyfunc_generate_dockerfile(model_uri=None, extra_args=None):
     if extra_args:
         cmd += extra_args
     subprocess.run(cmd, check=True)
-    return output_directory
 
 
 def pyfunc_build_image(model_uri=None, extra_args=None):

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -61,11 +61,11 @@ def random_file(ext):
 
 
 def score_model_in_sagemaker_docker_container(
-        model_uri,
-        data,
-        content_type,
-        flavor="python_function",
-        activity_polling_timeout_seconds=500,
+    model_uri,
+    data,
+    content_type,
+    flavor="python_function",
+    activity_polling_timeout_seconds=500,
 ):
     """
     :param model_uri: URI to the model to be served.
@@ -99,7 +99,7 @@ def pyfunc_generate_dockerfile(model_uri=None, extra_args=None):
         "generate-dockerfile",
         *(["-m", model_uri] if model_uri else []),
         "-d",
-        output_directory
+        output_directory,
     ]
     mlflow_home = os.environ.get("MLFLOW_HOME")
     if mlflow_home:
@@ -150,7 +150,7 @@ def pyfunc_serve_from_docker_image(image_name, host_port, extra_args=None):
 
 
 def pyfunc_serve_from_docker_image_with_env_override(
-        image_name, host_port, gunicorn_opts, extra_args=None, extra_docker_run_options=None
+    image_name, host_port, gunicorn_opts, extra_args=None, extra_docker_run_options=None
 ):
     """
     Serves a model from a docker container, exposing it as an endpoint at the specified port
@@ -174,12 +174,12 @@ def pyfunc_serve_from_docker_image_with_env_override(
 
 
 def pyfunc_serve_and_score_model(
-        model_uri,
-        data,
-        content_type,
-        activity_polling_timeout_seconds=500,
-        extra_args=None,
-        stdout=sys.stdout,
+    model_uri,
+    data,
+    content_type,
+    activity_polling_timeout_seconds=500,
+    extra_args=None,
+    stdout=sys.stdout,
 ):
     """
     :param model_uri: URI to the model to be served.
@@ -292,8 +292,8 @@ class RestEndpoint:
             if content_type == pyfunc_scoring_server.CONTENT_TYPE_JSON_RECORDS_ORIENTED:
                 data = data.to_json(orient="records")
             elif (
-                    content_type == pyfunc_scoring_server.CONTENT_TYPE_JSON
-                    or content_type == pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED
+                content_type == pyfunc_scoring_server.CONTENT_TYPE_JSON
+                or content_type == pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED
             ):
                 data = data.to_json(orient="split")
             elif content_type == pyfunc_scoring_server.CONTENT_TYPE_CSV:
@@ -431,9 +431,9 @@ def _is_available_on_pypi(package, version=None, module=None):
     version = version or _get_installed_version(module or package)
     dist_files = resp.json()["releases"].get(version)
     return (
-            dist_files is not None  # specified version exists
-            and (len(dist_files) > 0)  # at least one distribution file exists
-            and not dist_files[0].get("yanked", False)  # specified version is not yanked
+        dist_files is not None  # specified version exists
+        and (len(dist_files) > 0)  # at least one distribution file exists
+        and not dist_files[0].get("yanked", False)  # specified version is not yanked
     )
 
 

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -4,7 +4,6 @@ import functools
 from unittest import mock
 from contextlib import ExitStack, contextmanager
 
-
 import logging
 import requests
 import time
@@ -62,11 +61,11 @@ def random_file(ext):
 
 
 def score_model_in_sagemaker_docker_container(
-    model_uri,
-    data,
-    content_type,
-    flavor="python_function",
-    activity_polling_timeout_seconds=500,
+        model_uri,
+        data,
+        content_type,
+        flavor="python_function",
+        activity_polling_timeout_seconds=500,
 ):
     """
     :param model_uri: URI to the model to be served.
@@ -85,6 +84,31 @@ def score_model_in_sagemaker_docker_container(
         env=env,
     )
     return _evaluate_scoring_proc(proc, 5000, data, content_type, activity_polling_timeout_seconds)
+
+
+def pyfunc_generate_dockerfile(model_uri=None, extra_args=None):
+    """
+    Builds a dockerfile for the specified model, returning the path of the dockerfile.
+    :param model_uri: URI of model, e.g. runs:/some-run-id/run-relative/path/to/model
+    :param extra_args: List of extra args to pass to `mlflow models build-docker` command
+    """
+    output_directory = ".dockerfile-output-{}".format(uuid.uuid4().hex)
+    cmd = [
+        "mlflow",
+        "models",
+        "generate-dockerfile",
+        *(["-m", model_uri] if model_uri else []),
+        "-d",
+        output_directory
+    ]
+    mlflow_home = os.environ.get("MLFLOW_HOME")
+    if mlflow_home:
+        cmd += ["--mlflow-home", mlflow_home]
+    if extra_args:
+        cmd += extra_args
+    p = subprocess.Popen(cmd)
+    assert p.wait() == 0, "Failed to generate dockerfile for model %s" % model_uri
+    return output_directory
 
 
 def pyfunc_build_image(model_uri=None, extra_args=None):
@@ -126,7 +150,7 @@ def pyfunc_serve_from_docker_image(image_name, host_port, extra_args=None):
 
 
 def pyfunc_serve_from_docker_image_with_env_override(
-    image_name, host_port, gunicorn_opts, extra_args=None, extra_docker_run_options=None
+        image_name, host_port, gunicorn_opts, extra_args=None, extra_docker_run_options=None
 ):
     """
     Serves a model from a docker container, exposing it as an endpoint at the specified port
@@ -150,12 +174,12 @@ def pyfunc_serve_from_docker_image_with_env_override(
 
 
 def pyfunc_serve_and_score_model(
-    model_uri,
-    data,
-    content_type,
-    activity_polling_timeout_seconds=500,
-    extra_args=None,
-    stdout=sys.stdout,
+        model_uri,
+        data,
+        content_type,
+        activity_polling_timeout_seconds=500,
+        extra_args=None,
+        stdout=sys.stdout,
 ):
     """
     :param model_uri: URI to the model to be served.
@@ -268,8 +292,8 @@ class RestEndpoint:
             if content_type == pyfunc_scoring_server.CONTENT_TYPE_JSON_RECORDS_ORIENTED:
                 data = data.to_json(orient="records")
             elif (
-                content_type == pyfunc_scoring_server.CONTENT_TYPE_JSON
-                or content_type == pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED
+                    content_type == pyfunc_scoring_server.CONTENT_TYPE_JSON
+                    or content_type == pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED
             ):
                 data = data.to_json(orient="split")
             elif content_type == pyfunc_scoring_server.CONTENT_TYPE_CSV:
@@ -407,9 +431,9 @@ def _is_available_on_pypi(package, version=None, module=None):
     version = version or _get_installed_version(module or package)
     dist_files = resp.json()["releases"].get(version)
     return (
-        dist_files is not None  # specified version exists
-        and (len(dist_files) > 0)  # at least one distribution file exists
-        and not dist_files[0].get("yanked", False)  # specified version is not yanked
+            dist_files is not None  # specified version exists
+            and (len(dist_files) > 0)  # at least one distribution file exists
+            and not dist_files[0].get("yanked", False)  # specified version is not yanked
     )
 
 

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -106,8 +106,7 @@ def pyfunc_generate_dockerfile(model_uri=None, extra_args=None):
         cmd += ["--mlflow-home", mlflow_home]
     if extra_args:
         cmd += extra_args
-    p = subprocess.Popen(cmd)
-    assert p.wait() == 0, "Failed to generate dockerfile for model %s" % model_uri
+    subprocess.run(cmd, check=True)
     return output_directory
 
 

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -430,7 +430,6 @@ def test_generate_dockerfile(sk_model, enable_mlserver, tmp_path):
         extra_args.append("--enable_mlserver")
 
     pyfunc_generate_dockerfile(tmp_path, model_uri, extra_args=extra_args)
-    output_directory = Path(tmp_path)
     assert output_directory.is_dir()
     assert output_directory.joinpath("Dockerfile").exists()
     assert output_directory.joinpath("model_dir").is_dir()

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -426,7 +426,7 @@ def test_generate_dockerfile(sk_model, enable_mlserver, tmp_path):
         model_uri = "runs:/{run_id}/model".format(run_id=active_run.info.run_id)
     extra_args = ["--install-mlflow"]
     if enable_mlserver:
-        extra_args.append("--enable_mlserver")
+        extra_args.append("--enable-mlserver")
 
     output_directory = tmp_path.joinpath("output_directory")
     pyfunc_generate_dockerfile(output_directory, model_uri, extra_args=extra_args)

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -428,7 +428,7 @@ def test_generate_dockerfile(sk_model, enable_mlserver):
     if enable_mlserver:
         extra_args.append("--enable_mlserver")
 
-    output_directory_name = pyfunc_build_image(model_uri, extra_args=extra_args)
+    output_directory_name = pyfunc_generate_dockerfile(model_uri, extra_args=extra_args)
     assert Path(output_directory_name).is_dir()
     assert Path(output_directory_name).joinpath("Dockerfile").exists()
     assert Path(output_directory_name).joinpath("model_dir").is_dir()

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -3,7 +3,6 @@ import os
 import subprocess
 import sys
 import tempfile
-from pathlib import Path
 
 from click.testing import CliRunner
 import numpy as np

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -429,11 +429,12 @@ def test_generate_dockerfile(sk_model, enable_mlserver):
         extra_args.append("--enable_mlserver")
 
     output_directory_name = pyfunc_generate_dockerfile(model_uri, extra_args=extra_args)
-    assert Path(output_directory_name).is_dir()
-    assert Path(output_directory_name).joinpath("Dockerfile").exists()
-    assert Path(output_directory_name).joinpath("model_dir").is_dir()
+    output_directory = Path(output_directory_name)
+    assert output_directory.is_dir()
+    assert output_directory.joinpath("Dockerfile").exists()
+    assert output_directory.joinpath("model_dir").is_dir()
     # Assert file is not empty
-    assert Path(output_directory_name).joinpath("Dockerfile").stat().st_size != 0
+    assert output_directory.joinpath("Dockerfile").stat().st_size != 0
 
 
 @pytest.mark.parametrize("enable_mlserver", [True, False])

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -39,7 +39,8 @@ from tests.helper_functions import (
     RestEndpoint,
     get_safe_port,
     pyfunc_serve_and_score_model,
-    PROTOBUF_REQUIREMENT, pyfunc_generate_dockerfile,
+    PROTOBUF_REQUIREMENT,
+    pyfunc_generate_dockerfile,
 )
 from mlflow.protos.databricks_pb2 import ErrorCode, BAD_REQUEST
 from mlflow.pyfunc.scoring_server import (

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -430,7 +430,8 @@ def test_generate_dockerfile(sk_model, enable_mlserver, tmp_path):
     if enable_mlserver:
         extra_args.append("--enable_mlserver")
 
-    pyfunc_generate_dockerfile(tmp_path, model_uri, extra_args=extra_args)
+    output_directory = tmp_path.joinpath("output_directory")
+    pyfunc_generate_dockerfile(output_directory, model_uri, extra_args=extra_args)
     assert output_directory.is_dir()
     assert output_directory.joinpath("Dockerfile").exists()
     assert output_directory.joinpath("model_dir").is_dir()

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -430,7 +430,7 @@ def test_generate_dockerfile(sk_model, enable_mlserver, tmp_path):
         extra_args.append("--enable_mlserver")
 
     pyfunc_generate_dockerfile(tmp_path, model_uri, extra_args=extra_args)
-    output_directory = Path(temp_dir)
+    output_directory = Path(tmp_path)
     assert output_directory.is_dir()
     assert output_directory.joinpath("Dockerfile").exists()
     assert output_directory.joinpath("model_dir").is_dir()

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -429,14 +429,13 @@ def test_generate_dockerfile(sk_model, enable_mlserver, tmp_path):
     if enable_mlserver:
         extra_args.append("--enable_mlserver")
 
-    with tempfile.TemporaryDirectory() as temp_dir:
-        pyfunc_generate_dockerfile(temp_dir, model_uri, extra_args=extra_args)
-        output_directory = Path(temp_dir)
-        assert output_directory.is_dir()
-        assert output_directory.joinpath("Dockerfile").exists()
-        assert output_directory.joinpath("model_dir").is_dir()
-        # Assert file is not empty
-        assert output_directory.joinpath("Dockerfile").stat().st_size != 0
+    pyfunc_generate_dockerfile(tmp_path, model_uri, extra_args=extra_args)
+    output_directory = Path(temp_dir)
+    assert output_directory.is_dir()
+    assert output_directory.joinpath("Dockerfile").exists()
+    assert output_directory.joinpath("model_dir").is_dir()
+    # Assert file is not empty
+    assert output_directory.joinpath("Dockerfile").stat().st_size != 0
 
 
 @pytest.mark.parametrize("enable_mlserver", [True, False])

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -416,7 +416,7 @@ def test_prepare_env_fails(sk_model):
 
 
 @pytest.mark.parametrize("enable_mlserver", [True, False])
-def test_generate_dockerfile(sk_model, enable_mlserver):
+def test_generate_dockerfile(sk_model, enable_mlserver, tmp_path):
     with mlflow.start_run() as active_run:
         if enable_mlserver:
             mlflow.sklearn.log_model(

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -2,7 +2,6 @@ import json
 import os
 import subprocess
 import sys
-import tempfile
 
 from click.testing import CliRunner
 import numpy as np

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -520,7 +520,7 @@ def _validate_with_rest_endpoint(scoring_proc, host_port, df, x, sk_model, enabl
         for content_type in [CONTENT_TYPE_JSON_SPLIT_ORIENTED, CONTENT_TYPE_CSV, CONTENT_TYPE_JSON]:
             scoring_response = endpoint.invoke(df, content_type)
             assert scoring_response.status_code == 200, (
-                    "Failed to serve prediction, got response %s" % scoring_response.text
+                "Failed to serve prediction, got response %s" % scoring_response.text
             )
             np.testing.assert_array_equal(
                 np.array(json.loads(scoring_response.text)), sk_model.predict(x)
@@ -530,9 +530,9 @@ def _validate_with_rest_endpoint(scoring_proc, host_port, df, x, sk_model, enabl
             scoring_response = endpoint.invoke(data="", content_type=content_type)
             expected_status_code = 500 if enable_mlserver else 400
             assert scoring_response.status_code == expected_status_code, (
-                    "Expected server failure with error code %s, got response with status code %s "
-                    "and body %s"
-                    % (expected_status_code, scoring_response.status_code, scoring_response.text)
+                "Expected server failure with error code %s, got response with status code %s "
+                "and body %s"
+                % (expected_status_code, scoring_response.status_code, scoring_response.text)
             )
 
             if enable_mlserver:
@@ -570,8 +570,8 @@ def test_env_manager_specifying_both_no_conda_and_env_manager_is_not_allowed():
     )
     assert res.exit_code != 0
     assert (
-            "`--no-conda` (deprecated) and `--env-manager` cannot be used at the same time."
-            in res.stdout
+        "`--no-conda` (deprecated) and `--env-manager` cannot be used at the same time."
+        in res.stdout
     )
 
 
@@ -601,14 +601,14 @@ def test_change_conda_env_root_location(tmp_path, sk_model):
     for env_root_path, model_path, sklearn_ver in [
         (env_root1_path, model1_path, "1.0.1"),
         (
-                env_root2_path,
-                model1_path,
-                "1.0.1",
+            env_root2_path,
+            model1_path,
+            "1.0.1",
         ),  # test the same env created in different env root path.
         (
-                env_root1_path,
-                model2_path,
-                "1.0.2",
+            env_root1_path,
+            model2_path,
+            "1.0.2",
         ),  # test different env created in the same env root path.
     ]:
         _get_flavor_backend(
@@ -631,7 +631,7 @@ def test_change_conda_env_root_location(tmp_path, sk_model):
         _execute_in_conda_env(
             conda_env_name,
             command=f"python -c \"import sys; assert sys.executable == '{python_exec_path}'; "
-                    f"import sklearn; assert sklearn.__version__ == '{sklearn_ver}'\"",
+            f"import sklearn; assert sklearn.__version__ == '{sklearn_ver}'\"",
             install_mlflow=False,
             env_root_dir=str(env_root_path),
         )


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
Close #6532 

## What changes are proposed in this pull request?

This pull request proposes changes in CLI commands: it adds new `generate-dockerfile` command for `models`. It the outputs dockerfile with model directory in directory specified by CLI parameter. Resulting Dockerfile upon building and running behaves exactly like `models build-docker` image

example:
```bash
mlflow models generate-dockerfile -m <artifact> -d <name of the output directory>
```

To achieve this many functions of `build_docker` were reused and slightly refactored

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
I tested locally both `generate-dockerfile` and `build-docker` commands with seemingly expected behavior. Python is not my primary language, so I would be glad to hear any advise regarding writing adequate tests
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?
I am not entirely sure. I can see that `generate-dockerfile` cli command is present in `--help`, but I am not sure if any other documentation should be fixed for this matter

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

[CLI] [FR] Adding new CLI command for generating Dockerfile (issue #6532)
    
Implemented cli command to generate dockerfile identical to the one in `build-docker` command


### Is this a user-facing change?

- [] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add new CLI command for generating dockerfiles for model tracked and stored with mlflow

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
