### PR TITLE
Integrating step card with pandas_renderer

### DIFF
--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -42,7 +42,6 @@ from mlflow import projects  # pylint: disable=unused-import
 from mlflow import tracking  # pylint: disable=unused-import
 from mlflow import models  # pylint: disable=unused-import
 from mlflow import artifacts  # pylint: disable=unused-import
-from mlflow import pipelines  # pylint: disable=unused-import
 from mlflow import client  # pylint: disable=unused-import
 from mlflow import exceptions  # pylint: disable=unused-import
 
@@ -58,6 +57,7 @@ try:
     from mlflow import lightgbm
     from mlflow import mleap
     from mlflow import onnx
+    from mlflow import pipelines
     from mlflow import pyfunc
     from mlflow import pytorch
     from mlflow import sklearn

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -11,7 +11,6 @@ from datetime import timedelta
 import mlflow.db
 import mlflow.experiments
 import mlflow.deployments.cli
-import mlflow.pipelines.cli
 from mlflow import projects
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 import mlflow.runs
@@ -580,7 +579,6 @@ cli.add_command(mlflow.experiments.commands)
 cli.add_command(mlflow.store.artifact.cli.commands)
 cli.add_command(mlflow.runs.commands)
 cli.add_command(mlflow.db.commands)
-cli.add_command(mlflow.pipelines.cli.commands)
 
 # We are conditional loading these commands since the skinny client does
 # not support them due to the pandas and numpy dependencies of MLflow Models
@@ -598,6 +596,14 @@ try:
     cli.add_command(mlflow.azureml.cli.commands)
 except ImportError as e:
     pass
+
+try:
+    import mlflow.pipelines.cli  # pylint: disable=unused-import
+
+    cli.add_command(mlflow.pipelines.cli.commands)
+except ImportError as e:
+    pass
+
 
 try:
     import mlflow.sagemaker.cli  # pylint: disable=unused-import

--- a/mlflow/pipelines/cards/__init__.py
+++ b/mlflow/pipelines/cards/__init__.py
@@ -101,15 +101,9 @@ class CardTab:
         :return: the updated card instance
         """
         try:
-            # Add "anchor" class to variable links to override their click behaviors using
-            # this jQuery code in pandas-profiling:
-            # https://github.com/ydataai/pandas-profiling/blob/v3.2.0/src/pandas_profiling/report/presentation/flavours/html/templates/wrapper/assets/script.js#L5-L23
-            profile_html = _PP_VARIABLE_LINK_REGEX.sub(
-                r'<a class="anchor" href="\g<href>">', profile.to_html()
-            )
             profile_iframe = (
                 "<iframe srcdoc='{src}' width='100%' height='500' frameborder='0'></iframe>"
-            ).format(src=html.escape(profile_html))
+            ).format(src=html.escape(profile))
         except Exception as e:
             profile_iframe = f"Unable to create data profile. Error found:\n{e}"
         self.add_html(name, profile_iframe)

--- a/mlflow/pipelines/cards/__init__.py
+++ b/mlflow/pipelines/cards/__init__.py
@@ -92,12 +92,12 @@ class CardTab:
         )
         self.add_html(name, img_html)
 
-    def add_pandas_profile(self, name: str, profile) -> CardTab:
+    def add_pandas_profile(self, name: str, profile: str) -> CardTab:
         """
         Add a new tab representing the provided pandas profile to the card.
 
         :param name: name of the variable in the Jinja2 template
-        :param profile: the pandas profile object
+        :param profile: html string to render profile in the step card
         :return: the updated card instance
         """
         try:

--- a/mlflow/pipelines/cards/pandas_renderer.py
+++ b/mlflow/pipelines/cards/pandas_renderer.py
@@ -192,9 +192,10 @@ def convert_to_comparison_proto(
     """
     feature_stats_list = facet_feature_statistics_pb2.DatasetFeatureStatisticsList()
     for (name, df) in dfs:
-        proto = convert_to_dataset_feature_statistics(df)
-        proto.name = name
-        feature_stats_list.datasets.append(proto)
+        if not df.empty:
+            proto = convert_to_dataset_feature_statistics(df)
+            proto.name = name
+            feature_stats_list.datasets.append(proto)
     return feature_stats_list
 
 
@@ -229,8 +230,9 @@ def get_html(inputs: Union[pd.DataFrame, Iterable[Tuple[str, pd.DataFrame]]]) ->
     """
     if isinstance(inputs, pd.DataFrame):
         df: pd.DataFrame = inputs
-        proto = convert_to_proto(df)
-        compare = False
+        if not df.empty:
+            proto = convert_to_proto(df)
+            compare = False
     else:
         proto = convert_to_comparison_proto(inputs)
         compare = True

--- a/mlflow/pipelines/cards/pandas_renderer.py
+++ b/mlflow/pipelines/cards/pandas_renderer.py
@@ -227,8 +227,6 @@ def get_html(inputs: Union[pd.DataFrame, Iterable[Tuple[str, pd.DataFrame]]]) ->
         and they are all visualized in comparison mode.
     :return: None
     """
-    from IPython.display import display as ip_display, HTML
-
     if isinstance(inputs, pd.DataFrame):
         df: pd.DataFrame = inputs
         proto = convert_to_proto(df)

--- a/mlflow/pipelines/cards/pandas_renderer.py
+++ b/mlflow/pipelines/cards/pandas_renderer.py
@@ -219,7 +219,7 @@ def construct_facets_html(
     return html
 
 
-def render_html(inputs: Union[pd.DataFrame, Iterable[Tuple[str, pd.DataFrame]]]) -> None:
+def get_html(inputs: Union[pd.DataFrame, Iterable[Tuple[str, pd.DataFrame]]]) -> str:
     """Rendering the data statistics in a HTML format.
 
     :param inputs: Either a single "glimpse" DataFrame that contains the statistics, or a
@@ -238,4 +238,4 @@ def render_html(inputs: Union[pd.DataFrame, Iterable[Tuple[str, pd.DataFrame]]])
         compare = True
 
     html = construct_facets_html(proto, compare=compare)
-    ip_display(HTML(data=html))
+    return html

--- a/mlflow/pipelines/cards/pandas_renderer.py
+++ b/mlflow/pipelines/cards/pandas_renderer.py
@@ -229,9 +229,8 @@ def get_html(inputs: Union[pd.DataFrame, Iterable[Tuple[str, pd.DataFrame]]]) ->
     :return: None
     """
     if isinstance(inputs, pd.DataFrame):
-        df: pd.DataFrame = inputs
-        if not df.empty:
-            proto = convert_to_proto(df)
+        if not inputs.empty:
+            proto = convert_to_proto(inputs)
             compare = False
     else:
         proto = convert_to_comparison_proto(inputs)

--- a/mlflow/pipelines/steps/ingest/__init__.py
+++ b/mlflow/pipelines/steps/ingest/__init__.py
@@ -2,6 +2,7 @@ import abc
 import logging
 import os
 
+from pathlib import Path
 from mlflow.exceptions import MlflowException
 from mlflow.pipelines.cards import BaseCard
 from mlflow.pipelines.step import BaseStep
@@ -78,10 +79,10 @@ class BaseIngestStep(BaseStep, metaclass=abc.ABCMeta):
             ingested_dataset_profile = get_pandas_data_profile(
                 ingested_df, "Profile of Ingested Dataset"
             )
-            dataset_profile_path = os.path.join(
-                output_directory, BaseIngestStep._DATASET_PROFILE_OUTPUT_NAME
+            dataset_profile_path = Path(
+                str(os.path.join(output_directory, BaseIngestStep._DATASET_PROFILE_OUTPUT_NAME))
             )
-            ingested_dataset_profile.to_file(output_file=dataset_profile_path)
+            dataset_profile_path.write_text(ingested_dataset_profile, encoding="utf-8")
             _logger.info(f"Wrote dataset profile to '{dataset_profile_path}'")
 
         schema = pd.io.json.build_table_schema(ingested_df, index=False)

--- a/mlflow/pipelines/utils/step.py
+++ b/mlflow/pipelines/utils/step.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from mlflow.pipelines.cards import pandas_renderer
 
 from mlflow.exceptions import MlflowException, INVALID_PARAMETER_VALUE
 from mlflow.utils.databricks_utils import (
@@ -114,13 +115,7 @@ def get_pandas_data_profile(data_frame, title: str):
     from pandas_profiling import ProfileReport
 
     if len(data_frame) == 0:
-        return ProfileReport(
-            data_frame,
-            title=title,
-            minimal=True,
-            progress_bar=False,
-            pool_size=_get_pool_size(),
-        )
+        pandas_renderer.get_html([[title, data_frame]])
 
     max_cells = min(data_frame.size, _MAX_PROFILE_CELL_SIZE)
     max_cols = min(data_frame.columns.size, _MAX_PROFILE_COL_SIZE)
@@ -140,10 +135,4 @@ def get_pandas_data_profile(data_frame, title: str):
             max_cols,
             max_rows,
         )
-    return ProfileReport(
-        truncated_df,
-        title=title,
-        minimal=True,
-        progress_bar=False,
-        pool_size=_get_pool_size(),
-    )
+    return pandas_renderer.get_html([[title, truncated_df]])

--- a/mlflow/pipelines/utils/step.py
+++ b/mlflow/pipelines/utils/step.py
@@ -112,8 +112,6 @@ def get_pandas_data_profile(data_frame, title: str):
     :param title: String, the title of the data profile.
     :return: a data profiling object such as Pandas profiling ProfileReport.
     """
-    from pandas_profiling import ProfileReport
-
     if len(data_frame) == 0:
         pandas_renderer.get_html([[title, data_frame]])
 

--- a/tests/pipelines/cards/test_base_card.py
+++ b/tests/pipelines/cards/test_base_card.py
@@ -6,12 +6,8 @@ from mlflow.exceptions import MlflowException
 from mlflow.pipelines.cards import BaseCard, CardTab
 
 
-class ProfileReport:
-    def to_html(self):
-        return "pandas-profiling"
-
-
 def test_verify_card_information():
+    profile_report = "pandas-profiling"
     card = BaseCard(
         pipeline_name="fake pipeline",
         step_name="fake step",
@@ -28,8 +24,8 @@ def test_verify_card_information():
         .add_markdown("MARKDOWN_1", "#### Hello, world!")
         .add_html("HTML_1", "<span style='color:blue'>blue</span>")
     )
-    card.add_tab("Profile 1", "{{PROFILE}}").add_pandas_profile("PROFILE", ProfileReport())
-    card.add_tab("Profile 2", "{{PROFILE}}").add_pandas_profile("PROFILE", ProfileReport())
+    card.add_tab("Profile 1", "{{PROFILE}}").add_pandas_profile("PROFILE", profile_report)
+    card.add_tab("Profile 2", "{{PROFILE}}").add_pandas_profile("PROFILE", profile_report)
     card.add_text("1,2,3.")
 
     expected_html = """
@@ -45,11 +41,12 @@ def test_verify_card_information():
 
 
 def test_card_tab_works():
+    profile_report = "pandas-profiling"
     tab = (
         CardTab("tab", "{{MARKDOWN_1}}{{HTML_1}}{{PROFILE_1}}")
         .add_html("HTML_1", "<span style='color:blue'>blue</span>")
         .add_markdown("MARKDOWN_1", "#### Hello, world!")
-        .add_pandas_profile("PROFILE_1", ProfileReport())
+        .add_pandas_profile("PROFILE_1", profile_report)
     )
     assert (
         tab.to_html()

--- a/tests/pipelines/test_ingest_step.py
+++ b/tests/pipelines/test_ingest_step.py
@@ -509,7 +509,7 @@ def test_ingest_produces_expected_step_card(pandas_df, tmp_path):
 
     assert "Dataset source location" in step_card_html_content
     assert "Number of rows ingested" in step_card_html_content
-    assert "Profile of Ingested Dataset" in step_card_html_content
+    assert "facets-overview" in step_card_html_content
 
 
 @pytest.mark.usefixtures("enter_test_pipeline_directory")
@@ -656,5 +656,5 @@ def test_ingest_skips_profiling_when_specified(pandas_df, tmp_path):
     expected_step_card_path = os.path.join(tmp_path, "card.html")
     with open(expected_step_card_path, "r") as f:
         step_card_html_content = f.read()
-    assert "Profile of Ingested Dataset" not in step_card_html_content
+    assert "facets-overview" not in step_card_html_content
     mock_profiling.assert_not_called()

--- a/tests/pipelines/test_step_utils.py
+++ b/tests/pipelines/test_step_utils.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 from mlflow.exceptions import MlflowException
+from mlflow.pipelines.cards import pandas_renderer
 from mlflow.pipelines.utils.step import (
     display_html,
     get_merged_eval_metrics,
@@ -87,12 +88,14 @@ def test_get_data_profile_truncates_large_data_frame(
     step_utils._MAX_PROFILE_CELL_SIZE = max_cells
     step_utils._MAX_PROFILE_COL_SIZE = max_cols
     step_utils._MAX_PROFILE_ROW_SIZE = max_rows
-    profile = get_pandas_data_profile(data_frame, "fake profile")
-    assert json.loads(profile.to_json())["table"]["n_var"] == expected_cols
-    assert json.loads(profile.to_json())["variables"]["0"]["count"] == expected_rows
+    with mock.patch.object(pandas_renderer, "get_html") as mock_pandas_renderer_html:
+        get_pandas_data_profile(data_frame, "fake profile")
+        truncated_df = mock_pandas_renderer_html.call_args.args[0][0][1]
+        assert truncated_df.shape == (expected_rows, expected_cols)
 
 
 def test_get_data_profile_works_for_empty_data_frame():
-    profile = get_pandas_data_profile(DataFrame(), "fake profile")
-    assert json.loads(profile.to_json())["table"]["n_var"] == 1  # The index
-    assert json.loads(profile.to_json())["variables"]["df_index"]["count"] == 0
+    with mock.patch.object(pandas_renderer, "get_html") as mock_pandas_renderer_html:
+        get_pandas_data_profile(DataFrame(), "fake profile")
+        truncated_df = mock_pandas_renderer_html.call_args.args[0][0][1]
+        assert truncated_df.shape == (0, 0)

--- a/tests/pipelines/test_step_utils.py
+++ b/tests/pipelines/test_step_utils.py
@@ -1,4 +1,3 @@
-import json
 import mlflow.pipelines.utils.step as step_utils
 import numpy as np
 import pytest

--- a/tests/pipelines/test_step_utils.py
+++ b/tests/pipelines/test_step_utils.py
@@ -89,12 +89,12 @@ def test_get_data_profile_truncates_large_data_frame(
     step_utils._MAX_PROFILE_ROW_SIZE = max_rows
     with mock.patch.object(pandas_renderer, "get_html") as mock_pandas_renderer_html:
         get_pandas_data_profile(data_frame, "fake profile")
-        truncated_df = mock_pandas_renderer_html.call_args.args[0][0][1]
+        truncated_df = mock_pandas_renderer_html.call_args_list[0][0][0][0][1]
         assert truncated_df.shape == (expected_rows, expected_cols)
 
 
 def test_get_data_profile_works_for_empty_data_frame():
     with mock.patch.object(pandas_renderer, "get_html") as mock_pandas_renderer_html:
         get_pandas_data_profile(DataFrame(), "fake profile")
-        truncated_df = mock_pandas_renderer_html.call_args.args[0][0][1]
+        truncated_df = mock_pandas_renderer_html.call_args_list[0][0][0][0][1]
         assert truncated_df.shape == (0, 0)

--- a/tests/pipelines/test_step_utils.py
+++ b/tests/pipelines/test_step_utils.py
@@ -89,6 +89,9 @@ def test_get_data_profile_truncates_large_data_frame(
     step_utils._MAX_PROFILE_ROW_SIZE = max_rows
     with mock.patch.object(pandas_renderer, "get_html") as mock_pandas_renderer_html:
         get_pandas_data_profile(data_frame, "fake profile")
+        # Initial index of [0][0][0] are from call_args_list to get the 0th call.
+        # The next [0][1] are because of the pandas_renderer get_html API
+        # pandas_renderer.get_html([[title, truncated_df]])
         truncated_df = mock_pandas_renderer_html.call_args_list[0][0][0][0][1]
         assert truncated_df.shape == (expected_rows, expected_cols)
 
@@ -96,5 +99,8 @@ def test_get_data_profile_truncates_large_data_frame(
 def test_get_data_profile_works_for_empty_data_frame():
     with mock.patch.object(pandas_renderer, "get_html") as mock_pandas_renderer_html:
         get_pandas_data_profile(DataFrame(), "fake profile")
+        # Initial index of [0][0][0] are from call_args_list to get the 0th call.
+        # The next [0][1] are because of the pandas_renderer get_html API
+        # pandas_renderer.get_html([[title, truncated_df]])
         truncated_df = mock_pandas_renderer_html.call_args_list[0][0][0][0][1]
         assert truncated_df.shape == (0, 0)


### PR DESCRIPTION
## What changes are proposed in this pull request?
Integrating step card with pandas_renderer

## How is this patch tested?
- [x] Verified in dogfood that the step card is rendered correctly

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
Using custom created profile in MLP step cards

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
