### PR TITLE
Support disjoint DAGs in MLP

### DIFF
--- a/mlflow/pipelines/pipeline.py
+++ b/mlflow/pipelines/pipeline.py
@@ -80,12 +80,11 @@ class _BasePipeline:
 
         # TODO Record performance here.
         self._steps = self._resolve_pipeline_steps()
+        target_step = self._get_step(step) if step else self._get_default_step()
         last_executed_step = run_pipeline_step(
             self._pipeline_root_path,
-            self._steps,
-            # Runs the last step of the pipeline if no step is specified.
-            # TODO: Determine how this works in a world with disjoint DAGs
-            self._get_step(step) if step else self._steps[-1],
+            self._get_subgraph_for_target_step(target_step),
+            target_step,
             self._template,
         )
 
@@ -154,7 +153,28 @@ class _BasePipeline:
 
     @experimental
     @abc.abstractmethod
-    def _get_step_classes(self) -> List[BaseStep]:
+    def _get_subgraph_for_target_step(self, target_step: BaseStep) -> List[BaseStep]:
+        """
+        Return a list of step objects representing a connected DAG containing the target_step.
+        The returned list should be a sublist of self._steps.
+
+        Concrete pipeline class should implement this method.
+        """
+        pass
+
+    @experimental
+    @abc.abstractmethod
+    def _get_default_step(self) -> BaseStep:
+        """
+        Defines which step to run if no step is specified.
+
+        Concrete pipeline class should implement this method.
+        """
+        pass
+
+    @experimental
+    @abc.abstractmethod
+    def _get_step_classes(self):
         """
         Returns a list of step classes defined in the pipeline.
 

--- a/mlflow/pipelines/pipeline.py
+++ b/mlflow/pipelines/pipeline.py
@@ -43,6 +43,10 @@ class _BasePipeline:
         self._pipeline_root_path = pipeline_root_path
         self._profile = profile
         self._name = get_pipeline_name(pipeline_root_path)
+        # self._steps contains concatenated ordered lists of step objects representing multiple
+        # disjoint DAGs. To keep it in sync with the underlying config file, it should be reloaded
+        # from config files using self._resolve_pipeline_steps() at the beginning of __init__(),
+        # run(), and inspect(), and should not reload it elsewhere.
         self._steps = self._resolve_pipeline_steps()
         self._template = get_pipeline_config(self._pipeline_root_path, self._profile).get(
             # TODO: Think about renaming this to something else
@@ -75,7 +79,6 @@ class _BasePipeline:
         """
 
         # TODO Record performance here.
-        # Always resolve the steps to load latest step modules before execution.
         self._steps = self._resolve_pipeline_steps()
         last_executed_step = run_pipeline_step(
             self._pipeline_root_path,
@@ -118,6 +121,7 @@ class _BasePipeline:
                      specified, the DAG of the pipeline is shown instead.
         :return: None
         """
+        self._steps = self._resolve_pipeline_steps()
         if not step:
             display_html(html_file_path=self._get_pipeline_dag_file())
         else:
@@ -140,7 +144,7 @@ class _BasePipeline:
 
     def _get_step(self, step_name) -> BaseStep:
         """Returns a step class object from the pipeline."""
-        steps = self._steps or self._resolve_pipeline_steps()
+        steps = self._steps
         step_names = [s.name for s in steps]
         if step_name not in step_names:
             raise MlflowException(

--- a/mlflow/pipelines/regression/v1/pipeline.py
+++ b/mlflow/pipelines/regression/v1/pipeline.py
@@ -201,11 +201,11 @@ class RegressionPipeline(_BasePipeline):
     _SUBGRAPH_INDICES_MAP = {
         _TRAIN_DAG_NAME: (
             _PIPELINE_STEPS.index(_TRAIN_DAG_STEPS[0]),
-            _PIPELINE_STEPS.index(_TRAIN_DAG_STEPS[-1]) + 1,
+            _PIPELINE_STEPS.index(_TRAIN_DAG_STEPS[-1]),
         ),
         _SCORING_DAG_NAME: (
             _PIPELINE_STEPS.index(_SCORING_DAG_STEPS[0]),
-            _PIPELINE_STEPS.index(_SCORING_DAG_STEPS[-1]) + 1,
+            _PIPELINE_STEPS.index(_SCORING_DAG_STEPS[-1]),
         ),
     }
 
@@ -219,7 +219,7 @@ class RegressionPipeline(_BasePipeline):
 
         subgraph_name = self._STEPS_SUBGRAPH_MAP[target_step_class]
         s, e = self._SUBGRAPH_INDICES_MAP[subgraph_name]
-        return self._steps[s:e]
+        return self._steps[s : e + 1]
 
     def _get_default_step(self) -> BaseStep:
         return self._steps[self._DEFAULT_STEP_INDEX]

--- a/mlflow/pipelines/regression/v1/pipeline.py
+++ b/mlflow/pipelines/regression/v1/pipeline.py
@@ -209,7 +209,7 @@ class RegressionPipeline(_BasePipeline):
         ),
     }
 
-    _DEFAULT_STEP_INDEX = _PIPELINE_STEPS.index(PredictStep)
+    _DEFAULT_STEP_INDEX = _PIPELINE_STEPS.index(RegisterStep)
 
     def _get_step_classes(self):
         return self._PIPELINE_STEPS

--- a/mlflow/pipelines/regression/v1/pipeline.py
+++ b/mlflow/pipelines/regression/v1/pipeline.py
@@ -193,10 +193,10 @@ class RegressionPipeline(_BasePipeline):
     _PIPELINE_STEPS = _SCORING_DAG_STEPS + _TRAIN_DAG_STEPS
 
     _STEPS_SUBGRAPH_MAP = dict()
-    for step_class in _TRAIN_DAG_STEPS:
-        _STEPS_SUBGRAPH_MAP[step_class] = _TRAIN_DAG_NAME
-    for step_class in _SCORING_DAG_STEPS:
-        _STEPS_SUBGRAPH_MAP[step_class] = _SCORING_DAG_NAME
+    for _step_class in _TRAIN_DAG_STEPS:
+        _STEPS_SUBGRAPH_MAP[_step_class] = _TRAIN_DAG_NAME
+    for _step_class in _SCORING_DAG_STEPS:
+        _STEPS_SUBGRAPH_MAP[_step_class] = _SCORING_DAG_NAME
 
     _SUBGRAPH_INDICES_MAP = {
         _TRAIN_DAG_NAME: (

--- a/mlflow/pipelines/regression/v1/pipeline.py
+++ b/mlflow/pipelines/regression/v1/pipeline.py
@@ -171,10 +171,8 @@ class RegressionPipeline(_BasePipeline):
         regression_pipeline.inspect(step="evaluate")
     """
 
-    _PIPELINE_STEPS = (
-        # Batch scoring DAG
-        IngestScoringStep,
-        PredictStep,
+    _TRAIN_DAG_NAME = "train_dag"
+    _TRAIN_DAG_STEPS = (
         # Training data ingestion DAG
         IngestStep,
         # Model training DAG
@@ -185,8 +183,46 @@ class RegressionPipeline(_BasePipeline):
         RegisterStep,
     )
 
-    def _get_step_classes(self) -> List[BaseStep]:
+    _SCORING_DAG_NAME = "scoring_dag"
+    _SCORING_DAG_STEPS = (
+        # Batch scoring DAG
+        IngestScoringStep,
+        PredictStep,
+    )
+
+    _PIPELINE_STEPS = _SCORING_DAG_STEPS + _TRAIN_DAG_STEPS
+
+    _STEPS_SUBGRAPH_MAP = dict()
+    for step_class in _TRAIN_DAG_STEPS:
+        _STEPS_SUBGRAPH_MAP[step_class] = _TRAIN_DAG_NAME
+    for step_class in _SCORING_DAG_STEPS:
+        _STEPS_SUBGRAPH_MAP[step_class] = _SCORING_DAG_NAME
+
+    _SUBGRAPH_INDICES_MAP = {
+        _TRAIN_DAG_NAME: (
+            _PIPELINE_STEPS.index(_TRAIN_DAG_STEPS[0]),
+            _PIPELINE_STEPS.index(_TRAIN_DAG_STEPS[-1]),
+        ),
+        _SCORING_DAG_NAME: (
+            _PIPELINE_STEPS.index(_SCORING_DAG_STEPS[0]),
+            _PIPELINE_STEPS.index(_SCORING_DAG_STEPS[-1]),
+        ),
+    }
+
+    _DEFAULT_STEP_INDEX = _PIPELINE_STEPS.index(PredictStep)
+
+    def _get_step_classes(self):
         return self._PIPELINE_STEPS
+
+    def _get_subgraph_for_target_step(self, target_step: BaseStep) -> List[BaseStep]:
+        target_step_class = type(target_step)
+
+        subgraph_name = self._STEPS_SUBGRAPH_MAP[target_step_class]
+        s, e = self._SUBGRAPH_INDICES_MAP[subgraph_name]
+        return self._steps[s:e]
+
+    def _get_default_step(self) -> BaseStep:
+        return self._steps[self._DEFAULT_STEP_INDEX]
 
     def _get_pipeline_dag_file(self) -> str:
         import jinja2

--- a/mlflow/pipelines/regression/v1/pipeline.py
+++ b/mlflow/pipelines/regression/v1/pipeline.py
@@ -201,11 +201,11 @@ class RegressionPipeline(_BasePipeline):
     _SUBGRAPH_INDICES_MAP = {
         _TRAIN_DAG_NAME: (
             _PIPELINE_STEPS.index(_TRAIN_DAG_STEPS[0]),
-            _PIPELINE_STEPS.index(_TRAIN_DAG_STEPS[-1]),
+            _PIPELINE_STEPS.index(_TRAIN_DAG_STEPS[-1]) + 1,
         ),
         _SCORING_DAG_NAME: (
             _PIPELINE_STEPS.index(_SCORING_DAG_STEPS[0]),
-            _PIPELINE_STEPS.index(_SCORING_DAG_STEPS[-1]),
+            _PIPELINE_STEPS.index(_SCORING_DAG_STEPS[-1]) + 1,
         ),
     }
 

--- a/tests/pipelines/regression/v1/test_regression_pipeline.py
+++ b/tests/pipelines/regression/v1/test_regression_pipeline.py
@@ -54,3 +54,22 @@ def test_pipeline_run_and_clean_individual_step_works(step, create_pipeline):
     p = create_pipeline
     p.run(step)
     p.clean(step)
+
+
+def test_get_subgraph_for_target_step(create_pipeline):
+    p = create_pipeline
+    train_subgraph = p._get_subgraph_for_target_step(p._get_step("ingest"))
+    for step, expected_step_name in zip(
+        train_subgraph, ["ingest", "split", "transform", "train", "evaluate", "register"]
+    ):
+        assert step.name == expected_step_name
+    for step in ["split", "transform", "train", "evaluate", "register"]:
+        target_step = p._get_step(step)
+        assert p._get_subgraph_for_target_step(target_step) == train_subgraph
+
+    scoring_subgraph = p._get_subgraph_for_target_step(p._get_step("ingest_scoring"))
+    for step, expected_step_name in zip(scoring_subgraph, ["ingest_scoring", "predict"]):
+        assert step.name == expected_step_name
+    for step in ["predict"]:
+        target_step = p._get_step(step)
+        assert p._get_subgraph_for_target_step(target_step) == scoring_subgraph

--- a/tests/pipelines/test_pipeline.py
+++ b/tests/pipelines/test_pipeline.py
@@ -33,7 +33,9 @@ from tests.pipelines.helper_functions import (
     chdir,
 )  # pylint: enable=unused-import
 
-_STEP_NAMES = ["ingest", "split", "train", "transform", "evaluate"]
+# _STEP_NAMES must contain all step names that are expected to be executed when
+# `pipeline.run(step=None)` is called
+_STEP_NAMES = ["ingest", "split", "train", "transform", "evaluate", "register"]
 
 
 @pytest.mark.usefixtures("enter_pipeline_example_directory")


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->


## What changes are proposed in this pull request?

A pipeline can have multiple disjoint DAGs. Each DAG is composed of one or more steps.

1. Only reload `self._steps` from config files at the beginning of `__init__()`, `run()`, and `inspect()`, and assume they contain up-to-date info elsewhere. Previously we also reload in `self._get_step()`.
2. Add `_get_subgraph_for_target_step(target_step)` to `_BasePipeline`. Pass the subgraph DAG to `run_pipeline_step()` instead of the full `self._steps`.
3. Add `_get_default_step()`  to `_BasePipeline`, which defines the default step to run when no step is specified. Previously we run `self._steps[-1]`.
4. Implemented above methods in `mlflow/pipelines/regression/v1/pipeline.py`.

## How is this patch tested?
Existing tests
AND
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
