### PR TITLE
Fix batch scoring pipeline artifact writing on Databricks

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -263,4 +263,8 @@ jobs:
           pip install pyspark
       - name: Run python tests
         run: |
+          # Set Hadoop environment variables required for testing Spark integrations on Windows
+          export HADOOP_HOME=`realpath winutils/hadoop-3.2.2`
+          export PATH=$PATH:$HADOOP_HOME/bin
+          # run Windows tests
           pytest --ignore-flavors --ignore=tests/projects --ignore=tests/examples tests --ignore=tests/pipelines

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -269,5 +269,5 @@ jobs:
           # Set Hadoop environment variables required for testing Spark integrations on Windows
           export HADOOP_HOME=`realpath winutils/hadoop-3.2.2`
           export PATH=$PATH:$HADOOP_HOME/bin
-          # run Windows tests
+          # Run Windows tests
           pytest --ignore-flavors --ignore=tests/projects --ignore=tests/examples tests --ignore=tests/pipelines

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -261,6 +261,9 @@ jobs:
           pip install --no-dependencies tests/resources/mlflow-test-plugin
           pip install -e .[extras]
           pip install pyspark
+      - name: Download Hadoop winutils for Spark
+        run: |
+          git clone https://github.com/cdarlint/winutils
       - name: Run python tests
         run: |
           # Set Hadoop environment variables required for testing Spark integrations on Windows

--- a/mlflow/pipelines/regression/v1/pipeline.py
+++ b/mlflow/pipelines/regression/v1/pipeline.py
@@ -122,7 +122,11 @@ from mlflow.pipelines.steps.split import (
 from mlflow.pipelines.steps.transform import TransformStep
 from mlflow.pipelines.steps.train import TrainStep
 from mlflow.pipelines.steps.evaluate import EvaluateStep
-from mlflow.pipelines.steps.predict import PredictStep, _SCORED_OUTPUT_FILE_NAME
+from mlflow.pipelines.steps.predict import (
+    PredictStep,
+    _SCORED_OUTPUT_FILE_NAME,
+    _SCORED_OUTPUT_FOLDER_NAME,
+)
 from mlflow.pipelines.steps.register import RegisterStep, RegisteredModelVersionInfo
 from mlflow.pipelines.step import BaseStep
 from typing import List, Any, Optional
@@ -131,6 +135,7 @@ from mlflow.pipelines.utils.execution import get_or_create_base_execution_direct
 from mlflow.pipelines.utils.execution import get_step_output_path
 from mlflow.exceptions import MlflowException, INVALID_PARAMETER_VALUE
 from mlflow.tracking._tracking_service.utils import _use_tracking_uri
+from mlflow.utils import databricks_utils
 from mlflow.utils.annotations import experimental
 
 _logger = logging.getLogger(__name__)
@@ -616,6 +621,8 @@ class RegressionPipeline(_BasePipeline):
             predict_output_dir = get_step_output_path(
                 self._pipeline_root_path, predict_step.name, ""
             )
+            if databricks_utils.is_in_databricks_runtime():
+                return os.path.join("/dbfs", predict_output_dir, _SCORED_OUTPUT_FOLDER_NAME)
             return os.path.join(predict_output_dir, _SCORED_OUTPUT_FILE_NAME)
         else:
             raise MlflowException(

--- a/mlflow/pipelines/regression/v1/pipeline.py
+++ b/mlflow/pipelines/regression/v1/pipeline.py
@@ -125,7 +125,6 @@ from mlflow.pipelines.steps.evaluate import EvaluateStep
 from mlflow.pipelines.steps.predict import (
     PredictStep,
     _SCORED_OUTPUT_FILE_NAME,
-    _SCORED_OUTPUT_FOLDER_NAME,
 )
 from mlflow.pipelines.steps.register import RegisterStep, RegisteredModelVersionInfo
 from mlflow.pipelines.step import BaseStep
@@ -135,7 +134,6 @@ from mlflow.pipelines.utils.execution import get_or_create_base_execution_direct
 from mlflow.pipelines.utils.execution import get_step_output_path
 from mlflow.exceptions import MlflowException, INVALID_PARAMETER_VALUE
 from mlflow.tracking._tracking_service.utils import _use_tracking_uri
-from mlflow.utils import databricks_utils
 from mlflow.utils.annotations import experimental
 
 _logger = logging.getLogger(__name__)
@@ -621,8 +619,6 @@ class RegressionPipeline(_BasePipeline):
             predict_output_dir = get_step_output_path(
                 self._pipeline_root_path, predict_step.name, ""
             )
-            if databricks_utils.is_in_databricks_runtime():
-                return os.path.join("/dbfs", predict_output_dir, _SCORED_OUTPUT_FOLDER_NAME)
             return os.path.join(predict_output_dir, _SCORED_OUTPUT_FILE_NAME)
         else:
             raise MlflowException(

--- a/mlflow/pipelines/steps/predict.py
+++ b/mlflow/pipelines/steps/predict.py
@@ -129,6 +129,7 @@ class PredictStep(BaseStep):
             artifact_path = os.path.join(output_directory, _SCORED_OUTPUT_FOLDER_NAME)
             dbutils.fs.rm("dbfs:" + artifact_path, recurse=True)
             scored_sdf.coalesce(1).write.format("parquet").save(artifact_path)
+            _logger.info("Moving artifact from DBFS to driver disk")
             dbutils.fs.cp("dbfs:" + artifact_path, "file:" + artifact_path, recurse=True)
             dbutils.fs.rm("dbfs:" + artifact_path, recurse=True)
         else:

--- a/mlflow/pipelines/steps/predict.py
+++ b/mlflow/pipelines/steps/predict.py
@@ -40,9 +40,10 @@ class PredictStep(BaseStep):
         # Build profiles for scored dataset
         card = BaseCard(self.pipeline_name, self.name)
 
+        scored_size = scored_sdf.count()
+
         if not self.skip_data_profiling:
             _logger.info("Profiling scored dataset")
-            scored_size = scored_sdf.count()
             if scored_size > _MAX_PROFILE_SIZE:
                 _logger.info("Sampling scored dataset for profiling because dataset size is large.")
                 sample_percentage = _MAX_PROFILE_SIZE / scored_size
@@ -66,7 +67,7 @@ class PredictStep(BaseStep):
                 """,
             ).add_markdown(
                 "SCORED_DATA_NUM_ROWS",
-                f"**Number of scored dataset rows:** `{len(scored_df)}`",
+                f"**Number of scored dataset rows:** `{scored_size}`",
             )
         )
 

--- a/mlflow/pipelines/steps/predict.py
+++ b/mlflow/pipelines/steps/predict.py
@@ -137,7 +137,7 @@ class PredictStep(BaseStep):
                 _get_execution_directory_basename(self.pipeline_root),
                 _SCORED_OUTPUT_FOLDER_NAME,
             )
-            shutil.rmtree("/dbfs/" + dbfs_path)
+            shutil.rmtree("/dbfs/" + dbfs_path, ignore_errors=True)
             scored_sdf.coalesce(1).write.format("parquet").save(dbfs_path)
             _logger.info("Moving artifact from DBFS to driver disk")
             shutil.copytree(

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -627,7 +627,7 @@ def get_or_create_nfs_tmp_dir():
 
 def write_spark_dataframe_to_parquet_on_local_disk(spark_df, output_path):
     """
-    Write spark dataframe as in parquet format to local disk.
+    Write spark dataframe in parquet format to local disk.
 
     :param spark_df: Spark dataframe
     :param output_path: path to write the data to

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -623,3 +623,22 @@ def get_or_create_nfs_tmp_dir():
         atexit.register(shutil.rmtree, tmp_nfs_dir, ignore_errors=True)
 
     return tmp_nfs_dir
+
+
+def write_spark_dataframe_to_parquet_on_local_disk(spark_df, output_path):
+    """
+    Write spark dataframe as in parquet format to local disk.
+
+    :param spark_df: Spark dataframe
+    :param output_path: path to write the data to
+    """
+    from mlflow.utils.databricks_utils import is_in_databricks_runtime
+    import uuid
+
+    if is_in_databricks_runtime():
+        dbfs_path = os.path.join(".mlflow", "cache", str(uuid.uuid4()))
+        spark_df.coalesce(1).write.format("parquet").save(dbfs_path)
+        shutil.copytree("/dbfs/" + dbfs_path, output_path)
+        shutil.rmtree("/dbfs/" + dbfs_path)
+    else:
+        spark_df.coalesce(1).write.format("parquet").save(output_path)

--- a/tests/pipelines/test_predict_step.py
+++ b/tests/pipelines/test_predict_step.py
@@ -10,7 +10,7 @@ from unittest import mock
 
 from mlflow.exceptions import MlflowException
 from mlflow.pipelines.utils import _PIPELINE_CONFIG_FILE_NAME
-from mlflow.pipelines.steps.predict import PredictStep, _SCORED_OUTPUT_FILE_NAME
+from mlflow.pipelines.steps.predict import PredictStep, _INPUT_FILE_NAME, _SCORED_OUTPUT_FILE_NAME
 
 # pylint: disable=unused-import
 from tests.pipelines.helper_functions import (
@@ -67,7 +67,7 @@ def predict_step_output_dir(tmp_pipeline_root_path: Path, tmp_pipeline_exec_path
     )
     ingest_scoring_step_output_dir.mkdir(parents=True)
     X, _ = load_diabetes(as_frame=True, return_X_y=True)
-    X.to_parquet(ingest_scoring_step_output_dir.joinpath("scoring-dataset.parquet"))
+    X.to_parquet(ingest_scoring_step_output_dir.joinpath(_INPUT_FILE_NAME))
     predict_step_output_dir = tmp_pipeline_exec_path.joinpath("steps", "predict", "outputs")
     predict_step_output_dir.mkdir(parents=True)
     pipeline_yaml = tmp_pipeline_root_path.joinpath(_PIPELINE_CONFIG_FILE_NAME)


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

This change fixes the artifact writing and reading logic for the batch scoring predict step.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

I cloned the example MLP regression template repo. Updated the requirements.txt file to point to my fix branch. Ran the entire Databricks notebook in the example. Then, I added notebook cells and ran the ingest_scoring and predict steps. Both of which succeeded. Finally, I loaded the scored dataset artifact using the `get_artifact` API and it succeeded.

See screenshots:

<img width="1699" alt="Screen Shot 2022-09-13 at 2 28 21 PM" src="https://user-images.githubusercontent.com/66143562/190012636-d190df37-4a46-438c-8928-f0f4c29543ab.png">
<img width="1707" alt="Screen Shot 2022-09-13 at 2 28 29 PM" src="https://user-images.githubusercontent.com/66143562/190012645-a4a576ad-2c86-4520-9976-641e9d9b1ca7.png">

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
