### PR TITLE
hyperparameter tuning 

### DIFF
--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -144,14 +144,13 @@ class TrainStep(BaseStep):
                     with mlflow.start_run(tags=tags, nested=True):
                         # create unfitted estimator from yaml
                         estimator = estimator_fn(args)
-                        # TODO: sample training data
-                        sample_fraction = (  # pylint: disable=unused-variable
-                            tuning_params["sample_fraction"]
+                        sample_fraction = (
+                            float(tuning_params["sample_fraction"])
                             if "sample_fraction" in tuning_params
-                            else 1
+                            else 1.0
                         )
-                        X_train_sampled = X_train
-                        y_train_sampled = y_train
+                        X_train_sampled = X_train.sample(frac=sample_fraction, random_state=42)
+                        y_train_sampled = y_train.sample(frac=sample_fraction, random_state=42)
                         # fit estimator to training
                         estimator.fit(X_train_sampled, y_train_sampled)
                         if hasattr(estimator, "best_score_P"):

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -488,7 +488,7 @@ class TrainStep(BaseStep):
 
                 if "sample_fraction" in step_config["tuning"]:
                     sample_fraction = float(step_config["tuning"]["sample_fraction"])
-                    if sample_fraction >= 0 and sample_fraction <= 1.0:
+                    if sample_fraction > 0 and sample_fraction <= 1.0:
                         step_config["sample_fraction"] = sample_fraction
                     else:
                         raise MlflowException(
@@ -501,6 +501,18 @@ class TrainStep(BaseStep):
 
                 if "algorithm" not in step_config["tuning"]:
                     step_config["tuning"]["algorithm"] = "hyperopt.rand.suggest"
+
+                if "max_trials" not in step_config["tuning"]:
+                    raise MlflowException(
+                        "The 'max_trials' configuration in the train step must be provided.",
+                        error_code=INVALID_PARAMETER_VALUE,
+                    )
+
+                if "parameters" not in step_config["tuning"]:
+                    raise MlflowException(
+                        "The 'parameters' configuration in the train step must be provided.",
+                        error_code=INVALID_PARAMETER_VALUE,
+                    )
 
             else:
                 step_config["tuning_enabled"] = False

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -1,4 +1,3 @@
-from dis import dis
 import importlib
 import logging
 import os

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -124,6 +124,8 @@ class TrainStep(BaseStep):
             MLFLOW_PIPELINE_STEP_NAME: run_args.get("step", ""),
         }
 
+        mlflow.autolog(log_models=False)
+
         if self.step_config["tuning_enabled"]:
             # gate all HP tuning code within this condition
             tuning_params = self.step_config["tuning"]
@@ -152,7 +154,7 @@ class TrainStep(BaseStep):
                     y_train_sampled = y_train
                     # fit estimator to training
                     estimator.fit(X_train_sampled, y_train_sampled)
-                    if hasattr(estimator, "best_score_"):
+                    if hasattr(estimator, "best_score_P"):
                         mlflow.log_metric("best_cv_score", estimator.best_score_)
                     if hasattr(estimator, "best_params_"):
                         mlflow.log_params(estimator.best_params_)
@@ -206,14 +208,98 @@ class TrainStep(BaseStep):
                     )
             # minimize
             algorithm = tuning_params["algorithm"]  # pylint: disable=unused-variable
-            max_trials = tuning_params["max_trials"]  # pylint: disable=unused-variable
-            best = fmin(  # pylint: disable=unused-variable
-                objective, search_space, max_evals=max_trials
+            max_trials = tuning_params["max_trials"]
+            with mlflow.start_run(tags=tags) as run:
+                best_hp_params = fmin(objective, search_space, max_evals=max_trials)
+                best_estimator = estimator_fn(**best_hp_params)
+                best_estimator.fit(X_train, y_train)
+
+                if hasattr(best_estimator, "best_score_"):
+                    mlflow.log_metric("best_cv_score", best_estimator.best_score_)
+                if hasattr(best_estimator, "best_params_"):
+                    mlflow.log_params(best_estimator.best_params_)
+
+                code_paths = [os.path.join(self.pipeline_root, "steps")]
+                estimator_schema = infer_signature(X_train, best_estimator.predict(X_train.copy()))
+                logged_estimator = mlflow.sklearn.log_model(
+                    best_estimator,
+                    f"{self.name}/best_estimator",
+                    signature=estimator_schema,
+                    code_paths=code_paths,
+                )
+
+                # Create a pipeline consisting of the transformer+model for test data evaluation
+                with open(transformer_path, "rb") as f:
+                    transformer = cloudpickle.load(f)
+                mlflow.sklearn.log_model(
+                    transformer, "transform/transformer", code_paths=code_paths
+                )
+                model = make_pipeline(transformer, best_estimator)
+                model_schema = infer_signature(raw_X_train, model.predict(raw_X_train.copy()))
+                model_info = mlflow.sklearn.log_model(
+                    model, f"{self.name}/model", signature=model_schema, code_paths=code_paths
+                )
+                output_model_path = get_step_output_path(
+                    pipeline_root_path=self.pipeline_root,
+                    step_name=self.name,
+                    relative_path=TrainStep.MODEL_ARTIFACT_RELATIVE_PATH,
+                )
+                if os.path.exists(output_model_path) and os.path.isdir(output_model_path):
+                    shutil.rmtree(output_model_path)
+                mlflow.sklearn.save_model(model, output_model_path)
+
+                with open(os.path.join(output_directory, "run_id"), "w") as f:
+                    f.write(run.info.run_id)
+                log_code_snapshot(
+                    self.pipeline_root, run.info.run_id, pipeline_config=self.pipeline_config
+                )
+
+                eval_metrics = {}
+                for dataset_name, dataset in {
+                    "training": train_df,
+                    "validation": validation_df,
+                }.items():
+                    eval_result = mlflow.evaluate(
+                        model=logged_estimator.model_uri,
+                        data=dataset,
+                        targets=self.target_col,
+                        model_type="regressor",
+                        evaluators="default",
+                        dataset_name=dataset_name,
+                        custom_metrics=_load_custom_metric_functions(
+                            self.pipeline_root,
+                            self.evaluation_metrics.values(),
+                        ),
+                        evaluator_config={
+                            "log_model_explainability": False,
+                        },
+                    )
+                    eval_result.save(os.path.join(output_directory, f"eval_{dataset_name}"))
+                    eval_metrics[dataset_name] = eval_result.metrics
+
+            target_data = raw_validation_df[self.target_col]
+            prediction_result = model.predict(raw_validation_df.drop(self.target_col, axis=1))
+            pred_and_error_df = pd.DataFrame(
+                {
+                    "target": target_data,
+                    "prediction": prediction_result,
+                    "error": prediction_result - target_data,
+                }
             )
+            train_predictions = model.predict(raw_train_df.drop(self.target_col, axis=1))
+            worst_examples_df = BaseStep._generate_worst_examples_dataframe(
+                raw_train_df, train_predictions, self.target_col
+            )
+            leaderboard_df = None
+            try:
+                leaderboard_df = self._get_leaderboard_df(run, eval_metrics)
+            except Exception as e:
+                _logger.warning(
+                    "Failed to build model leaderboard due to unexpected failure: %s", e
+                )
 
         else:
             estimator = estimator_fn()
-            mlflow.autolog(log_models=False)
 
             with mlflow.start_run(tags=tags) as run:
                 estimator.fit(X_train, y_train)

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -124,7 +124,7 @@ class TrainStep(BaseStep):
             MLFLOW_PIPELINE_STEP_NAME: run_args.get("step", ""),
         }
 
-        mlflow.autolog(disable=True)
+        mlflow.autolog(log_models=False)
         with mlflow.start_run(tags=tags) as run:
             if self.step_config["tuning_enabled"]:
                 # gate all HP tuning code within this condition
@@ -141,7 +141,7 @@ class TrainStep(BaseStep):
                 # wrap training in objective fn
                 def objective(args):
                     # log as a child run
-                    with mlflow.start_run(nested=True):
+                    with mlflow.start_run(tags=tags, nested=True):
                         # create unfitted estimator from yaml
                         estimator = estimator_fn(args)
                         # TODO: sample training data

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -1,3 +1,4 @@
+from dis import dis
 import importlib
 import logging
 import os
@@ -124,7 +125,7 @@ class TrainStep(BaseStep):
             MLFLOW_PIPELINE_STEP_NAME: run_args.get("step", ""),
         }
 
-        mlflow.autolog(log_models=False)
+        mlflow.autolog(disable=True)
         with mlflow.start_run(tags=tags) as run:
             if self.step_config["tuning_enabled"]:
                 # gate all HP tuning code within this condition

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -143,7 +143,7 @@ class TrainStep(BaseStep):
                     # log as a child run
                     with mlflow.start_run(nested=True):
                         # create unfitted estimator from yaml
-                        estimator = estimator_fn(**args)
+                        estimator = estimator_fn(args)
                         # TODO: sample training data
                         sample_fraction = (  # pylint: disable=unused-variable
                             tuning_params["sample_fraction"]
@@ -210,7 +210,7 @@ class TrainStep(BaseStep):
                 algorithm = tuning_params["algorithm"]  # pylint: disable=unused-variable
                 max_trials = tuning_params["max_trials"]
                 best_hp_params = fmin(objective, search_space, max_evals=max_trials)
-                estimator = estimator_fn(**best_hp_params)
+                estimator = estimator_fn(best_hp_params)
             else:
                 estimator = estimator_fn()
 


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
building on https://github.com/mlflow/mlflow/pull/6680, blocked by https://github.com/mlflow/mlp-regression-template/pull/75

## What changes are proposed in this pull request?

Filling in the `objective()` function in HP tuning and handle hardcoded parameters. Some small refactors to reduce code repetition

## How is this patch tested?

Manual testing using mlp-regression-template repo and a source mlflow installation.
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
