### PR TITLE
Spark session jupyter

### DIFF
--- a/mlflow/pipelines/steps/ingest/datasets.py
+++ b/mlflow/pipelines/steps/ingest/datasets.py
@@ -508,7 +508,7 @@ class _SparkDatasetMixin:
             else:
                 spark_session = _create_spark_session()
                 _logger.info("Creating new spark session")
-                return spark_session
+            return spark_session
         except Exception as e:
             raise MlflowException(
                 message=(

--- a/mlflow/pipelines/steps/ingest/datasets.py
+++ b/mlflow/pipelines/steps/ingest/datasets.py
@@ -26,7 +26,10 @@ from mlflow.utils.file_utils import (
     read_parquet_as_pandas_df,
     download_file_using_http_uri,
 )
-from mlflow.utils._spark_utils import _get_active_spark_session, _create_spark_session
+from mlflow.utils._spark_utils import (
+    _get_active_spark_session,
+    _create_local_spark_session_for_pipelines,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -506,7 +509,7 @@ class _SparkDatasetMixin:
             if spark_session:
                 _logger.info("Found active spark session")
             else:
-                spark_session = _create_spark_session()
+                spark_session = _create_local_spark_session_for_pipelines()
                 _logger.info("Creating new spark session")
             return spark_session
         except Exception as e:

--- a/mlflow/pipelines/steps/ingest/datasets.py
+++ b/mlflow/pipelines/steps/ingest/datasets.py
@@ -504,10 +504,10 @@ class _SparkDatasetMixin:
         try:
             spark_session = _get_active_spark_session()
             if spark_session:
-                _logger.info("found active spark session")
+                _logger.info("Found active spark session")
             else:
                 spark_session = _create_spark_session()
-                _logger.info("creating new spark session")
+                _logger.info("Creating new spark session")
                 return spark_session
         except Exception as e:
             raise MlflowException(

--- a/mlflow/pipelines/steps/predict.py
+++ b/mlflow/pipelines/steps/predict.py
@@ -10,7 +10,10 @@ from mlflow.pipelines.step import BaseStep
 from mlflow.pipelines.utils.execution import get_step_output_path
 from mlflow.pipelines.utils.step import get_pandas_data_profile
 from mlflow.utils.file_utils import write_spark_dataframe_to_parquet_on_local_disk
-from mlflow.utils._spark_utils import _get_active_spark_session
+from mlflow.utils._spark_utils import (
+    _get_active_spark_session,
+    _create_local_spark_session_for_pipelines,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -80,6 +83,11 @@ class PredictStep(BaseStep):
         # Get or create spark session
         try:
             spark = _get_active_spark_session()
+            if spark:
+                _logger.info("Found active spark session")
+            else:
+                spark = _create_local_spark_session_for_pipelines()
+                _logger.info("Creating new spark session")
         except Exception as e:
             raise MlflowException(
                 message=(

--- a/mlflow/utils/_spark_utils.py
+++ b/mlflow/utils/_spark_utils.py
@@ -17,6 +17,23 @@ def _get_active_spark_session():
         return SparkSession._instantiatedSession
 
 
+def _create_spark_session():
+    try:
+        from pyspark.sql import SparkSession
+    except ImportError:
+        # Return None if user doesn't have PySpark installed
+        return None
+    return (
+        SparkSession.builder.master("local[*]")
+        .config("spark.jars.packages", "io.delta:delta-core_2.12:1.2.1")
+        .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+        .config(
+            "spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog"
+        )
+        .getOrCreate()
+    )
+
+
 class _SparkDirectoryDistributor:
     """Distribute spark directory from driver to executors."""
 

--- a/mlflow/utils/_spark_utils.py
+++ b/mlflow/utils/_spark_utils.py
@@ -17,7 +17,9 @@ def _get_active_spark_session():
         return SparkSession._instantiatedSession
 
 
-def _create_spark_session():
+def _create_local_spark_session_for_pipelines():
+    """Create a sparksession to be used within an pipeline step run in a subprocess locally."""
+
     try:
         from pyspark.sql import SparkSession
     except ImportError:

--- a/tests/pipelines/test_ingest_step.py
+++ b/tests/pipelines/test_ingest_step.py
@@ -535,6 +535,26 @@ def test_ingest_throws_when_spark_unavailable_for_spark_based_dataset(spark_df, 
 
 
 @pytest.mark.usefixtures("enter_test_pipeline_directory")
+def test_ingest_makes_spark_session_if_not_available_for_spark_based_dataset(spark_df, tmp_path):
+    dataset_path = tmp_path / "test.delta"
+    spark_df.write.format("delta").save(str(dataset_path))
+
+    with mock.patch(
+        "mlflow.utils._spark_utils._get_active_spark_session",
+    ) as _get_active_spark_session:
+        _get_active_spark_session.return_value = None
+        IngestStep.from_pipeline_config(
+            pipeline_config={
+                "data": {
+                    "format": "delta",
+                    "location": str(dataset_path),
+                }
+            },
+            pipeline_root=os.getcwd(),
+        ).run(output_directory=tmp_path)
+
+
+@pytest.mark.usefixtures("enter_test_pipeline_directory")
 def test_ingest_throws_when_dataset_format_unspecified():
     with pytest.raises(MlflowException, match="Dataset format must be specified"):
         IngestStep.from_pipeline_config(


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
https://github.com/mlflow/mlflow/issues/6369

## What changes are proposed in this pull request?

Creates a new spark session when spark is not available (such as when run on a subprocess via make).

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixing a bug where MLflow pipeline commands run via subprocess were not able to access a spark session by creating a new spark session in the subprocess.


### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
