### PR TITLE
Expand pytorch input options to iterable schemas

### DIFF
--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -322,15 +322,17 @@ def test_pyfunc_model_works_with_np_input_type(
     assert type(np_result) == np.ndarray
     np.testing.assert_array_almost_equal(np_result[:, 0], sequential_predicted, decimal=4)
 
-    # predict does not work with lists
+    # predict does not work with scalars
     with pytest.raises(
-        TypeError, match="The PyTorch flavor does not support List or Dict input types"
+        TypeError, match="Input data should be pandas.DataFrame, torch.Tensor, or numpy.ndarray"
+    ):
+        pyfunc_loaded.predict(4)
+
+    # predict also fails to work with lists of scalars
+    with pytest.raises(
+        TypeError, match="Input data should be pandas.DataFrame, torch.Tensor, or numpy.ndarray"
     ):
         pyfunc_loaded.predict([1, 2, 3, 4])
-
-    # predict does not work with scalars
-    with pytest.raises(TypeError, match="Input data should be pandas.DataFrame or numpy.ndarray"):
-        pyfunc_loaded.predict(4)
 
 
 @pytest.mark.parametrize("scripted_model", [True, False])

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -635,8 +635,6 @@ def test_load_model_succeeds_with_dependencies_specified_via_code_paths(
         def predict(self, context, model_input):
             # pylint: disable=unused-argument
             with torch.no_grad():
-                # context_tensor = context if context is not None else torch.empty(0)
-                # del context_tensor #pylint: disable=unused-variable
                 input_tensor = torch.from_numpy(model_input.values.astype(np.float32))
                 output_tensor = self.pytorch_model(input_tensor)
                 return pd.DataFrame(output_tensor.numpy())

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -633,7 +633,10 @@ def test_load_model_succeeds_with_dependencies_specified_via_code_paths(
             self.pytorch_model = mlflow.pytorch.load_model(context.artifacts["pytorch_model"])
 
         def predict(self, context, model_input):
+            # pylint: disable=unused-argument
             with torch.no_grad():
+                # context_tensor = context if context is not None else torch.empty(0)
+                # del context_tensor #pylint: disable=unused-variable
                 input_tensor = torch.from_numpy(model_input.values.astype(np.float32))
                 output_tensor = self.pytorch_model(input_tensor)
                 return pd.DataFrame(output_tensor.numpy())


### PR DESCRIPTION
This proposed change eliminates the requirements for the input to a PyTorch model to be a single input/output numpy array, independent of the schema used by the model.

## Related Issues/PRs

See https://github.com/mlflow/mlflow/issues/6820:


### Motivation

> #### What is the use case for this feature?

Mlflow allows considerable flexibility to define a model's signature. Supporting PyTorch is obviously something the Mlflow team strives for (as indicated by the website).

However, the PyTorch wrapper will straight up fail if
1. The input is not a numpy or pandas type - it will even fail if fed a pytorch tensor!
2. An iterable of tensor types
3. Input / Output schemas that would normally be supported by other Mlflow model flavors.

These limitations are not mentioned for other model flavors.

For PyTorch specifically, this is an issue. Increasingly many use cases involve the use of pre-trained models, for instance from HuggingFace.
HuggingFace models specifically take a dict-like input, and thus can not be used.
Similar cases can be made for more complex DL models, for instance

-> Language models with masking tensors
-> Transformer models with memory embeddings of some sort
-> Tabular transformer-models with categorical / continuous tensor inputs (that are embedded differently)
->  Contrastive learning models
-> Retrieval models with paired attention or cross attention
-> Neural search, retrieval enhanced models
-> and many, many more

> #### Why is this use case valuable to support for MLflow users in general?

PyTorch is now the dominant machine learning framework for deep learning models. Mlflow users will want to use deep learning models which typically require more flexible input and output signatures.

> #### Why is this use case valuable to support for your project(s) or organization?

We seek to deploy and train PyTorch models and immediately ran into this issue.

> #### Why is it currently difficult to achieve this use case?

Few SOTA models natively run a single input tensor and a single output tensor. 

## What changes are proposed in this pull request?

Simply expanded the input check for models to 

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

I am unsure about how to test, but I'd recommend just running the current testing suite to see if - as expected - this change does not affect outputs

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Allow PyTorch Model flavor to load inputs and output tensor types in lists, dicts, OrderedDicts etc.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
