### PR TITLE
Revert "Add setuptools for packaging dependency resolution"

### DIFF
--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -5,4 +5,3 @@ requests
 packaging
 pydantic
 pyyaml
-setuptools


### PR DESCRIPTION
Reverts mlflow/mlflow#6809 due to not being needed for CD pipeline