### PR TITLE
Add confs for metric prefix and metric dataset info to mlflow.evaluate(), rename accuracy to accuracy_score

### DIFF
--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -739,6 +739,9 @@ def evaluate(
           larger than the configured maximum, these curves are not logged.
         - **metric_prefix**: An optional prefix to prepend to the name of each metric produced
           during evaluation.
+        - **log_metrics_with_dataset_info**: A boolean value specifying whether or not to include
+          information about the evaluation dataset in the name of each metric logged to MLflow
+          Tracking during evaluation, default value is True.
 
      - Limitations of evaluation dataset:
         - For classification tasks, dataset labels are used to infer the total number of classes.

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -737,6 +737,8 @@ def evaluate(
           For multiclass classification tasks, the maximum number of classes for which to log
           the per-class ROC curve and Precision-Recall curve. If the number of classes is
           larger than the configured maximum, these curves are not logged.
+        - **metric_prefix**: An optional prefix to prepend to the name of each metric produced
+          during evaluation.
 
      - Limitations of evaluation dataset:
         - For classification tasks, dataset labels are used to infer the total number of classes.

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -636,9 +636,7 @@ class DefaultEvaluator(ModelEvaluator):
             _logger.debug("", exc_info=True)
             return
         try:
-            mlflow.shap.log_explainer(
-                explainer, artifact_path=self._gen_log_key("explainer")
-            )
+            mlflow.shap.log_explainer(explainer, artifact_path=self._gen_log_key("explainer"))
         except Exception as e:
             # TODO: The explainer saver is buggy, if `get_underlying_model_flavor` return "unknown",
             #   then fallback to shap explainer saver, and shap explainer will call `model.save`

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -421,7 +421,7 @@ class DefaultEvaluator(ModelEvaluator):
         return model_type in ["classifier", "regressor"]
 
     def _gen_log_key(self, key):
-        if self.evaluator_config.get("include_dataset_in_metric_names", True):
+        if self.evaluator_config.get("log_metrics_with_dataset_info", True):
             return f"{key}_on_data_{self.dataset_name}"
         else:
             return key

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -171,7 +171,7 @@ def _get_classifier_global_metrics(is_binomial, y, y_pred, y_probs, labels):
     get classifier metrics which computing over all classes examples.
     """
     metrics = {}
-    metrics["accuracy"] = sk_metrics.accuracy_score(y, y_pred)
+    metrics["accuracy_score"] = sk_metrics.accuracy_score(y, y_pred)
     metrics["example_count"] = len(y)
 
     if not is_binomial:

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -1200,14 +1200,13 @@ def test_evaluation_metric_name_configs(prefix, log_metrics_with_dataset_info):
     assert len(metrics) > 0
 
     if prefix is not None:
-        assert all([metric_name.startswith(prefix) for metric_name in metrics])
-        assert all([metric_name.startswith(prefix) for metric_name in result.metrics])
+        assert all(metric_name.startswith(prefix) for metric_name in metrics)
+        assert all(metric_name.startswith(prefix) for metric_name in result.metrics)
 
     if log_metrics_with_dataset_info:
-        assert all(["on_data_iris" in metric_name for metric_name in metrics])
+        assert all("on_data_iris" in metric_name for metric_name in metrics)
     else:
-        assert all(["on_data_iris" not in metric_name for metric_name in metrics])
+        assert all("on_data_iris" not in metric_name for metric_name in metrics)
 
     # Dataset info should only be included in logged metric names
-    assert all(["on_data_iris" not in metric_name for metric_name in result.metrics])
-
+    assert all("on_data_iris" not in metric_name for metric_name in result.metrics)

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -1176,8 +1176,8 @@ def test_evaluation_works_with_model_pipelines_that_modify_input_data():
 
 
 @pytest.mark.parametrize("prefix", ["train_", None])
-@pytest.mark.parametrize("include_dataset_in_metric_names", [True, False])
-def test_evaluation_metric_name_configs(prefix, include_dataset_in_metric_names):
+@pytest.mark.parametrize("log_metrics_with_dataset_info", [True, False])
+def test_evaluation_metric_name_configs(prefix, log_metrics_with_dataset_info):
     X, y = load_iris(as_frame=True, return_X_y=True)
     with mlflow.start_run() as run:
         model = LogisticRegression()
@@ -1191,8 +1191,8 @@ def test_evaluation_metric_name_configs(prefix, include_dataset_in_metric_names)
             dataset_name="iris",
             evaluators="default",
             evaluator_config={
-                "metric_prefix": "train_",
-                "include_dataset_in_metric_names": include_dataset_in_metric_names,
+                "metric_prefix": prefix,
+                "log_metrics_with_dataset_info": log_metrics_with_dataset_info,
             },
         )
 
@@ -1203,7 +1203,11 @@ def test_evaluation_metric_name_configs(prefix, include_dataset_in_metric_names)
         assert all([metric_name.startswith(prefix) for metric_name in metrics])
         assert all([metric_name.startswith(prefix) for metric_name in result.metrics])
 
-    if include_dataset_in_metric_names:
+    if log_metrics_with_dataset_info:
         assert all(["on_data_iris" in metric_name for metric_name in metrics])
     else:
         assert all(["on_data_iris" not in metric_name for metric_name in metrics])
+
+    # Dataset info should only be included in logged metric names
+    assert all(["on_data_iris" not in metric_name for metric_name in result.metrics])
+

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -500,7 +500,7 @@ def test_multiclass_get_classifier_global_metrics():
         is_binomial=False, y=y, y_pred=y_pred, y_probs=y_probs, labels=[0, 1, 2]
     )
     expected_metrics = {
-        "accuracy": 0.4,
+        "accuracy_score": 0.4,
         "example_count": 5,
         "f1_score_micro": 0.4,
         "f1_score_macro": 0.38888888888888884,

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -517,7 +517,7 @@ def test_binary_get_classifier_global_metrics():
     metrics = _get_classifier_global_metrics(
         is_binomial=True, y=y, y_pred=y_pred, y_probs=y_probs, labels=[0, 1]
     )
-    expected_metrics = {"accuracy": 0.7, "example_count": 10, "log_loss": 0.6665822319387167}
+    expected_metrics = {"accuracy_score": 0.7, "example_count": 10, "log_loss": 0.6665822319387167}
     assert_dict_equal(metrics, expected_metrics, 1e-3)
 
 


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## What changes are proposed in this pull request?

Add confs for metric prefix and metric dataset info to mlflow.evaluate(), rename accuracy to accuracy_score

## How is this patch tested?

Added integration tests

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

Add confs for metric prefix and metric dataset info to mlflow.evaluate(), rename accuracy to accuracy_score

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
