### PR TITLE
Remove unnecessary if condition in autoformat workflow

### DIFF
--- a/.github/workflows/autoformat.js
+++ b/.github/workflows/autoformat.js
@@ -35,8 +35,8 @@ const getPullInformation = async (context, github) => {
 };
 
 const createStatus = async (context, github, core) => {
-  const { sha, ref } = await getPullInformation(context, github);
-  if (full_name === 'mlflow/mlflow' && ref === 'master') {
+  const { sha, ref, repository } = await getPullInformation(context, github);
+  if (repository === 'mlflow/mlflow' && ref === 'master') {
     core.setFailed('Running autoformat bot against master branch of mlflow/mlflow is not allowed.');
   }
   await createCommitStatus(context, github, sha, 'pending');

--- a/.github/workflows/autoformat.js
+++ b/.github/workflows/autoformat.js
@@ -13,7 +13,11 @@ const createCommitStatus = async (context, github, sha, state) => {
   });
 };
 
-const createStatus = async (context, github, core) => {
+const shouldAutoformat = (comment) => {
+  return /^@mlflow-automation\s+autoformat$/.test(comment.body.trim());
+};
+
+const getPullInformation = async (context, github) => {
   const { owner, repo } = context.repo;
   const pull_number = context.issue.number;
   const pr = await github.pulls.get({ owner, repo, pull_number });
@@ -22,16 +26,20 @@ const createStatus = async (context, github, core) => {
     ref,
     repo: { full_name },
   } = pr.data.head;
-  await createCommitStatus(context, github, sha, 'pending');
-  if (full_name === 'mlflow/mlflow' && ref === 'master') {
-    core.setFailed('Running autoformat bot against master branch of mlflow/mlflow is not allowed.');
-  }
   return {
     repository: full_name,
     pull_number,
     sha,
     ref,
   };
+};
+
+const createStatus = async (context, github, core) => {
+  const { sha, ref } = await getPullInformation(context, github);
+  if (full_name === 'mlflow/mlflow' && ref === 'master') {
+    core.setFailed('Running autoformat bot against master branch of mlflow/mlflow is not allowed.');
+  }
+  await createCommitStatus(context, github, sha, 'pending');
 };
 
 const updateStatus = async (context, github, sha, needs) => {
@@ -41,6 +49,8 @@ const updateStatus = async (context, github, sha, needs) => {
 };
 
 module.exports = {
+  shouldAutoformat,
+  getPullInformation,
   createStatus,
   updateStatus,
 };

--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -12,36 +12,33 @@ defaults:
 jobs:
   check-comment:
     runs-on: ubuntu-latest
-    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, 'autoformat') }}
+    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '@mlflow-automation') && contains(github.event.comment.body, 'autoformat') }}
     outputs:
-      matched: ${{ steps.check-comment.outputs.result }}
+      should_autoformat: ${{ fromJSON(steps.create-status.outputs.result).shouldAutoformat }}
       repository: ${{ fromJSON(steps.create-status.outputs.result).repository }}
       ref: ${{ fromJSON(steps.create-status.outputs.result).ref }}
       sha: ${{ fromJSON(steps.create-status.outputs.result).sha }}
       pull_number: ${{ fromJSON(steps.create-status.outputs.result).pull_number }}
     steps:
       - uses: actions/checkout@v3
-      - name: Check comment
-        id: check-comment
-        uses: actions/github-script@v4
-        with:
-          result-encoding: string
-          script: |
-            return /^@mlflow-automation\s+autoformat$/.test(context.payload.comment.body.trim())
       - name: Create status
         id: create-status
-        if: ${{ steps.check-comment.outputs.result == 'true' }}
         uses: actions/github-script@v4
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const autoformat = require('./.github/workflows/autoformat.js');
-            return await autoformat.createStatus(context, github, core);
+            const shouldAutoformat = autoformat.shouldAutoformat(context.payload.comment);
+            if (shouldAutoformat) {
+              await autoformat.createStatus(context, github, core);
+            }
+            const pullInfo = await autoformat.getPullInformation();
+            return { ...pullInfo, shouldAutoformat };
 
   check-diff:
     runs-on: ubuntu-latest
     needs: check-comment
-    if: ${{ needs.check-comment.outputs.matched == 'true' }}
+    if: ${{ needs.check-comment.outputs.should_autoformat == 'true' }}
     outputs:
       py_changed: ${{ steps.check-diff.outputs.py_changed }}
       ui_changed: ${{ steps.check-diff.outputs.ui_changed }}
@@ -180,7 +177,7 @@ jobs:
   update-status:
     runs-on: ubuntu-latest
     needs: [check-comment, check-diff, python, ui, apply-patches]
-    if: ${{ always() && needs.check-comment.outputs.matched == 'true' }}
+    if: ${{ always() && needs.check-comment.outputs.should_autoformat == 'true' }}
     steps:
       - uses: actions/checkout@v3
       - name: Update status

--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -32,7 +32,7 @@ jobs:
             if (shouldAutoformat) {
               await autoformat.createStatus(context, github, core);
             }
-            const pullInfo = await autoformat.getPullInformation();
+            const pullInfo = await autoformat.getPullInformation(context, github);
             return { ...pullInfo, shouldAutoformat };
 
   check-diff:

--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -1,3 +1,14 @@
+# How to test this workflow:
+# 1. Create a PR on mlflow/mlflow from your fork.
+# 1. Change the default branch of your fork to the PR branch.
+# 2. Create a GitHub token with full repo permissions.
+# 3. Register the token as a repository secret with name MLFLOW_AUTOMATION_TOKEN in your fork.
+# 4. File a PR that contains formatting issues (e.g. trailing whitespace ) in your fork.
+# 5. Comment '@mlflow-automation autoformat test' (which should NOT trigger auto formatting) on the PR and ensure that the workflow terminates successfully without pushing a commit.
+#    You can check the workflow status on https://github.com/<your github username>/mlflow/actions/workflows/autoformat.yml.
+# 6. Comment '@mlflow-automation autoformat' on the PR and ensure that the workflow pushes a commit to fix the formatting issues.
+# 7. Once you confirm everything works fine, delete the token and repository secret and reset the default branch of your fork to master.
+
 # A workflow to apply autoformatting when a PR is commented with 'autoformat'.
 
 name: Autoformat


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Remove an unnecessary if condition in the autoformat workflow.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
