### PR TITLE
Removing actual code from DAG strings for MLP and just keeping user guide

### DIFF
--- a/mlflow/pipelines/regression/v1/dag_help_strings.py
+++ b/mlflow/pipelines/regression/v1/dag_help_strings.py
@@ -57,8 +57,6 @@ data:
 
 INGEST_USER_CODE = format_help_string(
     """\"\"\"\nsteps/ingest.py defines customizable logic for parsing arbitrary dataset formats (i.e. formats that are not natively parsed by MLflow Pipelines) via the `load_file_as_dataframe` function. Note that the Parquet, Delta, and Spark SQL dataset formats are natively parsed by MLflow Pipelines, and you do not need to define custom logic for parsing them. An example `load_file_as_dataframe` implementation is displayed below (note that a different function name or module can be specified via the 'custom_loader_method' attribute of the 'data' section in pipeline.yaml).\n\"\"\"\n
-import pandas
-
 def load_file_as_dataframe(
     file_path: str,
     file_format: str,
@@ -72,11 +70,6 @@ def load_file_as_dataframe(
     :param file_format: The file format string, such as "csv".
     :return: A Pandas DataFrame representing the content of the specified file.
     \"\"\"
-
-    if file_format == "csv":
-        return pandas.read_csv(file_path, index_col=0)
-    else:
-        raise NotImplementedError
 """
 )
 
@@ -96,8 +89,6 @@ steps:
 
 SPLIT_USER_CODE = format_help_string(
     """\"\"\"\nsteps/split.py defines customizable logic for preprocessing the training, validation, and test datasets prior to model creation via the `process_splits` function, an example of which is displayed below (note that a different function name or module can be specified via the 'post_split_method' attribute of the 'split' step definition in pipeline.yaml).\n\"\"\"\n
-import pandas
-
 def process_splits(
     train_df: pandas.DataFrame,
     validation_df: pandas.DataFrame,
@@ -111,8 +102,6 @@ def process_splits(
     :param test_df: The test dataset.
     :return: A tuple of containing, in order, the processed training dataset, the processed validation dataset, and the processed test dataset.
     \"\"\"
-
-    return train_df.dropna(), validation_df.dropna(), test_df.dropna()
 """
 )
 
@@ -143,23 +132,6 @@ def transformer_fn():
     \"\"\"
     Returns an *unfitted* transformer that defines ``fit()`` and ``transform()`` methods. The transformer's input and output signatures should be compatible with scikit-learn transformers.
     \"\"\"
-    from sklearn.compose import ColumnTransformer
-    from sklearn.pipeline import Pipeline
-    from sklearn.preprocessing import OneHotEncoder, StandardScaler
-
-    transformers = [
-        (
-            "hour_encoder",
-            OneHotEncoder(categories="auto", sparse=False),
-            ["pickup_hour"],
-        ),
-        (
-            "std_scaler",
-            StandardScaler(),
-            ["trip_distance"],
-        ),
-    ]
-    return Pipeline(steps=[("encoder", ColumnTransformer(transformers)]))
 """
 )
 
@@ -192,9 +164,6 @@ def estimator_fn():
     \"\"\"
     Returns an *unfitted* estimator that defines ``fit()`` and ``predict()`` methods. The estimator's input and output signatures should be compatible with scikit-learn estimators.
     \"\"\"
-    from sklearn.linear_model import SGDRegressor
-
-    return SGDRegressor()
 """
 )
 
@@ -217,11 +186,6 @@ metrics:
 
 An example custom_metrics.py file is displayed below.
 \"\"\"\
-
-
-import pandas
-from sklearn.metrics import mean_squared_error
-
 def weighted_mean_squared_error(
     eval_df: pandas.DataFrame,
     builtin_metrics: Dict[str, int],
@@ -237,13 +201,6 @@ def weighted_mean_squared_error(
     :param builtin_metrics: A dictionary containing the built-in metrics that are calculated automatically during model evaluation. The keys are the names of the metrics and the values are the scalar values of the metrics. For more information, see https://mlflow.org/docs/latest/python_api/mlflow.html#mlflow.evaluate.
     :return: A single-entry dictionary containing the MSE metric. The key is the metric names and the value is the scalar metric value. Note that custom metric functions can return dictionaries with multiple metric entries as well.
     \"\"\"
-    return {
-        "weighted_mean_squared_error": mean_squared_error(
-            eval_df["prediction"],
-            eval_df["target"],
-            sample_weight=1 / eval_df["prediction"].values,
-        )
-    }
 """
 )
 


### PR DESCRIPTION
## Related Issues/PRs
https://github.com/mlflow/mlp-regression-template/issues/58

## What changes are proposed in this pull request?
- Based on the above PR, users wanted to see the actual code in the DAG. But upon discussion we realized that the DAG was just meant to display user guide. Updating the DAG strings to just display the user guide and function signature and removing the code block implementation for clarity. 

## How is this patch tested?
- [x] Rendered the DAG locally to make sure all the strings are formatted correctly. 

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
