### PR TITLE
Changed the name Start Time to Created

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentView.js
@@ -821,7 +821,7 @@ export class ExperimentView extends Component {
                     </Tooltip>
                     <Tooltip
                       title={this.props.intl.formatMessage({
-                        defaultMessage: 'Started during',
+                        defaultMessage: 'Created during',
                         description:
                           'Label for the start time select dropdown for experiment runs view',
                       })}

--- a/mlflow/server/js/src/experiment-tracking/components/RunsTableColumnSelectionDropdown.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/RunsTableColumnSelectionDropdown.test.js
@@ -46,7 +46,7 @@ describe('RunsTableColumnSelectionDropdown', () => {
     instance.setState({ menuVisible: true });
     wrapper.update();
     expect(wrapper.find(SearchTree).prop('data')).toEqual([
-      { key: 'attributes-Start Time', title: 'Start Time' },
+      { key: 'attributes-Created', title: 'Created' },
       { key: 'attributes-Experiment Name', title: 'Experiment Name' },
       { key: 'attributes-Duration', title: 'Duration' },
       { key: 'attributes-User', title: 'User' },
@@ -87,7 +87,7 @@ describe('RunsTableColumnSelectionDropdown', () => {
     instance.setState({ menuVisible: true });
     wrapper.update();
     expect(wrapper.find(SearchTree).prop('checkedKeys')).toEqual([
-      'attributes-Start Time',
+      'attributes-Created',
       'attributes-Experiment Name',
       'attributes-Duration',
       'attributes-User',
@@ -119,7 +119,7 @@ describe('RunsTableColumnSelectionDropdown', () => {
     instance.setState({ menuVisible: true });
     wrapper.update();
     expect(wrapper.find(SearchTree).prop('checkedKeys')).toEqual([
-      'attributes-Start Time',
+      'attributes-Created',
       'attributes-Experiment Name',
       'attributes-Duration',
       'params-p2',
@@ -132,7 +132,7 @@ describe('RunsTableColumnSelectionDropdown', () => {
 describe('getCategorizedUncheckedKeys', () => {
   test('getCategorizedUncheckedKeys should return correct keys when all checked', () => {
     const allKeys = [
-      'attributes-Start Time',
+      'attributes-Created',
       'attributes-Duration',
       'attributes-User',
       'attributes-Run Name',
@@ -150,7 +150,7 @@ describe('getCategorizedUncheckedKeys', () => {
       'tags-t2',
     ];
     const checkedKeys = [
-      'attributes-Start Time',
+      'attributes-Created',
       'attributes-Duration',
       'attributes-User',
       'attributes-Run Name',
@@ -177,7 +177,7 @@ describe('getCategorizedUncheckedKeys', () => {
   });
   test('getCategorizedUncheckedKeys should return correct keys when some checked', () => {
     const allKeys = [
-      'attributes-Start Time',
+      'attributes-Created',
       'attributes-Duration',
       'attributes-User',
       'attributes-Run Name',
@@ -195,7 +195,7 @@ describe('getCategorizedUncheckedKeys', () => {
       'tags-t2',
     ];
     const checkedKeys = [
-      'attributes-Start Time',
+      'attributes-Created',
       'attributes-Duration',
       'attributes-Source',
       'attributes-Version',
@@ -214,7 +214,7 @@ describe('getCategorizedUncheckedKeys', () => {
   });
   test('getCategorizedUncheckedKeys should return correct keys when nothing checked', () => {
     const allKeys = [
-      'attributes-Start Time',
+      'attributes-Created',
       'attributes-Duration',
       'attributes-User',
       'attributes-Run Name',
@@ -234,7 +234,7 @@ describe('getCategorizedUncheckedKeys', () => {
     const checkedKeys = [];
     const expectedResult = {
       [COLUMN_TYPES.ATTRIBUTES]: [
-        'Start Time',
+        'Created',
         'Duration',
         'User',
         'Run Name',

--- a/mlflow/server/js/src/experiment-tracking/constants.js
+++ b/mlflow/server/js/src/experiment-tracking/constants.js
@@ -8,7 +8,7 @@ export const MLMODEL_FILE_NAME = 'MLmodel';
 export const ONE_MB = 1024 * 1024;
 
 export const ATTRIBUTE_COLUMN_LABELS = {
-  DATE: 'Start Time',
+  DATE: 'Created',
   EXPERIMENT_NAME: 'Experiment Name',
   DURATION: 'Duration',
   USER: 'User',
@@ -19,7 +19,7 @@ export const ATTRIBUTE_COLUMN_LABELS = {
 };
 
 export const ATTRIBUTE_COLUMN_SORT_LABEL = {
-  DATE: 'Start Time',
+  DATE: 'Created',
   USER: 'User',
   RUN_NAME: 'Run Name',
   SOURCE: 'Source',


### PR DESCRIPTION
Signed-off-by: Jin Zhang <jin.zhang@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs
None

## What changes are proposed in this pull request?
Changed the runs table column name from "Start Time" to "Created" for better UX. See screenshot below.
<img width="1140" alt="Screen Shot 2022-08-25 at 4 33 23 PM" src="https://user-images.githubusercontent.com/78067366/186787793-26577703-3426-4a80-9cdc-9c08dedc9020.png">


## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
