### PR TITLE
Fix flaky `test_download_artifacts`

### DIFF
--- a/tests/store/artifact/test_mlflow_artifact_repo.py
+++ b/tests/store/artifact/test_mlflow_artifact_repo.py
@@ -278,38 +278,41 @@ def test_download_artifacts(mlflow_artifact_repo, tmpdir):
     # - dir
     #   - b.txt
     # ---------
-    side_effect = [
-        # Response for `list_experiments("")` called by `_is_directory("")`
-        MockResponse(
-            {
-                "files": [
-                    {"path": "a.txt", "is_dir": False, "file_size": 6},
-                    {"path": "dir", "is_dir": True},
-                ]
-            },
-            200,
-        ),
-        # Response for `list_experiments("")`
-        MockResponse(
-            {
-                "files": [
-                    {"path": "a.txt", "is_dir": False, "file_size": 6},
-                    {"path": "dir", "is_dir": True},
-                ]
-            },
-            200,
-        ),
-        # Response for `_download_file("a.txt")`
-        MockStreamResponse("data_a", 200),
-        # Response for `list_experiments("dir")`
-        MockResponse({"files": [{"path": "b.txt", "is_dir": False, "file_size": 1}]}, 200),
-        # Response for `_download_file("dir/b.txt")`
-        MockStreamResponse("data_b", 200),
-    ]
-    with mock.patch(
-        "mlflow.store.artifact.http_artifact_repo.http_request",
-        side_effect=side_effect,
-    ):
+    def http_request(_host_creds, endpoint, _method, **kwargs):
+        # Responses for list_artifacts
+        params = kwargs.get("params")
+        if params:
+            if params.get("path") == "":
+                return MockResponse(
+                    {
+                        "files": [
+                            {"path": "a.txt", "is_dir": False, "file_size": 1},
+                            {"path": "dir", "is_dir": True},
+                        ]
+                    },
+                    200,
+                )
+            elif params.get("path") == "dir":
+                return MockResponse(
+                    {
+                        "files": [
+                            {"path": "b.txt", "is_dir": False, "file_size": 1},
+                        ]
+                    },
+                    200,
+                )
+            else:
+                Exception("Unreachable")
+
+        # Responses for _download_file
+        if endpoint == "/a.txt":
+            return MockStreamResponse("data_a", 200)
+        elif endpoint == "/dir/b.txt":
+            return MockStreamResponse("data_b", 200)
+        else:
+            raise Exception("Unreachable")
+
+    with mock.patch("mlflow.store.artifact.http_artifact_repo.http_request", http_request):
         mlflow_artifact_repo.download_artifacts("", tmpdir)
         paths = [os.path.join(root, f) for root, _, files in os.walk(tmpdir) for f in files]
         assert [os.path.relpath(p, tmpdir) for p in paths] == [


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
Applies the same change as https://github.com/mlflow/mlflow/pull/6702.

## What changes are proposed in this pull request?

Fix the following test failure:

https://github.com/mlflow/mlflow/actions/runs/3049784232/jobs/4916198812#step:7:1937

```
    def list_artifacts(self, path=None):
        endpoint = "/mlflow-artifacts/artifacts"
        url, tail = self.artifact_uri.split(endpoint, maxsplit=1)
        root = tail.lstrip("/")
        params = {"path": posixpath.join(root, path) if path else root}
        host_creds = _get_default_host_creds(url)
        resp = http_request(host_creds, endpoint, "GET", params=params)
        augmented_raise_for_status(resp)
        file_infos = []
>       for f in resp.json().get("files", []):
E       AttributeError: 'str' object has no attribute 'get'
```

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
