### PR TITLE
Update documentation for model version `run_link` field

### DIFF
--- a/mlflow/java/client/src/main/java/org/mlflow/api/proto/ModelRegistry.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/api/proto/ModelRegistry.java
@@ -2871,7 +2871,8 @@ public final class ModelRegistry {
 
     /**
      * <pre>
-     * Run Link: Direct link to the run that generated this version. This field is only populated when the tracking server is different from the registry server.
+     * Run Link: Direct link to the run that generated this version. This field is set at model version creation time
+     * only for model versions whose source run is from a tracking server that is different from the registry server.
      * </pre>
      *
      * <code>optional string run_link = 13;</code>
@@ -2880,7 +2881,8 @@ public final class ModelRegistry {
     boolean hasRunLink();
     /**
      * <pre>
-     * Run Link: Direct link to the run that generated this version. This field is only populated when the tracking server is different from the registry server.
+     * Run Link: Direct link to the run that generated this version. This field is set at model version creation time
+     * only for model versions whose source run is from a tracking server that is different from the registry server.
      * </pre>
      *
      * <code>optional string run_link = 13;</code>
@@ -2889,7 +2891,8 @@ public final class ModelRegistry {
     java.lang.String getRunLink();
     /**
      * <pre>
-     * Run Link: Direct link to the run that generated this version. This field is only populated when the tracking server is different from the registry server.
+     * Run Link: Direct link to the run that generated this version. This field is set at model version creation time
+     * only for model versions whose source run is from a tracking server that is different from the registry server.
      * </pre>
      *
      * <code>optional string run_link = 13;</code>
@@ -3704,7 +3707,8 @@ public final class ModelRegistry {
     private volatile java.lang.Object runLink_;
     /**
      * <pre>
-     * Run Link: Direct link to the run that generated this version. This field is only populated when the tracking server is different from the registry server.
+     * Run Link: Direct link to the run that generated this version. This field is set at model version creation time
+     * only for model versions whose source run is from a tracking server that is different from the registry server.
      * </pre>
      *
      * <code>optional string run_link = 13;</code>
@@ -3716,7 +3720,8 @@ public final class ModelRegistry {
     }
     /**
      * <pre>
-     * Run Link: Direct link to the run that generated this version. This field is only populated when the tracking server is different from the registry server.
+     * Run Link: Direct link to the run that generated this version. This field is set at model version creation time
+     * only for model versions whose source run is from a tracking server that is different from the registry server.
      * </pre>
      *
      * <code>optional string run_link = 13;</code>
@@ -3739,7 +3744,8 @@ public final class ModelRegistry {
     }
     /**
      * <pre>
-     * Run Link: Direct link to the run that generated this version. This field is only populated when the tracking server is different from the registry server.
+     * Run Link: Direct link to the run that generated this version. This field is set at model version creation time
+     * only for model versions whose source run is from a tracking server that is different from the registry server.
      * </pre>
      *
      * <code>optional string run_link = 13;</code>
@@ -5768,7 +5774,8 @@ public final class ModelRegistry {
       private java.lang.Object runLink_ = "";
       /**
        * <pre>
-       * Run Link: Direct link to the run that generated this version. This field is only populated when the tracking server is different from the registry server.
+       * Run Link: Direct link to the run that generated this version. This field is set at model version creation time
+       * only for model versions whose source run is from a tracking server that is different from the registry server.
        * </pre>
        *
        * <code>optional string run_link = 13;</code>
@@ -5779,7 +5786,8 @@ public final class ModelRegistry {
       }
       /**
        * <pre>
-       * Run Link: Direct link to the run that generated this version. This field is only populated when the tracking server is different from the registry server.
+       * Run Link: Direct link to the run that generated this version. This field is set at model version creation time
+       * only for model versions whose source run is from a tracking server that is different from the registry server.
        * </pre>
        *
        * <code>optional string run_link = 13;</code>
@@ -5801,7 +5809,8 @@ public final class ModelRegistry {
       }
       /**
        * <pre>
-       * Run Link: Direct link to the run that generated this version. This field is only populated when the tracking server is different from the registry server.
+       * Run Link: Direct link to the run that generated this version. This field is set at model version creation time
+       * only for model versions whose source run is from a tracking server that is different from the registry server.
        * </pre>
        *
        * <code>optional string run_link = 13;</code>
@@ -5822,7 +5831,8 @@ public final class ModelRegistry {
       }
       /**
        * <pre>
-       * Run Link: Direct link to the run that generated this version. This field is only populated when the tracking server is different from the registry server.
+       * Run Link: Direct link to the run that generated this version. This field is set at model version creation time
+       * only for model versions whose source run is from a tracking server that is different from the registry server.
        * </pre>
        *
        * <code>optional string run_link = 13;</code>
@@ -5841,7 +5851,8 @@ public final class ModelRegistry {
       }
       /**
        * <pre>
-       * Run Link: Direct link to the run that generated this version. This field is only populated when the tracking server is different from the registry server.
+       * Run Link: Direct link to the run that generated this version. This field is set at model version creation time
+       * only for model versions whose source run is from a tracking server that is different from the registry server.
        * </pre>
        *
        * <code>optional string run_link = 13;</code>
@@ -5855,7 +5866,8 @@ public final class ModelRegistry {
       }
       /**
        * <pre>
-       * Run Link: Direct link to the run that generated this version. This field is only populated when the tracking server is different from the registry server.
+       * Run Link: Direct link to the run that generated this version. This field is set at model version creation time
+       * only for model versions whose source run is from a tracking server that is different from the registry server.
        * </pre>
        *
        * <code>optional string run_link = 13;</code>

--- a/mlflow/java/client/src/main/java/org/mlflow/api/proto/ModelRegistry.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/api/proto/ModelRegistry.java
@@ -2871,7 +2871,7 @@ public final class ModelRegistry {
 
     /**
      * <pre>
-     * Run Link: Direct link to the run that generated this version
+     * Run Link: Direct link to the run that generated this version. This field is only populated when the tracking server is different from the registry server.
      * </pre>
      *
      * <code>optional string run_link = 13;</code>
@@ -2880,7 +2880,7 @@ public final class ModelRegistry {
     boolean hasRunLink();
     /**
      * <pre>
-     * Run Link: Direct link to the run that generated this version
+     * Run Link: Direct link to the run that generated this version. This field is only populated when the tracking server is different from the registry server.
      * </pre>
      *
      * <code>optional string run_link = 13;</code>
@@ -2889,7 +2889,7 @@ public final class ModelRegistry {
     java.lang.String getRunLink();
     /**
      * <pre>
-     * Run Link: Direct link to the run that generated this version
+     * Run Link: Direct link to the run that generated this version. This field is only populated when the tracking server is different from the registry server.
      * </pre>
      *
      * <code>optional string run_link = 13;</code>
@@ -3704,7 +3704,7 @@ public final class ModelRegistry {
     private volatile java.lang.Object runLink_;
     /**
      * <pre>
-     * Run Link: Direct link to the run that generated this version
+     * Run Link: Direct link to the run that generated this version. This field is only populated when the tracking server is different from the registry server.
      * </pre>
      *
      * <code>optional string run_link = 13;</code>
@@ -3716,7 +3716,7 @@ public final class ModelRegistry {
     }
     /**
      * <pre>
-     * Run Link: Direct link to the run that generated this version
+     * Run Link: Direct link to the run that generated this version. This field is only populated when the tracking server is different from the registry server.
      * </pre>
      *
      * <code>optional string run_link = 13;</code>
@@ -3739,7 +3739,7 @@ public final class ModelRegistry {
     }
     /**
      * <pre>
-     * Run Link: Direct link to the run that generated this version
+     * Run Link: Direct link to the run that generated this version. This field is only populated when the tracking server is different from the registry server.
      * </pre>
      *
      * <code>optional string run_link = 13;</code>
@@ -5768,7 +5768,7 @@ public final class ModelRegistry {
       private java.lang.Object runLink_ = "";
       /**
        * <pre>
-       * Run Link: Direct link to the run that generated this version
+       * Run Link: Direct link to the run that generated this version. This field is only populated when the tracking server is different from the registry server.
        * </pre>
        *
        * <code>optional string run_link = 13;</code>
@@ -5779,7 +5779,7 @@ public final class ModelRegistry {
       }
       /**
        * <pre>
-       * Run Link: Direct link to the run that generated this version
+       * Run Link: Direct link to the run that generated this version. This field is only populated when the tracking server is different from the registry server.
        * </pre>
        *
        * <code>optional string run_link = 13;</code>
@@ -5801,7 +5801,7 @@ public final class ModelRegistry {
       }
       /**
        * <pre>
-       * Run Link: Direct link to the run that generated this version
+       * Run Link: Direct link to the run that generated this version. This field is only populated when the tracking server is different from the registry server.
        * </pre>
        *
        * <code>optional string run_link = 13;</code>
@@ -5822,7 +5822,7 @@ public final class ModelRegistry {
       }
       /**
        * <pre>
-       * Run Link: Direct link to the run that generated this version
+       * Run Link: Direct link to the run that generated this version. This field is only populated when the tracking server is different from the registry server.
        * </pre>
        *
        * <code>optional string run_link = 13;</code>
@@ -5841,7 +5841,7 @@ public final class ModelRegistry {
       }
       /**
        * <pre>
-       * Run Link: Direct link to the run that generated this version
+       * Run Link: Direct link to the run that generated this version. This field is only populated when the tracking server is different from the registry server.
        * </pre>
        *
        * <code>optional string run_link = 13;</code>
@@ -5855,7 +5855,7 @@ public final class ModelRegistry {
       }
       /**
        * <pre>
-       * Run Link: Direct link to the run that generated this version
+       * Run Link: Direct link to the run that generated this version. This field is only populated when the tracking server is different from the registry server.
        * </pre>
        *
        * <code>optional string run_link = 13;</code>

--- a/mlflow/protos/model_registry.proto
+++ b/mlflow/protos/model_registry.proto
@@ -397,7 +397,7 @@ message ModelVersion {
   // Tags: Additional metadata key-value pairs for this ``model_version``.
   repeated ModelVersionTag tags = 12;
 
-  // Run Link: Direct link to the run that generated this version
+  // Run Link: Direct link to the run that generated this version. This field is only populated when the tracking server is different from the registry server.
   optional string run_link = 13;
 }
 

--- a/mlflow/protos/model_registry.proto
+++ b/mlflow/protos/model_registry.proto
@@ -397,7 +397,8 @@ message ModelVersion {
   // Tags: Additional metadata key-value pairs for this ``model_version``.
   repeated ModelVersionTag tags = 12;
 
-  // Run Link: Direct link to the run that generated this version. This field is only populated when the tracking server is different from the registry server.
+  // Run Link: Direct link to the run that generated this version. This field is set at model version creation time
+  // only for model versions whose source run is from a tracking server that is different from the registry server.
   optional string run_link = 13;
 }
 


### PR DESCRIPTION
Signed-off-by: Arpit Jasapara <arpit.jasapara@databricks.com>

## What changes are proposed in this pull request?
The `run_link` field for Model Registry Versions is only populated when the tracking server is different from the registry server. Updating the MLflow REST API docs to reflect this.

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

The `run_link` field for Model Registry Versions is only populated when the tracking server is different from the registry server. Updating the MLflow REST API docs to reflect this.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [X] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [X] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
