### PR TITLE
[JS] Remove use of experiment, run, and model listing APIs in favor of search

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/actions.js
+++ b/mlflow/server/js/src/experiment-tracking/actions.js
@@ -9,7 +9,7 @@ export const searchExperimentsApi = (id = getUUID()) => {
   return {
     type: SEARCH_EXPERIMENTS_API,
     payload: MlflowService.searchExperiments({
-      max_results: 20000
+      max_results: 20000,
     }),
     meta: { id: id },
   };

--- a/mlflow/server/js/src/experiment-tracking/actions.js
+++ b/mlflow/server/js/src/experiment-tracking/actions.js
@@ -4,11 +4,11 @@ import { ErrorCodes } from '../common/constants';
 
 export const SEARCH_MAX_RESULTS = 100;
 
-export const LIST_EXPERIMENTS_API = 'LIST_EXPERIMENTS_API';
-export const listExperimentsApi = (id = getUUID()) => {
+export const SEARCH_EXPERIMENTS_API = 'SEARCH_EXPERIMENTS_API';
+export const searchExperimentsApi = (id = getUUID()) => {
   return {
-    type: LIST_EXPERIMENTS_API,
-    payload: MlflowService.listExperiments({}),
+    type: SEARCH_EXPERIMENTS_API,
+    payload: MlflowService.searchExperiments({}),
     meta: { id: id },
   };
 };

--- a/mlflow/server/js/src/experiment-tracking/actions.js
+++ b/mlflow/server/js/src/experiment-tracking/actions.js
@@ -2,13 +2,15 @@ import { MlflowService } from './sdk/MlflowService';
 import { getUUID } from '../common/utils/ActionUtils';
 import { ErrorCodes } from '../common/constants';
 
-export const SEARCH_MAX_RESULTS = 100;
+export const RUNS_SEARCH_MAX_RESULTS = 100;
 
 export const SEARCH_EXPERIMENTS_API = 'SEARCH_EXPERIMENTS_API';
 export const searchExperimentsApi = (id = getUUID()) => {
   return {
     type: SEARCH_EXPERIMENTS_API,
-    payload: MlflowService.searchExperiments({}),
+    payload: MlflowService.searchExperiments({
+      max_results: 20000
+    }),
     meta: { id: id },
   };
 };
@@ -162,7 +164,7 @@ export const searchRunsPayload = ({
     experiment_ids: experimentIds,
     filter: filter,
     run_view_type: runViewType,
-    max_results: maxResults || SEARCH_MAX_RESULTS,
+    max_results: maxResults || RUNS_SEARCH_MAX_RESULTS,
     order_by: orderBy,
     page_token: pageToken,
   }).then((res) => (shouldFetchParents ? fetchMissingParents(res) : res));

--- a/mlflow/server/js/src/experiment-tracking/components/HomePage.js
+++ b/mlflow/server/js/src/experiment-tracking/components/HomePage.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import qs from 'qs';
-import { listExperimentsApi } from '../actions';
+import { searchExperimentsApi } from '../actions';
 import RequestStateWrapper from '../../common/components/RequestStateWrapper';
 import './HomePage.css';
 import HomeView from './HomeView';
@@ -12,7 +12,7 @@ import Routes from '../routes';
 export class HomePageImpl extends Component {
   static propTypes = {
     history: PropTypes.shape({}),
-    dispatchListExperimentsApi: PropTypes.func.isRequired,
+    dispatchSearchExperimentsApi: PropTypes.func.isRequired,
     experimentIds: PropTypes.arrayOf(PropTypes.string),
     compareExperiments: PropTypes.bool,
   };
@@ -22,12 +22,12 @@ export class HomePageImpl extends Component {
   };
 
   state = {
-    listExperimentsRequestId: getUUID(),
+    searchExperimentsRequestId: getUUID(),
   };
 
   componentDidMount() {
     if (process.env.HIDE_EXPERIMENT_LIST !== 'true') {
-      this.props.dispatchListExperimentsApi(this.state.listExperimentsRequestId);
+      this.props.dispatchSearchExperimentsApi(this.state.searchExperimentsRequestId);
     }
   }
 
@@ -43,7 +43,7 @@ export class HomePageImpl extends Component {
       homeView
     ) : (
       <RequestStateWrapper
-        requestIds={[this.state.listExperimentsRequestId]}
+        requestIds={[this.state.searchExperimentsRequestId]}
         // eslint-disable-next-line no-trailing-spaces
       >
         {homeView}
@@ -74,8 +74,8 @@ const mapStateToProps = (state, ownProps) => {
 
 const mapDispatchToProps = (dispatch) => {
   return {
-    dispatchListExperimentsApi: (requestId) => {
-      return dispatch(listExperimentsApi(requestId));
+    dispatchSearchExperimentsApi: (requestId) => {
+      return dispatch(searchExperimentsApi(requestId));
     },
   };
 };

--- a/mlflow/server/js/src/experiment-tracking/components/HomePage.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/HomePage.test.js
@@ -19,7 +19,7 @@ describe('HomePage', () => {
   beforeEach(() => {
     minimalProps = {
       history: {},
-      dispatchListExperimentsApi: jest.fn(),
+      dispatchSearchExperimentsApi: jest.fn(),
     };
     minimalStore = mockStore({
       entities: {},

--- a/mlflow/server/js/src/experiment-tracking/components/modals/CreateExperimentModal.js
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/CreateExperimentModal.js
@@ -9,7 +9,7 @@ import { GenericInputModal } from './GenericInputModal';
 import { CreateExperimentForm, EXP_NAME_FIELD, ARTIFACT_LOCATION } from './CreateExperimentForm';
 import { getExperimentNameValidator } from '../../../common/forms/validations';
 
-import { createExperimentApi, listExperimentsApi } from '../../actions';
+import { createExperimentApi, searchExperimentsApi } from '../../actions';
 import { getExperiments } from '../../reducers/Reducers';
 
 export class CreateExperimentModalImpl extends Component {
@@ -18,7 +18,7 @@ export class CreateExperimentModalImpl extends Component {
     onClose: PropTypes.func.isRequired,
     experimentNames: PropTypes.arrayOf(PropTypes.string).isRequired,
     createExperimentApi: PropTypes.func.isRequired,
-    listExperimentsApi: PropTypes.func.isRequired,
+    searchExperimentsApi: PropTypes.func.isRequired,
     history: PropTypes.object.isRequired,
   };
 
@@ -27,10 +27,10 @@ export class CreateExperimentModalImpl extends Component {
     const experimentName = values[EXP_NAME_FIELD];
     const artifactLocation = values[ARTIFACT_LOCATION];
 
-    // Both createExperimentApi and listExperimentsApi calls need to be fulfilled sequentially
+    // Both createExperimentApi and searchExperimentsApi calls need to be fulfilled sequentially
     // before redirecting the user to the newly created experiment page (history.push())
     const response = await this.props.createExperimentApi(experimentName, artifactLocation);
-    await this.props.listExperimentsApi();
+    await this.props.searchExperimentsApi();
 
     const {
       value: { experiment_id: newExperimentId },
@@ -69,7 +69,7 @@ const mapStateToProps = (state) => {
 
 const mapDispatchToProps = {
   createExperimentApi,
-  listExperimentsApi,
+  searchExperimentsApi,
 };
 
 export const CreateExperimentModal = withRouter(

--- a/mlflow/server/js/src/experiment-tracking/components/modals/CreateExperimentModal.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/CreateExperimentModal.test.js
@@ -25,7 +25,7 @@ describe('CreateExperimentModal', () => {
         const response = { value: { experiment_id: fakeExperimentId } };
         return Promise.resolve(response);
       },
-      listExperimentsApi: () => Promise.resolve([]),
+      searchExperimentsApi: () => Promise.resolve([]),
       history: history,
     };
     wrapper = shallow(<CreateExperimentModalImpl {...minimalProps} />);
@@ -51,7 +51,7 @@ describe('CreateExperimentModal', () => {
     const propsVals = [
       {
         ...minimalProps,
-        listExperimentsApi: () => Promise.reject(new Error('ListExperiments failed!')),
+        searchExperimentsApi: () => Promise.reject(new Error('SearchExperiments failed!')),
       },
       {
         ...minimalProps,

--- a/mlflow/server/js/src/experiment-tracking/components/modals/DeleteExperimentModal.js
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/DeleteExperimentModal.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { ConfirmModal } from './ConfirmModal';
 import PropTypes from 'prop-types';
-import { deleteExperimentApi, listExperimentsApi } from '../../actions';
+import { deleteExperimentApi, searchExperimentsApi } from '../../actions';
 import Routes from '../../routes';
 import Utils from '../../../common/utils/Utils';
 import { connect } from 'react-redux';
@@ -16,7 +16,7 @@ export class DeleteExperimentModalImpl extends Component {
     experimentId: PropTypes.string.isRequired,
     experimentName: PropTypes.string.isRequired,
     deleteExperimentApi: PropTypes.func.isRequired,
-    listExperimentsApi: PropTypes.func.isRequired,
+    searchExperimentsApi: PropTypes.func.isRequired,
     history: PropTypes.object.isRequired,
   };
 
@@ -42,7 +42,7 @@ export class DeleteExperimentModalImpl extends Component {
           }
         }
       })
-      .then(() => this.props.listExperimentsApi(deleteExperimentRequestId))
+      .then(() => this.props.searchExperimentsApi(deleteExperimentRequestId))
       .catch((e) => {
         Utils.logErrorAndNotifyUser(e);
       });
@@ -83,7 +83,7 @@ export class DeleteExperimentModalImpl extends Component {
 
 const mapDispatchToProps = {
   deleteExperimentApi,
-  listExperimentsApi,
+  searchExperimentsApi,
 };
 
 export const DeleteExperimentModal = withRouter(

--- a/mlflow/server/js/src/experiment-tracking/components/modals/DeleteExperimentModal.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/DeleteExperimentModal.test.js
@@ -28,7 +28,7 @@ describe('DeleteExperimentModal', () => {
         const response = { value: { experiment_id: fakeExperimentId } };
         return Promise.resolve(response);
       },
-      listExperimentsApi: () => Promise.resolve([]),
+      searchExperimentsApi: () => Promise.resolve([]),
       history: history,
     };
     wrapper = shallow(<DeleteExperimentModalImpl {...minimalProps} />);

--- a/mlflow/server/js/src/experiment-tracking/reducers/Reducers.js
+++ b/mlflow/server/js/src/experiment-tracking/reducers/Reducers.js
@@ -4,7 +4,7 @@ import {
   GET_EXPERIMENT_API,
   GET_RUN_API,
   LIST_ARTIFACTS_API,
-  LIST_EXPERIMENTS_API,
+  SEARCH_EXPERIMENTS_API,
   OPEN_ERROR_MODAL,
   SEARCH_RUNS_API,
   LOAD_MORE_RUNS_API,
@@ -44,7 +44,7 @@ export const getExperiment = (id, state) => {
 
 export const experimentsById = (state = {}, action) => {
   switch (action.type) {
-    case fulfilled(LIST_EXPERIMENTS_API): {
+    case fulfilled(SEARCH_EXPERIMENTS_API): {
       let newState = Object.assign({}, state);
       if (action.payload && action.payload.experiments) {
         // reset experimentsById state

--- a/mlflow/server/js/src/experiment-tracking/reducers/Reducers.test.js
+++ b/mlflow/server/js/src/experiment-tracking/reducers/Reducers.test.js
@@ -27,7 +27,7 @@ import {
 import { mockExperiment, mockRunInfo } from '../utils/test-utils/ReduxStoreFixtures';
 import { RunTag, RunInfo, Param, Experiment, ExperimentTag } from '../sdk/MlflowMessages';
 import {
-  LIST_EXPERIMENTS_API,
+  SEARCH_EXPERIMENTS_API,
   GET_EXPERIMENT_API,
   GET_RUN_API,
   SEARCH_RUNS_API,
@@ -48,12 +48,12 @@ describe('test experimentsById', () => {
     expect(experimentsById(undefined, {})).toEqual({});
   });
 
-  test('listExperiments correctly updates empty state', () => {
+  test('searchExperiments correctly updates empty state', () => {
     const experimentA = mockExperiment('experiment01', 'experimentA');
     const experimentB = mockExperiment('experiment02', 'experimentB');
     const state = undefined;
     const action = {
-      type: fulfilled(LIST_EXPERIMENTS_API),
+      type: fulfilled(SEARCH_EXPERIMENTS_API),
       payload: {
         experiments: [experimentA.toJSON(), experimentB.toJSON()],
       },
@@ -65,7 +65,7 @@ describe('test experimentsById', () => {
     });
   });
 
-  test('listExperiments correctly updates state', () => {
+  test('searchExperiments correctly updates state', () => {
     const newA = mockExperiment('experiment01', 'experimentA');
     const newB = mockExperiment('experiment02', 'experimentB');
     const preserved = mockExperiment('experiment03', 'still exists');
@@ -78,7 +78,7 @@ describe('test experimentsById', () => {
       [replacedOld.getExperimentId()]: replacedOld,
     });
     const action = {
-      type: fulfilled(LIST_EXPERIMENTS_API),
+      type: fulfilled(SEARCH_EXPERIMENTS_API),
       payload: {
         experiments: [preserved.toJSON(), newA.toJSON(), newB.toJSON(), replacedNew.toJSON()],
       },
@@ -1223,7 +1223,7 @@ describe('test public accessors', () => {
     });
 
     const action = new_action({
-      type: fulfilled(LIST_EXPERIMENTS_API),
+      type: fulfilled(SEARCH_EXPERIMENTS_API),
       payload: { experiments: [A.toJSON(), B.toJSON()] },
     });
     const state = rootReducer(undefined, action);

--- a/mlflow/server/js/src/experiment-tracking/sdk/MlflowMessages.js
+++ b/mlflow/server/js/src/experiment-tracking/sdk/MlflowMessages.js
@@ -408,12 +408,12 @@ CreateExperiment.fromJs = function fromJs(pojo) {
   return new extended_CreateExperiment(pojoWithNestedImmutables);
 };
 
-export const ListExperiments = Immutable.Record(
+export const SearchExperiments = Immutable.Record(
   {
     // optional ViewType
     view_type: undefined,
   },
-  'ListExperiments',
+  'SearchExperiments',
 );
 
 /**
@@ -421,14 +421,14 @@ export const ListExperiments = Immutable.Record(
  * This reviver allow us to keep the Immutable.Record type when serializing JSON message
  * into nested Immutable Record class.
  */
-ListExperiments.fromJsReviver = function fromJsReviver(key, value) {
+SearchExperiments.fromJsReviver = function fromJsReviver(key, value) {
   switch (key) {
     default:
       return Immutable.fromJS(value);
   }
 };
 
-const extended_ListExperiments = ModelBuilder.extend(ListExperiments, {
+const extended_SearchExperiments = ModelBuilder.extend(SearchExperiments, {
   getViewType() {
     return this.view_type !== undefined ? this.view_type : 'ACTIVE_ONLY';
   },
@@ -439,11 +439,11 @@ const extended_ListExperiments = ModelBuilder.extend(ListExperiments, {
  * objects into this Immutable Record.  Example usage:
  *
  *   // The pojo is your javascript object
- *   const record = ListExperiments.fromJs(pojo);
+ *   const record = SearchExperiments.fromJs(pojo);
  */
-ListExperiments.fromJs = function fromJs(pojo) {
-  const pojoWithNestedImmutables = RecordUtils.fromJs(pojo, ListExperiments.fromJsReviver);
-  return new extended_ListExperiments(pojoWithNestedImmutables);
+SearchExperiments.fromJs = function fromJs(pojo) {
+  const pojoWithNestedImmutables = RecordUtils.fromJs(pojo, SearchExperiments.fromJsReviver);
+  return new extended_SearchExperiments(pojoWithNestedImmutables);
 };
 
 export const GetExperiment = Immutable.Record(

--- a/mlflow/server/js/src/experiment-tracking/sdk/MlflowService.js
+++ b/mlflow/server/js/src/experiment-tracking/sdk/MlflowService.js
@@ -28,10 +28,10 @@ export class MlflowService {
     postJson({ relativeUrl: 'ajax-api/2.0/mlflow/experiments/update', data });
 
   /**
-   * List mlflow experiments
+   * Search mlflow experiments
    */
-  static listExperiments = (data) =>
-    getBigIntJson({ relativeUrl: 'ajax-api/2.0/mlflow/experiments/list', data });
+  static searchExperiments = (data) =>
+    getBigIntJson({ relativeUrl: 'ajax-api/2.0/mlflow/experiments/search', data });
 
   /**
    * Get mlflow experiment

--- a/mlflow/server/js/src/model-registry/actions.js
+++ b/mlflow/server/js/src/model-registry/actions.js
@@ -10,13 +10,6 @@ export const createRegisteredModelApi = (name, id = getUUID()) => ({
   meta: { id, name },
 });
 
-export const LIST_REGISTERED_MODELS = 'LIST_REGISTERED_MODELS';
-export const listRegisteredModelsApi = (id = getUUID()) => ({
-  type: LIST_REGISTERED_MODELS,
-  payload: Services.listRegisteredModels({}),
-  meta: { id },
-});
-
 export const SEARCH_REGISTERED_MODELS = 'SEARCH_REGISTERED_MODELS';
 export const searchRegisteredModelsApi = (
   filter,

--- a/mlflow/server/js/src/model-registry/components/RegisterModelButton.js
+++ b/mlflow/server/js/src/model-registry/components/RegisterModelButton.js
@@ -12,7 +12,6 @@ import {
 import {
   createRegisteredModelApi,
   createModelVersionApi,
-  listRegisteredModelsApi,
   searchModelVersionsApi,
   searchRegisteredModelsApi,
 } from '../actions';
@@ -34,7 +33,6 @@ export class RegisterModelButtonImpl extends React.Component {
     modelByName: PropTypes.object.isRequired,
     createRegisteredModelApi: PropTypes.func.isRequired,
     createModelVersionApi: PropTypes.func.isRequired,
-    listRegisteredModelsApi: PropTypes.func.isRequired,
     searchModelVersionsApi: PropTypes.func.isRequired,
     searchRegisteredModelsApi: PropTypes.func.isRequired,
     intl: PropTypes.shape({ formatMessage: PropTypes.func.isRequired }).isRequired,
@@ -124,13 +122,13 @@ export class RegisterModelButtonImpl extends React.Component {
   };
 
   componentDidMount() {
-    this.props.listRegisteredModelsApi();
+    this.props.searchRegisteredModelsApi();
   }
 
   componentDidUpdate(prevProps, prevState) {
     // Repopulate registered model list every time user launch the modal
     if (prevState.visible === false && this.state.visible === true) {
-      this.props.listRegisteredModelsApi();
+      this.props.searchRegisteredModelsApi();
     }
   }
 
@@ -204,7 +202,6 @@ const mapStateToProps = (state) => ({
 const mapDispatchToProps = {
   createRegisteredModelApi,
   createModelVersionApi,
-  listRegisteredModelsApi,
   searchModelVersionsApi,
   searchRegisteredModelsApi,
 };

--- a/mlflow/server/js/src/model-registry/components/RegisterModelButton.test.js
+++ b/mlflow/server/js/src/model-registry/components/RegisterModelButton.test.js
@@ -52,8 +52,9 @@ describe('RegisterModelButton', () => {
     wrapper = shallowWithInjectIntl(
       <RegisterModelButtonWithIntl {...props} store={minimalStore} />,
     );
+    expect(props.searchRegisteredModelsApi.mock.calls.length).toBe(1);
     const instance = wrapper.instance();
     instance.handleSearchRegisteredModels('A');
-    expect(props.searchRegisteredModelsApi.mock.calls.length).toBe(1);
+    expect(props.searchRegisteredModelsApi.mock.calls.length).toBe(2);
   });
 });

--- a/mlflow/server/js/src/model-registry/components/RegisterModelButton.test.js
+++ b/mlflow/server/js/src/model-registry/components/RegisterModelButton.test.js
@@ -21,7 +21,6 @@ describe('RegisterModelButton', () => {
       modelByName: {},
       createRegisteredModelApi: jest.fn(() => Promise.resolve({})),
       createModelVersionApi: jest.fn(() => Promise.resolve({})),
-      listRegisteredModelsApi: jest.fn(() => Promise.resolve({})),
       searchModelVersionsApi: jest.fn(() => Promise.resolve({})),
       searchRegisteredModelsApi: jest.fn(() => Promise.resolve({})),
     };

--- a/mlflow/server/js/src/model-registry/reducers.js
+++ b/mlflow/server/js/src/model-registry/reducers.js
@@ -1,5 +1,4 @@
 import {
-  LIST_REGISTERED_MODELS,
   SEARCH_REGISTERED_MODELS,
   SEARCH_MODEL_VERSIONS,
   GET_REGISTERED_MODEL,
@@ -19,9 +18,7 @@ import { RegisteredModelTag, ModelVersionTag } from './sdk/ModelRegistryMessages
 
 const modelByName = (state = {}, action) => {
   switch (action.type) {
-    case fulfilled(SEARCH_REGISTERED_MODELS):
-    // eslint-disable-next-line no-fallthrough
-    case fulfilled(LIST_REGISTERED_MODELS): {
+    case fulfilled(SEARCH_REGISTERED_MODELS): {
       const models = action.payload[getProtoField('registered_models')];
       const nameToModelMap = {};
       if (models) {

--- a/mlflow/server/js/src/model-registry/reducers.test.js
+++ b/mlflow/server/js/src/model-registry/reducers.test.js
@@ -12,7 +12,6 @@ import {
   DELETE_REGISTERED_MODEL,
   GET_MODEL_VERSION,
   GET_REGISTERED_MODEL,
-  LIST_REGISTERED_MODELS,
   SEARCH_MODEL_VERSIONS,
   SET_REGISTERED_MODEL_TAG,
   DELETE_REGISTERED_MODEL_TAG,
@@ -34,73 +33,6 @@ const {
 describe('test modelByName', () => {
   test('initial state', () => {
     expect(modelByName(undefined, {})).toEqual({});
-  });
-
-  test('LIST_REGISTERED_MODELS handles empty state correctly', () => {
-    const modelA = mockRegisteredModelDetailed('modelA');
-    const modelB = mockRegisteredModelDetailed('modelB');
-    const state = {};
-    const action = {
-      type: fulfilled(LIST_REGISTERED_MODELS),
-      payload: {
-        registered_models: [modelA, modelB],
-      },
-    };
-    expect(modelByName(state, action)).toEqual({ modelA, modelB });
-  });
-
-  test('LIST_REGISTERED_MODELS flushes previous loaded models in state (1)', () => {
-    const modelA = mockRegisteredModelDetailed('modelA');
-    const modelB = mockRegisteredModelDetailed('modelB');
-    const modelC = mockRegisteredModelDetailed('modelC');
-    const state = { modelA };
-    const action = {
-      type: fulfilled(LIST_REGISTERED_MODELS),
-      payload: {
-        registered_models: [modelB, modelC],
-      },
-    };
-    expect(modelByName(state, action)).toEqual({ modelB, modelC });
-  });
-
-  test('LIST_REGISTERED_MODELS flushes previous loaded models in state (2)', () => {
-    const modelA = mockRegisteredModelDetailed('modelA');
-    const modelB = mockRegisteredModelDetailed('modelB');
-    const modelC = mockRegisteredModelDetailed('modelC');
-    const state = { modelA, modelB };
-    const action = {
-      type: fulfilled(LIST_REGISTERED_MODELS),
-      payload: {
-        registered_models: [modelB, modelC],
-      },
-    };
-    expect(modelByName(state, action)).toEqual({ modelB, modelC });
-  });
-
-  test('LIST_REGISTERED_MODELS flushes previous loaded models in state (3)', () => {
-    const modelA = mockRegisteredModelDetailed('modelA');
-    const modelB = mockRegisteredModelDetailed('modelB');
-    const state = { modelA, modelB };
-    const action = {
-      type: fulfilled(LIST_REGISTERED_MODELS),
-      payload: {
-        registered_models: [],
-      },
-    };
-    expect(modelByName(state, action)).toEqual({});
-  });
-
-  test('LIST_REGISTERED_MODELS should have no effect on valid state', () => {
-    const modelA = mockRegisteredModelDetailed('modelA');
-    const modelB = mockRegisteredModelDetailed('modelB');
-    const state = { modelA, modelB };
-    const action = {
-      type: fulfilled(LIST_REGISTERED_MODELS),
-      payload: {
-        registered_models: [modelB, modelA],
-      },
-    };
-    expect(modelByName(state, action)).toEqual({ modelB, modelA });
   });
 
   test('GET_REGISTERED_MODEL updates empty state correctly', () => {

--- a/mlflow/server/js/src/model-registry/services.js
+++ b/mlflow/server/js/src/model-registry/services.js
@@ -16,12 +16,6 @@ export class Services {
     postBigIntJson({ relativeUrl: 'ajax-api/2.0/mlflow/registered-models/create', data });
 
   /**
-   * List all registered models
-   */
-  static listRegisteredModels = (data) =>
-    getBigIntJson({ relativeUrl: 'ajax-api/2.0/mlflow/registered-models/list', data });
-
-  /**
    * Search registered models
    */
   static searchRegisteredModels = (data) =>


### PR DESCRIPTION
Signed-off-by: dbczumar <corey.zumar@databricks.com>

## What changes are proposed in this pull request?

Remove experiment, run, and model listing APIs in favor of search

## How is this patch tested?

Existing tests, manual inspection of UI

<img width="2414" alt="Screen Shot 2022-09-13 at 6 42 51 PM" src="https://user-images.githubusercontent.com/39497902/190039808-d84f294c-ae52-49a0-942f-4f73891a9bbd.png">

<img width="1850" alt="Screen Shot 2022-09-13 at 6 43 00 PM" src="https://user-images.githubusercontent.com/39497902/190039827-fa1a25de-09c6-4c75-8bf9-768fefcef867.png">

<img width="2474" alt="Screen Shot 2022-09-13 at 6 43 05 PM" src="https://user-images.githubusercontent.com/39497902/190039844-431f0b34-2c14-43c0-b43a-c1c03da3e8e9.png">

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [X] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
