### PR TITLE
Remove `tabulate`

### DIFF
--- a/mlflow/experiments.py
+++ b/mlflow/experiments.py
@@ -1,12 +1,13 @@
 import os
 
 import click
-from tabulate import tabulate
 
 import mlflow
 from mlflow.data import is_uri
 from mlflow.entities import ViewType
 from mlflow.tracking import _get_store, fluent
+from mlflow.utils.string_utils import _create_table
+
 
 EXPERIMENT_ID = click.option("--experiment-id", "-x", type=click.STRING, required=True)
 
@@ -71,7 +72,7 @@ def list_experiments(view):
         ]
         for exp in experiments
     ]
-    click.echo(tabulate(sorted(table), headers=["Experiment Id", "Name", "Artifact Location"]))
+    click.echo(_create_table(sorted(table), headers=["Experiment Id", "Name", "Artifact Location"]))
 
 
 @commands.command("delete")

--- a/mlflow/runs.py
+++ b/mlflow/runs.py
@@ -6,9 +6,9 @@ import json
 import mlflow.tracking
 from mlflow.entities import ViewType
 from mlflow.tracking import _get_store
-from tabulate import tabulate
 from mlflow.utils.mlflow_tags import MLFLOW_RUN_NAME
 from mlflow.utils.time_utils import conv_longdate_to_str
+from mlflow.utils.string_utils import _create_table
 
 RUN_ID = click.option("--run-id", type=click.STRING, required=True)
 
@@ -48,7 +48,7 @@ def list_run(experiment_id, view):
     for run in runs:
         run_name = run.data.tags.get(MLFLOW_RUN_NAME, "")
         table.append([conv_longdate_to_str(run.info.start_time), run_name, run.info.run_id])
-    click.echo(tabulate(sorted(table, reverse=True), headers=["Date", "Name", "ID"]))
+    click.echo(_create_table(sorted(table, reverse=True), headers=["Date", "Name", "ID"]))
 
 
 @commands.command("delete")

--- a/mlflow/utils/string_utils.py
+++ b/mlflow/utils/string_utils.py
@@ -1,3 +1,6 @@
+from typing import List
+
+
 def strip_prefix(original, prefix):
     if original.startswith(prefix):
         return original[len(prefix) :]
@@ -29,3 +32,32 @@ def truncate_str_from_middle(s, max_length):
         left_part_len = (max_length - 3) // 2
         right_part_len = max_length - 3 - left_part_len
         return f"{s[:left_part_len]}...{s[-right_part_len:]}"
+
+
+def _create_table(
+    rows: List[List[str]], headers: List[str], column_sep: str = "  ", min_column_width=4
+) -> str:
+    """
+    Creates a table from a list of rows and headers.
+
+    Example
+    =======
+    >>> print(_create_table([["a", "b", "c"], ["d", "e", "f"]], ["x", "y", "z"]))
+    x     y     z
+    ----  ----  ----
+    a     b     c
+    d     e     f
+    """
+    column_widths = [
+        max(len(max(col, key=len)), len(header) + 2, min_column_width)
+        for col, header in zip(zip(*rows), headers)
+    ]
+    aligned_rows = [
+        column_sep.join(header.ljust(width) for header, width in zip(headers, column_widths)),
+        column_sep.join("-" * width for width in column_widths),
+        *(
+            column_sep.join(cell.ljust(width) for cell, width in zip(row, column_widths))
+            for row in rows
+        ),
+    ]
+    return "\n".join(aligned_rows)

--- a/mlflow/utils/string_utils.py
+++ b/mlflow/utils/string_utils.py
@@ -35,7 +35,7 @@ def truncate_str_from_middle(s, max_length):
 
 
 def _create_table(
-    rows: List[List[str]], headers: List[str], column_sep: str = "  ", min_column_width=4
+    rows: List[List[str]], headers: List[str], column_sep: str = "  ", min_column_width: int = 4
 ) -> str:
     """
     Creates a table from a list of rows and headers.

--- a/mlflow/utils/string_utils.py
+++ b/mlflow/utils/string_utils.py
@@ -35,7 +35,7 @@ def truncate_str_from_middle(s, max_length):
 
 
 def _create_table(
-    rows: List[List[str]], headers: List[str], column_sep: str = "  ", min_column_width: int = 4
+    rows: List[List[str]], headers: List[str], column_sep: str = " " * 2, min_column_width: int = 4
 ) -> str:
     """
     Creates a table from a list of rows and headers.


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Remove `tabulate` (which `pandas` depends on) because it's not included in MLflow's python dependencies.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

## Before

```
> mlflow runs list --experiment-id 1
Date                     Name                         ID                              
-----------------------  ---------------------------  --------------------------------
2022-09-06 14:04:27 JST  e53ad2b810724051             a51e5272cfff4373bbaf32d4b42997e0
2022-09-06 14:04:27 JST  e2b11a1edfff4622a409eea4     afa3a9e134f442859d26378f0ef4cc8d
2022-09-06 14:04:27 JST  d8e26499021e496              97fb0bd8d14141dcbdca8f6fc41ecfb0
2022-09-06 14:04:27 JST  ba4996635f27449              949c3d315e664a039cee5b751c886569
2022-09-06 14:04:27 JST  552a1b44ad2d4                937dd99541c442b9b67ee6e157e132ae
2022-09-06 14:04:27 JST  5332af1d511                  893728347f984d5fba1a5e1b9587df42
2022-09-06 14:04:27 JST  384f9908fb8e46ffae1f89d93ba  b10a4bb4a64049a380b45a6020374877
2022-09-06 14:04:27 JST  243ae0d44e3f47d08d6d6a       3695845110924fc6915a345966c765db
2022-09-06 14:04:27 JST  15a51e1bcaa644dbbef          d44b9c28e51e4ffb91bb2d790ed9b5c4
2022-09-06 14:04:27 JST  0f7c51a233274f               a172a5307ac14427939678bd6480eace

> mlflow experiments list
Experiment Id    Name                            Artifact Location                                      
---------------  ------------------------------  -------------------------------------------------------
0                Default                         file:///home/haru/Desktop/repositories/mlflow/mlruns/0 
1                70532dc9732f4a03bcb4e24cb       file:///home/haru/Desktop/repositories/mlflow/mlruns/1 
10               386e1018e59b4a4baf316e3b43437f  file:///home/haru/Desktop/repositories/mlflow/mlruns/10
11               b1afc754b81140e3a5bb            file:///home/haru/Desktop/repositories/mlflow/mlruns/11
12               ead82456ede142                  file:///home/haru/Desktop/repositories/mlflow/mlruns/12
13               80a6985303b5436d821e9d          file:///home/haru/Desktop/repositories/mlflow/mlruns/13
14               95c67f115fe74                   file:///home/haru/Desktop/repositories/mlflow/mlruns/14
15               9d70d745c3aa4f                  file:///home/haru/Desktop/repositories/mlflow/mlruns/15
16               2d901361cfbf4807b012f4789a0e78  file:///home/haru/Desktop/repositories/mlflow/mlruns/16
17               c5ff77b93e8d403c854958b1e4de    file:///home/haru/Desktop/repositories/mlflow/mlruns/17
18               ae9461057bbb43f28ced84e624bf3   file:///home/haru/Desktop/repositories/mlflow/mlruns/18
19               615ca37502e3493f8edf            file:///home/haru/Desktop/repositories/mlflow/mlruns/19
2                2db71a8cd11d4b5d                file:///home/haru/Desktop/repositories/mlflow/mlruns/2 
20               891c9a2170                      file:///home/haru/Desktop/repositories/mlflow/mlruns/20
21               a7cca473baf045b2a6a46a          file:///home/haru/Desktop/repositories/mlflow/mlruns/21
22               0302d5d2966f44e9a0b             file:///home/haru/Desktop/repositories/mlflow/mlruns/22
23               87260ace13c                     file:///home/haru/Desktop/repositories/mlflow/mlruns/23
24               56b7eb2d969f410fb5f6ed8         file:///home/haru/Desktop/repositories/mlflow/mlruns/24
25               8d77311505db42a7951             file:///home/haru/Desktop/repositories/mlflow/mlruns/25
26               67bbed316a75411390              file:///home/haru/Desktop/repositories/mlflow/mlruns/26
27               ef495707770f424790592d8ad8      file:///home/haru/Desktop/repositories/mlflow/mlruns/27
28               6886d2e31dd04950b3              file:///home/haru/Desktop/repositories/mlflow/mlruns/28
29               347137f9bbc                     file:///home/haru/Desktop/repositories/mlflow/mlruns/29
3                260a7de126de499b954e8ebd14ca    file:///home/haru/Desktop/repositories/mlflow/mlruns/3 
30               cd3a645b71074b9da8e9224e        file:///home/haru/Desktop/repositories/mlflow/mlruns/30
4                be341e11816649ab8f159812cea8    file:///home/haru/Desktop/repositories/mlflow/mlruns/4 
5                c9627e4e4bca4b4c96b2238b4       file:///home/haru/Desktop/repositories/mlflow/mlruns/5 
6                133ca0da0ff34620bbd55e5874f     file:///home/haru/Desktop/repositories/mlflow/mlruns/6 
7                f4a6ac821a74419aa               file:///home/haru/Desktop/repositories/mlflow/mlruns/7 
8                f45502b2d3e946b8a32e03e14       file:///home/haru/Desktop/repositories/mlflow/mlruns/8 
9                8fafbc3974e849a                 file:///home/haru/Desktop/repositories/mlflow/mlruns/9 
```

## After

```
> mlflow runs list --experiment-id 1
Date                     Name                         ID                              
-----------------------  ---------------------------  --------------------------------
2022-09-06 14:04:27 JST  e53ad2b810724051             a51e5272cfff4373bbaf32d4b42997e0
2022-09-06 14:04:27 JST  e2b11a1edfff4622a409eea4     afa3a9e134f442859d26378f0ef4cc8d
2022-09-06 14:04:27 JST  d8e26499021e496              97fb0bd8d14141dcbdca8f6fc41ecfb0
2022-09-06 14:04:27 JST  ba4996635f27449              949c3d315e664a039cee5b751c886569
2022-09-06 14:04:27 JST  552a1b44ad2d4                937dd99541c442b9b67ee6e157e132ae
2022-09-06 14:04:27 JST  5332af1d511                  893728347f984d5fba1a5e1b9587df42
2022-09-06 14:04:27 JST  384f9908fb8e46ffae1f89d93ba  b10a4bb4a64049a380b45a6020374877
2022-09-06 14:04:27 JST  243ae0d44e3f47d08d6d6a       3695845110924fc6915a345966c765db
2022-09-06 14:04:27 JST  15a51e1bcaa644dbbef          d44b9c28e51e4ffb91bb2d790ed9b5c4
2022-09-06 14:04:27 JST  0f7c51a233274f               a172a5307ac14427939678bd6480eace

> mlflow experiments list
Experiment Id    Name                            Artifact Location                                      
---------------  ------------------------------  -------------------------------------------------------
0                Default                         file:///home/haru/Desktop/repositories/mlflow/mlruns/0 
1                70532dc9732f4a03bcb4e24cb       file:///home/haru/Desktop/repositories/mlflow/mlruns/1 
10               386e1018e59b4a4baf316e3b43437f  file:///home/haru/Desktop/repositories/mlflow/mlruns/10
11               b1afc754b81140e3a5bb            file:///home/haru/Desktop/repositories/mlflow/mlruns/11
12               ead82456ede142                  file:///home/haru/Desktop/repositories/mlflow/mlruns/12
13               80a6985303b5436d821e9d          file:///home/haru/Desktop/repositories/mlflow/mlruns/13
14               95c67f115fe74                   file:///home/haru/Desktop/repositories/mlflow/mlruns/14
15               9d70d745c3aa4f                  file:///home/haru/Desktop/repositories/mlflow/mlruns/15
16               2d901361cfbf4807b012f4789a0e78  file:///home/haru/Desktop/repositories/mlflow/mlruns/16
17               c5ff77b93e8d403c854958b1e4de    file:///home/haru/Desktop/repositories/mlflow/mlruns/17
18               ae9461057bbb43f28ced84e624bf3   file:///home/haru/Desktop/repositories/mlflow/mlruns/18
19               615ca37502e3493f8edf            file:///home/haru/Desktop/repositories/mlflow/mlruns/19
2                2db71a8cd11d4b5d                file:///home/haru/Desktop/repositories/mlflow/mlruns/2 
20               891c9a2170                      file:///home/haru/Desktop/repositories/mlflow/mlruns/20
21               a7cca473baf045b2a6a46a          file:///home/haru/Desktop/repositories/mlflow/mlruns/21
22               0302d5d2966f44e9a0b             file:///home/haru/Desktop/repositories/mlflow/mlruns/22
23               87260ace13c                     file:///home/haru/Desktop/repositories/mlflow/mlruns/23
24               56b7eb2d969f410fb5f6ed8         file:///home/haru/Desktop/repositories/mlflow/mlruns/24
25               8d77311505db42a7951             file:///home/haru/Desktop/repositories/mlflow/mlruns/25
26               67bbed316a75411390              file:///home/haru/Desktop/repositories/mlflow/mlruns/26
27               ef495707770f424790592d8ad8      file:///home/haru/Desktop/repositories/mlflow/mlruns/27
28               6886d2e31dd04950b3              file:///home/haru/Desktop/repositories/mlflow/mlruns/28
29               347137f9bbc                     file:///home/haru/Desktop/repositories/mlflow/mlruns/29
3                260a7de126de499b954e8ebd14ca    file:///home/haru/Desktop/repositories/mlflow/mlruns/3 
30               cd3a645b71074b9da8e9224e        file:///home/haru/Desktop/repositories/mlflow/mlruns/30
4                be341e11816649ab8f159812cea8    file:///home/haru/Desktop/repositories/mlflow/mlruns/4 
5                c9627e4e4bca4b4c96b2238b4       file:///home/haru/Desktop/repositories/mlflow/mlruns/5 
6                133ca0da0ff34620bbd55e5874f     file:///home/haru/Desktop/repositories/mlflow/mlruns/6 
7                f4a6ac821a74419aa               file:///home/haru/Desktop/repositories/mlflow/mlruns/7 
8                f45502b2d3e946b8a32e03e14       file:///home/haru/Desktop/repositories/mlflow/mlruns/8 
9                8fafbc3974e849a                 file:///home/haru/Desktop/repositories/mlflow/mlruns/9 
```

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
