### PR TITLE
hp tuning with sparktrials

### DIFF
--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -639,6 +639,8 @@ class TrainStep(BaseStep):
         tuning_params = self.step_config["tuning"]
         try:
             from hyperopt import fmin, Trials
+            from hyperopt.mlflow_utils import _MLflowLogging
+            _MLflowLogging._EN_WORKER_USER_LOGGING = False
         except ModuleNotFoundError:
             raise MlflowException(
                 "Hyperopt not installed and is required if tuning is enabled",
@@ -726,7 +728,6 @@ class TrainStep(BaseStep):
         else:
             hp_trials = Trials()
 
-        mlflow.autolog(disable=True)
         best_hp_params = fmin(
             lambda params: objective(X_train, y_train, validation_df, params),
             search_space,
@@ -734,7 +735,6 @@ class TrainStep(BaseStep):
             max_evals=max_trials,
             trials=hp_trials,
         )
-        mlflow.autolog(disable=False)
         best_hp_estimator_loss = hp_trials.best_trial["result"]["loss"]
         hardcoded_estimator_loss = objective(
             X_train, y_train, validation_df, estimator_hardcoded_params

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -650,8 +650,6 @@ class TrainStep(BaseStep):
         # wrap training in objective fn
         def objective(X_train, y_train, validation_df, hyperparameter_args, on_worker=False):
             if on_worker:
-                from mlflow.tracking import MlflowClient
-
                 client = MlflowClient()
                 parent_tags = client.get_run(parent_run_id).data.tags
                 child_run = client.create_run(

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -145,6 +145,7 @@ class TrainStep(BaseStep):
             if self.step_config["tuning_enabled"]:
                 best_estimator_params = self._tune_and_get_best_estimator_params(
                     run.info.run_id,
+                    tags,
                     estimator_hardcoded_params,
                     estimator_fn,
                     X_train,
@@ -631,6 +632,7 @@ class TrainStep(BaseStep):
     def _tune_and_get_best_estimator_params(
         self,
         parent_run_id,
+        tags,
         estimator_hardcoded_params,
         estimator_fn,
         X_train,
@@ -657,7 +659,7 @@ class TrainStep(BaseStep):
 
                 client = MlflowClient()
                 child_run = client.create_run(
-                    _get_experiment_id(), tags={"mlflow.parentRunId": parent_run_id}
+                    _get_experiment_id(), tags={**tags, "mlflow.parentRunId": parent_run_id}
                 )
                 run_args = {"run_id": child_run.info.run_id}
             else:

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -779,6 +779,7 @@ class TrainStep(BaseStep):
 
         if on_worker:
             mlflow.log_params(estimator.get_params())
+            mlflow.set_tags(mlflow.sklearn.utils._get_estimator_info_tags(estimator))
         estimator_schema = infer_signature(
             X_train_sampled, estimator.predict(X_train_sampled.copy())
         )

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -724,9 +724,11 @@ class TrainStep(BaseStep):
         parallelism = tuning_params["parallelism"]
 
         if parallelism > 1:
-            from mlflow.utils._spark_utils import _get_active_spark_session
+            from pyspark.sql import SparkSession
 
-            spark_session = _get_active_spark_session()
+            spark_session = SparkSession.builder.config(
+                "spark.databricks.mlflow.trackHyperopt.enabled", "false"
+            ).getOrCreate()
             sc = spark_session.sparkContext
 
             X_train = sc.broadcast(X_train)

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -654,67 +654,70 @@ class TrainStep(BaseStep):
 
         # wrap training in objective fn
         def objective(X_train, y_train, validation_df, hyperparameter_args):
-            with mlflow.start_run(run_id=parent_run_id):
-                with mlflow.start_run(nested=True) as tuning_run:
-                    estimator_args = dict(estimator_hardcoded_params, **hyperparameter_args)
-                    estimator = estimator_fn(estimator_args)
+            from mlflow.tracking import MlflowClient
 
-                    sample_fraction = self.step_config["sample_fraction"]
+            client = MlflowClient()
+            child_run = client.create_run(
+                _get_experiment_id(), tags={"mlflow.parentRunId": parent_run_id}
+            )
+            with mlflow.start_run(run_id=child_run.info.run_id) as tuning_run:
+                estimator_args = dict(estimator_hardcoded_params, **hyperparameter_args)
+                estimator = estimator_fn(estimator_args)
 
-                    # if sparktrials, then read from broadcast
-                    if tuning_params["parallelism"] > 1:
-                        X_train = X_train.value
-                        y_train = y_train.value
-                        validation_df = validation_df.value
+                sample_fraction = self.step_config["sample_fraction"]
 
-                    X_train_sampled = X_train.sample(frac=sample_fraction, random_state=42)
-                    y_train_sampled = y_train.sample(frac=sample_fraction, random_state=42)
+                # if sparktrials, then read from broadcast
+                if tuning_params["parallelism"] > 1:
+                    X_train = X_train.value
+                    y_train = y_train.value
+                    validation_df = validation_df.value
 
-                    estimator.fit(X_train_sampled, y_train_sampled)
+                X_train_sampled = X_train.sample(frac=sample_fraction, random_state=42)
+                y_train_sampled = y_train.sample(frac=sample_fraction, random_state=42)
 
-                    logged_estimator = self._log_estimator_to_mlflow(estimator, X_train_sampled)
+                estimator.fit(X_train_sampled, y_train_sampled)
 
-                    eval_result = mlflow.evaluate(
-                        model=logged_estimator.model_uri,
-                        data=validation_df,
-                        targets=self.target_col,
-                        model_type="regressor",
-                        evaluators="default",
-                        dataset_name="validation",
-                        custom_metrics=_load_custom_metric_functions(
-                            self.pipeline_root,
-                            self.evaluation_metrics.values(),
-                        ),
-                        evaluator_config={
-                            "log_model_explainability": False,
-                        },
-                    )
-                    autologged_params = mlflow.get_run(run_id=tuning_run.info.run_id).data.params
-                    manual_log_params = {}
-                    for param_name, param_value in estimator_args.items():
-                        if param_name in autologged_params:
-                            if not self._is_tuning_param_equal(
-                                param_value, autologged_params[param_name]
-                            ):
-                                _logger.warning(
-                                    f"Failed to log search space parameter due to conflict. "
-                                    f"Attempted to log search space parameter {param_name} as "
-                                    f"{param_value}, but {param_name} is already logged as "
-                                    f"{autologged_params[param_name]} during training. "
-                                    f"Are you passing `estimator_params` properly to the "
-                                    f" estimator?"
-                                )
-                        else:
-                            manual_log_params[param_name] = param_value
+                logged_estimator = self._log_estimator_to_mlflow(estimator, X_train_sampled)
 
-                    if len(manual_log_params) > 0:
-                        mlflow.log_params(manual_log_params)
+                eval_result = mlflow.evaluate(
+                    model=logged_estimator.model_uri,
+                    data=validation_df,
+                    targets=self.target_col,
+                    model_type="regressor",
+                    evaluators="default",
+                    dataset_name="validation",
+                    custom_metrics=_load_custom_metric_functions(
+                        self.pipeline_root,
+                        self.evaluation_metrics.values(),
+                    ),
+                    evaluator_config={
+                        "log_model_explainability": False,
+                    },
+                )
+                autologged_params = mlflow.get_run(run_id=tuning_run.info.run_id).data.params
+                manual_log_params = {}
+                for param_name, param_value in estimator_args.items():
+                    if param_name in autologged_params:
+                        if not self._is_tuning_param_equal(
+                            param_value, autologged_params[param_name]
+                        ):
+                            _logger.warning(
+                                f"Failed to log search space parameter due to conflict. "
+                                f"Attempted to log search space parameter {param_name} as "
+                                f"{param_value}, but {param_name} is already logged as "
+                                f"{autologged_params[param_name]} during training. "
+                                f"Are you passing `estimator_params` properly to the "
+                                f" estimator?"
+                            )
+                    else:
+                        manual_log_params[param_name] = param_value
 
-                    # return +/- metric
-                    sign = (
-                        -1 if self.evaluation_metrics_greater_is_better[self.primary_metric] else 1
-                    )
-                    return sign * eval_result.metrics[self.primary_metric]
+                if len(manual_log_params) > 0:
+                    mlflow.log_params(manual_log_params)
+
+                # return +/- metric
+                sign = -1 if self.evaluation_metrics_greater_is_better[self.primary_metric] else 1
+                return sign * eval_result.metrics[self.primary_metric]
 
         search_space = self._construct_search_space_from_yaml(tuning_params["parameters"])
         algo_type, algo_name = tuning_params["algorithm"].rsplit(".", 1)

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -726,6 +726,7 @@ class TrainStep(BaseStep):
         else:
             hp_trials = Trials()
 
+        mlflow.autolog(disable=True)
         best_hp_params = fmin(
             lambda params: objective(X_train, y_train, validation_df, params),
             search_space,
@@ -733,6 +734,7 @@ class TrainStep(BaseStep):
             max_evals=max_trials,
             trials=hp_trials,
         )
+        mlflow.autolog(disable=False)
         best_hp_estimator_loss = hp_trials.best_trial["result"]["loss"]
         hardcoded_estimator_loss = objective(
             X_train, y_train, validation_df, estimator_hardcoded_params
@@ -760,7 +762,7 @@ class TrainStep(BaseStep):
         if hasattr(estimator, "best_params_"):
             mlflow.log_params(estimator.best_params_)
 
-        mlflow.log_params(estimator.get_params())
+        # mlflow.log_params(estimator.get_params())
         estimator_schema = infer_signature(
             X_train_sampled, estimator.predict(X_train_sampled.copy())
         )

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -641,10 +641,8 @@ class TrainStep(BaseStep):
         tuning_params = self.step_config["tuning"]
         try:
             import hyperopt
-            from hyperopt import fmin, Trials
-            from hyperopt.mlflow_utils import _MLflowLogging
 
-            _MLflowLogging._EN_WORKER_USER_LOGGING = False
+            hyperopt.mlflow_utils._MLflowLogging._EN_WORKER_USER_LOGGING = False
             hyperopt._mlflow = None
         except ModuleNotFoundError:
             raise MlflowException(
@@ -726,7 +724,6 @@ class TrainStep(BaseStep):
         parallelism = tuning_params["parallelism"]
 
         if parallelism > 1:
-            from hyperopt import SparkTrials
             from mlflow.utils._spark_utils import _get_active_spark_session
 
             spark_session = _get_active_spark_session()
@@ -736,11 +733,11 @@ class TrainStep(BaseStep):
             y_train = sc.broadcast(y_train)
             validation_df = sc.broadcast(validation_df)
 
-            hp_trials = SparkTrials(parallelism, spark_session=spark_session)
+            hp_trials = hyperopt.SparkTrials(parallelism, spark_session=spark_session)
         else:
-            hp_trials = Trials()
+            hp_trials = hyperopt.Trials()
 
-        best_hp_params = fmin(
+        best_hp_params = hyperopt.fmin(
             lambda params: objective(X_train, y_train, validation_df, params),
             search_space,
             algo=tuning_algo,

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -779,7 +779,13 @@ class TrainStep(BaseStep):
 
         if on_worker:
             mlflow.log_params(estimator.get_params())
-            mlflow.set_tags(mlflow.sklearn.utils._get_estimator_info_tags(estimator))
+            estimator_tags = {
+                "estimator_name": estimator.__class__.__name__,
+                "estimator_class": (
+                    estimator.__class__.__module__ + "." + estimator.__class__.__name__
+                ),
+            }
+            mlflow.set_tags(estimator_tags)
         estimator_schema = infer_signature(
             X_train_sampled, estimator.predict(X_train_sampled.copy())
         )

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -638,9 +638,12 @@ class TrainStep(BaseStep):
     ):
         tuning_params = self.step_config["tuning"]
         try:
+            import hyperopt
             from hyperopt import fmin, Trials
             from hyperopt.mlflow_utils import _MLflowLogging
+
             _MLflowLogging._EN_WORKER_USER_LOGGING = False
+            hyperopt._mlflow = None    
         except ModuleNotFoundError:
             raise MlflowException(
                 "Hyperopt not installed and is required if tuning is enabled",

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -744,11 +744,13 @@ class TrainStep(BaseStep):
             validation_df = sc.broadcast(validation_df)
 
             hp_trials = hyperopt.SparkTrials(parallelism, spark_session=spark_session)
+            on_worker = True
         else:
             hp_trials = hyperopt.Trials()
+            on_worker = False
 
         best_hp_params = hyperopt.fmin(
-            lambda params: objective(X_train, y_train, validation_df, params, on_worker=True),
+            lambda params: objective(X_train, y_train, validation_df, params, on_worker=on_worker),
             search_space,
             algo=tuning_algo,
             max_evals=max_trials,

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -784,6 +784,14 @@ class TrainStep(BaseStep):
             mlflow.log_params(estimator.best_params_)
 
         if on_worker:
+            tags = {
+                MLFLOW_SOURCE_TYPE: SourceType.to_string(SourceType.PIPELINE),
+                MLFLOW_PIPELINE_TEMPLATE_NAME: self.step_config["template_name"],
+                MLFLOW_PIPELINE_PROFILE_NAME: self.step_config["profile"],
+                MLFLOW_PIPELINE_STEP_NAME: os.getenv(
+                    _MLFLOW_PIPELINES_EXECUTION_TARGET_STEP_NAME_ENV_VAR
+                ),
+            }
             mlflow.set_tags(tags)
             mlflow.log_params(estimator.get_params())
         estimator_schema = infer_signature(

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -726,7 +726,6 @@ class TrainStep(BaseStep):
         else:
             hp_trials = Trials()
 
-        mlflow.autolog(disable=True)
         best_hp_params = fmin(
             lambda params: objective(X_train, y_train, validation_df, params),
             search_space,
@@ -738,7 +737,6 @@ class TrainStep(BaseStep):
         hardcoded_estimator_loss = objective(
             X_train, y_train, validation_df, estimator_hardcoded_params
         )
-        mlflow.autolog(disable=False)
 
         if best_hp_estimator_loss < hardcoded_estimator_loss:
             best_hardcoded_params = {
@@ -762,6 +760,7 @@ class TrainStep(BaseStep):
         if hasattr(estimator, "best_params_"):
             mlflow.log_params(estimator.best_params_)
 
+        mlflow.log_params(estimator.get_params())
         estimator_schema = infer_signature(
             X_train_sampled, estimator.predict(X_train_sampled.copy())
         )

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -652,13 +652,14 @@ class TrainStep(BaseStep):
 
         # wrap training in objective fn
         def objective(X_train, y_train, validation_df, hyperparameter_args):
-            from mlflow.tracking import MlflowClient
+            # from mlflow.tracking import MlflowClient
 
-            client = MlflowClient()
-            child_run = client.create_run(
-                _get_experiment_id(), tags={"mlflow.parentRunId": parent_run_id}
-            )
-            with mlflow.start_run(run_id=child_run.info.run_id) as tuning_run:
+            # client = MlflowClient()
+            # child_run = client.create_run(
+            #     _get_experiment_id(), tags={"mlflow.parentRunId": parent_run_id}
+            # )
+            # with mlflow.start_run(run_id=child_run.info.run_id) as tuning_run:
+            with mlflow.start_run(nested=True) as tuning_run:
                 estimator_args = dict(estimator_hardcoded_params, **hyperparameter_args)
                 estimator = estimator_fn(estimator_args)
 

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -159,7 +159,7 @@ class TrainStep(BaseStep):
 
             estimator.fit(X_train, y_train)
 
-            logged_estimator = self._log_estimator_to_mlflow(estimator, tags, X_train)
+            logged_estimator = self._log_estimator_to_mlflow(estimator, X_train, tags)
 
             # Create a pipeline consisting of the transformer+model for test data evaluation
             with open(transformer_path, "rb") as f:
@@ -651,7 +651,6 @@ class TrainStep(BaseStep):
 
         # wrap training in objective fn
         def objective(X_train, y_train, validation_df, hyperparameter_args, tags, on_worker=False):
-            print("tags in objective: ", tags)
             if on_worker:
                 from mlflow.tracking import MlflowClient
 
@@ -784,14 +783,6 @@ class TrainStep(BaseStep):
             mlflow.log_params(estimator.best_params_)
 
         if on_worker:
-            tags = {
-                MLFLOW_SOURCE_TYPE: SourceType.to_string(SourceType.PIPELINE),
-                MLFLOW_PIPELINE_TEMPLATE_NAME: self.step_config["template_name"],
-                MLFLOW_PIPELINE_PROFILE_NAME: self.step_config["profile"],
-                MLFLOW_PIPELINE_STEP_NAME: os.getenv(
-                    _MLFLOW_PIPELINES_EXECUTION_TARGET_STEP_NAME_ENV_VAR
-                ),
-            }
             mlflow.set_tags(tags)
             mlflow.log_params(estimator.get_params())
         estimator_schema = infer_signature(

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -726,6 +726,7 @@ class TrainStep(BaseStep):
         else:
             hp_trials = Trials()
 
+        mlflow.autolog(disable=True)
         best_hp_params = fmin(
             lambda params: objective(X_train, y_train, validation_df, params),
             search_space,
@@ -737,6 +738,7 @@ class TrainStep(BaseStep):
         hardcoded_estimator_loss = objective(
             X_train, y_train, validation_df, estimator_hardcoded_params
         )
+        mlflow.autolog(disable=False)
 
         if best_hp_estimator_loss < hardcoded_estimator_loss:
             best_hardcoded_params = {


### PR DESCRIPTION
Signed-off-by: Prithvi Kannan <prithvi.kannan@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Support hyperopt sparktrials parallelism using spark broadcast.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
