### PR TITLE
Add run name field to MLflow create/get/update API implementations for all stores

### DIFF
--- a/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
+++ b/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
@@ -59,7 +59,7 @@ test_that("mlflow_end_run() works properly", {
 
   # Verify that only expected run field names are present and that all run info fields are set
   # (not NA).
-  run_info_names <- c("run_uuid", "experiment_id", "user_id", "status", "start_time",
+  run_info_names <- c("run_uuid", "experiment_id", "user_id", "run_name", "status", "start_time",
   "artifact_uri", "lifecycle_stage", "run_id", "end_time")
   run_data_names <- c("metrics", "params", "tags")
   expect_setequal(c(run_info_names, run_data_names), names(run))

--- a/mlflow/entities/run_info.py
+++ b/mlflow/entities/run_info.py
@@ -43,6 +43,7 @@ class RunInfo(_MLflowObject):
         lifecycle_stage,
         artifact_uri=None,
         run_id=None,
+        run_name=None,
     ):
         if experiment_id is None:
             raise Exception("experiment_id cannot be None")
@@ -64,6 +65,7 @@ class RunInfo(_MLflowObject):
         self._end_time = end_time
         self._lifecycle_stage = lifecycle_stage
         self._artifact_uri = artifact_uri
+        self._run_name = run_name
 
     def __eq__(self, other):
         if type(other) is type(self):
@@ -71,7 +73,7 @@ class RunInfo(_MLflowObject):
             return self.__dict__ == other.__dict__
         return False
 
-    def _copy_with_overrides(self, status=None, end_time=None, lifecycle_stage=None):
+    def _copy_with_overrides(self, status=None, end_time=None, lifecycle_stage=None, run_name=None):
         """A copy of the RunInfo with certain attributes modified."""
         proto = self.to_proto()
         if status:
@@ -80,6 +82,8 @@ class RunInfo(_MLflowObject):
             proto.end_time = end_time
         if lifecycle_stage:
             proto.lifecycle_stage = lifecycle_stage
+        if run_name:
+            proto.run_name = run_name
         return RunInfo.from_proto(proto)
 
     @property
@@ -96,6 +100,11 @@ class RunInfo(_MLflowObject):
     def experiment_id(self):
         """String ID of the experiment for the current run."""
         return self._experiment_id
+
+    @property
+    def run_name(self):
+        """String containing run name."""
+        return self._run_name
 
     @property
     def user_id(self):
@@ -133,6 +142,7 @@ class RunInfo(_MLflowObject):
         proto = ProtoRunInfo()
         proto.run_uuid = self.run_uuid
         proto.run_id = self.run_id
+        proto.run_name = self.run_name
         proto.experiment_id = self.experiment_id
         proto.user_id = self.user_id
         proto.status = RunStatus.from_string(self.status)
@@ -154,6 +164,7 @@ class RunInfo(_MLflowObject):
         return cls(
             run_uuid=proto.run_uuid,
             run_id=proto.run_id,
+            run_name=proto.run_name,
             experiment_id=proto.experiment_id,
             user_id=proto.user_id,
             status=RunStatus.to_string(proto.status),

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
@@ -544,7 +544,7 @@ public class MlflowClientTest {
       Arrays.asList(1L, -5L, 4L, 4L));
 
     List<RunTag> tags = run.getData().getTagsList();
-    Assert.assertEquals(tags.size(), 2);
+    Assert.assertEquals(tags.size(), 1);
     assertTag(tags, "user_email", USER_EMAIL);
   }
 

--- a/mlflow/runs.py
+++ b/mlflow/runs.py
@@ -6,7 +6,6 @@ import json
 import mlflow.tracking
 from mlflow.entities import ViewType
 from mlflow.tracking import _get_store
-from mlflow.utils.mlflow_tags import MLFLOW_RUN_NAME
 from mlflow.utils.time_utils import conv_longdate_to_str
 from mlflow.utils.string_utils import _create_table
 

--- a/mlflow/runs.py
+++ b/mlflow/runs.py
@@ -46,7 +46,7 @@ def list_run(experiment_id, view):
     runs = store.search_runs([experiment_id], None, view_type)
     table = []
     for run in runs:
-        run_name = run.data.tags.get(MLFLOW_RUN_NAME, "")
+        run_name = run.info.run_name or ""
         table.append([conv_longdate_to_str(run.info.start_time), run_name, run.info.run_id])
     click.echo(_create_table(sorted(table, reverse=True), headers=["Date", "Name", "ID"]))
 

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -683,7 +683,7 @@ def _create_run():
         user_id=request_message.user_id,
         start_time=request_message.start_time,
         tags=tags,
-        name=run_name,
+        run_name=run_name,
     )
 
     response_message = CreateRun.Response()

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -80,7 +80,6 @@ from mlflow.store.artifact.artifact_repository_registry import get_artifact_repo
 from mlflow.store.db.db_types import DATABASE_ENGINES
 from mlflow.tracking._model_registry.registry import ModelRegistryStoreRegistry
 from mlflow.tracking._tracking_service.registry import TrackingStoreRegistry
-from mlflow.utils.mlflow_tags import MLFLOW_RUN_NAME
 from mlflow.utils.name_utils import _generate_random_name
 from mlflow.utils.proto_json_utils import message_to_json, parse_dict
 from mlflow.utils.validation import _validate_batch_log_api_req
@@ -667,17 +666,24 @@ def _update_experiment():
 @_disable_if_artifacts_only
 def _create_run():
     request_message = _get_request_message(
-        CreateRun(), schema={"experiment_id": [_assert_string], "start_time": [_assert_intlike]}
+        CreateRun(),
+        schema={
+            "experiment_id": [_assert_string],
+            "start_time": [_assert_intlike],
+            "run_name": [_assert_string],
+        },
     )
 
     tags = [RunTag(tag.key, tag.value) for tag in request_message.tags]
-    if MLFLOW_RUN_NAME not in [tag.key for tag in tags]:
-        tags.append(RunTag(MLFLOW_RUN_NAME, _generate_random_name()))
+    run_name = (
+        _generate_random_name() if request_message.run_name is None else request_message.run_name
+    )
     run = _get_tracking_store().create_run(
         experiment_id=request_message.experiment_id,
         user_id=request_message.user_id,
         start_time=request_message.start_time,
         tags=tags,
+        name=run_name,
     )
 
     response_message = CreateRun.Response()
@@ -696,11 +702,12 @@ def _update_run():
             "run_id": [_assert_required, _assert_string],
             "end_time": [_assert_intlike],
             "status": [_assert_string],
+            "run_name": [_assert_string],
         },
     )
     run_id = request_message.run_id or request_message.run_uuid
     updated_info = _get_tracking_store().update_run_info(
-        run_id, request_message.status, request_message.end_time
+        run_id, request_message.status, request_message.end_time, request_message.run_name
     )
     response_message = UpdateRun.Response(run_info=updated_info.to_proto())
     response = Response(mimetype="application/json")

--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -176,7 +176,7 @@ class AbstractStore:
         pass
 
     @abstractmethod
-    def update_run_info(self, run_id, run_status, end_time, name):
+    def update_run_info(self, run_id, run_status, end_time, run_name):
         """
         Update the metadata of the specified run.
 
@@ -185,7 +185,7 @@ class AbstractStore:
         pass
 
     @abstractmethod
-    def create_run(self, experiment_id, user_id, start_time, tags, name):
+    def create_run(self, experiment_id, user_id, start_time, tags, run_name):
         """
         Create a run under the specified experiment ID, setting the run's status to "RUNNING"
         and the start time to the current time.

--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -176,7 +176,7 @@ class AbstractStore:
         pass
 
     @abstractmethod
-    def update_run_info(self, run_id, run_status, end_time):
+    def update_run_info(self, run_id, run_status, end_time, name):
         """
         Update the metadata of the specified run.
 
@@ -185,7 +185,7 @@ class AbstractStore:
         pass
 
     @abstractmethod
-    def create_run(self, experiment_id, user_id, start_time, tags):
+    def create_run(self, experiment_id, user_id, start_time, tags, name):
         """
         Create a run under the specified experiment ID, setting the run's status to "RUNNING"
         and the start time to the current time.

--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -208,6 +208,7 @@ class SqlRun(Base):
         run_info = RunInfo(
             run_uuid=self.run_uuid,
             run_id=self.run_uuid,
+            run_name=self.name,
             experiment_id=str(self.experiment_id),
             user_id=self.user_id,
             status=self.status,

--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -119,7 +119,7 @@ class SqlRun(Base):
     """
     Run UUID: `String` (limit 32 characters). *Primary Key* for ``runs`` table.
     """
-    name = Column(String(250))
+    run_name = Column(String(250))
     """
     Run name: `String` (limit 250 characters).
     """
@@ -208,7 +208,7 @@ class SqlRun(Base):
         run_info = RunInfo(
             run_uuid=self.run_uuid,
             run_id=self.run_uuid,
-            run_name=self.name,
+            run_name=self.run_name,
             experiment_id=str(self.experiment_id),
             user_id=self.user_id,
             status=self.status,

--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -119,7 +119,7 @@ class SqlRun(Base):
     """
     Run UUID: `String` (limit 32 characters). *Primary Key* for ``runs`` table.
     """
-    run_name = Column(String(250))
+    name = Column(String(250))
     """
     Run name: `String` (limit 250 characters).
     """
@@ -208,7 +208,7 @@ class SqlRun(Base):
         run_info = RunInfo(
             run_uuid=self.run_uuid,
             run_id=self.run_uuid,
-            run_name=self.run_name,
+            run_name=self.name,
             experiment_id=str(self.experiment_id),
             user_id=self.user_id,
             status=self.status,

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -566,15 +566,15 @@ class FileStore(AbstractStore):
             return os.path.basename(os.path.abspath(experiment_dir)), runs[0]
         return None, None
 
-    def update_run_info(self, run_id, run_status, end_time, name):
+    def update_run_info(self, run_id, run_status, end_time, run_name):
         _validate_run_id(run_id)
         run_info = self._get_run_info(run_id)
         check_run_is_active(run_info)
-        new_info = run_info._copy_with_overrides(run_status, end_time, run_name=name)
+        new_info = run_info._copy_with_overrides(run_status, end_time, run_name=run_name)
         self._overwrite_run_info(new_info)
         return new_info
 
-    def create_run(self, experiment_id, user_id, start_time, tags, name):
+    def create_run(self, experiment_id, user_id, start_time, tags, run_name):
         """
         Creates a run with the specified attributes.
         """
@@ -591,7 +591,7 @@ class FileStore(AbstractStore):
                 "Could not create run under non-active experiment with ID %s." % experiment_id,
                 databricks_pb2.INVALID_STATE,
             )
-        run_name = name if name is not None else _generate_random_name()
+        run_name = run_name if run_name is not None else _generate_random_name()
         run_uuid = uuid.uuid4().hex
         artifact_uri = self._get_artifact_dir(experiment_id, run_uuid)
         run_info = RunInfo(

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -570,7 +570,7 @@ class FileStore(AbstractStore):
         _validate_run_id(run_id)
         run_info = self._get_run_info(run_id)
         check_run_is_active(run_info)
-        new_info = run_info._copy_with_overrides(run_status, end_time, name)
+        new_info = run_info._copy_with_overrides(run_status, end_time, run_name=name)
         self._overwrite_run_info(new_info)
         return new_info
 

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -75,7 +75,7 @@ from mlflow.utils.file_utils import (
 from mlflow.utils.search_utils import SearchUtils, SearchExperimentsUtils
 from mlflow.utils.string_utils import is_string_type
 from mlflow.utils.uri import append_to_uri_path
-from mlflow.utils.mlflow_tags import MLFLOW_LOGGED_MODELS, MLFLOW_RUN_NAME
+from mlflow.utils.mlflow_tags import MLFLOW_LOGGED_MODELS
 
 _TRACKING_DIR_ENV_VAR = "MLFLOW_TRACKING_DIR"
 

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -163,15 +163,17 @@ class RestStore(AbstractStore):
         response_proto = self._call_endpoint(GetRun, req_body)
         return Run.from_proto(response_proto.run)
 
-    def update_run_info(self, run_id, run_status, end_time):
+    def update_run_info(self, run_id, run_status, end_time, name):
         """Updates the metadata of the specified run."""
         req_body = message_to_json(
-            UpdateRun(run_uuid=run_id, run_id=run_id, status=run_status, end_time=end_time)
+            UpdateRun(
+                run_uuid=run_id, run_id=run_id, status=run_status, end_time=end_time, run_name=name
+            )
         )
         response_proto = self._call_endpoint(UpdateRun, req_body)
         return RunInfo.from_proto(response_proto.run_info)
 
-    def create_run(self, experiment_id, user_id, start_time, tags):
+    def create_run(self, experiment_id, user_id, start_time, tags, name):
         """
         Create a run under the specified experiment ID, setting the run's status to "RUNNING"
         and the start time to the current time.
@@ -180,6 +182,7 @@ class RestStore(AbstractStore):
         :param user_id: ID of the user launching this run
         :param start_time: timestamp of the initialization of the run
         :param tags: tags to apply to this run at initialization
+        :param name: Name of this run.
 
         :return: The created Run object
         """
@@ -191,6 +194,7 @@ class RestStore(AbstractStore):
                 user_id=user_id,
                 start_time=start_time,
                 tags=tag_protos,
+                run_name=name,
             )
         )
         response_proto = self._call_endpoint(CreateRun, req_body)

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -163,17 +163,17 @@ class RestStore(AbstractStore):
         response_proto = self._call_endpoint(GetRun, req_body)
         return Run.from_proto(response_proto.run)
 
-    def update_run_info(self, run_id, run_status, end_time, name):
+    def update_run_info(self, run_id, run_status, end_time, run_name):
         """Updates the metadata of the specified run."""
         req_body = message_to_json(
             UpdateRun(
-                run_uuid=run_id, run_id=run_id, status=run_status, end_time=end_time, run_name=name
+                run_uuid=run_id, run_id=run_id, status=run_status, end_time=end_time, run_name=run_name
             )
         )
         response_proto = self._call_endpoint(UpdateRun, req_body)
         return RunInfo.from_proto(response_proto.run_info)
 
-    def create_run(self, experiment_id, user_id, start_time, tags, name):
+    def create_run(self, experiment_id, user_id, start_time, tags, run_name):
         """
         Create a run under the specified experiment ID, setting the run's status to "RUNNING"
         and the start time to the current time.
@@ -194,7 +194,7 @@ class RestStore(AbstractStore):
                 user_id=user_id,
                 start_time=start_time,
                 tags=tag_protos,
-                run_name=name,
+                run_name=run_name,
             )
         )
         response_proto = self._call_endpoint(CreateRun, req_body)

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -167,7 +167,11 @@ class RestStore(AbstractStore):
         """Updates the metadata of the specified run."""
         req_body = message_to_json(
             UpdateRun(
-                run_uuid=run_id, run_id=run_id, status=run_status, end_time=end_time, run_name=run_name
+                run_uuid=run_id,
+                run_id=run_id,
+                status=run_status,
+                end_time=end_time,
+                run_name=run_name,
             )
         )
         response_proto = self._call_endpoint(UpdateRun, req_body)

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -516,7 +516,7 @@ class SqlAlchemyStore(AbstractStore):
             experiment.last_update_time = int(time.time() * 1000)
             self._save_to_db(objs=experiment, session=session)
 
-    def create_run(self, experiment_id, user_id, start_time, tags):
+    def create_run(self, experiment_id, user_id, start_time, tags, name):
         with self.ManagedSessionMaker() as session:
             experiment = self.get_experiment(experiment_id)
             self._check_experiment_is_active(experiment)
@@ -530,7 +530,7 @@ class SqlAlchemyStore(AbstractStore):
                 experiment.artifact_location, run_id, SqlAlchemyStore.ARTIFACTS_FOLDER_NAME
             )
             run = SqlRun(
-                name="",
+                name=name,
                 artifact_uri=artifact_location,
                 run_uuid=run_id,
                 experiment_id=experiment_id,
@@ -613,12 +613,14 @@ class SqlAlchemyStore(AbstractStore):
                 INVALID_PARAMETER_VALUE,
             )
 
-    def update_run_info(self, run_id, run_status, end_time):
+    def update_run_info(self, run_id, run_status, end_time, name):
         with self.ManagedSessionMaker() as session:
             run = self._get_run(run_uuid=run_id, session=session)
             self._check_run_is_active(run)
             run.status = RunStatus.to_string(run_status)
             run.end_time = end_time
+            if name is not None:
+                run.name = name
 
             self._save_to_db(objs=run, session=session)
             run = run.to_mlflow_entity()

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -25,7 +25,7 @@ from mlflow.store.tracking.dbmodels.models import (
     SqlLatestMetric,
 )
 from mlflow.store.db.base_sql_model import Base
-from mlflow.entities import RunStatus, SourceType, Experiment, RunTag
+from mlflow.entities import RunStatus, SourceType, Experiment
 from mlflow.store.tracking.abstract_store import AbstractStore
 from mlflow.store.entities.paged_list import PagedList
 from mlflow.entities import ViewType
@@ -55,7 +55,7 @@ from mlflow.utils.validation import (
     _validate_param,
     _validate_experiment_name,
 )
-from mlflow.utils.mlflow_tags import MLFLOW_LOGGED_MODELS, MLFLOW_RUN_NAME
+from mlflow.utils.mlflow_tags import MLFLOW_LOGGED_MODELS
 
 _logger = logging.getLogger(__name__)
 

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -516,7 +516,7 @@ class SqlAlchemyStore(AbstractStore):
             experiment.last_update_time = int(time.time() * 1000)
             self._save_to_db(objs=experiment, session=session)
 
-    def create_run(self, experiment_id, user_id, start_time, tags, name):
+    def create_run(self, experiment_id, user_id, start_time, tags, run_name):
         with self.ManagedSessionMaker() as session:
             experiment = self.get_experiment(experiment_id)
             self._check_experiment_is_active(experiment)
@@ -529,8 +529,9 @@ class SqlAlchemyStore(AbstractStore):
             artifact_location = append_to_uri_path(
                 experiment.artifact_location, run_id, SqlAlchemyStore.ARTIFACTS_FOLDER_NAME
             )
+            run_name = run_name if run_name is not None else _generate_random_name()
             run = SqlRun(
-                name=name,
+                run_name=run_name,
                 artifact_uri=artifact_location,
                 run_uuid=run_id,
                 experiment_id=experiment_id,
@@ -546,12 +547,8 @@ class SqlAlchemyStore(AbstractStore):
                 lifecycle_stage=LifecycleStage.ACTIVE,
             )
 
-            if tags is None:
-                tags = [RunTag(MLFLOW_RUN_NAME, _generate_random_name())]
-            elif MLFLOW_RUN_NAME not in [tag.key for tag in tags]:
-                tags.append(RunTag(MLFLOW_RUN_NAME, _generate_random_name()))
-
-            run.tags = [SqlTag(key=tag.key, value=tag.value) for tag in tags]
+            if tags is not None:
+                run.tags = [SqlTag(key=tag.key, value=tag.value) for tag in tags]
             self._save_to_db(objs=run, session=session)
 
             return run.to_mlflow_entity()
@@ -613,14 +610,14 @@ class SqlAlchemyStore(AbstractStore):
                 INVALID_PARAMETER_VALUE,
             )
 
-    def update_run_info(self, run_id, run_status, end_time, name):
+    def update_run_info(self, run_id, run_status, end_time, run_name):
         with self.ManagedSessionMaker() as session:
             run = self._get_run(run_uuid=run_id, session=session)
             self._check_run_is_active(run)
             run.status = RunStatus.to_string(run_status)
             run.end_time = end_time
-            if name is not None:
-                run.name = name
+            if run_name is not None:
+                run.name = run_name
 
             self._save_to_db(objs=run, session=session)
             run = run.to_mlflow_entity()

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -531,7 +531,7 @@ class SqlAlchemyStore(AbstractStore):
             )
             run_name = run_name if run_name is not None else _generate_random_name()
             run = SqlRun(
-                run_name=run_name,
+                name=run_name,
                 artifact_uri=artifact_location,
                 run_uuid=run_id,
                 experiment_id=experiment_id,

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -82,7 +82,7 @@ class TrackingServiceClient:
         """
         return self.store.get_metric_history(run_id=run_id, metric_key=key)
 
-    def create_run(self, experiment_id, start_time=None, tags=None, name=None):
+    def create_run(self, experiment_id, start_time=None, tags=None, run_name=None):
         """
         Create a :py:class:`mlflow.entities.Run` object that can be associated with
         metrics, parameters, artifacts, etc.
@@ -110,7 +110,7 @@ class TrackingServiceClient:
             user_id=user_id,
             start_time=start_time or int(time.time() * 1000),
             tags=[RunTag(key, value) for (key, value) in tags.items()],
-            name=name,
+            run_name=run_name,
         )
 
     def list_run_infos(
@@ -471,7 +471,7 @@ class TrackingServiceClient:
             run_id,
             run_status=RunStatus.from_string(status),
             end_time=end_time,
-            name=None,
+            run_name=None,
         )
 
     def delete_run(self, run_id):

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -82,7 +82,7 @@ class TrackingServiceClient:
         """
         return self.store.get_metric_history(run_id=run_id, metric_key=key)
 
-    def create_run(self, experiment_id, start_time=None, tags=None):
+    def create_run(self, experiment_id, start_time=None, tags=None, name=None):
         """
         Create a :py:class:`mlflow.entities.Run` object that can be associated with
         metrics, parameters, artifacts, etc.
@@ -90,10 +90,11 @@ class TrackingServiceClient:
         Unlike :py:func:`mlflow.start_run`, does not change the "active run" used by
         :py:func:`mlflow.log_param`.
 
-        :param experiment_id: The ID of then experiment to create a run in.
+        :param experiment_id: The ID of the experiment to create a run in.
         :param start_time: If not provided, use the current timestamp.
         :param tags: A dictionary of key-value pairs that are converted into
                      :py:class:`mlflow.entities.RunTag` objects.
+        :param name: The name of this run.
         :return: :py:class:`mlflow.entities.Run` that was created.
         """
 
@@ -109,6 +110,7 @@ class TrackingServiceClient:
             user_id=user_id,
             start_time=start_time or int(time.time() * 1000),
             tags=[RunTag(key, value) for (key, value) in tags.items()],
+            name=name,
         )
 
     def list_run_infos(
@@ -466,7 +468,10 @@ class TrackingServiceClient:
         end_time = end_time if end_time else int(time.time() * 1000)
         status = status if status else RunStatus.to_string(RunStatus.FINISHED)
         self.store.update_run_info(
-            run_id, run_status=RunStatus.from_string(status), end_time=end_time
+            run_id,
+            run_status=RunStatus.from_string(status),
+            end_time=end_time,
+            name=None,
         )
 
     def delete_run(self, run_id):

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -221,7 +221,7 @@ class MlflowClient:
         experiment_id: str,
         start_time: Optional[int] = None,
         tags: Optional[Dict[str, Any]] = None,
-        name: Optional[str] = None,
+        run_name: Optional[str] = None,
     ) -> Run:
         """
         Create a :py:class:`mlflow.entities.Run` object that can be associated with
@@ -234,7 +234,7 @@ class MlflowClient:
         :param start_time: If not provided, use the current timestamp.
         :param tags: A dictionary of key-value pairs that are converted into
                      :py:class:`mlflow.entities.RunTag` objects.
-        :param name: The name of this run.
+        :param run_name: The name of this run.
         :return: :py:class:`mlflow.entities.Run` that was created.
 
         .. code-block:: python
@@ -247,7 +247,7 @@ class MlflowClient:
             name = "platform-run-24"
             client = MlflowClient()
             experiment_id = "0"
-            run = client.create_run(experiment_id, tags=tags, name=name)
+            run = client.create_run(experiment_id, tags=tags, run_name=name)
 
             # Show newly created run metadata info
             print("Run tags: {}".format(run.data.tags))
@@ -267,7 +267,7 @@ class MlflowClient:
             lifecycle_stage: active
             status: RUNNING
         """
-        return self._tracking_client.create_run(experiment_id, start_time, tags, name)
+        return self._tracking_client.create_run(experiment_id, start_time, tags, run_name)
 
     @deprecated(alternative="search_runs()")
     def list_run_infos(

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -221,6 +221,7 @@ class MlflowClient:
         experiment_id: str,
         start_time: Optional[int] = None,
         tags: Optional[Dict[str, Any]] = None,
+        name: Optional[str] = None,
     ) -> Run:
         """
         Create a :py:class:`mlflow.entities.Run` object that can be associated with
@@ -233,6 +234,7 @@ class MlflowClient:
         :param start_time: If not provided, use the current timestamp.
         :param tags: A dictionary of key-value pairs that are converted into
                      :py:class:`mlflow.entities.RunTag` objects.
+        :param name: The name of this run.
         :return: :py:class:`mlflow.entities.Run` that was created.
 
         .. code-block:: python
@@ -242,14 +244,16 @@ class MlflowClient:
 
             # Create a run with a tag under the default experiment (whose id is '0').
             tags = {"engineering": "ML Platform"}
+            name = "platform-run-24"
             client = MlflowClient()
             experiment_id = "0"
-            run = client.create_run(experiment_id, tags=tags)
+            run = client.create_run(experiment_id, tags=tags, name=name)
 
             # Show newly created run metadata info
             print("Run tags: {}".format(run.data.tags))
             print("Experiment id: {}".format(run.info.experiment_id))
             print("Run id: {}".format(run.info.run_id))
+            print("Run name: {}".format(run.info.run_name))
             print("lifecycle_stage: {}".format(run.info.lifecycle_stage))
             print("status: {}".format(run.info.status))
 
@@ -259,10 +263,11 @@ class MlflowClient:
             Run tags: {'engineering': 'ML Platform'}
             Experiment id: 0
             Run id: 65fb9e2198764354bab398105f2e70c1
+            Run name: platform-run-24
             lifecycle_stage: active
             status: RUNNING
         """
-        return self._tracking_client.create_run(experiment_id, start_time, tags)
+        return self._tracking_client.create_run(experiment_id, start_time, tags, name)
 
     @deprecated(alternative="search_runs()")
     def list_run_infos(

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -36,7 +36,6 @@ from mlflow.utils.autologging_utils import (
 from mlflow.utils.import_hooks import register_post_import_hook
 from mlflow.utils.mlflow_tags import (
     MLFLOW_PARENT_RUN_ID,
-    MLFLOW_RUN_NAME,
     MLFLOW_RUN_NOTE,
     MLFLOW_EXPERIMENT_PRIMARY_METRIC_NAME,
     MLFLOW_EXPERIMENT_PRIMARY_METRIC_GREATER_IS_BETTER,
@@ -202,7 +201,7 @@ def start_run(
                           activated using ``set_experiment``, ``MLFLOW_EXPERIMENT_NAME``
                           environment variable, ``MLFLOW_EXPERIMENT_ID`` environment variable,
                           or the default experiment as defined by the tracking server.
-    :param run_name: Name of new run (stored as a ``mlflow.runName`` tag).
+    :param run_name: Name of new run.
                      Used only when ``run_id`` is unspecified. If a new run is created and
                      ``run_name`` is not specified, a unique name will be generated for the run.
     :param nested: Controls whether run is nested in parent run. ``True`` creates a nested run.
@@ -308,7 +307,7 @@ def start_run(
         # Use previous end_time because a value is required for update_run_info
         end_time = active_run_obj.info.end_time
         _get_store().update_run_info(
-            existing_run_id, run_status=RunStatus.RUNNING, end_time=end_time
+            existing_run_id, run_status=RunStatus.RUNNING, end_time=end_time, name=None
         )
         tags = tags or {}
         if description:
@@ -345,12 +344,12 @@ def start_run(
             user_specified_tags[MLFLOW_RUN_NOTE] = description
         if parent_run_id is not None:
             user_specified_tags[MLFLOW_PARENT_RUN_ID] = parent_run_id
-        if run_name is not None:
-            user_specified_tags[MLFLOW_RUN_NAME] = run_name
 
         resolved_tags = context_registry.resolve_tags(user_specified_tags)
 
-        active_run_obj = client.create_run(experiment_id=exp_id_for_run, tags=resolved_tags)
+        active_run_obj = client.create_run(
+            experiment_id=exp_id_for_run, tags=resolved_tags, name=run_name
+        )
 
     _active_run_stack.append(ActiveRun(active_run_obj))
     return _active_run_stack[-1]

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -307,7 +307,7 @@ def start_run(
         # Use previous end_time because a value is required for update_run_info
         end_time = active_run_obj.info.end_time
         _get_store().update_run_info(
-            existing_run_id, run_status=RunStatus.RUNNING, end_time=end_time, name=None
+            existing_run_id, run_status=RunStatus.RUNNING, end_time=end_time, run_name=None
         )
         tags = tags or {}
         if description:
@@ -348,7 +348,7 @@ def start_run(
         resolved_tags = context_registry.resolve_tags(user_specified_tags)
 
         active_run_obj = client.create_run(
-            experiment_id=exp_id_for_run, tags=resolved_tags, name=run_name
+            experiment_id=exp_id_for_run, tags=resolved_tags, run_name=run_name
         )
 
     _active_run_stack.append(ActiveRun(active_run_obj))

--- a/mlflow/utils/autologging_utils/client.py
+++ b/mlflow/utils/autologging_utils/client.py
@@ -32,7 +32,7 @@ from mlflow.utils.validation import (
 
 _logger = logging.getLogger(__name__)
 
-_PendingCreateRun = namedtuple("_PendingCreateRun", ["experiment_id", "start_time", "tags"])
+_PendingCreateRun = namedtuple("_PendingCreateRun", ["experiment_id", "start_time", "tags", "name"])
 _PendingSetTerminated = namedtuple("_PendingSetTerminated", ["status", "end_time"])
 
 
@@ -136,6 +136,7 @@ class MlflowAutologgingQueueingClient:
         experiment_id: str,
         start_time: Optional[int] = None,
         tags: Optional[Dict[str, Any]] = None,
+        name: Optional[str] = None,
     ) -> PendingRunId:
         """
         Enqueues a CreateRun operation with the specified attributes, returning a `PendingRunId`
@@ -155,6 +156,7 @@ class MlflowAutologgingQueueingClient:
                 experiment_id=experiment_id,
                 start_time=start_time,
                 tags=[RunTag(key, str(value)) for key, value in tags.items()],
+                name=name,
             )
         )
         return run_id

--- a/mlflow/utils/autologging_utils/client.py
+++ b/mlflow/utils/autologging_utils/client.py
@@ -32,7 +32,7 @@ from mlflow.utils.validation import (
 
 _logger = logging.getLogger(__name__)
 
-_PendingCreateRun = namedtuple("_PendingCreateRun", ["experiment_id", "start_time", "tags", "name"])
+_PendingCreateRun = namedtuple("_PendingCreateRun", ["experiment_id", "start_time", "tags", "run_name"])
 _PendingSetTerminated = namedtuple("_PendingSetTerminated", ["status", "end_time"])
 
 
@@ -136,7 +136,7 @@ class MlflowAutologgingQueueingClient:
         experiment_id: str,
         start_time: Optional[int] = None,
         tags: Optional[Dict[str, Any]] = None,
-        name: Optional[str] = None,
+        run_name: Optional[str] = None,
     ) -> PendingRunId:
         """
         Enqueues a CreateRun operation with the specified attributes, returning a `PendingRunId`
@@ -156,7 +156,7 @@ class MlflowAutologgingQueueingClient:
                 experiment_id=experiment_id,
                 start_time=start_time,
                 tags=[RunTag(key, str(value)) for key, value in tags.items()],
-                name=name,
+                run_name=run_name,
             )
         )
         return run_id

--- a/mlflow/utils/autologging_utils/client.py
+++ b/mlflow/utils/autologging_utils/client.py
@@ -32,7 +32,9 @@ from mlflow.utils.validation import (
 
 _logger = logging.getLogger(__name__)
 
-_PendingCreateRun = namedtuple("_PendingCreateRun", ["experiment_id", "start_time", "tags", "run_name"])
+_PendingCreateRun = namedtuple(
+    "_PendingCreateRun", ["experiment_id", "start_time", "tags", "run_name"]
+)
 _PendingSetTerminated = namedtuple("_PendingSetTerminated", ["status", "end_time"])
 
 

--- a/tests/autologging/test_autologging_client.py
+++ b/tests/autologging/test_autologging_client.py
@@ -90,7 +90,7 @@ def test_client_logs_expected_run_data():
     }
     metrics_to_log = {"metric_key_{}".format(i): i for i in range((4 * MAX_METRICS_PER_BATCH) + 1)}
 
-    with mlflow.start_run() as run:
+    with mlflow.start_run(run_name="my name") as run:
         client.log_params(run_id=run.info.run_id, params=params_to_log)
         client.set_tags(run_id=run.info.run_id, tags=tags_to_log)
         client.log_metrics(run_id=run.info.run_id, metrics=metrics_to_log)
@@ -100,6 +100,7 @@ def test_client_logs_expected_run_data():
     assert run_params == params_to_log
     assert run_metrics == metrics_to_log
     assert run_tags == tags_to_log
+    assert run.info.run_name == "my name"
 
 
 def test_client_logs_metric_steps_correctly():

--- a/tests/entities/test_run.py
+++ b/tests/entities/test_run.py
@@ -27,6 +27,7 @@ class TestRun(TestRunInfo, TestRunData):
         (
             run_info,
             run_id,
+            run_name,
             experiment_id,
             user_id,
             status,
@@ -43,6 +44,7 @@ class TestRun(TestRunInfo, TestRunData):
         expected_info_dict = {
             "run_uuid": run_id,
             "run_id": run_id,
+            "run_name": run_name,
             "experiment_id": experiment_id,
             "user_id": user_id,
             "status": status,
@@ -74,6 +76,7 @@ class TestRun(TestRunInfo, TestRunData):
         run_info = RunInfo(
             run_uuid="hi",
             run_id="hi",
+            run_name="name",
             experiment_id=0,
             user_id="user-id",
             status=RunStatus.FAILED,
@@ -88,7 +91,7 @@ class TestRun(TestRunInfo, TestRunData):
             "<Run: data=<RunData: metrics={'key-0': 0, 'key-1': 1, 'key-2': 2}, "
             "params={}, tags={}>, info=<RunInfo: artifact_uri=None, end_time=1, "
             "experiment_id=0, "
-            "lifecycle_stage='active', run_id='hi', run_uuid='hi', "
+            "lifecycle_stage='active', run_id='hi', run_name='name', run_uuid='hi', "
             "start_time=0, status=4, user_id='user-id'>>"
         )
         assert str(run1) == expected

--- a/tests/entities/test_run_info.py
+++ b/tests/entities/test_run_info.py
@@ -35,6 +35,7 @@ class TestRunInfo(unittest.TestCase):
         run_id = str(uuid.uuid4())
         experiment_id = str(random_int(10, 2000))
         user_id = random_str(random_int(10, 25))
+        run_name = random_str(random_int(10, 25))
         status = RunStatus.to_string(random.choice(RunStatus.all_status()))
         start_time = random_int(1, 10)
         end_time = start_time + random_int(1, 10)
@@ -43,6 +44,7 @@ class TestRunInfo(unittest.TestCase):
         ri = RunInfo(
             run_uuid=run_id,
             run_id=run_id,
+            run_name=run_name,
             experiment_id=experiment_id,
             user_id=user_id,
             status=status,
@@ -54,6 +56,7 @@ class TestRunInfo(unittest.TestCase):
         return (
             ri,
             run_id,
+            run_name,
             experiment_id,
             user_id,
             status,
@@ -67,6 +70,7 @@ class TestRunInfo(unittest.TestCase):
         (
             ri1,
             run_id,
+            run_name,
             experiment_id,
             user_id,
             status,
@@ -89,6 +93,7 @@ class TestRunInfo(unittest.TestCase):
         as_dict = {
             "run_uuid": run_id,
             "run_id": run_id,
+            "run_name": run_name,
             "experiment_id": experiment_id,
             "user_id": user_id,
             "status": status,

--- a/tests/store/tracking/test_abstract_store.py
+++ b/tests/store/tracking/test_abstract_store.py
@@ -33,10 +33,10 @@ class AbstractStoreTestImpl(AbstractStore):
     def get_run(self, run_id):
         raise NotImplementedError()
 
-    def update_run_info(self, run_id, run_status, end_time):
+    def update_run_info(self, run_id, run_status, end_time, name):
         raise NotImplementedError()
 
-    def create_run(self, experiment_id, user_id, start_time, tags):
+    def create_run(self, experiment_id, user_id, start_time, tags, name):
         raise NotImplementedError()
 
     def delete_run(self, run_id):

--- a/tests/store/tracking/test_abstract_store.py
+++ b/tests/store/tracking/test_abstract_store.py
@@ -33,10 +33,10 @@ class AbstractStoreTestImpl(AbstractStore):
     def get_run(self, run_id):
         raise NotImplementedError()
 
-    def update_run_info(self, run_id, run_status, end_time, name):
+    def update_run_info(self, run_id, run_status, end_time, run_name):
         raise NotImplementedError()
 
-    def create_run(self, experiment_id, user_id, start_time, tags, name):
+    def create_run(self, experiment_id, user_id, start_time, tags, run_name):
         raise NotImplementedError()
 
     def delete_run(self, run_id):

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -651,7 +651,7 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
                 fs = FileStore(tmp.path(), artifact_root_uri)
                 exp_id = fs.create_experiment("exp")
                 run = fs.create_run(
-                    experiment_id=exp_id, user_id="user", start_time=0, tags=[], name="name"
+                    experiment_id=exp_id, user_id="user", start_time=0, tags=[], run_name="name"
                 )
                 self.assertEqual(
                     run.info.artifact_uri,
@@ -673,7 +673,7 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
             user_id="user",
             start_time=0,
             tags=[],
-            name=None,
+            run_name=None,
         )
         assert isinstance(no_tags_run.data, RunData)
         assert len(no_tags_run.data.tags) == 0
@@ -691,7 +691,7 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
             user_id="user",
             start_time=0,
             tags=tags_entities,
-            name=None,
+            run_name=None,
         )
         assert isinstance(tags_run.data, RunData)
         assert tags_run.data.tags == tags_dict
@@ -703,7 +703,7 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
             user_id="user",
             start_time=0,
             tags=[],
-            name="my name",
+            run_name="my name",
         )
 
         run_name = run.info.run_name
@@ -742,7 +742,7 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
             user_id="user",
             start_time=0,
             tags=[],
-            name="my name",
+            run_name="my name",
         ).info.run_id
 
         get_run = fs.get_run(run_id)
@@ -785,7 +785,7 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
             user_id="user",
             start_time=0,
             tags=[],
-            name="first name",
+            run_name="first name",
         ).info.run_id
         fs.update_run_info(run_id, RunStatus.FINISHED, 1000, "new name")
         get_run = fs.get_run(run_id)
@@ -798,7 +798,7 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
             user_id="user",
             start_time=0,
             tags=[],
-            name="first name",
+            run_name="first name",
         ).info.run_id
         fs.update_run_info(run_id, RunStatus.FINISHED, 1000, None)
         get_run = fs.get_run(run_id)
@@ -1296,7 +1296,7 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
             user_id="user",
             start_time=0,
             tags=[],
-            name="name",
+            run_name="name",
         )
         run_id = run.info.run_id
         metric_entities = [Metric("m1", 0.87, 12345, 0), Metric("m2", 0.49, 12345, 0)]
@@ -1313,7 +1313,7 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
             user_id="user",
             start_time=0,
             tags=[],
-            name="name",
+            run_name="name",
         )
 
     def test_log_batch_max_length_value(self):

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -32,7 +32,6 @@ from mlflow.protos.databricks_pb2 import (
     INTERNAL_ERROR,
     INVALID_PARAMETER_VALUE,
 )
-from mlflow.utils.mlflow_tags import MLFLOW_RUN_NAME
 
 from tests.helper_functions import random_int, random_str, safe_edit_yaml
 from tests.store.tracking import AbstractStoreTest

--- a/tests/store/tracking/test_rest_store.py
+++ b/tests/store/tracking/test_rest_store.py
@@ -173,11 +173,12 @@ class TestRestStore:
         ), mock.patch(
             "time.time", return_value=13579
         ), source_name_patch, source_type_patch:
-            with mlflow.start_run(experiment_id="43"):
+            with mlflow.start_run(experiment_id="43", run_name="my name"):
                 cr_body = message_to_json(
                     CreateRun(
                         experiment_id="43",
                         user_id=user_name,
+                        run_name="my name",
                         start_time=13579000,
                         tags=[
                             ProtoRunTag(key="mlflow.source.name", value=source_name),

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -821,7 +821,13 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         self.assertEqual(run.info.experiment_id, experiment_id)
         self.assertEqual(run.info.run_name, configs["run_name"])
 
-        no_run_configs = configs.pop("run_name")
+        no_run_configs = {
+            "experiment_id": experiment_id,
+            "user_id": "Anderson",
+            "start_time": int(time.time()),
+            "tags": [],
+            "run_name": None,
+        }
         run_id = self.store.create_run(**no_run_configs).info.run_id
         run = self.store.get_run(run_id)
         assert run.info.run_name.split("-")[0] in _GENERATOR_PREDICATES

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -644,7 +644,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
                     )
                     exp_id = store.create_experiment(name="exp")
                     run = store.create_run(
-                        experiment_id=exp_id, user_id="user", start_time=0, tags=[], name="name"
+                        experiment_id=exp_id, user_id="user", start_time=0, tags=[], run_name="name"
                     )
                     self.assertEqual(
                         run.info.artifact_uri,
@@ -780,7 +780,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
             "user_id": "Anderson",
             "start_time": start_time if start_time is not None else int(time.time()),
             "tags": tags,
-            "name": "name",
+            "run_name": "name",
         }
 
     def _run_factory(self, config=None):
@@ -1387,7 +1387,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
                     entities.RunTag(mlflow_tags.MLFLOW_RUN_NAME, name),
                     entities.RunTag("metric", names[1]),
                 ],
-                name="name",
+                run_name="name",
             ).info.run_id
             if names[0] is not None:
                 self.store.log_metric(run_id, entities.Metric("x", float(names[0]), 1, 0))
@@ -1446,7 +1446,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
                 user_id="MrDuck",
                 start_time=start_time,
                 tags=[entities.RunTag(mlflow_tags.MLFLOW_RUN_NAME, end)],
-                name="name",
+                run_name="name",
             ).info.run_id
 
         start_time = 123
@@ -2235,7 +2235,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
                 start_time=current_run,
                 tags=[],
                 user_id="Anderson",
-                name="name",
+                run_name="name",
             ).info.run_uuid
 
             run_ids.append(run_id)
@@ -2332,10 +2332,10 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         experiment_id = self.store.create_experiment("test_experiment1")
 
         r1 = self.store.create_run(
-            experiment_id=experiment_id, start_time=0, tags=[], user_id="Me", name="name"
+            experiment_id=experiment_id, start_time=0, tags=[], user_id="Me", run_name="name"
         ).info.run_uuid
         r2 = self.store.create_run(
-            experiment_id=experiment_id, start_time=0, tags=[], user_id="Me", name="name"
+            experiment_id=experiment_id, start_time=0, tags=[], user_id="Me", run_name="name"
         ).info.run_uuid
         self.store.set_tag(r1, RunTag(key="t1", value="1"))
         self.store.set_tag(r1, RunTag(key="t2", value="1"))
@@ -2351,7 +2351,7 @@ def test_sqlalchemy_store_behaves_as_expected_with_inmemory_sqlite_db():
     store = SqlAlchemyStore("sqlite:///:memory:", ARTIFACT_URI)
     experiment_id = store.create_experiment(name="exp1")
     run = store.create_run(
-        experiment_id=experiment_id, user_id="user", start_time=0, tags=[], name="name"
+        experiment_id=experiment_id, user_id="user", start_time=0, tags=[], run_name="name"
     )
     run_id = run.info.run_id
     metric = entities.Metric("mymetric", 1, 0, 0)

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -1453,7 +1453,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         for end in [234, None, 456, -123, 789, 123]:
             run_id = create_run(start_time, end)
             self.store.update_run_info(
-                run_id, run_status=RunStatus.FINISHED, end_time=end, name=None
+                run_id, run_status=RunStatus.FINISHED, end_time=end, run_name=None
             )
             start_time += 1
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -174,6 +174,7 @@ def _create_run_in_store(store, create_artifacts=True):
         "user_id": "Anderson",
         "start_time": int(time.time()),
         "tags": [],
+        "name": "name",
     }
     run = store.create_run(**config)
     if create_artifacts:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -174,7 +174,7 @@ def _create_run_in_store(store, create_artifacts=True):
         "user_id": "Anderson",
         "start_time": int(time.time()),
         "tags": [],
-        "name": "name",
+        "run_name": "name",
     }
     run = store.create_run(**config)
     if create_artifacts:

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -473,7 +473,7 @@ def test_start_run_defaults(empty_active_run_stack):  # pylint: disable=unused-a
     ):
         active_run = start_run()
         MlflowClient.create_run.assert_called_once_with(
-            experiment_id=mock_experiment_id, tags=expected_tags
+            experiment_id=mock_experiment_id, tags=expected_tags, name=None
         )
         assert is_from_run(active_run, MlflowClient.create_run.return_value)
 
@@ -547,7 +547,7 @@ def test_start_run_defaults_databricks_notebook(
     ):
         active_run = start_run()
         MlflowClient.create_run.assert_called_once_with(
-            experiment_id=mock_experiment_id, tags=expected_tags
+            experiment_id=mock_experiment_id, tags=expected_tags, name=None
         )
         assert is_from_run(active_run, MlflowClient.create_run.return_value)
 
@@ -607,7 +607,7 @@ def test_start_run_creates_new_run_with_user_specified_tags():
     ):
         active_run = start_run(tags=user_specified_tags)
         MlflowClient.create_run.assert_called_once_with(
-            experiment_id=mock_experiment_id, tags=expected_tags
+            experiment_id=mock_experiment_id, tags=expected_tags, name=None
         )
         assert is_from_run(active_run, MlflowClient.create_run.return_value)
 
@@ -656,7 +656,7 @@ def test_start_run_with_parent():
     ):
         active_run = start_run(experiment_id=mock_experiment_id, nested=True)
         MlflowClient.create_run.assert_called_once_with(
-            experiment_id=mock_experiment_id, tags=expected_tags
+            experiment_id=mock_experiment_id, tags=expected_tags, name=None
         )
         assert is_from_run(active_run, MlflowClient.create_run.return_value)
 
@@ -792,7 +792,7 @@ def test_start_run_with_description(empty_active_run_stack):  # pylint: disable=
     ):
         active_run = start_run(description=description)
         MlflowClient.create_run.assert_called_once_with(
-            experiment_id=mock_experiment_id, tags=expected_tags
+            experiment_id=mock_experiment_id, tags=expected_tags, name=None
         )
         assert is_from_run(active_run, MlflowClient.create_run.return_value)
 

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -471,9 +471,9 @@ def test_start_run_defaults(empty_active_run_stack):  # pylint: disable=unused-a
         source_version_patch,
         create_run_patch,
     ):
-        active_run = start_run()
+        active_run = start_run(run_name="my name")
         MlflowClient.create_run.assert_called_once_with(
-            experiment_id=mock_experiment_id, tags=expected_tags, name=None
+            experiment_id=mock_experiment_id, tags=expected_tags, name="my name"
         )
         assert is_from_run(active_run, MlflowClient.create_run.return_value)
 

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -473,7 +473,7 @@ def test_start_run_defaults(empty_active_run_stack):  # pylint: disable=unused-a
     ):
         active_run = start_run(run_name="my name")
         MlflowClient.create_run.assert_called_once_with(
-            experiment_id=mock_experiment_id, tags=expected_tags, name="my name"
+            experiment_id=mock_experiment_id, tags=expected_tags, run_name="my name"
         )
         assert is_from_run(active_run, MlflowClient.create_run.return_value)
 
@@ -547,7 +547,7 @@ def test_start_run_defaults_databricks_notebook(
     ):
         active_run = start_run()
         MlflowClient.create_run.assert_called_once_with(
-            experiment_id=mock_experiment_id, tags=expected_tags, name=None
+            experiment_id=mock_experiment_id, tags=expected_tags, run_name=None
         )
         assert is_from_run(active_run, MlflowClient.create_run.return_value)
 
@@ -607,7 +607,7 @@ def test_start_run_creates_new_run_with_user_specified_tags():
     ):
         active_run = start_run(tags=user_specified_tags)
         MlflowClient.create_run.assert_called_once_with(
-            experiment_id=mock_experiment_id, tags=expected_tags, name=None
+            experiment_id=mock_experiment_id, tags=expected_tags, run_name=None
         )
         assert is_from_run(active_run, MlflowClient.create_run.return_value)
 
@@ -656,7 +656,7 @@ def test_start_run_with_parent():
     ):
         active_run = start_run(experiment_id=mock_experiment_id, nested=True)
         MlflowClient.create_run.assert_called_once_with(
-            experiment_id=mock_experiment_id, tags=expected_tags, name=None
+            experiment_id=mock_experiment_id, tags=expected_tags, run_name=None
         )
         assert is_from_run(active_run, MlflowClient.create_run.return_value)
 
@@ -792,7 +792,7 @@ def test_start_run_with_description(empty_active_run_stack):  # pylint: disable=
     ):
         active_run = start_run(description=description)
         MlflowClient.create_run.assert_called_once_with(
-            experiment_id=mock_experiment_id, tags=expected_tags, name=None
+            experiment_id=mock_experiment_id, tags=expected_tags, run_name=None
         )
         assert is_from_run(active_run, MlflowClient.create_run.return_value)
 

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -95,6 +95,20 @@ def test_client_create_run(mock_store, mock_time):
     )
 
 
+def test_client_create_run_with_name(mock_store, mock_time):
+    experiment_id = mock.Mock()
+
+    MlflowClient().create_run(experiment_id, name="my name")
+
+    mock_store.create_run.assert_called_once_with(
+        experiment_id=experiment_id,
+        user_id="unknown",
+        start_time=int(mock_time * 1000),
+        tags=[],
+        name="my name",
+    )
+
+
 def test_client_create_experiment(mock_store):
     MlflowClient().create_experiment("someName", "someLocation", {"key1": "val1", "key2": "val2"})
 
@@ -138,6 +152,14 @@ def test_client_create_run_overrides(mock_store):
         tags=[RunTag(key, value) for key, value in tags.items()],
         name=None,
     )
+
+
+def test_client_set_terminated_no_change_name(mock_store):
+    experiment_id = mock.Mock()
+    run = MlflowClient().create_run(experiment_id, name="my name")
+    MlflowClient().set_terminated(run.info.run_id)
+    _, kwargs = mock_store.update_run_info.call_args
+    assert kwargs["name"] is None
 
 
 def test_client_search_runs_defaults(mock_store):

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -91,7 +91,7 @@ def test_client_create_run(mock_store, mock_time):
         user_id="unknown",
         start_time=int(mock_time * 1000),
         tags=[],
-        name=None,
+        run_name=None,
     )
 
 
@@ -105,7 +105,7 @@ def test_client_create_run_with_name(mock_store, mock_time):
         user_id="unknown",
         start_time=int(mock_time * 1000),
         tags=[],
-        name="my name",
+        run_name="my name",
     )
 
 
@@ -123,7 +123,7 @@ def test_client_create_run_overrides(mock_store):
     experiment_id = mock.Mock()
     user = mock.Mock()
     start_time = mock.Mock()
-    name = mock.Mock()
+    run_name = mock.Mock()
     tags = {
         MLFLOW_USER: user,
         MLFLOW_PARENT_RUN_ID: mock.Mock(),
@@ -134,14 +134,14 @@ def test_client_create_run_overrides(mock_store):
         "other-key": "other-value",
     }
 
-    MlflowClient().create_run(experiment_id, start_time, tags, name)
+    MlflowClient().create_run(experiment_id, start_time, tags, run_name)
 
     mock_store.create_run.assert_called_once_with(
         experiment_id=experiment_id,
         user_id=user,
         start_time=start_time,
         tags=[RunTag(key, value) for key, value in tags.items()],
-        name=name,
+        run_name=run_name,
     )
     mock_store.reset_mock()
     MlflowClient().create_run(experiment_id, start_time, tags)
@@ -150,16 +150,16 @@ def test_client_create_run_overrides(mock_store):
         user_id=user,
         start_time=start_time,
         tags=[RunTag(key, value) for key, value in tags.items()],
-        name=None,
+        run_name=None,
     )
 
 
 def test_client_set_terminated_no_change_name(mock_store):
     experiment_id = mock.Mock()
-    run = MlflowClient().create_run(experiment_id, name="my name")
+    run = MlflowClient().create_run(experiment_id, run_name="my name")
     MlflowClient().set_terminated(run.info.run_id)
     _, kwargs = mock_store.update_run_info.call_args
-    assert kwargs["name"] is None
+    assert kwargs["run_name"] is None
 
 
 def test_client_search_runs_defaults(mock_store):

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -98,7 +98,7 @@ def test_client_create_run(mock_store, mock_time):
 def test_client_create_run_with_name(mock_store, mock_time):
     experiment_id = mock.Mock()
 
-    MlflowClient().create_run(experiment_id, name="my name")
+    MlflowClient().create_run(experiment_id, run_name="my name")
 
     mock_store.create_run.assert_called_once_with(
         experiment_id=experiment_id,

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -91,6 +91,7 @@ def test_client_create_run(mock_store, mock_time):
         user_id="unknown",
         start_time=int(mock_time * 1000),
         tags=[],
+        name=None,
     )
 
 
@@ -108,6 +109,7 @@ def test_client_create_run_overrides(mock_store):
     experiment_id = mock.Mock()
     user = mock.Mock()
     start_time = mock.Mock()
+    name = mock.Mock()
     tags = {
         MLFLOW_USER: user,
         MLFLOW_PARENT_RUN_ID: mock.Mock(),
@@ -118,13 +120,14 @@ def test_client_create_run_overrides(mock_store):
         "other-key": "other-value",
     }
 
-    MlflowClient().create_run(experiment_id, start_time, tags)
+    MlflowClient().create_run(experiment_id, start_time, tags, name)
 
     mock_store.create_run.assert_called_once_with(
         experiment_id=experiment_id,
         user_id=user,
         start_time=start_time,
         tags=[RunTag(key, value) for key, value in tags.items()],
+        name=name,
     )
     mock_store.reset_mock()
     MlflowClient().create_run(experiment_id, start_time, tags)
@@ -133,6 +136,7 @@ def test_client_create_run_overrides(mock_store):
         user_id=user,
         start_time=start_time,
         tags=[RunTag(key, value) for key, value in tags.items()],
+        name=None,
     )
 
 

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -206,7 +206,7 @@ def test_create_run_all_args(mlflow_client, parent_run_id_kwarg):
     source_version = "abc"
     create_run_kwargs = {
         "start_time": 456,
-        "name": "my name",
+        "run_name": "my name",
         "tags": {
             MLFLOW_USER: user,
             MLFLOW_SOURCE_TYPE: "LOCAL",

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -23,7 +23,6 @@ from mlflow import MlflowClient
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils.mlflow_tags import (
     MLFLOW_USER,
-    MLFLOW_RUN_NAME,
     MLFLOW_PARENT_RUN_ID,
     MLFLOW_SOURCE_TYPE,
     MLFLOW_SOURCE_NAME,
@@ -207,6 +206,7 @@ def test_create_run_all_args(mlflow_client, parent_run_id_kwarg):
     source_version = "abc"
     create_run_kwargs = {
         "start_time": 456,
+        "name": "my name",
         "tags": {
             MLFLOW_USER: user,
             MLFLOW_SOURCE_TYPE: "LOCAL",
@@ -214,7 +214,6 @@ def test_create_run_all_args(mlflow_client, parent_run_id_kwarg):
             MLFLOW_PROJECT_ENTRY_POINT: entry_point,
             MLFLOW_GIT_COMMIT: source_version,
             MLFLOW_PARENT_RUN_ID: "7",
-            MLFLOW_RUN_NAME: "my name",
             "my": "tag",
             "other": "tag",
         },
@@ -232,10 +231,10 @@ def test_create_run_all_args(mlflow_client, parent_run_id_kwarg):
         assert run.info.experiment_id == experiment_id
         assert run.info.user_id == user
         assert run.info.start_time == create_run_kwargs["start_time"]
+        assert run.info.run_name == "my name"
         for tag in create_run_kwargs["tags"]:
             assert tag in run.data.tags
         assert run.data.tags.get(MLFLOW_USER) == user
-        assert run.data.tags.get(MLFLOW_RUN_NAME) == "my name"
         assert run.data.tags.get(MLFLOW_PARENT_RUN_ID) == parent_run_id_kwarg or "7"
         assert mlflow_client.list_run_infos(experiment_id) == [run.info]
 

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -296,7 +296,7 @@ def test_log_batch():
     expected_metrics = {"metric-key0": 1.0, "metric-key1": 4.0}
     expected_params = {"param-key0": "param-val0", "param-key1": "param-val1"}
     exact_expected_tags = {"tag-key0": "tag-val0", "tag-key1": "tag-val1"}
-    approx_expected_tags = {MLFLOW_USER, MLFLOW_SOURCE_NAME, MLFLOW_SOURCE_TYPE, MLFLOW_RUN_NAME}
+    approx_expected_tags = {MLFLOW_USER, MLFLOW_SOURCE_NAME, MLFLOW_SOURCE_TYPE}
 
     t = int(time.time())
     sorted_expected_metrics = sorted(expected_metrics.items(), key=lambda kv: kv[0])
@@ -475,7 +475,7 @@ def get_store_mock():
 
 def test_set_tags():
     exact_expected_tags = {"name_1": "c", "name_2": "b", "nested/nested/name": 5}
-    approx_expected_tags = {MLFLOW_USER, MLFLOW_SOURCE_NAME, MLFLOW_SOURCE_TYPE, MLFLOW_RUN_NAME}
+    approx_expected_tags = {MLFLOW_USER, MLFLOW_SOURCE_NAME, MLFLOW_SOURCE_TYPE}
     with start_run() as active_run:
         run_id = active_run.info.run_id
         mlflow.set_tags(exact_expected_tags)

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -25,7 +25,6 @@ from mlflow.utils.mlflow_tags import (
     MLFLOW_USER,
     MLFLOW_SOURCE_NAME,
     MLFLOW_SOURCE_TYPE,
-    MLFLOW_RUN_NAME,
 )
 from mlflow.utils.validation import (
     MAX_METRICS_PER_BATCH,


### PR DESCRIPTION
Signed-off-by: apurva-koti <apurva.koti@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#6798

## What changes are proposed in this pull request?

Add a `run_name` parameter to the implementations of the `CreateRun` `UpdateRun` and `RunInfo` proto messages. This affects all stores (file, sql and REST). Accordingly, add parameters up the chain to the fluent API at all call sites of these functions.
Accordingly, we _stop_ populating the run name in the tags and instead use the new parameter.
The implementation of `UpdateRun` in the file and SQL stores will _not_ update the run name if the passed argument is `None`. (This is to ensure run termination can occur safely without overwriting run name). This is not the case with the REST store, where it is up to the backend to determine whether to overwrite the name or not.
The majority of the diff is fixing tests that were breaking due to missing parameters.

## How is this patch tested?
Ensure tests work, and write tests for new behavior (setting and getting run name)
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
