### PR TITLE
Fixing boolean columns type for profile rendering

### DIFF
--- a/mlflow/pipelines/cards/pandas_renderer.py
+++ b/mlflow/pipelines/cards/pandas_renderer.py
@@ -93,7 +93,7 @@ def convert_to_dataset_feature_statistics(
     feature_stats.num_examples = len(df)
     quantiles_to_get = [x * 10 / 100 for x in range(10 + 1)]
     try:
-        quantiles = df.quantile(quantiles_to_get)
+        quantiles = df.select_dtypes(exclude=["bool"]).quantile(quantiles_to_get)
     except:
         raise MlflowException("Error in generating quantiles")
 
@@ -139,10 +139,16 @@ def convert_to_dataset_feature_statistics(
                 if equal_height_hist:
                     feat_stats.histograms.append(equal_height_hist)
         elif feat.type == fs_proto.STRING:
+            isCurrentColumnBooleanType = False
+            if current_column_value.dtype == bool:
+                current_column_value = current_column_value.replace({True: "True", False: "False"})
+                isCurrentColumnBooleanType = True
             feat_stats = feat.string_stats
             strs = current_column_value.dropna()
 
-            feat_stats.avg_length = np.mean(np.vectorize(len)(strs))
+            feat_stats.avg_length = (
+                np.mean(np.vectorize(len)(strs)) if not isCurrentColumnBooleanType else 0
+            )
             vals, counts = np.unique(strs, return_counts=True)
             feat_stats.unique = pandas_describe_key.get("unique", len(vals))
             sorted_vals = sorted(zip(counts, vals), reverse=True)

--- a/tests/pipelines/cards/test_pandas_renderer.py
+++ b/tests/pipelines/cards/test_pandas_renderer.py
@@ -101,6 +101,7 @@ def test_convert_to_proto():
     data = {
         "Symbol": ["MSFT", "AAPL", "MSFT", "AAPL", "NFLX"],
         "Shares": [100, 170, 150, 200, None],
+        "Access": [True, True, False, True, False],
     }
     df = pd.DataFrame(data)
 
@@ -263,6 +264,43 @@ def test_convert_to_proto():
                   high_value: 200.0
                 }
                 type: QUANTILES
+              }
+            }
+          }
+          features {
+            name: "Access"
+            type: STRING
+            string_stats {
+              common_stats {
+                num_non_missing: 5
+                num_missing: 0
+                min_num_values: 1
+                max_num_values: 1
+                avg_num_values: 1.0
+              }
+              unique: 2
+              top_values {
+                value: "True"
+                frequency: 3.0
+              }
+              top_values {
+                value: "False"
+                frequency: 2.0
+              }
+              avg_length: 0
+              rank_histogram {
+                buckets {
+                  low_rank: 0
+                  high_rank: 0
+                  label: "True"
+                  sample_count: 3.0
+                }
+                buckets {
+                  low_rank: 1
+                  high_rank: 1
+                  label: "False"
+                  sample_count: 2.0
+                }
               }
             }
           }


### PR DESCRIPTION
Signed-off-by: Sunish Sheth <sunishsheth2009@gmail.com>
## What changes are proposed in this pull request?
Fixing boolean columns type for profile rendering

## How is this patch tested?
- [x] Test added for boolean use case
- [x] Screenshot
<img width="672" alt="image" src="https://user-images.githubusercontent.com/5621432/192583502-e0b6c321-14e6-4f84-8dcc-161548ecdb6e.png">


## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
Fixing MLP step card profiling not working boolean columns

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
