### PR TITLE
Simplify user requirements for MLP in transform step

### DIFF
--- a/mlflow/pipelines/steps/transform.py
+++ b/mlflow/pipelines/steps/transform.py
@@ -78,8 +78,6 @@ class TransformStep(BaseStep):
 
             return Pipeline(steps=[("identity", FunctionTransformer())])
 
-        transformer = get_identity_transformer()
-
         method_config = self.step_config.get("transformer_method")
         if method_config:
             (
@@ -90,6 +88,7 @@ class TransformStep(BaseStep):
                 importlib.import_module(transformer_module_name), transformer_method_name
             )
             transformer = transformer_fn()
+        transformer = transformer if transformer else get_identity_transformer()
 
         transformer.fit(train_df.drop(columns=[self.target_col]))
 

--- a/mlflow/pipelines/steps/transform.py
+++ b/mlflow/pipelines/steps/transform.py
@@ -80,7 +80,7 @@ class TransformStep(BaseStep):
 
         transformer = get_identity_transformer()
 
-        method_config = self.step_config.get("transformer_method", None)
+        method_config = self.step_config.get("transformer_method")
         if method_config:
             (
                 transformer_module_name,

--- a/mlflow/pipelines/steps/transform.py
+++ b/mlflow/pipelines/steps/transform.py
@@ -7,7 +7,6 @@ import time
 import cloudpickle
 from packaging.version import Version
 
-from mlflow.exceptions import MlflowException, INVALID_PARAMETER_VALUE
 from mlflow.pipelines.cards import BaseCard
 from mlflow.pipelines.step import BaseStep
 from mlflow.pipelines.utils.execution import get_step_output_path
@@ -83,7 +82,10 @@ class TransformStep(BaseStep):
 
         method_config = self.step_config.get("transformer_method", None)
         if method_config:
-            (transformer_module_name, transformer_method_name,) = method_config.rsplit(".", 1)
+            (
+                transformer_module_name,
+                transformer_method_name,
+            ) = method_config.rsplit(".", 1)
             transformer_fn = getattr(
                 importlib.import_module(transformer_module_name), transformer_method_name
             )

--- a/mlflow/pipelines/steps/transform.py
+++ b/mlflow/pipelines/steps/transform.py
@@ -89,7 +89,6 @@ class TransformStep(BaseStep):
             )
             transformer = transformer_fn()
         transformer = transformer if transformer else get_identity_transformer()
-
         transformer.fit(train_df.drop(columns=[self.target_col]))
 
         def transform_dataset(dataset):


### PR DESCRIPTION
Signed-off-by: Apurva Koti <apurva.koti@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Relax the requirements for a first-time user of MLP by allowing the `transform` step configuration to be nonexistent (and if it is, for the user's `transform.py` file to be blank).
This is already the case for `split`, so no changes there.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
