### PR TITLE
Make run & experiment deletion / restoration idempotent

### DIFF
--- a/mlflow/entities/run_info.py
+++ b/mlflow/entities/run_info.py
@@ -15,14 +15,6 @@ def check_run_is_active(run_info):
         )
 
 
-def check_run_is_deleted(run_info):
-    if run_info.lifecycle_stage != LifecycleStage.DELETED:
-        raise MlflowException(
-            "The run {} must be in 'deleted' lifecycle_stage.".format(run_info.run_id),
-            error_code=INVALID_PARAMETER_VALUE,
-        )
-
-
 class searchable_attribute(property):
     # Wrapper class over property to designate some of the properties as searchable
     # run attributes

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -22,7 +22,7 @@ from mlflow.entities import (
     ExperimentTag,
 )
 from mlflow.entities.lifecycle_stage import LifecycleStage
-from mlflow.entities.run_info import check_run_is_active, check_run_is_deleted
+from mlflow.entities.run_info import check_run_is_active
 from mlflow.exceptions import MlflowException, MissingConfigException
 from mlflow.protos import databricks_pb2
 from mlflow.protos.databricks_pb2 import (

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -480,7 +480,6 @@ class FileStore(AbstractStore):
             raise MlflowException(
                 "Run '%s' metadata is in invalid state." % run_id, databricks_pb2.INVALID_STATE
             )
-        check_run_is_active(run_info)
         new_info = run_info._copy_with_overrides(lifecycle_stage=LifecycleStage.DELETED)
         self._overwrite_run_info(new_info, deleted_time=int(time.time() * 1000))
 

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -480,6 +480,7 @@ class FileStore(AbstractStore):
             raise MlflowException(
                 "Run '%s' metadata is in invalid state." % run_id, databricks_pb2.INVALID_STATE
             )
+        check_run_is_active(run_info)
         new_info = run_info._copy_with_overrides(lifecycle_stage=LifecycleStage.DELETED)
         self._overwrite_run_info(new_info, deleted_time=int(time.time() * 1000))
 
@@ -518,7 +519,6 @@ class FileStore(AbstractStore):
             raise MlflowException(
                 "Run '%s' metadata is in invalid state." % run_id, databricks_pb2.INVALID_STATE
             )
-        check_run_is_deleted(run_info)
         new_info = run_info._copy_with_overrides(lifecycle_stage=LifecycleStage.ACTIVE)
         self._overwrite_run_info(new_info, deleted_time=None)
 

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -478,7 +478,6 @@ class SqlAlchemyStore(AbstractStore):
             self._save_to_db(objs=experiment, session=session)
 
     def _mark_run_deleted(self, session, run):
-        self._check_run_is_active(run)
         run.lifecycle_stage = LifecycleStage.DELETED
         run.deleted_time = int(time.time() * 1000)
         self._save_to_db(objs=run, session=session)
@@ -645,7 +644,6 @@ class SqlAlchemyStore(AbstractStore):
     def restore_run(self, run_id):
         with self.ManagedSessionMaker() as session:
             run = self._get_run(run_uuid=run_id, session=session)
-            self._check_run_is_deleted(run)
             run.lifecycle_stage = LifecycleStage.ACTIVE
             run.deleted_time = None
             self._save_to_db(objs=run, session=session)
@@ -653,7 +651,6 @@ class SqlAlchemyStore(AbstractStore):
     def delete_run(self, run_id):
         with self.ManagedSessionMaker() as session:
             run = self._get_run(run_uuid=run_id, session=session)
-            self._check_run_is_active(run)
             run.lifecycle_stage = LifecycleStage.DELETED
             run.deleted_time = int(time.time() * 1000)
             self._save_to_db(objs=run, session=session)

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -601,15 +601,6 @@ class SqlAlchemyStore(AbstractStore):
                 INVALID_PARAMETER_VALUE,
             )
 
-    def _check_run_is_deleted(self, run):
-        if run.lifecycle_stage != LifecycleStage.DELETED:
-            raise MlflowException(
-                "The run {} must be in the 'deleted' state. Current state is {}.".format(
-                    run.run_uuid, run.lifecycle_stage
-                ),
-                INVALID_PARAMETER_VALUE,
-            )
-
     def update_run_info(self, run_id, run_status, end_time):
         with self.ManagedSessionMaker() as session:
             run = self._get_run(run_uuid=run_id, session=session)

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -542,10 +542,13 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         _, run_dir = fs._find_run_root(run_id)
         # Should not throw.
         assert fs.get_run(run_id).info.lifecycle_stage == "active"
+        # Verify that run deletion is idempotent by deleting twice
         fs.delete_run(run_id)
         assert fs.get_run(run_id).info.lifecycle_stage == "deleted"
         meta = read_yaml(run_dir, FileStore.META_DATA_FILE_NAME)
         assert "deleted_time" in meta and meta["deleted_time"] is not None
+        # Verify that run restoration is idempotent by restoring twice
+        fs.restore_run(run_id)
         fs.restore_run(run_id)
         assert fs.get_run(run_id).info.lifecycle_stage == "active"
         meta = read_yaml(run_dir, FileStore.META_DATA_FILE_NAME)

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -544,6 +544,7 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         assert fs.get_run(run_id).info.lifecycle_stage == "active"
         # Verify that run deletion is idempotent by deleting twice
         fs.delete_run(run_id)
+        fs.delete_run(run_id)
         assert fs.get_run(run_id).info.lifecycle_stage == "deleted"
         meta = read_yaml(run_dir, FileStore.META_DATA_FILE_NAME)
         assert "deleted_time" in meta and meta["deleted_time"] is not None

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -1249,7 +1249,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
 
         # Verify that active runs can be restored (run restoration is idempotent)
         self.store.restore_run(run.info.run_id)
-    
+
         # Verify that run deletion is idempotent
         self.store.delete_run(run.info.run_id)
         self.store.delete_run(run.info.run_id)

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -259,6 +259,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         experiment_id = self._experiment_factory("test exp")
         run1 = self._run_factory(config=self._get_run_configs(experiment_id)).info.run_id
         run2 = self._run_factory(config=self._get_run_configs(experiment_id)).info.run_id
+        self.store.delete_run(run1)
         run_ids = [run1, run2]
 
         self.store.delete_experiment(experiment_id)
@@ -1246,21 +1247,21 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         run = self._run_factory()
         self.assertEqual(run.info.lifecycle_stage, entities.LifecycleStage.ACTIVE)
 
-        with pytest.raises(MlflowException, match=r"The run .+ must be in the 'deleted' state"):
-            self.store.restore_run(run.info.run_id)
-
+        # Verify that active runs can be restored (run restoration is idempotent)
+        self.store.restore_run(run.info.run_id)
+    
+        # Verify that run deletion is idempotent
         self.store.delete_run(run.info.run_id)
-        with pytest.raises(MlflowException, match=r"The run .+ must be in the 'active' state"):
-            self.store.delete_run(run.info.run_id)
+        self.store.delete_run(run.info.run_id)
 
         deleted = self.store.get_run(run.info.run_id)
         self.assertEqual(deleted.info.run_id, run.info.run_id)
         self.assertEqual(deleted.info.lifecycle_stage, entities.LifecycleStage.DELETED)
         with self.store.ManagedSessionMaker() as session:
             assert self.store._get_run(session, deleted.info.run_id).deleted_time is not None
+        # Verify that restoration of a deleted run is idempotent
         self.store.restore_run(run.info.run_id)
-        with pytest.raises(MlflowException, match=r"The run .+ must be in the 'deleted' state"):
-            self.store.restore_run(run.info.run_id)
+        self.store.restore_run(run.info.run_id)
         restored = self.store.get_run(run.info.run_id)
         self.assertEqual(restored.info.run_id, run.info.run_id)
         self.assertEqual(restored.info.lifecycle_stage, entities.LifecycleStage.ACTIVE)


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

Fixes #6606 

## What changes are proposed in this pull request?

Make run & experiment deletion / restoration idempotent

## How is this patch tested?

Added unit tests

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

Make run & experiment deletion / restoration idempotent

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
