### PR TITLE
Fix single upload

### DIFF
--- a/mlflow/azure/client.py
+++ b/mlflow/azure/client.py
@@ -51,7 +51,8 @@ def patch_adls_file_upload(sas_url, data, position, headers, is_single):
     """
     new_params = {"action": "append", "position": str(position)}
     if is_single:
-    request_url = _append_query_parameters(sas_url, {"action": "append", "position": str(position)})
+        new_params["flush"] = "true"
+    request_url = _append_query_parameters(sas_url, new_params)
 
     request_headers = {}
     for name, value in headers.items():

--- a/mlflow/azure/client.py
+++ b/mlflow/azure/client.py
@@ -38,7 +38,7 @@ def put_adls_file_creation(sas_url, headers):
         rest_utils.augmented_raise_for_status(response)
 
 
-def patch_adls_file_upload(sas_url, data, position, headers):
+def patch_adls_file_upload(sas_url, data, position, headers, is_single):
     """
     Performs an ADLS Azure file create `Patch` operation
     (https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update)
@@ -49,6 +49,8 @@ def patch_adls_file_upload(sas_url, data, position, headers):
     :param position: Positional offset of the data in the Patch request
     :param headers: Additional headers to include in the Patch request body
     """
+    new_params = {"action": "append", "position": str(position)}
+    if is_single:
     request_url = _append_query_parameters(sas_url, {"action": "append", "position": str(position)})
 
     request_headers = {}

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -291,7 +291,11 @@ class DatabricksArtifactRepository(ArtifactRepository):
                             run_id=self.run_id, paths=[artifact_path]
                         )[0]
                         patch_adls_file_upload(
-                            credential_info.signed_uri, chunk, offset, headers=headers
+                            credential_info.signed_uri,
+                            chunk,
+                            offset,
+                            headers=headers,
+                            is_single=use_single_part_upload,
                         )
                     else:
                         raise e

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -272,7 +272,13 @@ class DatabricksArtifactRepository(ArtifactRepository):
                     cur_offset = len(chunk)
                     if is_first_chunk and cur_offset < _AZURE_MAX_BLOCK_CHUNK_SIZE:
                         use_single_part_upload = True
-                    patch_adls_file_upload(credentials.signed_uri, chunk, offset, headers=headers, is_single=use_single_part_upload)
+                    patch_adls_file_upload(
+                        credentials.signed_uri,
+                        chunk,
+                        offset,
+                        headers=headers,
+                        is_single=use_single_part_upload,
+                    )
                     is_first_chunk = False
                     offset += cur_offset
                 except requests.HTTPError as e:

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -265,10 +265,16 @@ class DatabricksArtifactRepository(ArtifactRepository):
 
             # next try to patch the file
             offset = 0
+            is_first_chunk = True
+            use_single_part_upload = False
             for chunk in yield_file_in_chunks(local_file, _AZURE_MAX_BLOCK_CHUNK_SIZE):
                 try:
-                    patch_adls_file_upload(credentials.signed_uri, chunk, offset, headers=headers)
-                    offset += len(chunk)
+                    cur_offset = len(chunk)
+                    if is_first_chunk and cur_offset < _AZURE_MAX_BLOCK_CHUNK_SIZE:
+                        use_single_part_upload = True
+                    patch_adls_file_upload(credentials.signed_uri, chunk, offset, headers=headers, is_single=use_single_part_upload)
+                    is_first_chunk = False
+                    offset += cur_offset
                 except requests.HTTPError as e:
                     if e.response.status_code in [401, 403]:
                         _logger.info(
@@ -286,7 +292,8 @@ class DatabricksArtifactRepository(ArtifactRepository):
 
             # finally flush the file
             try:
-                patch_adls_flush(credentials.signed_uri, offset, headers=headers)
+                if not use_single_part_upload:
+                    patch_adls_flush(credentials.signed_uri, offset, headers=headers)
             except requests.HTTPError as e:
                 if e.response.status_code in [401, 403]:
                     _logger.info(

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -393,7 +393,7 @@ class TestDatabricksArtifactRepository:
                 MOCK_ADLS_GEN2_SIGNED_URI + "?resource=file",
                 headers={},
             )
-            # test with asure max block size
+            # test with azure max block size
             request_mock.assert_any_call(
                 "patch",
                 MOCK_ADLS_GEN2_SIGNED_URI + "?action=append&position=0&flush=true",

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -378,7 +378,7 @@ class TestDatabricksArtifactRepository:
             DATABRICKS_ARTIFACT_REPOSITORY + "._get_write_credential_infos"
         ) as write_credential_infos_mock, mock.patch(
             "mlflow.utils.rest_utils.cloud_storage_http_request",
-            side_effect=[mock_successful_response, mock_successful_response, mock_error_response],
+            side_effect=[mock_successful_response, mock_error_response],
         ) as request_mock:
             mock_credential_info = ArtifactCredentialInfo(
                 signed_uri=MOCK_ADLS_GEN2_SIGNED_URI,
@@ -396,7 +396,7 @@ class TestDatabricksArtifactRepository:
             # test with asure max block size
             request_mock.assert_any_call(
                 "patch",
-                MOCK_ADLS_GEN2_SIGNED_URI + "?action=append&position=0",
+                MOCK_ADLS_GEN2_SIGNED_URI + "?action=append&position=0&flush=true",
                 data=ANY,
                 headers={},
             )


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Added single part upload optimization

## How is this patch tested?

Fixed the unit tests to account for this new behavior (new unit tests already test multi-part and single part uploads).
Liang reran her notebook test using this PR.
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
