### PR TITLE
Implemented `unwrap_python_model()` method in mlflow.pyfunc.PyFuncModel

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -372,6 +372,19 @@ class PyFuncModel:
             data = _enforce_schema(data, input_schema)
         return self._predict_fn(data)
 
+    def unwrap_python_model(self, unwrap_metadata: bool = False):
+        """
+        Unwrap the underlying Python model object, and it's metadata (optionally).
+
+        :param unwrap_metadata: (optional) If True, return a tuple of the
+        underlying Python model object and metadata loaded from the MLmodel file.
+        """
+        return (
+            self._model_impl.python_model
+            if not unwrap_metadata
+            else (self._model_impl.python_model, self._model_meta)
+        )
+
     def __eq__(self, other):
         if not isinstance(other, PyFuncModel):
             return False

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -381,7 +381,9 @@ class PyFuncModel:
             if python_model is None:
                 raise AttributeError("Expected python_model attribute not to be None.")
         except AttributeError as e:
-            raise MlflowException("Model does not contain a python_model attribute or it's None.", e)
+            raise MlflowException(
+                "Model does not contain a python_model attribute or it's None.", e
+            )
         return python_model
 
     def __eq__(self, other):
@@ -402,8 +404,8 @@ class PyFuncModel:
             if hasattr(self._model_meta, "run_id") and self._model_meta.run_id is not None:
                 info["run_id"] = self._model_meta.run_id
             if (
-                    hasattr(self._model_meta, "artifact_path")
-                    and self._model_meta.artifact_path is not None
+                hasattr(self._model_meta, "artifact_path")
+                and self._model_meta.artifact_path is not None
             ):
                 info["artifact_path"] = self._model_meta.artifact_path
             info["flavor"] = self._model_meta.flavors[FLAVOR_NAME]["loader_module"]
@@ -447,9 +449,9 @@ def _warn_dependency_requirement_mismatches(model_path):
 
 
 def load_model(
-        model_uri: str,
-        suppress_warnings: bool = False,
-        dst_path: str = None,
+    model_uri: str,
+    suppress_warnings: bool = False,
+    dst_path: str = None,
 ) -> PyFuncModel:
     """
     Load a model stored in Python function format.
@@ -788,7 +790,7 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
     if not any(isinstance(elem_type, x) for x in supported_types):
         raise MlflowException(
             message="Invalid result_type '{}'. Result type can only be one of or an array of one "
-                    "of the following types: {}".format(str(elem_type), str(supported_types)),
+            "of the following types: {}".format(str(elem_type), str(supported_types)),
             error_code=INVALID_PARAMETER_VALUE,
         )
 
@@ -898,8 +900,8 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
         if len(result.columns) == 0:
             raise MlflowException(
                 message="The the model did not produce any values compatible with the requested "
-                        "type '{}'. Consider requesting udf with StringType or "
-                        "Arraytype(StringType).".format(str(elem_type)),
+                "type '{}'. Consider requesting udf with StringType or "
+                "Arraytype(StringType).".format(str(elem_type)),
                 error_code=INVALID_PARAMETER_VALUE,
             )
 
@@ -917,7 +919,7 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
 
     @pandas_udf(result_type)
     def udf(
-            iterator: Iterator[Tuple[Union[pandas.Series, pandas.DataFrame], ...]]
+        iterator: Iterator[Tuple[Union[pandas.Series, pandas.DataFrame], ...]]
     ) -> Iterator[result_type_hint]:
         # importing here to prevent circular import
         from mlflow.pyfunc.scoring_server.client import ScoringServerClient
@@ -1050,8 +1052,8 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
                 else:
                     raise MlflowException(
                         message="Cannot apply udf because no column names specified. The udf "
-                                "expects {} columns with types: {}. Input column names could not be "
-                                "inferred from the model signature (column names not found).".format(
+                        "expects {} columns with types: {}. Input column names could not be "
+                        "inferred from the model signature (column names not found).".format(
                             len(input_schema.inputs),
                             input_schema.inputs,
                         ),
@@ -1071,19 +1073,19 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
 
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name="scikit-learn"))
 def save_model(
-        path,
-        loader_module=None,
-        data_path=None,
-        code_path=None,
-        conda_env=None,
-        mlflow_model=None,
-        python_model=None,
-        artifacts=None,
-        signature: ModelSignature = None,
-        input_example: ModelInputExample = None,
-        pip_requirements=None,
-        extra_pip_requirements=None,
-        **kwargs,
+    path,
+    loader_module=None,
+    data_path=None,
+    code_path=None,
+    conda_env=None,
+    mlflow_model=None,
+    python_model=None,
+    artifacts=None,
+    signature: ModelSignature = None,
+    input_example: ModelInputExample = None,
+    pip_requirements=None,
+    extra_pip_requirements=None,
+    **kwargs,
 ):
     """
     save_model(path, loader_module=None, data_path=None, code_path=None, conda_env=None,\
@@ -1243,19 +1245,19 @@ def save_model(
 
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name="scikit-learn"))
 def log_model(
-        artifact_path,
-        loader_module=None,
-        data_path=None,
-        code_path=None,
-        conda_env=None,
-        python_model=None,
-        artifacts=None,
-        registered_model_name=None,
-        signature: ModelSignature = None,
-        input_example: ModelInputExample = None,
-        await_registration_for=DEFAULT_AWAIT_MAX_SLEEP_SECONDS,
-        pip_requirements=None,
-        extra_pip_requirements=None,
+    artifact_path,
+    loader_module=None,
+    data_path=None,
+    code_path=None,
+    conda_env=None,
+    python_model=None,
+    artifacts=None,
+    registered_model_name=None,
+    signature: ModelSignature = None,
+    input_example: ModelInputExample = None,
+    await_registration_for=DEFAULT_AWAIT_MAX_SLEEP_SECONDS,
+    pip_requirements=None,
+    extra_pip_requirements=None,
 ):
     """
     Log a Pyfunc model with custom inference logic and optional data dependencies as an MLflow
@@ -1363,14 +1365,14 @@ def log_model(
 
 
 def _save_model_with_loader_module_and_data_path(
-        path,
-        loader_module,
-        data_path=None,
-        code_paths=None,
-        conda_env=None,
-        mlflow_model=None,
-        pip_requirements=None,
-        extra_pip_requirements=None,
+    path,
+    loader_module,
+    data_path=None,
+    code_paths=None,
+    conda_env=None,
+    mlflow_model=None,
+    pip_requirements=None,
+    extra_pip_requirements=None,
 ):
     """
     Export model as a generic Python function model.

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -207,45 +207,55 @@ You may prefer the second, lower-level workflow for the following reasons:
   artifacts.
 """
 
+import collections
 import importlib
-import tempfile
+import logging
+import os
 import signal
+import subprocess
 import sys
+import tempfile
+import threading
+from copy import deepcopy
+from typing import Any, Union, Iterator, Tuple
 
 import numpy as np
-import os
 import pandas
 import yaml
-from copy import deepcopy
-import logging
-import threading
-import collections
-import subprocess
 
-from typing import Any, Union, Iterator, Tuple
 import mlflow
 import mlflow.pyfunc.model
+from mlflow.exceptions import MlflowException
 from mlflow.models import Model, ModelSignature, ModelInputExample
 from mlflow.models.model import MLMODEL_FILE_NAME
-from mlflow.models.utils import PyFuncInput, PyFuncOutput, _enforce_schema, _save_example
+from mlflow.models.utils import (
+    PyFuncInput,
+    PyFuncOutput,
+    _enforce_schema,
+    _save_example,
+)
+from mlflow.protos.databricks_pb2 import (
+    INVALID_PARAMETER_VALUE,
+    RESOURCE_DOES_NOT_EXIST,
+)
 from mlflow.pyfunc.model import (  # pylint: disable=unused-import
     PythonModel,
     PythonModelContext,
     get_default_conda_env,
 )
 from mlflow.pyfunc.model import get_default_pip_requirements
+from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
-from mlflow.utils import PYTHON_VERSION, get_major_minor_py_version, _is_in_ipython_notebook
-from mlflow.utils.annotations import deprecated
-from mlflow.utils.file_utils import _copy_file_or_tree, write_to
-from mlflow.utils.model_utils import (
-    _get_flavor_configuration,
-    _validate_and_copy_code_paths,
-    _add_code_from_conf_to_system_path,
-    _get_flavor_configuration_from_uri,
-    _validate_and_prepare_target_save_path,
+from mlflow.utils import (
+    PYTHON_VERSION,
+    get_major_minor_py_version,
+    _is_in_ipython_notebook,
 )
-from mlflow.utils.uri import append_to_uri_path
+from mlflow.utils import env_manager as _EnvManager
+from mlflow.utils import find_free_port
+from mlflow.utils.annotations import deprecated
+from mlflow.utils.databricks_utils import is_in_databricks_runtime
+from mlflow.utils.docstring_utils import format_docstring, LOG_MODEL_PARAM_DOCS
 from mlflow.utils.environment import (
     _validate_env_arguments,
     _process_pip_requirements,
@@ -256,24 +266,22 @@ from mlflow.utils.environment import (
     _PYTHON_ENV_FILE_NAME,
     _PythonEnv,
 )
-from mlflow.utils import env_manager as _EnvManager
-from mlflow.utils.docstring_utils import format_docstring, LOG_MODEL_PARAM_DOCS
-from mlflow.utils.databricks_utils import is_in_databricks_runtime
+from mlflow.utils.file_utils import _copy_file_or_tree, write_to
 from mlflow.utils.file_utils import get_or_create_tmp_dir, get_or_create_nfs_tmp_dir
-from mlflow.utils.process import cache_return_value_per_process
-from mlflow.exceptions import MlflowException
-from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
-from mlflow.protos.databricks_pb2 import (
-    INVALID_PARAMETER_VALUE,
-    RESOURCE_DOES_NOT_EXIST,
+from mlflow.utils.model_utils import (
+    _get_flavor_configuration,
+    _validate_and_copy_code_paths,
+    _add_code_from_conf_to_system_path,
+    _get_flavor_configuration_from_uri,
+    _validate_and_prepare_target_save_path,
 )
-
+from mlflow.utils.nfs_on_spark import get_nfs_cache_root_dir
+from mlflow.utils.process import cache_return_value_per_process
 from mlflow.utils.requirements_utils import (
     _check_requirement_satisfied,
     _parse_requirements,
 )
-from mlflow.utils import find_free_port
-from mlflow.utils.nfs_on_spark import get_nfs_cache_root_dir
+from mlflow.utils.uri import append_to_uri_path
 
 FLAVOR_NAME = "python_function"
 MAIN = "loader_module"
@@ -381,9 +389,7 @@ class PyFuncModel:
             if python_model is None:
                 raise AttributeError("Expected python_model attribute not to be None.")
         except AttributeError as e:
-            raise MlflowException(
-                "Unable to retrieve base model object from pyfunc."
-            ) from e
+            raise MlflowException("Unable to retrieve base model object from pyfunc.") from e
         return python_model
 
     def __eq__(self, other):
@@ -764,7 +770,13 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
         DataType as SparkDataType,
         StructType as SparkStructType,
     )
-    from pyspark.sql.types import DoubleType, IntegerType, FloatType, LongType, StringType
+    from pyspark.sql.types import (
+        DoubleType,
+        IntegerType,
+        FloatType,
+        LongType,
+        StringType,
+    )
     from mlflow.models.cli import _get_flavor_backend
 
     _EnvManager.validate(env_manager)
@@ -795,7 +807,8 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
         )
 
     local_model_path = _download_artifact_from_uri(
-        artifact_uri=model_uri, output_path=_create_model_downloading_tmp_dir(should_use_nfs)
+        artifact_uri=model_uri,
+        output_path=_create_model_downloading_tmp_dir(should_use_nfs),
     )
 
     if env_manager == _EnvManager.LOCAL:
@@ -986,7 +999,8 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
                     sys.stdout.write("[model server] " + decoded)
 
             server_redirect_log_thread = threading.Thread(
-                target=server_redirect_log_thread_func, args=(scoring_server_proc.stdout,)
+                target=server_redirect_log_thread_func,
+                args=(scoring_server_proc.stdout,),
             )
             server_redirect_log_thread.setDaemon(True)
             server_redirect_log_thread.start()

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -382,8 +382,8 @@ class PyFuncModel:
                 raise AttributeError("Expected python_model attribute not to be None.")
         except AttributeError as e:
             raise MlflowException(
-                "Model does not contain a python_model attribute or it's None.", e
-            )
+                "Unable to retrieve base model object from pyfunc."
+            ) from e
         return python_model
 
     def __eq__(self, other):

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -372,18 +372,17 @@ class PyFuncModel:
             data = _enforce_schema(data, input_schema)
         return self._predict_fn(data)
 
-    def unwrap_python_model(self, unwrap_metadata: bool = False):
+    def unwrap_python_model(self):
         """
-        Unwrap the underlying Python model object, and it's metadata (optionally).
-
-        :param unwrap_metadata: (optional) If True, return a tuple of the
-        underlying Python model object and metadata loaded from the MLmodel file.
+        Unwrap the underlying Python model object.
         """
-        return (
-            self._model_impl.python_model
-            if not unwrap_metadata
-            else (self._model_impl.python_model, self._model_meta)
-        )
+        try:
+            python_model = self._model_impl.python_model
+            if python_model is None:
+                raise AttributeError("Expected python_model attribute not to be None.")
+        except AttributeError as e:
+            raise MlflowException("Model does not contain a python_model attribute or it's None.", e)
+        return python_model
 
     def __eq__(self, other):
         if not isinstance(other, PyFuncModel):
@@ -403,8 +402,8 @@ class PyFuncModel:
             if hasattr(self._model_meta, "run_id") and self._model_meta.run_id is not None:
                 info["run_id"] = self._model_meta.run_id
             if (
-                hasattr(self._model_meta, "artifact_path")
-                and self._model_meta.artifact_path is not None
+                    hasattr(self._model_meta, "artifact_path")
+                    and self._model_meta.artifact_path is not None
             ):
                 info["artifact_path"] = self._model_meta.artifact_path
             info["flavor"] = self._model_meta.flavors[FLAVOR_NAME]["loader_module"]
@@ -448,9 +447,9 @@ def _warn_dependency_requirement_mismatches(model_path):
 
 
 def load_model(
-    model_uri: str,
-    suppress_warnings: bool = False,
-    dst_path: str = None,
+        model_uri: str,
+        suppress_warnings: bool = False,
+        dst_path: str = None,
 ) -> PyFuncModel:
     """
     Load a model stored in Python function format.
@@ -789,7 +788,7 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
     if not any(isinstance(elem_type, x) for x in supported_types):
         raise MlflowException(
             message="Invalid result_type '{}'. Result type can only be one of or an array of one "
-            "of the following types: {}".format(str(elem_type), str(supported_types)),
+                    "of the following types: {}".format(str(elem_type), str(supported_types)),
             error_code=INVALID_PARAMETER_VALUE,
         )
 
@@ -899,8 +898,8 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
         if len(result.columns) == 0:
             raise MlflowException(
                 message="The the model did not produce any values compatible with the requested "
-                "type '{}'. Consider requesting udf with StringType or "
-                "Arraytype(StringType).".format(str(elem_type)),
+                        "type '{}'. Consider requesting udf with StringType or "
+                        "Arraytype(StringType).".format(str(elem_type)),
                 error_code=INVALID_PARAMETER_VALUE,
             )
 
@@ -918,7 +917,7 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
 
     @pandas_udf(result_type)
     def udf(
-        iterator: Iterator[Tuple[Union[pandas.Series, pandas.DataFrame], ...]]
+            iterator: Iterator[Tuple[Union[pandas.Series, pandas.DataFrame], ...]]
     ) -> Iterator[result_type_hint]:
         # importing here to prevent circular import
         from mlflow.pyfunc.scoring_server.client import ScoringServerClient
@@ -1051,8 +1050,8 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
                 else:
                     raise MlflowException(
                         message="Cannot apply udf because no column names specified. The udf "
-                        "expects {} columns with types: {}. Input column names could not be "
-                        "inferred from the model signature (column names not found).".format(
+                                "expects {} columns with types: {}. Input column names could not be "
+                                "inferred from the model signature (column names not found).".format(
                             len(input_schema.inputs),
                             input_schema.inputs,
                         ),
@@ -1072,19 +1071,19 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
 
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name="scikit-learn"))
 def save_model(
-    path,
-    loader_module=None,
-    data_path=None,
-    code_path=None,
-    conda_env=None,
-    mlflow_model=None,
-    python_model=None,
-    artifacts=None,
-    signature: ModelSignature = None,
-    input_example: ModelInputExample = None,
-    pip_requirements=None,
-    extra_pip_requirements=None,
-    **kwargs,
+        path,
+        loader_module=None,
+        data_path=None,
+        code_path=None,
+        conda_env=None,
+        mlflow_model=None,
+        python_model=None,
+        artifacts=None,
+        signature: ModelSignature = None,
+        input_example: ModelInputExample = None,
+        pip_requirements=None,
+        extra_pip_requirements=None,
+        **kwargs,
 ):
     """
     save_model(path, loader_module=None, data_path=None, code_path=None, conda_env=None,\
@@ -1244,19 +1243,19 @@ def save_model(
 
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name="scikit-learn"))
 def log_model(
-    artifact_path,
-    loader_module=None,
-    data_path=None,
-    code_path=None,
-    conda_env=None,
-    python_model=None,
-    artifacts=None,
-    registered_model_name=None,
-    signature: ModelSignature = None,
-    input_example: ModelInputExample = None,
-    await_registration_for=DEFAULT_AWAIT_MAX_SLEEP_SECONDS,
-    pip_requirements=None,
-    extra_pip_requirements=None,
+        artifact_path,
+        loader_module=None,
+        data_path=None,
+        code_path=None,
+        conda_env=None,
+        python_model=None,
+        artifacts=None,
+        registered_model_name=None,
+        signature: ModelSignature = None,
+        input_example: ModelInputExample = None,
+        await_registration_for=DEFAULT_AWAIT_MAX_SLEEP_SECONDS,
+        pip_requirements=None,
+        extra_pip_requirements=None,
 ):
     """
     Log a Pyfunc model with custom inference logic and optional data dependencies as an MLflow
@@ -1364,14 +1363,14 @@ def log_model(
 
 
 def _save_model_with_loader_module_and_data_path(
-    path,
-    loader_module,
-    data_path=None,
-    code_paths=None,
-    conda_env=None,
-    mlflow_model=None,
-    pip_requirements=None,
-    extra_pip_requirements=None,
+        path,
+        loader_module,
+        data_path=None,
+        code_paths=None,
+        conda_env=None,
+        mlflow_model=None,
+        pip_requirements=None,
+        extra_pip_requirements=None,
 ):
     """
     Export model as a generic Python function model.

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactTextView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactTextView.js
@@ -58,6 +58,7 @@ class ShowArtifactTextView extends Component {
         marginTop: '0',
         width: '100%',
         height: '100%',
+        padding: '5px',
       };
       const renderedContent = ShowArtifactTextView.prettifyText(language, this.state.text);
       return (

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactTextView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactTextView.js
@@ -58,7 +58,6 @@ class ShowArtifactTextView extends Component {
         marginTop: '0',
         width: '100%',
         height: '100%',
-        padding: '5px',
       };
       const renderedContent = ShowArtifactTextView.prettifyText(language, this.state.text);
       return (

--- a/tests/pyfunc/test_pyfunc_class_methods.py
+++ b/tests/pyfunc/test_pyfunc_class_methods.py
@@ -1,5 +1,8 @@
+import os
+
+import mlflow
+from mlflow import set_experiment, set_tracking_uri
 from mlflow.pyfunc import PythonModel, log_model, load_model
-from mlflow import set_experiment
 
 
 def test_unwrap_python_model_from_pyfunc_class():
@@ -14,12 +17,12 @@ def test_unwrap_python_model_from_pyfunc_class():
         def upper_param_1(self):
             return self.param_1.upper()
 
-    set_experiment("test_unwrap_python_model_from_pyfunc_class")
-    model = MyModel("this is test message", 2)
-    model_uri = log_model(python_model=model, artifact_path="model").model_uri
-    loaded_model = load_model(model_uri).unwrap_python_model()
-    assert isinstance(loaded_model, MyModel)
-    assert loaded_model.param_1 == "this is test message"
-    assert loaded_model.param_2 == 2
-    assert loaded_model.predict(None, 1) == 3
-    assert loaded_model.upper_param_1() == "THIS IS TEST MESSAGE"
+    with mlflow.start_run():
+        model = MyModel("this is test message", 2)
+        model_uri = log_model(python_model=model, artifact_path="mlruns").model_uri
+        loaded_model = load_model(model_uri).unwrap_python_model()
+        assert isinstance(loaded_model, MyModel)
+        assert loaded_model.param_1 == "this is test message"
+        assert loaded_model.param_2 == 2
+        assert loaded_model.predict(None, 1) == 3
+        assert loaded_model.upper_param_1() == "THIS IS TEST MESSAGE"

--- a/tests/pyfunc/test_pyfunc_class_methods.py
+++ b/tests/pyfunc/test_pyfunc_class_methods.py
@@ -1,0 +1,25 @@
+from mlflow.pyfunc import PythonModel, log_model, load_model
+from mlflow import set_experiment
+
+
+def test_unwrap_python_model_from_pyfunc_class():
+    class MyModel(PythonModel):
+        def __init__(self, param_1: str, param_2: int):
+            self.param_1 = param_1
+            self.param_2 = param_2
+
+        def predict(self, context, model_input):
+            return model_input + self.param_2
+
+        def upper_param_1(self):
+            return self.param_1.upper()
+
+    set_experiment("test_unwrap_python_model_from_pyfunc_class")
+    model = MyModel("this is test message", 2)
+    model_uri = log_model(python_model=model, artifact_path="model").model_uri
+    loaded_model = load_model(model_uri).unwrap_python_model()
+    assert isinstance(loaded_model, MyModel)
+    assert loaded_model.param_1 == "this is test message"
+    assert loaded_model.param_2 == 2
+    assert loaded_model.predict(None, 1) == 3
+    assert loaded_model.upper_param_1() == "THIS IS TEST MESSAGE"

--- a/tests/pyfunc/test_pyfunc_class_methods.py
+++ b/tests/pyfunc/test_pyfunc_class_methods.py
@@ -1,7 +1,4 @@
-import os
-
 import mlflow
-from mlflow import set_experiment, set_tracking_uri
 from mlflow.pyfunc import PythonModel, log_model, load_model
 
 


### PR DESCRIPTION
Signed-off-by: Ivan Križanić <ikrizanic75@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
Close #6794 

## What changes are proposed in this pull request?

Implemented `unwrap_python_model()` method in `mlflow.pyfunc.PyFuncModel` class which enables direct access to wrapped python module when loading model with `mlfow.pyfunc.load_model`

## How is this patch tested?

There are no dedicated tests for this method, but it's tested by using it in an appropriate workflow.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Users are now able to load wrapped python model when using `mlflow.pyfunc.load_model()` method and use custom implemented methods of that object. 

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
