### PR TITLE
Revert "Temporarily use `tensorflow>=2.10.0rc3` in `keras>=2.10.0`"

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -106,9 +106,7 @@ keras:
       "<= 2.3.1": ["tensorflow==2.2.1", "transformers<=4.11.3"]
       "> 2.3.1, < 2.6.0": ["tensorflow<2.5.0", "transformers"]
       "< 2.6.0": ["protobuf<4.0.0"]
-      ">= 2.6.0, < 2.10.0": ["tensorflow", "transformers"]
-      # TODO: Remove this requirement once tensorflow 2.10 is released
-      ">= 2.10.0": ["tensorflow>=2.10.0rc3", "transformers"]
+      ">= 2.6.0": ["tensorflow", "transformers"]
     run: |
       pytest tests/keras/test_keras_model_export.py
 
@@ -121,9 +119,7 @@ keras:
       "<= 2.3.1": ["tensorflow==2.2.1"]
       "> 2.3.1, < 2.6.0": ["tensorflow<2.5.0"]
       "< 2.6.0": ["protobuf<4.0.0"]
-      ">= 2.6.0, < 2.10.0": ["tensorflow"]
-      # TODO: Remove this requirement once tensorflow 2.10 is released
-      ">= 2.10.0": ["tensorflow>=2.10.0rc3"]
+      ">= 2.6.0": ["tensorflow"]
     run: |
       pytest tests/keras/test_keras_autolog.py
 


### PR DESCRIPTION
[TensorFlow 2.10.0](https://pypi.org/project/tensorflow/2.10.0/) has been released. Reverts mlflow/mlflow#6700.