### PR TITLE
Fix shap plot feature name de-duplication

### DIFF
--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -9,7 +9,7 @@ from mlflow.models.evaluation.base import (
 from mlflow.entities.metric import Metric
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.utils.file_utils import TempDir
-from mlflow.utils.string_utils import truncate_str_from_middle
+from mlflow.utils.string_utils import dedup_string_list, truncate_str_from_middle
 from mlflow.models.utils import plot_lines
 from mlflow.models.evaluation.artifacts import (
     ImageEvaluationArtifact,
@@ -560,11 +560,9 @@ class DefaultEvaluator(ModelEvaluator):
             "explainability_nsamples", _DEFAULT_SAMPLE_ROWS_FOR_SHAP
         )
 
-        truncated_feature_names = [truncate_str_from_middle(f, 20) for f in self.feature_names]
-        for i, truncated_name in enumerate(truncated_feature_names):
-            if truncated_name != self.feature_names[i]:
-                # For duplicated truncated name, attach "(f_{feature_index})" at the end
-                truncated_feature_names[i] = f"{truncated_name}(f_{i + 1})"
+        truncated_feature_names = dedup_string_list(
+            [truncate_str_from_middle(f, 20) for f in self.feature_names]
+        )
 
         truncated_feature_name_map = dict(zip(self.feature_names, truncated_feature_names))
 

--- a/mlflow/utils/string_utils.py
+++ b/mlflow/utils/string_utils.py
@@ -29,3 +29,20 @@ def truncate_str_from_middle(s, max_length):
         left_part_len = (max_length - 3) // 2
         right_part_len = max_length - 3 - left_part_len
         return f"{s[:left_part_len]}...{s[-right_part_len:]}"
+
+
+def dedup_string_list(str_list):
+    """
+    De-duplicate a list of strings. For duplicated strings, add suffix such as (1), (2), etc.
+    """
+    count_dict = {}
+    dedup_list = []
+    for s in str_list:
+        if s not in count_dict:
+            count_dict[s] = 1
+            new_s = s
+        else:
+            count_dict[s] += 1
+            new_s = f"{s}({count_dict[s]})"
+        dedup_list.append(new_s)
+    return dedup_list

--- a/tests/utils/test_string_utils.py
+++ b/tests/utils/test_string_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mlflow.utils.string_utils import strip_prefix, strip_suffix, is_string_type
+from mlflow.utils.string_utils import strip_prefix, strip_suffix, is_string_type, dedup_string_list
 
 
 @pytest.mark.parametrize(
@@ -30,3 +30,15 @@ def test_is_string_type():
     assert not is_string_type({"test": "string"})
     assert not is_string_type(12)
     assert not is_string_type(12.7)
+
+
+def test_dedup_string_list():
+    assert dedup_string_list(["xb", "ab", "xb", "abc", "ab", "xb", "abd"]) == [
+        "xb",
+        "ab",
+        "xb(2)",
+        "abc",
+        "ab(2)",
+        "xb(3)",
+        "abd",
+    ]


### PR DESCRIPTION
Signed-off-by: Weichen Xu <weichen.xu@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Fix shap plot feature name de-duplication.

Before:
It always append suffix `(f_{feature_index})` on truncated names.

After:
Only append suffix `({dup_index}` on duplicated names. 

## How is this patch tested?
Unit tests.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Before:
It always append suffix (f_{feature_index}) on truncated names.

After:
Only append suffix ({dup_index} on duplicated names.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
