### PR TITLE
Improve styling of DAG and rearrange transform step node

### DIFF
--- a/mlflow/pipelines/regression/v1/resources/pipeline_dag_template.html
+++ b/mlflow/pipelines/regression/v1/resources/pipeline_dag_template.html
@@ -39,6 +39,11 @@
         font-size: 24px;
         padding: 24px;
       }
+      .node:hover {
+        stroke: #2272B4 !important;
+        color: #0E538B !important;
+        background-color: #bbdaf4;
+      }
     </style>
 
     <div class="wrapper">
@@ -50,6 +55,7 @@
           ingestMLPStep --> dataParquet[(ingested_data)]
 
           data[(ingested_data)] --> splitStep[["<font>split</font>"]]
+          transformUserCode([steps/transform.py]) --> transformMLPStep
           splitUserCode([steps/split.py]) --> splitStep
           splitStep --> splitData0[(training_data)]
           splitStep --> splitData1[(validation_data)]
@@ -57,7 +63,6 @@
           splitData0 --> transformMLPStep[["<font>transform</font>"]]
           splitData1 --> transformMLPStep[["<font>transform</font>"]]
 
-          transformUserCode([steps/transform.py]) --> transformMLPStep
           transformMLPStep --> transformedParquet[(transformed_training_data, <br/> transformed_validation_data)]
           transformMLPStep --> transformer{{transformer}}
           transformedParquet --> trainMLPStep[["<font>train</font>"]]
@@ -150,24 +155,31 @@
               nodeLabel.setAttribute("title", JSON.parse(nodeInfo).help_string)
             }
           })
-
+          resetStyles()
           window.editor = null;
         }
       );
 
+      var resetStyles = function() {
+        const allNodes = document.querySelector('.nodes').querySelectorAll('[id^="flowchart-"]');
+          [...allNodes].forEach(node => {
+            const rect = node.firstChild
+            if (rect) {
+              rect.style.fill = "inherit";
+              rect.style.stroke = "inherit";
+            }
+            node.style.fill = "#F2F5F7";
+            node.style.stroke = "#CDDAE5";
+            node.style.color = "#20272E";
+            const span = node.querySelector('span')
+            const label = node.querySelector('.label')
+            span.style.color = "inherit";
+            label.style.color = "inherit";
+          });
+      }
       var noOp = function() {}
       var renderMoreInformation = function(nodeId) {
-        const allNodes = document.querySelector('.nodes').querySelectorAll('[id^="flowchart-"]');
-        [...allNodes].forEach(nodes => {
-          const rect = nodes.firstChild
-          if (rect) {
-            rect.style.stroke = "";
-            rect.style.strokeWidth = "";
-            rect.style.color = "";
-            rect.style.strokeDasharray = "";
-          }
-        });
-
+        resetStyles()
         regex = `[id^="flowchart-${nodeId}-"]`
         const node = document.querySelector(regex);
         var nodeInfo = node.getAttribute('title');
@@ -183,10 +195,9 @@
         nodeInfo = JSON.parse(nodeInfo)
 
         const rect = node.firstChild;
-        rect.style.stroke = "#f66";
-        rect.style.strokeWidth = "2px";
-        rect.style.color = "#fff";
-        rect.style.strokeDasharray = "5 5";
+        rect.style.stroke = "#04355D";
+        rect.style.fill = "#bbdaf4";
+        rect.style.color = "#04355D";
 
         document.querySelector("#editor").classList.add('pane-loading');
         const hideSpinner = () => document.querySelector("#editor").classList.remove('pane-loading');


### PR DESCRIPTION
## What changes are proposed in this pull request?
Improve styling of DAG and rearrange transform step node

## How is this patch tested?
Before: 
![image](https://user-images.githubusercontent.com/5621432/186998784-c4a9d8c2-28ea-4452-a343-6ff2d7262879.png)

After UI screengrab:

https://user-images.githubusercontent.com/5621432/186998816-ca67cc48-3106-4988-9353-8471f8452c1c.mov



## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
