### PR TITLE
Removing validation profiling from transform step

### DIFF
--- a/mlflow/pipelines/steps/transform.py
+++ b/mlflow/pipelines/steps/transform.py
@@ -115,29 +115,19 @@ class TransformStep(BaseStep):
         self.run_end_time = time.time()
         self.execution_duration = self.run_end_time - run_start_time
 
-        return self._build_profiles_and_card(
-            train_df, train_transformed, validation_transformed, transformer
-        )
+        return self._build_profiles_and_card(train_df, train_transformed, transformer)
 
-    def _build_profiles_and_card(
-        self, train_df, train_transformed, validation_transformed, transformer
-    ) -> BaseCard:
+    def _build_profiles_and_card(self, train_df, train_transformed, transformer) -> BaseCard:
         # Build card
         card = BaseCard(self.pipeline_name, self.name)
 
         if not self.skip_data_profiling:
-            # Tab 1 and 2: build profiles for train_transformed, validation_transformed
+            # Tab 1: build profiles for train_transformed
             train_transformed_profile = get_pandas_data_profiles(
                 [["Profile of Train Transformed Dataset", train_transformed]]
             )
-            validation_transformed_profile = get_pandas_data_profiles(
-                [["Profile of Validation Transformed Dataset", validation_transformed]]
-            )
             card.add_tab("Data Profile (Train Transformed)", "{{PROFILE}}").add_pandas_profile(
                 "PROFILE", train_transformed_profile
-            )
-            card.add_tab("Data Profile (Validation Transformed)", "{{PROFILE}}").add_pandas_profile(
-                "PROFILE", validation_transformed_profile
             )
 
         # Tab 3: transformer diagram


### PR DESCRIPTION
## What changes are proposed in this pull request?
Removing validation profiling from transform step

## How is this patch tested?
- [x] Screenshot of no validation profile in transform step
<img width="1275" alt="image" src="https://user-images.githubusercontent.com/5621432/192347055-5e299857-e11c-4bf2-8a83-6f7f16e8ba4b.png">


## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Removing validation profiling from transform step

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
