### PR TITLE
[FR] support argument dfs_tmpdir in mlflow.pyspark.ml.autolog

### DIFF
--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -758,6 +758,7 @@ def autolog(
     silent=False,
     log_post_training_metrics=True,
     registered_model_name=None,
+    dfs_tmpdir=None,
     log_input_examples=False,
     log_model_signatures=True,
 ):  # pylint: disable=unused-argument
@@ -877,6 +878,12 @@ def autolog(
     :param registered_model_name: If given, each time a model is trained, it is registered as a
                                   new model version of the registered model with this name.
                                   The registered model is created if it does not already exist.
+    :param dfs_tmpdir: Temporary directory path on Distributed (Hadoop) File System (DFS) or local
+                       filesystem if running in local mode. The model is written in this
+                       destination and then copied into the model's artifact directory. This is
+                       necessary as Spark ML models read from and write to DFS if running on a
+                       cluster. If this operation completes successfully, all temporary files
+                       created on the DFS are removed. Defaults to ``/tmp/mlflow``.
     :param log_input_examples: If ``True``, input examples from training datasets are collected and
                                logged along with pyspark ml model artifacts during training. If
                                ``False``, input examples are not logged.
@@ -1051,6 +1058,7 @@ def autolog(
                 mlflow.spark.log_model(
                     spark_model,
                     artifact_path="model",
+                    dfs_tmpdir=dfs_tmpdir,
                     registered_model_name=registered_model_name,
                     input_example=input_example,
                     signature=signature,
@@ -1059,6 +1067,7 @@ def autolog(
                     mlflow.spark.log_model(
                         spark_model.bestModel,
                         artifact_path="best_model",
+                        dfs_tmpdir=dfs_tmpdir,
                     )
             else:
                 _logger.warning(_get_warning_msg_for_skip_log_model(spark_model))


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
None

## What changes are proposed in this pull request?

`mlflow.spark.log_model` supports customized temporary DFS path with `dfs_tmpdir`, but `mlflow.pyspark.ml.autolog` doesn't support it. However, it's a must for us since the default `/tmp/mlflow` doesn't work in our DFS.

Thus we propose to add param `dfs_tmpdir` to `mlflow.pyspark.ml.autolog`, it will improve the flexibility of `autolog`. Detailed changes are as below:

```diff
diff --git a/mlflow/pyspark/ml/__init__.py b/mlflow/pyspark/ml/__init__.py
index b3c85732..5a13e380 100644
--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -758,6 +758,7 @@ def autolog(
     silent=False,
     log_post_training_metrics=True,
     registered_model_name=None,
+    dfs_tmpdir=None,
     log_input_examples=False,
     log_model_signatures=True,
 ):  # pylint: disable=unused-argument
@@ -877,6 +878,12 @@ def autolog(
     :param registered_model_name: If given, each time a model is trained, it is registered as a
                                   new model version of the registered model with this name.
                                   The registered model is created if it does not already exist.
+    :param dfs_tmpdir: Temporary directory path on Distributed (Hadoop) File System (DFS) or local
+                       filesystem if running in local mode. The model is written in this
+                       destination and then copied into the model's artifact directory. This is
+                       necessary as Spark ML models read from and write to DFS if running on a
+                       cluster. If this operation completes successfully, all temporary files
+                       created on the DFS are removed. Defaults to ``/tmp/mlflow``.
     :param log_input_examples: If ``True``, input examples from training datasets are collected and
                                logged along with pyspark ml model artifacts during training. If
                                ``False``, input examples are not logged.
@@ -1051,6 +1058,7 @@ def autolog(
                 mlflow.spark.log_model(
                     spark_model,
                     artifact_path="model",
+                    dfs_tmpdir=dfs_tmpdir,
                     registered_model_name=registered_model_name,
                     input_example=input_example,
                     signature=signature,
@@ -1059,6 +1067,7 @@ def autolog(
                     mlflow.spark.log_model(
                         spark_model.bestModel,
                         artifact_path="best_model",
+                        dfs_tmpdir=dfs_tmpdir,
                     )
             else:
                 _logger.warning(_get_warning_msg_for_skip_log_model(spark_model))
````

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

Code for current version of mlflow can't log models because `/tmp/mlflow` is not a proper path in our DFS.
```python
mlflow.pyspark.ml.autolog()
```
After applying the PR code, it works well.
```python
mlflow.pyspark.ml.autolog(dfs_tmpdir=<Proper_Path>)
```

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Users now can specify a temporary path `dfs_tmpdir` for DFS or local filesystem when using `mlflow.pyspark.ml.autolog`.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
