### PR TITLE
Merge train/validation/test profiles into one card in the split step

### DIFF
--- a/mlflow/pipelines/steps/ingest/__init__.py
+++ b/mlflow/pipelines/steps/ingest/__init__.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from mlflow.exceptions import MlflowException
 from mlflow.pipelines.cards import BaseCard
 from mlflow.pipelines.step import BaseStep
-from mlflow.pipelines.utils.step import get_pandas_data_profile
+from mlflow.pipelines.utils.step import get_pandas_data_profiles
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.utils.file_utils import read_parquet_as_pandas_df
 from mlflow.pipelines.steps.ingest.datasets import (
@@ -76,8 +76,8 @@ class BaseIngestStep(BaseStep, metaclass=abc.ABCMeta):
         ingested_dataset_profile = None
         if not self.skip_data_profiling:
             _logger.info("Profiling ingested dataset")
-            ingested_dataset_profile = get_pandas_data_profile(
-                ingested_df, "Profile of Ingested Dataset"
+            ingested_dataset_profile = get_pandas_data_profiles(
+                [["Profile of Ingested Dataset", ingested_df]]
             )
             dataset_profile_path = Path(
                 str(os.path.join(output_directory, BaseIngestStep._DATASET_PROFILE_OUTPUT_NAME))

--- a/mlflow/pipelines/steps/predict.py
+++ b/mlflow/pipelines/steps/predict.py
@@ -8,7 +8,7 @@ from mlflow.exceptions import MlflowException, BAD_REQUEST, INVALID_PARAMETER_VA
 from mlflow.pipelines.cards import BaseCard
 from mlflow.pipelines.step import BaseStep
 from mlflow.pipelines.utils.execution import get_step_output_path
-from mlflow.pipelines.utils.step import get_pandas_data_profile
+from mlflow.pipelines.utils.step import get_pandas_data_profiles
 from mlflow.utils.file_utils import write_spark_dataframe_to_parquet_on_local_disk
 from mlflow.utils._spark_utils import _get_active_spark_session
 
@@ -47,7 +47,9 @@ class PredictStep(BaseStep):
                 sample_percentage = _MAX_PROFILE_SIZE / scored_size
                 scored_sdf = scored_sdf.sample(sample_percentage)
             scored_df = scored_sdf.toPandas()
-            scored_dataset_profile = get_pandas_data_profile(scored_df, "Profile of Scored Dataset")
+            scored_dataset_profile = get_pandas_data_profiles(
+                [["Profile of Scored Dataset", scored_df]]
+            )
 
             # Optional tab : data profile for scored data:
             card.add_tab("Scored Data Profile", "{{PROFILE}}").add_pandas_profile(

--- a/mlflow/pipelines/steps/split.py
+++ b/mlflow/pipelines/steps/split.py
@@ -8,7 +8,7 @@ from typing import Dict, Any
 from mlflow.pipelines.cards import BaseCard
 from mlflow.pipelines.step import BaseStep
 from mlflow.pipelines.utils.execution import get_step_output_path
-from mlflow.pipelines.utils.step import get_pandas_data_profile
+from mlflow.pipelines.utils.step import get_pandas_data_profiles
 from mlflow.exceptions import MlflowException, INVALID_PARAMETER_VALUE
 
 
@@ -117,28 +117,17 @@ class SplitStep(BaseStep):
 
         if not self.skip_data_profiling:
             # Build profiles for input dataset, and train / validation / test splits
-            train_profile = get_pandas_data_profile(
-                train_df.reset_index(drop=True),
-                "Profile of Train Dataset",
-            )
-            validation_profile = get_pandas_data_profile(
-                validation_df.reset_index(drop=True),
-                "Profile of Validation Dataset",
-            )
-            test_profile = get_pandas_data_profile(
-                test_df.reset_index(drop=True),
-                "Profile of Test Dataset",
+            data_profile = get_pandas_data_profiles(
+                [
+                    ["Train", train_df.reset_index(drop=True)],
+                    ["Validation", validation_df.reset_index(drop=True)],
+                    ["Test", test_df.reset_index(drop=True)],
+                ]
             )
 
             # Tab #1 - #3: data profiles for train/validation and test.
-            card.add_tab("Data Profile (Train)", "{{PROFILE}}").add_pandas_profile(
-                "PROFILE", train_profile
-            )
-            card.add_tab("Data Profile (Validation)", "{{PROFILE}}").add_pandas_profile(
-                "PROFILE", validation_profile
-            )
-            card.add_tab("Data Profile (Test)", "{{PROFILE}}").add_pandas_profile(
-                "PROFILE", test_profile
+            card.add_tab("Compare Splits", "{{PROFILE}}").add_pandas_profile(
+                "PROFILE", data_profile
             )
 
         # Tab #4: run summary.

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -22,7 +22,10 @@ from mlflow.pipelines.utils.metrics import (
     _get_custom_metrics,
     _load_custom_metric_functions,
 )
-from mlflow.pipelines.utils.step import get_merged_eval_metrics, get_pandas_data_profile
+from mlflow.pipelines.utils.step import (
+    get_merged_eval_metrics,
+    get_pandas_data_profiles,
+)
 from mlflow.pipelines.utils.tracking import (
     get_pipeline_tracking_config,
     apply_pipeline_tracking_config,
@@ -367,9 +370,13 @@ class TrainStep(BaseStep):
 
         if not self.skip_data_profiling:
             # Tab 2: Prediction and error data profile.
-            pred_and_error_df_profile = get_pandas_data_profile(
-                pred_and_error_df.reset_index(drop=True),
-                "Predictions and Errors (Validation Dataset)",
+            pred_and_error_df_profile = get_pandas_data_profiles(
+                [
+                    [
+                        "Predictions and Errors (Validation Dataset)",
+                        pred_and_error_df.reset_index(drop=True),
+                    ]
+                ]
             )
             card.add_tab("Profile of Predictions and Errors", "{{PROFILE}}").add_pandas_profile(
                 "PROFILE", pred_and_error_df_profile

--- a/mlflow/pipelines/steps/transform.py
+++ b/mlflow/pipelines/steps/transform.py
@@ -11,7 +11,7 @@ from mlflow.exceptions import MlflowException, INVALID_PARAMETER_VALUE
 from mlflow.pipelines.cards import BaseCard
 from mlflow.pipelines.step import BaseStep
 from mlflow.pipelines.utils.execution import get_step_output_path
-from mlflow.pipelines.utils.step import get_pandas_data_profile
+from mlflow.pipelines.utils.step import get_pandas_data_profiles
 from mlflow.pipelines.utils.tracking import get_pipeline_tracking_config
 
 _logger = logging.getLogger(__name__)
@@ -127,13 +127,11 @@ class TransformStep(BaseStep):
 
         if not self.skip_data_profiling:
             # Tab 1 and 2: build profiles for train_transformed, validation_transformed
-            train_transformed_profile = get_pandas_data_profile(
-                train_transformed,
-                "Profile of Train Transformed Dataset",
+            train_transformed_profile = get_pandas_data_profiles(
+                [["Profile of Train Transformed Dataset", train_transformed]]
             )
-            validation_transformed_profile = get_pandas_data_profile(
-                validation_transformed,
-                "Profile of Validation Transformed Dataset",
+            validation_transformed_profile = get_pandas_data_profiles(
+                [["Profile of Validation Transformed Dataset", validation_transformed]]
             )
             card.add_tab("Data Profile (Train Transformed)", "{{PROFILE}}").add_pandas_profile(
                 "PROFILE", train_transformed_profile

--- a/mlflow/pipelines/utils/step.py
+++ b/mlflow/pipelines/utils/step.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import pandas as pd
 from mlflow.pipelines.cards import pandas_renderer
 
 from mlflow.exceptions import MlflowException, INVALID_PARAMETER_VALUE
@@ -7,7 +8,7 @@ from mlflow.utils.databricks_utils import (
     is_running_in_ipython_environment,
     is_in_databricks_runtime,
 )
-from typing import Dict, List
+from typing import Dict, List, Iterable, Tuple
 
 _logger = logging.getLogger(__name__)
 
@@ -105,15 +106,28 @@ def _get_pool_size():
     return 1 if "PYTEST_CURRENT_TEST" in os.environ and os.name == "nt" else 0
 
 
-def get_pandas_data_profile(data_frame, title: str):
-    """Returns a data profiling object over input data frame.
+def get_pandas_data_profiles(inputs: Iterable[Tuple[str, pd.DataFrame]]) -> str:
+    """
+    Returns a data profiling string over input data frame.
 
-    :param data_frame: DataFrame, contains data to be profiled.
+    :param inputs: Either a single "glimpse" DataFrame that contains the statistics, or a
+    collection of (title, DataFrame) pairs where each pair names a separate "glimpse"
+    and they are all visualized in comparison mode.
+    :return: a data profiling string such as Pandas profiling ProfileReport.
+    """
+    truncated_input = list(map(lambda input: truncate_pandas_data_profile(*input), inputs))
+    return pandas_renderer.get_html(truncated_input)
+
+
+def truncate_pandas_data_profile(title: str, data_frame) -> str:
+    """Returns a data profiling string over input data frame.
+
     :param title: String, the title of the data profile.
-    :return: a data profiling object such as Pandas profiling ProfileReport.
+    :param data_frame: DataFrame, contains data to be profiled.
+    :return: a data profiling string such as Pandas profiling ProfileReport.
     """
     if len(data_frame) == 0:
-        pandas_renderer.get_html([[title, data_frame]])
+        return (title, data_frame)
 
     max_cells = min(data_frame.size, _MAX_PROFILE_CELL_SIZE)
     max_cols = min(data_frame.columns.size, _MAX_PROFILE_COL_SIZE)
@@ -133,4 +147,4 @@ def get_pandas_data_profile(data_frame, title: str):
             max_cols,
             max_rows,
         )
-    return pandas_renderer.get_html([[title, truncated_df]])
+    return (title, truncated_df)

--- a/tests/pipelines/test_ingest_step.py
+++ b/tests/pipelines/test_ingest_step.py
@@ -641,7 +641,7 @@ def test_ingest_skips_profiling_when_specified(pandas_df, tmp_path):
     dataset_path = tmp_path / "df.parquet"
     pandas_df.to_parquet(dataset_path)
 
-    with mock.patch("mlflow.pipelines.utils.step.get_pandas_data_profile") as mock_profiling:
+    with mock.patch("mlflow.pipelines.utils.step.get_pandas_data_profiles") as mock_profiling:
         IngestStep.from_pipeline_config(
             pipeline_config={
                 "data": {

--- a/tests/pipelines/test_predict_step.py
+++ b/tests/pipelines/test_predict_step.py
@@ -309,7 +309,7 @@ def test_predict_skips_profiling_when_specified(
 ):
     model_name = "model_" + get_random_id()
     model_uri = train_log_and_register_model(model_name, is_dummy=True)
-    with mock.patch("mlflow.pipelines.utils.step.get_pandas_data_profile") as mock_profiling:
+    with mock.patch("mlflow.pipelines.utils.step.get_pandas_data_profiles") as mock_profiling:
         PredictStep.from_pipeline_config(
             {
                 "steps": {

--- a/tests/pipelines/test_split_step.py
+++ b/tests/pipelines/test_split_step.py
@@ -148,7 +148,7 @@ def test_split_step_skips_profiling_when_specified(tmp_path):
     with mock.patch.dict(
         os.environ, {_MLFLOW_PIPELINES_EXECUTION_DIRECTORY_ENV_VAR: str(tmp_path)}
     ), mock.patch(
-        "mlflow.pipelines.utils.step.get_pandas_data_profile"
+        "mlflow.pipelines.utils.step.get_pandas_data_profiles"
     ) as mock_profiling, mock.patch(
         "mlflow.pipelines.step.get_pipeline_name", return_value="fake_name"
     ):

--- a/tests/pipelines/test_step_utils.py
+++ b/tests/pipelines/test_step_utils.py
@@ -7,7 +7,8 @@ from mlflow.pipelines.cards import pandas_renderer
 from mlflow.pipelines.utils.step import (
     display_html,
     get_merged_eval_metrics,
-    get_pandas_data_profile,
+    truncate_pandas_data_profile,
+    get_pandas_data_profiles,
 )
 from pandas import DataFrame
 from unittest import mock
@@ -88,19 +89,23 @@ def test_get_data_profile_truncates_large_data_frame(
     step_utils._MAX_PROFILE_COL_SIZE = max_cols
     step_utils._MAX_PROFILE_ROW_SIZE = max_rows
     with mock.patch.object(pandas_renderer, "get_html") as mock_pandas_renderer_html:
-        get_pandas_data_profile(data_frame, "fake profile")
+        truncated_df = truncate_pandas_data_profile("fake profile", data_frame)
+        assert truncated_df[1].shape == (expected_rows, expected_cols)
+        get_pandas_data_profiles([["fake profile", data_frame]])
         # Initial index of [0][0][0] are from call_args_list to get the 0th call.
         # The next [0][1] are because of the pandas_renderer get_html API
-        # pandas_renderer.get_html([[title, truncated_df]])
-        truncated_df = mock_pandas_renderer_html.call_args_list[0][0][0][0][1]
-        assert truncated_df.shape == (expected_rows, expected_cols)
+        assert mock_pandas_renderer_html.call_args_list[0][0][0][0][1].shape == (
+            expected_rows,
+            expected_cols,
+        )
 
 
 def test_get_data_profile_works_for_empty_data_frame():
     with mock.patch.object(pandas_renderer, "get_html") as mock_pandas_renderer_html:
-        get_pandas_data_profile(DataFrame(), "fake profile")
+        data_frame = DataFrame()
+        truncated_df = truncate_pandas_data_profile("fake profile", data_frame)
+        assert truncated_df[1].shape == (0, 0)
+        get_pandas_data_profiles([["fake profile", data_frame]])
         # Initial index of [0][0][0] are from call_args_list to get the 0th call.
         # The next [0][1] are because of the pandas_renderer get_html API
-        # pandas_renderer.get_html([[title, truncated_df]])
-        truncated_df = mock_pandas_renderer_html.call_args_list[0][0][0][0][1]
-        assert truncated_df.shape == (0, 0)
+        assert mock_pandas_renderer_html.call_args_list[0][0][0][0][1].shape == (0, 0)


### PR DESCRIPTION
## What changes are proposed in this pull request?
Merge train/validation/test profiles into one card in the split step

## How is this patch tested?
- [x] Created a notebook to make sure this works
<img width="1703" alt="image" src="https://user-images.githubusercontent.com/5621432/191816154-58663936-596a-4594-befb-348277ff1209.png">


## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Merging split step profiles into 1 card for easy comparison of profiles

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
