### PR TITLE
Retry conda env creation in pytest session

### DIFF
--- a/mlflow/utils/conda.py
+++ b/mlflow/utils/conda.py
@@ -164,7 +164,7 @@ def _create_conda_env_retry(
     num_attempts = 3
     for attempt in range(num_attempts):
         try:
-            _create_conda_env(
+            return _create_conda_env(
                 conda_env_path,
                 conda_env_create_path,
                 project_env_name,
@@ -174,7 +174,7 @@ def _create_conda_env_retry(
         except process.ShellCommandException as e:
             if (num_attempts - attempt - 1) > 0 and "ConnectionResetError" in str(e):
                 _logger.warning(
-                    "Conda env creation failed due to ConnectionResetError, retrying..."
+                    "Conda env creation failed due to ConnectionResetError. Retrying..."
                 )
                 continue
             raise
@@ -276,10 +276,10 @@ def get_or_create_conda_env(conda_env_path, env_id=None, capture_output=False, e
     _logger.info("=== Creating conda environment %s ===", project_env_path)
     try:
         _create_conda_env_func = (
-            _create_conda_env
             # Retry conda env creation in a pytest session to avoid flaky test failures
+            _create_conda_env_retry
             if "PYTEST_CURRENT_TEST" in os.environ
-            else _create_conda_env_retry
+            else _create_conda_env
         )
         _create_conda_env_func(
             conda_env_path,

--- a/mlflow/utils/conda.py
+++ b/mlflow/utils/conda.py
@@ -172,7 +172,7 @@ def _create_conda_env_retry(
                 capture_output=True,
             )
         except process.ShellCommandException as e:
-            if "ConnectionResetError" in str(e) and (num_attempts - attempt - 1) > 0:
+            if (num_attempts - attempt - 1) > 0 and "ConnectionResetError" in str(e):
                 _logger.warning(
                     "Conda env creation failed due to ConnectionResetError, retrying..."
                 )

--- a/mlflow/utils/conda.py
+++ b/mlflow/utils/conda.py
@@ -115,6 +115,71 @@ _CONDA_CACHE_PKGS_DIR = "conda_cache_pkgs"
 _PIP_CACHE_DIR = "pip_cache_pkgs"
 
 
+def _create_conda_env(
+    conda_env_path,
+    conda_env_create_path,
+    project_env_name,
+    conda_extra_env_vars,
+    capture_output,
+):
+    if conda_env_path:
+        return process._exec_cmd(
+            [
+                conda_env_create_path,
+                "env",
+                "create",
+                "-n",
+                project_env_name,
+                "--file",
+                conda_env_path,
+            ],
+            extra_env=conda_extra_env_vars,
+            capture_output=capture_output,
+        )
+    else:
+        return process._exec_cmd(
+            [
+                conda_env_create_path,
+                "create",
+                "--channel",
+                "conda-forge",
+                "--yes",
+                "--override-channels",
+                "-n",
+                project_env_name,
+                "python",
+            ],
+            extra_env=conda_extra_env_vars,
+            capture_output=capture_output,
+        )
+
+
+def _create_conda_env_retry(
+    conda_env_path, conda_env_create_path, project_env_name, conda_extra_env_vars, _capture_output
+):
+    """
+    `conda env create` command can fail with `ConnectionResetError` while downloading a package or
+    fetching repository metadata. This function retries the command up to 3 times.
+    """
+    num_attempts = 3
+    for attempt in range(num_attempts):
+        try:
+            _create_conda_env(
+                conda_env_path,
+                conda_env_create_path,
+                project_env_name,
+                conda_extra_env_vars,
+                capture_output=True,
+            )
+        except process.ShellCommandException as e:
+            if "ConnectionResetError" in str(e) and (num_attempts - attempt - 1) > 0:
+                _logger.warning(
+                    "Conda env creation failed due to ConnectionResetError, retrying..."
+                )
+                continue
+            raise
+
+
 def _get_conda_extra_env_vars(env_root_dir=None):
     """
     Given the `env_root_dir` (See doc of PyFuncBackend constructor argument `env_root_dir`),
@@ -210,36 +275,19 @@ def get_or_create_conda_env(conda_env_path, env_id=None, capture_output=False, e
 
     _logger.info("=== Creating conda environment %s ===", project_env_path)
     try:
-        if conda_env_path:
-            process._exec_cmd(
-                [
-                    conda_env_create_path,
-                    "env",
-                    "create",
-                    "-n",
-                    project_env_name,
-                    "--file",
-                    conda_env_path,
-                ],
-                extra_env=conda_extra_env_vars,
-                capture_output=capture_output,
-            )
-        else:
-            process._exec_cmd(
-                [
-                    conda_env_create_path,
-                    "create",
-                    "--channel",
-                    "conda-forge",
-                    "--yes",
-                    "--override-channels",
-                    "-n",
-                    project_env_name,
-                    "python",
-                ],
-                extra_env=conda_extra_env_vars,
-                capture_output=capture_output,
-            )
+        _create_conda_env_func = (
+            _create_conda_env
+            # Retry conda env creation in a pytest session to avoid flaky test failures
+            if "PYTEST_CURRENT_TEST" in os.environ
+            else _create_conda_env_retry
+        )
+        _create_conda_env_func(
+            conda_env_path,
+            conda_env_create_path,
+            project_env_name,
+            conda_extra_env_vars,
+            capture_output,
+        )
         return project_env_name
     except Exception:
         try:

--- a/tests/projects/test_projects.py
+++ b/tests/projects/test_projects.py
@@ -369,7 +369,7 @@ def test_create_env_with_mamba():
                 mlflow.utils.conda.get_or_create_conda_env(conda_env_path)
 
 
-def test_conda_environment_cleaned_up_when_pip_fails(tmp_path, capfd):
+def test_conda_environment_cleaned_up_when_pip_fails(tmp_path):
     conda_yaml = tmp_path / "conda.yaml"
     content = """
 name: {name}
@@ -389,13 +389,8 @@ dependencies:
     envs_before = mlflow.utils.conda._list_conda_environments()
 
     # `conda create` should fail because mlflow 999.999.999 doesn't exist
-    with pytest.raises(ShellCommandException, match=r".*"):
-        mlflow.utils.conda.get_or_create_conda_env(conda_yaml)
-
-    # Ensure `conda create` failed because of pip failure
-    captured = capfd.readouterr()
-    assert "ERROR: No matching distribution found for mlflow==999.999.999" in captured.err
-    assert "CondaEnvException: Pip failed" in captured.err
+    with pytest.raises(ShellCommandException, match=r"No matching distribution found"):
+        mlflow.utils.conda.get_or_create_conda_env(conda_yaml, capture_output=True)
 
     # Ensure the environment is cleaned up
     envs_after = mlflow.utils.conda._list_conda_environments()


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Retry conda env creation in pytest session to avoid flaky test failures.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
