### PR TITLE
Fix bug with 1-D arrays

### DIFF
--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -543,7 +543,8 @@ class _TF2Wrapper:
         raw_preds = self.infer(**feed_dict)
         pred_dict = {col_name: raw_preds[col_name].numpy() for col_name in raw_preds.keys()}
         for col in pred_dict.keys():
-            if all(len(element) == 1 for element in pred_dict[col]):
+            # If the output tensor is not 1-dimensional AND all elements have length of 1, flatten the array with `ravel()`
+            if len(pred_dict[col].shape) != 1 and all(len(element) == 1 for element in pred_dict[col]):
                 pred_dict[col] = pred_dict[col].ravel()
             else:
                 pred_dict[col] = pred_dict[col].tolist()

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -543,8 +543,10 @@ class _TF2Wrapper:
         raw_preds = self.infer(**feed_dict)
         pred_dict = {col_name: raw_preds[col_name].numpy() for col_name in raw_preds.keys()}
         for col in pred_dict.keys():
-            # If the output tensor is not 1-dimensional AND all elements have length of 1, flatten the array with `ravel()`
-            if len(pred_dict[col].shape) != 1 and all(len(element) == 1 for element in pred_dict[col]):
+            # If the output tensor is not 1-dimensional
+            # AND all elements have length of 1, flatten the array with `ravel()`
+            if (len(pred_dict[col].shape) != 1 and
+                    all(len(element) == 1 for element in pred_dict[col])):
                 pred_dict[col] = pred_dict[col].ravel()
             else:
                 pred_dict[col] = pred_dict[col].tolist()

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -545,8 +545,9 @@ class _TF2Wrapper:
         for col in pred_dict.keys():
             # If the output tensor is not 1-dimensional
             # AND all elements have length of 1, flatten the array with `ravel()`
-            if (len(pred_dict[col].shape) != 1 and
-                    all(len(element) == 1 for element in pred_dict[col])):
+            if len(pred_dict[col].shape) != 1 and all(
+                len(element) == 1 for element in pred_dict[col]
+            ):
                 pred_dict[col] = pred_dict[col].ravel()
             else:
                 pred_dict[col] = pred_dict[col].tolist()

--- a/tests/tensorflow/test_tensorflow2_model_export.py
+++ b/tests/tensorflow/test_tensorflow2_model_export.py
@@ -820,7 +820,8 @@ def test_saved_model_support_array_type_input():
 
 def test_tf2_wrapper_handles_1d_output_data_shape():
     def infer(features):
-        res = features.numpy().sum(axis=1)  # NOTE: by removing `np.expand_dims` we create a 1D output.
+        # NOTE: by removing `np.expand_dims` we create a 1D output.
+        res = features.numpy().sum(axis=1)
         return {"prediction": tf.constant(res)}
 
     model = _TF2Wrapper(None, infer)

--- a/tests/tensorflow/test_tensorflow2_model_export.py
+++ b/tests/tensorflow/test_tensorflow2_model_export.py
@@ -816,3 +816,17 @@ def test_saved_model_support_array_type_input():
     result = model.predict(infer_df)
 
     np.testing.assert_allclose(result["prediction"], infer_df.applymap(sum).values[:, 0])
+
+
+def test_tf2_wrapper_handles_1d_output_data_shape():
+    def infer(features):
+        res = features.numpy().sum(axis=1)  # NOTE: by removing `np.expand_dims` we create a 1D output.
+        return {"prediction": tf.constant(res)}
+
+    model = _TF2Wrapper(None, infer)
+
+    infer_df = pd.DataFrame({"features": [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]]})
+
+    result = model.predict(infer_df)
+
+    np.testing.assert_allclose(result["prediction"], infer_df.applymap(sum).values[:, 0])


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#6610

## What changes are proposed in this pull request?

Add logic to handle 1-dimensional output tensors in `_TF2Wrapper.predict()` method. 

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add logic to handle 1-dimensional output tensors in `_TF2Wrapper.predict()` method. 

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
