### PR TITLE
Add unit test for DatabricksArtifactRepository uploading artifacts through ADL Gen2

### DIFF
--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -211,10 +211,10 @@ class DatabricksArtifactRepository(ArtifactRepository):
                             "Failed to authorize request, possibly due to credential expiration."
                             " Refreshing credentials and trying again..."
                         )
-                        credential_info = self._get_write_credential_infos(
+                        credentials = self._get_write_credential_infos(
                             run_id=self.run_id, paths=[artifact_path]
                         )[0]
-                        put_block(credential_info.signed_uri, block_id, chunk, headers=headers)
+                        put_block(credentials.signed_uri, block_id, chunk, headers=headers)
                     else:
                         raise e
                 uploading_block_list.append(block_id)
@@ -226,12 +226,10 @@ class DatabricksArtifactRepository(ArtifactRepository):
                         "Failed to authorize request, possibly due to credential expiration."
                         " Refreshing credentials and trying again..."
                     )
-                    credential_info = self._get_write_credential_infos(
+                    credentials = self._get_write_credential_infos(
                         run_id=self.run_id, paths=[artifact_path]
                     )[0]
-                    put_block_list(
-                        credential_info.signed_uri, uploading_block_list, headers=headers
-                    )
+                    put_block_list(credentials.signed_uri, uploading_block_list, headers=headers)
                 else:
                     raise e
         except Exception as err:
@@ -253,10 +251,10 @@ class DatabricksArtifactRepository(ArtifactRepository):
                         "Failed to authorize ADLS file creation request, possibly due "
                         "to credential expiration. Refreshing credentials and trying again..."
                     )
-                    credential_info = self._get_write_credential_infos(
+                    credentials = self._get_write_credential_infos(
                         run_id=self.run_id, paths=[artifact_path]
                     )[0]
-                    put_adls_file_creation(credential_info.signed_uri, headers=headers)
+                    put_adls_file_creation(credentials.signed_uri, headers=headers)
                 else:
                     raise e
 
@@ -272,11 +270,11 @@ class DatabricksArtifactRepository(ArtifactRepository):
                             "Failed to authorize ADLS patch request, possibly due to "
                             "credential expiration. Refreshing credentials and trying again..."
                         )
-                        credential_info = self._get_write_credential_infos(
+                        credentials = self._get_write_credential_infos(
                             run_id=self.run_id, paths=[artifact_path]
                         )[0]
                         patch_adls_file_upload(
-                            credential_info.signed_uri, chunk, offset, headers=headers
+                            credentials.signed_uri, chunk, offset, headers=headers
                         )
                     else:
                         raise e
@@ -290,10 +288,10 @@ class DatabricksArtifactRepository(ArtifactRepository):
                         "Failed to authorize flush request, possibly due to credential expiration."
                         " Refreshing credentials and trying again..."
                     )
-                    credential_info = self._get_write_credential_infos(
+                    credentials = self._get_write_credential_infos(
                         run_id=self.run_id, paths=[artifact_path]
                     )[0]
-                    patch_adls_flush(credential_info.signed_uri, offset, headers=headers)
+                    patch_adls_flush(credentials.signed_uri, offset, headers=headers)
                 else:
                     raise e
         except Exception as err:

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -211,10 +211,10 @@ class DatabricksArtifactRepository(ArtifactRepository):
                             "Failed to authorize request, possibly due to credential expiration."
                             " Refreshing credentials and trying again..."
                         )
-                        credentials = self._get_write_credential_infos(
+                        credential_info = self._get_write_credential_infos(
                             run_id=self.run_id, paths=[artifact_path]
                         )[0]
-                        put_block(credentials.signed_uri, block_id, chunk, headers=headers)
+                        put_block(credential_info.signed_uri, block_id, chunk, headers=headers)
                     else:
                         raise e
                 uploading_block_list.append(block_id)
@@ -226,10 +226,12 @@ class DatabricksArtifactRepository(ArtifactRepository):
                         "Failed to authorize request, possibly due to credential expiration."
                         " Refreshing credentials and trying again..."
                     )
-                    credentials = self._get_write_credential_infos(
+                    credential_info = self._get_write_credential_infos(
                         run_id=self.run_id, paths=[artifact_path]
                     )[0]
-                    put_block_list(credentials.signed_uri, uploading_block_list, headers=headers)
+                    put_block_list(
+                        credential_info.signed_uri, uploading_block_list, headers=headers
+                    )
                 else:
                     raise e
         except Exception as err:
@@ -251,10 +253,10 @@ class DatabricksArtifactRepository(ArtifactRepository):
                         "Failed to authorize ADLS file creation request, possibly due "
                         "to credential expiration. Refreshing credentials and trying again..."
                     )
-                    credentials = self._get_write_credential_infos(
+                    credential_info = self._get_write_credential_infos(
                         run_id=self.run_id, paths=[artifact_path]
                     )[0]
-                    put_adls_file_creation(credentials.signed_uri, headers=headers)
+                    put_adls_file_creation(credential_info.signed_uri, headers=headers)
                 else:
                     raise e
 
@@ -270,11 +272,11 @@ class DatabricksArtifactRepository(ArtifactRepository):
                             "Failed to authorize ADLS patch request, possibly due to "
                             "credential expiration. Refreshing credentials and trying again..."
                         )
-                        credentials = self._get_write_credential_infos(
+                        credential_info = self._get_write_credential_infos(
                             run_id=self.run_id, paths=[artifact_path]
                         )[0]
                         patch_adls_file_upload(
-                            credentials.signed_uri, chunk, offset, headers=headers
+                            credential_info.signed_uri, chunk, offset, headers=headers
                         )
                     else:
                         raise e
@@ -288,10 +290,10 @@ class DatabricksArtifactRepository(ArtifactRepository):
                         "Failed to authorize flush request, possibly due to credential expiration."
                         " Refreshing credentials and trying again..."
                     )
-                    credentials = self._get_write_credential_infos(
+                    credential_info = self._get_write_credential_infos(
                         run_id=self.run_id, paths=[artifact_path]
                     )[0]
-                    patch_adls_flush(credentials.signed_uri, offset, headers=headers)
+                    patch_adls_flush(credential_info.signed_uri, offset, headers=headers)
                 else:
                     raise e
         except Exception as err:

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -308,7 +308,7 @@ class TestDatabricksArtifactRepository:
         mock_azure_headers = {
             "x-ms-content-type": "test-type",
             "x-ms-owner": "some-owner",
-            "x-ms-blob-type": "some-type",
+            "x-ms-something_not_supported": "some-value",
         }
         filtered_azure_headers = {
             "x-ms-content-type": "test-type",
@@ -339,6 +339,7 @@ class TestDatabricksArtifactRepository:
             write_credential_infos_mock.assert_called_with(
                 run_id=MOCK_RUN_ID, paths=[expected_location]
             )
+            # test with block size 5
             request_mock.assert_any_call(
                 "put",
                 MOCK_ADLS_GEN2_SIGNED_URI + "?resource=file",
@@ -392,6 +393,7 @@ class TestDatabricksArtifactRepository:
                 MOCK_ADLS_GEN2_SIGNED_URI + "?resource=file",
                 headers={},
             )
+            # test with asure max block size
             request_mock.assert_any_call(
                 "patch",
                 MOCK_ADLS_GEN2_SIGNED_URI + "?action=append&position=0",

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -321,7 +321,10 @@ class TestDatabricksArtifactRepository:
             DATABRICKS_ARTIFACT_REPOSITORY + "._get_write_credential_infos"
         ) as write_credential_infos_mock, mock.patch(
             "mlflow.utils.rest_utils.cloud_storage_http_request"
-        ) as request_mock:
+        ) as request_mock, mock.patch(
+            "mlflow.store.artifact.databricks_artifact_repo._AZURE_MAX_BLOCK_CHUNK_SIZE",
+            5,
+        ):
             mock_credential_info = ArtifactCredentialInfo(
                 signed_uri=MOCK_ADLS_GEN2_SIGNED_URI,
                 type=ArtifactCredentialType.AZURE_ADLS_GEN2_SAS_URI,
@@ -344,6 +347,18 @@ class TestDatabricksArtifactRepository:
             request_mock.assert_any_call(
                 "patch",
                 MOCK_ADLS_GEN2_SIGNED_URI + "?action=append&position=0",
+                data=ANY,
+                headers=filtered_azure_headers,
+            )
+            request_mock.assert_any_call(
+                "patch",
+                MOCK_ADLS_GEN2_SIGNED_URI + "?action=append&position=5",
+                data=ANY,
+                headers=filtered_azure_headers,
+            )
+            request_mock.assert_any_call(
+                "patch",
+                MOCK_ADLS_GEN2_SIGNED_URI + "?action=append&position=10",
                 data=ANY,
                 headers=filtered_azure_headers,
             )

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -336,15 +336,24 @@ class TestDatabricksArtifactRepository:
             write_credential_infos_mock.assert_called_with(
                 run_id=MOCK_RUN_ID, paths=[expected_location]
             )
+            request_mock.assert_any_call(
+                "put",
+                MOCK_ADLS_GEN2_SIGNED_URI + "?resource=file",
+                headers=filtered_azure_headers,
+            )
+            request_mock.assert_any_call(
+                "patch",
+                MOCK_ADLS_GEN2_SIGNED_URI + "?action=append&position=0",
+                data=ANY,
+                headers=filtered_azure_headers,
+            )
             request_mock.assert_called_with(
                 "patch",
                 MOCK_ADLS_GEN2_SIGNED_URI + "?action=flush&position=14",
                 headers=filtered_azure_headers,
             )
 
-    def test_log_artifact_adls_gen2_blob_client_sas_error(
-        self, databricks_artifact_repo, test_file
-    ):
+    def test_log_artifact_adls_gen2_flush_error(self, databricks_artifact_repo, test_file):
         with mock.patch(
             DATABRICKS_ARTIFACT_REPOSITORY + "._get_write_credential_infos"
         ) as write_credential_infos_mock, mock.patch(

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -29,7 +29,7 @@ DATABRICKS_ARTIFACT_REPOSITORY = (
 )
 
 MOCK_AZURE_SIGNED_URI = "http://this_is_a_mock_sas_for_azure"
-MOCK_ADL_GEN2_SIGNED_URI = "http://this_is_a_mock_sas_for_adl_gen2"
+MOCK_ADLS_GEN2_SIGNED_URI = "http://this_is_a_mock_sas_for_adls_gen2"
 MOCK_AWS_SIGNED_URI = "http://this_is_a_mock_presigned_uri_for_aws?"
 MOCK_GCP_SIGNED_URL = "http://this_is_a_mock_signed_url_for_gcp?"
 MOCK_RUN_ID = "MOCK-RUN-ID"
@@ -279,7 +279,7 @@ class TestDatabricksArtifactRepository:
         ("artifact_path", "expected_location"),
         [(None, "test.txt"), ("output", "output/test.txt"), ("", "test.txt")],
     )
-    def test_log_artifact_adl_gen2(
+    def test_log_artifact_adls_gen2(
         self, databricks_artifact_repo, test_file, artifact_path, expected_location
     ):
         with mock.patch(
@@ -288,7 +288,7 @@ class TestDatabricksArtifactRepository:
             DATABRICKS_ARTIFACT_REPOSITORY + "._azure_adls_gen2_upload_file"
         ) as azure_upload_mock:
             mock_credential_info = ArtifactCredentialInfo(
-                signed_uri=MOCK_ADL_GEN2_SIGNED_URI,
+                signed_uri=MOCK_ADLS_GEN2_SIGNED_URI,
                 type=ArtifactCredentialType.AZURE_ADLS_GEN2_SAS_URI,
             )
             write_credential_infos_mock.return_value = [mock_credential_info]
@@ -302,7 +302,7 @@ class TestDatabricksArtifactRepository:
             )
 
     @pytest.mark.parametrize(("artifact_path", "expected_location"), [(None, "test.txt")])
-    def test_log_artifact_adl_gen2_with_headers(
+    def test_log_artifact_adls_gen2_with_headers(
         self, databricks_artifact_repo, test_file, artifact_path, expected_location
     ):
         mock_azure_headers = {
@@ -323,7 +323,7 @@ class TestDatabricksArtifactRepository:
             "mlflow.utils.rest_utils.cloud_storage_http_request"
         ) as request_mock:
             mock_credential_info = ArtifactCredentialInfo(
-                signed_uri=MOCK_ADL_GEN2_SIGNED_URI,
+                signed_uri=MOCK_ADLS_GEN2_SIGNED_URI,
                 type=ArtifactCredentialType.AZURE_ADLS_GEN2_SAS_URI,
                 headers=[
                     ArtifactCredentialInfo.HttpHeader(name=header_name, value=header_value)
@@ -338,18 +338,20 @@ class TestDatabricksArtifactRepository:
             )
             request_mock.assert_called_with(
                 "patch",
-                MOCK_ADL_GEN2_SIGNED_URI + "?action=flush&position=14",
+                MOCK_ADLS_GEN2_SIGNED_URI + "?action=flush&position=14",
                 headers=filtered_azure_headers,
             )
 
-    def test_log_artifact_adl_gen2_blob_client_sas_error(self, databricks_artifact_repo, test_file):
+    def test_log_artifact_adls_gen2_blob_client_sas_error(
+        self, databricks_artifact_repo, test_file
+    ):
         with mock.patch(
             DATABRICKS_ARTIFACT_REPOSITORY + "._get_write_credential_infos"
         ) as write_credential_infos_mock, mock.patch(
             "azure.storage.blob.BlobClient.from_blob_url"
         ) as mock_create_blob_client:
             mock_credential_info = ArtifactCredentialInfo(
-                signed_uri=MOCK_ADL_GEN2_SIGNED_URI,
+                signed_uri=MOCK_ADLS_GEN2_SIGNED_URI,
                 type=ArtifactCredentialType.AZURE_ADLS_GEN2_SAS_URI,
             )
             write_credential_infos_mock.return_value = [mock_credential_info]

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -286,18 +286,18 @@ class TestDatabricksArtifactRepository:
             DATABRICKS_ARTIFACT_REPOSITORY + "._get_write_credential_infos"
         ) as write_credential_infos_mock, mock.patch(
             DATABRICKS_ARTIFACT_REPOSITORY + "._azure_adls_gen2_upload_file"
-        ) as azure_upload_mock:
+        ) as azure_adls_gen2_upload_mock:
             mock_credential_info = ArtifactCredentialInfo(
                 signed_uri=MOCK_ADLS_GEN2_SIGNED_URI,
                 type=ArtifactCredentialType.AZURE_ADLS_GEN2_SAS_URI,
             )
             write_credential_infos_mock.return_value = [mock_credential_info]
-            azure_upload_mock.return_value = None
+            azure_adls_gen2_upload_mock.return_value = None
             databricks_artifact_repo.log_artifact(test_file.strpath, artifact_path)
             write_credential_infos_mock.assert_called_with(
                 run_id=MOCK_RUN_ID, paths=[expected_location]
             )
-            azure_upload_mock.assert_called_with(
+            azure_adls_gen2_upload_mock.assert_called_with(
                 mock_credential_info, test_file.strpath, expected_location
             )
 

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -29,7 +29,7 @@ DATABRICKS_ARTIFACT_REPOSITORY = (
 )
 
 MOCK_AZURE_SIGNED_URI = "http://this_is_a_mock_sas_for_azure"
-MOCK_ADL_GEN2_SIGNED_URI = "http://this_is_a_mock_sas_for_ADL Gen2"
+MOCK_ADL_GEN2_SIGNED_URI = "http://this_is_a_mock_sas_for_adl_gen2"
 MOCK_AWS_SIGNED_URI = "http://this_is_a_mock_presigned_uri_for_aws?"
 MOCK_GCP_SIGNED_URL = "http://this_is_a_mock_signed_url_for_gcp?"
 MOCK_RUN_ID = "MOCK-RUN-ID"

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -384,7 +384,7 @@ class TestDatabricksArtifactRepository:
                 type=ArtifactCredentialType.AZURE_ADLS_GEN2_SAS_URI,
             )
             write_credential_infos_mock.return_value = [mock_credential_info]
-            with pytest.raises(MlflowException, match=r".+"):
+            with pytest.raises(MlflowException, match=r"MOCK ERROR"):
                 databricks_artifact_repo.log_artifact(test_file.strpath)
             write_credential_infos_mock.assert_called_with(run_id=MOCK_RUN_ID, paths=ANY)
             request_mock.assert_any_call(


### PR DESCRIPTION
Signed-off-by: Mingyu Li <mingyu.li@databricks.com>
## Changes 
**Added unit test**
<img width="1552" alt="Screen Shot 2022-09-20 at 5 59 19 PM" src="https://user-images.githubusercontent.com/12734110/191391021-e6efe18b-2051-408c-8972-7440c2f59f77.png">

**Minor improvement to avoid fetching credentials more times than needed when initial credentials expires**

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->


## What changes are proposed in this pull request?



## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->


<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
