### PR TITLE
Add `--only-latest` option to `set_matrix.py`

### DIFF
--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -86,9 +86,9 @@ jobs:
             PR_NUMBER="${{ github.event.pull_request.number }}"
             REF_VERSIONS_YAML="https://raw.githubusercontent.com/$REPO/master/mlflow/ml-package-versions.yml"
             CHANGED_FILES="$(python dev/list_changed_files.py --repository $REPO --pr-num $PR_NUMBER)"
-            ENABLE_DEV_TESTS="${{ fromJson(steps.enable-dev-tests.outputs.result).enable_dev_tests }}"
+            ENABLE_DEV_TESTS="${{ fromJson(steps.check-labels.outputs.result).enable_dev_tests }}"
             NO_DEV_FLAG=$([ "$ENABLE_DEV_TESTS" == "true" ] && echo "" || echo "--no-dev")
-            LATEST_ONLY="${{ fromJson(steps.enable-dev-tests.outputs.result).latest_only }}"
+            LATEST_ONLY="${{ fromJson(steps.check-labels.outputs.result).latest_only }}"
             LATEST_ONLY_FLAG=$([ "$LATEST_ONLY" == "true" ] && echo "" || echo "--latest-only")
             python dev/set_matrix.py --ref-versions-yaml $REF_VERSIONS_YAML --changed-files "$CHANGED_FILES" $NO_DEV_FLAG $LATEST_ONLY_FLAG
           elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -89,7 +89,7 @@ jobs:
             ENABLE_DEV_TESTS="${{ fromJson(steps.check-labels.outputs.result).enable_dev_tests }}"
             NO_DEV_FLAG=$([ "$ENABLE_DEV_TESTS" == "true" ] && echo "" || echo "--no-dev")
             ONLY_LATEST="${{ fromJson(steps.check-labels.outputs.result).only_latest }}"
-            ONLY_LATEST_FLAG=$([ "$ONLY_LATEST" == "true" ] && echo "" || echo "--only-latest")
+            ONLY_LATEST_FLAG=$([ "$ONLY_LATEST" == "true" ] && echo "--only-latest" || echo "")
             python dev/set_matrix.py --ref-versions-yaml $REF_VERSIONS_YAML --changed-files "$CHANGED_FILES" $NO_DEV_FLAG $ONLY_LATEST_FLAG
           elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             python dev/set_matrix.py --flavors "${{ github.event.inputs.flavors }}" --versions "${{ github.event.inputs.versions }}"

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -67,7 +67,7 @@ jobs:
               repo: context.repo.repo,
               issue_number: context.issue.number,
             });
-            const labelNames = labels.data(({ name }) => name);
+            const labelNames = labels.data.map(({ name }) => name);
             return {
               enable_dev_tests: labelNames.includes("enable-dev-tests"),
               only_latest: labelNames.includes("only-latest"),

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -70,7 +70,7 @@ jobs:
             const labelNames = labels.data(({ name }) => name);
             return {
               enable_dev_tests: labelNames.includes("enable-dev-tests"),
-              latest_only: labelNames.includes("latest-only"),
+              only_latest: labelNames.includes("only-latest"),
             };
       - name: Test set_matrix.py
         run: |
@@ -88,9 +88,9 @@ jobs:
             CHANGED_FILES="$(python dev/list_changed_files.py --repository $REPO --pr-num $PR_NUMBER)"
             ENABLE_DEV_TESTS="${{ fromJson(steps.check-labels.outputs.result).enable_dev_tests }}"
             NO_DEV_FLAG=$([ "$ENABLE_DEV_TESTS" == "true" ] && echo "" || echo "--no-dev")
-            LATEST_ONLY="${{ fromJson(steps.check-labels.outputs.result).latest_only }}"
-            LATEST_ONLY_FLAG=$([ "$LATEST_ONLY" == "true" ] && echo "" || echo "--latest-only")
-            python dev/set_matrix.py --ref-versions-yaml $REF_VERSIONS_YAML --changed-files "$CHANGED_FILES" $NO_DEV_FLAG $LATEST_ONLY_FLAG
+            ONLY_LATEST="${{ fromJson(steps.check-labels.outputs.result).only_latest }}"
+            ONLY_LATEST_FLAG=$([ "$ONLY_LATEST" == "true" ] && echo "" || echo "--only-latest")
+            python dev/set_matrix.py --ref-versions-yaml $REF_VERSIONS_YAML --changed-files "$CHANGED_FILES" $NO_DEV_FLAG $ONLY_LATEST_FLAG
           elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             python dev/set_matrix.py --flavors "${{ github.event.inputs.flavors }}" --versions "${{ github.event.inputs.versions }}"
           else

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -58,17 +58,20 @@ jobs:
           pip install pytest pytest-cov
       - name: Check labels
         uses: actions/github-script@v4
-        id: enable-dev-tests
+        id: check-labels
         if: ${{ github.event_name == 'pull_request' }}
         with:
-          result-encoding: string
           script: |
             const labels = await github.issues.listLabelsOnIssue({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
             });
-            return labels.data.some(({ name }) => name === "enable-dev-tests");
+            const labelNames = labels.data(({ name }) => name);
+            return {
+              enable_dev_tests: labelNames.includes("enable-dev-tests"),
+              latest_only: labelNames.includes("latest-only"),
+            };
       - name: Test set_matrix.py
         run: |
           python -m pytest --noconftest tests/dev/test_set_matrix.py
@@ -83,9 +86,11 @@ jobs:
             PR_NUMBER="${{ github.event.pull_request.number }}"
             REF_VERSIONS_YAML="https://raw.githubusercontent.com/$REPO/master/mlflow/ml-package-versions.yml"
             CHANGED_FILES="$(python dev/list_changed_files.py --repository $REPO --pr-num $PR_NUMBER)"
-            ENABLE_DEV_TESTS="${{ steps.enable-dev-tests.outputs.result }}"
+            ENABLE_DEV_TESTS="${{ fromJson(steps.enable-dev-tests.outputs.result).enable_dev_tests }}"
             NO_DEV_FLAG=$([ "$ENABLE_DEV_TESTS" == "true" ] && echo "" || echo "--no-dev")
-            python dev/set_matrix.py --ref-versions-yaml $REF_VERSIONS_YAML --changed-files "$CHANGED_FILES" $NO_DEV_FLAG
+            LATEST_ONLY="${{ fromJson(steps.enable-dev-tests.outputs.result).latest_only }}"
+            LATEST_ONLY_FLAG=$([ "$LATEST_ONLY" == "true" ] && echo "" || echo "--latest-only")
+            python dev/set_matrix.py --ref-versions-yaml $REF_VERSIONS_YAML --changed-files "$CHANGED_FILES" $NO_DEV_FLAG $LATEST_ONLY_FLAG
           elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             python dev/set_matrix.py --flavors "${{ github.event.inputs.flavors }}" --versions "${{ github.event.inputs.versions }}"
           else

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -300,7 +300,7 @@ def parse_args(args):
         help="If True, exclude dev versions in the test matrix.",
     )
     parser.add_argument(
-        "--latest-only",
+        "--only-latest",
         action="store_true",
         help=(
             "If True, only test the latest version of each group. Useful when you want to save "
@@ -417,7 +417,7 @@ def generate_matrix(args):
     if args.flavors:
         matrix = filter(lambda x: x.flavor in args.flavors, matrix)
 
-    if args.latest_only:
+    if args.only_latest:
         groups = defaultdict(list)
         for item in matrix:
             groups[(item.name, item.category)].append(item)

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -32,6 +32,7 @@ import re
 import shutil
 import functools
 import typing as t
+from collections import defaultdict
 
 import yaml
 import requests
@@ -298,6 +299,14 @@ def parse_args(args):
         default=False,
         help="If True, exclude dev versions in the test matrix.",
     )
+    parser.add_argument(
+        "--latest-only",
+        action="store_true",
+        help=(
+            "If True, only test the latest version of each group. Useful when you want to save "
+            "the number of GitHub Action runs."
+        ),
+    )
 
     return parser.parse_args(args)
 
@@ -408,8 +417,11 @@ def generate_matrix(args):
     if args.flavors:
         matrix = filter(lambda x: x.flavor in args.flavors, matrix)
 
-    if args.versions:
-        matrix = filter(lambda x: x.version in map(Version, args.versions), matrix)
+    if args.latest_only:
+        groups = defaultdict(list)
+        for item in matrix:
+            groups[(item.name, item.category)].append(item)
+        matrix = {max(group, key=lambda x: x.version) for group in groups.values()}
 
     return set(matrix)
 

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -303,8 +303,8 @@ def parse_args(args):
         "--only-latest",
         action="store_true",
         help=(
-            "If True, only test the latest version of each group. Useful when you want to save "
-            "the number of GitHub Action runs."
+            "If True, only test the latest version of each group. Useful when you want to avoid "
+            "running too many GitHub Action jobs."
         ),
     )
 

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -418,6 +418,9 @@ def generate_matrix(args):
     if args.flavors:
         matrix = filter(lambda x: x.flavor in args.flavors, matrix)
 
+    if args.versions:
+        matrix = filter(lambda x: x.version in map(Version, args.versions), matrix)
+
     if args.only_latest:
         groups = defaultdict(list)
         for item in matrix:

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -302,6 +302,7 @@ def parse_args(args):
     parser.add_argument(
         "--only-latest",
         action="store_true",
+        default=False,
         help=(
             "If True, only test the latest version of each group. Useful when you want to avoid "
             "running too many GitHub Action jobs."


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Add `--latest-only` option to `set_matrix.py` to allow us to save the number of GitHub action runs.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
