### PR TITLE
Fix `ShowArtifactPage` to display mlflow model correctly

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactPage.js
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactPage.js
@@ -72,7 +72,6 @@ class ShowArtifactPage extends Component {
             />
           );
         }
-        return getSelectFileView();
       } else if (normalizedExtension) {
         if (IMAGE_EXTENSIONS.has(normalizedExtension.toLowerCase())) {
           return <ShowArtifactImageView runUuid={this.props.runUuid} path={this.props.path} />;

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactPage.js
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactPage.js
@@ -58,7 +58,22 @@ class ShowArtifactPage extends Component {
       }
       if (this.props.size > MAX_PREVIEW_ARTIFACT_SIZE_MB * ONE_MB) {
         return getFileTooLargeView();
-      } else if (!this.props.isDirectory && normalizedExtension) {
+      } else if (this.props.isDirectory) {
+        if (
+          this.props.runTags &&
+          getLoggedModelPathsFromTags(this.props.runTags).includes(this.props.path)
+        ) {
+          return (
+            <ShowArtifactLoggedModelView
+              runUuid={this.props.runUuid}
+              path={this.props.path}
+              artifactRootUri={this.props.artifactRootUri}
+              registeredModelLink={registeredModelLink}
+            />
+          );
+        }
+        return getSelectFileView();
+      } else if (normalizedExtension) {
         if (IMAGE_EXTENSIONS.has(normalizedExtension.toLowerCase())) {
           return <ShowArtifactImageView runUuid={this.props.runUuid} path={this.props.path} />;
         } else if (DATA_EXTENSIONS.has(normalizedExtension.toLowerCase())) {
@@ -71,18 +86,6 @@ class ShowArtifactPage extends Component {
           return <ShowArtifactHtmlView runUuid={this.props.runUuid} path={this.props.path} />;
         } else if (PDF_EXTENSIONS.has(normalizedExtension.toLowerCase())) {
           return <ShowArtifactPdfView runUuid={this.props.runUuid} path={this.props.path} />;
-        } else if (
-          this.props.runTags &&
-          getLoggedModelPathsFromTags(this.props.runTags).includes(normalizedExtension)
-        ) {
-          return (
-            <ShowArtifactLoggedModelView
-              runUuid={this.props.runUuid}
-              path={this.props.path}
-              artifactRootUri={this.props.artifactRootUri}
-              registeredModelLink={registeredModelLink}
-            />
-          );
         }
       }
     }

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactPage.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactPage.test.js
@@ -55,6 +55,7 @@ describe('ShowArtifactPage', () => {
   test('should render logged model view when path is in runs tag logged model history', () => {
     wrapper.setProps({
       path: 'somePath',
+      isDirectory: true,
       runTags: {
         'mlflow.log-model.history': RunTag.fromJs({
           key: 'mlflow.log-model.history',

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactPage.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactPage.test.js
@@ -72,6 +72,26 @@ describe('ShowArtifactPage', () => {
     expect(wrapper.find(ShowArtifactLoggedModelView).length).toBe(1);
   });
 
+  test('should render logged model view when path is nested in subdirectory', () => {
+    wrapper.setProps({
+      path: 'dir/somePath',
+      isDirectory: true,
+      runTags: {
+        'mlflow.log-model.history': RunTag.fromJs({
+          key: 'mlflow.log-model.history',
+          value: JSON.stringify([
+            {
+              run_id: 'run-uuid',
+              artifact_path: 'dir/somePath',
+              flavors: { keras: {}, python_function: {} },
+            },
+          ]),
+        }),
+      },
+    });
+    expect(wrapper.find(ShowArtifactLoggedModelView).length).toBe(1);
+  });
+
   test('should render "select to preview" view when path has no extension', () => {
     wrapper.setProps({ path: 'file_without_extension', runUuid: 'runId' });
     expect(wrapper.text().includes('Select a file to preview')).toBe(true);


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Fixed the bug introduced in https://github.com/mlflow/mlflow/pull/6753.

```python
import mlflow
from sklearn.linear_model import LogisticRegression
import tempfile

# model directory in root
with mlflow.start_run():
    mlflow.sklearn.log_model(LogisticRegression(), "model")


# model directory in subdirectory
with mlflow.start_run():
    mlflow.sklearn.log_model(LogisticRegression(), "dir/model")


# non-model model directory
with mlflow.start_run():
    mlflow.log_artifact(__file__, "model")
    mlflow.log_artifact(__file__, "model/model")
    mlflow.log_artifact(__file__, "model/model/model")


with tempfile.TemporaryDirectory() as tmpdir:
    mlflow.log_artifacts(tmpdir, "empty")
```

### Before

https://user-images.githubusercontent.com/17039389/191215285-42bd48e7-df44-498e-ab4e-9aa6e2d4e7ce.mov

When the model directory is selected, the artifact viewer should show the model summary, but it doesn't.

### After

https://user-images.githubusercontent.com/17039389/191215853-f585711b-2d9b-40dc-8d93-87d8f825dcbf.mov

When the model directory is selected, the artifact viewer shows the model summary.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
