### PR TITLE
Fix infinite recursion in `get_feature_cols`

### DIFF
--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -1003,7 +1003,7 @@ def autolog(
                 spark = SparkSession.builder.getOrCreate()
 
                 def _get_input_example_as_pd_df():
-                    feature_cols = list(get_feature_cols(input_df.schema, spark_model))
+                    feature_cols = list(get_feature_cols(input_df, spark_model))
                     limited_input_df = input_df.select(feature_cols).limit(
                         INPUT_EXAMPLE_SAMPLE_ROWS
                     )

--- a/mlflow/pyspark/ml/_autolog.py
+++ b/mlflow/pyspark/ml/_autolog.py
@@ -71,7 +71,7 @@ def get_feature_cols(
     df_subset = df.limit(1).cache()
     for column in df.columns:
         try:
-            transformer.transform(df_subset)
+            transformer.transform(df_subset.drop(column))
         except IllegalArgumentException as iae:
             if re.search("(.*) does not exist.", iae.desc, re.IGNORECASE):
                 feature_cols.add(column)

--- a/mlflow/pyspark/ml/_autolog.py
+++ b/mlflow/pyspark/ml/_autolog.py
@@ -67,11 +67,11 @@ def get_feature_cols(
     :return: A set of all the feature columns that are required
              for the pipeline/transformer plus any initial columns passed in.
     """
-    necessary_columns = set()
+    feature_cols = set()
     for column in df.columns:
         try:
             transformer.transform(df.drop(column).limit(1))
         except IllegalArgumentException as iae:
             if re.search("(.*) does not exist.", iae.desc, re.IGNORECASE):
-                necessary_columns.add(column)
-    return necessary_columns
+                feature_cols.add(column)
+    return feature_cols

--- a/mlflow/pyspark/ml/_autolog.py
+++ b/mlflow/pyspark/ml/_autolog.py
@@ -68,10 +68,14 @@ def get_feature_cols(
              for the pipeline/transformer plus any initial columns passed in.
     """
     feature_cols = set()
+    df_subset = df.limit(1).cache()
     for column in df.columns:
         try:
-            transformer.transform(df.drop(column).limit(1))
+            transformer.transform(df_subset.limit(1))
         except IllegalArgumentException as iae:
             if re.search("(.*) does not exist.", iae.desc, re.IGNORECASE):
                 feature_cols.add(column)
+                continue
+            raise
+    df_subset.unpersist()
     return feature_cols

--- a/mlflow/pyspark/ml/_autolog.py
+++ b/mlflow/pyspark/ml/_autolog.py
@@ -1,5 +1,5 @@
 from pyspark.sql.utils import IllegalArgumentException
-from pyspark.sql import SparkSession, DataFrame
+from pyspark.sql import DataFrame
 import re
 from functools import reduce
 from pyspark.ml.functions import vector_to_array
@@ -53,10 +53,8 @@ def _get_struct_type_by_cols(input_fields: Set[str], df_schema: t.StructType) ->
 
 
 def get_feature_cols(
-    df_schema: t.StructType,
+    df: DataFrame,
     transformer: Union[Transformer, PipelineModel],
-    input_fields: Set[str] = None,
-    spark: SparkSession = None,
 ) -> Set[str]:
     """
     Finds feature columns from an input dataset. If a dataset
@@ -64,32 +62,16 @@ def get_feature_cols(
     if `input_fields` is set to include non-feature columns those
     will be included in the return set of column names.
 
-    :param df_schema: An input spark schema to look for the feature columns
+    :param df: An input spark dataframe.
     :param transformer: A pipeline/transformer to get the required feature columns
-    :param input_fields: Initial columns to keep in the returned list
-    :param spark: A spark session
     :return: A set of all the feature columns that are required
              for the pipeline/transformer plus any initial columns passed in.
     """
-    if spark is None:
-        spark = SparkSession.builder.getOrCreate()
-    if input_fields is None:
-        input_fields = set()
-        # Using an empty dataset doesn't work for all estimators
-        # such as: pyspark.ml.classification.OneVsRest, so set
-        # a single row and column of double type
-        df = spark.createDataFrame([(1.0,)])
-    else:
-        df = spark.createDataFrame(
-            spark.sparkContext.emptyRDD(),
-            _get_struct_type_by_cols(input_fields, df_schema),
-        )
-    try:
-        _do_pipeline_transform(df, transformer)
-    except IllegalArgumentException as iae:
-        col_name_search = re.search("(.*) does not exist.", iae.desc, re.IGNORECASE)
-        if col_name_search:
-            col_name = col_name_search.group(1)
-            input_fields.add(col_name)
-            get_feature_cols(df_schema, transformer, input_fields, spark)
-    return input_fields
+    necessary_columns = set()
+    for column in df.columns:
+        try:
+            transformer.transform(df.drop(column).limit(1))
+        except IllegalArgumentException as iae:
+            if re.search("(.*) does not exist.", iae.desc, re.IGNORECASE):
+                necessary_columns.add(column)
+    return necessary_columns

--- a/mlflow/pyspark/ml/_autolog.py
+++ b/mlflow/pyspark/ml/_autolog.py
@@ -71,7 +71,7 @@ def get_feature_cols(
     df_subset = df.limit(1).cache()
     for column in df.columns:
         try:
-            transformer.transform(df_subset.limit(1))
+            transformer.transform(df_subset)
         except IllegalArgumentException as iae:
             if re.search("(.*) does not exist.", iae.desc, re.IGNORECASE):
                 feature_cols.add(column)


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Fix infinite recursion in `get_feature_cols`.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
