### PR TITLE
[UI][easy] In addition to the file extension, also check if the selected artifact is directory when we show artifact view

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/ArtifactView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ArtifactView.js
@@ -314,6 +314,7 @@ export class ArtifactViewImpl extends Component {
             <ShowArtifactPage
               runUuid={this.props.runUuid}
               path={this.state.activeNodeId}
+              isDirectory={this.activeNodeIsDirectory()}
               size={this.getActiveNodeSize()}
               runTags={this.props.runTags}
               artifactRootUri={this.props.artifactRootUri}

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactPage.js
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactPage.js
@@ -32,6 +32,7 @@ class ShowArtifactPage extends Component {
     artifactRootUri: PropTypes.string.isRequired,
     // If path is not defined don't render anything
     path: PropTypes.string,
+    isDirectory: PropTypes.bool,
     size: PropTypes.number,
     runTags: PropTypes.object,
     modelVersions: PropTypes.arrayOf(PropTypes.object),
@@ -55,7 +56,7 @@ class ShowArtifactPage extends Component {
       }
       if (this.props.size > MAX_PREVIEW_ARTIFACT_SIZE_MB * ONE_MB) {
         return getFileTooLargeView();
-      } else if (normalizedExtension) {
+      } else if (!this.props.isDirectory && normalizedExtension) {
         if (IMAGE_EXTENSIONS.has(normalizedExtension.toLowerCase())) {
           return <ShowArtifactImageView runUuid={this.props.runUuid} path={this.props.path} />;
         } else if (TEXT_EXTENSIONS.has(normalizedExtension.toLowerCase())) {

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactPage.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactPage.test.js
@@ -86,6 +86,13 @@ describe('ShowArtifactPage', () => {
     });
   });
 
+  test('should render "select to preview" view for folder with common image extensions', () => {
+    IMAGE_EXTENSIONS.forEach((ext) => {
+      wrapper.setProps({ path: `image.${ext}`, runUuid: 'runId', isDirectory: 'true' });
+      expect(wrapper.text().includes('Select a file to preview')).toBe(true);
+    });
+  });
+
   test('should render html view for common html extensions', () => {
     HTML_EXTENSIONS.forEach((ext) => {
       wrapper.setProps({ path: `image.${ext}`, runUuid: 'runId' });


### PR DESCRIPTION
Signed-off-by: Mingyu Li <mingyu.li@databricks.com>
# context
We show selected artifact content by proxying request to backend when the file is image, text, map, html or pdf.
The format is decided only based on the extension of the file name.
When a directory name has one of the above extensions, we send the request to backend to preview the file and got 500 error.  

The fix is to check both extension and if the artifact is a directory.

# Test
## Before the fix 

<img width="1682" alt="Screen Shot 2022-09-09 at 3 00 26 PM" src="https://user-images.githubusercontent.com/12734110/189451597-3a160660-3786-4439-b8f6-455bd7d41531.png">

## After the fix 
empty folder
<img width="1675" alt="Screen Shot 2022-09-08 at 5 13 03 PM" src="https://user-images.githubusercontent.com/12734110/189452183-1f83fc4e-85e4-486e-b141-eadd85d9a792.png">

non-empty folder
<img width="1678" alt="Screen Shot 2022-09-08 at 5 13 10 PM" src="https://user-images.githubusercontent.com/12734110/189452199-2de9d645-84ae-4dd9-8466-955a1868ccd0.png">

## unit test
Added unit test 
<img width="890" alt="Screen Shot 2022-09-09 at 1 47 21 PM" src="https://user-images.githubusercontent.com/12734110/189452232-5fa5244f-adcb-420c-930f-d85a8aae249d.png">



<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [X] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [X] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
