### PR TITLE
minor UI fixes in train output card

### DIFF
--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -266,7 +266,7 @@ class TrainStep(BaseStep):
         except Exception as e:
             _logger.warning("Failed to build model leaderboard due to unexpected failure: %s", e)
         tuning_df = None
-        if best_estimator_params:
+        if self.step_config["tuning_enabled"]:
             try:
                 tuning_df = self._get_tuning_df(run, params=best_estimator_params.keys())
             except Exception as e:
@@ -285,7 +285,6 @@ class TrainStep(BaseStep):
             output_directory=output_directory,
             leaderboard_df=leaderboard_df,
             tuning_df=tuning_df,
-            best_estimator_params=best_estimator_params,
         )
         card.save_as_html(output_directory)
         for step_name in ("ingest", "split", "transform", "train"):
@@ -425,7 +424,6 @@ class TrainStep(BaseStep):
         output_directory,
         leaderboard_df=None,
         tuning_df=None,
-        best_estimator_params=None,
     ):
         import pandas as pd
         from sklearn.utils import estimator_html_repr
@@ -519,7 +517,7 @@ class TrainStep(BaseStep):
             )
 
         # Tab 7: Best Parameters
-        if best_estimator_params:
+        if self.step_config["tuning_enabled"]:
             best_parameters_card_tab = card.add_tab(
                 "Best Parameters",
                 "{{ BEST_PARAMETERS }} ",

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -823,7 +823,7 @@ class TrainStep(BaseStep):
             else:
                 best_hp_params = {}
                 best_hardcoded_params = estimator_hardcoded_params
-
+        best_hardcoded_params = {}
         best_combined_params = dict(estimator_hardcoded_params, **best_hp_params)
         self._write_tuning_yaml_outputs(best_hp_params, best_hardcoded_params, output_directory)
         return best_combined_params

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -408,8 +408,10 @@ class TrainStep(BaseStep):
             )
         else:
             tuning_runs = tuning_runs.filter([f"metrics.{self.primary_metric}_on_data_validation"])
-        tuning_runs = tuning_runs.reset_index().rename(columns={"index": "Model Rank"})
-        return tuning_runs
+        tuning_runs = tuning_runs.reset_index().rename(
+            columns={"index": "Model Rank", primary_metric_tag: self.primary_metric}
+        )
+        return tuning_runs.head(10)
 
     def _build_step_card(
         self,

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -807,12 +807,12 @@ class TrainStep(BaseStep):
             early_stop_fn = getattr(importlib.import_module(train_module_name), early_stop_fn_name)
             fmin_kwargs["early_stop_fn"] = early_stop_fn
         best_hp_params = fmin(**fmin_kwargs)
+        best_hp_params = space_eval(search_space, best_hp_params)
         best_hp_estimator_loss = hp_trials.best_trial["result"]["loss"]
         if len(estimator_hardcoded_params) > 1:
             hardcoded_estimator_loss = objective(
                 X_train, y_train, validation_df, estimator_hardcoded_params
             )
-            best_hp_params = space_eval(search_space, best_hp_params)
 
             if best_hp_estimator_loss < hardcoded_estimator_loss:
                 best_hardcoded_params = {

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -398,7 +398,7 @@ class TrainStep(BaseStep):
         tuning_runs = mlflow.search_runs(
             [exp_id],
             filter_string=f"tags.mlflow.parentRunId like '{run.info.run_id}'",
-            order_by=[f"{primary_metric_tag} {order_str}"],
+            order_by=[f"{primary_metric_tag} {order_str}", "start_time ASC"],
         )
         if params:
             params = [f"params.{param}" for param in params]

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -518,7 +518,46 @@ class TrainStep(BaseStep):
                 )
             )
 
-        # Tab 7: Run summary.
+        # Tab 7: Best Parameters
+        if best_estimator_params:
+            best_parameters_card_tab = card.add_tab(
+                "Best Parameters",
+                "{{ BEST_PARAMETERS }} ",
+            )
+            best_parameters_yaml = os.path.join(output_directory, "best_parameters.yaml")
+            if os.path.exists(best_parameters_yaml):
+                best_hardcoded_parameters = open(best_parameters_yaml).read()
+                best_parameters_card_tab.add_html(
+                    "BEST_PARAMETERS",
+                    f"<b>Best parameters:</b><br>"
+                    f"<pre>{best_hardcoded_parameters}</pre><br><br>",
+                )
+
+        # Tab 8: HP trials
+        if tuning_df is not None:
+            tuning_trials_card_tab = card.add_tab(
+                "Tuning Trials",
+                "{{ SEARCH_SPACE }}" + "{{ TUNING_TABLE_TITLE }}" + "{{ TUNING_TABLE }}",
+            )
+            tuning_params = yaml.dump(self.step_config["tuning"]["parameters"])
+            tuning_trials_card_tab.add_html(
+                "SEARCH_SPACE",
+                f"<b>Tuning search space:</b> <br><pre>{tuning_params}</pre><br><br>",
+            )
+            tuning_trials_card_tab.add_html("TUNING_TABLE_TITLE", "<b>Tuning results:</b><br>")
+            tuning_trials_card_tab.add_html(
+                "TUNING_TABLE",
+                BaseCard.render_table(
+                    tuning_df.style.apply(
+                        lambda row: pd.Series("font-weight: bold", row.index),
+                        axis=1,
+                        subset=tuning_df.index[0],
+                    ),
+                    hide_index=True,
+                ),
+            )
+
+        # Tab 9: Run summary.
         run_card_tab = card.add_tab(
             "Run Summary",
             "{{ RUN_ID }} " + "{{ MODEL_URI }}" + "{{ EXE_DURATION }}" + "{{ LAST_UPDATE_TIME }}",
@@ -546,45 +585,6 @@ class TrainStep(BaseStep):
             )
         else:
             run_card_tab.add_markdown("MODEL_URI", f"**MLflow Model URI:** `{model_uri}`")
-
-        # Tab 8: Best Parameters
-        if best_estimator_params:
-            best_parameters_card_tab = card.add_tab(
-                "Best Parameters",
-                "{{ BEST_PARAMETERS }} ",
-            )
-            best_parameters_yaml = os.path.join(output_directory, "best_parameters.yaml")
-            if os.path.exists(best_parameters_yaml):
-                best_hardcoded_parameters = open(best_parameters_yaml).read()
-                best_parameters_card_tab.add_html(
-                    "BEST_PARAMETERS",
-                    f"<b>Best parameters:</b><br>"
-                    f"<pre>{best_hardcoded_parameters}</pre><br><br>",
-                )
-
-        # Tab 9: HP trials
-        if tuning_df is not None:
-            tuning_trials_card_tab = card.add_tab(
-                "Tuning Trials",
-                "{{ SEARCH_SPACE }}" + "{{ TUNING_TABLE_TITLE }}" + "{{ TUNING_TABLE }}",
-            )
-            tuning_params = yaml.dump(self.step_config["tuning"]["parameters"])
-            tuning_trials_card_tab.add_html(
-                "SEARCH_SPACE",
-                f"<b>Tuning search space:</b> <br><pre>{tuning_params}</pre><br><br>",
-            )
-            tuning_trials_card_tab.add_html("TUNING_TABLE_TITLE", "<b>Tuning results:</b><br>")
-            tuning_trials_card_tab.add_html(
-                "TUNING_TABLE",
-                BaseCard.render_table(
-                    tuning_df.style.apply(
-                        lambda row: pd.Series("font-weight: bold", row.index),
-                        axis=1,
-                        subset=tuning_df.index[0],
-                    ),
-                    hide_index=True,
-                ),
-            )
 
         return card
 

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -410,6 +410,7 @@ class TrainStep(BaseStep):
         tuning_runs = tuning_runs.reset_index().rename(
             columns={"index": "Model Rank", primary_metric_tag: self.primary_metric}
         )
+        tuning_runs["Model Rank"] += 1
         return tuning_runs.head(10)
 
     def _build_step_card(

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -398,7 +398,7 @@ class TrainStep(BaseStep):
         tuning_runs = mlflow.search_runs(
             [exp_id],
             filter_string=f"tags.mlflow.parentRunId like '{run.info.run_id}'",
-            order_by=[f"{primary_metric_tag} {order_str}", "start_time ASC"],
+            order_by=[f"{primary_metric_tag} {order_str}", "attribute.start_time ASC"],
         )
         if params:
             params = [f"params.{param}" for param in params]

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -808,20 +808,21 @@ class TrainStep(BaseStep):
             fmin_kwargs["early_stop_fn"] = early_stop_fn
         best_hp_params = fmin(**fmin_kwargs)
         best_hp_estimator_loss = hp_trials.best_trial["result"]["loss"]
-        hardcoded_estimator_loss = objective(
-            X_train, y_train, validation_df, estimator_hardcoded_params
-        )
-        best_hp_params = space_eval(search_space, best_hp_params)
+        if len(estimator_hardcoded_params) > 1:
+            hardcoded_estimator_loss = objective(
+                X_train, y_train, validation_df, estimator_hardcoded_params
+            )
+            best_hp_params = space_eval(search_space, best_hp_params)
 
-        if best_hp_estimator_loss < hardcoded_estimator_loss:
-            best_hardcoded_params = {
-                param_name: param_value
-                for param_name, param_value in estimator_hardcoded_params.items()
-                if param_name not in best_hp_params
-            }
-        else:
-            best_hp_params = {}
-            best_hardcoded_params = estimator_hardcoded_params
+            if best_hp_estimator_loss < hardcoded_estimator_loss:
+                best_hardcoded_params = {
+                    param_name: param_value
+                    for param_name, param_value in estimator_hardcoded_params.items()
+                    if param_name not in best_hp_params
+                }
+            else:
+                best_hp_params = {}
+                best_hardcoded_params = estimator_hardcoded_params
 
         best_combined_params = dict(estimator_hardcoded_params, **best_hp_params)
         self._write_tuning_yaml_outputs(best_hp_params, best_hardcoded_params, output_directory)

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -823,7 +823,8 @@ class TrainStep(BaseStep):
             else:
                 best_hp_params = {}
                 best_hardcoded_params = estimator_hardcoded_params
-        best_hardcoded_params = {}
+        else:
+            best_hardcoded_params = {}
         best_combined_params = dict(estimator_hardcoded_params, **best_hp_params)
         self._write_tuning_yaml_outputs(best_hp_params, best_hardcoded_params, output_directory)
         return best_combined_params

--- a/tests/pipelines/test_train_step.py
+++ b/tests/pipelines/test_train_step.py
@@ -266,7 +266,7 @@ def test_train_step_with_tuning_child_runs_and_early_stop(tmp_pipeline_root_path
     assert "params.penalty" in child_runs.columns
     assert "params.eta0" in child_runs.columns
 
-    ordered_metrics = list(child_runs["metrics.root_mean_squared_error_on_data_validation"])
+    ordered_metrics = list(child_runs["root_mean_squared_error"])
     assert ordered_metrics == sorted(ordered_metrics)
 
 

--- a/tests/pipelines/test_train_step.py
+++ b/tests/pipelines/test_train_step.py
@@ -60,8 +60,18 @@ def setup_train_dataset(pipeline_root: Path):
 
 
 # Sets up the constructed TrainStep instance
-def setup_train_step(pipeline_root: Path, use_tuning: bool):
+def setup_train_step(pipeline_root: Path, use_tuning: bool, with_hardcoded_params: bool = True):
     pipeline_yaml = pipeline_root.joinpath(_PIPELINE_CONFIG_FILE_NAME)
+    if with_hardcoded_params:
+        estimator_params = """
+                    estimator_params:
+                        alpha: 0.1
+                        penalty: l1
+                        eta0: 0.1
+                        fit_intercept: true
+        """
+    else:
+        estimator_params = ""
     if use_tuning:
         pipeline_yaml.write_text(
             """
@@ -77,10 +87,7 @@ def setup_train_step(pipeline_root: Path, use_tuning: bool):
                 train:
                     using: estimator_spec
                     estimator_method: tests.pipelines.test_train_step.estimator_fn
-                    estimator_params:
-                        alpha: 0.1
-                        penalty: l1
-                        eta0: 0.1
+                    {estimator_params}
                     tuning:
                         enabled: true
                         max_trials: 2
@@ -98,7 +105,7 @@ def setup_train_step(pipeline_root: Path, use_tuning: bool):
                                 mu: 0.01
                                 sigma: 0.0001     
             """.format(
-                tracking_uri=mlflow.get_tracking_uri()
+                tracking_uri=mlflow.get_tracking_uri(), estimator_params=estimator_params
             )
         )
     else:
@@ -246,6 +253,30 @@ def test_train_step_with_tuning_best_parameters(tmp_pipeline_root_path):
     assert "alpha" in parent_run_params
     assert "penalty" in parent_run_params
     assert "eta0" in parent_run_params
+
+
+@pytest.mark.parametrize(
+    "with_hardcoded_params, expected_num_tuned, expected_num_hardcoded",
+    [(True, 3, 1), (False, 3, 0)],
+)
+def test_train_step_with_tuning_output_yaml_correct(
+    tmp_pipeline_root_path, with_hardcoded_params, expected_num_tuned, expected_num_hardcoded
+):
+    with mock.patch.dict(
+        os.environ, {_MLFLOW_PIPELINES_EXECUTION_DIRECTORY_ENV_VAR: str(tmp_pipeline_root_path)}
+    ):
+        train_step_output_dir = setup_train_dataset(tmp_pipeline_root_path)
+        train_step = setup_train_step(
+            tmp_pipeline_root_path, use_tuning=True, with_hardcoded_params=with_hardcoded_params
+        )
+        train_step._run(str(train_step_output_dir))
+    assert (train_step_output_dir / "best_parameters.yaml").exists()
+
+    with open(os.path.join(train_step_output_dir, "best_parameters.yaml")) as f:
+        lines = f.readlines()
+        assert lines[0] == "# tuned hyperparameters\n"
+        assert lines[expected_num_tuned + 2] == "# hardcoded parameters\n"
+        assert len(lines) == expected_num_tuned + expected_num_hardcoded + 3
 
 
 def test_train_step_with_tuning_child_runs_and_early_stop(tmp_pipeline_root_path):


### PR DESCRIPTION
Signed-off-by: Prithvi Kannan <prithvi.kannan@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

* show only top 10 and clean metric name in tuning results
* move run summary to last tab
* call `_get_tuning_df` whenever tuning is enabled
* only run "baseline" if hardcoded parameters are specified 

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
