### PR TITLE
Clear PySpark gateway environment variables for OSS SparkML flavor dependency inference

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -164,3 +164,10 @@ MLFLOW_SQLALCHEMYSTORE_ECHO = _BooleanEnvironmentVariable("MLFLOW_SQLALCHEMYSTOR
 MLFLOW_SQLALCHEMYSTORE_POOLCLASS = _EnvironmentVariable(
     "MLFLOW_SQLALCHEMYSTORE_POOLCLASS", str, None
 )
+
+#: Specifies the ``timeout_seconds`` parameter to use for ``_run_command`` in the dependency
+#: inference subprocess task.
+#: (default: ``120``)
+MLFLOW_REQUIREMENTS_INFERENCE_TIMEOUT = _EnvironmentVariable(
+    "MLFLOW_REQUIREMENTS_INFERENCE_TIMEOUT", int, 120
+)

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -165,7 +165,7 @@ MLFLOW_SQLALCHEMYSTORE_POOLCLASS = _EnvironmentVariable(
     "MLFLOW_SQLALCHEMYSTORE_POOLCLASS", str, None
 )
 
-#: Specifies the ``timeout_seconds`` for dependency inference operations.
+#: Specifies the ``timeout_seconds`` for MLflow Model dependency inference operations.
 #: (default: ``120``)
 MLFLOW_REQUIREMENTS_INFERENCE_TIMEOUT = _EnvironmentVariable(
     "MLFLOW_REQUIREMENTS_INFERENCE_TIMEOUT", int, 120

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -165,8 +165,7 @@ MLFLOW_SQLALCHEMYSTORE_POOLCLASS = _EnvironmentVariable(
     "MLFLOW_SQLALCHEMYSTORE_POOLCLASS", str, None
 )
 
-#: Specifies the ``timeout_seconds`` parameter to use for ``_run_command`` in the dependency
-#: inference subprocess task.
+#: Specifies the ``timeout_seconds`` for dependency inference operations.
 #: (default: ``120``)
 MLFLOW_REQUIREMENTS_INFERENCE_TIMEOUT = _EnvironmentVariable(
     "MLFLOW_REQUIREMENTS_INFERENCE_TIMEOUT", int, 120

--- a/mlflow/utils/_capture_modules.py
+++ b/mlflow/utils/_capture_modules.py
@@ -118,14 +118,6 @@ def main():
         os.environ.pop("PYSPARK_GATEWAY_PORT", None)
         os.environ.pop("PYSPARK_GATEWAY_SECRET", None)
 
-        # TODO: remove below debugging code
-        import logging
-
-        _logger = logging.getLogger(__name__)
-        _logger.info(f"Subprocess python executable: {sys.executable}")
-        _logger.info("Subprocess environment variables: ")
-        _logger.info(os.environ.values())
-
     if flavor == mlflow.spark.FLAVOR_NAME and is_in_databricks_runtime():
         os.environ["SPARK_DIST_CLASSPATH"] = "/databricks/jars/*"
 

--- a/mlflow/utils/_capture_modules.py
+++ b/mlflow/utils/_capture_modules.py
@@ -125,16 +125,18 @@ def main():
         # Create a local spark environment within the subprocess if using OSS Spark
         from pyspark.sql import SparkSession
 
-        SparkSession.builder.config("spark.python.worker.reuse", "true").config(
-            "spark.databricks.io.cache.enabled", "false"
-        ).config("spark.executor.allowSparkContext", "true").config(
-            "spark.driver.bindAddress", "127.0.0.1"
-        ).config(
-            "spark.driver.extraJavaOptions",
-            "-Dlog4j.configuration=file:/usr/local/spark/conf/log4j.properties",
-        ).master(
-            "local[1]"
-        ).getOrCreate()
+        (
+            SparkSession.builder.config("spark.python.worker.reuse", "true")
+            .config("spark.databricks.io.cache.enabled", "false")
+            .config("spark.executor.allowSparkContext", "true")
+            .config("spark.driver.bindAddress", "127.0.0.1")
+            .config(
+                "spark.driver.extraJavaOptions",
+                "-Dlog4j.configuration=file:/usr/local/spark/conf/log4j.properties",
+            )
+            .master("local[1]")
+            .getOrCreate()
+        )
 
     cap_cm = _CaptureImportedModules()
 

--- a/mlflow/utils/_capture_modules.py
+++ b/mlflow/utils/_capture_modules.py
@@ -118,6 +118,14 @@ def main():
         os.environ.pop("PYSPARK_GATEWAY_PORT", None)
         os.environ.pop("PYSPARK_GATEWAY_SECRET", None)
 
+        # TODO: remove below debugging code
+        import logging
+
+        _logger = logging.getLogger(__name__)
+        _logger.info(f"Subprocess python executable: {sys.executable}")
+        _logger.info("Subprocess environment variables: ")
+        _logger.info(os.environ.values())
+
     if flavor == mlflow.spark.FLAVOR_NAME and is_in_databricks_runtime():
         os.environ["SPARK_DIST_CLASSPATH"] = "/databricks/jars/*"
 

--- a/mlflow/utils/_capture_modules.py
+++ b/mlflow/utils/_capture_modules.py
@@ -122,7 +122,7 @@ def main():
         os.environ["SPARK_DIST_CLASSPATH"] = "/databricks/jars/*"
 
     if flavor == mlflow.spark.FLAVOR_NAME and not is_in_databricks_runtime():
-        # Create a local spark environment within the subprocess
+        # Create a local spark environment within the subprocess if using OSS Spark
         from pyspark.sql import SparkSession
 
         SparkSession.builder.config("spark.python.worker.reuse", "true").config(

--- a/mlflow/utils/_capture_modules.py
+++ b/mlflow/utils/_capture_modules.py
@@ -111,12 +111,14 @@ def main():
     # Mirror `sys.path` of the parent process
     sys.path = json.loads(args.sys_path)
 
-    if flavor == mlflow.spark.FLAVOR_NAME and is_in_databricks_runtime():
+    if flavor == mlflow.spark.FLAVOR_NAME:
         # Clear 'PYSPARK_GATEWAY_PORT' and 'PYSPARK_GATEWAY_SECRET' to enforce launching a new JVM
         # gateway before calling `mlflow.spark._load_pyfunc` that creates a new spark session
         # if it doesn't exist.
         os.environ.pop("PYSPARK_GATEWAY_PORT", None)
         os.environ.pop("PYSPARK_GATEWAY_SECRET", None)
+
+    if flavor == mlflow.spark.FLAVOR_NAME and is_in_databricks_runtime():
         os.environ["SPARK_DIST_CLASSPATH"] = "/databricks/jars/*"
 
     cap_cm = _CaptureImportedModules()

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -268,12 +268,6 @@ def _capture_imported_modules(model_uri, flavor):
 
     process_timeout = os.environ.get("REQUIREMENTS_INFERENCE_TIMEOUT", 2 * 60)
 
-    # TODO: remove below debugging code
-    _logger = logging.getLogger(__name__)
-    _logger.info(f"Main process python executable: {sys.executable}")
-    _logger.info("Main process environment variables: ")
-    _logger.info(os.environ.values())
-
     # Run `_capture_modules.py` to capture modules imported during the loading procedure
     with tempfile.TemporaryDirectory() as tmpdir:
         output_file = os.path.join(tmpdir, "imported_modules.txt")

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -266,7 +266,13 @@ def _capture_imported_modules(model_uri, flavor):
 
     local_model_path = _download_artifact_from_uri(model_uri)
 
-    process_timeout = os.environ.get("REQUIREMENTS_INFERENCE_TIMEOUT", 300)
+    process_timeout = os.environ.get("REQUIREMENTS_INFERENCE_TIMEOUT", 2 * 60)
+
+    # TODO: remove below debugging code
+    _logger = logging.getLogger(__name__)
+    _logger.info(f"Main process python executable: {sys.executable}")
+    _logger.info("Main process environment variables: ")
+    _logger.info(os.environ.values())
 
     # Run `_capture_modules.py` to capture modules imported during the loading procedure
     with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
Signed-off-by: Ben Wilson <benjamin.wilson@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#6905 

## What changes are proposed in this pull request?

Clear gateway env variables for OSS SparkML flavor dependency inference to not attempt to point to the driver SparkSession context from within a subprocess.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
