### PR TITLE
Run MLP tests against a specific "next-release" MLP template branch

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -58,6 +58,7 @@ jobs:
           pytest tests/pipelines
           # Run pipelines tests against the next MLP template release branch
           cd examples/pipelines/sklearn_regression
+          git fetch
           git checkout next-release
           cd $MLFLOW_HOME
           pytest tests/pipelines --mlp_next_release
@@ -90,6 +91,7 @@ jobs:
           pytest tests/pipelines
           # Run pipelines tests against the next MLP template release branch
           cd examples/pipelines/sklearn_regression
+          git fetch
           git checkout next-release
           cd $MLFLOW_HOME
           pytest tests/pipelines --mlp_next_release

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -90,6 +90,6 @@ jobs:
           pytest tests/pipelines
           # Run pipelines tests against the next MLP template release branch
           cd examples/pipelines/sklearn_regression
-          git fetch origin && git checkout origin/next-release
+          git checkout next-release
           cd $MLFLOW_HOME
           pytest tests/pipelines --mlp_next_release

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -56,6 +56,11 @@ jobs:
         run: |
           export MLFLOW_HOME=$(pwd)
           pytest tests/pipelines
+          # Run pipelines tests against the next MLP template release branch
+          cd examples/pipelines/sklearn_regression
+          git fetch origin && git checkout origin/next-release
+          cd $MLFLOW_HOME
+          pytest tests/pipelines --mlp_next_release
 
   pipelines-windows:
     runs-on: windows-latest
@@ -83,3 +88,8 @@ jobs:
           # Run pipelines tests
           export MLFLOW_HOME=$(pwd)
           pytest tests/pipelines
+          # Run pipelines tests against the next MLP template release branch
+          cd examples/pipelines/sklearn_regression
+          git fetch origin && git checkout origin/next-release
+          cd $MLFLOW_HOME
+          pytest tests/pipelines --mlp_next_release

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -58,7 +58,7 @@ jobs:
           pytest tests/pipelines
           # Run pipelines tests against the next MLP template release branch
           cd examples/pipelines/sklearn_regression
-          git fetch origin && git checkout origin/next-release
+          git checkout next-release
           cd $MLFLOW_HOME
           pytest tests/pipelines --mlp_next_release
 

--- a/tests/pipelines/test_split_step.py
+++ b/tests/pipelines/test_split_step.py
@@ -128,7 +128,7 @@ def test_from_pipeline_config_works_with_target_col(tmp_path):
         assert SplitStep.from_pipeline_config({"target_col": "fake_col"}, "fake_root") is not None
 
 
-@pytest.mark.mlp_next_release
+@pytest.mark.mlp_next_release("1.29.0")
 def test_split_step_skips_profiling_when_specified(tmp_path):
     ingest_output_dir = tmp_path / "steps" / "ingest" / "outputs"
     ingest_output_dir.mkdir(parents=True)

--- a/tests/pipelines/test_split_step.py
+++ b/tests/pipelines/test_split_step.py
@@ -128,6 +128,7 @@ def test_from_pipeline_config_works_with_target_col(tmp_path):
         assert SplitStep.from_pipeline_config({"target_col": "fake_col"}, "fake_root") is not None
 
 
+@pytest.mark.mlp_next_release
 def test_split_step_skips_profiling_when_specified(tmp_path):
     ingest_output_dir = tmp_path / "steps" / "ingest" / "outputs"
     ingest_output_dir.mkdir(parents=True)


### PR DESCRIPTION
Signed-off-by: dbczumar <corey.zumar@databricks.com>

## What changes are proposed in this pull request?

Run MLP tests against a specific "next-release" MLP template branch (https://github.com/mlflow/mlp-regression-template/tree/next-release). This PR introduces a `@pytest.mark.mlp_next_release("<mlflow_next_release_version>")` decorator and an associated `--mlp-next-release` flag with the following behavior:

1. When `pytest --mlp-next-release` is executed, only run test cases that include the decorator with the specified `mlflow_next_release_version` greater than the current MLflow version.
2. When `pytest` is executed without the `--mlp-next-release` flag, run all test cases *except* ones that include the decorator with the specified `mlflow_next_release_version` greater than the current MLflow version; we still run test cases that include the decorator with `mlflow_next_release_version` less than the current mlflow version.

## How is this patch tested?

- GitHub Actions CI
- Decorate `test_split_step_skips_profiling_when_specified` in `tests/pipelines/test_split_step.py` and test as follows:

1. Decorate with `@pytest.mark.mlp_next_release("1.29.0")`

- Confirm that running `pytest tests/pipelines/test_split_step.py` runs all test cases in `tests/pipelines/test_split_step.py` *except* `test_split_step_skips_profiling_when_specified` because MLflow 1.28.0.dev < MLflow 1.29.0

- Confirm that running `pytest tests/pipelines/test_split_step.py --mlp-next-release` runs *only* the `test_split_step_skips_profiling_when_specified` test case because MLflow 1.28.0.dev < MLflow 1.29.0

3. Decorate with `@pytest.mark.mlp_next_release("1.28.0")`

- Confirm that running `pytest tests/pipelines/test_split_step.py` runs all test cases in `tests/pipelines/test_split_step.py` *including* `test_split_step_skips_profiling_when_specified` because MLflow 1.28.0.dev > MLflow 1.28.0

- Confirm that running `pytest tests/pipelines/test_split_step.py --mlp-next-release` *does not run any test cases* because MLflow 1.28.0.dev > MLflow 1.28.0

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
4. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [X] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
