### PR TITLE
Fix bug when reloading modules

### DIFF
--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -122,7 +122,9 @@ def _add_code_to_system_path(code_path):
     # Delete cached modules so they will get reloaded anew from the correct code path
     # Otherwise python will use the cached modules
     modules = [
-        p.stem for p in Path(code_path).rglob("*.py") if p.is_file() and p.name != "__init__.py"
+        p.stem
+        for p in Path(code_path).rglob("*.py")
+        if p.is_file() and p.name != "__init__.py" and p.name != "__main__.py"
     ]
     for module in modules:
         sys.modules.pop(module, None)

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -1,6 +1,7 @@
 import cloudpickle
 import os
 import json
+import sys
 from subprocess import Popen, PIPE
 from unittest import mock
 
@@ -1090,3 +1091,21 @@ def predict():
     assert loaded_model1.predict(model_input) == 1
     loaded_model2 = mlflow.pyfunc.load_model(model_info2.model_uri)
     assert loaded_model2.predict(model_input) == 2
+
+
+def test_model_with_code_path_containing_main(tmp_path):
+    """Test that the __main__ module is unaffected by model loading"""
+    dir = tmp_path.joinpath("model_with_main")
+    dir.mkdir()
+    main = dir.joinpath("__main__.py")
+    main.write_text("# empty main")
+    with mlflow.start_run():
+        model_info = mlflow.pyfunc.log_model(
+            artifact_path="model",
+            python_model=mlflow.pyfunc.model.PythonModel(),
+            code_path=[str(dir)],
+        )
+
+    assert "__main__" in sys.modules
+    mlflow.pyfunc.load_model(model_info.model_uri)
+    assert "__main__" in sys.modules

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -1095,15 +1095,15 @@ def predict():
 
 def test_model_with_code_path_containing_main(tmp_path):
     """Test that the __main__ module is unaffected by model loading"""
-    dir = tmp_path.joinpath("model_with_main")
-    dir.mkdir()
-    main = dir.joinpath("__main__.py")
+    directory = tmp_path.joinpath("model_with_main")
+    directory.mkdir()
+    main = directory.joinpath("__main__.py")
     main.write_text("# empty main")
     with mlflow.start_run():
         model_info = mlflow.pyfunc.log_model(
             artifact_path="model",
             python_model=mlflow.pyfunc.model.PythonModel(),
-            code_path=[str(dir)],
+            code_path=[str(directory)],
         )
 
     assert "__main__" in sys.modules


### PR DESCRIPTION
Signed-off-by: jandersson <joakim.andersson@recordedfuture.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#5926

## What changes are proposed in this pull request?

I had some problem loading a model after upgrading mlflow to 1.27 from 1.26 and got some obscure error message from a 3rd party library (datasets -> dill)
```
 ...
    import datasets
  File "/home/joakim/.virtualenvs/dev-qyrv/lib/python3.8/site-packages/datasets/__init__.py", line 37, in <module>
    from .arrow_dataset import Dataset
  File "/home/joakim/.virtualenvs/dev-qyrv/lib/python3.8/site-packages/datasets/arrow_dataset.py", line 61, in <module>
    from .arrow_reader import ArrowReader
  File "/home/joakim/.virtualenvs/dev-qyrv/lib/python3.8/site-packages/datasets/arrow_reader.py", line 29, in <module>
    from .download.download_config import DownloadConfig
  File "/home/joakim/.virtualenvs/dev-qyrv/lib/python3.8/site-packages/datasets/download/__init__.py", line 9, in <module>
    from .download_manager import DownloadManager, DownloadMode
  File "/home/joakim/.virtualenvs/dev-qyrv/lib/python3.8/site-packages/datasets/download/download_manager.py", line 32, in <module>
    from ..utils.py_utils import NestedDataStructure, map_nested, size_str
  File "/home/joakim/.virtualenvs/dev-qyrv/lib/python3.8/site-packages/datasets/utils/py_utils.py", line 38, in <module>
    import dill
  File "/home/joakim/.virtualenvs/dev-qyrv/lib/python3.8/site-packages/dill/__init__.py", line 286, in <module>
    from ._dill import dump, dumps, load, loads, dump_session, load_session, \
  File "/home/joakim/.virtualenvs/dev-qyrv/lib/python3.8/site-packages/dill/_dill.py", line 83, in <module>
    import __main__ as _main_module
ModuleNotFoundError: No module named '__main__'
```
After some investigation I found  the reason to be that the code I bundled together with my model artifact had a `__main__.py` file in a module and after the changes in #5926 the `__main__` module that dill imports globally was popped from sys.modules.

This patch avoids popping `__main__` from the sys.modules

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
