### PR TITLE
Add BooleanType support to pyfunc spark udf

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -2074,26 +2074,29 @@ numeric column as a double. You can control what result is returned by supplying
 argument. The following values are supported:
 
 * ``'int'`` or IntegerType_: The leftmost integer that can fit in
-  ``int32`` result is returned or exception is raised if there is none.
+  ``int32`` result is returned or an exception is raised if there are none.
 * ``'long'`` or LongType_: The leftmost long integer that can fit in ``int64``
-  result is returned or exception is raised if there is none.
+  result is returned or an exception is raised if there are none.
 * ArrayType_ (IntegerType_ | LongType_): Return all integer columns that can fit
   into the requested size.
 * ``'float'`` or FloatType_: The leftmost numeric result cast to
-  ``float32`` is returned or exception is raised if there is no numeric column.
+  ``float32`` is returned or an exception is raised if there are no numeric columns.
 * ``'double'`` or DoubleType_: The leftmost numeric result cast to
-  ``double`` is returned or exception is raised if there is no numeric column.
+  ``double`` is returned or an exception is raised if there are no numeric columns.
 * ArrayType_ ( FloatType_ | DoubleType_ ): Return all numeric columns cast to the
-  requested. type. Exception is raised if there are numeric columns.
-* ``'string'`` or StringType_: Result is the leftmost column converted to string.
-* ArrayType_ ( StringType_ ): Return all columns converted to string.
+  requested type. An exception is raised if there are no numeric columns.
+* ``'string'`` or StringType_: Result is the leftmost column cast as string.
+* ArrayType_ ( StringType_ ): Return all columns cast as string.
+* ``'bool'`` or ``'boolean'`` or BooleanType_: The leftmost column cast to ``bool``
+  is returned or an exception is raised if the values cannot be coerced.
 
-.. _IntegerType: https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.sql.types.IntegerType.html#pyspark.sql.types.IntegerType
-.. _LongType: https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.sql.types.LongType.html#pyspark.sql.types.LongType
-.. _FloatType: https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.sql.types.FloatType.html#pyspark.sql.types.FloatType
-.. _DoubleType: https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.sql.types.DoubleType.html#pyspark.sql.types.DoubleType
-.. _StringType: https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.sql.types.StringType.html#pyspark.sql.types.StringType
-.. _ArrayType: https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.sql.types.ArrayType.html#pyspark.sql.types.ArrayType
+.. _IntegerType: https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.types.IntegerType.html#pyspark.sql.types.IntegerType
+.. _LongType: https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.types.LongType.html#pyspark.sql.types.LongType
+.. _FloatType: https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.types.FloatType.html#pyspark.sql.types.FloatType
+.. _DoubleType: https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.types.DoubleType.html#pyspark.sql.types.DoubleType
+.. _StringType: https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.types.StringType.html#pyspark.sql.types.StringType
+.. _ArrayType: https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.types.ArrayType.html#pyspark.sql.types.ArrayType
+.. _BooleanType: https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.types.BooleanType.html#pyspark.sql.types.BooleanType
 
 .. rubric:: Example
 

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -990,7 +990,7 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
             result = result.select_dtypes(include=(np.number,)).astype(np.float64)
 
         elif type(elem_type) == BooleanType:
-            result = result.select_dtypes([np.bool, bool])
+            result = result.select_dtypes([bool, np.bool_])
 
         if len(result.columns) == 0:
             raise MlflowException(

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -854,6 +854,7 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
         FloatType,
         LongType,
         StringType,
+        BooleanType,
     )
     from mlflow.models.cli import _get_flavor_backend
 
@@ -875,7 +876,7 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
     if isinstance(elem_type, ArrayType):
         elem_type = elem_type.elementType
 
-    supported_types = [IntegerType, LongType, FloatType, DoubleType, StringType]
+    supported_types = [IntegerType, LongType, FloatType, DoubleType, StringType, BooleanType]
 
     if not any(isinstance(elem_type, x) for x in supported_types):
         raise MlflowException(
@@ -988,9 +989,12 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
         elif type(elem_type) == DoubleType:
             result = result.select_dtypes(include=(np.number,)).astype(np.float64)
 
+        elif type(elem_type) == BooleanType:
+            result = result.select_dtypes([np.bool, bool])
+
         if len(result.columns) == 0:
             raise MlflowException(
-                message="The the model did not produce any values compatible with the requested "
+                message="The model did not produce any values compatible with the requested "
                 "type '{}'. Consider requesting udf with StringType or "
                 "Arraytype(StringType).".format(str(elem_type)),
                 error_code=INVALID_PARAMETER_VALUE,

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -816,6 +816,9 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
 
         - "string" or ``pyspark.sql.types.StringType``: The leftmost column converted to ``string``.
 
+        - "boolean" or "bool" or ``pyspark.sql.types.BooleanType``: The leftmost column converted
+          to ``bool`` or an exception if there is none.
+
         - ``ArrayType(StringType)``: All columns converted to ``string``.
 
     :param env_manager: The environment manager to use in order to create the python environment
@@ -868,6 +871,8 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
     should_use_nfs = nfs_root_dir is not None
     should_use_spark_to_broadcast_file = not (is_spark_in_local_mode or should_use_nfs)
     env_root_dir = _get_or_create_env_root_dir(should_use_nfs)
+
+    result_type = "boolean" if result_type == "bool" else result_type
 
     if not isinstance(result_type, SparkDataType):
         result_type = _parse_datatype_string(result_type)

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -990,7 +990,7 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
             result = result.select_dtypes(include=(np.number,)).astype(np.float64)
 
         elif type(elem_type) == BooleanType:
-            result = result.select_dtypes([bool, np.bool_])
+            result = result.select_dtypes([bool, np.bool_]).astype(bool)
 
         if len(result.columns) == 0:
             raise MlflowException(

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -12,7 +12,15 @@ import pandas as pd
 import pytest
 
 import pyspark
-from pyspark.sql.types import ArrayType, DoubleType, LongType, StringType, FloatType, IntegerType
+from pyspark.sql.types import (
+    ArrayType,
+    DoubleType,
+    LongType,
+    StringType,
+    FloatType,
+    IntegerType,
+    BooleanType,
+)
 from pyspark.sql.utils import AnalysisException
 
 import mlflow
@@ -38,7 +46,7 @@ from pyspark.sql.functions import col, struct
 
 
 prediction = [int(1), int(2), "class1", float(0.1), 0.2]
-types = [np.int32, int, str, np.float32, np.double]
+types = [np.int32, int, str, np.float32, np.double, bool]
 
 
 def score_model_as_udf(model_uri, pandas_df, result_type="double"):
@@ -134,6 +142,7 @@ def test_spark_udf(spark, model_path):
         "double": (DoubleType(), np.number),
         "long": (LongType(), int),
         "string": (StringType(), None),
+        "bool": (BooleanType(), np.bool),
     }
 
     for tname, tdef in type_map.items():

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -45,7 +45,7 @@ from pyspark.sql.functions import pandas_udf
 from pyspark.sql.functions import col, struct
 
 
-prediction = [int(1), int(2), "class1", float(0.1), 0.2]
+prediction = [int(1), int(2), "class1", float(0.1), 0.2, True]
 types = [np.int32, int, str, np.float32, np.double, bool]
 
 
@@ -152,12 +152,12 @@ def test_spark_udf(spark, model_path):
             t = ArrayType(spark_type) if is_array else spark_type
             if tname == "string":
                 expected = prediction_df.applymap(str)
-            elif tname == "bool":
-                expected = prediction_df.astype(bool)
             else:
                 expected = prediction_df.select_dtypes(np_type)
                 if tname == "float":
                     expected = expected.astype(np.float32)
+                if tname == "bool":
+                    expected = expected.astype(bool)
 
             expected = [list(row[1]) if is_array else row[1][0] for row in expected.iterrows()]
             pyfunc_udf = spark_udf(spark, model_path, result_type=t)

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -143,6 +143,7 @@ def test_spark_udf(spark, model_path):
         "long": (LongType(), int),
         "string": (StringType(), None),
         "bool": (BooleanType(), bool),
+        "boolean": (BooleanType(), bool),
     }
 
     for tname, tdef in type_map.items():
@@ -156,7 +157,7 @@ def test_spark_udf(spark, model_path):
                 expected = prediction_df.select_dtypes(np_type)
                 if tname == "float":
                     expected = expected.astype(np.float32)
-                if tname == "bool":
+                if tname == "bool" or tname == "boolean":
                     expected = expected.astype(bool)
 
             expected = [list(row[1]) if is_array else row[1][0] for row in expected.iterrows()]

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -142,7 +142,7 @@ def test_spark_udf(spark, model_path):
         "double": (DoubleType(), np.number),
         "long": (LongType(), int),
         "string": (StringType(), None),
-        "bool": (BooleanType(), bool),
+        "boolean": (BooleanType(), bool),
     }
 
     for tname, tdef in type_map.items():

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -142,7 +142,7 @@ def test_spark_udf(spark, model_path):
         "double": (DoubleType(), np.number),
         "long": (LongType(), int),
         "string": (StringType(), None),
-        "bool": (BooleanType(), np.bool),
+        "bool": (BooleanType(), bool),
     }
 
     for tname, tdef in type_map.items():
@@ -152,6 +152,8 @@ def test_spark_udf(spark, model_path):
             t = ArrayType(spark_type) if is_array else spark_type
             if tname == "string":
                 expected = prediction_df.applymap(str)
+            elif tname == "bool":
+                expected = prediction_df.astype(bool)
             else:
                 expected = prediction_df.select_dtypes(np_type)
                 if tname == "float":

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -156,7 +156,7 @@ def test_spark_udf(spark, model_path):
                 expected = prediction_df.select_dtypes(np_type)
                 if tname == "float":
                     expected = expected.astype(np.float32)
-                if tname == "bool":
+                if tname == "boolean":
                     expected = expected.astype(bool)
 
             expected = [list(row[1]) if is_array else row[1][0] for row in expected.iterrows()]


### PR DESCRIPTION
Signed-off-by: Ben Wilson <benjamin.wilson@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Add support for Spark BooleanType (and, by extension, bool type and np.bool) for spark_udf for pyfunc

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [X] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add BooleanType (bool) support for pyfunc spark_udf return types.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [X] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [X] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
