### PR TITLE
Fix metric names in `examples/evaluation/evaluate_with_model_validation.py`

### DIFF
--- a/examples/evaluation/evaluate_with_model_validation.py
+++ b/examples/evaluation/evaluate_with_model_validation.py
@@ -30,9 +30,11 @@ def double_positive(_, builtin_metrics):
 # Define criteria for model to be validated against
 thresholds = {
     # Specify metric value threshold
-    "precision": MetricThreshold(threshold=0.7, higher_is_better=True),  # precision should be >=0.7
+    "precision_score": MetricThreshold(
+        threshold=0.7, higher_is_better=True
+    ),  # precision should be >=0.7
     # Specify model comparison thresholds
-    "recall": MetricThreshold(
+    "recall_score": MetricThreshold(
         min_absolute_change=0.1,  # recall should be at least 0.1 greater than baseline model recall
         min_relative_change=0.1,  # recall should be at least 10 percent greater than baseline model recall
         higher_is_better=True,

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -1122,7 +1122,7 @@ def evaluate(
                                                      ),
                                                      # Both metric value and model comparison \
 thresholds
-                                                     "accuarcy": MetricThreshold(
+                                                     "accuracy_score": MetricThreshold(
                                                          threshold=0.8,
                                                          min_absolute_change=0.09,
                                                          min_relative_change=0.05,


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

The metric names logged by the default evalutor for `mlflow.evaluate` have been changed. `examples/evaluation/evaluate_with_model_validation.py` needs to be fixed.

https://github.com/mlflow/mlflow/runs/8292505818?check_suite_focus=true

```
E           mlflow.utils.process.ShellCommandException: Non-zero exit code: 1
E           Command: ['python', 'evaluate_with_model_validation.py']
E           
E           STDERR:
E           IPython could not be loaded!
E           2022/09/11 13:51:41 INFO mlflow.models.evaluation.base: Evaluating the model with the default evaluator.
E           2022/09/11 13:51:41 INFO mlflow.models.evaluation.default_evaluator: Evaluating candidate model:
E           2022/09/11 13:51:41 INFO mlflow.models.evaluation.default_evaluator: The evaluation dataset is inferred as binary dataset, positive label is True, negative label is False.
E           2022/09/11 13:51:42 INFO mlflow.models.evaluation.default_evaluator: Shap explainer Tree is used.
E           Unable to serialize underlying model using MLflow, will use SHAP serialization
E           2022/09/11 13:51:47 WARNING mlflow.models.evaluation.default_evaluator: Logging explainer failed. Reason: AttributeError("'TreeEnsemble' object has no attribute 'save'").Set logging level to DEBUG to see the full traceback.
E           2022/09/11 13:51:49 INFO mlflow.models.evaluation.default_evaluator: Evaluating baseline model:
E           2022/09/11 13:51:49 INFO mlflow.models.evaluation.default_evaluator: The evaluation dataset is inferred as binary dataset, positive label is True, negative label is False.
E           Traceback (most recent call last):
E             File "evaluate_with_model_validation.py", line 69, in <module>
E               baseline_model=baseline_model_uri,
E             File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/mlflow/models/evaluation/base.py", line 1214, in evaluate
E               evaluate_result.baseline_model_metrics,
E             File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/mlflow/models/evaluation/base.py", line 773, in _validate
E               raise ModelValidationFailedException(message=os.linesep.join(failure_messages))
E           mlflow.models.evaluation.validation.ModelValidationFailedException: Metric validation failed: metric precision was missing from the evaluation result of the candidate model.
E           Metric validation failed: metric recall was missing from the evaluation result of the candidate model.
```

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
