### PR TITLE
Improve flexibility of PyFuncModel prediction

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -624,13 +624,15 @@ class PyFuncModel:
     ``model_meta`` contains model metadata loaded from the MLmodel file.
     """
 
-    def __init__(self, model_meta: Model, model_impl: Any):
+    def __init__(self, model_meta: Model, model_impl: Any, pyfunc_predict_func: str = "predict"):
         if not hasattr(model_impl, "predict"):
             raise MlflowException("Model implementation is missing required predict method.")
         if not model_meta:
             raise MlflowException("Model is missing metadata.")
         self._model_meta = model_meta
         self._model_impl = model_impl
+        assert hasattr(model_impl, pyfunc_predict_func)
+        self._predict_fn = getattr(model_impl, pyfunc_predict_func)
 
     def predict(self, data: PyFuncInput) -> PyFuncOutput:
         """
@@ -649,7 +651,7 @@ class PyFuncModel:
         input_schema = self.metadata.get_input_schema()
         if input_schema is not None:
             data = _enforce_schema(data, input_schema)
-        return self._model_impl.predict(data)
+        return self._predict_fn(data)
 
     def __eq__(self, other):
         if not isinstance(other, PyFuncModel):
@@ -714,7 +716,9 @@ def _warn_dependency_requirement_mismatches(model_path):
 
 
 def load_model(
-    model_uri: str, suppress_warnings: bool = False, dst_path: str = None
+    model_uri: str,
+    suppress_warnings: bool = False,
+    dst_path: str = None,
 ) -> PyFuncModel:
     """
     Load a model stored in Python function format.
@@ -759,7 +763,10 @@ def load_model(
     _add_code_from_conf_to_system_path(local_path, conf, code_key=CODE)
     data_path = os.path.join(local_path, conf[DATA]) if (DATA in conf) else local_path
     model_impl = importlib.import_module(conf[MAIN])._load_pyfunc(data_path)
-    return PyFuncModel(model_meta=model_meta, model_impl=model_impl)
+    pyfunc_predict_func = conf.get("pyfunc_predict_func", "predict")
+    return PyFuncModel(
+        model_meta=model_meta, model_impl=model_impl, pyfunc_predict_func=pyfunc_predict_func
+    )
 
 
 def _download_model_conda_env(model_uri):

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -624,7 +624,7 @@ class PyFuncModel:
     ``model_meta`` contains model metadata loaded from the MLmodel file.
     """
 
-    def __init__(self, model_meta: Model, model_impl: Any, pyfunc_predict_func: str = "predict"):
+    def __init__(self, model_meta: Model, model_impl: Any, predict_fn: str = "predict"):
         if not hasattr(model_impl, "predict"):
             raise MlflowException("Model implementation is missing required predict method.")
         if not model_meta:

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -625,14 +625,13 @@ class PyFuncModel:
     """
 
     def __init__(self, model_meta: Model, model_impl: Any, predict_fn: str = "predict"):
-        if not hasattr(model_impl, "predict"):
-            raise MlflowException("Model implementation is missing required predict method.")
+        if not hasattr(model_impl, predict_fn):
+            raise MlflowException(f"Model implementation is missing required {predict_fn} method.")
         if not model_meta:
             raise MlflowException("Model is missing metadata.")
         self._model_meta = model_meta
         self._model_impl = model_impl
-        assert hasattr(model_impl, pyfunc_predict_func)
-        self._predict_fn = getattr(model_impl, pyfunc_predict_func)
+        self._predict_fn = getattr(model_impl, predict_fn)
 
     def predict(self, data: PyFuncInput) -> PyFuncOutput:
         """
@@ -763,10 +762,8 @@ def load_model(
     _add_code_from_conf_to_system_path(local_path, conf, code_key=CODE)
     data_path = os.path.join(local_path, conf[DATA]) if (DATA in conf) else local_path
     model_impl = importlib.import_module(conf[MAIN])._load_pyfunc(data_path)
-    pyfunc_predict_func = conf.get("pyfunc_predict_func", "predict")
-    return PyFuncModel(
-        model_meta=model_meta, model_impl=model_impl, pyfunc_predict_func=pyfunc_predict_func
-    )
+    predict_fn = conf.get("predict_fn", "predict")
+    return PyFuncModel(model_meta=model_meta, model_impl=model_impl, predict_fn=predict_fn)
 
 
 def _download_model_conda_env(model_uri):

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -152,6 +152,7 @@ def save_model(
     input_example: ModelInputExample = None,
     pip_requirements=None,
     extra_pip_requirements=None,
+    pyfunc_predict_func="predict",
 ):
     """
     Save a scikit-learn model to a path on the local file system. Produces an MLflow Model
@@ -195,6 +196,7 @@ def save_model(
                           base64-encoded.
     :param pip_requirements: {{ pip_requirements }}
     :param extra_pip_requirements: {{ extra_pip_requirements }}
+    :param pyfunc_predict_fun: the name of the prediction function to use; e.g. 'predict_proba'.
 
     .. code-block:: python
         :caption: Example
@@ -254,14 +256,15 @@ def save_model(
         serialization_format=serialization_format,
     )
 
-    # `PyFuncModel` only works for sklearn models that define `predict()`.
-    if hasattr(sk_model, "predict"):
+    # `PyFuncModel` only works for sklearn models that define a predict function
+    if hasattr(sk_model, pyfunc_predict_func):
         pyfunc.add_to_model(
             mlflow_model,
             loader_module="mlflow.sklearn",
             model_path=model_data_subpath,
             env=_CONDA_ENV_FILE_NAME,
             code=code_path_subdir,
+            pyfunc_predict_func=pyfunc_predict_func,
         )
     mlflow_model.add_flavor(
         FLAVOR_NAME,
@@ -320,6 +323,7 @@ def log_model(
     await_registration_for=DEFAULT_AWAIT_MAX_SLEEP_SECONDS,
     pip_requirements=None,
     extra_pip_requirements=None,
+    pyfunc_predict_func="predict",
 ):
     """
     Log a scikit-learn model as an MLflow artifact for the current run. Produces an MLflow Model
@@ -368,6 +372,7 @@ def log_model(
                             waits for five minutes. Specify 0 or None to skip waiting.
     :param pip_requirements: {{ pip_requirements }}
     :param extra_pip_requirements: {{ extra_pip_requirements }}
+    :param pyfunc_predict_func: the prediction function to use for the pyfunc flavor
     :return: A :py:class:`ModelInfo <mlflow.models.model.ModelInfo>` instance that contains the
              metadata of the logged model.
 
@@ -404,6 +409,7 @@ def log_model(
         await_registration_for=await_registration_for,
         pip_requirements=pip_requirements,
         extra_pip_requirements=extra_pip_requirements,
+        pyfunc_predict_func=pyfunc_predict_func,
     )
 
 

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -196,7 +196,8 @@ def save_model(
                           base64-encoded.
     :param pip_requirements: {{ pip_requirements }}
     :param extra_pip_requirements: {{ extra_pip_requirements }}
-    :param pyfunc_predict_fn: The name of the prediction function to use for inference with the pyfunc representation of the resulting MLflow Model; e.g. ``"predict_proba"``.
+    :param pyfunc_predict_fn: The name of the prediction function to use for inference with the
+           pyfunc representation of the resulting MLflow Model; e.g. ``"predict_proba"``.
 
     .. code-block:: python
         :caption: Example
@@ -257,14 +258,14 @@ def save_model(
     )
 
     # `PyFuncModel` only works for sklearn models that define a predict function
-    if hasattr(sk_model, pyfunc_predict_func):
+    if hasattr(sk_model, pyfunc_predict_fn):
         pyfunc.add_to_model(
             mlflow_model,
             loader_module="mlflow.sklearn",
             model_path=model_data_subpath,
             env=_CONDA_ENV_FILE_NAME,
             code=code_path_subdir,
-            predict_fn=pyfunc_predict_func,
+            predict_fn=pyfunc_predict_fn,
         )
     mlflow_model.add_flavor(
         FLAVOR_NAME,
@@ -323,7 +324,7 @@ def log_model(
     await_registration_for=DEFAULT_AWAIT_MAX_SLEEP_SECONDS,
     pip_requirements=None,
     extra_pip_requirements=None,
-    pyfunc_predict_func="predict",
+    pyfunc_predict_fn="predict",
 ):
     """
     Log a scikit-learn model as an MLflow artifact for the current run. Produces an MLflow Model
@@ -372,7 +373,8 @@ def log_model(
                             waits for five minutes. Specify 0 or None to skip waiting.
     :param pip_requirements: {{ pip_requirements }}
     :param extra_pip_requirements: {{ extra_pip_requirements }}
-    :param pyfunc_predict_func: the prediction function to use for the pyfunc flavor
+    :param pyfunc_predict_fn: The name of the prediction function to use for inference with the
+           pyfunc representation of the resulting MLflow Model; e.g. ``"predict_proba"``.
     :return: A :py:class:`ModelInfo <mlflow.models.model.ModelInfo>` instance that contains the
              metadata of the logged model.
 
@@ -409,7 +411,7 @@ def log_model(
         await_registration_for=await_registration_for,
         pip_requirements=pip_requirements,
         extra_pip_requirements=extra_pip_requirements,
-        pyfunc_predict_func=pyfunc_predict_func,
+        pyfunc_predict_fn=pyfunc_predict_fn,
     )
 
 

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -152,7 +152,7 @@ def save_model(
     input_example: ModelInputExample = None,
     pip_requirements=None,
     extra_pip_requirements=None,
-    pyfunc_predict_func="predict",
+    pyfunc_predict_fn="predict",
 ):
     """
     Save a scikit-learn model to a path on the local file system. Produces an MLflow Model

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -258,6 +258,7 @@ def save_model(
     )
 
     # `PyFuncModel` only works for sklearn models that define a predict function
+
     if hasattr(sk_model, pyfunc_predict_fn):
         pyfunc.add_to_model(
             mlflow_model,
@@ -267,6 +268,11 @@ def save_model(
             code=code_path_subdir,
             predict_fn=pyfunc_predict_fn,
         )
+    else:
+        _logger.warning(
+            f"Model was missing function: {pyfunc_predict_fn}. Not logging python_function flavor!"
+        )
+
     mlflow_model.add_flavor(
         FLAVOR_NAME,
         pickled_model=model_data_subpath,

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -264,7 +264,7 @@ def save_model(
             model_path=model_data_subpath,
             env=_CONDA_ENV_FILE_NAME,
             code=code_path_subdir,
-            pyfunc_predict_func=pyfunc_predict_func,
+            predict_fn=pyfunc_predict_func,
         )
     mlflow_model.add_flavor(
         FLAVOR_NAME,

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -196,7 +196,7 @@ def save_model(
                           base64-encoded.
     :param pip_requirements: {{ pip_requirements }}
     :param extra_pip_requirements: {{ extra_pip_requirements }}
-    :param pyfunc_predict_fun: the name of the prediction function to use; e.g. 'predict_proba'.
+    :param pyfunc_predict_fn: The name of the prediction function to use for inference with the pyfunc representation of the resulting MLflow Model; e.g. ``"predict_proba"``.
 
     .. code-block:: python
         :caption: Example

--- a/tests/sklearn/test_sklearn_model_export.py
+++ b/tests/sklearn/test_sklearn_model_export.py
@@ -621,11 +621,12 @@ def test_log_model_with_code_paths(sklearn_knn_model):
 
 def test_log_predict_proba(sklearn_logreg_model):
     model, inference_dataframe = sklearn_logreg_model
+    expected_scores = model.predict_proba(inference_dataframe)
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.sklearn.log_model(model, artifact_path, pyfunc_predict_func="predict_proba")
+        mlflow.sklearn.log_model(model, artifact_path, pyfunc_predict_fn="predict_proba")
         model_uri = mlflow.get_artifact_uri(artifact_path)
 
     loaded_model = pyfunc.load_model(model_uri)
-    scores = loaded_model.predict(inference_dataframe)
-    assert scores.shape[1] == 3
+    actual_scores = loaded_model.predict(inference_dataframe)
+    np.testing.assert_array_almost_equal(expected_scores, actual_scores)

--- a/tests/sklearn/test_sklearn_model_export.py
+++ b/tests/sklearn/test_sklearn_model_export.py
@@ -617,3 +617,15 @@ def test_log_model_with_code_paths(sklearn_knn_model):
         _compare_logged_code_paths(__file__, model_uri, mlflow.sklearn.FLAVOR_NAME)
         mlflow.sklearn.load_model(model_uri=model_uri)
         add_mock.assert_called()
+
+
+def test_log_predict_proba(sklearn_logreg_model):
+    model, inference_dataframe = sklearn_logreg_model
+    artifact_path = "model"
+    with mlflow.start_run():
+        mlflow.sklearn.log_model(model, artifact_path, pyfunc_predict_func="predict_proba")
+        model_uri = mlflow.get_artifact_uri(artifact_path)
+
+    loaded_model = pyfunc.load_model(model_uri)
+    scores = loaded_model.predict(inference_dataframe)
+    assert scores.shape[1] == 3


### PR DESCRIPTION
## Related Issues/PRs
https://github.com/mlflow/mlflow/issues/694

# Improve flexibility of PyFuncModel prediction

## What changes are proposed in this pull request?

Prior to this change, `PyFuncModel` assumes the implemented class has a `predict` function. This is a common interface, notably used in libraries such as `scikit-learn`. However, there are many use cases where we may want to use the `pyfunc` model flavor (as it is flexible!) while customizing the actual predict function used.

A common use case is illustrated in [issue 694](https://github.com/mlflow/mlflow/issues/694); folks want to use the `predict_proba` function instead of `predict`. However, the resolution in that ticket is effectively to have users write their own custom wrappers.

Given that (as far as I can tell), the pyfunc flavor is intended to "unify" underlying base implementations so you can have a similar interface for potentially dissimilar model formats, it seems prudent to allow folks to customize the predict function used without having to write a custom wrapper. Such functionality is demonstrated in this PR for the `sklearn` model logging, but can possibly be leveraged by other model flavors as well.

## How is this patch tested?

A new test is added which failed before implementation.
Existing tests all pass ensuring backwards compatibility.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

Improve flexibility of `PyFuncModel` by allowing predict function override. For example, this can be used to log a `pyfunc` flavor which uses the `scikit-learn` `predict_proba` function instead of `predict`.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
