### PR TITLE
Change base image to `python:3.7` in `Dockerfile`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,8 @@ RUN apt-get update && \
     apt-get install -y default-libmysqlclient-dev build-essential curl \
     # cmake and protobuf-compiler required for onnx install
     cmake protobuf-compiler &&  \
-    # Without `charset-normalizer=2.0.12`, `conda install` below would fail with:
-    # CondaHTTPError: HTTP 404 NOT FOUND for url <https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-2.0.11-pyhd8ed1ab_0.conda>
-    conda install python=3.7 charset-normalizer=2.0.12 && \
+    conda create -n mlflow-dev-env python=3.7 && \
+    echo "conda activate mlflow-dev-env" >> ~/.bashrc && \
     # install required python packages
     pip install -r requirements/dev-requirements.txt --no-cache-dir && \
     # install mlflow in editable form

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,9 @@ RUN apt-get update && \
     conda create -n mlflow-dev-env python=3.7 && \
     echo "conda activate mlflow-dev-env" >> ~/.bashrc && \
     # install required python packages
-    pip install -r requirements/dev-requirements.txt --no-cache-dir && \
+    conda run -n mlflow-dev-env pip install -r requirements/dev-requirements.txt --no-cache-dir && \
     # install mlflow in editable form
-    pip install --no-cache-dir -e . && \
+    conda run -n mlflow-dev-env pip install --no-cache-dir -e . && \
     # mkdir required to support install openjdk-11-jre-headless
     mkdir -p /usr/share/man/man1 && apt-get install -y openjdk-11-jre-headless
 # Build MLflow UI

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM condaforge/miniforge3
+FROM python:3.7
 
 WORKDIR /app
 
@@ -7,17 +7,14 @@ ADD . /app
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     # install prequired modules to support install of mlflow and related components
-    apt-get install -y default-libmysqlclient-dev build-essential curl \
+    apt-get install -y default-libmysqlclient-dev build-essential curl openjdk-11-jre-headless \
     # cmake and protobuf-compiler required for onnx install
     cmake protobuf-compiler &&  \
-    conda create -n mlflow-dev-env python=3.7 && \
-    echo "conda activate mlflow-dev-env" >> ~/.bashrc && \
     # install required python packages
-    conda run -n mlflow-dev-env pip install -r requirements/dev-requirements.txt --no-cache-dir && \
+    pip install -r requirements/dev-requirements.txt --no-cache-dir && \
     # install mlflow in editable form
-    conda run -n mlflow-dev-env pip install --no-cache-dir -e . && \
-    # mkdir required to support install openjdk-11-jre-headless
-    mkdir -p /usr/share/man/man1 && apt-get install -y openjdk-11-jre-headless
+    pip install --no-cache-dir -e .
+
 # Build MLflow UI
 RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
     apt-get update && apt-get install -y nodejs && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,3 +22,5 @@ RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
     cd mlflow/server/js && \
     yarn install && \
     yarn build
+
+CMD ["bash"]

--- a/dev/Dockerfile.test
+++ b/dev/Dockerfile.test
@@ -9,9 +9,7 @@ RUN apt-get update && \
     apt-get install -y default-libmysqlclient-dev build-essential curl \
     # cmake and protobuf-compiler required for onnx install
     cmake protobuf-compiler &&  \
-    # Without `charset-normalizer=2.0.12`, `conda install` below would fail with:
-    # CondaHTTPError: HTTP 404 NOT FOUND for url <https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-2.0.11-pyhd8ed1ab_0.conda>
-    conda install python=3.7 charset-normalizer=2.0.12 && \
+    conda create -n mlflow-dev-env python=3.7 && \
     # mkdir required to support install openjdk-11-jre-headless
     mkdir -p /usr/share/man/man1 && apt-get install -y openjdk-11-jre-headless
 

--- a/dev/Dockerfile.test
+++ b/dev/Dockerfile.test
@@ -10,6 +10,7 @@ RUN apt-get update && \
     # cmake and protobuf-compiler required for onnx install
     cmake protobuf-compiler &&  \
     conda create -n mlflow-dev-env python=3.7 && \
+    echo "conda activate mlflow-dev-env" >> ~/.bashrc && \
     # mkdir required to support install openjdk-11-jre-headless
     mkdir -p /usr/share/man/man1 && apt-get install -y openjdk-11-jre-headless
 

--- a/dev/Dockerfile.test
+++ b/dev/Dockerfile.test
@@ -16,8 +16,8 @@ RUN apt-get update && \
 
 # Install required python packages first
 ADD requirements /app/requirements
-RUN pip install -r requirements/test-requirements.txt -r requirements/lint-requirements.txt --no-cache-dir
+RUN conda run -n mlflow-dev-env pip install -r requirements/test-requirements.txt -r requirements/lint-requirements.txt --no-cache-dir
 
 # Add the rest of files and install mlflow in editable form + packages necessary for development
 ADD . /app
-RUN pip install --no-cache-dir -e .[pipelines]
+RUN conda run -n mlflow-dev-env pip install --no-cache-dir -e .[pipelines]

--- a/dev/Dockerfile.test
+++ b/dev/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM condaforge/miniforge3
+FROM python:3.7
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -6,18 +6,14 @@ WORKDIR /app
 
 RUN apt-get update && \
     # install prequired modules to support install of mlflow and related components
-    apt-get install -y default-libmysqlclient-dev build-essential curl \
+    apt-get install -y default-libmysqlclient-dev build-essential curl openjdk-11-jre-headless \
     # cmake and protobuf-compiler required for onnx install
-    cmake protobuf-compiler &&  \
-    conda create -n mlflow-dev-env python=3.7 && \
-    echo "conda activate mlflow-dev-env" >> ~/.bashrc && \
-    # mkdir required to support install openjdk-11-jre-headless
-    mkdir -p /usr/share/man/man1 && apt-get install -y openjdk-11-jre-headless
+    cmake protobuf-compiler
 
 # Install required python packages first
 ADD requirements /app/requirements
-RUN conda run -n mlflow-dev-env pip install -r requirements/test-requirements.txt -r requirements/lint-requirements.txt --no-cache-dir
+RUN pip install -r requirements/test-requirements.txt -r requirements/lint-requirements.txt --no-cache-dir
 
 # Add the rest of files and install mlflow in editable form + packages necessary for development
 ADD . /app
-RUN conda run -n mlflow-dev-env pip install --no-cache-dir -e .[pipelines]
+RUN pip install --no-cache-dir -e .[pipelines]

--- a/dev/Dockerfile.test
+++ b/dev/Dockerfile.test
@@ -17,3 +17,5 @@ RUN pip install -r requirements/test-requirements.txt -r requirements/lint-requi
 # Add the rest of files and install mlflow in editable form + packages necessary for development
 ADD . /app
 RUN pip install --no-cache-dir -e .[pipelines]
+
+CMD ["bash"]

--- a/examples/docker/Dockerfile
+++ b/examples/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM condaforge/miniforge3
+FROM python:3.7
 
 RUN pip install mlflow>=1.0 \
     && pip install azure-storage-blob==12.3.0 \

--- a/tests/resources/example_docker_project/Dockerfile
+++ b/tests/resources/example_docker_project/Dockerfile
@@ -4,5 +4,5 @@ RUN apt-get update -y && apt-get install build-essential -y
 RUN echo foo
 RUN conda --version
 RUN conda create -n mlflow-dev-env python=3.7
-RUN echo "conda activate mlflow-dev-env" >> ~/.bashrc && \
-RUN pip install mlflow
+RUN echo "conda activate mlflow-dev-env" >> ~/.bashrc
+RUN conda run -n pip install mlflow

--- a/tests/resources/example_docker_project/Dockerfile
+++ b/tests/resources/example_docker_project/Dockerfile
@@ -1,8 +1,4 @@
-FROM condaforge/miniforge3
+FROM python:3.7
 
 RUN apt-get update -y && apt-get install build-essential -y
-RUN echo foo
-RUN conda --version
-RUN conda create -n mlflow-dev-env python=3.7
-RUN echo "conda activate mlflow-dev-env" >> ~/.bashrc
-RUN conda run -n pip install mlflow
+RUN pip install mlflow

--- a/tests/resources/example_docker_project/Dockerfile
+++ b/tests/resources/example_docker_project/Dockerfile
@@ -3,7 +3,6 @@ FROM condaforge/miniforge3
 RUN apt-get update -y && apt-get install build-essential -y
 RUN echo foo
 RUN conda --version
-# Without `charset-normalizer=2.0.12`, `conda install` below would fail with:
-# CondaHTTPError: HTTP 404 NOT FOUND for url <https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-2.0.11-pyhd8ed1ab_0.conda>
-RUN conda install python=3.7 charset-normalizer=2.0.12
+RUN conda create -n mlflow-dev-env python=3.7
+RUN echo "conda activate mlflow-dev-env" >> ~/.bashrc && \
 RUN pip install mlflow


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Avoid using `condaforge/miniforge3` as a base environment in `Dockerfile` to fix the following error: 

https://github.com/mlflow/mlflow/runs/8189395961?check_suite_focus=true

```
Traceback (most recent call last):
  File "/opt/conda/lib/python3.10/site-packages/conda/exceptions.py", line 1125, in __call__
  File "/opt/conda/lib/python3.10/site-packages/conda/cli/main.py", line 86, in main_subshell
  File "/opt/conda/lib/python3.10/site-packages/conda/cli/conda_argparse.py", line 93, in do_call
  File "/opt/conda/lib/python3.10/site-packages/conda/notices/core.py", line 75, in wrapper
  File "/opt/conda/lib/python3.10/site-packages/conda/notices/core.py", line 39, in display_notices
  File "/opt/conda/lib/python3.10/site-packages/conda/notices/http.py", line 36, in get_notice_responses
  File "/opt/conda/lib/python3.10/site-packages/conda/notices/http.py", line 39, in <genexpr>
  File "/opt/conda/lib/python3.10/concurrent/futures/_base.py", line 621, in result_iterator
  File "/opt/conda/lib/python3.10/concurrent/futures/_base.py", line 319, in _result_or_cancel
  File "/opt/conda/lib/python3.10/concurrent/futures/_base.py", line 458, in result
  File "/opt/conda/lib/python3.10/concurrent/futures/_base.py", line 403, in __get_result
  File "/opt/conda/lib/python3.10/concurrent/futures/thread.py", line 58, in run
  File "/opt/conda/lib/python3.10/site-packages/conda/notices/http.py", line 42, in <lambda>
  File "/opt/conda/lib/python3.10/site-packages/conda/notices/cache.py", line 37, in wrapper
  File "/opt/conda/lib/python3.10/site-packages/conda/notices/http.py", line 58, in get_channel_notice_response
  File "/opt/conda/lib/python3.10/site-packages/requests/sessions.py", line 600, in get
  File "/opt/conda/lib/python3.10/site-packages/requests/sessions.py", line 587, in request
  File "/opt/conda/lib/python3.10/site-packages/requests/sessions.py", line 701, in send
  File "/opt/conda/lib/python3.10/site-packages/requests/adapters.py", line 460, in send
  File "/opt/conda/lib/python3.10/site-packages/requests/adapters.py", line 263, in cert_verify
OSError: Could not find a suitable TLS CA certificate bundle, invalid path: /opt/conda/lib/python3.10/site-packages/certifi/cacert.pem

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/conda/bin/conda", line 13, in <module>
    sys.exit(main())
  File "/opt/conda/lib/python3.10/site-packages/conda/cli/main.py", line 129, in main
  File "/opt/conda/lib/python3.10/site-packages/conda/exceptions.py", line 1413, in conda_exception_handler
  File "/opt/conda/lib/python3.10/site-packages/conda/exceptions.py", line 1128, in __call__
  File "/opt/conda/lib/python3.10/site-packages/conda/exceptions.py", line 1170, in handle_exception
  File "/opt/conda/lib/python3.10/site-packages/conda/exceptions.py", line 1181, in handle_unexpected_exception
  File "/opt/conda/lib/python3.10/site-packages/conda/exceptions.py", line 1251, in print_unexpected_error_report
ModuleNotFoundError: No module named 'conda.cli.main_info'
```

https://github.com/conda-forge/miniforge/issues/341 reports the same error.

In https://github.com/conda-forge/miniforge/issues/341#issuecomment-1234546134, a miniforge maintainer says:

> Why do you need to change the base environment. This isn't supported.



## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
