### PR TITLE
[ML-24539] add logging for process during split step

### DIFF
--- a/mlflow/pipelines/steps/split.py
+++ b/mlflow/pipelines/steps/split.py
@@ -202,7 +202,7 @@ class SplitStep(BaseStep):
                 importlib.import_module(post_split_module_name), post_split_fn_name
             )
             (train_df, validation_df, test_df) = post_split(train_df, validation_df, test_df)
-
+            _logger.info(f"Running {post_split_fn_name} on train_df, validation_df, and test_df.")
         # Output train / validation / test splits
         train_df.to_parquet(os.path.join(output_directory, _OUTPUT_TRAIN_FILE_NAME))
         validation_df.to_parquet(os.path.join(output_directory, _OUTPUT_VALIDATION_FILE_NAME))

--- a/mlflow/pipelines/steps/split.py
+++ b/mlflow/pipelines/steps/split.py
@@ -201,8 +201,8 @@ class SplitStep(BaseStep):
             post_split = getattr(
                 importlib.import_module(post_split_module_name), post_split_fn_name
             )
-            (train_df, validation_df, test_df) = post_split(train_df, validation_df, test_df)
             _logger.info(f"Running {post_split_fn_name} on train_df, validation_df, and test_df.")
+            (train_df, validation_df, test_df) = post_split(train_df, validation_df, test_df)
         # Output train / validation / test splits
         train_df.to_parquet(os.path.join(output_directory, _OUTPUT_TRAIN_FILE_NAME))
         validation_df.to_parquet(os.path.join(output_directory, _OUTPUT_VALIDATION_FILE_NAME))

--- a/mlflow/pipelines/steps/split.py
+++ b/mlflow/pipelines/steps/split.py
@@ -201,7 +201,7 @@ class SplitStep(BaseStep):
             post_split = getattr(
                 importlib.import_module(post_split_module_name), post_split_fn_name
             )
-            _logger.info(f"Running {post_split_fn_name} on train_df, validation_df, and test_df.")
+            _logger.info(f"Running {post_split_fn_name} on train, validation and test datasets.")
             (train_df, validation_df, test_df) = post_split(train_df, validation_df, test_df)
         # Output train / validation / test splits
         train_df.to_parquet(os.path.join(output_directory, _OUTPUT_TRAIN_FILE_NAME))


### PR DESCRIPTION
Signed-off-by: Prithvi Kannan <prithvi.kannan@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Add logging to indicate that a post split function is applied to the dataset
```
(venv) (base) prithvi.kannan@NR93P4PJF3 mlp-regression-template % mlflow pipelines run -s split -p local
2022/08/29 12:14:46 INFO mlflow.pipelines.pipeline: Creating MLflow Pipeline 'mlp-regression-template' with profile: 'local'
...
2022/08/29 12:14:49 INFO mlflow.pipelines.steps.split: Creating hash buckets on input dataset containing 10000 rows consumes 0.02860403060913086 seconds.
2022/08/29 12:14:49 INFO mlflow.pipelines.steps.split: Running process_splits on train_df, validation_df, and test_df.
2022/08/29 12:14:53 INFO mlflow.pipelines.utils.step: Opening HTML file at: '/Users/prithvi.kannan/.mlflow/pipelines/7b06dd31d05e3ac726d92323678fb44b96b88f7a6d665c19076b325770fc89b1/steps/split/outputs/card.html'

```

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Adds logging output to describe the post split function being run. 

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
