### PR TITLE
Define all pylint-plugin errors in one file

### DIFF
--- a/pylint_plugins/errors.py
+++ b/pylint_plugins/errors.py
@@ -1,0 +1,61 @@
+from typing import NamedTuple, Dict, Tuple
+from functools import reduce
+
+
+class Message(NamedTuple):
+    id: str
+    name: str
+    message: str
+    reason: str
+
+    def to_dict(self) -> Dict[str, Tuple[str, str, str]]:
+        return {self.id: (self.message, self.name, self.reason)}
+
+
+def to_msgs(*messages: Message) -> Dict[str, Tuple[str, str, str]]:
+    return reduce(lambda x, y: {**x, **y.to_dict()}, messages, {})
+
+
+PYTEST_RAISES_WITHOUT_MATCH = Message(
+    id="W0001",
+    name="pytest-raises-without-match",
+    message="`pytest.raises` must be called with `match` argument`.",
+    reason="`pytest.raises` without `match` argument can lead to false positives.",
+)
+
+PRINT_FUNCTION = Message(
+    id="W0002",
+    name="print-function",
+    message="`print()` should not be used. Consider using a logger instead.",
+    reason="`print()` should not be used.",
+)
+
+UNITTEST_PYTEST_RAISES = Message(
+    id="W0003",
+    name="unittest-assert-raises",
+    message="Use `pytest.raises` instead of `unittest.TestCase.assertRaises`.",
+    reason="To enforce 'pytest-raises-multiple-statements' Message.",
+)
+
+PYTEST_RAISES_MULTIPLE_STATEMENTS = Message(
+    id="W0004",
+    name="pytest-raises-multiple-statements",
+    message=(
+        "`with pytest.raises` should not contain multiple statements. "
+        "It should only contain a single statement that throws an exception."
+    ),
+    reason=(
+        "To prevent unreachable assertions and make it easier to tell which line is "
+        "expected to throw."
+    ),
+)
+
+USE_SET_LITERAL = Message(
+    id="W0005",
+    name="use-set-literal",
+    message=(
+        "Use set literal (e.g. `{'a', 'b'}`) instead of applying `set()` on "
+        "list or tuple literal (e.g. `set(['a', 'b'])`)"
+    ),
+    reason="`{1, 2}` is more efficient than `set([1, 2])`.",
+)

--- a/pylint_plugins/pytest_raises_checker/__init__.py
+++ b/pylint_plugins/pytest_raises_checker/__init__.py
@@ -2,6 +2,8 @@ import astroid
 from pylint.interfaces import IAstroidChecker
 from pylint.checkers import BaseChecker
 
+from ..errors import PYTEST_RAISES_WITHOUT_MATCH, PYTEST_RAISES_MULTIPLE_STATEMENTS, to_msgs
+
 
 def _is_pytest_raises_call(node: astroid.NodeNG):
     if not isinstance(node, astroid.Call):
@@ -25,21 +27,7 @@ class PytestRaisesChecker(BaseChecker):
     __implements__ = IAstroidChecker
 
     name = "pytest-raises-checker"
-    WITHOUT_MATCH = "pytest-raises-without-match"
-    MULTIPLE_STATEMENTS = "pytest-raises-multiple-statements"
-    msgs = {
-        "W0001": (
-            "`pytest.raises` must be called with `match` argument`",
-            WITHOUT_MATCH,
-            "Use `pytest.raises(<exception>, match=...)`",
-        ),
-        "W0004": (
-            "`pytest.raises` block should not contain multiple statements."
-            " It should only contain a single statement that throws an exception.",
-            MULTIPLE_STATEMENTS,
-            "Any initialization/finalization code should be moved outside of `pytest.raises` block",
-        ),
-    }
+    msgs = to_msgs(PYTEST_RAISES_WITHOUT_MATCH, PYTEST_RAISES_MULTIPLE_STATEMENTS)
     priority = -1
 
     def visit_call(self, node: astroid.Call):
@@ -47,10 +35,10 @@ class PytestRaisesChecker(BaseChecker):
             return
 
         if not _called_with_match(node):
-            self.add_message(PytestRaisesChecker.WITHOUT_MATCH, node=node)
+            self.add_message(PYTEST_RAISES_WITHOUT_MATCH.name, node=node)
 
     def visit_with(self, node: astroid.With):
         if any(_is_pytest_raises_call(item[0]) for item in node.items) and (
             _contains_multiple_statements(node)
         ):
-            self.add_message(PytestRaisesChecker.MULTIPLE_STATEMENTS, node=node)
+            self.add_message(PYTEST_RAISES_MULTIPLE_STATEMENTS.name, node=node)

--- a/pylint_plugins/set_checker.py
+++ b/pylint_plugins/set_checker.py
@@ -2,20 +2,14 @@ import astroid
 from pylint.interfaces import IAstroidChecker
 from pylint.checkers import BaseChecker
 
+from .errors import USE_SET_LITERAL, to_msgs
+
 
 class SetChecker(BaseChecker):
     __implements__ = IAstroidChecker
 
     name = "set-checker"
-    USE_SET_LITERAL = "use-set-literal"
-    msgs = {
-        "W0005": (
-            "Use set literal (e.g. `{'a', 'b'}`) instead of applying `set()` on list or "
-            "tuple literal (e.g. `set(['a', 'b'])`)",
-            USE_SET_LITERAL,
-            "Use set literal",
-        ),
-    }
+    msgs = to_msgs(USE_SET_LITERAL)
     priority = -1
 
     def visit_call(self, node: astroid.Call):
@@ -24,4 +18,4 @@ class SetChecker(BaseChecker):
             and node.args
             and isinstance(node.args[0], (astroid.List, astroid.Tuple))
         ):
-            self.add_message(SetChecker.USE_SET_LITERAL, node=node)
+            self.add_message(USE_SET_LITERAL.name, node=node)

--- a/pylint_plugins/tests/test_pytest_raises_checker.py
+++ b/pylint_plugins/tests/test_pytest_raises_checker.py
@@ -73,7 +73,7 @@ def test_without_raises(test_case):
     for root_node, error_node, (line, col_offset) in without_raises_bad_cases():
         with test_case.assertAddsMessages(
             MessageTest(
-                test_case.CHECKER_CLASS.WITHOUT_MATCH,
+                "pytest-raises-without-match",
                 node=error_node,
                 line=line,
                 col_offset=col_offset,
@@ -131,7 +131,7 @@ def test_multiple_statements(test_case):
     for root_node, error_node, (line, col_offset) in multiple_statements_bad_cases():
         with test_case.assertAddsMessages(
             MessageTest(
-                test_case.CHECKER_CLASS.MULTIPLE_STATEMENTS,
+                "pytest-raises-multiple-statements",
                 node=error_node,
                 line=line,
                 col_offset=col_offset,

--- a/pylint_plugins/tests/test_set_checker.py
+++ b/pylint_plugins/tests/test_set_checker.py
@@ -19,13 +19,13 @@ def test_case():
 def test_use_set_literal(test_case):
     node = astroid.extract_node("set(['a', 'b'])")
     with test_case.assertAddsMessages(
-        MessageTest(test_case.CHECKER_CLASS.USE_SET_LITERAL, node=node, line=1, col_offset=0)
+        MessageTest("use-set-literal", node=node, line=1, col_offset=0)
     ):
         test_case.walk(node)
 
     node = astroid.extract_node("set(('a', 'b'))")
     with test_case.assertAddsMessages(
-        MessageTest(test_case.CHECKER_CLASS.USE_SET_LITERAL, node=node, line=1, col_offset=0)
+        MessageTest("use-set-literal", node=node, line=1, col_offset=0)
     ):
         test_case.walk(node)
 

--- a/pylint_plugins/unittest_assert_raises.py
+++ b/pylint_plugins/unittest_assert_raises.py
@@ -2,6 +2,8 @@ import astroid
 from pylint.interfaces import IAstroidChecker
 from pylint.checkers import BaseChecker
 
+from .errors import UNITTEST_PYTEST_RAISES, to_msgs
+
 
 def _is_unittest_assert_raises(node: astroid.Call):
     return isinstance(node.func, astroid.Attribute) and (
@@ -13,15 +15,9 @@ class UnittestAssertRaises(BaseChecker):
     __implements__ = IAstroidChecker
 
     name = "unittest-assert-raises"
-    msgs = {
-        "W0003": (
-            "`assertRaises` and `assertRaisesRegex` must be replaced with `pytest.raises`",
-            name,
-            "Use `pytest.raises` instead",
-        ),
-    }
+    msgs = to_msgs(UNITTEST_PYTEST_RAISES)
     priority = -1
 
     def visit_call(self, node: astroid.Call):
         if _is_unittest_assert_raises(node):
-            self.add_message(self.name, node=node)
+            self.add_message(UNITTEST_PYTEST_RAISES.name, node=node)


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Define all the pylint-plugin errors in one file to make it easier to add a new rule.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
