### PR TITLE
SSE-CPK support added to MLflow

### DIFF
--- a/mlflow/azure/client.py
+++ b/mlflow/azure/client.py
@@ -38,7 +38,7 @@ def put_adls_file_creation(sas_url, headers):
         rest_utils.augmented_raise_for_status(response)
 
 
-def patch_adls_file_upload(sas_url, data, position, headers):
+def patch_adls_file_upload(sas_url, data, position, headers, is_single):
     """
     Performs an ADLS Azure file create `Patch` operation
     (https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update)
@@ -49,7 +49,10 @@ def patch_adls_file_upload(sas_url, data, position, headers):
     :param position: Positional offset of the data in the Patch request
     :param headers: Additional headers to include in the Patch request body
     """
-    request_url = _append_query_parameters(sas_url, {"action": "append", "position": str(position)})
+    new_params = {"action": "append", "position": str(position)}
+    if is_single:
+        new_params["flush"] = "true"
+    request_url = _append_query_parameters(sas_url, new_params)
 
     request_headers = {}
     for name, value in headers.items():

--- a/mlflow/azure/client.py
+++ b/mlflow/azure/client.py
@@ -40,11 +40,11 @@ def put_adls_file_creation(sas_url, headers):
 
 def patch_adls_file_upload(sas_url, data, position, headers):
     """
-    Performs an ADLS Azure file create `Put` operation
-    (https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/create)
+    Performs an ADLS Azure file create `Patch` operation
+    (https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update)
 
     :param sas_url: A shared access signature URL referring to the Azure ADLS server
-                    to which the file creation command should be issued.
+                    to which the file update command should be issued.
     :param data: Data to include in the Patch request body.
     :param position: Positional offset of the data in the Patch request
     :param headers: Additional headers to include in the Patch request body
@@ -67,12 +67,12 @@ def patch_adls_file_upload(sas_url, data, position, headers):
 def patch_adls_flush(sas_url, position, headers):
     """
     Performs an ADLS Azure file flush `Patch` operation
-    (https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/create)
+    (https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update)
 
     :param sas_url: A shared access signature URL referring to the Azure ADLS server
-                    to which the file creation command should be issued.
+                    to which the file update command should be issued.
     :param position: The final size of the file to flush.
-    :param headers: Additional headers to include in the Put request body.
+    :param headers: Additional headers to include in the Patch request body.
     """
     request_url = _append_query_parameters(sas_url, {"action": "flush", "position": str(position)})
 

--- a/mlflow/azure/client.py
+++ b/mlflow/azure/client.py
@@ -14,6 +14,81 @@ _PUT_BLOCK_HEADERS = {
 }
 
 
+def put_adls_file_creation(sas_url, headers):
+    """
+    Performs an ADLS Azure file create `Put` operation
+    (https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/create)
+
+    :param sas_url: A shared access signature URL referring to the Azure ADLS server
+                    to which the file creation command should be issued.
+    :param headers: Additional headers to include in the Put request body
+    """
+    request_url = _append_query_parameters(sas_url, {"resource": "file"})
+
+    request_headers = {}
+    for name, value in headers.items():
+        if _is_valid_adls_put_header(name):
+            request_headers[name] = value
+        else:
+            _logger.debug("Removed unsupported '%s' header for ADLS Gen2 Put operation", name)
+
+    with rest_utils.cloud_storage_http_request(
+        "put", request_url, headers=request_headers
+    ) as response:
+        rest_utils.augmented_raise_for_status(response)
+
+
+def patch_adls_file_upload(sas_url, data, position, headers):
+    """
+    Performs an ADLS Azure file create `Put` operation
+    (https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/create)
+
+    :param sas_url: A shared access signature URL referring to the Azure ADLS server
+                    to which the file creation command should be issued.
+    :param data: Data to include in the Patch request body.
+    :param position: Positional offset of the data in the Patch request
+    :param headers: Additional headers to include in the Patch request body
+    """
+    request_url = _append_query_parameters(sas_url, {"action": "append", "position": str(position)})
+
+    request_headers = {}
+    for name, value in headers.items():
+        if _is_valid_adls_patch_header(name):
+            request_headers[name] = value
+        else:
+            _logger.debug("Removed unsupported '%s' header for ADLS Gen2 Patch operation", name)
+
+    with rest_utils.cloud_storage_http_request(
+        "patch", request_url, data=data, headers=request_headers
+    ) as response:
+        rest_utils.augmented_raise_for_status(response)
+
+
+def patch_adls_flush(sas_url, position, headers):
+    """
+    Performs an ADLS Azure file flush `Patch` operation
+    (https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/create)
+
+    :param sas_url: A shared access signature URL referring to the Azure ADLS server
+                    to which the file creation command should be issued.
+    :param position: The final size of the file to flush.
+    :param headers: Additional headers to include in the Put request body.
+    """
+    request_url = _append_query_parameters(sas_url, {"action": "flush", "position": str(position)})
+
+    request_headers = {}
+    for name, value in headers.items():
+        if _is_valid_adls_put_header(name):
+            request_headers[name] = value
+        else:
+            _logger.debug("Removed unsupported '%s' header for ADLS Gen2 Patch operation", name)
+
+    with rest_utils.cloud_storage_http_request(
+        "patch", request_url, headers=request_headers
+    ) as response:
+        rest_utils.augmented_raise_for_status(response)
+
+
 def put_block(sas_url, block_id, data, headers):
     """
     Performs an Azure `Put Block` operation
@@ -145,4 +220,84 @@ def _is_valid_put_block_header(header_name):
         "x-ms-encryption-key",
         "x-ms-encryption-key-sha256",
         "x-ms-encryption-algorithm",
+    }
+
+
+def _is_valid_adls_put_header(header_name):
+    """
+    :return: True if the specified header name is a valid header for the ADLS Put operation, False
+             otherwise. For a list of valid headers, see
+             https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/create
+    """
+    return header_name in {
+        "Cache-Control",
+        "Content-Encoding",
+        "Content-Language",
+        "Content-Disposition",
+        "x-ms-cache-control",
+        "x-ms-content-type",
+        "x-ms-content-encoding",
+        "x-ms-content-language",
+        "x-ms-content-disposition",
+        "x-ms-rename-source",
+        "x-ms-lease-id",
+        "x-ms-properties",
+        "x-ms-permissions",
+        "x-ms-umask",
+        "x-ms-owner",
+        "x-ms-group",
+        "x-ms-acl",
+        "x-ms-proposed-lease-id",
+        "x-ms-expiry-option",
+        "x-ms-expiry-time",
+        "If-Match",
+        "If-None-Match",
+        "If-Modified-Since",
+        "If-Unmodified-Since",
+        "x-ms-source-if-match",
+        "x-ms-source-if-none-match",
+        "x-ms-source-if-modified-since",
+        "x-ms-source-if-unmodified-since",
+        "x-ms-encryption-key",
+        "x-ms-encryption-key-sha256",
+        "x-ms-encryption-algorithm",
+        "x-ms-encryption-context",
+        "x-ms-client-request-id",
+        "x-ms-date",
+        "x-ms-version",
+    }
+
+
+def _is_valid_adls_patch_header(header_name):
+    """
+    :return: True if the specified header name is a valid header for the ADLS Patch operation, False
+             otherwise. For a list of valid headers, see
+             https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update
+    """
+    return header_name in {
+        "Content-Length",
+        "Content-MD5",
+        "x-ms-lease-id",
+        "x-ms-cache-control",
+        "x-ms-content-type",
+        "x-ms-content-disposition",
+        "x-ms-content-encoding",
+        "x-ms-content-language",
+        "x-ms-content-md5",
+        "x-ms-properties",
+        "x-ms-owner",
+        "x-ms-group",
+        "x-ms-permissions",
+        "x-ms-acl",
+        "If-Match",
+        "If-None-Match",
+        "If-Modified-Since",
+        "If-Unmodified-Since",
+        "x-ms-encryption-key",
+        "x-ms-encryption-key-sha256",
+        "x-ms-encryption-algorithm",
+        "x-ms-encryption-context",
+        "x-ms-client-request-id",
+        "x-ms-date",
+        "x-ms-version",
     }

--- a/mlflow/java/client/src/main/java/com/databricks/api/proto/mlflow/DatabricksArtifacts.java
+++ b/mlflow/java/client/src/main/java/com/databricks/api/proto/mlflow/DatabricksArtifacts.java
@@ -50,6 +50,18 @@ public final class DatabricksArtifacts {
      * <code>GCP_SIGNED_URL = 3;</code>
      */
     GCP_SIGNED_URL(3),
+    /**
+     * <pre>
+     * The credential is an Azure Shared Access Signature URI for ADLS.  For more
+     * information see
+     * https://docs.microsoft.com/en-us/rest/api/storageservices/data-lake-storage-gen2
+     * and
+     * https://docs.microsoft.com/en-us/azure/storage/common/storage-sas-overview
+     * </pre>
+     *
+     * <code>AZURE_ADLS_GEN2_SAS_URI = 4;</code>
+     */
+    AZURE_ADLS_GEN2_SAS_URI(4),
     ;
 
     /**
@@ -79,6 +91,18 @@ public final class DatabricksArtifacts {
      * <code>GCP_SIGNED_URL = 3;</code>
      */
     public static final int GCP_SIGNED_URL_VALUE = 3;
+    /**
+     * <pre>
+     * The credential is an Azure Shared Access Signature URI for ADLS.  For more
+     * information see
+     * https://docs.microsoft.com/en-us/rest/api/storageservices/data-lake-storage-gen2
+     * and
+     * https://docs.microsoft.com/en-us/azure/storage/common/storage-sas-overview
+     * </pre>
+     *
+     * <code>AZURE_ADLS_GEN2_SAS_URI = 4;</code>
+     */
+    public static final int AZURE_ADLS_GEN2_SAS_URI_VALUE = 4;
 
 
     public final int getNumber() {
@@ -104,6 +128,7 @@ public final class DatabricksArtifacts {
         case 1: return AZURE_SAS_URI;
         case 2: return AWS_PRESIGNED_URL;
         case 3: return GCP_SIGNED_URL;
+        case 4: return AZURE_ADLS_GEN2_SAS_URI;
         default: return null;
       }
     }
@@ -7543,19 +7568,20 @@ public final class DatabricksArtifacts {
       "ctCredentialInfo\022\027\n\017next_page_token\030\003 \001(" +
       "\tJ\004\010\001\020\002:_\342?(\n&com.databricks.rpc.RPC[$th" +
       "is.Response]\342?1\n/com.databricks.mlflow.a" +
-      "pi.MlflowTrackingMessage*V\n\026ArtifactCred" +
+      "pi.MlflowTrackingMessage*s\n\026ArtifactCred" +
       "entialType\022\021\n\rAZURE_SAS_URI\020\001\022\025\n\021AWS_PRE" +
-      "SIGNED_URL\020\002\022\022\n\016GCP_SIGNED_URL\020\0032\344\002\n Dat" +
-      "abricksMlflowArtifactsService\022\234\001\n\025getCre" +
-      "dentialsForRead\022\035.mlflow.GetCredentialsF" +
-      "orRead\032&.mlflow.GetCredentialsForRead.Re" +
-      "sponse\"<\362\206\0318\n4\n\004POST\022&/mlflow/artifacts/" +
-      "credentials-for-read\032\004\010\002\020\000\020\003\022\240\001\n\026getCred" +
-      "entialsForWrite\022\036.mlflow.GetCredentialsF" +
-      "orWrite\032\'.mlflow.GetCredentialsForWrite." +
-      "Response\"=\362\206\0319\n5\n\004POST\022\'/mlflow/artifact" +
-      "s/credentials-for-write\032\004\010\002\020\000\020\003B,\n\037com.d" +
-      "atabricks.api.proto.mlflow\220\001\001\240\001\001\342?\002\020\001"
+      "SIGNED_URL\020\002\022\022\n\016GCP_SIGNED_URL\020\003\022\033\n\027AZUR" +
+      "E_ADLS_GEN2_SAS_URI\020\0042\344\002\n DatabricksMlfl" +
+      "owArtifactsService\022\234\001\n\025getCredentialsFor" +
+      "Read\022\035.mlflow.GetCredentialsForRead\032&.ml" +
+      "flow.GetCredentialsForRead.Response\"<\362\206\031" +
+      "8\n4\n\004POST\022&/mlflow/artifacts/credentials" +
+      "-for-read\032\004\010\002\020\000\020\003\022\240\001\n\026getCredentialsForW" +
+      "rite\022\036.mlflow.GetCredentialsForWrite\032\'.m" +
+      "lflow.GetCredentialsForWrite.Response\"=\362" +
+      "\206\0319\n5\n\004POST\022\'/mlflow/artifacts/credentia" +
+      "ls-for-write\032\004\010\002\020\000\020\003B,\n\037com.databricks.a" +
+      "pi.proto.mlflow\220\001\001\240\001\001\342?\002\020\001"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,

--- a/mlflow/protos/databricks_artifacts.proto
+++ b/mlflow/protos/databricks_artifacts.proto
@@ -58,6 +58,13 @@ enum ArtifactCredentialType {
   // The credential is a GCP Signed URL. For more information, see
   // https://cloud.google.com/storage/docs/access-control/signed-urls
   GCP_SIGNED_URL = 3;
+
+  // The credential is an Azure Shared Access Signature URI for ADLS.  For more
+  // information see
+  // https://docs.microsoft.com/en-us/rest/api/storageservices/data-lake-storage-gen2
+  // and
+  // https://docs.microsoft.com/en-us/azure/storage/common/storage-sas-overview
+  AZURE_ADLS_GEN2_SAS_URI = 4;
 }
 
 message ArtifactCredentialInfo {

--- a/mlflow/protos/databricks_artifacts_pb2.py
+++ b/mlflow/protos/databricks_artifacts_pb2.py
@@ -19,13 +19,14 @@ from .scalapb import scalapb_pb2 as scalapb_dot_scalapb__pb2
 from . import databricks_pb2 as databricks__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1a\x64\x61tabricks_artifacts.proto\x12\x06mlflow\x1a\x15scalapb/scalapb.proto\x1a\x10\x64\x61tabricks.proto\"\xdf\x01\n\x16\x41rtifactCredentialInfo\x12\x0e\n\x06run_id\x18\x01 \x01(\t\x12\x0c\n\x04path\x18\x02 \x01(\t\x12\x12\n\nsigned_uri\x18\x03 \x01(\t\x12:\n\x07headers\x18\x04 \x03(\x0b\x32).mlflow.ArtifactCredentialInfo.HttpHeader\x12,\n\x04type\x18\x05 \x01(\x0e\x32\x1e.mlflow.ArtifactCredentialType\x1a)\n\nHttpHeader\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"\x95\x02\n\x15GetCredentialsForRead\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0c\n\x04path\x18\x02 \x03(\t\x12\x12\n\npage_token\x18\x03 \x01(\t\x1a\x63\n\x08Response\x12\x38\n\x10\x63redential_infos\x18\x02 \x03(\x0b\x32\x1e.mlflow.ArtifactCredentialInfo\x12\x17\n\x0fnext_page_token\x18\x03 \x01(\tJ\x04\x08\x01\x10\x02:_\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\xe2?1\n/com.databricks.mlflow.api.MlflowTrackingMessage\"\x96\x02\n\x16GetCredentialsForWrite\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0c\n\x04path\x18\x02 \x03(\t\x12\x12\n\npage_token\x18\x03 \x01(\t\x1a\x63\n\x08Response\x12\x38\n\x10\x63redential_infos\x18\x02 \x03(\x0b\x32\x1e.mlflow.ArtifactCredentialInfo\x12\x17\n\x0fnext_page_token\x18\x03 \x01(\tJ\x04\x08\x01\x10\x02:_\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\xe2?1\n/com.databricks.mlflow.api.MlflowTrackingMessage*V\n\x16\x41rtifactCredentialType\x12\x11\n\rAZURE_SAS_URI\x10\x01\x12\x15\n\x11\x41WS_PRESIGNED_URL\x10\x02\x12\x12\n\x0eGCP_SIGNED_URL\x10\x03\x32\xe4\x02\n DatabricksMlflowArtifactsService\x12\x9c\x01\n\x15getCredentialsForRead\x12\x1d.mlflow.GetCredentialsForRead\x1a&.mlflow.GetCredentialsForRead.Response\"<\xf2\x86\x19\x38\n4\n\x04POST\x12&/mlflow/artifacts/credentials-for-read\x1a\x04\x08\x02\x10\x00\x10\x03\x12\xa0\x01\n\x16getCredentialsForWrite\x12\x1e.mlflow.GetCredentialsForWrite\x1a\'.mlflow.GetCredentialsForWrite.Response\"=\xf2\x86\x19\x39\n5\n\x04POST\x12\'/mlflow/artifacts/credentials-for-write\x1a\x04\x08\x02\x10\x00\x10\x03\x42,\n\x1f\x63om.databricks.api.proto.mlflow\x90\x01\x01\xa0\x01\x01\xe2?\x02\x10\x01')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1a\x64\x61tabricks_artifacts.proto\x12\x06mlflow\x1a\x15scalapb/scalapb.proto\x1a\x10\x64\x61tabricks.proto\"\xdf\x01\n\x16\x41rtifactCredentialInfo\x12\x0e\n\x06run_id\x18\x01 \x01(\t\x12\x0c\n\x04path\x18\x02 \x01(\t\x12\x12\n\nsigned_uri\x18\x03 \x01(\t\x12:\n\x07headers\x18\x04 \x03(\x0b\x32).mlflow.ArtifactCredentialInfo.HttpHeader\x12,\n\x04type\x18\x05 \x01(\x0e\x32\x1e.mlflow.ArtifactCredentialType\x1a)\n\nHttpHeader\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"\x95\x02\n\x15GetCredentialsForRead\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0c\n\x04path\x18\x02 \x03(\t\x12\x12\n\npage_token\x18\x03 \x01(\t\x1a\x63\n\x08Response\x12\x38\n\x10\x63redential_infos\x18\x02 \x03(\x0b\x32\x1e.mlflow.ArtifactCredentialInfo\x12\x17\n\x0fnext_page_token\x18\x03 \x01(\tJ\x04\x08\x01\x10\x02:_\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\xe2?1\n/com.databricks.mlflow.api.MlflowTrackingMessage\"\x96\x02\n\x16GetCredentialsForWrite\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0c\n\x04path\x18\x02 \x03(\t\x12\x12\n\npage_token\x18\x03 \x01(\t\x1a\x63\n\x08Response\x12\x38\n\x10\x63redential_infos\x18\x02 \x03(\x0b\x32\x1e.mlflow.ArtifactCredentialInfo\x12\x17\n\x0fnext_page_token\x18\x03 \x01(\tJ\x04\x08\x01\x10\x02:_\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\xe2?1\n/com.databricks.mlflow.api.MlflowTrackingMessage*s\n\x16\x41rtifactCredentialType\x12\x11\n\rAZURE_SAS_URI\x10\x01\x12\x15\n\x11\x41WS_PRESIGNED_URL\x10\x02\x12\x12\n\x0eGCP_SIGNED_URL\x10\x03\x12\x1b\n\x17\x41ZURE_ADLS_GEN2_SAS_URI\x10\x04\x32\xe4\x02\n DatabricksMlflowArtifactsService\x12\x9c\x01\n\x15getCredentialsForRead\x12\x1d.mlflow.GetCredentialsForRead\x1a&.mlflow.GetCredentialsForRead.Response\"<\xf2\x86\x19\x38\n4\n\x04POST\x12&/mlflow/artifacts/credentials-for-read\x1a\x04\x08\x02\x10\x00\x10\x03\x12\xa0\x01\n\x16getCredentialsForWrite\x12\x1e.mlflow.GetCredentialsForWrite\x1a\'.mlflow.GetCredentialsForWrite.Response\"=\xf2\x86\x19\x39\n5\n\x04POST\x12\'/mlflow/artifacts/credentials-for-write\x1a\x04\x08\x02\x10\x00\x10\x03\x42,\n\x1f\x63om.databricks.api.proto.mlflow\x90\x01\x01\xa0\x01\x01\xe2?\x02\x10\x01')
 
 _ARTIFACTCREDENTIALTYPE = DESCRIPTOR.enum_types_by_name['ArtifactCredentialType']
 ArtifactCredentialType = enum_type_wrapper.EnumTypeWrapper(_ARTIFACTCREDENTIALTYPE)
 AZURE_SAS_URI = 1
 AWS_PRESIGNED_URL = 2
 GCP_SIGNED_URL = 3
+AZURE_ADLS_GEN2_SAS_URI = 4
 
 
 _ARTIFACTCREDENTIALINFO = DESCRIPTOR.message_types_by_name['ArtifactCredentialInfo']
@@ -97,7 +98,7 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _DATABRICKSMLFLOWARTIFACTSSERVICE.methods_by_name['getCredentialsForWrite']._options = None
   _DATABRICKSMLFLOWARTIFACTSSERVICE.methods_by_name['getCredentialsForWrite']._serialized_options = b'\362\206\0319\n5\n\004POST\022\'/mlflow/artifacts/credentials-for-write\032\004\010\002\020\000\020\003'
   _ARTIFACTCREDENTIALTYPE._serialized_start=866
-  _ARTIFACTCREDENTIALTYPE._serialized_end=952
+  _ARTIFACTCREDENTIALTYPE._serialized_end=981
   _ARTIFACTCREDENTIALINFO._serialized_start=80
   _ARTIFACTCREDENTIALINFO._serialized_end=303
   _ARTIFACTCREDENTIALINFO_HTTPHEADER._serialized_start=262
@@ -110,8 +111,8 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _GETCREDENTIALSFORWRITE._serialized_end=864
   _GETCREDENTIALSFORWRITE_RESPONSE._serialized_start=387
   _GETCREDENTIALSFORWRITE_RESPONSE._serialized_end=486
-  _DATABRICKSMLFLOWARTIFACTSSERVICE._serialized_start=955
-  _DATABRICKSMLFLOWARTIFACTSSERVICE._serialized_end=1311
+  _DATABRICKSMLFLOWARTIFACTSSERVICE._serialized_start=984
+  _DATABRICKSMLFLOWARTIFACTSSERVICE._serialized_end=1340
 DatabricksMlflowArtifactsService = service_reflection.GeneratedServiceType('DatabricksMlflowArtifactsService', (_service.Service,), dict(
   DESCRIPTOR = _DATABRICKSMLFLOWARTIFACTSSERVICE,
   __module__ = 'databricks_artifacts_pb2'

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -780,8 +780,6 @@ def load_model(model_uri, dfs_tmpdir=None, dst_path=None):
 
     flavor_conf = _get_flavor_configuration_from_uri(model_uri, FLAVOR_NAME)
     model_uri = append_to_uri_path(model_uri, flavor_conf["model_data"])
-    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
-    _add_code_from_conf_to_system_path(local_model_path, flavor_conf)
 
     if _should_use_mlflowdbfs(model_uri):
         from pyspark.ml.pipeline import PipelineModel
@@ -794,6 +792,8 @@ def load_model(model_uri, dfs_tmpdir=None, dst_path=None):
         ):
             return PipelineModel.load(mlflowdbfs_path)
 
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
+    _add_code_from_conf_to_system_path(local_model_path, flavor_conf)
     return _load_model(
         model_uri=model_uri, dfs_tmpdir_base=dfs_tmpdir, local_model_path=local_model_path
     )

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -780,6 +780,8 @@ def load_model(model_uri, dfs_tmpdir=None, dst_path=None):
 
     flavor_conf = _get_flavor_configuration_from_uri(model_uri, FLAVOR_NAME)
     model_uri = append_to_uri_path(model_uri, flavor_conf["model_data"])
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
+    _add_code_from_conf_to_system_path(local_model_path, flavor_conf)
 
     if _should_use_mlflowdbfs(model_uri):
         from pyspark.ml.pipeline import PipelineModel
@@ -792,8 +794,6 @@ def load_model(model_uri, dfs_tmpdir=None, dst_path=None):
         ):
             return PipelineModel.load(mlflowdbfs_path)
 
-    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
-    _add_code_from_conf_to_system_path(local_model_path, flavor_conf)
     return _load_model(
         model_uri=model_uri, dfs_tmpdir_base=dfs_tmpdir, local_model_path=local_model_path
     )

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -343,15 +343,6 @@ class DatabricksArtifactRepository(ArtifactRepository):
                 message="Cloud provider not supported.", error_code=INTERNAL_ERROR
             )
 
-    def _convert_http_headers(self, artifact_service_headers):
-        if artifact_service_headers == None or len(artifact_service_headers) == 0:
-            return {}
-        ret_val = {}
-        for cur_header in artifact_service_headers:
-            if "name" in cur_header and "value" in cur_header:
-                ret_val[cur_header["name"]] = cur_header["value"]
-        return ret_val
-
     def _download_from_cloud(self, cloud_credential_info, dst_local_file_path):
         """
         Download a file from the input `cloud_credential_info` and save it to `dst_local_file_path`.
@@ -370,7 +361,7 @@ class DatabricksArtifactRepository(ArtifactRepository):
                 cloud_credential_info.signed_uri,
                 dst_local_file_path,
                 _DOWNLOAD_CHUNK_SIZE,
-                self._convert_http_headers(cloud_credential_info.headers),
+                self._extract_headers_from_credentials(cloud_credential_info.headers),
             )
         except Exception as err:
             raise MlflowException(err)

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -271,6 +271,15 @@ class DatabricksArtifactRepository(ArtifactRepository):
                 message="Cloud provider not supported.", error_code=INTERNAL_ERROR
             )
 
+    def _convert_http_headers(self, artifact_service_headers):
+        if artifact_service_headers == None or len(artifact_service_headers) == 0:
+            return {}
+        ret_val = {}
+        for cur_header in artifact_service_headers:
+            if "name" in cur_header and "value" in cur_header:
+                ret_val[cur_header["name"]] = cur_header["value"]
+        return ret_val
+
     def _download_from_cloud(self, cloud_credential_info, dst_local_file_path):
         """
         Download a file from the input `cloud_credential_info` and save it to `dst_local_file_path`.
@@ -285,7 +294,10 @@ class DatabricksArtifactRepository(ArtifactRepository):
             )
         try:
             download_file_using_http_uri(
-                cloud_credential_info.signed_uri, dst_local_file_path, _DOWNLOAD_CHUNK_SIZE
+                cloud_credential_info.signed_uri,
+                dst_local_file_path,
+                _DOWNLOAD_CHUNK_SIZE,
+                self._convert_http_headers(cloud_credential_info.headers),
             )
         except Exception as err:
             raise MlflowException(err)

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -183,6 +183,9 @@ class DatabricksArtifactRepository(ArtifactRepository):
         return self._get_credential_infos(GetCredentialsForRead, run_id, paths)
 
     def _extract_headers_from_credentials(self, headers):
+        """
+        :return: A python dictionary of http headers converted from the protobuf credentials
+        """
         return {header.name: header.value for header in headers}
 
     def _azure_upload_file(self, credentials, local_file, artifact_path):

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -244,7 +244,6 @@ class DatabricksArtifactRepository(ArtifactRepository):
         # Attempt to call the passed function.  Retry if the credentials have expired
         try:
             func(**kwargs)
-            #put_adls_file_creation(credentials.signed_uri, headers=headers)
         except requests.HTTPError as e:
             if e.response.status_code in [403]:
                 _logger.info(

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -532,7 +532,7 @@ def yield_file_in_chunks(file, chunk_size=100000000):
                 break
 
 
-def download_file_using_http_uri(http_uri, download_path, chunk_size=100000000):
+def download_file_using_http_uri(http_uri, download_path, chunk_size=100000000, headers=None):
     """
     Downloads a file specified using the `http_uri` to a local `download_path`. This function
     uses a `chunk_size` to ensure an OOM error is not raised a large file is downloaded.
@@ -540,7 +540,7 @@ def download_file_using_http_uri(http_uri, download_path, chunk_size=100000000):
     Note : This function is meant to download files using presigned urls from various cloud
             providers.
     """
-    with cloud_storage_http_request("get", http_uri, stream=True) as response:
+    with cloud_storage_http_request("get", http_uri, stream=True, headers=headers) as response:
         augmented_raise_for_status(response)
         with open(download_path, "wb") as output_file:
             for chunk in response.iter_content(chunk_size=chunk_size):

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -529,7 +529,7 @@ def yield_file_in_chunks(file, chunk_size=100000000):
                 break
 
 
-def download_file_using_http_uri(http_uri, download_path, chunk_size=100000000):
+def download_file_using_http_uri(http_uri, download_path, chunk_size=100000000, headers=None):
     """
     Downloads a file specified using the `http_uri` to a local `download_path`. This function
     uses a `chunk_size` to ensure an OOM error is not raised a large file is downloaded.
@@ -537,7 +537,7 @@ def download_file_using_http_uri(http_uri, download_path, chunk_size=100000000):
     Note : This function is meant to download files using presigned urls from various cloud
             providers.
     """
-    with cloud_storage_http_request("get", http_uri, stream=True) as response:
+    with cloud_storage_http_request("get", http_uri, stream=True, headers=headers) as response:
         augmented_raise_for_status(response)
         with open(download_path, "wb") as output_file:
             for chunk in response.iter_content(chunk_size=chunk_size):

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -299,9 +299,9 @@ def cloud_storage_http_request(
     **kwargs,
 ):
     """
-    Performs an HTTP PUT/GET request using Python's `requests` module with automatic retry.
+    Performs an HTTP PUT/GET/PATCH request using Python's `requests` module with automatic retry.
 
-    :param method: string of 'PUT' or 'GET', specify to do http PUT or GET
+    :param method: string of 'PUT' or 'GET' or 'PATCH', specify to do http PUT or GET or PATCH
     :param url: the target URL address for the HTTP request.
     :param max_retries: maximum number of retries before throwing an exception.
     :param backoff_factor: a time factor for exponential backoff. e.g. value 5 means the HTTP
@@ -314,7 +314,7 @@ def cloud_storage_http_request(
 
     :return requests.Response object.
     """
-    if method.lower() not in ("put", "get"):
+    if method.lower() not in ("put", "get", "patch"):
         raise ValueError("Illegal http method: " + method)
     try:
         with _get_http_response_with_retries(

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -378,7 +378,7 @@ class TestDatabricksArtifactRepository:
             DATABRICKS_ARTIFACT_REPOSITORY + "._get_write_credential_infos"
         ) as write_credential_infos_mock, mock.patch(
             "mlflow.utils.rest_utils.cloud_storage_http_request",
-            side_effect=[mock_successful_response, mock_successful_response, mock_error_response],
+            side_effect=[mock_successful_response, mock_error_response],
         ) as request_mock:
             mock_credential_info = ArtifactCredentialInfo(
                 signed_uri=MOCK_ADLS_GEN2_SIGNED_URI,
@@ -393,10 +393,10 @@ class TestDatabricksArtifactRepository:
                 MOCK_ADLS_GEN2_SIGNED_URI + "?resource=file",
                 headers={},
             )
-            # test with asure max block size
+            # test with azure max block size
             request_mock.assert_any_call(
                 "patch",
-                MOCK_ADLS_GEN2_SIGNED_URI + "?action=append&position=0",
+                MOCK_ADLS_GEN2_SIGNED_URI + "?action=append&position=0&flush=true",
                 data=ANY,
                 headers={},
             )

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -380,7 +380,7 @@ class TestDatabricksArtifactRepository:
         )
         with mock.patch(
             DATABRICKS_ARTIFACT_REPOSITORY + "._get_write_credential_infos",
-            return_value=[mock_credential_info]
+            return_value=[mock_credential_info],
         ) as write_credential_infos_mock, mock.patch(
             "mlflow.utils.rest_utils.cloud_storage_http_request",
             side_effect=[mock_successful_response, mock_error_response],
@@ -403,7 +403,7 @@ class TestDatabricksArtifactRepository:
                     MOCK_ADLS_GEN2_SIGNED_URI + "?action=append&position=0&flush=true",
                     data=ANY,
                     headers={},
-                )
+                ),
             ]
 
     @pytest.mark.parametrize(("artifact_path", "expected_location"), [(None, "test.txt")])

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -29,6 +29,7 @@ DATABRICKS_ARTIFACT_REPOSITORY = (
 )
 
 MOCK_AZURE_SIGNED_URI = "http://this_is_a_mock_sas_for_azure"
+MOCK_ADLS_GEN2_SIGNED_URI = "http://this_is_a_mock_sas_for_adls_gen2"
 MOCK_AWS_SIGNED_URI = "http://this_is_a_mock_presigned_uri_for_aws?"
 MOCK_GCP_SIGNED_URL = "http://this_is_a_mock_signed_url_for_gcp?"
 MOCK_RUN_ID = "MOCK-RUN-ID"
@@ -273,6 +274,132 @@ class TestDatabricksArtifactRepository:
             with pytest.raises(MlflowException, match=r".+"):
                 databricks_artifact_repo.log_artifact(test_file.strpath)
             write_credential_infos_mock.assert_called_with(run_id=MOCK_RUN_ID, paths=ANY)
+
+    @pytest.mark.parametrize(
+        ("artifact_path", "expected_location"),
+        [(None, "test.txt"), ("output", "output/test.txt"), ("", "test.txt")],
+    )
+    def test_log_artifact_adls_gen2(
+        self, databricks_artifact_repo, test_file, artifact_path, expected_location
+    ):
+        with mock.patch(
+            DATABRICKS_ARTIFACT_REPOSITORY + "._get_write_credential_infos"
+        ) as write_credential_infos_mock, mock.patch(
+            DATABRICKS_ARTIFACT_REPOSITORY + "._azure_adls_gen2_upload_file"
+        ) as azure_adls_gen2_upload_mock:
+            mock_credential_info = ArtifactCredentialInfo(
+                signed_uri=MOCK_ADLS_GEN2_SIGNED_URI,
+                type=ArtifactCredentialType.AZURE_ADLS_GEN2_SAS_URI,
+            )
+            write_credential_infos_mock.return_value = [mock_credential_info]
+            azure_adls_gen2_upload_mock.return_value = None
+            databricks_artifact_repo.log_artifact(test_file.strpath, artifact_path)
+            write_credential_infos_mock.assert_called_with(
+                run_id=MOCK_RUN_ID, paths=[expected_location]
+            )
+            azure_adls_gen2_upload_mock.assert_called_with(
+                mock_credential_info, test_file.strpath, expected_location
+            )
+
+    @pytest.mark.parametrize(("artifact_path", "expected_location"), [(None, "test.txt")])
+    def test_log_artifact_adls_gen2_with_headers(
+        self, databricks_artifact_repo, test_file, artifact_path, expected_location
+    ):
+        mock_azure_headers = {
+            "x-ms-content-type": "test-type",
+            "x-ms-owner": "some-owner",
+            "x-ms-something_not_supported": "some-value",
+        }
+        filtered_azure_headers = {
+            "x-ms-content-type": "test-type",
+            "x-ms-owner": "some-owner",
+        }
+        mock_response = Response()
+        mock_response.status_code = 200
+        mock_response.close = lambda: None
+        with mock.patch(
+            DATABRICKS_ARTIFACT_REPOSITORY + "._get_write_credential_infos"
+        ) as write_credential_infos_mock, mock.patch(
+            "mlflow.utils.rest_utils.cloud_storage_http_request"
+        ) as request_mock, mock.patch(
+            "mlflow.store.artifact.databricks_artifact_repo._AZURE_MAX_BLOCK_CHUNK_SIZE",
+            5,
+        ):
+            mock_credential_info = ArtifactCredentialInfo(
+                signed_uri=MOCK_ADLS_GEN2_SIGNED_URI,
+                type=ArtifactCredentialType.AZURE_ADLS_GEN2_SAS_URI,
+                headers=[
+                    ArtifactCredentialInfo.HttpHeader(name=header_name, value=header_value)
+                    for header_name, header_value in mock_azure_headers.items()
+                ],
+            )
+            write_credential_infos_mock.return_value = [mock_credential_info]
+            request_mock.return_value = mock_response
+            databricks_artifact_repo.log_artifact(test_file.strpath, artifact_path)
+            write_credential_infos_mock.assert_called_with(
+                run_id=MOCK_RUN_ID, paths=[expected_location]
+            )
+            # test with block size 5
+            request_mock.assert_any_call(
+                "put",
+                MOCK_ADLS_GEN2_SIGNED_URI + "?resource=file",
+                headers=filtered_azure_headers,
+            )
+            request_mock.assert_any_call(
+                "patch",
+                MOCK_ADLS_GEN2_SIGNED_URI + "?action=append&position=0",
+                data=ANY,
+                headers=filtered_azure_headers,
+            )
+            request_mock.assert_any_call(
+                "patch",
+                MOCK_ADLS_GEN2_SIGNED_URI + "?action=append&position=5",
+                data=ANY,
+                headers=filtered_azure_headers,
+            )
+            request_mock.assert_any_call(
+                "patch",
+                MOCK_ADLS_GEN2_SIGNED_URI + "?action=append&position=10",
+                data=ANY,
+                headers=filtered_azure_headers,
+            )
+            request_mock.assert_called_with(
+                "patch",
+                MOCK_ADLS_GEN2_SIGNED_URI + "?action=flush&position=14",
+                headers=filtered_azure_headers,
+            )
+
+    def test_log_artifact_adls_gen2_flush_error(self, databricks_artifact_repo, test_file):
+        mock_successful_response = Response()
+        mock_successful_response.status_code = 200
+        mock_successful_response.close = lambda: None
+        mock_error_response = MlflowException("MOCK ERROR")
+        with mock.patch(
+            DATABRICKS_ARTIFACT_REPOSITORY + "._get_write_credential_infos"
+        ) as write_credential_infos_mock, mock.patch(
+            "mlflow.utils.rest_utils.cloud_storage_http_request",
+            side_effect=[mock_successful_response, mock_successful_response, mock_error_response],
+        ) as request_mock:
+            mock_credential_info = ArtifactCredentialInfo(
+                signed_uri=MOCK_ADLS_GEN2_SIGNED_URI,
+                type=ArtifactCredentialType.AZURE_ADLS_GEN2_SAS_URI,
+            )
+            write_credential_infos_mock.return_value = [mock_credential_info]
+            with pytest.raises(MlflowException, match=r"MOCK ERROR"):
+                databricks_artifact_repo.log_artifact(test_file.strpath)
+            write_credential_infos_mock.assert_called_with(run_id=MOCK_RUN_ID, paths=ANY)
+            request_mock.assert_any_call(
+                "put",
+                MOCK_ADLS_GEN2_SIGNED_URI + "?resource=file",
+                headers={},
+            )
+            # test with asure max block size
+            request_mock.assert_any_call(
+                "patch",
+                MOCK_ADLS_GEN2_SIGNED_URI + "?action=append&position=0",
+                data=ANY,
+                headers={},
+            )
 
     @pytest.mark.parametrize(("artifact_path", "expected_location"), [(None, "test.txt")])
     def test_log_artifact_aws(

--- a/tests/store/artifact/test_databricks_models_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_models_artifact_repo.py
@@ -221,8 +221,10 @@ class TestDatabricksModelArtifactRepository:
         signed_uri_response_mock = mock.MagicMock()
         signed_uri_response_mock.status_code = 200
         signed_uri_mock = {
-            "signed_uri": "https://my-amazing-signed-uri-to-rule-them-all.com/1234-numbers-yay-567"
+            "signed_uri": "https://my-amazing-signed-uri-to-rule-them-all.com/1234-numbers-yay-567",
+            "headers": [{"name": "header_name", "value": "header_value"}],
         }
+        expected_headers = {"header_name": "header_value"}
         signed_uri_response_mock.text = json.dumps(signed_uri_mock)
         with mock.patch(
             DATABRICKS_MODEL_ARTIFACT_REPOSITORY + "._call_endpoint"
@@ -233,7 +235,12 @@ class TestDatabricksModelArtifactRepository:
             download_mock.return_value = None
             databricks_model_artifact_repo.download_artifacts(remote_file_path, local_path)
             call_endpoint_mock.assert_called_with(ANY, REGISTRY_ARTIFACT_PRESIGNED_URI_ENDPOINT)
-            download_mock.assert_called_with(signed_uri_mock["signed_uri"], ANY, ANY)
+            download_mock.assert_called_with(
+                signed_uri_mock["signed_uri"],
+                ANY,
+                ANY,
+                expected_headers,
+            )
 
     def test_download_file_get_request_fail(self, databricks_model_artifact_repo):
         with mock.patch(


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

In this PR we:

- Add protobuf definitions to support the new presigned URL type
- Add azure client support for ADLS Gen2 HTTP create, append and flush operations
- Update the artifact repositories that use the current Azure blob store upload/download APIs to be able to handle the new PresignedUrl type and handle ADLS Gen2 URLs.
- Single part and multipart upload for ADLS Gen2 in the databricks artifact repository.
- Threaded encryption headers into all upload and download calls
- Unit tests

## How is this patch tested?

We have added new unit tests to unit test the repository code paths.  We have also manually tested this change on a CPK test shard and manually validated that this feature branch works.

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
