### PR TITLE
add run_name support for created runs in Projects

### DIFF
--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -132,7 +132,7 @@ def cli():
     "--run-name",
     metavar="RUN_NAME",
     help="The name to give the MLflow Run associated with the project execution. If not specified, "
-    "the MLflow Run name is left unset.",
+    "the MLflow Run name will be automatically generated.",
 )
 def run(
     uri,

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -26,7 +26,7 @@ from mlflow.projects.utils import (
 )
 from mlflow.projects.backend import loader
 from mlflow.tracking.fluent import _get_experiment_id
-from mlflow.utils.mlflow_tags import MLFLOW_PROJECT_ENV, MLFLOW_PROJECT_BACKEND, MLFLOW_RUN_NAME
+from mlflow.utils.mlflow_tags import MLFLOW_PROJECT_ENV, MLFLOW_PROJECT_BACKEND
 from mlflow.utils import env_manager as _EnvManager
 import mlflow.utils.uri
 
@@ -100,12 +100,11 @@ def _run(
                 backend_config,
                 tracking_store_uri,
                 experiment_id,
+                run_name,
             )
             tracking.MlflowClient().set_tag(
                 submitted_run.run_id, MLFLOW_PROJECT_BACKEND, backend_name
             )
-            if run_name is not None:
-                tracking.MlflowClient().set_tag(submitted_run.run_id, MLFLOW_RUN_NAME, run_name)
             return submitted_run
 
     work_dir = fetch_and_validate_project(uri, version, entry_point, parameters)
@@ -113,11 +112,8 @@ def _run(
     _validate_execution_environment(project, backend_name)
 
     active_run = get_or_create_run(
-        None, uri, experiment_id, work_dir, version, entry_point, parameters
+        None, uri, experiment_id, work_dir, version, entry_point, parameters, run_name
     )
-
-    if run_name is not None:
-        tracking.MlflowClient().set_tag(active_run.info.run_id, MLFLOW_RUN_NAME, run_name)
 
     if backend_name == "databricks":
         tracking.MlflowClient().set_tag(
@@ -252,7 +248,7 @@ def run(
                    not be specified. If specified, the run ID will be used instead of
                    creating a new run.
     :param run_name: The name to give the MLflow Run associated with the project execution.
-                     If ``None``, the MLflow Run name is left unset.
+                     If ``None``, the MLflow Run name will be automatically generated.
     :param env_manager: Specify an environment manager to create a new environment for the run and
                         install project dependencies within that environment. The following values
                         are supported:

--- a/mlflow/projects/backend/abstract_backend.py
+++ b/mlflow/projects/backend/abstract_backend.py
@@ -14,7 +14,15 @@ class AbstractBackend:
 
     @abstractmethod
     def run(
-        self, project_uri, entry_point, params, version, backend_config, tracking_uri, experiment_id
+        self,
+        project_uri,
+        entry_point,
+        params,
+        version,
+        backend_config,
+        tracking_uri,
+        experiment_id,
+        run_name,
     ):
         """
         Submit an entrypoint. It must return a SubmittedRun object to track the execution
@@ -31,6 +39,7 @@ class AbstractBackend:
         :param tracking_uri: URI of tracking server against which to log run information related
                              to project execution.
         :param experiment_id: ID of experiment under which to launch the run.
+        :param run_name: Name of the run to use for starting an MLflow run.
 
         :return: A :py:class:`mlflow.projects.SubmittedRun`. This function is expected to run
                  the project asynchronously, i.e. it should trigger project execution and then

--- a/mlflow/projects/backend/local.py
+++ b/mlflow/projects/backend/local.py
@@ -64,7 +64,15 @@ def _env_type_to_env_manager(env_typ):
 
 class LocalBackend(AbstractBackend):
     def run(
-        self, project_uri, entry_point, params, version, backend_config, tracking_uri, experiment_id
+        self,
+        project_uri,
+        entry_point,
+        params,
+        version,
+        backend_config,
+        tracking_uri,
+        experiment_id,
+        run_name,
     ):
         work_dir = fetch_and_validate_project(project_uri, version, entry_point, params)
         project = load_project(work_dir)
@@ -73,7 +81,7 @@ class LocalBackend(AbstractBackend):
         else:
             run_id = None
         active_run = get_or_create_run(
-            run_id, project_uri, experiment_id, work_dir, version, entry_point, params
+            run_id, project_uri, experiment_id, work_dir, version, entry_point, params, run_name
         )
         command_args = []
         command_separator = " "

--- a/mlflow/projects/utils.py
+++ b/mlflow/projects/utils.py
@@ -251,14 +251,16 @@ def _fetch_zip_repo(uri):
     return BytesIO(response.content)
 
 
-def get_or_create_run(run_id, uri, experiment_id, work_dir, version, entry_point, parameters):
+def get_or_create_run(
+    run_id, uri, experiment_id, work_dir, version, entry_point, parameters, run_name
+):
     if run_id:
         return tracking.MlflowClient().get_run(run_id)
     else:
-        return _create_run(uri, experiment_id, work_dir, version, entry_point, parameters)
+        return _create_run(uri, experiment_id, work_dir, version, entry_point, parameters, run_name)
 
 
-def _create_run(uri, experiment_id, work_dir, version, entry_point, parameters):
+def _create_run(uri, experiment_id, work_dir, version, entry_point, parameters, run_name):
     """
     Create a ``Run`` against the current MLflow tracking server, logging metadata (e.g. the URI,
     entry point, and parameters of the project) about the run. Return an ``ActiveRun`` that can be
@@ -295,7 +297,9 @@ def _create_run(uri, experiment_id, work_dir, version, entry_point, parameters):
     if _is_valid_branch_name(work_dir, version):
         tags[MLFLOW_GIT_BRANCH] = version
         tags[LEGACY_MLFLOW_GIT_BRANCH_NAME] = version
-    active_run = tracking.MlflowClient().create_run(experiment_id=experiment_id, tags=tags)
+    active_run = tracking.MlflowClient().create_run(
+        experiment_id=experiment_id, tags=tags, run_name=run_name
+    )
 
     project = _project_spec.load_project(work_dir)
     # Consolidate parameters for logging.

--- a/tests/projects/test_utils.py
+++ b/tests/projects/test_utils.py
@@ -196,6 +196,7 @@ def test_fetch_create_and_log(tmpdir):
     expected_dir = tmpdir
     project_uri = "http://someuri/myproject.git"
     user_param = {"method_name": "newton"}
+    run_name = "my_project"
     with mock.patch("mlflow.projects.utils._fetch_project", return_value=expected_dir):
         with mock.patch(
             "mlflow.projects._project_spec.load_project", return_value=mock_fetched_project
@@ -213,6 +214,7 @@ def test_fetch_create_and_log(tmpdir):
                 version=None,
                 entry_point=entry_point_name,
                 parameters=user_param,
+                run_name=run_name,
             )
 
             # check tags
@@ -222,3 +224,4 @@ def test_fetch_create_and_log(tmpdir):
             assert entry_point_name == run.data.tags[MLFLOW_PROJECT_ENTRY_POINT]
             assert project_uri == run.data.tags[MLFLOW_SOURCE_NAME]
             assert user_param == run.data.params
+            assert run_name == run.info.run_name


### PR DESCRIPTION
Signed-off-by: Ben Wilson <benjamin.wilson@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Support passing `run_name` attribute to the top-level `run_name` argument during run creation in MLflow Projects. Previously, `run_name` was written to a tag entry.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [X] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [X] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
