### PR TITLE
Add logger documentation and set capture output for evaluate env restoration

### DIFF
--- a/docs/source/python_api/index.rst
+++ b/docs/source/python_api/index.rst
@@ -13,3 +13,19 @@ exposed in the :py:mod:`mlflow` module, so we recommend starting there.
 
 
 See also the :ref:`index of all functions and classes<genindex>`.
+
+Log Levels
+----------
+
+MLflow Python APIs log information during execution using the Python Logging API. You can 
+configure the log level for MLflow logs using the following code snippet. Learn more about how to 
+Python log levels at the
+`Python language logging guide <https://docs.python.org/3/howto/logging.html>`_.
+
+.. code-block:: py
+
+    import logging
+    logger = logging.getLogger("mlflow")
+
+    # Set log level to debugging
+    logger.setLevel(logging.DEBUG)

--- a/docs/source/python_api/index.rst
+++ b/docs/source/python_api/index.rst
@@ -18,8 +18,8 @@ Log Levels
 ----------
 
 MLflow Python APIs log information during execution using the Python Logging API. You can 
-configure the log level for MLflow logs using the following code snippet. Learn more about how to 
-Python log levels at the
+configure the log level for MLflow logs using the following code snippet. Learn more about Python
+log levels at the
 `Python language logging guide <https://docs.python.org/3/howto/logging.html>`_.
 
 .. code-block:: py

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -557,7 +557,10 @@ def _load_model_or_server(model_uri: str, env_manager: str):
         env_root_dir=env_root_dir,
     )
     _logger.info("Restoring model environment. This can take a few minutes.")
-    pyfunc_backend.prepare_env(model_uri=local_path, capture_output=False)
+    # Set capture_output to True in Databricks so that when environment preparation fails, the
+    # exception message of the notebook cell output will include child process command execution
+    # stdout/stderr output.
+    pyfunc_backend.prepare_env(model_uri=local_path, capture_output=is_in_databricks_runtime())
     server_port = find_free_port()
     scoring_server_proc = pyfunc_backend.serve(
         model_uri=local_path,


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

As title

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

I ran this MLflow evaluation workflows manually with environment restoration in Databricks two times. First with well defined dependencies, the second with a broken dependency. When the dependency was broken, the error message was surfaced. See screenshots:
Happy path
<img width="1824" alt="Screen Shot 2022-09-26 at 12 00 17 PM" src="https://user-images.githubusercontent.com/66143562/192358878-1d625a0d-5def-42a2-8dce-bc347a3376a8.png">
Sad path
<img width="1827" alt="Screen Shot 2022-09-26 at 12 01 45 PM" src="https://user-images.githubusercontent.com/66143562/192358913-c6d36fad-dd7b-427e-a2b8-29926c049ebb.png">

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly by following the steps below.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
