### PR TITLE
Remove useless `pylint: disable=unused-variable`

### DIFF
--- a/tests/autologging/test_autologging_behaviors_integration.py
+++ b/tests/autologging/test_autologging_behaviors_integration.py
@@ -314,9 +314,9 @@ def test_autolog_globally_configured_flag_set_correctly():
     from mlflow.utils.autologging_utils import AUTOLOGGING_INTEGRATIONS
 
     AUTOLOGGING_INTEGRATIONS.clear()
-    import sklearn  # pylint: disable=unused-import,unused-variable
-    import pyspark  # pylint: disable=unused-import,unused-variable
-    import pyspark.ml  # pylint: disable=unused-import,unused-variable
+    import sklearn  # pylint: disable=unused-import
+    import pyspark  # pylint: disable=unused-import
+    import pyspark.ml  # pylint: disable=unused-import
 
     integrations_to_test = ["sklearn", "spark", "pyspark.ml"]
     mlflow.autolog()

--- a/tests/projects/backend/test_local.py
+++ b/tests/projects/backend/test_local.py
@@ -30,7 +30,7 @@ def test_docker_s3_artifact_cmd_and_envs_from_home():
 
 
 def test_docker_wasbs_artifact_cmd_and_envs_from_home():
-    # pylint: disable=unused-import, unused-variable
+    # pylint: disable=unused-import
     from azure.storage.blob import BlobServiceClient
 
     mock_env = {

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -1387,14 +1387,14 @@ def test_fluent_autolog_with_tf_keras_preserves_v2_model_reference():
 def test_import_tensorflow_with_fluent_autolog_enables_tf_autologging():
     mlflow.autolog()
 
-    import tensorflow  # pylint: disable=unused-variable,unused-import,reimported
+    import tensorflow  # pylint: disable=unused-import,reimported
 
     assert not autologging_is_disabled(mlflow.tensorflow.FLAVOR_NAME)
 
     # NB: In Tensorflow >= 2.6, we redirect keras autologging to tensorflow autologging
     # so the original keras autologging is disabled
     if Version(tf.__version__) >= Version("2.6"):
-        import keras  # pylint: disable=unused-variable,unused-import
+        import keras  # pylint: disable=unused-import
 
         assert autologging_is_disabled(mlflow.keras.FLAVOR_NAME)
 
@@ -1402,7 +1402,7 @@ def test_import_tensorflow_with_fluent_autolog_enables_tf_autologging():
 def test_import_tf_keras_with_fluent_autolog_enables_tf_autologging():
     mlflow.autolog()
 
-    import tensorflow.keras  # pylint: disable=unused-variable,unused-import
+    import tensorflow.keras  # pylint: disable=unused-import
 
     assert not autologging_is_disabled(mlflow.tensorflow.FLAVOR_NAME)
 
@@ -1420,7 +1420,7 @@ def test_import_tf_keras_with_fluent_autolog_enables_tf_autologging():
 def test_import_keras_with_fluent_autolog_enables_tensorflow_autologging():
     mlflow.autolog()
 
-    import keras  # pylint: disable=unused-variable,unused-import
+    import keras  # pylint: disable=unused-import
 
     assert not autologging_is_disabled(mlflow.tensorflow.FLAVOR_NAME)
     assert autologging_is_disabled(mlflow.keras.FLAVOR_NAME)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -335,7 +335,7 @@ def test_mlflow_gc_file_store_older_than(file_store):
 )
 def test_mlflow_models_serve(enable_mlserver):
     class MyModel(pyfunc.PythonModel):
-        def predict(self, context, model_input):  # pylint: disable=unused-variable
+        def predict(self, context, model_input):
             return np.array([1, 2, 3])
 
     model = MyModel()

--- a/tests/utils/test_requirements_utils.py
+++ b/tests/utils/test_requirements_utils.py
@@ -207,7 +207,7 @@ def test_capture_imported_modules():
     from mlflow.utils._capture_modules import _CaptureImportedModules
 
     with _CaptureImportedModules() as cap:
-        # pylint: disable=unused-import,unused-variable
+        # pylint: disable=unused-import
         import math
 
         __import__("pandas")
@@ -337,7 +337,7 @@ def test_capture_imported_modules_scopes_databricks_imports(monkeypatch, tmpdir)
             pass
 
     with _CaptureImportedModules() as cap:
-        # pylint: disable=unused-import,unused-variable
+        # pylint: disable=unused-import
         import databricks
         import databricks.automl
         import databricks.automl_foo
@@ -350,7 +350,7 @@ def test_capture_imported_modules_scopes_databricks_imports(monkeypatch, tmpdir)
     assert "databricks.automl_foo" not in cap.imported_modules
 
     with _CaptureImportedModules() as cap:
-        # pylint: disable=unused-import,unused-variable
+        # pylint: disable=unused-import
         import databricks.automl
         import databricks.automl_foo
         import databricks.automl_runtime


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Remove useless `pylint: disable=unused-variable`.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
