### PR TITLE
pytorch examples - PTL 1.7.6 fixes

### DIFF
--- a/examples/pytorch/AxHyperOptimizationPTL/conda.yaml
+++ b/examples/pytorch/AxHyperOptimizationPTL/conda.yaml
@@ -13,3 +13,4 @@ dependencies:
   # gyptorch 1.9.0 is incompatible with the versions of botorch
   # required by many versions of pytorch
   - gpytorch!=1.9.0
+  - pandas<=1.4.4

--- a/examples/pytorch/AxHyperOptimizationPTL/conda.yaml
+++ b/examples/pytorch/AxHyperOptimizationPTL/conda.yaml
@@ -5,7 +5,7 @@ dependencies:
 - pip
 - pip:
   - mlflow
-  - pytorch-lightning==1.6.1
+  - pytorch-lightning==1.7.6
   - ax-platform
   - torchvision>=0.9.1
   - torch>=1.9.0

--- a/examples/pytorch/AxHyperOptimizationPTL/conda.yaml
+++ b/examples/pytorch/AxHyperOptimizationPTL/conda.yaml
@@ -13,4 +13,5 @@ dependencies:
   # gyptorch 1.9.0 is incompatible with the versions of botorch
   # required by many versions of pytorch
   - gpytorch!=1.9.0
+  # Pinning pandas version less than 1.4.4 due to https://github.com/facebook/Ax/issues/1153
   - pandas<=1.4.4

--- a/examples/pytorch/BertNewsClassification/MLproject
+++ b/examples/pytorch/BertNewsClassification/MLproject
@@ -6,8 +6,9 @@ entry_points:
   main:
     parameters:
       max_epochs: {type: int, default: 5}
-      gpus: {type: int, default: 0}
+      devices: {type: int, default: "None"}
       strategy: {type str, default: "None"}
+      accelerator: {type str, default: "cpu"}
       batch_size: {type: int, default: 64}
       num_workers: {type: int, default: 3}
       learning_rate: {type: float, default: 0.001}
@@ -17,8 +18,9 @@ entry_points:
     command: |
           python bert_classification.py \
             --max_epochs {max_epochs} \
-            --gpus {gpus} \
+            --devices {devices} \
             --strategy {strategy} \
+            --accelerator {accelerator} \
             --batch_size {batch_size} \
             --num_workers {num_workers} \
             --num_samples {num_samples} \

--- a/examples/pytorch/BertNewsClassification/README.md
+++ b/examples/pytorch/BertNewsClassification/README.md
@@ -42,22 +42,23 @@ For more details on MLflow tracking, see [the docs](https://www.mlflow.org/docs/
 The parameters can be overridden via the command line:
 
 1. max_epochs - Number of epochs to train model. Training can be interrupted early via Ctrl+C
-2. gpus - Number of GPUs
+2. devices - Number of GPUs
 3. strategy - [strategy](https://pytorch-lightning.readthedocs.io/en/stable/common/trainer.html#trainer-class-api) (e.g. "ddp" for the Distributed Data Parallel backend) to use for training. By default, no strategy is used.
-4. batch_size - Input batch size for training
-5. num_workers - Number of worker threads to load training data
-6. lr - Learning rate
+4. accelerator - [accelerator](https://pytorch-lightning.readthedocs.io/en/stable/api/pytorch_lightning.accelerators.Accelerator.html#pytorch_lightning.accelerators.Accelerator) (e.g. "gpu" - for running in GPU environment. Set to "cpu" by default)
+5. batch_size - Input batch size for training
+6. num_workers - Number of worker threads to load training data
+7. lr - Learning rate
 
 For example:
 ```
-mlflow run . -P max_epochs=5 -P gpus=1 -P batch_size=32 -P num_workers=2 -P learning_rate=0.01 -P strategy="ddp"
+mlflow run . -P max_epochs=5 -P devices=1 -P batch_size=32 -P num_workers=2 -P learning_rate=0.01 -P strategy=ddp -P accelerator=gpu
 ```
 Or to run the training script directly with custom parameters:
 
 ```
 python bert_classification.py \
     --max_epochs 5 \
-    --gpus 1 \
+    --devices 1 \
     --strategy "ddp" \
     --batch_size 64 \
     --num_workers 2 \

--- a/examples/pytorch/BertNewsClassification/bert_classification.py
+++ b/examples/pytorch/BertNewsClassification/bert_classification.py
@@ -429,6 +429,10 @@ if __name__ == "__main__":
     args = parser.parse_args()
     dict_args = vars(args)
 
+    if "devices" in dict_args:
+        if dict_args["devices"] == "None":
+            dict_args["devices"] = None
+
     if "strategy" in dict_args:
         if dict_args["strategy"] == "None":
             dict_args["strategy"] = None
@@ -459,9 +463,9 @@ if __name__ == "__main__":
     # autolog with only rank 0 gpu.
 
     # For CPU Training
-    if dict_args["gpus"] is None or int(dict_args["gpus"]) == 0:
+    if dict_args["devices"] is None or int(dict_args["devices"]) == 0:
         mlflow.pytorch.autolog()
-    elif int(dict_args["gpus"]) >= 1 and trainer.global_rank == 0:
+    elif int(dict_args["devices"]) >= 1 and trainer.global_rank == 0:
         # In case of multi gpu training, the training script is invoked multiple times,
         # The following condition is needed to avoid multiple copies of mlflow runs.
         # When one or more gpus are used for training, it is enough to save

--- a/examples/pytorch/BertNewsClassification/conda.yaml
+++ b/examples/pytorch/BertNewsClassification/conda.yaml
@@ -13,5 +13,5 @@ dependencies:
   - torch>=1.11.0
   - torchdata
   - torchtext==0.12.0
-  - pytorch-lightning==1.6.1
+  - pytorch-lightning==1.7.6
   - protobuf<4.0.0

--- a/examples/pytorch/IterativePruning/conda.yaml
+++ b/examples/pytorch/IterativePruning/conda.yaml
@@ -7,7 +7,7 @@ dependencies:
   - mlflow
   - torchvision>=0.9.1
   - cloudpickle==1.6.0
-  - pytorch_lightning==1.6.1
+  - pytorch_lightning==1.7.6
   - ax-platform
   - prettytable
   - torch>=1.9.0

--- a/examples/pytorch/IterativePruning/conda.yaml
+++ b/examples/pytorch/IterativePruning/conda.yaml
@@ -15,4 +15,5 @@ dependencies:
   # gyptorch 1.9.0 is incompatible with the versions of botorch
   # required by many versions of pytorch
   - gpytorch!=1.9.0
+  # Pinning pandas version less than 1.4.4 due to https://github.com/facebook/Ax/issues/1153
   - pandas<=1.4.4

--- a/examples/pytorch/IterativePruning/conda.yaml
+++ b/examples/pytorch/IterativePruning/conda.yaml
@@ -15,3 +15,4 @@ dependencies:
   # gyptorch 1.9.0 is incompatible with the versions of botorch
   # required by many versions of pytorch
   - gpytorch!=1.9.0
+  - pandas<=1.4.4

--- a/examples/pytorch/MNIST/MLproject
+++ b/examples/pytorch/MNIST/MLproject
@@ -6,8 +6,9 @@ entry_points:
   main:
     parameters:
       max_epochs: {type: int, default: 5}
-      gpus: {type: int, default: 0}
+      devices : {type: str, default: "None"}
       strategy: {type str, default: "None"}
+      accelerator: {type str, default: "cpu"}
       batch_size: {type: int, default: 64}
       num_workers: {type: int, default: 3}
       learning_rate: {type: float, default: 0.001}
@@ -19,8 +20,9 @@ entry_points:
     command: |
           python mnist_autolog_example.py \
             --max_epochs {max_epochs} \
-            --gpus {gpus} \
+            --devices {devices} \
             --strategy {strategy} \
+            --accelerator {accelerator} \
             --batch_size {batch_size} \
             --num_workers {num_workers} \
             --lr {learning_rate} \

--- a/examples/pytorch/MNIST/README.md
+++ b/examples/pytorch/MNIST/README.md
@@ -48,7 +48,7 @@ The parameters can be overridden via the command line:
 1. max_epochs - Number of epochs to train model. Training can be interrupted early via Ctrl+C
 2. devices - Number of GPUs.
 3. strategy - [strategy](https://pytorch-lightning.readthedocs.io/en/stable/common/trainer.html#trainer-class-api) (e.g. "ddp" for the Distributed Data Parallel backend) to use for training. By default, no strategy is used.
-4. strategy - [strategy](https://pytorch-lightning.readthedocs.io/en/stable/api/pytorch_lightning.accelerators.Accelerator.html#pytorch_lightning.accelerators.Accelerator) (e.g. "gpu" - for running in GPU environment. Set to "cpu" by default)
+4. accelerator - [accelerator](https://pytorch-lightning.readthedocs.io/en/stable/api/pytorch_lightning.accelerators.Accelerator.html#pytorch_lightning.accelerators.Accelerator) (e.g. "gpu" - for running in GPU environment. Set to "cpu" by default)
 5. batch_size - Input batch size for training
 6. num_workers - Number of worker threads to load training data
 7. lr - Learning rate

--- a/examples/pytorch/MNIST/README.md
+++ b/examples/pytorch/MNIST/README.md
@@ -46,15 +46,16 @@ For more details on MLflow tracking, see [the docs](https://www.mlflow.org/docs/
 The parameters can be overridden via the command line:
 
 1. max_epochs - Number of epochs to train model. Training can be interrupted early via Ctrl+C
-2. gpus - Number of GPUs
+2. devices - Number of GPUs.
 3. strategy - [strategy](https://pytorch-lightning.readthedocs.io/en/stable/common/trainer.html#trainer-class-api) (e.g. "ddp" for the Distributed Data Parallel backend) to use for training. By default, no strategy is used.
-4. batch_size - Input batch size for training
-5. num_workers - Number of worker threads to load training data
-6. lr - Learning rate
-7. patience -parameter of early stopping
-8. mode - parameter of early stopping
-9. monitor - parameter of early stopping
-10.verbose - parameter of early stopping
+4. strategy - [strategy](https://pytorch-lightning.readthedocs.io/en/stable/api/pytorch_lightning.accelerators.Accelerator.html#pytorch_lightning.accelerators.Accelerator) (e.g. "gpu" - for running in GPU environment. Set to "cpu" by default)
+5. batch_size - Input batch size for training
+6. num_workers - Number of worker threads to load training data
+7. lr - Learning rate
+8. patience -parameter of early stopping
+9. mode - parameter of early stopping
+10. monitor - parameter of early stopping
+11.verbose - parameter of early stopping
 
 For example:
 ```
@@ -65,8 +66,9 @@ Or to run the training script directly with custom parameters:
 ```
 python mnist_autolog_example.py \
     --max_epochs 5 \
-    --gpus 1 \
+    --devices 1 \
     --strategy "ddp" \
+    --accelerator "gpu" \
     --batch_size 64 \
     --num_workers 3 \
     --lr 0.001 \

--- a/examples/pytorch/MNIST/conda.yaml
+++ b/examples/pytorch/MNIST/conda.yaml
@@ -7,5 +7,5 @@ dependencies:
   - mlflow
   - torchvision>=0.9.1
   - torch>=1.9.0
-  - pytorch-lightning==1.6.1
+  - pytorch-lightning==1.7.6
   - protobuf<4.0.0

--- a/examples/pytorch/MNIST/mnist_autolog_example.py
+++ b/examples/pytorch/MNIST/mnist_autolog_example.py
@@ -231,7 +231,7 @@ class LightningMNISTClassifier(pl.LightningModule):
         :return: output - average test loss
         """
         avg_test_acc = torch.stack([x["test_acc"] for x in outputs]).mean()
-        self.log("avg_test_acc", avg_test_acc)
+        self.log("avg_test_acc", avg_test_acc, sync_dist=True)
 
     def configure_optimizers(self):
         """
@@ -278,9 +278,14 @@ if __name__ == "__main__":
     args = parser.parse_args()
     dict_args = vars(args)
 
+
     if "strategy" in dict_args:
         if dict_args["strategy"] == "None":
             dict_args["strategy"] = None
+
+    if "devices" in dict_args:
+        if dict_args["devices"] == "None":
+            dict_args["devices"] = None
 
     model = LightningMNISTClassifier(**dict_args)
 
@@ -300,16 +305,16 @@ if __name__ == "__main__":
     lr_logger = LearningRateMonitor()
 
     trainer = pl.Trainer.from_argparse_args(
-        args, callbacks=[lr_logger, early_stopping, checkpoint_callback], checkpoint_callback=True
+        args, callbacks=[lr_logger, early_stopping, checkpoint_callback]
     )
 
     # It is safe to use `mlflow.pytorch.autolog` in DDP training, as below condition invokes
     # autolog with only rank 0 gpu.
 
     # For CPU Training
-    if dict_args["gpus"] is None or int(dict_args["gpus"]) == 0:
+    if dict_args["devices"] is None or int(dict_args["devices"]) == 0:
         mlflow.pytorch.autolog()
-    elif int(dict_args["gpus"]) >= 1 and trainer.global_rank == 0:
+    elif int(dict_args["devices"]) >= 1 and trainer.global_rank == 0:
         # In case of multi gpu training, the training script is invoked multiple times,
         # The following condition is needed to avoid multiple copies of mlflow runs.
         # When one or more gpus are used for training, it is enough to save
@@ -322,4 +327,4 @@ if __name__ == "__main__":
         logging.info("Active run exists.. ")
 
     trainer.fit(model, dm)
-    trainer.test(datamodule=dm)
+    trainer.test(datamodule=dm, ckpt_path='best')

--- a/examples/pytorch/MNIST/mnist_autolog_example.py
+++ b/examples/pytorch/MNIST/mnist_autolog_example.py
@@ -278,7 +278,6 @@ if __name__ == "__main__":
     args = parser.parse_args()
     dict_args = vars(args)
 
-
     if "strategy" in dict_args:
         if dict_args["strategy"] == "None":
             dict_args["strategy"] = None
@@ -327,4 +326,4 @@ if __name__ == "__main__":
         logging.info("Active run exists.. ")
 
     trainer.fit(model, dm)
-    trainer.test(datamodule=dm, ckpt_path='best')
+    trainer.test(datamodule=dm, ckpt_path="best")


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Pytorch examples - Pytorch lightning 1.7 fixes


https://pytorch-lightning.readthedocs.io/en/stable/accelerators/gpu_faq.html 

In the recent version of pytorch lightning (1.7.6), the argument `gpu` has been changed to `devices` and `accelerator` can be set as `gpu` or `cpu` based on the environment.


## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

Existing unit tests should pass

Local testing logs

[ax_mlflowrun.txt](https://github.com/mlflow/mlflow/files/9601311/ax_mlflowrun.txt)
[ax_python.txt](https://github.com/mlflow/mlflow/files/9601312/ax_python.txt)
[bert_mlflowrun.txt](https://github.com/mlflow/mlflow/files/9601314/bert_mlflowrun.txt)
[bert_python_cpu.txt](https://github.com/mlflow/mlflow/files/9601315/bert_python_cpu.txt)
[bert_python_gpu.txt](https://github.com/mlflow/mlflow/files/9601316/bert_python_gpu.txt)
[mnist_mlflowrun.txt](https://github.com/mlflow/mlflow/files/9601317/mnist_mlflowrun.txt)
[mnist_python_cpu.txt](https://github.com/mlflow/mlflow/files/9601318/mnist_python_cpu.txt)
[mnist_python_gpu.txt](https://github.com/mlflow/mlflow/files/9601319/mnist_python_gpu.txt)
[pruning_mlflowrun.txt](https://github.com/mlflow/mlflow/files/9601320/pruning_mlflowrun.txt)
[pruning_python.txt](https://github.com/mlflow/mlflow/files/9601321/pruning_python.txt)


## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
3. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [x] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
