### PR TITLE
update DFS_TMP in mlflow.spark to accept environment variable

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -64,6 +64,13 @@ class _BooleanEnvironmentVariable(_EnvironmentVariable):
         return lowercased in ["true", "1"]
 
 
+#: Specifies the ``dfs_tmpdir`` parameter to use for ``mlflow.spark.save_model``,
+#: ``mlflow.spark.log_model`` and ``mlflow.spark.load_model``. See
+#: https://www.mlflow.org/docs/latest/python_api/mlflow.spark.html#mlflow.spark.save_model
+#: for more information.
+#: (default: ``/tmp/mlflow``)
+MLFLOW_DFS_TMP = _EnvironmentVariable("MLFLOW_DFS_TMP", str, "/tmp/mlflow")
+
 #: Specifies the maximum number of retries for MLflow HTTP requests
 #: (default: ``5``)
 MLFLOW_HTTP_REQUEST_MAX_RETRIES = _EnvironmentVariable("MLFLOW_HTTP_REQUEST_MAX_RETRIES", int, 5)

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -76,7 +76,7 @@ from mlflow.utils.autologging_utils import autologging_integration, safe_patch
 FLAVOR_NAME = "spark"
 
 # Default temporary directory on DFS. Used to write / read from Spark ML models.
-DFS_TMP = "/tmp/mlflow"
+DFS_TMP = os.environ.get("MLFLOW_DFS_TMP", "/tmp/mlflow")
 _SPARK_MODEL_PATH_SUB = "sparkml"
 _MLFLOWDBFS_SCHEME = "mlflowdbfs"
 

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -28,6 +28,7 @@ import yaml
 
 import mlflow
 from mlflow import environment_variables, pyfunc, mleap
+from mlflow.environment_variables import MLFLOW_DFS_TMP
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model
 from mlflow.models.model import MLMODEL_FILE_NAME
@@ -75,8 +76,6 @@ from mlflow.utils.autologging_utils import autologging_integration, safe_patch
 
 FLAVOR_NAME = "spark"
 
-# Default temporary directory on DFS. Used to write / read from Spark ML models.
-DFS_TMP = os.environ.get("MLFLOW_DFS_TMP", "/tmp/mlflow")
 _SPARK_MODEL_PATH_SUB = "sparkml"
 _MLFLOWDBFS_SCHEME = "mlflowdbfs"
 
@@ -653,7 +652,7 @@ def save_model(
     # Spark ML stores the model on DFS if running on a cluster
     # Save it to a DFS temp dir first and copy it to local path
     if dfs_tmpdir is None:
-        dfs_tmpdir = DFS_TMP
+        dfs_tmpdir = MLFLOW_DFS_TMP.get()
     tmp_path = _tmp_path(dfs_tmpdir)
     spark_model.save(tmp_path)
     sparkml_data_path = os.path.abspath(os.path.join(path, _SPARK_MODEL_PATH_SUB))
@@ -720,7 +719,7 @@ def _load_model_databricks(dfs_tmpdir, local_model_path):
 def _load_model(model_uri, dfs_tmpdir_base=None, local_model_path=None):
     from pyspark.ml.pipeline import PipelineModel
 
-    dfs_tmpdir = _tmp_path(dfs_tmpdir_base or DFS_TMP)
+    dfs_tmpdir = _tmp_path(dfs_tmpdir_base or MLFLOW_DFS_TMP.get())
     if databricks_utils.is_in_cluster() and databricks_utils.is_dbfs_fuse_available():
         return _load_model_databricks(
             dfs_tmpdir, local_model_path or _download_artifact_from_uri(model_uri)

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -11,7 +11,6 @@ from pyspark.ml.feature import VectorAssembler
 from pyspark.ml.pipeline import Pipeline
 import pytest
 from sklearn import datasets
-import shutil
 from collections import namedtuple
 import yaml
 from packaging.version import Version
@@ -212,7 +211,7 @@ def test_model_export(spark_model_iris, model_path, spark_custom_env):
     # 3. score and compare reloaded pyfunc Spark udf
     preds3 = score_model_as_udf(model_uri=model_path, pandas_df=spark_model_iris.pandas_df)
     assert spark_model_iris.predictions == preds3
-    assert os.path.exists(MLFLOW_DFS_TMP)
+    assert os.path.exists(MLFLOW_DFS_TMP.get())
 
 
 def test_model_export_with_signature_and_examples(iris_df, spark_model_iris):
@@ -392,41 +391,33 @@ def test_sparkml_estimator_model_log(
 def test_log_model_calls_register_model(tmpdir, spark_model_iris):
     artifact_path = "model"
     dfs_tmp_dir = os.path.join(str(tmpdir), "test")
-    try:
-        register_model_patch = mock.patch("mlflow.register_model")
-        with mlflow.start_run(), register_model_patch:
-            sparkm.log_model(
-                artifact_path=artifact_path,
-                spark_model=spark_model_iris.model,
-                dfs_tmpdir=dfs_tmp_dir,
-                registered_model_name="AdsModel1",
-            )
-            model_uri = "runs:/{run_id}/{artifact_path}".format(
-                run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path
-            )
-            mlflow.register_model.assert_called_once_with(
-                model_uri, "AdsModel1", await_registration_for=DEFAULT_AWAIT_MAX_SLEEP_SECONDS
-            )
-    finally:
-        x = dfs_tmp_dir or MLFLOW_DFS_TMP
-        shutil.rmtree(x)
+    register_model_patch = mock.patch("mlflow.register_model")
+    with mlflow.start_run(), register_model_patch:
+        sparkm.log_model(
+            artifact_path=artifact_path,
+            spark_model=spark_model_iris.model,
+            dfs_tmpdir=dfs_tmp_dir,
+            registered_model_name="AdsModel1",
+        )
+        model_uri = "runs:/{run_id}/{artifact_path}".format(
+            run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path
+        )
+        mlflow.register_model.assert_called_once_with(
+            model_uri, "AdsModel1", await_registration_for=DEFAULT_AWAIT_MAX_SLEEP_SECONDS
+        )
 
 
 def test_log_model_no_registered_model_name(tmpdir, spark_model_iris):
     artifact_path = "model"
     dfs_tmp_dir = os.path.join(str(tmpdir), "test")
-    try:
-        register_model_patch = mock.patch("mlflow.register_model")
-        with mlflow.start_run(), register_model_patch:
-            sparkm.log_model(
-                artifact_path=artifact_path,
-                spark_model=spark_model_iris.model,
-                dfs_tmpdir=dfs_tmp_dir,
-            )
-            mlflow.register_model.assert_not_called()
-    finally:
-        x = dfs_tmp_dir or MLFLOW_DFS_TMP
-        shutil.rmtree(x)
+    register_model_patch = mock.patch("mlflow.register_model")
+    with mlflow.start_run(), register_model_patch:
+        sparkm.log_model(
+            artifact_path=artifact_path,
+            spark_model=spark_model_iris.model,
+            dfs_tmpdir=dfs_tmp_dir,
+        )
+        mlflow.register_model.assert_not_called()
 
 
 def test_sparkml_model_load_from_remote_uri_succeeds(spark_model_iris, model_path, mock_s3_bucket):

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -21,6 +21,7 @@ import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 import mlflow.tracking
 from mlflow import pyfunc
 from mlflow import spark as sparkm
+from mlflow.environment_variables import MLFLOW_DFS_TMP
 from mlflow.models import Model, infer_signature
 from mlflow.models.utils import _read_example
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
@@ -211,7 +212,7 @@ def test_model_export(spark_model_iris, model_path, spark_custom_env):
     # 3. score and compare reloaded pyfunc Spark udf
     preds3 = score_model_as_udf(model_uri=model_path, pandas_df=spark_model_iris.pandas_df)
     assert spark_model_iris.predictions == preds3
-    assert os.path.exists(sparkm.DFS_TMP)
+    assert os.path.exists(MLFLOW_DFS_TMP)
 
 
 def test_model_export_with_signature_and_examples(iris_df, spark_model_iris):
@@ -407,7 +408,7 @@ def test_log_model_calls_register_model(tmpdir, spark_model_iris):
                 model_uri, "AdsModel1", await_registration_for=DEFAULT_AWAIT_MAX_SLEEP_SECONDS
             )
     finally:
-        x = dfs_tmp_dir or sparkm.DFS_TMP
+        x = dfs_tmp_dir or MLFLOW_DFS_TMP
         shutil.rmtree(x)
 
 
@@ -424,7 +425,7 @@ def test_log_model_no_registered_model_name(tmpdir, spark_model_iris):
             )
             mlflow.register_model.assert_not_called()
     finally:
-        x = dfs_tmp_dir or sparkm.DFS_TMP
+        x = dfs_tmp_dir or MLFLOW_DFS_TMP
         shutil.rmtree(x)
 
 


### PR DESCRIPTION
Signed-off-by: Xinyue Ruan <serena.rxy@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

None

## What changes are proposed in this pull request?

Updated DFS_TMP constant variable to get an environment variable first, then default to /tmp/mlflow. This would give users more flexibility when configuring their own environment.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
