### PR TITLE
Replace `CONTRIBUTING.rst` with `CONTRIBUTING.md`

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request_template.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request_template.yaml
@@ -7,7 +7,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thank you for submitting a feature request. **Before proceeding, please review MLflow's [Issue Policy for feature requests](https://www.github.com/mlflow/mlflow/blob/master/ISSUE_POLICY.md#feature-requests) and the [MLflow Contributing Guide](https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.rst)**.
+        Thank you for submitting a feature request. **Before proceeding, please review MLflow's [Issue Policy for feature requests](https://www.github.com/mlflow/mlflow/blob/master/ISSUE_POLICY.md#feature-requests) and the [MLflow Contributing Guide](https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.md)**.
         **Please fill in this feature request template to ensure a timely and thorough response.**
   - type: dropdown
     id: contribution
@@ -49,7 +49,7 @@ body:
     attributes:
       label: Details
       description: |
-        Use this section to include any additional information about the feature. If you have a proposal for how to implement this feature, please include it here. For implementation guidelines, please refer to the [Contributing Guide](https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.rst#contribution-guidelines).
+        Use this section to include any additional information about the feature. If you have a proposal for how to implement this feature, please include it here. For implementation guidelines, please refer to the [Contributing Guide](https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.md#contribution-guidelines).
     validations:
       required: false
   - type: checkboxes

--- a/.github/workflows/notify-dco-failure.js
+++ b/.github/workflows/notify-dco-failure.js
@@ -36,7 +36,7 @@ module.exports = async ({ context, github }) => {
     const body = [
       `@${user.login} Thanks for the contribution! The DCO check failed. `,
       `Please sign off your commits by following the instructions here: ${dcoCheck.html_url}. `,
-      "See https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.rst#sign-your-work for more ",
+      "See https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.md#sign-your-work for more ",
       "details.",
     ].join("");
     await github.issues.createComment({

--- a/CODE_OF_CONDUCT.rst
+++ b/CODE_OF_CONDUCT.rst
@@ -62,7 +62,7 @@ Enforcement
 ###########
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the Technical Steering Committee defined `here <https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.rst#governance>`_.
+reported by contacting the Technical Steering Committee defined `here <https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.md#governance>`_.
 All complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,13 +65,13 @@ MLflow committers actively [triage](ISSUE_TRIAGE.rst) and respond to
 GitHub issues. In general, we recommend waiting for feedback from an
 MLflow committer or community member before proceeding to implement a
 feature or patch. This is particularly important for [significant
-changes](https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.rst#write-designs-for-significant-changes),
+changes](https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.md#write-designs-for-significant-changes),
 and will typically be labeled during triage with `needs design`.
 
 After you have agreed upon an implementation strategy for your feature
 or patch with an MLflow committer, the next step is to introduce your
 changes (see [developing
-changes](https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.rst#developing-and-testing-mlflow))
+changes](https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.md#developing-and-testing-mlflow))
 as a pull request against the MLflow Repository (we recommend pull
 requests be filed from a non-master branch on a repository fork) or as a
 standalone MLflow Plugin. MLflow committers actively review pull

--- a/README.rst
+++ b/README.rst
@@ -116,7 +116,7 @@ Start it with::
 **Note:** Running ``mlflow ui`` from within a clone of MLflow is not recommended - doing so will
 run the dev UI from source. We recommend running the UI from a different working directory,
 specifying a backend store via the ``--backend-store-uri`` option. Alternatively, see
-instructions for running the dev UI in the `contributor guide <CONTRIBUTING.rst>`_.
+instructions for running the dev UI in the `contributor guide <CONTRIBUTING.md>`_.
 
 
 Running a Project from a URI
@@ -150,4 +150,4 @@ Contributing
 ------------
 We happily welcome contributions to MLflow. We are also seeking contributions to items on the
 `MLflow Roadmap <https://github.com/mlflow/mlflow/milestone/3>`_. Please see our
-`contribution guide <CONTRIBUTING.rst>`_ to learn more about contributing to MLflow.
+`contribution guide <CONTRIBUTING.md>`_ to learn more about contributing to MLflow.

--- a/docs/theme/mlflow/side_nav.html
+++ b/docs/theme/mlflow/side_nav.html
@@ -40,7 +40,7 @@
     {% include "build_info.html" %}
 
     <p>
-      <a id='feedbacklink' href="https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.rst" target="_blank">Contribute</a>
+      <a id='feedbacklink' href="https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.md" target="_blank">Contribute</a>
     </p>
   </div>
 </div>

--- a/mlflow/R/mlflow/README.Rmd
+++ b/mlflow/R/mlflow/README.Rmd
@@ -242,4 +242,4 @@ To enable fast iteration while tracking with MLflow improvements over a model, [
 
 ## Contributing
 
-See the [MLflow contribution guidelines](../../../CONTRIBUTING.rst).
+See the [MLflow contribution guidelines](../../../CONTRIBUTING.md).

--- a/mlflow/R/mlflow/README.md
+++ b/mlflow/R/mlflow/README.md
@@ -291,4 +291,4 @@ follows:
 
 ## Contributing
 
-See the [MLflow contribution guidelines](https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.rst).
+See the [MLflow contribution guidelines](https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.md).

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -82,7 +82,7 @@ def serve():
 
     If you are a developer making MLflow source code changes and intentionally running a source
     installation of MLflow, you can view the UI by running the Javascript dev server:
-    https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.rst#running-the-javascript-dev-server
+    https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.md#running-the-javascript-dev-server
 
     Otherwise, uninstall MLflow via 'pip uninstall mlflow', reinstall an official MLflow release
     from PyPI via 'pip install mlflow', and rerun the MLflow server.

--- a/mlflow/store/db_migrations/README.md
+++ b/mlflow/store/db_migrations/README.md
@@ -3,7 +3,7 @@
 This directory contains configuration scripts and database migration logic for MLflow tracking
 databases, using the Alembic migration library (https://alembic.sqlalchemy.org). To run database
 migrations, use the ``mlflow db upgrade`` CLI command. To add and modify database migration logic,
-see the contributor guide at https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.rst.
+see the contributor guide at https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.md.
 
 If you encounter failures while executing migrations, please file a GitHub issue at
 https://github.com/mlflow/mlflow/issues.

--- a/tests/tracking/_model_registry/test_utils.py
+++ b/tests/tracking/_model_registry/test_utils.py
@@ -15,7 +15,7 @@ from mlflow.tracking.registry import UnsupportedModelRegistryStoreURIException
 # Disable mocking tracking URI here, as we want to test setting the tracking URI via
 # environment variable. See
 # http://doc.pytest.org/en/latest/skipping.html#skip-all-test-functions-of-a-class-or-module
-# and https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.rst#writing-python-tests
+# and https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.md#writing-python-tests
 # for more information.
 pytestmark = pytest.mark.notrackingurimock
 

--- a/tests/tracking/_tracking_service/test_utils.py
+++ b/tests/tracking/_tracking_service/test_utils.py
@@ -32,7 +32,7 @@ from mlflow.tracking._tracking_service.utils import (
 # Disable mocking tracking URI here, as we want to test setting the tracking URI via
 # environment variable. See
 # http://doc.pytest.org/en/latest/skipping.html#skip-all-test-functions-of-a-class-or-module
-# and https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.rst#writing-python-tests
+# and https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.md#writing-python-tests
 # for more information.
 pytestmark = pytest.mark.notrackingurimock
 


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#6777 

## What changes are proposed in this pull request?

Replace `CONTRIBUTING.rst` with `CONTRIBUTING.md`.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
