### PR TITLE
Scope Databricks inferred pip requirements to modules

### DIFF
--- a/mlflow/utils/_capture_modules.py
+++ b/mlflow/utils/_capture_modules.py
@@ -65,7 +65,8 @@ class _CaptureImportedModules:
 
         top_level_module = _get_top_level_module(full_module_name)
         second_level_module = _get_second_level_module(full_module_name)
-        print("NAME", full_module_name, "TOP_LEVEL", top_level_module, "SECOND LEVEL", second_level_module, DATABRICKS_MODULES_TO_PACKAGES)
+        if top_level_module == "databricks" and second_level_module not in ["databricks.automl", "databricks.model_monitoring"]:
+            raise Exception("UNEXPECTED: " + str(second_level_module))
         if second_level_module in DATABRICKS_MODULES_TO_PACKAGES:
             # Multiple packages populate the `databricks` module namespace on Databricks;
             # to avoid bundling extraneous Databricks packages into model dependencies, we

--- a/mlflow/utils/_capture_modules.py
+++ b/mlflow/utils/_capture_modules.py
@@ -74,7 +74,6 @@ class _CaptureImportedModules:
                 self.imported_modules.add(second_level_module)
                 return
 
-
             for databricks_module in DATABRICKS_MODULES_TO_PACKAGES:
                 if full_module_name.startswith(databricks_module):
                     self.imported_modules.add(databricks_module)

--- a/mlflow/utils/_capture_modules.py
+++ b/mlflow/utils/_capture_modules.py
@@ -78,8 +78,8 @@ class _CaptureImportedModules:
                 if full_module_name.startswith(databricks_module):
                     self.imported_modules.add(databricks_module)
                     return
-        else:
-            self.imported_modules.add(top_level_module)
+
+        self.imported_modules.add(top_level_module)
 
     def __enter__(self):
         # Patch `builtins.__import__` and `importlib.import_module`

--- a/mlflow/utils/_capture_modules.py
+++ b/mlflow/utils/_capture_modules.py
@@ -48,6 +48,7 @@ class _CaptureImportedModules:
             ):
                 top_level_module = _get_top_level_module(name)
                 second_level_module = _get_second_level_module(name)
+                print("NAME", name, "TOP_LEVEL", top_level_module, "SECOND LEVEL", second_level_module, DATABRICKS_MODULES_TO_PACKAGES)
                 if second_level_module in DATABRICKS_MODULES_TO_PACKAGES:
                     # Multiple packages populate the `databricks` module namespace on Databricks;
                     # to avoid bundling extraneous Databricks packages into model dependencies, we

--- a/mlflow/utils/_capture_modules.py
+++ b/mlflow/utils/_capture_modules.py
@@ -56,6 +56,10 @@ class _CaptureImportedModules:
         return wrapper
 
     def _record_imported_module(self, full_module_name):
+        # If the module is an internal module (prefixed by "_") or is the "databricks"
+        # module, which is populated by many different packages, don't record it (specific
+        # module imports within the databricks namespace are still recorded and mapped to
+        # their corresponding packages)
         if full_module_name.startswith("_") or full_module_name == "databricks":
             return
 

--- a/mlflow/utils/_capture_modules.py
+++ b/mlflow/utils/_capture_modules.py
@@ -41,7 +41,11 @@ class _CaptureImportedModules:
         @functools.wraps(original)
         def wrapper(name, globals=None, locals=None, fromlist=(), level=0):
             is_absolute_import = level == 0
-            if not name.startswith("_") and is_absolute_import:
+            if (
+                not name.startswith("_") and
+                is_absolute_import and
+                name != "databricks"
+            ):
                 top_level_module = _get_top_level_module(name)
                 second_level_module = _get_second_level_module(name)
                 if second_level_module in DATABRICKS_MODULES_TO_PACKAGES:

--- a/mlflow/utils/_capture_modules.py
+++ b/mlflow/utils/_capture_modules.py
@@ -65,13 +65,20 @@ class _CaptureImportedModules:
 
         top_level_module = _get_top_level_module(full_module_name)
         second_level_module = _get_second_level_module(full_module_name)
-        if top_level_module == "databricks" and second_level_module not in ["databricks.automl", "databricks.model_monitoring"]:
-            raise Exception("UNEXPECTED: " + str(second_level_module))
-        if second_level_module in DATABRICKS_MODULES_TO_PACKAGES:
+
+        if top_level_module == "databricks":
             # Multiple packages populate the `databricks` module namespace on Databricks;
             # to avoid bundling extraneous Databricks packages into model dependencies, we
             # scope each module to its relevant package
-            self.imported_modules.add(second_level_module)
+            if second_level_module in DATABRICKS_MODULES_TO_PACKAGES:
+                self.imported_modules.add(second_level_module)
+                return
+
+
+            for databricks_module in DATABRICKS_MODULES_TO_PACKAGES:
+                if full_module_name.startswith(databricks_module):
+                    self.imported_modules.add(databricks_module)
+                    return
         else:
             self.imported_modules.add(top_level_module)
 

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -283,6 +283,7 @@ def _capture_imported_modules(model_uri, flavor):
 
 DATABRICKS_MODULES_TO_PACKAGES = {
     "databricks.automl": ["databricks-automl-runtime"],
+    "databricks.automl_runtime": ["databricks-automl-runtime"],
     "databricks.model_monitoring": ["databricks-model-monitoring"],
 }
 _MODULES_TO_PACKAGES = None

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -281,6 +281,10 @@ def _capture_imported_modules(model_uri, flavor):
             return f.read().splitlines()
 
 
+DATABRICKS_MODULES_TO_PACKAGES = {
+    "databricks.automl": ["databricks-automl-runtime"],
+    "databricks.model_monitoring": ["databricks-model-monitoring"],
+}
 _MODULES_TO_PACKAGES = None
 _PACKAGES_TO_MODULES = None
 
@@ -292,6 +296,17 @@ def _init_modules_to_packages_map():
         # Python’s site-packages directory via tools such as pip:
         # https://importlib-metadata.readthedocs.io/en/latest/using.html#using-importlib-metadata
         _MODULES_TO_PACKAGES = importlib_metadata.packages_distributions()
+
+        # Multiple packages populate the `databricks` module namespace on Databricks; to avoid
+        # bundling extraneous Databricks packages into model dependencies, we scope each module
+        # to its relevant package
+        _MODULES_TO_PACKAGES.update(DATABRICKS_MODULES_TO_PACKAGES)
+        if "databricks" in _MODULES_TO_PACKAGES:
+            _MODULES_TO_PACKAGES["databricks"] = [
+                package
+                for package in _MODULES_TO_PACKAGES["databricks"]
+                if package not in _flatten(DATABRICKS_MODULES_TO_PACKAGES.values())
+            ]
 
         # In Databricks, `_MODULES_TO_PACKAGES` doesn't contain pyspark since it's not installed
         # via pip or conda. To work around this issue, manually add pyspark.

--- a/tests/utils/test_requirements_utils.py
+++ b/tests/utils/test_requirements_utils.py
@@ -365,6 +365,9 @@ def test_capture_imported_modules_scopes_databricks_imports(monkeypatch, tmpdir)
 
 
 def test_infer_pip_requirements_scopes_databricks_imports():
+    mlflow.utils.requirements_utils._MODULES_TO_PACKAGES = None
+    mlflow.utils.requirements_utils._PACKAGES_TO_MODULES = None
+
     with mock.patch(
         "mlflow.utils.requirements_utils._capture_imported_modules",
         return_value=[

--- a/tests/utils/test_requirements_utils.py
+++ b/tests/utils/test_requirements_utils.py
@@ -368,10 +368,8 @@ def test_infer_pip_requirements_scopes_databricks_imports():
             "databricks": ["databricks-automl-runtime", "databricks-model-monitoring", "koalas"],
         },
     ):
-        assert (
-            _infer_requirements("path/to/model", "sklearn") == [
-                "databricks-automl-runtime==1.0",
-                "databricks-model-monitoring==1.0",
-            ]
-        )
+        assert _infer_requirements("path/to/model", "sklearn") == [
+            "databricks-automl-runtime==1.0",
+            "databricks-model-monitoring==1.0",
+        ]
         assert mlflow.utils.requirements_utils._MODULES_TO_PACKAGES["databricks"] == ["koalas"]


### PR DESCRIPTION
Signed-off-by: dbczumar <corey.zumar@databricks.com>

## What changes are proposed in this pull request?

Scope Databricks inferred pip requirements to modules

## How is this patch tested?

- Added unit tests
- Tested manually on Databricks:
```
import mlflow.pyfunc


import logging
logging.getLogger("mlflow").setLevel(logging.DEBUG)

class MyModel(mlflow.pyfunc.PythonModel):
  def load_context(self, context):
    import sklearn
    import databricks.model_monitoring
    
  def predict(self, ctx, inp):
    return 7
  
with mlflow.start_run():
  model = mlflow.pyfunc.log_model(
    python_model=MyModel(),
    artifact_path="model"
  )

import mlflow.models

mlflow.models.infer_pip_requirements(model.model_uri, "python_function")
```

```
Out[2]: ['configparser==5.0.1',
 'databricks-model-monitoring==0.0.2',
 'psutil==5.8.0',
 'pyspark==3.2.1',
 'scikit-learn==0.24.1']
```

```
import mlflow.pyfunc


import logging
logging.getLogger("mlflow").setLevel(logging.DEBUG)

class MyModel(mlflow.pyfunc.PythonModel):
  def load_context(self, context):
    import sklearn
    import databricks.model_monitoring
    import databricks.automl
    
  def predict(self, ctx, inp):
    return 7
  
with mlflow.start_run():
  model = mlflow.pyfunc.log_model(
    python_model=MyModel(),
    artifact_path="model"
  )

import mlflow.models

mlflow.models.infer_pip_requirements(model.model_uri, "python_function")
```

```
Out[4]: ['configparser==5.0.1',
 'databricks-automl-runtime==0.2.7',
 'databricks-model-monitoring==0.0.2',
 'fasttext==0.9.2',
 'future==0.18.2',
 'holidays==0.13',
 'networkx==2.5',
 'notebook==6.3.0',
 'psutil==5.8.0',
 'pyspark==3.2.1',
 'scikit-learn==0.24.1',
 'simplejson==3.17.2',
 'tqdm==4.59.0',
 'wrapt==1.12.1']
```

```
import mlflow.pyfunc


import logging
logging.getLogger("mlflow").setLevel(logging.DEBUG)

class MyModel(mlflow.pyfunc.PythonModel):
  def load_context(self, context):
    import sklearn
    import databricks.model_monitoring
    import databricks.automl
    import databricks.koalas
    
  def predict(self, ctx, inp):
    return 7
  
with mlflow.start_run():
  model = mlflow.pyfunc.log_model(
    python_model=MyModel(),
    artifact_path="model"
  )

import mlflow.models

mlflow.models.infer_pip_requirements(model.model_uri, "python_function")
```

# PySpark already includes koalas, so the set of dependencies doesn't contain a koalas entry:
```
Out[6]: ['configparser==5.0.1',
 'databricks-automl-runtime==0.2.7',
 'databricks-model-monitoring==0.0.2',
 'fasttext==0.9.2',
 'future==0.18.2',
 'holidays==0.13',
 'networkx==2.5',
 'notebook==6.3.0',
 'psutil==5.8.0',
 'pyspark==3.2.1',
 'scikit-learn==0.24.1',
 'simplejson==3.17.2',
 'tqdm==4.59.0',
 'wrapt==1.12.1']
```

```
WARNING:root:Found pyspark version "3.2.1" installed. The pyspark version 3.2 and above has a built-in "pandas APIs on Spark" module ported from Koalas. Try `import pyspark.pandas as ps` instead. 
```

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

When inferring model requirements, only include Databricks libraries if their corresponding modules are imported by the model.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
