### PR TITLE
Correctly calculate average precision, add titles to evaluator plots

### DIFF
--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -241,6 +241,7 @@ def _gen_classifier_curve(
     y_probs,
     labels,
     curve_type,
+    title,
 ):
     """
     Generate precision-recall curve or ROC curve for classifier.
@@ -250,6 +251,7 @@ def _gen_classifier_curve(
                     if multiclass classifier, the predicted probabilities for all classes.
     :param labels: The set of labels.
     :param curve_type: "pr" or "roc"
+    :param title: Title of the plot
     :return: An instance of "_Curve" which includes attributes "plot_fn", "plot_fn_args", "auc".
     """
     if curve_type == "roc":
@@ -265,16 +267,11 @@ def _gen_classifier_curve(
 
         def gen_line_x_y_label_fn(_y, _y_prob):
             precision, recall, _thresholds = sk_metrics.precision_recall_curve(_y, _y_prob)
-            # print("mean precision:", np.mean(precision))
-            # print(len(precision))
-            # print("mean recall:", np.mean(recall))
-            # print(len(recall))
-            # for i in range(len())
             ap = sk_metrics.average_precision_score(_y, _y_prob)
             return recall, precision, f"AP={ap:.3f}"
 
-        xlabel = "recall"
-        ylabel = "precision"
+        xlabel = "Recall"
+        ylabel = "Precision"
     else:
         assert False, "illegal curve type"
 
@@ -326,6 +323,7 @@ def _gen_classifier_curve(
             "xlabel": xlabel,
             "ylabel": ylabel,
             "line_kwargs": {"drawstyle": "steps-post", "linewidth": 1},
+            "title": title,
         },
         auc=auc,
     )
@@ -736,6 +734,7 @@ class DefaultEvaluator(ModelEvaluator):
                 y_probs=self.y_prob,
                 labels=self.label_list,
                 curve_type="roc",
+                title="ROC curve",
             )
 
             self.metrics["roc_auc"] = self.roc_curve.auc
@@ -745,6 +744,7 @@ class DefaultEvaluator(ModelEvaluator):
                 y_probs=self.y_prob,
                 labels=self.label_list,
                 curve_type="pr",
+                title="Precision recall curve",
             )
 
             self.metrics["precision_recall_auc"] = self.pr_curve.auc
@@ -775,6 +775,7 @@ class DefaultEvaluator(ModelEvaluator):
                 y_probs=self.y_probs,
                 labels=self.label_list,
                 curve_type="roc",
+                title="ROC curve",
             )
 
             def plot_roc_curve():
@@ -789,6 +790,7 @@ class DefaultEvaluator(ModelEvaluator):
                 y_probs=self.y_probs,
                 labels=self.label_list,
                 curve_type="pr",
+                title="Precision recall curve",
             )
 
             def plot_pr_curve():
@@ -945,10 +947,11 @@ class DefaultEvaluator(ModelEvaluator):
                 }
             ):
                 _, ax = plt.subplots(1, 1, figsize=(6.0, 4.0), dpi=175)
-                sk_metrics.ConfusionMatrixDisplay(
+                disp = sk_metrics.ConfusionMatrixDisplay(
                     confusion_matrix=confusion_matrix,
                     display_labels=self.label_list,
                 ).plot(cmap="Blues", ax=ax)
+                disp.ax_.set_title("Normalized confusion matrix")
 
         if hasattr(sk_metrics, "ConfusionMatrixDisplay"):
             self._log_image_artifact(

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -264,6 +264,8 @@ def _gen_classifier_curve(
 
         def gen_line_x_y_label_fn(_y, _y_prob):
             precision, recall, _thresholds = sk_metrics.precision_recall_curve(_y, _y_prob)
+            print("precision:", precision)
+            print("recall:", recall)
             ap = np.mean(precision)
             return recall, precision, f"AP={ap:.3f}"
 

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -240,7 +240,7 @@ def _gen_classifier_curve(
     y_probs,
     labels,
     curve_type,
-    pos_label=None,
+    pos_label,
 ):
     """
     Generate precision-recall curve or ROC curve for classifier.
@@ -270,7 +270,7 @@ def _gen_classifier_curve(
 
         def gen_line_x_y_label_fn(_y, _y_prob):
             precision, recall, _thresholds = sk_metrics.precision_recall_curve(_y, _y_prob)
-            ap = sk_metrics.average_precision_score(_y, _y_prob, pos_label)
+            ap = sk_metrics.average_precision_score(_y, _y_prob, pos_label=pos_label)
             return recall, precision, f"AP={ap:.3f}"
 
         xlabel = "Recall"
@@ -741,6 +741,7 @@ class DefaultEvaluator(ModelEvaluator):
                 y_probs=self.y_prob,
                 labels=self.label_list,
                 curve_type="roc",
+                pos_label=self.pos_label
             )
 
             self.metrics["roc_auc"] = self.roc_curve.auc
@@ -750,6 +751,7 @@ class DefaultEvaluator(ModelEvaluator):
                 y_probs=self.y_prob,
                 labels=self.label_list,
                 curve_type="pr",
+                pos_label=self.pos_label
             )
 
             self.metrics["precision_recall_auc"] = self.pr_curve.auc
@@ -780,6 +782,7 @@ class DefaultEvaluator(ModelEvaluator):
                 y_probs=self.y_probs,
                 labels=self.label_list,
                 curve_type="roc",
+                pos_label=self.pos_label
             )
 
             def plot_roc_curve():
@@ -794,6 +797,7 @@ class DefaultEvaluator(ModelEvaluator):
                 y_probs=self.y_probs,
                 labels=self.label_list,
                 curve_type="pr",
+                pos_label=self.pos_label
             )
 
             def plot_pr_curve():
@@ -820,7 +824,7 @@ class DefaultEvaluator(ModelEvaluator):
             self._log_image_artifact(plot_pr_curve, "precision_recall_curve_plot")
 
             self._log_image_artifact(
-                lambda: plot_lift_curve(self.y, self.y_probs),
+                lambda: plot_lift_curve(self.y, self.y_probs, pos_label=self.pos_label),
                 "lift_curve_plot",
             )
 
@@ -1116,6 +1120,7 @@ class DefaultEvaluator(ModelEvaluator):
         self.feature_names = dataset.feature_names
         self.custom_metrics = custom_metrics
         self.y = dataset.labels_data
+        self.pos_label = self.evaluator_config.get("pos_label")
 
         inferred_model_type = _infer_model_type_by_labels(self.y)
 

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -239,8 +239,8 @@ def _gen_classifier_curve(
     y,
     y_probs,
     labels,
-    curve_type,
     pos_label,
+    curve_type,
 ):
     """
     Generate precision-recall curve or ROC curve for classifier.
@@ -249,8 +249,8 @@ def _gen_classifier_curve(
     :param y_probs: if binary classifier, the predicted probability for positive class.
                     if multiclass classifier, the predicted probabilities for all classes.
     :param labels: The set of labels.
-    :param curve_type: "pr" or "roc"
     :param pos_label: The label of the positive class.
+    :param curve_type: "pr" or "roc"
     :return: An instance of "_Curve" which includes attributes "plot_fn", "plot_fn_args", "auc".
     """
     if curve_type == "roc":
@@ -1120,7 +1120,7 @@ class DefaultEvaluator(ModelEvaluator):
         self.feature_names = dataset.feature_names
         self.custom_metrics = custom_metrics
         self.y = dataset.labels_data
-        self.pos_label = self.evaluator_config.get("pos_label")
+        self.pos_label = self.evaluator_config.get("pos_label", 1)
 
         inferred_model_type = _infer_model_type_by_labels(self.y)
 

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -240,7 +240,7 @@ def _gen_classifier_curve(
     y_probs,
     labels,
     curve_type,
-    title,
+    pos_label=None,
 ):
     """
     Generate precision-recall curve or ROC curve for classifier.
@@ -250,7 +250,7 @@ def _gen_classifier_curve(
                     if multiclass classifier, the predicted probabilities for all classes.
     :param labels: The set of labels.
     :param curve_type: "pr" or "roc"
-    :param title: Title of the plot
+    :param pos_label: The label of the positive class.
     :return: An instance of "_Curve" which includes attributes "plot_fn", "plot_fn_args", "auc".
     """
     if curve_type == "roc":
@@ -262,15 +262,23 @@ def _gen_classifier_curve(
 
         xlabel = "False Positive Rate"
         ylabel = "True Positive Rate"
+        title = "ROC curve"
+        if pos_label:
+            xlabel = f"False Positive Rate (Positive label: {pos_label})"
+            ylabel = f"True Positive Rate (Positive label: {pos_label})"
     elif curve_type == "pr":
 
         def gen_line_x_y_label_fn(_y, _y_prob):
             precision, recall, _thresholds = sk_metrics.precision_recall_curve(_y, _y_prob)
-            ap = sk_metrics.average_precision_score(_y, _y_prob)
+            ap = sk_metrics.average_precision_score(_y, _y_prob, pos_label)
             return recall, precision, f"AP={ap:.3f}"
 
         xlabel = "Recall"
         ylabel = "Precision"
+        title = "Precision recall curve"
+        if pos_label:
+            xlabel = f"Recall (Positive label: {pos_label})"
+            ylabel = f"Precision (Positive label: {pos_label})"
     else:
         assert False, "illegal curve type"
 
@@ -733,7 +741,6 @@ class DefaultEvaluator(ModelEvaluator):
                 y_probs=self.y_prob,
                 labels=self.label_list,
                 curve_type="roc",
-                title="ROC curve",
             )
 
             self.metrics["roc_auc"] = self.roc_curve.auc
@@ -743,7 +750,6 @@ class DefaultEvaluator(ModelEvaluator):
                 y_probs=self.y_prob,
                 labels=self.label_list,
                 curve_type="pr",
-                title="Precision recall curve",
             )
 
             self.metrics["precision_recall_auc"] = self.pr_curve.auc
@@ -774,7 +780,6 @@ class DefaultEvaluator(ModelEvaluator):
                 y_probs=self.y_probs,
                 labels=self.label_list,
                 curve_type="roc",
-                title="ROC curve",
             )
 
             def plot_roc_curve():
@@ -789,7 +794,6 @@ class DefaultEvaluator(ModelEvaluator):
                 y_probs=self.y_probs,
                 labels=self.label_list,
                 curve_type="pr",
-                title="Precision recall curve",
             )
 
             def plot_pr_curve():

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -265,10 +265,10 @@ def _gen_classifier_curve(
 
         def gen_line_x_y_label_fn(_y, _y_prob):
             precision, recall, _thresholds = sk_metrics.precision_recall_curve(_y, _y_prob)
-            print("precision:", precision)
             print("mean precision:", np.mean(precision))
-            print("recall:", recall)
+            print(len(precision))
             print("mean recall:", np.mean(recall))
+            print(len(recall))
             ap = np.mean(precision)
             return recall, precision, f"AP={ap:.3f}"
 

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -28,7 +28,6 @@ from typing import NamedTuple, Callable
 import tempfile
 import pandas as pd
 import numpy as np
-np.set_printoptions(threshold=np.inf)
 import copy
 import shutil
 import time

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -265,11 +265,12 @@ def _gen_classifier_curve(
 
         def gen_line_x_y_label_fn(_y, _y_prob):
             precision, recall, _thresholds = sk_metrics.precision_recall_curve(_y, _y_prob)
-            print("mean precision:", np.mean(precision))
-            print(len(precision))
-            print("mean recall:", np.mean(recall))
-            print(len(recall))
-            ap = np.mean(precision)
+            # print("mean precision:", np.mean(precision))
+            # print(len(precision))
+            # print("mean recall:", np.mean(recall))
+            # print(len(recall))
+            # for i in range(len())
+            ap = sk_metrics.average_precision_score(_y, _y_prob)
             return recall, precision, f"AP={ap:.3f}"
 
         xlabel = "recall"

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -28,6 +28,7 @@ from typing import NamedTuple, Callable
 import tempfile
 import pandas as pd
 import numpy as np
+np.set_printoptions(threshold=np.inf)
 import copy
 import shutil
 import time
@@ -265,7 +266,9 @@ def _gen_classifier_curve(
         def gen_line_x_y_label_fn(_y, _y_prob):
             precision, recall, _thresholds = sk_metrics.precision_recall_curve(_y, _y_prob)
             print("precision:", precision)
+            print("mean precision:", np.mean(precision))
             print("recall:", recall)
+            print("mean recall:", np.mean(recall))
             ap = np.mean(precision)
             return recall, precision, f"AP={ap:.3f}"
 

--- a/mlflow/models/evaluation/lift_curve.py
+++ b/mlflow/models/evaluation/lift_curve.py
@@ -75,6 +75,7 @@ def plot_lift_curve(
     figsize=None,
     title_fontsize="large",
     text_fontsize="medium",
+    pos_label=None,
 ):
     """
     This method is copied from scikit-plot package.
@@ -111,6 +112,8 @@ def plot_lift_curve(
         text_fontsize (string or int, optional): Matplotlib-style fontsizes.
             Use e.g. "small", "medium", "large" or integer-values. Defaults to
             "medium".
+
+        pos_label (optional): Label for the positive class.
 
     Returns:
         ax (:class:`matplotlib.axes.Axes`): The axes on which the plot was
@@ -153,8 +156,18 @@ def plot_lift_curve(
 
     ax.set_title(title, fontsize=title_fontsize)
 
-    ax.plot(percentages, gains1, lw=3, label="Class {}".format(classes[0]))
-    ax.plot(percentages, gains2, lw=3, label="Class {}".format(classes[1]))
+    label0 = "Class {}".format(classes[0])
+    label1 = "Class {}".format(classes[1])
+    # show (positive) next to the positive class in the legend
+    if pos_label:
+        if pos_label == classes[0]:
+            label0 = "Class {} (positive)".format(classes[0])
+        elif pos_label == classes[1]:
+            label1 = "Class {} (positive)".format(classes[1])
+        # do not mark positive class if pos_label is not in classes
+
+    ax.plot(percentages, gains1, lw=3, label=label0)
+    ax.plot(percentages, gains2, lw=3, label=label1)
 
     ax.plot([0, 1], [1, 1], "k--", lw=2, label="Baseline")
 

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -262,7 +262,7 @@ def _read_sparse_matrix_from_json(path, example_type):
             return csr_matrix((data, indices, indptr), shape=shape)
 
 
-def plot_lines(data_series, xlabel, ylabel, legend_loc=None, line_kwargs=None):
+def plot_lines(data_series, xlabel, ylabel, legend_loc=None, line_kwargs=None, title=None):
     import matplotlib.pyplot as plt
 
     fig, ax = plt.subplots()
@@ -276,7 +276,7 @@ def plot_lines(data_series, xlabel, ylabel, legend_loc=None, line_kwargs=None):
     if legend_loc:
         ax.legend(loc=legend_loc)
 
-    ax.set(xlabel=xlabel, ylabel=ylabel)
+    ax.set(xlabel=xlabel, ylabel=ylabel, title=title)
 
     return fig, ax
 

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -930,8 +930,9 @@ def test_gen_binary_precision_recall_curve():
         np.array([0.55555556, 0.5, 0.57142857, 0.66666667, 0.6, 0.5, 0.66666667, 1.0, 1.0]),
         rtol=1e-3,
     )
-    assert results.plot_fn_args["xlabel"] == "recall"
-    assert results.plot_fn_args["ylabel"] == "precision"
+    assert results.plot_fn_args["xlabel"] == "Recall"
+    assert results.plot_fn_args["ylabel"] == "Precision"
+    assert results.plot_fn_args["title"] == "Precision recall curve"
     assert results.plot_fn_args["line_kwargs"] == {"drawstyle": "steps-post", "linewidth": 1}
     assert np.isclose(results.auc, 0.7088888888888889, rtol=1e-3)
 
@@ -955,6 +956,7 @@ def test_gen_binary_roc_curve():
     )
     assert results.plot_fn_args["xlabel"] == "False Positive Rate"
     assert results.plot_fn_args["ylabel"] == "True Positive Rate"
+    assert results.plot_fn_args["title"] == "ROC curve"
     assert results.plot_fn_args["line_kwargs"] == {"drawstyle": "steps-post", "linewidth": 1}
     assert np.isclose(results.auc, 0.66, rtol=1e-3)
 
@@ -984,8 +986,9 @@ def test_gen_multiclass_precision_recall_curve():
         np.testing.assert_allclose(x_data, expected_x_data_list[index], rtol=1e-3)
         np.testing.assert_allclose(y_data, expected_y_data_list[index], rtol=1e-3)
 
-    assert results.plot_fn_args["xlabel"] == "recall"
-    assert results.plot_fn_args["ylabel"] == "precision"
+    assert results.plot_fn_args["xlabel"] == "Recall"
+    assert results.plot_fn_args["ylabel"] == "Precision"
+    assert results.plot_fn_args["title"] == "Precision recall curve"
     assert results.plot_fn_args["line_kwargs"] == {"drawstyle": "steps-post", "linewidth": 1}
 
     expected_auc = [0.25, 0.6666666666666666, 0.2875]
@@ -1020,6 +1023,7 @@ def test_gen_multiclass_roc_curve():
 
     assert results.plot_fn_args["xlabel"] == "False Positive Rate"
     assert results.plot_fn_args["ylabel"] == "True Positive Rate"
+    assert results.plot_fn_args["title"] == "ROC curve"
     assert results.plot_fn_args["line_kwargs"] == {"drawstyle": "steps-post", "linewidth": 1}
 
     expected_auc = [0.75, 0.75, 0.3333]

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -918,7 +918,7 @@ def test_gen_binary_precision_recall_curve():
     y_prob = [0.1, 0.9, 0.8, 0.2, 0.7, 0.8, 0.3, 0.6, 0.65, 0.4]
 
     results = _gen_classifier_curve(
-        is_binomial=True, y=y, y_probs=y_prob, labels=[0, 1], curve_type="pr"
+        is_binomial=True, y=y, y_probs=y_prob, labels=[0, 1], pos_label=1, curve_type="pr"
     )
     np.testing.assert_allclose(
         results.plot_fn_args["data_series"][0][1],
@@ -930,8 +930,8 @@ def test_gen_binary_precision_recall_curve():
         np.array([0.55555556, 0.5, 0.57142857, 0.66666667, 0.6, 0.5, 0.66666667, 1.0, 1.0]),
         rtol=1e-3,
     )
-    assert results.plot_fn_args["xlabel"] == "Recall"
-    assert results.plot_fn_args["ylabel"] == "Precision"
+    assert results.plot_fn_args["xlabel"] == "Recall (Positive label: 1)"
+    assert results.plot_fn_args["ylabel"] == "Precision (Positive label: 1)"
     assert results.plot_fn_args["title"] == "Precision recall curve"
     assert results.plot_fn_args["line_kwargs"] == {"drawstyle": "steps-post", "linewidth": 1}
     assert np.isclose(results.auc, 0.7088888888888889, rtol=1e-3)
@@ -942,7 +942,7 @@ def test_gen_binary_roc_curve():
     y_prob = [0.1, 0.9, 0.8, 0.2, 0.7, 0.8, 0.3, 0.6, 0.65, 0.4]
 
     results = _gen_classifier_curve(
-        is_binomial=True, y=y, y_probs=y_prob, labels=[0, 1], curve_type="roc"
+        is_binomial=True, y=y, y_probs=y_prob, labels=[0, 1], curve_type="roc", pos_label=1
     )
     np.testing.assert_allclose(
         results.plot_fn_args["data_series"][0][1],
@@ -954,8 +954,8 @@ def test_gen_binary_roc_curve():
         np.array([0.0, 0.2, 0.4, 0.4, 0.8, 0.8, 1.0, 1.0]),
         rtol=1e-3,
     )
-    assert results.plot_fn_args["xlabel"] == "False Positive Rate"
-    assert results.plot_fn_args["ylabel"] == "True Positive Rate"
+    assert results.plot_fn_args["xlabel"] == "False Positive Rate (Positive label: 1)"
+    assert results.plot_fn_args["ylabel"] == "True Positive Rate (Positive label: 1)"
     assert results.plot_fn_args["title"] == "ROC curve"
     assert results.plot_fn_args["line_kwargs"] == {"drawstyle": "steps-post", "linewidth": 1}
     assert np.isclose(results.auc, 0.66, rtol=1e-3)
@@ -972,7 +972,7 @@ def test_gen_multiclass_precision_recall_curve():
     ]
 
     results = _gen_classifier_curve(
-        is_binomial=False, y=y, y_probs=y_probs, labels=[0, 1, 2], curve_type="pr"
+        is_binomial=False, y=y, y_probs=y_probs, labels=[0, 1, 2], pos_label=1, curve_type="pr"
     )
     expected_x_data_list = [[1.0, 0.0, 0.0], [1.0, 0.5, 0.0], [1.0, 0.5, 0.5, 0.5, 0.0, 0.0]]
     expected_y_data_list = [
@@ -986,8 +986,8 @@ def test_gen_multiclass_precision_recall_curve():
         np.testing.assert_allclose(x_data, expected_x_data_list[index], rtol=1e-3)
         np.testing.assert_allclose(y_data, expected_y_data_list[index], rtol=1e-3)
 
-    assert results.plot_fn_args["xlabel"] == "Recall"
-    assert results.plot_fn_args["ylabel"] == "Precision"
+    assert results.plot_fn_args["xlabel"] == "Recall (Positive label: 1)"
+    assert results.plot_fn_args["ylabel"] == "Precision (Positive label: 1)"
     assert results.plot_fn_args["title"] == "Precision recall curve"
     assert results.plot_fn_args["line_kwargs"] == {"drawstyle": "steps-post", "linewidth": 1}
 
@@ -1006,7 +1006,7 @@ def test_gen_multiclass_roc_curve():
     ]
 
     results = _gen_classifier_curve(
-        is_binomial=False, y=y, y_probs=y_probs, labels=[0, 1, 2], curve_type="roc"
+        is_binomial=False, y=y, y_probs=y_probs, labels=[0, 1, 2], pos_label=1, curve_type="roc"
     )
 
     expected_x_data_list = [
@@ -1021,8 +1021,8 @@ def test_gen_multiclass_roc_curve():
         np.testing.assert_allclose(x_data, expected_x_data_list[index], rtol=1e-3)
         np.testing.assert_allclose(y_data, expected_y_data_list[index], rtol=1e-3)
 
-    assert results.plot_fn_args["xlabel"] == "False Positive Rate"
-    assert results.plot_fn_args["ylabel"] == "True Positive Rate"
+    assert results.plot_fn_args["xlabel"] == "False Positive Rate (Positive label: 1)"
+    assert results.plot_fn_args["ylabel"] == "True Positive Rate (Positive label: 1)"
     assert results.plot_fn_args["title"] == "ROC curve"
     assert results.plot_fn_args["line_kwargs"] == {"drawstyle": "steps-post", "linewidth": 1}
 


### PR DESCRIPTION
Signed-off-by: Jimmy Xu <jimmy.xu@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

1. Previously, the AP was incorrectly calculated as the mean of the precision values. This has been fixed to use sklearn.metrics.average_precision_score.
2. Added titles to all evaluator plots.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
3. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Previously, the AP was incorrectly calculated as the mean of the precision values. This has been fixed to use sklearn.metrics.average_precision_score.
Added titles to all evaluator plots.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
