### PR TITLE
change logic for experiment env variables

### DIFF
--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1635,18 +1635,44 @@ def _get_or_start_run():
 
 def _get_experiment_id_from_env():
     experiment_name = env.get_env(_EXPERIMENT_NAME_ENV_VAR)
+    experiment_id = env.get_env(_EXPERIMENT_ID_ENV_VAR)
     if experiment_name is not None:
         exp = MlflowClient().get_experiment_by_name(experiment_name)
-        return exp.experiment_id if exp else None
-    return env.get_env(_EXPERIMENT_ID_ENV_VAR)
+        if exp:
+            if experiment_id and experiment_id != exp.experiment_id:
+                raise MlflowException(
+                    message=f"The provided environment variable {_EXPERIMENT_ID_ENV_VAR} "
+                    f"`{experiment_id}` does not match the experiment id "
+                    f"`{exp.experiment_id}` for experiment name `{experiment_name}`",
+                    error_code=INVALID_PARAMETER_VALUE,
+                )
+            else:
+                return exp.experiment_id
+        else:
+            raise MlflowException(
+                message=f"The provided environment variable {_EXPERIMENT_NAME_ENV_VAR} "
+                f"`{experiment_name}` does not exist. Create an experiment with this name "
+                f"by using `mlflow.create_experiment(name='{experiment_name}')`",
+                error_code=INVALID_PARAMETER_VALUE,
+            )
+    if experiment_id is not None:
+        try:
+            exp = MlflowClient().get_experiment(experiment_id)
+            return exp.experiment_id
+        except MlflowException as exc:
+            raise MlflowException(
+                message=f"The provided environment variable {_EXPERIMENT_ID_ENV_VAR} "
+                f"`{experiment_id}` does not exist in the tracking server. Provide a valid "
+                f"experiment_id.\nTracker exception: {exc.message}",
+                error_code=INVALID_PARAMETER_VALUE,
+            )
 
 
 def _get_experiment_id():
-    return (
-        _active_experiment_id
-        or _get_experiment_id_from_env()
-        or default_experiment_registry.get_experiment_id()
-    )
+    if _active_experiment_id:
+        return _active_experiment_id
+    else:
+        return _get_experiment_id_from_env() or default_experiment_registry.get_experiment_id()
 
 
 @autologging_integration("mlflow")

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1649,12 +1649,8 @@ def _get_experiment_id_from_env():
             else:
                 return exp.experiment_id
         else:
-            raise MlflowException(
-                message=f"The provided environment variable {_EXPERIMENT_NAME_ENV_VAR} "
-                f"`{experiment_name}` does not exist. Create an experiment with this name "
-                f"by using `mlflow.create_experiment(name='{experiment_name}')`",
-                error_code=INVALID_PARAMETER_VALUE,
-            )
+            experiment_id = MlflowClient().create_experiment(name=experiment_name)
+            return experiment_id
     if experiment_id is not None:
         try:
             exp = MlflowClient().get_experiment(experiment_id)
@@ -1663,9 +1659,9 @@ def _get_experiment_id_from_env():
             raise MlflowException(
                 message=f"The provided environment variable {_EXPERIMENT_ID_ENV_VAR} "
                 f"`{experiment_id}` does not exist in the tracking server. Provide a valid "
-                f"experiment_id.\nTracker exception: {exc.message}",
+                f"experiment_id.",
                 error_code=INVALID_PARAMETER_VALUE,
-            )
+            ) from exc
 
 
 def _get_experiment_id():

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1641,8 +1641,8 @@ def _get_experiment_id_from_env():
         if exp:
             if experiment_id and experiment_id != exp.experiment_id:
                 raise MlflowException(
-                    message=f"The provided environment variable {_EXPERIMENT_ID_ENV_VAR} "
-                    f"`{experiment_id}` does not match the experiment id "
+                    message=f"The provided {_EXPERIMENT_ID_ENV_VAR} environment variable "
+                    f"value `{experiment_id}` does not match the experiment id "
                     f"`{exp.experiment_id}` for experiment name `{experiment_name}`",
                     error_code=INVALID_PARAMETER_VALUE,
                 )
@@ -1657,8 +1657,8 @@ def _get_experiment_id_from_env():
             return exp.experiment_id
         except MlflowException as exc:
             raise MlflowException(
-                message=f"The provided environment variable {_EXPERIMENT_ID_ENV_VAR} "
-                f"`{experiment_id}` does not exist in the tracking server. Provide a valid "
+                message=f"The provided {_EXPERIMENT_ID_ENV_VAR} environment variable "
+                f"value `{experiment_id}` does not exist in the tracking server. Provide a valid "
                 f"experiment_id.",
                 error_code=INVALID_PARAMETER_VALUE,
             ) from exc

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -252,7 +252,7 @@ def test_get_experiment_id_from_env():
         HelperEnv.assert_values(str(random_id), None)
         with pytest.raises(
             MlflowException,
-            match=f"The provided environment variable {_EXPERIMENT_ID_ENV_VAR} `{random_id}` "
+            match=f"The provided {_EXPERIMENT_ID_ENV_VAR} environment variable value `{random_id}` "
             "does not exist in the tracking server",
         ):
             _get_experiment_id_from_env()
@@ -267,7 +267,7 @@ def test_get_experiment_id_from_env():
         HelperEnv.assert_values(str(random_id), name)
         with pytest.raises(
             MlflowException,
-            match=f"The provided environment variable {_EXPERIMENT_ID_ENV_VAR} `{random_id}` "
+            match=f"The provided {_EXPERIMENT_ID_ENV_VAR} environment variable value `{random_id}` "
             "does not match the experiment id",
         ):
             _get_experiment_id_from_env()

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -226,29 +226,21 @@ def test_get_experiment_id_from_env():
         HelperEnv.assert_values(None, name)
         assert _get_experiment_id_from_env() == exp_id
 
-    # set invalid experiment name to env variable and assert raises
+    # create experiment from env name
     with TempDir(chdr=True):
-        invalid_name = "invalid experiment"
-        HelperEnv.set_values(name=invalid_name)
-        HelperEnv.assert_values(None, invalid_name)
-        with pytest.raises(
-            MlflowException,
-            match=f"The provided environment variable {_EXPERIMENT_NAME_ENV_VAR} "
-            f"`invalid experiment` does not exist.",
-        ):
-            _get_experiment_id_from_env()
+        name = "random experiment %d" % random.randint(1, 1e6)
+        HelperEnv.set_values(name=name)
+        HelperEnv.assert_values(None, name)
+        assert MlflowClient().get_experiment_by_name(name) is None
+        assert _get_experiment_id_from_env() is not None
 
-    # assert raises from encapsulating function
+    # assert experiment creation from encapsulating function
     with TempDir(chdr=True):
-        invalid_name = "invalid experiment"
-        HelperEnv.set_values(name=invalid_name)
-        HelperEnv.assert_values(None, invalid_name)
-        with pytest.raises(
-            MlflowException,
-            match=f"The provided environment variable {_EXPERIMENT_NAME_ENV_VAR} "
-            "`invalid experiment` does not exist.",
-        ):
-            _get_experiment_id()
+        name = "random experiment %d" % random.randint(1, 1e6)
+        HelperEnv.set_values(name=name)
+        HelperEnv.assert_values(None, name)
+        assert MlflowClient().get_experiment_by_name(name) is None
+        assert _get_experiment_id() is not None
 
     # assert raises from conflicting experiment_ids
     with TempDir(chdr=True):


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Update the behavior of MLFLOW_EXPERIMENT_NAME and MLFLOW_EXPERIMENT_ID logic such that values provided in either of these variables are validated against the tracking server to ensure that the user's intent is preserved and no silent failures send runs to the default experiment id.

Prior behavior:
If `experiment_name` or `experiment_id` in environment variables does not exist in the tracking server, use the default `experiment_id`.

New behavior:
If an experiment is active, use that experiment (ignore environment variables).
Otherwise:
If `experiment_name` is provided in environment variables, validate that experiment name exists in tracking server. If not, raise an Exception.
If `experiment name` and `experiment_id` are both provided, check that the `experiment_name` is registered in the tracking server AND that the `experiment_id` from the tracking server matches the environment variable `experiment_id`. If not, raise and Exception.
If `experiment_id` is provided, validate tracking server registration. If non-existent, provide a custom exception that explains that the environment variable is what is causing the issue (instead of the general tracking server exception about `experiment_id` not being found).

## How is this patch tested?

Modification to existing test suite for the fluent api.
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [X] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

Update the behavior of MLFLOW_EXPERIMENT_NAME and MLFLOW_EXPERIMENT_ID logic such that values provided in either of these variables are validated against the tracking server to ensure that the user's intent is preserved and no silent failures send runs to the default experiment id.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [X] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
