### PR TITLE
Deprecate mlflow.sagemaker.deploy() & mlflow.sagemaker.delete()

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -30,7 +30,7 @@ function" flavor that describes how to run the model as a Python function. Howev
 also define and use other flavors. For example, MLflow's :py:mod:`mlflow.sklearn` library allows
 loading models back as a scikit-learn ``Pipeline`` object for use in code that is aware of
 scikit-learn, or as a generic Python function for use in tools that just need to apply the model
-(for example, the ``mlflow sagemaker`` tool for deploying models to Amazon SageMaker).
+(for example, the ``mlflow deployments -t sagemaker`` tool for deploying models to Amazon SageMaker).
 
 All of the flavors that a particular model supports are defined in its ``MLmodel`` file in YAML
 format. For example, :py:mod:`mlflow.sklearn` outputs models as follows:
@@ -67,12 +67,12 @@ can serve a model with the ``python_function`` or the ``crate`` (R Function) fla
 
     mlflow models serve -m my_model
 
-In addition, the ``mlflow sagemaker`` command-line tool can package and deploy models to AWS
+In addition, the ``mlflow deployments`` command-line tool can package and deploy models to AWS
 SageMaker as long as they support the ``python_function`` flavor:
 
 .. code-block:: bash
 
-    mlflow sagemaker deploy -m my_model [other options]
+    mlflow deployments create -t sagemaker -m my_model [other options]
 
 Fields in the MLmodel Format
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1920,12 +1920,14 @@ For more info, see:
 Deploy a ``python_function`` model on Amazon SageMaker
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The :py:mod:`mlflow.sagemaker` module can deploy ``python_function`` models locally in a Docker
-container with SageMaker compatible environment and remotely on SageMaker.
-To deploy remotely to SageMaker you need to set up your environment and user accounts.
-To export a custom model to SageMaker, you need a MLflow-compatible Docker image to be available on Amazon ECR.
-MLflow provides a default Docker image definition; however, it is up to you to build the image and upload it to ECR.
-MLflow includes the utility function ``build_and_push_container`` to perform this step. Once built and uploaded, you can use the MLflow container for all MLflow Models. Model webservers deployed using the :py:mod:`mlflow.sagemaker`
+The :py:mod:`mlflow.deployments` and py:mod:`mlflow.sagemaker` modules can deploy
+``python_function`` models locally in a Docker container with SageMaker compatible environment and
+remotely on SageMaker. To deploy remotely to SageMaker you need to set up your environment and user
+accounts. To export a custom model to SageMaker, you need a MLflow-compatible Docker image to be
+available on Amazon ECR. MLflow provides a default Docker image definition; however, it is up to you
+to build the image and upload it to ECR. MLflow includes the utility function
+``build_and_push_container`` to perform this step. Once built and uploaded, you can use the MLflow
+container for all MLflow Models. Model webservers deployed using the :py:mod:`mlflow.deployments`
 module accept the following data formats as input, depending on the deployment flavor:
 
 * ``python_function``: For this deployment flavor, the endpoint accepts the same formats described
@@ -1939,17 +1941,17 @@ module accept the following data formats as input, depending on the deployment f
 Commands
 ~~~~~~~~~
 
-* :py:func:`run-local <mlflow.sagemaker.run_local>` deploys the model locally in a Docker
-  container. The image and the environment should be identical to how the model would be run
-  remotely and it is therefore useful for testing the model prior to deployment.
+* :py:func:`run-local <mlflow.sagemaker.run_local>` deploys the model locally in a Docker container.
+  The image and the environment should be identical to how the model would be run remotely and it is
+  therefore useful for testing the model prior to deployment.
 
 * `build-and-push-container <cli.html#mlflow-sagemaker-build-and-push-container>`_ builds an MLfLow
   Docker image and uploads it to ECR. The caller must have the correct permissions set up. The image
   is built locally and requires Docker to be present on the machine that performs this step.
 
-* :py:func:`deploy <mlflow.sagemaker.deploy>` deploys the model on Amazon SageMaker. MLflow
-  uploads the Python Function model into S3 and starts an Amazon SageMaker endpoint serving
-  the model.
+* :py:func:`deploy <mlflow.sagemaker.SageMakerDeploymentClient>` deploys the model on Amazon
+  SageMaker. MLflow uploads the Python Function model into S3 and starts an Amazon SageMaker
+  endpoint serving the model.
 
 .. rubric:: Example workflow using the MLflow CLI
 
@@ -1957,7 +1959,7 @@ Commands
 
     mlflow sagemaker build-and-push-container  - build the container (only needs to be called once)
     mlflow sagemaker run-local -m <path-to-model>  - test the model locally
-    mlflow sagemaker deploy <parameters> - deploy the model remotely
+    mlflow deployments -t sagemaker create - deploy the model remotely
 
 
 For more info, see:
@@ -1965,10 +1967,8 @@ For more info, see:
 .. code-block:: bash
 
     mlflow sagemaker --help
-    mlflow sagemaker build-and-push-container --help
     mlflow sagemaker run-local --help
-    mlflow sagemaker deploy --help
-
+    mlflow deployments help -t sagemaker
 
 Export a ``python_function`` model as an Apache Spark UDF
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -30,7 +30,8 @@ function" flavor that describes how to run the model as a Python function. Howev
 also define and use other flavors. For example, MLflow's :py:mod:`mlflow.sklearn` library allows
 loading models back as a scikit-learn ``Pipeline`` object for use in code that is aware of
 scikit-learn, or as a generic Python function for use in tools that just need to apply the model
-(for example, the ``mlflow deployments -t sagemaker`` tool for deploying models to Amazon SageMaker).
+(for example, the ``mlflow deployments`` tool with the option ``-t sagemaker`` for deploying models
+to Amazon SageMaker).
 
 All of the flavors that a particular model supports are defined in its ``MLmodel`` file in YAML
 format. For example, :py:mod:`mlflow.sklearn` outputs models as follows:
@@ -1920,7 +1921,7 @@ For more info, see:
 Deploy a ``python_function`` model on Amazon SageMaker
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The :py:mod:`mlflow.deployments` and py:mod:`mlflow.sagemaker` modules can deploy
+The :py:mod:`mlflow.deployments` and :py:mod:`mlflow.sagemaker` modules can deploy
 ``python_function`` models locally in a Docker container with SageMaker compatible environment and
 remotely on SageMaker. To deploy remotely to SageMaker you need to set up your environment and user
 accounts. To export a custom model to SageMaker, you need a MLflow-compatible Docker image to be
@@ -1941,25 +1942,26 @@ module accept the following data formats as input, depending on the deployment f
 Commands
 ~~~~~~~~~
 
-* :py:func:`run-local <mlflow.sagemaker.run_local>` deploys the model locally in a Docker container.
-  The image and the environment should be identical to how the model would be run remotely and it is
-  therefore useful for testing the model prior to deployment.
+* :py:func:`mlflow sagemaker run-local <mlflow.sagemaker.run_local>` deploys the model locally in a
+  Docker container. The image and the environment should be identical to how the model would be run
+  remotely and it is therefore useful for testing the model prior to deployment.
 
-* `build-and-push-container <cli.html#mlflow-sagemaker-build-and-push-container>`_ builds an MLfLow
-  Docker image and uploads it to ECR. The caller must have the correct permissions set up. The image
-  is built locally and requires Docker to be present on the machine that performs this step.
+* `mlflow sagemaker build-and-push-container <cli.html#mlflow-sagemaker-build-and-push-container>`_
+  builds an MLfLow Docker image and uploads it to ECR. The caller must have the correct permissions
+  set up. The image is built locally and requires Docker to be present on the machine that performs
+  this step.
 
-* :py:func:`deploy <mlflow.sagemaker.SageMakerDeploymentClient>` deploys the model on Amazon
-  SageMaker. MLflow uploads the Python Function model into S3 and starts an Amazon SageMaker
-  endpoint serving the model.
+* :py:func:`mlflow deployments create -t sagemaker <mlflow.sagemaker.SageMakerDeploymentClient.create_deployment>`
+  deploys the model on Amazon SageMaker. MLflow uploads the Python Function model into S3 and starts
+  an Amazon SageMaker endpoint serving the model.
 
 .. rubric:: Example workflow using the MLflow CLI
 
 .. code-block:: bash
 
-    mlflow sagemaker build-and-push-container  - build the container (only needs to be called once)
-    mlflow sagemaker run-local -m <path-to-model>  - test the model locally
-    mlflow deployments -t sagemaker create - deploy the model remotely
+    mlflow sagemaker build-and-push-container  # build the container (only needs to be called once)
+    mlflow sagemaker run-local -m <path-to-model>  # test the model locally
+    mlflow deployments sagemaker create -t  # deploy the model remotely
 
 
 For more info, see:

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -19,7 +19,7 @@ from mlflow.models.model import MLMODEL_FILE_NAME
 from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST, INVALID_PARAMETER_VALUE
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils import get_unique_resource_id
-from mlflow.utils.annotations import experimental
+from mlflow.utils.annotations import experimental, deprecated
 from mlflow.utils.file_utils import TempDir
 from mlflow.models.container import SUPPORTED_FLAVORS as SUPPORTED_DEPLOYMENT_FLAVORS
 from mlflow.models.container import DEPLOYMENT_CONFIG_KEY_FLAVOR_NAME, SERVING_ENVIRONMENT
@@ -160,6 +160,12 @@ def push_image_to_ecr(image=DEFAULT_IMAGE_NAME):
     os.system(cmd)
 
 
+@deprecated(
+    alternative=(
+        "mlflow.deployments.get_deploy_client('sagemaker').create_deployment()"
+        " and mlflow.deployments.get_deploy_client('sagemaker').update_deployment()"
+    )
+)
 def deploy(
     app_name,
     model_uri,
@@ -439,6 +445,7 @@ def deploy(
     return app_name, flavor
 
 
+@deprecated(alternative="mlflow.deployments.get_deploy_client('sagemaker').delete_deployment()")
 def delete(
     app_name,
     region_name="us-west-2",
@@ -2056,7 +2063,7 @@ class SageMakerDeploymentClient(BaseDeploymentClient):
         .. code-block:: python
             :caption: Python example
 
-            from mlflow.sagemaker import SageMakerDeploymentClient
+            from mlflow.deployments import get_deploy_client
 
             vpc_config = {
                 'SecurityGroupIds': [
@@ -2080,7 +2087,7 @@ class SageMakerDeploymentClient(BaseDeploymentClient):
                 timeout_seconds=300,
                 vpc_config=vpc_config
             )
-            client = SageMakerDeploymentClient("sagemaker")
+            client = get_deploy_client("sagemaker")
             client.create_deployment(
                 "my-deployment",
                 model_uri="/mlruns/0/abc/model",
@@ -2269,7 +2276,7 @@ class SageMakerDeploymentClient(BaseDeploymentClient):
         .. code-block:: python
             :caption: Python example
 
-            from mlflow.sagemaker import SageMakerDeploymentClient
+            from mlflow.deployments import get_deploy_client
 
             vpc_config = {
                 'SecurityGroupIds': [
@@ -2302,7 +2309,7 @@ class SageMakerDeploymentClient(BaseDeploymentClient):
                 vpc_config=vpc_config
                 data_capture_config=data_capture_config
             )
-            client = SageMakerDeploymentClient("sagemaker")
+            client = get_deploy_client("sagemaker")
             client.update_deployment(
                 "my-deployment",
                 model_uri="/mlruns/0/abc/model",
@@ -2410,7 +2417,7 @@ class SageMakerDeploymentClient(BaseDeploymentClient):
         .. code-block:: python
             :caption: Python example
 
-            from mlflow.sagemaker import SageMakerDeploymentClient
+            from mlflow.deployments import get_deploy_client
 
             config = dict(
                 assume_role_arn="arn:aws:123:role/assumed_role",
@@ -2419,7 +2426,7 @@ class SageMakerDeploymentClient(BaseDeploymentClient):
                 synchronous=True,
                 timeout_seconds=300
             )
-            client = SageMakerDeploymentClient("sagemaker")
+            client = get_deploy_client("sagemaker")
             client.delete_deployment("my-deployment", config=config)
 
         .. code-block:: bash
@@ -2471,9 +2478,9 @@ class SageMakerDeploymentClient(BaseDeploymentClient):
         .. code-block:: python
             :caption: Python example
 
-            from mlflow.sagemaker import SageMakerDeploymentClient
+            from mlflow.deployments import get_deploy_client
 
-            client = SageMakerDeploymentClient("sagemaker:/us-east-1/arn:aws:123:role/assumed_role")
+            client = get_deploy_client("sagemaker:/us-east-1/arn:aws:123:role/assumed_role")
             client.list_deployments()
 
         .. code-block:: bash
@@ -2514,9 +2521,9 @@ class SageMakerDeploymentClient(BaseDeploymentClient):
         .. code-block:: python
             :caption: Python example
 
-            from mlflow.sagemaker import SageMakerDeploymentClient
+            from mlflow.deployments import get_deploy_client
 
-            client = SageMakerDeploymentClient("sagemaker:/us-east-1/arn:aws:123:role/assumed_role")
+            client = get_deploy_client("sagemaker:/us-east-1/arn:aws:123:role/assumed_role")
             client.get_deployment("my-deployment")
 
         .. code-block:: bash
@@ -2566,10 +2573,10 @@ class SageMakerDeploymentClient(BaseDeploymentClient):
             :caption: Python example
 
             import pandas as pd
-            from mlflow.sagemaker import SageMakerDeploymentClient
+            from mlflow.deployments import get_deploy_client
 
             df = pd.DataFrame(data=[[1, 2, 3]], columns=["feat1", "feat2", "feat3"])
-            client = SageMakerDeploymentClient("sagemaker:/us-east-1/arn:aws:123:role/assumed_role")
+            client = get_deploy_client("sagemaker:/us-east-1/arn:aws:123:role/assumed_role")
             client.predict("my-deployment", df)
 
         .. code-block:: bash

--- a/mlflow/sagemaker/cli.py
+++ b/mlflow/sagemaker/cli.py
@@ -7,7 +7,7 @@ import mlflow
 import mlflow.sagemaker
 from mlflow.sagemaker import DEFAULT_IMAGE_NAME as IMAGE
 from mlflow.utils import cli_args
-from mlflow.utils.annotations import experimental
+from mlflow.utils.annotations import experimental, deprecated
 import mlflow.models.docker_utils
 from mlflow.utils import env_manager as em
 
@@ -111,6 +111,9 @@ def commands():
         " asynchronously using the `--async` flag, this value is ignored."
     ),
 )
+@deprecated(
+    alternative="mlflow deployments create -t sagemaker and mlflow deployments update -t sagemaker"
+)
 def deploy(
     app_name,
     model_uri,
@@ -204,6 +207,7 @@ def deploy(
         " asynchronously using the `--async` flag, this value is ignored."
     ),
 )
+@deprecated(alternative="mlflow deployments delete -t sagemaker")
 def delete(app_name, region_name, archive, asynchronous, timeout):
     """
     Delete the specified application. Unless ``--archive`` is specified, all SageMaker resources


### PR DESCRIPTION
Signed-off-by: dbczumar <corey.zumar@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## What changes are proposed in this pull request?

Deprecate mlflow.sagemaker.deploy() & mlflow.sagemaker.delete() in favor of methods defined on `mlflow.deployments.get_deployment_client('sagemaker')` (`SageMakerDeploymentClient`)

## How is this patch tested?

Existing tests

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

Deprecate mlflow.sagemaker.deploy() & mlflow.sagemaker.delete() in favor of methods defined on `mlflow.deployments.get_deployment_client('sagemaker')` (`SageMakerDeploymentClient`)

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [X] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [X] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [X] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
