### PR TITLE
[do-not-merge][ML-25305] reduce logging output

### DIFF
--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -811,7 +811,7 @@ def _evaluate(
 
         _last_failed_evaluator = evaluator_name
         if evaluator.can_evaluate(model_type=model_type, evaluator_config=config):
-            _logger.info(f"Evaluating the model with the {evaluator_name} evaluator.")
+            _logger.debug(f"Evaluating the model with the {evaluator_name} evaluator.")
             eval_result = evaluator.evaluate(
                 model=model,
                 model_type=model_type,

--- a/mlflow/pipelines/steps/ingest/__init__.py
+++ b/mlflow/pipelines/steps/ingest/__init__.py
@@ -70,12 +70,12 @@ class BaseIngestStep(BaseStep, metaclass=abc.ABCMeta):
         self.dataset.resolve_to_parquet(
             dst_path=dataset_dst_path,
         )
-        _logger.info("Successfully stored data in parquet format at '%s'", dataset_dst_path)
+        _logger.debug("Successfully stored data in parquet format at '%s'", dataset_dst_path)
 
         ingested_df = read_parquet_as_pandas_df(data_parquet_path=dataset_dst_path)
         ingested_dataset_profile = None
         if not self.skip_data_profiling:
-            _logger.info("Profiling ingested dataset")
+            _logger.debug("Profiling ingested dataset")
             ingested_dataset_profile = get_pandas_data_profile(
                 ingested_df, "Profile of Ingested Dataset"
             )
@@ -83,7 +83,7 @@ class BaseIngestStep(BaseStep, metaclass=abc.ABCMeta):
                 str(os.path.join(output_directory, BaseIngestStep._DATASET_PROFILE_OUTPUT_NAME))
             )
             dataset_profile_path.write_text(ingested_dataset_profile, encoding="utf-8")
-            _logger.info(f"Wrote dataset profile to '{dataset_profile_path}'")
+            _logger.debug(f"Wrote dataset profile to '{dataset_profile_path}'")
 
         schema = pd.io.json.build_table_schema(ingested_df, index=False)
 

--- a/mlflow/pipelines/steps/ingest/datasets.py
+++ b/mlflow/pipelines/steps/ingest/datasets.py
@@ -237,7 +237,7 @@ class _DownloadThenConvertDataset(_LocationBasedDataset):
 
     def resolve_to_parquet(self, dst_path: str):
         with TempDir(chdr=True) as tmpdir:
-            _logger.info("Resolving input data from '%s'", self.location)
+            _logger.debug("Resolving input data from '%s'", self.location)
             local_dataset_path = _DownloadThenConvertDataset._download_dataset(
                 dataset_location=self.location,
                 dst_path=tmpdir.path(),
@@ -270,8 +270,8 @@ class _DownloadThenConvertDataset(_LocationBasedDataset):
                     )
                 dataset_file_paths = [local_dataset_path]
 
-            _logger.info("Resolved input data to '%s'", local_dataset_path)
-            _logger.info("Converting dataset to parquet format, if necessary")
+            _logger.debug("Resolved input data to '%s'", local_dataset_path)
+            _logger.debug("Converting dataset to parquet format, if necessary")
             return self._convert_to_parquet(
                 dataset_file_paths=dataset_file_paths,
                 dst_path=dst_path,
@@ -507,10 +507,10 @@ class _SparkDatasetMixin:
         try:
             spark_session = _get_active_spark_session()
             if spark_session:
-                _logger.info("Found active spark session")
+                _logger.debug("Found active spark session")
             else:
                 spark_session = _create_local_spark_session_for_pipelines()
-                _logger.info("Creating new spark session")
+                _logger.debug("Creating new spark session")
             return spark_session
         except Exception as e:
             raise MlflowException(

--- a/mlflow/pipelines/steps/split.py
+++ b/mlflow/pipelines/steps/split.py
@@ -76,7 +76,7 @@ def _create_hash_buckets(input_df):
         lambda x: (x % _SPLIT_HASH_BUCKET_NUM) / _SPLIT_HASH_BUCKET_NUM
     )
     execution_duration = time.time() - start_time
-    _logger.info(
+    _logger.debug(
         f"Creating hash buckets on input dataset containing {len(input_df)} "
         f"rows consumes {execution_duration} seconds."
     )
@@ -201,7 +201,7 @@ class SplitStep(BaseStep):
             post_split = getattr(
                 importlib.import_module(post_split_module_name), post_split_fn_name
             )
-            _logger.info(f"Running {post_split_fn_name} on train, validation and test datasets.")
+            _logger.debug(f"Running {post_split_fn_name} on train, validation and test datasets.")
             (train_df, validation_df, test_df) = post_split(train_df, validation_df, test_df)
         # Output train / validation / test splits
         train_df.to_parquet(os.path.join(output_directory, _OUTPUT_TRAIN_FILE_NAME))

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -119,7 +119,7 @@ class TrainStep(BaseStep):
             importlib.import_module(self.train_module_name), self.estimator_method_name
         )
         estimator = estimator_fn()
-        mlflow.autolog(log_models=False)
+        mlflow.autolog(log_models=False, silent=True)
 
         tags = {
             MLFLOW_SOURCE_TYPE: SourceType.to_string(SourceType.PIPELINE),

--- a/mlflow/pipelines/utils/execution.py
+++ b/mlflow/pipelines/utils/execution.py
@@ -328,8 +328,8 @@ class _ExecutionPlan:
         return pipeline_step_names[:first_step_index]
 
     def print(self) -> None:
-        for step in self.steps_cached:
-            _logger.info(self._FORMAT_STEPS_CACHED, step)
+        steps_cached_str = ", ".join(self.steps_cached)
+        _logger.info(self._FORMAT_STEPS_CACHED, steps_cached_str)
 
 
 def _run_make(

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -1,11 +1,14 @@
+import logging
+
 from mlflow.tracking.client import MlflowClient
 from mlflow.exceptions import MlflowException
 from mlflow.entities.model_registry import ModelVersion
 from mlflow.protos.databricks_pb2 import RESOURCE_ALREADY_EXISTS, ErrorCode
 from mlflow.store.artifact.runs_artifact_repo import RunsArtifactRepository
-from mlflow.utils.logging_utils import eprint
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from typing import Any, Dict, Optional
+
+_logger = logging.getLogger(__name__)
 
 
 def register_model(
@@ -63,12 +66,12 @@ def register_model(
     client = MlflowClient()
     try:
         create_model_response = client.create_registered_model(name)
-        eprint("Successfully registered model '%s'." % create_model_response.name)
+        _logger.debug("Successfully registered model '%s'.", create_model_response.name)
     except MlflowException as e:
         if e.error_code == ErrorCode.Name(RESOURCE_ALREADY_EXISTS):
-            eprint(
-                "Registered model '%s' already exists. Creating a new version of this model..."
-                % name
+            _logger.debug(
+                "Registered model '%s' already exists. Creating a new version of this model...",
+                name,
             )
         else:
             raise e
@@ -87,9 +90,8 @@ def register_model(
             tags=tags,
             await_creation_for=await_registration_for,
         )
-    eprint(
-        "Created version '{version}' of model '{model_name}'.".format(
-            version=create_version_response.version, model_name=create_version_response.name
-        )
+    _logger.info(
+        f"Created version '{create_version_response.version}' of model "
+        f"'{create_version_response.name}'."
     )
     return create_version_response

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -90,7 +90,7 @@ def register_model(
             tags=tags,
             await_creation_for=await_registration_for,
         )
-    _logger.info(
+    _logger.debug(
         f"Created version '{create_version_response.version}' of model "
         f"'{create_version_response.name}'."
     )

--- a/tests/pipelines/test_pipeline.py
+++ b/tests/pipelines/test_pipeline.py
@@ -336,9 +336,9 @@ def test_print_cached_steps_and_running_steps(capsys):
     captured = capsys.readouterr()
     output_info = captured.err
     cached_step_pattern = "{step}: No changes. Skipping."
-    for step in _STEP_NAMES:
-        # Check for printed message when every step is cached
-        assert re.search(cached_step_pattern.format(step=step), output_info) is not None
+    cached_steps = ", ".join(_STEP_NAMES)
+    # Check for printed message when steps are cached
+    assert re.search(cached_step_pattern.format(step=cached_steps), output_info) is not None
 
 
 @pytest.mark.usefixtures("enter_pipeline_example_directory")


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

* show cached step output in one line
* move ingest logging output to debug
* move split logging output to debug
* disable autologging output in train
* move debug logging output to debug
* fix schema precision warning by auto converting integer types to doubles
* change model registry logging to use logger and set to debug

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
