### PR TITLE
Move data capture config argument to end of mlflow.sagemaker.deploy()

### DIFF
--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -173,10 +173,10 @@ def deploy(
     instance_type=DEFAULT_SAGEMAKER_INSTANCE_TYPE,
     instance_count=DEFAULT_SAGEMAKER_INSTANCE_COUNT,
     vpc_config=None,
-    data_capture_config=None,
     flavor=None,
     synchronous=True,
     timeout_seconds=1200,
+    data_capture_config=None,
 ):
     """
     Deploy an MLflow model on AWS SageMaker.
@@ -275,6 +275,23 @@ def deploy(
                      }
         mfs.deploy(..., vpc_config=vpc_config)
 
+    :param flavor: The name of the flavor of the model to use for deployment. Must be either
+                   ``None`` or one of mlflow.sagemaker.SUPPORTED_DEPLOYMENT_FLAVORS. If ``None``,
+                   a flavor is automatically selected from the model's available flavors. If the
+                   specified flavor is not present or not supported for deployment, an exception
+                   will be thrown.
+    :param synchronous: If ``True``, this function will block until the deployment process succeeds
+                        or encounters an irrecoverable failure. If ``False``, this function will
+                        return immediately after starting the deployment process. It will not wait
+                        for the deployment process to complete; in this case, the caller is
+                        responsible for monitoring the health and status of the pending deployment
+                        via native SageMaker APIs or the AWS console.
+    :param timeout_seconds: If ``synchronous`` is ``True``, the deployment process will return after
+                            the specified number of seconds if no definitive result (success or
+                            failure) is achieved. Once the function returns, the caller is
+                            responsible for monitoring the health and status of the pending
+                            deployment using native SageMaker APIs or the AWS console. If
+                            ``synchronous`` is ``False``, this parameter is ignored.
     :param data_capture_config: A dictionary specifying the data capture configuration to use when
                        creating the new SageMaker model associated with this application. For more
                        information, see
@@ -294,23 +311,6 @@ def deploy(
                      }
         mfs.deploy(..., data_capture_config=data_capture_config)
 
-    :param flavor: The name of the flavor of the model to use for deployment. Must be either
-                   ``None`` or one of mlflow.sagemaker.SUPPORTED_DEPLOYMENT_FLAVORS. If ``None``,
-                   a flavor is automatically selected from the model's available flavors. If the
-                   specified flavor is not present or not supported for deployment, an exception
-                   will be thrown.
-    :param synchronous: If ``True``, this function will block until the deployment process succeeds
-                        or encounters an irrecoverable failure. If ``False``, this function will
-                        return immediately after starting the deployment process. It will not wait
-                        for the deployment process to complete; in this case, the caller is
-                        responsible for monitoring the health and status of the pending deployment
-                        via native SageMaker APIs or the AWS console.
-    :param timeout_seconds: If ``synchronous`` is ``True``, the deployment process will return after
-                            the specified number of seconds if no definitive result (success or
-                            failure) is achieved. Once the function returns, the caller is
-                            responsible for monitoring the health and status of the pending
-                            deployment using native SageMaker APIs or the AWS console. If
-                            ``synchronous`` is ``False``, this parameter is ignored.
     """
     import boto3
 


### PR DESCRIPTION
Signed-off-by: dbczumar <corey.zumar@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## What changes are proposed in this pull request?

Move data capture config argument to end of `mlflow.sagemaker.deploy()` to the end for backwards compatibility (feature has yet to be released).

## How is this patch tested?

Existing unit / integration tests

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [X] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
