### PR TITLE
Rename `df` arg in deploy predict abstract method

### DIFF
--- a/mlflow/deployments/base.py
+++ b/mlflow/deployments/base.py
@@ -187,15 +187,13 @@ class BaseDeploymentClient(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def predict(self, deployment_name=None, df=None, endpoint=None):
+    def predict(self, deployment_name=None, data=None, endpoint=None):
         """
-        Compute predictions on the pandas DataFrame ``df`` using the specified deployment.
-        Note that the input/output types of this method matches that of `mlflow pyfunc predict`
-        (we accept a pandas DataFrame as input and return either a pandas DataFrame,
-        pandas Series, or numpy array as output).
+        Compute predictions on input data using the specified deployment.
+        Note that the input/output types of this method matches that of `mlflow pyfunc predict`.
 
         :param deployment_name: Name of deployment to predict against
-        :param df: Pandas DataFrame to use for inference
+        :param data: Input data to be used for inference
         :param endpoint: Endpoint to predict against. May not be supported by all targets
         :return: A pandas DataFrame, pandas Series, or numpy array
         """

--- a/mlflow/deployments/base.py
+++ b/mlflow/deployments/base.py
@@ -189,11 +189,12 @@ class BaseDeploymentClient(abc.ABC):
     @abc.abstractmethod
     def predict(self, deployment_name=None, inputs=None, endpoint=None):
         """
-        Compute predictions on input data using the specified deployment.
-        Note that the input/output types of this method matches that of `mlflow pyfunc predict`.
+        Compute predictions on inputs using the specified deployment or model endpoint.
+        Note that the input/output types of this method match those of `mlflow pyfunc predict`.
 
         :param deployment_name: Name of deployment to predict against
-        :param inputs: Input data (or arguments) used to generate inference from a model endpoint
+        :param inputs: Input data (or arguments) to pass to the deployment or model endpoint for
+                       inference
         :param endpoint: Endpoint to predict against. May not be supported by all targets
         :return: A pandas DataFrame, pandas Series, or numpy array
         """

--- a/mlflow/deployments/base.py
+++ b/mlflow/deployments/base.py
@@ -187,13 +187,13 @@ class BaseDeploymentClient(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def predict(self, deployment_name=None, data=None, endpoint=None):
+    def predict(self, deployment_name=None, inputs=None, endpoint=None):
         """
         Compute predictions on input data using the specified deployment.
         Note that the input/output types of this method matches that of `mlflow pyfunc predict`.
 
         :param deployment_name: Name of deployment to predict against
-        :param data: Input data to be used for inference
+        :param inputs: Input data (or arguments) used to generate inference from a model endpoint
         :param endpoint: Endpoint to predict against. May not be supported by all targets
         :return: A pandas DataFrame, pandas Series, or numpy array
         """

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -2582,7 +2582,7 @@ class SageMakerDeploymentClient(BaseDeploymentClient):
                 message=(f"There was an error while retrieving the deployment: {exc}\n")
             )
 
-    def predict(self, deployment_name=None, df=None, endpoint=None):
+    def predict(self, deployment_name=None, inputs=None, endpoint=None):
         """
         Compute predictions from the specified deployment using the provided PyFunc input.
 
@@ -2597,8 +2597,9 @@ class SageMakerDeploymentClient(BaseDeploymentClient):
         ``sagemaker:/us-east-1/arn:aws:1234:role/assumed_role``.
 
         :param deployment_name: Name of the deployment to predict against.
-        :param df: A PyFunc input, such as a Pandas DataFrame, NumPy array, list, or dictionary.
-                   For a complete list of supported input types, see :ref:`pyfunc-inference-api`.
+        :param inputs: Input data (or arguments) to pass to the deployment or model endpoint for
+                       inference. For a complete list of supported input types, see
+                       :ref:`pyfunc-inference-api`.
         :param endpoint: Endpoint to predict against. Currently unsupported
         :return: A PyFunc output, such as a Pandas DataFrame, Pandas Series, or NumPy array.
                  For a complete list of supported output types, see :ref:`pyfunc-inference-api`.
@@ -2640,7 +2641,7 @@ class SageMakerDeploymentClient(BaseDeploymentClient):
             )
             response = sage_client.invoke_endpoint(
                 EndpointName=deployment_name,
-                Body=json.dumps(_get_jsonable_obj(df, pandas_orient="split")),
+                Body=json.dumps(_get_jsonable_obj(inputs, pandas_orient="split")),
                 ContentType="application/json",
             )
 

--- a/tests/resources/mlflow-test-plugin/mlflow_test_plugin/fake_deployment_plugin.py
+++ b/tests/resources/mlflow-test-plugin/mlflow_test_plugin/fake_deployment_plugin.py
@@ -27,7 +27,7 @@ class PluginDeploymentClient(BaseDeploymentClient):
     def get_deployment(self, name, endpoint=None):
         return {"key1": "val1", "key2": "val2"}
 
-    def predict(self, deployment_name=None, df=None, endpoint=None):
+    def predict(self, deployment_name=None, inputs=None, endpoint=None):
         return "1"
 
     def explain(self, deployment_name=None, df=None, endpoint=None):


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

rename the argument from `df` to `data` to reflect the broad allowable input types for pyfunc deployment serving in the .predict() abstract method.

## How is this patch tested?

Existing tests
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [X] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [X] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
