### PR TITLE
Support an environment variable option to use sqlalchemy.pool.NullPool

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -157,10 +157,10 @@ MLFLOW_SQLALCHEMYSTORE_MAX_OVERFLOW = _EnvironmentVariable(
 #: (default: ``False``)
 MLFLOW_SQLALCHEMYSTORE_ECHO = _BooleanEnvironmentVariable("MLFLOW_SQLALCHEMYSTORE_ECHO", False)
 
-#: Specifies whether to set the poolclass parameter to NullPool to disable pooling.
-#: See https://docs.sqlalchemy.org/en/14/core/engines.html#sqlalchemy.create_engine.params.poolclass
+#: Specifies the ``poolclass`` parameter to use for ``sqlalchemy.create_engine`` in the
+#: SQLAlchemy tracking store. See https://docs.sqlalchemy.org/en/14/core/engines.html#sqlalchemy.create_engine.params.poolclass
 #: for more information.
-#: (default: ``False``)
-MLFLOW_SQLALCHEMYSTORE_DISABLE_POOLING = _BooleanEnvironmentVariable(
-    "MLFLOW_SQLALCHEMYSTORE_DISABLE_POOLING", False
+#: (default: ``None``)
+MLFLOW_SQLALCHEMYSTORE_POOLCLASS = _EnvironmentVariable(
+    "MLFLOW_SQLALCHEMYSTORE_POOLCLASS", str, None
 )

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -156,3 +156,11 @@ MLFLOW_SQLALCHEMYSTORE_MAX_OVERFLOW = _EnvironmentVariable(
 #: for more information.
 #: (default: ``False``)
 MLFLOW_SQLALCHEMYSTORE_ECHO = _BooleanEnvironmentVariable("MLFLOW_SQLALCHEMYSTORE_ECHO", False)
+
+#: Specifies whether to set the poolclass parameter to NullPool to disable pooling.
+#: See https://docs.sqlalchemy.org/en/14/core/engines.html#sqlalchemy.create_engine.params.poolclass
+#: for more information.
+#: (default: ``False``)
+MLFLOW_SQLALCHEMYSTORE_DISABLE_POOLING = _BooleanEnvironmentVariable(
+    "MLFLOW_SQLALCHEMYSTORE_DISABLE_POOLING", False
+)

--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -7,7 +7,17 @@ import logging
 from alembic.migration import MigrationContext  # pylint: disable=import-error
 from alembic.script import ScriptDirectory
 import sqlalchemy
-from sqlalchemy.pool import NullPool
+
+# We need to import sqlalchemy.pool to convert poolclass string to class object
+from sqlalchemy.pool import (
+    AssertionPool,
+    AsyncAdaptedQueuePool,
+    FallbackAsyncAdaptedQueuePool,
+    NullPool,
+    QueuePool,
+    SingletonThreadPool,
+    StaticPool,
+)
 
 
 from mlflow.exceptions import MlflowException
@@ -19,7 +29,7 @@ from mlflow.environment_variables import (
     MLFLOW_SQLALCHEMYSTORE_POOL_RECYCLE,
     MLFLOW_SQLALCHEMYSTORE_MAX_OVERFLOW,
     MLFLOW_SQLALCHEMYSTORE_ECHO,
-    MLFLOW_SQLALCHEMYSTORE_DISABLE_POOLING,
+    MLFLOW_SQLALCHEMYSTORE_POOLCLASS,
 )
 
 _logger = logging.getLogger(__name__)
@@ -189,7 +199,7 @@ def create_sqlalchemy_engine(db_uri):
     pool_max_overflow = MLFLOW_SQLALCHEMYSTORE_MAX_OVERFLOW.get()
     pool_recycle = MLFLOW_SQLALCHEMYSTORE_POOL_RECYCLE.get()
     echo = MLFLOW_SQLALCHEMYSTORE_ECHO.get()
-    disable_pooling = MLFLOW_SQLALCHEMYSTORE_DISABLE_POOLING.get()
+    poolclass = MLFLOW_SQLALCHEMYSTORE_POOLCLASS.get()
     pool_kwargs = {}
     # Send argument only if they have been injected.
     # Some engine does not support them (for example sqllite)
@@ -201,8 +211,25 @@ def create_sqlalchemy_engine(db_uri):
         pool_kwargs["pool_recycle"] = pool_recycle
     if echo:
         pool_kwargs["echo"] = echo
-    if disable_pooling:
-        pool_kwargs["poolclass"] = NullPool
+    if poolclass:
+        pool_class_map = {
+            "AssertionPool": AssertionPool,
+            "AsyncAdaptedQueuePool": AsyncAdaptedQueuePool,
+            "FallbackAsyncAdaptedQueuePool": FallbackAsyncAdaptedQueuePool,
+            "NullPool": NullPool,
+            "QueuePool": QueuePool,
+            "SingletonThreadPool": SingletonThreadPool,
+            "StaticPool": StaticPool,
+        }
+        if poolclass not in pool_class_map:
+            list_str = " ".join(pool_class_map.keys())
+            err_str = (
+                "Invalid poolclass parameter. Provide set environment variable "
+                "poolclass to empty or one of the following values: " + list_str
+            )
+            _logger.warning(err_str)
+            raise ValueError(err_str)
+        pool_kwargs["poolclass"] = pool_class_map[poolclass]
     if pool_kwargs:
         _logger.info("Create SQLAlchemy engine with pool options %s", pool_kwargs)
     return sqlalchemy.create_engine(db_uri, pool_pre_ping=True, **pool_kwargs)

--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -7,6 +7,8 @@ import logging
 from alembic.migration import MigrationContext  # pylint: disable=import-error
 from alembic.script import ScriptDirectory
 import sqlalchemy
+from sqlalchemy.pool import NullPool
+
 
 from mlflow.exceptions import MlflowException
 from mlflow.store.tracking.dbmodels.initial_models import Base as InitialBase
@@ -17,6 +19,7 @@ from mlflow.environment_variables import (
     MLFLOW_SQLALCHEMYSTORE_POOL_RECYCLE,
     MLFLOW_SQLALCHEMYSTORE_MAX_OVERFLOW,
     MLFLOW_SQLALCHEMYSTORE_ECHO,
+    MLFLOW_SQLALCHEMYSTORE_DISABLE_POOLING,
 )
 
 _logger = logging.getLogger(__name__)
@@ -186,6 +189,7 @@ def create_sqlalchemy_engine(db_uri):
     pool_max_overflow = MLFLOW_SQLALCHEMYSTORE_MAX_OVERFLOW.get()
     pool_recycle = MLFLOW_SQLALCHEMYSTORE_POOL_RECYCLE.get()
     echo = MLFLOW_SQLALCHEMYSTORE_ECHO.get()
+    disable_pooling = MLFLOW_SQLALCHEMYSTORE_DISABLE_POOLING.get()
     pool_kwargs = {}
     # Send argument only if they have been injected.
     # Some engine does not support them (for example sqllite)
@@ -197,6 +201,8 @@ def create_sqlalchemy_engine(db_uri):
         pool_kwargs["pool_recycle"] = pool_recycle
     if echo:
         pool_kwargs["echo"] = echo
+    if disable_pooling:
+        pool_kwargs["poolclass"] = NullPool
     if pool_kwargs:
         _logger.info("Create SQLAlchemy engine with pool options %s", pool_kwargs)
     return sqlalchemy.create_engine(db_uri, pool_pre_ping=True, **pool_kwargs)

--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -224,7 +224,7 @@ def create_sqlalchemy_engine(db_uri):
         if poolclass not in pool_class_map:
             list_str = " ".join(pool_class_map.keys())
             err_str = (
-                f"Invalid poolclass parameter: {poolclass}. Provide set environment variable "
+                f"Invalid poolclass parameter: {poolclass}. Set environment variable "
                 f"poolclass to empty or one of the following values: {list_str}"
             )
             _logger.warning(err_str)

--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -224,8 +224,8 @@ def create_sqlalchemy_engine(db_uri):
         if poolclass not in pool_class_map:
             list_str = " ".join(pool_class_map.keys())
             err_str = (
-                "Invalid poolclass parameter. Provide set environment variable "
-                "poolclass to empty or one of the following values: " + list_str
+                f"Invalid poolclass parameter: {poolclass}. Provide set environment variable "
+                f"poolclass to empty or one of the following values: {list_str}"
             )
             _logger.warning(err_str)
             raise ValueError(err_str)

--- a/tests/store/db/test_utils.py
+++ b/tests/store/db/test_utils.py
@@ -4,6 +4,7 @@ from unittest import mock, TestCase
 
 from mlflow.store.db import utils
 from sqlalchemy.pool import NullPool
+from sqlalchemy.pool.impl import QueuePool
 
 
 def test_create_sqlalchemy_engine_inject_pool_options():
@@ -14,7 +15,7 @@ def test_create_sqlalchemy_engine_inject_pool_options():
             "MLFLOW_SQLALCHEMYSTORE_POOL_RECYCLE": "3600",
             "MLFLOW_SQLALCHEMYSTORE_MAX_OVERFLOW": "4",
             "MLFLOW_SQLALCHEMYSTORE_ECHO": "TRUE",
-            "MLFLOW_SQLALCHEMYSTORE_DISABLE_POOLING": "TRUE",
+            "MLFLOW_SQLALCHEMYSTORE_POOLCLASS": "QueuePool",
         },
     ):
         with mock.patch("sqlalchemy.create_engine") as mock_create_engine:
@@ -26,8 +27,36 @@ def test_create_sqlalchemy_engine_inject_pool_options():
                 max_overflow=4,
                 pool_recycle=3600,
                 echo=True,
+                poolclass=QueuePool,
+            )
+
+
+def test_create_sqlalchemy_engine_null_pool():
+    with mock.patch.dict(
+        os.environ,
+        {
+            "MLFLOW_SQLALCHEMYSTORE_POOLCLASS": "NullPool",
+        },
+    ):
+        with mock.patch("sqlalchemy.create_engine") as mock_create_engine:
+            utils.create_sqlalchemy_engine("mydb://host:port/")
+            mock_create_engine.assert_called_once_with(
+                "mydb://host:port/",
+                pool_pre_ping=True,
                 poolclass=NullPool,
             )
+
+
+def test_create_sqlalchemy_engine_invalid_pool():
+    with mock.patch.dict(
+        os.environ,
+        {
+            "MLFLOW_SQLALCHEMYSTORE_POOLCLASS": "SomethingInvalid",
+        },
+    ):
+        with mock.patch("sqlalchemy.create_engine"):
+            with pytest.raises(Exception, match=r"Invalid poolclass parameter.*"):
+                utils.create_sqlalchemy_engine("mydb://host:port/")
 
 
 def test_create_sqlalchemy_engine_no_pool_options():

--- a/tests/store/db/test_utils.py
+++ b/tests/store/db/test_utils.py
@@ -45,7 +45,7 @@ def test_create_sqlalchemy_engine_null_pool(monkeypatch):
 def test_create_sqlalchemy_engine_invalid_pool(monkeypatch):
     monkeypatch.setenv("MLFLOW_SQLALCHEMYSTORE_POOLCLASS": "SomethingInvalid")
         with mock.patch("sqlalchemy.create_engine"):
-            with pytest.raises(Exception, match=r"Invalid poolclass parameter.*"):
+            with pytest.raises(ValueError, match=r"Invalid poolclass parameter.*"):
                 utils.create_sqlalchemy_engine("mydb://host:port/")
 
 

--- a/tests/store/db/test_utils.py
+++ b/tests/store/db/test_utils.py
@@ -30,19 +30,6 @@ def test_create_sqlalchemy_engine_inject_pool_options():
             )
 
 
-def test_create_sqlalchemy_engine_not_inject_pool_options():
-    with mock.patch.dict(
-        os.environ,
-        {},
-    ):
-        with mock.patch("sqlalchemy.create_engine") as mock_create_engine:
-            utils.create_sqlalchemy_engine("mydb://host:port/")
-            mock_create_engine.assert_called_once_with(
-                "mydb://host:port/",
-                pool_pre_ping=True,
-            )
-
-
 def test_create_sqlalchemy_engine_no_pool_options():
     with mock.patch.dict(os.environ, {}):
         with mock.patch("sqlalchemy.create_engine") as mock_create_engine:

--- a/tests/store/db/test_utils.py
+++ b/tests/store/db/test_utils.py
@@ -32,21 +32,21 @@ def test_create_sqlalchemy_engine_inject_pool_options():
 
 
 def test_create_sqlalchemy_engine_null_pool(monkeypatch):
-    monkeypatch.setenv("MLFLOW_SQLALCHEMYSTORE_POOLCLASS": "NullPool")
-        with mock.patch("sqlalchemy.create_engine") as mock_create_engine:
-            utils.create_sqlalchemy_engine("mydb://host:port/")
-            mock_create_engine.assert_called_once_with(
-                "mydb://host:port/",
-                pool_pre_ping=True,
-                poolclass=NullPool,
-            )
+    monkeypatch.setenv("MLFLOW_SQLALCHEMYSTORE_POOLCLASS", "NullPool")
+    with mock.patch("sqlalchemy.create_engine") as mock_create_engine:
+        utils.create_sqlalchemy_engine("mydb://host:port/")
+        mock_create_engine.assert_called_once_with(
+            "mydb://host:port/",
+            pool_pre_ping=True,
+            poolclass=NullPool,
+        )
 
 
 def test_create_sqlalchemy_engine_invalid_pool(monkeypatch):
-    monkeypatch.setenv("MLFLOW_SQLALCHEMYSTORE_POOLCLASS": "SomethingInvalid")
-        with mock.patch("sqlalchemy.create_engine"):
-            with pytest.raises(ValueError, match=r"Invalid poolclass parameter.*"):
-                utils.create_sqlalchemy_engine("mydb://host:port/")
+    monkeypatch.setenv("MLFLOW_SQLALCHEMYSTORE_POOLCLASS", "SomethingInvalid")
+    with mock.patch("sqlalchemy.create_engine"):
+        with pytest.raises(ValueError, match=r"Invalid poolclass parameter.*"):
+            utils.create_sqlalchemy_engine("mydb://host:port/")
 
 
 def test_create_sqlalchemy_engine_no_pool_options():

--- a/tests/store/db/test_utils.py
+++ b/tests/store/db/test_utils.py
@@ -31,13 +31,8 @@ def test_create_sqlalchemy_engine_inject_pool_options():
             )
 
 
-def test_create_sqlalchemy_engine_null_pool():
-    with mock.patch.dict(
-        os.environ,
-        {
-            "MLFLOW_SQLALCHEMYSTORE_POOLCLASS": "NullPool",
-        },
-    ):
+def test_create_sqlalchemy_engine_null_pool(monkeypatch):
+    monkeypatch.setenv("MLFLOW_SQLALCHEMYSTORE_POOLCLASS": "NullPool")
         with mock.patch("sqlalchemy.create_engine") as mock_create_engine:
             utils.create_sqlalchemy_engine("mydb://host:port/")
             mock_create_engine.assert_called_once_with(

--- a/tests/store/db/test_utils.py
+++ b/tests/store/db/test_utils.py
@@ -47,13 +47,8 @@ def test_create_sqlalchemy_engine_null_pool():
             )
 
 
-def test_create_sqlalchemy_engine_invalid_pool():
-    with mock.patch.dict(
-        os.environ,
-        {
-            "MLFLOW_SQLALCHEMYSTORE_POOLCLASS": "SomethingInvalid",
-        },
-    ):
+def test_create_sqlalchemy_engine_invalid_pool(monkeypatch):
+    monkeypatch.setenv("MLFLOW_SQLALCHEMYSTORE_POOLCLASS": "SomethingInvalid")
         with mock.patch("sqlalchemy.create_engine"):
             with pytest.raises(Exception, match=r"Invalid poolclass parameter.*"):
                 utils.create_sqlalchemy_engine("mydb://host:port/")


### PR DESCRIPTION
Signed-off-by: Mingyu Li <mingyu.li@databricks.com>

Added environment variable MLFLOW_SQLALCHEMYSTORE_POOLCLASS to set the poolclass to one of the available pool class. See https://docs.sqlalchemy.org/en/14/core/engines.html#sqlalchemy.create_engine.params.poolclass

Available classes : 
   - AssertionPool
   - AsyncAdaptedQueuePool
   - FallbackAsyncAdaptedQueuePool
   - NullPool
   - QueuePool
   - SingletonThreadPool
   - StaticPool

Added unit tests to make sure the following scenarios are covered : 
 - pool class env var not set
 - pool class is set to NullPool
 - pool class is set to QueuePool
 - pool class is something invalid


<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs
https://github.com/mlflow/mlflow/issues/5209

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

## What changes are proposed in this pull request?



## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [X] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.
Add an environment variable MLFLOW_SQLALCHEMYSTORE_ECHO to enable the use of sqlalchemy.pool.NullPool

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [X] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
