### PR TITLE
tuning tests

### DIFF
--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -184,8 +184,10 @@ class TrainStep(BaseStep):
                     output_directory,
                 )
                 estimator = estimator_fn(best_estimator_params)
-            else:
+            elif estimator_hardcoded_params != {}:
                 estimator = estimator_fn(estimator_hardcoded_params)
+            else:
+                estimator = estimator_fn
 
             estimator.fit(X_train, y_train)
 

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -184,8 +184,10 @@ class TrainStep(BaseStep):
                     output_directory,
                 )
                 estimator = estimator_fn(best_estimator_params)
-            else:
+            elif estimator_hardcoded_params != {}:
                 estimator = estimator_fn(estimator_hardcoded_params)
+            else:
+                estimator = estimator_fn()
 
             estimator.fit(X_train, y_train)
 

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -786,30 +786,20 @@ class TrainStep(BaseStep):
             hp_trials = Trials()
             on_worker = False
 
+        fmin_kwargs = {
+            "fn": lambda params: objective(
+                X_train, y_train, validation_df, params, on_worker=on_worker
+            ),
+            "space": search_space,
+            "algo": tuning_algo,
+            "max_evals": max_trials,
+            "trials": hp_trials,
+        }
         if "early_stop_fn" in tuning_params:
             train_module_name, early_stop_fn_name = tuning_params["early_stop_fn"].rsplit(".", 1)
             early_stop_fn = getattr(importlib.import_module(train_module_name), early_stop_fn_name)
-            best_hp_params = fmin(
-                lambda params: objective(
-                    X_train, y_train, validation_df, params, on_worker=on_worker
-                ),
-                search_space,
-                algo=tuning_algo,
-                max_evals=max_trials,
-                trials=hp_trials,
-                early_stop_fn=early_stop_fn,
-            )
-        else:
-            best_hp_params = fmin(
-                lambda params: objective(
-                    X_train, y_train, validation_df, params, on_worker=on_worker
-                ),
-                search_space,
-                algo=tuning_algo,
-                max_evals=max_trials,
-                trials=hp_trials,
-                early_stop_fn=early_stop_fn,
-            )
+            fmin_kwargs["early_stop_fn"] = early_stop_fn
+        best_hp_params = fmin(**fmin_kwargs)
         best_hp_estimator_loss = hp_trials.best_trial["result"]["loss"]
         hardcoded_estimator_loss = objective(
             X_train, y_train, validation_df, estimator_hardcoded_params

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -81,7 +81,7 @@ class TrainStep(BaseStep):
         self.code_paths = [os.path.join(self.pipeline_root, "steps")]
 
     @classmethod
-    def _construct_search_space_from_yaml(cls, params):
+    def construct_search_space_from_yaml(cls, params):
         from hyperopt import hp
 
         search_space = {}
@@ -102,7 +102,7 @@ class TrainStep(BaseStep):
         return search_space
 
     @classmethod
-    def _is_tuning_param_equal(cls, tuning_param, logged_param):
+    def is_tuning_param_equal(cls, tuning_param, logged_param):
         if isinstance(tuning_param, int):
             return tuning_param == int(logged_param)
         elif isinstance(tuning_param, float):
@@ -712,7 +712,7 @@ class TrainStep(BaseStep):
                 manual_log_params = {}
                 for param_name, param_value in estimator_args.items():
                     if param_name in autologged_params:
-                        if not TrainStep._is_tuning_param_equal(
+                        if not TrainStep.is_tuning_param_equal(
                             param_value, autologged_params[param_name]
                         ):
                             _logger.warning(
@@ -732,7 +732,7 @@ class TrainStep(BaseStep):
                 sign = -1 if self.evaluation_metrics_greater_is_better[self.primary_metric] else 1
                 return sign * eval_result.metrics[self.primary_metric]
 
-        search_space = TrainStep._construct_search_space_from_yaml(tuning_params["parameters"])
+        search_space = TrainStep.construct_search_space_from_yaml(tuning_params["parameters"])
         algo_type, algo_name = tuning_params["algorithm"].rsplit(".", 1)
         tuning_algo = getattr(importlib.import_module(algo_type, "hyperopt"), algo_name)
         max_trials = tuning_params["max_trials"]

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -187,7 +187,7 @@ class TrainStep(BaseStep):
                     output_directory,
                 )
                 estimator = estimator_fn(best_estimator_params)
-            elif estimator_hardcoded_params != {}:
+            elif len(estimator_hardcoded_params) > 0:
                 estimator = estimator_fn(estimator_hardcoded_params)
             else:
                 estimator = estimator_fn()

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -187,7 +187,7 @@ class TrainStep(BaseStep):
             elif estimator_hardcoded_params != {}:
                 estimator = estimator_fn(estimator_hardcoded_params)
             else:
-                estimator = estimator_fn
+                estimator = estimator_fn()
 
             estimator.fit(X_train, y_train)
 

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -101,6 +101,17 @@ class TrainStep(BaseStep):
                 )
         return search_space
 
+    @classmethod
+    def _is_tuning_param_equal(cls, tuning_param, logged_param):
+        if isinstance(tuning_param, int):
+            return tuning_param == int(logged_param)
+        elif isinstance(tuning_param, float):
+            return tuning_param == float(logged_param)
+        elif isinstance(tuning_param, str):
+            return tuning_param.strip() == logged_param.strip()
+        else:
+            return tuning_param == logged_param
+
     def _run(self, output_directory):
         import pandas as pd
         import shutil
@@ -701,7 +712,7 @@ class TrainStep(BaseStep):
                 manual_log_params = {}
                 for param_name, param_value in estimator_args.items():
                     if param_name in autologged_params:
-                        if not self._is_tuning_param_equal(
+                        if not TrainStep._is_tuning_param_equal(
                             param_value, autologged_params[param_name]
                         ):
                             _logger.warning(
@@ -795,13 +806,3 @@ class TrainStep(BaseStep):
             else:
                 processed_data[key] = value
         return yaml.safe_dump(processed_data, file, **kwargs)
-
-    def _is_tuning_param_equal(self, tuning_param, logged_param):
-        if isinstance(tuning_param, int):
-            return tuning_param == int(logged_param)
-        elif isinstance(tuning_param, float):
-            return tuning_param == float(logged_param)
-        elif isinstance(tuning_param, str):
-            return tuning_param.strip() == logged_param.strip()
-        else:
-            return tuning_param == logged_param

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -184,10 +184,8 @@ class TrainStep(BaseStep):
                     output_directory,
                 )
                 estimator = estimator_fn(best_estimator_params)
-            elif estimator_hardcoded_params != {}:
-                estimator = estimator_fn(estimator_hardcoded_params)
             else:
-                estimator = estimator_fn()
+                estimator = estimator_fn(estimator_hardcoded_params)
 
             estimator.fit(X_train, y_train)
 

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -790,7 +790,9 @@ class TrainStep(BaseStep):
             train_module_name, early_stop_fn_name = tuning_params["early_stop_fn"].rsplit(".", 1)
             early_stop_fn = getattr(importlib.import_module(train_module_name), early_stop_fn_name)
             best_hp_params = fmin(
-                lambda params: objective(X_train, y_train, validation_df, params, on_worker=on_worker),
+                lambda params: objective(
+                    X_train, y_train, validation_df, params, on_worker=on_worker
+                ),
                 search_space,
                 algo=tuning_algo,
                 max_evals=max_trials,
@@ -799,7 +801,9 @@ class TrainStep(BaseStep):
             )
         else:
             best_hp_params = fmin(
-                lambda params: objective(X_train, y_train, validation_df, params, on_worker=on_worker),
+                lambda params: objective(
+                    X_train, y_train, validation_df, params, on_worker=on_worker
+                ),
                 search_space,
                 algo=tuning_algo,
                 max_evals=max_trials,

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -19,3 +19,4 @@ plotly
 kaleido
 # The latest flask version requires werkzeug>=2.2.0
 werkzeug>=2.2.0
+hyperopt

--- a/tests/pipelines/test_train_step.py
+++ b/tests/pipelines/test_train_step.py
@@ -133,7 +133,7 @@ def estimator_fn(estimator_params={}):  # pylint: disable=dangerous-default-valu
     return SGDRegressor(random_state=42, **estimator_params)
 
 
-def early_stop_fn(trial, count=0): # pylint: disable=unused-argument
+def early_stop_fn(trial, count=0):  # pylint: disable=unused-argument
     return count + 1 <= 2, [count + 1]
 
 

--- a/tests/pipelines/test_train_step.py
+++ b/tests/pipelines/test_train_step.py
@@ -256,3 +256,8 @@ def test_search_space(tmp_pipeline_root_path):
     tuning_params = read_yaml(tmp_pipeline_root_path, "tuning_params.yaml")
     search_space = TrainStep._construct_search_space_from_yaml(tuning_params["parameters"])
     assert "alpha" in search_space
+
+
+@pytest.mark.parametrize("tuning_param,logged_param", [(1, "1"), (1.0, "1.0"), ("a", " a ")])
+def test_tuning_param_equal(tuning_param, logged_param):
+    assert TrainStep._is_tuning_param_equal(tuning_param, logged_param)

--- a/tests/pipelines/test_train_step.py
+++ b/tests/pipelines/test_train_step.py
@@ -119,7 +119,7 @@ def setup_train_step(pipeline_root: Path, use_tuning: bool):
     return train_step
 
 
-def estimator_fn(estimator_params=None):
+def estimator_fn(estimator_params={}):  # pylint: disable=dangerous-default-value
     from sklearn.linear_model import SGDRegressor
 
     return SGDRegressor(random_state=42, **estimator_params)

--- a/tests/pipelines/test_train_step.py
+++ b/tests/pipelines/test_train_step.py
@@ -254,10 +254,10 @@ def test_search_space(tmp_pipeline_root_path):
         """
     )
     tuning_params = read_yaml(tmp_pipeline_root_path, "tuning_params.yaml")
-    search_space = TrainStep._construct_search_space_from_yaml(tuning_params["parameters"])
+    search_space = TrainStep.construct_search_space_from_yaml(tuning_params["parameters"])
     assert "alpha" in search_space
 
 
 @pytest.mark.parametrize("tuning_param,logged_param", [(1, "1"), (1.0, "1.0"), ("a", " a ")])
 def test_tuning_param_equal(tuning_param, logged_param):
-    assert TrainStep._is_tuning_param_equal(tuning_param, logged_param)
+    assert TrainStep.is_tuning_param_equal(tuning_param, logged_param)


### PR DESCRIPTION
Signed-off-by: Prithvi Kannan <prithvi.kannan@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Parameterize existing train step tests to run with and without tuning. Adding additional test for tuning-specific features and utils.

Making some small changes to `train.py` to (1) fix issues and (2) make testing easier. 

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
