### PR TITLE
Add `pos_label` to `mlflow.evaluate`

### DIFF
--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -926,12 +926,13 @@ def evaluate(
         - **log_metrics_with_dataset_info**: A boolean value specifying whether or not to include
           information about the evaluation dataset in the name of each metric logged to MLflow
           Tracking during evaluation, default value is True.
-        - **pos_label**: The positive label used to compute binary classification metrics such as
-          precision, recall, f1, etc (default: ``None``). This parameter is only used for binary
-          classification models. For multi-class classification models, keep this parameter unset
-          (or set to ``None``), and the function will calculate metrics for each label and find
-          their average weighted by support (number of true instances for each label). For
-          regression models, this parameter will be ignored.
+        - **pos_label**: The positive label to use when computing classification metrics such as
+          precision, recall, f1, etc. for binary classification models (default: ``1``). This
+          parameter is only used for binary classification models. For multiclass classification
+          and regression models, this parameter will be ignored.
+        - **average**: The averaging method to use when computing classification metrics such as
+          precision, recall, f1, etc. for multiclass classification model (default: ``'weighted'``).
+          For binary classification and regression models, this parameter will be ignored.
 
      - Limitations of evaluation dataset:
         - For classification tasks, dataset labels are used to infer the total number of classes.

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -926,7 +926,7 @@ def evaluate(
         - **log_metrics_with_dataset_info**: A boolean value specifying whether or not to include
           information about the evaluation dataset in the name of each metric logged to MLflow
           Tracking during evaluation, default value is True.
-        - pos_label: The positive label used to compute binary classification metrics such as
+        - **pos_label**: The positive label used to compute binary classification metrics such as
           precision, recall, f1, etc. This parameter is only used for binary classification model.
           If unspecified, defaults to 1.
 

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -508,7 +508,6 @@ class ModelEvaluator(metaclass=ABCMeta):
         evaluator_config,
         custom_metrics=None,
         baseline_model=None,
-        pos_label=None,
         **kwargs,
     ):
         """
@@ -525,7 +524,6 @@ class ModelEvaluator(metaclass=ABCMeta):
         :param evaluator_config: A dictionary of additional configurations for
                                  the evaluator.
         :param custom_metrics: A list of callable custom metric functions.
-        :param pos_label: The positive label for binary classification models.
         :param kwargs: For forwards compatibility, a placeholder for additional arguments that
                        may be added to the evaluation interface in the future.
         :param baseline_model: (Optional) A string URI referring to a MLflow model with the pyfunc
@@ -782,7 +780,6 @@ def _evaluate(
     evaluator_name_to_conf_map,
     custom_metrics,
     baseline_model,
-    pos_label,
 ):
     """
     The public API "evaluate" will verify argument first, and then pass normalized arguments
@@ -820,7 +817,6 @@ def _evaluate(
                 evaluator_config=config,
                 custom_metrics=custom_metrics,
                 baseline_model=baseline_model,
-                pos_label=pos_label,
             )
             eval_results.append(eval_result)
 
@@ -861,7 +857,6 @@ def evaluate(
     custom_metrics=None,
     validation_thresholds=None,
     baseline_model=None,
-    pos_label=None,
 ):
     """
     Evaluate a PyFunc model on the specified dataset using one or more specified ``evaluators``, and
@@ -931,6 +926,8 @@ def evaluate(
         - **log_metrics_with_dataset_info**: A boolean value specifying whether or not to include
           information about the evaluation dataset in the name of each metric logged to MLflow
           Tracking during evaluation, default value is True.
+        - pos_label: The positive label used to compute binary classification metrics such as
+          precision, recall, f1, etc. This parameter is only used for binary classification model.
 
      - Limitations of evaluation dataset:
         - For classification tasks, dataset labels are used to infer the total number of classes.
@@ -1141,13 +1138,6 @@ thresholds
     :param baseline_model: (Optional) A string URI referring to an MLflow model with the pyfunc
                                       flavor. If specified, the candidate ``model`` is compared to
                                       this baseline for model validation purposes.
-    :param pos_label: The positive label used to compute binary classification metrics such as
-        precision, recall, f1, etc. This parameter is only used for binary classification model
-        - If specified for multi-label model, the evaluation will fail;
-        - If specified for regression model, the parameter will be ignored.
-        For multi-label classification, keep `pos_label` unset (or set to `None`), and the
-        function will calculate metrics for each label and find their average weighted by support
-        (number of true instances for each label).
 
     :return: An :py:class:`mlflow.models.EvaluationResult` instance containing
              metrics of candidate model and baseline model, and artifacts of candidate model.
@@ -1204,7 +1194,6 @@ thresholds
             evaluator_name_to_conf_map=evaluator_name_to_conf_map,
             custom_metrics=custom_metrics,
             baseline_model=baseline_model,
-            pos_label=pos_label,
         )
 
         if not validation_thresholds:

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -927,12 +927,12 @@ def evaluate(
           information about the evaluation dataset in the name of each metric logged to MLflow
           Tracking during evaluation, default value is True.
         - **pos_label**: The positive label to use when computing classification metrics such as
-          precision, recall, f1, etc. for binary classification models (default: ``1``). This
-          parameter is only used for binary classification models. For multiclass classification
-          and regression models, this parameter will be ignored.
+          precision, recall, f1, etc. for binary classification models (default: ``1``). For
+          multiclass classification and regression models, this parameter will be ignored.
         - **average**: The averaging method to use when computing classification metrics such as
-          precision, recall, f1, etc. for multiclass classification model (default: ``'weighted'``).
-          For binary classification and regression models, this parameter will be ignored.
+          precision, recall, f1, etc. for multiclass classification models
+          (default: ``'weighted'``). For binary classification and regression models, this
+          parameter will be ignored.
 
      - Limitations of evaluation dataset:
         - For classification tasks, dataset labels are used to infer the total number of classes.

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -927,11 +927,11 @@ def evaluate(
           information about the evaluation dataset in the name of each metric logged to MLflow
           Tracking during evaluation, default value is True.
         - **pos_label**: The positive label used to compute binary classification metrics such as
-          precision, recall, f1, etc. This parameter is only used for binary classification models.
-          For multi-class classification models, keep `pos_label` unset (or set to `None`), and the
-          function will calculate metrics for each label and find their average weighted by support
-          (number of true instances for each label). For regression models, this parameter will be
-          ignored.
+          precision, recall, f1, etc (default: ``None``). This parameter is only used for binary
+          classification models. For multi-class classification models, keep `pos_label` unset
+          (or set to `None`), and the function will calculate metrics for each label and find their
+          average weighted by support (number of true instances for each label). For regression
+          models, this parameter will be ignored.
 
      - Limitations of evaluation dataset:
         - For classification tasks, dataset labels are used to infer the total number of classes.

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -927,8 +927,8 @@ def evaluate(
           information about the evaluation dataset in the name of each metric logged to MLflow
           Tracking during evaluation, default value is True.
         - **pos_label**: The positive label used to compute binary classification metrics such as
-          precision, recall, f1, etc. This parameter is only used for binary classification model.
-          If unspecified, defaults to 1.
+          precision, recall, f1, etc. This parameter is only used for binary classification models.
+          If unspecified, defaults to ``1``.
 
      - Limitations of evaluation dataset:
         - For classification tasks, dataset labels are used to infer the total number of classes.

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -508,6 +508,7 @@ class ModelEvaluator(metaclass=ABCMeta):
         evaluator_config,
         custom_metrics=None,
         baseline_model=None,
+        pos_label=None,
         **kwargs,
     ):
         """
@@ -524,6 +525,7 @@ class ModelEvaluator(metaclass=ABCMeta):
         :param evaluator_config: A dictionary of additional configurations for
                                  the evaluator.
         :param custom_metrics: A list of callable custom metric functions.
+        :param pos_label: The positive label for binary classification models.
         :param kwargs: For forwards compatibility, a placeholder for additional arguments that
                        may be added to the evaluation interface in the future.
         :param baseline_model: (Optional) A string URI referring to a MLflow model with the pyfunc
@@ -780,6 +782,7 @@ def _evaluate(
     evaluator_name_to_conf_map,
     custom_metrics,
     baseline_model,
+    pos_label,
 ):
     """
     The public API "evaluate" will verify argument first, and then pass normalized arguments
@@ -817,6 +820,7 @@ def _evaluate(
                 evaluator_config=config,
                 custom_metrics=custom_metrics,
                 baseline_model=baseline_model,
+                pos_label=pos_label,
             )
             eval_results.append(eval_result)
 
@@ -857,6 +861,7 @@ def evaluate(
     custom_metrics=None,
     validation_thresholds=None,
     baseline_model=None,
+    pos_label=None,
 ):
     """
     Evaluate a PyFunc model on the specified dataset using one or more specified ``evaluators``, and
@@ -1136,6 +1141,13 @@ thresholds
     :param baseline_model: (Optional) A string URI referring to an MLflow model with the pyfunc
                                       flavor. If specified, the candidate ``model`` is compared to
                                       this baseline for model validation purposes.
+    :param pos_label: The positive label used to compute binary classification metrics such as
+        precision, recall, f1, etc. This parameter is only used for binary classification model
+        - If specified for multi-label model, the evaluation will fail;
+        - If specified for regression model, the parameter will be ignored.
+        For multi-label classification, keep `pos_label` unset (or set to `None`), and the
+        function will calculate metrics for each label and find their average weighted by support
+        (number of true instances for each label).
 
     :return: An :py:class:`mlflow.models.EvaluationResult` instance containing
              metrics of candidate model and baseline model, and artifacts of candidate model.
@@ -1192,6 +1204,7 @@ thresholds
             evaluator_name_to_conf_map=evaluator_name_to_conf_map,
             custom_metrics=custom_metrics,
             baseline_model=baseline_model,
+            pos_label=pos_label,
         )
 
         if not validation_thresholds:

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -928,6 +928,7 @@ def evaluate(
           Tracking during evaluation, default value is True.
         - pos_label: The positive label used to compute binary classification metrics such as
           precision, recall, f1, etc. This parameter is only used for binary classification model.
+          If unspecified, defaults to 1.
 
      - Limitations of evaluation dataset:
         - For classification tasks, dataset labels are used to infer the total number of classes.

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -928,10 +928,10 @@ def evaluate(
           Tracking during evaluation, default value is True.
         - **pos_label**: The positive label used to compute binary classification metrics such as
           precision, recall, f1, etc (default: ``None``). This parameter is only used for binary
-          classification models. For multi-class classification models, keep `pos_label` unset
-          (or set to `None`), and the function will calculate metrics for each label and find their
-          average weighted by support (number of true instances for each label). For regression
-          models, this parameter will be ignored.
+          classification models. For multi-class classification models, keep this parameter unset
+          (or set to ``None``), and the function will calculate metrics for each label and find
+          their average weighted by support (number of true instances for each label). For
+          regression models, this parameter will be ignored.
 
      - Limitations of evaluation dataset:
         - For classification tasks, dataset labels are used to infer the total number of classes.

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -928,7 +928,10 @@ def evaluate(
           Tracking during evaluation, default value is True.
         - **pos_label**: The positive label used to compute binary classification metrics such as
           precision, recall, f1, etc. This parameter is only used for binary classification models.
-          If unspecified, defaults to ``1``.
+          For multi-class classification models, keep `pos_label` unset (or set to `None`), and the
+          function will calculate metrics for each label and find their average weighted by support
+          (number of true instances for each label). For regression models, this parameter will be
+          ignored.
 
      - Limitations of evaluation dataset:
         - For classification tasks, dataset labels are used to infer the total number of classes.

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -972,7 +972,7 @@ class DefaultEvaluator(ModelEvaluator):
             )
             if self.is_binomial:
                 pos_label = self.evaluator_config.get("pos_label", 1)
-                self.metrics.update(_get_binary_classifier_metrics(self.y, self.y_prob, pos_label))
+                self.metrics.update(_get_binary_classifier_metrics(self.y, self.y_pred, pos_label))
                 self._compute_roc_and_pr_curve()
             else:
                 average = self.evaluator_config.get("average", "weighted")

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -147,7 +147,7 @@ def _get_binary_sum_up_label_pred_prob(positive_class_index, positive_class, y, 
     return y_bin, y_pred_bin, y_prob_bin
 
 
-def _get_classifier_per_class_metrics(y, y_pred):
+def _get_classifier_per_class_metrics(y, y_pred, *, pos_label=None):
     """
     get classifier metrics which computing over a specific class.
     For binary classifier, y/y_pred is for the positive class.
@@ -160,9 +160,12 @@ def _get_classifier_per_class_metrics(y, y_pred):
     metrics["false_positives"] = fp
     metrics["false_negatives"] = fn
     metrics["true_positives"] = tp
-    metrics["recall"] = sk_metrics.recall_score(y, y_pred)
-    metrics["precision"] = sk_metrics.precision_score(y, y_pred)
-    metrics["f1_score"] = sk_metrics.f1_score(y, y_pred)
+    average = "weighted" if pos_label is None else "binary"
+    metrics["recall"] = sk_metrics.recall_score(y, y_pred, average=average, pos_label=pos_label)
+    metrics["precision"] = sk_metrics.precision_score(
+        y, y_pred, average=average, pos_label=pos_label
+    )
+    metrics["f1_score"] = sk_metrics.f1_score(y, y_pred, average=average, pos_label=pos_label)
     return metrics
 
 
@@ -184,7 +187,7 @@ def _get_classifier_global_metrics(is_binomial, y, y_pred, y_probs, labels):
     return metrics
 
 
-def _get_classifier_per_class_metrics_collection_df(y, y_pred, labels):
+def _get_classifier_per_class_metrics_collection_df(y, y_pred, *, labels, pos_label):
     per_class_metrics_list = []
     for positive_class_index, positive_class in enumerate(labels):
         (y_bin, y_pred_bin, _,) = _get_binary_sum_up_label_pred_prob(
@@ -192,7 +195,9 @@ def _get_classifier_per_class_metrics_collection_df(y, y_pred, labels):
         )
 
         per_class_metrics = {"positive_class": positive_class}
-        per_class_metrics.update(_get_classifier_per_class_metrics(y_bin, y_pred_bin))
+        per_class_metrics.update(
+            _get_classifier_per_class_metrics(y_bin, y_pred_bin, pos_label=pos_label)
+        )
         per_class_metrics_list.append(per_class_metrics)
 
     return pd.DataFrame(per_class_metrics_list)
@@ -710,7 +715,7 @@ class DefaultEvaluator(ModelEvaluator):
 
     def _log_multiclass_classifier_artifacts(self):
         per_class_metrics_collection_df = _get_classifier_per_class_metrics_collection_df(
-            self.y, self.y_pred, self.label_list
+            self.y, self.y_pred, labels=self.label_list, pos_label=self.pos_label
         )
 
         log_roc_pr_curve = False
@@ -972,7 +977,9 @@ class DefaultEvaluator(ModelEvaluator):
                 )
             )
             if self.is_binomial:
-                self.metrics.update(_get_classifier_per_class_metrics(self.y, self.y_pred))
+                self.metrics.update(
+                    _get_classifier_per_class_metrics(self.y, self.y_pred, pos_label=self.pos_label)
+                )
                 self._compute_roc_and_pr_curve()
         elif self.model_type == "regressor":
             self.metrics.update(_get_regressor_metrics(self.y, self.y_pred))
@@ -1048,6 +1055,7 @@ class DefaultEvaluator(ModelEvaluator):
         evaluator_config,
         custom_metrics=None,
         baseline_model=None,
+        pos_label=None,
         **kwargs,
     ):
         self.dataset = dataset
@@ -1058,6 +1066,7 @@ class DefaultEvaluator(ModelEvaluator):
         self.feature_names = dataset.feature_names
         self.custom_metrics = custom_metrics
         self.y = dataset.labels_data
+        self.pos_label = pos_label
 
         inferred_model_type = _infer_model_type_by_labels(self.y)
 

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -977,7 +977,7 @@ class DefaultEvaluator(ModelEvaluator):
             else:
                 average = self.evaluator_config.get("average", "weighted")
                 self.metrics.update(
-                    _get_multiclass_classifier_metrics(self.y, self.y_prob, average)
+                    _get_multiclass_classifier_metrics(self.y, self.y_pred, average)
                 )
         elif self.model_type == "regressor":
             self.metrics.update(_get_regressor_metrics(self.y, self.y_pred))

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -961,8 +961,6 @@ class DefaultEvaluator(ModelEvaluator):
         """
         Helper method for computing builtin metrics
         """
-        pos_label = self.evaluator_config.get("pos_label", 1)
-        average = self.evaluator_config.get("average", "weighted")
         self._evaluate_sklearn_model_score_if_scorable()
         if self.model_type == "classifier":
             self.metrics.update(
@@ -973,9 +971,11 @@ class DefaultEvaluator(ModelEvaluator):
                 )
             )
             if self.is_binomial:
+                pos_label = self.evaluator_config.get("pos_label", 1)
                 self.metrics.update(_get_binary_classifier_metrics(self.y, self.y_prob, pos_label))
                 self._compute_roc_and_pr_curve()
             else:
+                average = self.evaluator_config.get("average", "weighted")
                 self.metrics.update(
                     _get_multiclass_classifier_metrics(self.y, self.y_prob, average)
                 )

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -147,8 +147,9 @@ def _get_binary_sum_up_label_pred_prob(positive_class_index, positive_class, y, 
     return y_bin, y_pred_bin, y_prob_bin
 
 
-def _get_common_classifier_metrics(y_true, y_pred, average, pos_label):
-    return {
+def _get_common_classifier_metrics(*, y_true, y_pred, y_proba, labels, average, pos_label):
+    metrics = {
+        "example_count": len(y_true),
         "accuracy_score": sk_metrics.accuracy_score(y_true, y_pred),
         "recall_score": sk_metrics.recall_score(
             y_true, y_pred, average=average, pos_label=pos_label
@@ -158,32 +159,41 @@ def _get_common_classifier_metrics(y_true, y_pred, average, pos_label):
         ),
         "f1_score": sk_metrics.f1_score(y_true, y_pred, average=average, pos_label=pos_label),
     }
+    if y_proba is not None:
+        metrics["log_loss"] = sk_metrics.log_loss(y_true, y_proba, labels=labels)
+
+    return metrics
 
 
-def _get_binary_classifier_metrics(y_true, y_pred, pos_label):
+def _get_binary_classifier_metrics(*, y_true, y_pred, y_proba=None, labels=None, pos_label=1):
     tn, fp, fn, tp = sk_metrics.confusion_matrix(y_true, y_pred).ravel()
     return {
         "true_negatives": tn,
         "false_positives": fp,
         "false_negatives": fn,
         "true_positives": tp,
-        **_get_common_classifier_metrics(y_true, y_pred, average="binary", pos_label=pos_label),
+        **_get_common_classifier_metrics(
+            y_true=y_true,
+            y_pred=y_pred,
+            y_proba=y_proba,
+            labels=labels,
+            average="binary",
+            pos_label=pos_label,
+        ),
     }
 
 
-def _get_multiclass_classifier_metrics(y_true, y_pred, average):
-    return _get_common_classifier_metrics(y_true, y_pred, average=average, pos_label=None)
-
-
-def _get_classifier_global_metrics(y_true, y_probs, labels):
-    """
-    get classifier metrics which computing over all classes examples.
-    """
-    metrics = {}
-    metrics["example_count"] = len(y_true)
-    if y_probs is not None:
-        metrics["log_loss"] = sk_metrics.log_loss(y_true, y_probs, labels=labels)
-    return metrics
+def _get_multiclass_classifier_metrics(
+    *, y_true, y_pred, y_proba=None, labels=None, average="weighted"
+):
+    return _get_common_classifier_metrics(
+        y_true=y_true,
+        y_pred=y_pred,
+        y_proba=y_proba,
+        labels=labels,
+        average=average,
+        pos_label=None,
+    )
 
 
 def _get_classifier_per_class_metrics_collection_df(y, y_pred, labels):
@@ -193,7 +203,15 @@ def _get_classifier_per_class_metrics_collection_df(y, y_pred, labels):
             positive_class_index, positive_class, y, y_pred, None
         )
         per_class_metrics = {"positive_class": positive_class}
-        per_class_metrics.update(_get_binary_classifier_metrics(y_bin, y_pred_bin, pos_label=1))
+        per_class_metrics.update(
+            _get_binary_classifier_metrics(
+                y_true=y_bin,
+                y_pred=y_pred_bin,
+                y_proba=None,
+                labels=None,
+                pos_label=1,
+            )
+        )
         per_class_metrics_list.append(per_class_metrics)
 
     return pd.DataFrame(per_class_metrics_list)
@@ -963,21 +981,28 @@ class DefaultEvaluator(ModelEvaluator):
         """
         self._evaluate_sklearn_model_score_if_scorable()
         if self.model_type == "classifier":
-            self.metrics.update(
-                _get_classifier_global_metrics(
-                    self.y,
-                    self.y_probs,
-                    self.label_list,
-                )
-            )
             if self.is_binomial:
                 pos_label = self.evaluator_config.get("pos_label", 1)
-                self.metrics.update(_get_binary_classifier_metrics(self.y, self.y_pred, pos_label))
+                self.metrics.update(
+                    _get_binary_classifier_metrics(
+                        y_true=self.y,
+                        y_pred=self.y_pred,
+                        y_proba=self.y_probs,
+                        labels=self.label_list,
+                        pos_label=pos_label,
+                    )
+                )
                 self._compute_roc_and_pr_curve()
             else:
                 average = self.evaluator_config.get("average", "weighted")
                 self.metrics.update(
-                    _get_multiclass_classifier_metrics(self.y, self.y_pred, average)
+                    _get_multiclass_classifier_metrics(
+                        y_true=self.y,
+                        y_pred=self.y_pred,
+                        y_proba=self.y_probs,
+                        labels=self.label_list,
+                        average=average,
+                    )
                 )
         elif self.model_type == "regressor":
             self.metrics.update(_get_regressor_metrics(self.y, self.y_pred))

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -187,7 +187,7 @@ def _get_classifier_global_metrics(is_binomial, y, y_pred, y_probs, labels):
     return metrics
 
 
-def _get_classifier_per_class_metrics_collection_df(y, y_pred, *, labels, pos_label):
+def _get_classifier_per_class_metrics_collection_df(y, y_pred, *, labels):
     per_class_metrics_list = []
     for positive_class_index, positive_class in enumerate(labels):
         (y_bin, y_pred_bin, _,) = _get_binary_sum_up_label_pred_prob(
@@ -196,7 +196,7 @@ def _get_classifier_per_class_metrics_collection_df(y, y_pred, *, labels, pos_la
 
         per_class_metrics = {"positive_class": positive_class}
         per_class_metrics.update(
-            _get_classifier_per_class_metrics(y_bin, y_pred_bin, pos_label=pos_label)
+            _get_classifier_per_class_metrics(y_bin, y_pred_bin, pos_label=positive_class)
         )
         per_class_metrics_list.append(per_class_metrics)
 
@@ -715,7 +715,7 @@ class DefaultEvaluator(ModelEvaluator):
 
     def _log_multiclass_classifier_artifacts(self):
         per_class_metrics_collection_df = _get_classifier_per_class_metrics_collection_df(
-            self.y, self.y_pred, labels=self.label_list, pos_label=self.pos_label
+            self.y, self.y_pred, labels=self.label_list
         )
 
         log_roc_pr_curve = False

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -195,9 +195,7 @@ def _get_classifier_per_class_metrics_collection_df(y, y_pred, *, labels):
         )
 
         per_class_metrics = {"positive_class": positive_class}
-        per_class_metrics.update(
-            _get_classifier_per_class_metrics(y_bin, y_pred_bin, pos_label=positive_class)
-        )
+        per_class_metrics.update(_get_classifier_per_class_metrics(y_bin, y_pred_bin, pos_label=1))
         per_class_metrics_list.append(per_class_metrics)
 
     return pd.DataFrame(per_class_metrics_list)

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -156,8 +156,10 @@ def _get_classifier_metrics(y, y_pred, average, pos_label):
         metrics["false_negatives"] = fn
         metrics["true_positives"] = tp
     metrics["accuracy_score"] = sk_metrics.accuracy_score(y, y_pred)
-    metrics["recall"] = sk_metrics.recall_score(y, y_pred, average=average, pos_label=pos_label)
-    metrics["precision"] = sk_metrics.precision_score(
+    metrics["recall_score"] = sk_metrics.recall_score(
+        y, y_pred, average=average, pos_label=pos_label
+    )
+    metrics["precision_score"] = sk_metrics.precision_score(
         y, y_pred, average=average, pos_label=pos_label
     )
     metrics["f1_score"] = sk_metrics.f1_score(y, y_pred, average=average, pos_label=pos_label)

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -207,8 +207,6 @@ def _get_classifier_per_class_metrics_collection_df(y, y_pred, labels):
             _get_binary_classifier_metrics(
                 y_true=y_bin,
                 y_pred=y_pred_bin,
-                y_proba=None,
-                labels=None,
                 pos_label=1,
             )
         )

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -147,25 +147,6 @@ def _get_binary_sum_up_label_pred_prob(positive_class_index, positive_class, y, 
     return y_bin, y_pred_bin, y_prob_bin
 
 
-def _get_classifier_metrics(y, y_pred, average, pos_label):
-    metrics = {}
-    if average == "binary":
-        tn, fp, fn, tp = sk_metrics.confusion_matrix(y, y_pred).ravel()
-        metrics["true_negatives"] = tn
-        metrics["false_positives"] = fp
-        metrics["false_negatives"] = fn
-        metrics["true_positives"] = tp
-    metrics["accuracy_score"] = sk_metrics.accuracy_score(y, y_pred)
-    metrics["recall_score"] = sk_metrics.recall_score(
-        y, y_pred, average=average, pos_label=pos_label
-    )
-    metrics["precision_score"] = sk_metrics.precision_score(
-        y, y_pred, average=average, pos_label=pos_label
-    )
-    metrics["f1_score"] = sk_metrics.f1_score(y, y_pred, average=average, pos_label=pos_label)
-    return metrics
-
-
 def _get_common_classifier_metrics(y_true, y_pred, average, pos_label):
     return {
         "accuracy_score": sk_metrics.accuracy_score(y_true, y_pred),

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -850,7 +850,7 @@ def test_get_classifier_per_class_metrics():
         "precision": 0.6666666666666666,
         "f1_score": 0.7272727272727272,
     }
-    metrics = _get_classifier_per_class_metrics(y, y_pred, pos_label=1)
+    metrics = _get_classifier_per_class_metrics(y, y_pred)
     assert_dict_equal(metrics, expected_metrics, rtol=1e-3)
 
 
@@ -1581,7 +1581,7 @@ def test_evaluation_metric_name_configs(prefix, log_metrics_with_dataset_info):
     assert all("on_data_iris" not in metric_name for metric_name in result.metrics)
 
 
-@pytest.mark.parametrize("pos_label", [0, 1, None])
+@pytest.mark.parametrize("pos_label", [0, 1])
 def test_evaluation_pos_label(pos_label):
     X, y = load_breast_cancer(as_frame=True, return_X_y=True)
     X = X.iloc[:, :4].head(100)
@@ -1597,7 +1597,7 @@ def test_evaluation_pos_label(pos_label):
             targets="target",
             dataset_name="breast_cancer",
             evaluators="default",
-            pos_label=pos_label,
+            evaluator_config={"pos_label": pos_label},
         )
         y_pred = model.predict(X)
         average = "weighted" if pos_label is None else "binary"

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -1580,7 +1580,7 @@ def test_evaluation_metric_name_configs(prefix, log_metrics_with_dataset_info):
     assert all("on_data_iris" not in metric_name for metric_name in result.metrics)
 
 
-@pytest.mark.parametrize("pos_label", [0, 1])
+@pytest.mark.parametrize("pos_label", [None, 0, 1])
 def test_evaluation_binary_classification_with_pos_label(pos_label):
     X, y = load_breast_cancer(as_frame=True, return_X_y=True)
     X = X.iloc[:, :4].head(100)
@@ -1599,9 +1599,10 @@ def test_evaluation_binary_classification_with_pos_label(pos_label):
             evaluator_config={"pos_label": pos_label},
         )
         y_pred = model.predict(X)
-        precision = precision_score(y, y_pred, pos_label=pos_label)
-        recall = recall_score(y, y_pred, pos_label=pos_label)
-        f1 = f1_score(y, y_pred, pos_label=pos_label)
+        pl = 1 if pos_label is None else 0
+        precision = precision_score(y, y_pred, pos_label=pl)
+        recall = recall_score(y, y_pred, pos_label=pl)
+        f1 = f1_score(y, y_pred, pos_label=pl)
         np.testing.assert_almost_equal(result.metrics["precision_score"], precision)
         np.testing.assert_almost_equal(result.metrics["recall_score"], recall)
         np.testing.assert_almost_equal(result.metrics["f1_score"], f1)

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -850,7 +850,7 @@ def test_get_classifier_per_class_metrics():
         "precision": 0.6666666666666666,
         "f1_score": 0.7272727272727272,
     }
-    metrics = _get_classifier_per_class_metrics(y, y_pred)
+    metrics = _get_classifier_per_class_metrics(y, y_pred, pos_label=1)
     assert_dict_equal(metrics, expected_metrics, rtol=1e-3)
 
 

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -612,7 +612,7 @@ def test_svm_classifier_evaluation(svm_model_uri, breast_cancer_dataset, baselin
     y = breast_cancer_dataset.labels_data
     y_pred = predict_fn(breast_cancer_dataset.features_data)
 
-    expected_metrics = _get_binary_classifier_metrics(y_true=y, y_pred=y_pred, y_proba=None)
+    expected_metrics = _get_binary_classifier_metrics(y_true=y, y_pred=y_pred)
     expected_metrics["score"] = model._model_impl.score(
         breast_cancer_dataset.features_data, breast_cancer_dataset.labels_data
     )
@@ -667,7 +667,7 @@ def test_svm_classifier_evaluation_disable_logging_metrics_and_artifacts(
     y = breast_cancer_dataset.labels_data
     y_pred = predict_fn(breast_cancer_dataset.features_data)
 
-    expected_metrics = _get_binary_classifier_metrics(y_true=y, y_pred=y_pred, y_proba=None)
+    expected_metrics = _get_binary_classifier_metrics(y_true=y, y_pred=y_pred)
     expected_metrics["score"] = model._model_impl.score(
         breast_cancer_dataset.features_data, breast_cancer_dataset.labels_data
     )

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -1599,7 +1599,7 @@ def test_evaluation_binary_classification_with_pos_label(pos_label):
             evaluator_config={"pos_label": pos_label},
         )
         y_pred = model.predict(X)
-        pl = 1 if pos_label is None else 0
+        pl = 1 if pos_label is None else pos_label
         precision = precision_score(y, y_pred, pos_label=pl)
         recall = recall_score(y, y_pred, pos_label=pl)
         f1 = f1_score(y, y_pred, pos_label=pl)

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -36,7 +36,8 @@ import mlflow
 from sklearn.linear_model import LogisticRegression, LinearRegression
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import FunctionTransformer
-from sklearn.datasets import load_iris
+from sklearn.datasets import load_iris, load_breast_cancer
+from sklearn.metrics import precision_score, recall_score, f1_score
 
 from tempfile import TemporaryDirectory
 from os.path import join as path_join
@@ -1578,3 +1579,31 @@ def test_evaluation_metric_name_configs(prefix, log_metrics_with_dataset_info):
 
     # Dataset info should only be included in logged metric names
     assert all("on_data_iris" not in metric_name for metric_name in result.metrics)
+
+
+@pytest.mark.parametrize("pos_label", [0, 1, None])
+def test_evaluation_pos_label(pos_label):
+    X, y = load_breast_cancer(as_frame=True, return_X_y=True)
+    X = X.iloc[:, :4].head(100)
+    y = y.head(len(X))
+    with mlflow.start_run():
+        model = LogisticRegression()
+        model.fit(X, y)
+        model_info = mlflow.sklearn.log_model(model, "model")
+        result = evaluate(
+            model_info.model_uri,
+            X.assign(target=y),
+            model_type="classifier",
+            targets="target",
+            dataset_name="iris",
+            evaluators="default",
+            pos_label=pos_label,
+        )
+        y_pred = model.predict(X)
+        average = "weighted" if pos_label is None else "binary"
+        precision = precision_score(y, y_pred, average=average, pos_label=pos_label)
+        recall = recall_score(y, y_pred, average=average, pos_label=pos_label)
+        f1 = f1_score(y, y_pred, average=average, pos_label=pos_label)
+        np.testing.assert_almost_equal(result.metrics["precision"], precision)
+        np.testing.assert_almost_equal(result.metrics["recall"], recall)
+        np.testing.assert_almost_equal(result.metrics["f1_score"], f1)

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -1595,7 +1595,7 @@ def test_evaluation_pos_label(pos_label):
             X.assign(target=y),
             model_type="classifier",
             targets="target",
-            dataset_name="iris",
+            dataset_name="breast_cancer",
             evaluators="default",
             pos_label=pos_label,
         )

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -1596,16 +1596,16 @@ def test_evaluation_binary_classification_with_pos_label(pos_label):
             targets="target",
             dataset_name="breast_cancer",
             evaluators="default",
-            evaluator_config={"pos_label": pos_label},
+            evaluator_config=None if pos_label is None else {"pos_label": pos_label},
         )
         y_pred = model.predict(X)
         pl = 1 if pos_label is None else pos_label
         precision = precision_score(y, y_pred, pos_label=pl)
         recall = recall_score(y, y_pred, pos_label=pl)
         f1 = f1_score(y, y_pred, pos_label=pl)
-        np.testing.assert_almost_equal(result.metrics["precision_score"], precision)
-        np.testing.assert_almost_equal(result.metrics["recall_score"], recall)
-        np.testing.assert_almost_equal(result.metrics["f1_score"], f1)
+        np.testing.assert_allclose(result.metrics["precision_score"], precision)
+        np.testing.assert_allclose(result.metrics["recall_score"], recall)
+        np.testing.assert_allclose(result.metrics["f1_score"], f1)
 
 
 @pytest.mark.parametrize("average", [None, "weighted", "macro", "micro"])
@@ -1622,13 +1622,13 @@ def test_evaluation_multiclass_classification_with_average(average):
             targets="target",
             dataset_name="iris",
             evaluators="default",
-            evaluator_config={"average": average},
+            evaluator_config=None if average is None else {"average": average},
         )
         y_pred = model.predict(X)
         avg = average or "weighted"
         precision = precision_score(y, y_pred, average=avg)
         recall = recall_score(y, y_pred, average=avg)
         f1 = f1_score(y, y_pred, average=avg)
-        np.testing.assert_almost_equal(result.metrics["precision_score"], precision)
-        np.testing.assert_almost_equal(result.metrics["recall_score"], recall)
-        np.testing.assert_almost_equal(result.metrics["f1_score"], f1)
+        np.testing.assert_allclose(result.metrics["precision_score"], precision)
+        np.testing.assert_allclose(result.metrics["recall_score"], recall)
+        np.testing.assert_allclose(result.metrics["f1_score"], f1)

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -1610,7 +1610,6 @@ def test_evaluation_binary_classification_with_pos_label(pos_label):
 @pytest.mark.parametrize("average", [None, "weighted", "macro", "micro"])
 def test_evaluation_multiclass_classification_with_average(average):
     X, y = load_iris(as_frame=True, return_X_y=True)
-    evaluator_config = {"average": average} if average else None
     with mlflow.start_run():
         model = LogisticRegression()
         model.fit(X, y)
@@ -1622,7 +1621,7 @@ def test_evaluation_multiclass_classification_with_average(average):
             targets="target",
             dataset_name="iris",
             evaluators="default",
-            evaluator_config=evaluator_config,
+            evaluator_config={"average": average},
         )
         y_pred = model.predict(X)
         avg = average or "weighted"

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -1600,10 +1600,9 @@ def test_evaluation_pos_label(pos_label):
             evaluator_config={"pos_label": pos_label},
         )
         y_pred = model.predict(X)
-        average = "weighted" if pos_label is None else "binary"
-        precision = precision_score(y, y_pred, average=average, pos_label=pos_label)
-        recall = recall_score(y, y_pred, average=average, pos_label=pos_label)
-        f1 = f1_score(y, y_pred, average=average, pos_label=pos_label)
+        precision = precision_score(y, y_pred, pos_label=pos_label)
+        recall = recall_score(y, y_pred, pos_label=pos_label)
+        f1 = f1_score(y, y_pred, pos_label=pos_label)
         np.testing.assert_almost_equal(result.metrics["precision"], precision)
         np.testing.assert_almost_equal(result.metrics["recall"], recall)
         np.testing.assert_almost_equal(result.metrics["f1_score"], f1)

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -1620,7 +1620,7 @@ def test_evaluation_multiclass_classification_with_average(average):
             X.assign(target=y),
             model_type="classifier",
             targets="target",
-            dataset_name="breast_cancer",
+            dataset_name="iris",
             evaluators="default",
             evaluator_config=evaluator_config,
         )

--- a/tests/models/test_evaluation.py
+++ b/tests/models/test_evaluation.py
@@ -798,6 +798,7 @@ def test_evaluator_evaluation_interface(multiclass_logistic_regressor_model_uri,
                     evaluator_config=evaluator1_config,
                     custom_metrics=None,
                     baseline_model=None,
+                    pos_label=None,
                 )
 
 
@@ -840,6 +841,7 @@ def test_model_validation_interface_invalid_baseline_model_should_throw(
                 evaluator_config=evaluator1_config,
                 custom_metrics=None,
                 baseline_model=baseline_model_uri,
+                pos_label=None,
             )
 
 
@@ -878,6 +880,7 @@ def test_evaluate_with_multi_evaluators(
             "evaluator_config": evaluator_config,
             "custom_metrics": None,
             "baseline_model": baseline_model,
+            "pos_label": None,
         }
         # evaluators = None is the case evaluators unspecified, it should fetch all registered
         # evaluators, and the evaluation results should equal to the case of

--- a/tests/models/test_evaluation.py
+++ b/tests/models/test_evaluation.py
@@ -798,7 +798,6 @@ def test_evaluator_evaluation_interface(multiclass_logistic_regressor_model_uri,
                     evaluator_config=evaluator1_config,
                     custom_metrics=None,
                     baseline_model=None,
-                    pos_label=None,
                 )
 
 
@@ -841,7 +840,6 @@ def test_model_validation_interface_invalid_baseline_model_should_throw(
                 evaluator_config=evaluator1_config,
                 custom_metrics=None,
                 baseline_model=baseline_model_uri,
-                pos_label=None,
             )
 
 
@@ -880,7 +878,6 @@ def test_evaluate_with_multi_evaluators(
             "evaluator_config": evaluator_config,
             "custom_metrics": None,
             "baseline_model": baseline_model,
-            "pos_label": None,
         }
         # evaluators = None is the case evaluators unspecified, it should fetch all registered
         # evaluators, and the evaluation results should equal to the case of


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Add `pos_label` to `mlflow.evaluate` to provide a way to specify the positive label to use when computing metrics for binary classification.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

- Unit tests
- Manual test

```python
import mlflow
from sklearn.linear_model import LogisticRegression
from sklearn.datasets import load_iris, load_breast_cancer
from sklearn.model_selection import train_test_split
from pprint import pprint
import warnings

warnings.simplefilter("ignore")
client = mlflow.MlflowClient()

# Binary
X, y = load_breast_cancer(return_X_y=True)
X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.33, random_state=42)
model = LogisticRegression().fit(X_train, y_train)

with mlflow.start_run() as run:
    info = mlflow.sklearn.log_model(model, "model")
    result = mlflow.evaluate(
        info.model_uri,
        X_test,
        targets=y_test,
        model_type="classifier",
        dataset_name="binary",
        evaluators="default",
        evaluator_config={"log_model_explainability": False},
    )

print(f"Binary: pos_label = None")
pprint(client.get_run(run.info.run_id).data.metrics)

print("\n" + "=" * 80 + "\n")

with mlflow.start_run() as run:
    info = mlflow.sklearn.log_model(model, "model")
    result = mlflow.evaluate(
        info.model_uri,
        X_test,
        targets=y_test,
        model_type="classifier",
        dataset_name="binary",
        evaluators="default",
        evaluator_config={
            "log_model_explainability": False,
            "pos_label": 1,
        },
    )

print(f"Binary: pos_label = 1s")
pprint(client.get_run(run.info.run_id).data.metrics)

print("\n" + "=" * 80 + "\n")

# Multi-class
X, y = load_iris(return_X_y=True)
X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.33, random_state=42)
model = LogisticRegression().fit(X_train, y_train)

with mlflow.start_run() as run:
    info = mlflow.sklearn.log_model(model, "model")
    result = mlflow.evaluate(
        info.model_uri,
        X_test,
        targets=y_test,
        model_type="classifier",
        dataset_name="multiclass",
        evaluators="default",
        evaluator_config={"log_model_explainability": False},
    )

print(f"Multi-class: pos_label = None")
pprint(client.get_run(run.info.run_id).data.metrics)

```

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.


Add `pos_label` to `mlflow.evaluate` to specify the positive label to use when computing metrics for binary classification.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
