### PR TITLE
Fix command to trigger auto-formatting

### DIFF
--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           result-encoding: string
           script: |
-            return context.payload.comment.body.trim().test(/^@mlflow-automation\s+autoformat$/)
+            return /^@mlflow-automation\s+autoformat$/.test(context.payload.comment.body.trim())
       - name: Create status
         id: create-status
         if: ${{ steps.check-comment.outputs.result == 'true' }}

--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           result-encoding: string
           script: |
-            return context.payload.comment.body.trim() === 'autoformat';
+            return context.payload.comment.body.trim().match(/^@mlflow-automation\s+autoformat$/)
       - name: Create status
         id: create-status
         if: ${{ steps.check-comment.outputs.result == 'true' }}

--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           result-encoding: string
           script: |
-            return context.payload.comment.body.trim().match(/^@mlflow-automation\s+autoformat$/)
+            return context.payload.comment.body.trim().test(/^@mlflow-automation\s+autoformat$/)
       - name: Create status
         id: create-status
         if: ${{ steps.check-comment.outputs.result == 'true' }}

--- a/dev/lint.sh
+++ b/dev/lint.sh
@@ -10,7 +10,7 @@ if [ -z "${GITHUB_ACTIONS}" ]; then
   black --check .
 else
   black --check . > .black-output 2>&1
-  sed 's/^would reformat \(.*\)/\1: This file is unformatted. Run `black .` or comment `autoformat` on the PR to format./' .black-output
+  sed 's/^would reformat \(.*\)/\1: This file is unformatted. Run `black .` or comment `@mlflow-automation autoformat` on the PR to format./' .black-output
 fi
 
 echo -e "\n========== pylint ==========\n"


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

We comment `autoformat` as a command to trigger auto-formatting, but the PR author might not know what `autoformat` means and get confused:

https://github.com/mlflow/mlflow/pull/6570#issuecomment-1225337861

To avoid confusion, include `@mlflow-automation` in the command.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
