### PR TITLE
Fix `test_pyfunc_serve_and_score_transformers`

### DIFF
--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -685,7 +685,12 @@ def test_pyfunc_serve_and_score_transformers():
         model_uri = mlflow.get_artifact_uri("model")
 
     data = json.dumps({"inputs": dummy_inputs.tolist()})
-    resp = pyfunc_serve_and_score_model(model_uri, data, pyfunc_scoring_server.CONTENT_TYPE_JSON)
+    resp = pyfunc_serve_and_score_model(
+        model_uri,
+        data,
+        pyfunc_scoring_server.CONTENT_TYPE_JSON,
+        extra_args=EXTRA_PYFUNC_SERVING_TEST_ARGS,
+    )
     np.testing.assert_array_equal(json.loads(resp.content), model.predict(dummy_inputs))
 
 


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Fix the following error:

https://github.com/mlflow/mlflow/actions/runs/3122287185/jobs/5064137564#step:12:148

```
___________________ test_pyfunc_serve_and_score_transformers ___________________

    @pytest.mark.skipif(
        not (_is_importable("transformers") and keras_version >= Version("2.6.0")),
        reason="This test requires transformers, which is no longer compatible with Keras < 2.6.0",
    )
    def test_pyfunc_serve_and_score_transformers():
        from transformers import BertConfig, TFBertModel  # pylint: disable=import-error
    
        bert = TFBertModel(
            BertConfig(
                vocab_size=16,
                hidden_size=2,
                num_hidden_layers=2,
                num_attention_heads=2,
                intermediate_size=2,
            )
        )
        dummy_inputs = bert.dummy_inputs["input_ids"].numpy()
        input_ids = tf.keras.layers.Input(shape=(dummy_inputs.shape[1],), dtype=tf.int32)
        model = tf.keras.Model(inputs=[input_ids], outputs=[bert(input_ids).last_hidden_state])
        model.compile()
    
        with mlflow.start_run():
            mlflow.keras.log_model(
                model,
                artifact_path="model",
                keras_module=tf.keras,
                extra_pip_requirements=extra_pip_requirements,
            )
            model_uri = mlflow.get_artifact_uri("model")
    
        data = json.dumps({"inputs": dummy_inputs.tolist()})
>       resp = pyfunc_serve_and_score_model(model_uri, data, pyfunc_scoring_server.CONTENT_TYPE_JSON)

BertConfig = <class 'transformers.models.bert.configuration_bert.BertConfig'>
TFBertModel = <class 'transformers.models.bert.modeling_tf_bert.TFBertModel'>
bert       = <transformers.models.bert.modeling_tf_bert.TFBertModel object at 0x7f24008fb390>
data       = '{"inputs": [[7, 6, 0, 0, 1], [1, 2, 3, 0, 0], [0, 0, 0, 4, 5]]}'
dummy_inputs = array([[7, 6, 0, 0, 1],
       [1, 2, 3, 0, 0],
       [0, 0, 0, 4, 5]], dtype=int32)
input_ids  = <KerasTensor: shape=(None, 5) dtype=int32 (created by layer 'input_1')>
model      = <keras.engine.functional.Functional object at 0x7f23e46fff10>
model_uri  = './mlruns/0/9d822a099f1d4301a8d3e1999b08b341/artifacts/model'

tests/keras/test_keras_model_export.py:688: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
tests/helper_functions.py:213: in pyfunc_serve_and_score_model
    return _evaluate_scoring_proc(proc, port, data, content_type, activity_polling_timeout_seconds)
        activity_polling_timeout_seconds = 500
        content_type = 'application/json'
        data       = '{"inputs": [[7, 6, 0, 0, 1], [1, 2, 3, 0, 0], [0, 0, 0, 4, 5]]}'
        env        = {'ACCEPT_EULA': 'Y', 'AGENT_TOOLSDIRECTORY': '/opt/hostedtoolcache', 'ANDROID_HOME': '/usr/local/lib/android/sdk', 'ANDROID_NDK': '/usr/local/lib/android/sdk/ndk/25.1.8937393', ...}
        extra_args = None
        model_uri  = './mlruns/0/9d822a099f1d4301a8d3e1999b08b341/artifacts/model'
        port       = 38643
        proc       = <subprocess.Popen object at 0x7f23e440bf10>
        scoring_cmd = ['mlflow', 'models', 'serve', '-m', './mlruns/0/9d822a099f1d4301a8d3e1999b08b341/artifacts/model', '-p', ...]
        stdout     = <_io.TextIOWrapper name="<_io.FileIO name=6 mode='rb+' closefd=True>" mode='r+' encoding='utf-8'>
tests/helper_functions.py:316: in _evaluate_scoring_proc
    with RestEndpoint(proc, port, activity_polling_timeout_seconds) as endpoint:
        activity_polling_timeout_seconds = 500
        content_type = 'application/json'
        data       = '{"inputs": [[7, 6, 0, 0, 1], [1, 2, 3, 0, 0], [0, 0, 0, 4, 5]]}'
        port       = 38643
        proc       = <subprocess.Popen object at 0x7f23e440bf10>
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <tests.helper_functions.RestEndpoint object at 0x7f2400087490>

    def __enter__(self):
        for i in range(self._activity_polling_timeout_seconds):
>           assert self._proc.poll() is None, "scoring process died"
E           AssertionError: scoring process died

i          = 105
self       = <tests.helper_functions.RestEndpoint object at 0x7f2400087490>

tests/helper_functions.py:258: AssertionError
----------------------------- Captured stdout call -----------------------------
2022/09/25 14:33:55 INFO mlflow.models.cli: Selected backend for flavor 'python_function'
2022/09/25 14:33:59 INFO mlflow.utils.conda: === Creating conda environment mlflow-05c2ba166dc5016d4d769bbfb19aa913b994f2e6 ===
2022/09/25 14:35:37 WARNING mlflow.utils.conda: Encountered unexpected error while creating conda environment. Removing mlflow-05c2ba166dc5016d4d769bbfb19aa913b994f2e6.

Remove all packages in environment /usr/share/miniconda/envs/mlflow-05c2ba166dc5016d4d769bbfb19aa913b994f2e6:


## Package Plan ##

  environment location: /usr/share/miniconda/envs/mlflow-05c2ba166dc5016d4d769bbfb19aa913b994f2e6


The following packages will be REMOVED:

  _libgcc_mutex-0.1-conda_forge
  _openmp_mutex-4.5-2_gnu
  ca-certificates-2022.9.24-ha878542_0
  ld_impl_linux-64-2.36.1-hea4e1c9_2
  libffi-3.4.2-h7f98852_5
  libgcc-ng-12.1.0-h8d9b700_16
  libgomp-12.1.0-h8d9b700_16
  libnsl-2.0.0-h7f98852_0
  libsqlite-3.39.3-h753d276_0
  libstdcxx-ng-12.1.0-ha89aaad_16
  libzlib-1.2.12-h166bdaf_3
  ncurses-6.3-h27087fc_1
  openssl-3.0.5-h166bdaf_2
  pip-22.2.2-pyhd8ed1ab_0
  python-3.7.12-hf930737_100_cpython
  python_abi-3.7-2_cp37m
  readline-8.1.2-h0f457ee_0
  setuptools-65.3.0-py37h89c1867_0
  sqlite-3.39.3-h4ff8645_0
  tk-8.6.12-h27826a3_0
  wheel-0.37.1-pyhd8ed1ab_0
  xz-5.2.6-h166bdaf_0


Preparing transaction: ...working... done
Verifying transaction: ...working... done
Executing transaction: ...working... done
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.7.12/x64/bin/mlflow", line 8, in <module>
    sys.exit(cli())
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/click/core.py", line [165](https://github.com/mlflow/mlflow/actions/runs/3122287185/jobs/5064137564#step:12:166)7, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/runner/work/mlflow/mlflow/mlflow/models/cli.py", line 71, in serve
    model_uri=model_uri, port=port, host=host, timeout=timeout, enable_mlserver=enable_mlserver
  File "/home/runner/work/mlflow/mlflow/mlflow/pyfunc/backend.py", line 221, in serve
    env_root_dir=self._env_root_dir,
  File "/home/runner/work/mlflow/mlflow/mlflow/utils/conda.py", line 293, in get_or_create_conda_env
    capture_output,
  File "/home/runner/work/mlflow/mlflow/mlflow/utils/conda.py", line 173, in _create_conda_env_retry
    capture_output=True,
  File "/home/runner/work/mlflow/mlflow/mlflow/utils/conda.py", line 138, in _create_conda_env
    capture_output=capture_output,
  File "/home/runner/work/mlflow/mlflow/mlflow/utils/process.py", line 116, in _exec_cmd
    raise ShellCommandException.from_completed_process(comp_process)
mlflow.utils.process.ShellCommandException: Non-zero exit code: 1
Command: ['/usr/share/miniconda/bin/conda', 'env', 'create', '-n', 'mlflow-05c2ba[166](https://github.com/mlflow/mlflow/actions/runs/3122287185/jobs/5064137564#step:12:167)dc5016d4d769bbfb19aa913b994f2e6', '--file', '/home/runner/work/mlflow/mlflow/mlruns/0/9d822a099f1d4301a8d3e1999b08b341/artifacts/model/conda.yaml', '--quiet']

STDOUT:
Collecting package metadata (repodata.json): ...working... done
Solving environment: ...working... done
Preparing transaction: ...working... done
Verifying transaction: ...working... done
Executing transaction: ...working... done
Installing pip dependencies: ...working... failed


STDERR:
Pip subprocess error:
ERROR: Could not find a version that satisfies the requirement keras==2.11.0 (from versions: 0.2.0, 0.3.0, 0.3.1, 0.3.2, 0.3.3, 1.0.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4, 1.0.5, 1.0.6, 1.0.7, 1.0.8, 1.1.0, 1.1.1, 1.1.2, 1.2.0, 1.2.1, 1.2.2, 2.0.0, 2.0.1, 2.0.2, 2.0.3, 2.0.4, 2.0.5, 2.0.6, 2.0.7, 2.0.8, 2.0.9, 2.1.0, 2.1.1, 2.1.2, 2.1.3, 2.1.4, 2.1.5, 2.1.6, 2.2.0, 2.2.1, 2.2.2, 2.2.3, 2.2.4, 2.2.5, 2.3.0, 2.3.1, 2.4.0, 2.4.1, 2.4.2, 2.4.3, 2.5.0rc0, 2.6.0rc0, 2.6.0rc1, 2.6.0rc2, 2.6.0rc3, 2.6.0, 2.7.0rc0, 2.7.0rc2, 2.7.0, 2.8.0rc0, 2.8.0rc1, 2.8.0, 2.9.0rc0, 2.9.0rc1, 2.9.0rc2, 2.9.0, 2.10.0rc0, 2.10.0rc1, 2.10.0)
ERROR: No matching distribution found for keras==2.11.0
```

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
