### PR TITLE
Refactor mlflow pipelines code in preparation for classification template

### DIFF
--- a/mlflow/pipelines/step.py
+++ b/mlflow/pipelines/step.py
@@ -321,6 +321,7 @@ class BaseStep(metaclass=abc.ABCMeta):
     def _generate_worst_examples_dataframe(
         dataframe,
         predictions,
+        error,
         target_col,
         worst_k=10,
     ):
@@ -333,7 +334,7 @@ class BaseStep(metaclass=abc.ABCMeta):
         import numpy as np
 
         predictions = np.array(predictions)
-        abs_error = np.absolute(predictions - dataframe[target_col].to_numpy())
+        abs_error = np.absolute(error)
         worst_k_indexes = np.argsort(abs_error)[::-1][:worst_k]
         result_df = dataframe.iloc[worst_k_indexes].assign(
             prediction=predictions[worst_k_indexes],

--- a/tests/pipelines/test_pipeline.py
+++ b/tests/pipelines/test_pipeline.py
@@ -300,7 +300,7 @@ def test_generate_worst_examples_dataframe():
     predictions = [5, 3, 4]
 
     result_df = BaseStep._generate_worst_examples_dataframe(
-        test_df, predictions, target_col, worst_k=2
+        test_df, predictions, predictions - test_df[target_col].to_numpy(), target_col, worst_k=2
     )
 
     def assert_result_correct(df):
@@ -315,7 +315,7 @@ def test_generate_worst_examples_dataframe():
 
     test_df2 = test_df.set_axis([2, 1, 0], axis="index")
     result_df2 = BaseStep._generate_worst_examples_dataframe(
-        test_df2, predictions, target_col, worst_k=2
+        test_df2, predictions, predictions - test_df2[target_col].to_numpy(), target_col, worst_k=2
     )
     assert_result_correct(result_df2)
 


### PR DESCRIPTION
Signed-off-by: Brian Barnes <brian.barnes@databricks.com>

## What changes are proposed in this pull request?

This PR makes a few small adjustments to step implementations and utility methods that are tightly coupled to the only existing template (regression). It does so as succinctly as possible in an effort to avoid a larger refactor, and compromises a bit on code quality as a result. In particular, the introduction of utility functions that switch on the template type is an anti-pattern, a cleaner approach would be to introduce an interface with methods such as `get_builtin_metrics` and implement a new object for each template type that implements this interface.

## How is this patch tested?

The [MLP regression template](https://github.com/mlflow/mlp-regression-template/blob/main/pipeline.yaml) was run locally with these changes.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
