### PR TITLE
Fix `TypeError: None has type NoneType, but expected one of: bytes, unicode` in `RunInfo.to_proto`

### DIFF
--- a/mlflow/entities/run_info.py
+++ b/mlflow/entities/run_info.py
@@ -142,7 +142,8 @@ class RunInfo(_MLflowObject):
         proto = ProtoRunInfo()
         proto.run_uuid = self.run_uuid
         proto.run_id = self.run_id
-        proto.run_name = self.run_name
+        if self.run_name:
+            proto.run_name = self.run_name
         proto.experiment_id = self.experiment_id
         proto.user_id = self.user_id
         proto.status = RunStatus.from_string(self.status)

--- a/mlflow/entities/run_info.py
+++ b/mlflow/entities/run_info.py
@@ -142,7 +142,7 @@ class RunInfo(_MLflowObject):
         proto = ProtoRunInfo()
         proto.run_uuid = self.run_uuid
         proto.run_id = self.run_id
-        if self.run_name:
+        if self.run_name is not None:
             proto.run_name = self.run_name
         proto.experiment_id = self.experiment_id
         proto.user_id = self.user_id


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Fix the following error that occurs when `RunInfo.to_proto` is called on a run logged in MLflow <= 1.29.0:

```
Traceback (most recent call last):
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.7/site-packages/flask/app.py", line 2463, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.7/site-packages/flask/app.py", line 1760, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.7/site-packages/flask/app.py", line 1758, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.7/site-packages/flask/app.py", line 1734, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
  File "/home/haru/Desktop/repositories/mlflow/mlflow/server/handlers.py", line 455, in wrapper
    return func(*args, **kwargs)
  File "/home/haru/Desktop/repositories/mlflow/mlflow/server/handlers.py", line 525, in wrapper
    return func(*args, **kwargs)
  File "/home/haru/Desktop/repositories/mlflow/mlflow/server/handlers.py", line 883, in _search_runs
    response_message.runs.extend([r.to_proto() for r in run_entities])
  File "/home/haru/Desktop/repositories/mlflow/mlflow/server/handlers.py", line 883, in <listcomp>
    response_message.runs.extend([r.to_proto() for r in run_entities])
  File "/home/haru/Desktop/repositories/mlflow/mlflow/entities/run.py", line 39, in to_proto
    run.info.MergeFrom(self.info.to_proto())
  File "/home/haru/Desktop/repositories/mlflow/mlflow/entities/run_info.py", line 145, in to_proto
    proto.run_name = self.run_name
TypeError: None has type NoneType, but expected one of: bytes, unicode
```

Steps to reproduce:

1. Log a run using MLflow 1.28.0.
2. Run `mlflow server`.
3. Open another terminal and run `MLFLOW_TRACKING_URI=http://localhost:5000 python -c "import mlflow; print(mlflow.search_runs())"`.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
4. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
