### PR TITLE
Add /version path to scoring_server that returns mlflow version

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -1597,6 +1597,16 @@ be used to safely deploy the model to various environments such as Kubernetes.
 You deploy MLflow model locally or generate a Docker image using the CLI interface to the
 :py:mod:`mlflow.models` module.
 
+The REST API defines 4 endpoints:
+
+* /ping used for health check
+
+* /health (same as /ping)
+
+* /version used for getting the mlflow version
+
+* /invocations used for scoring
+
 The REST API server accepts the following data formats as POST input to the ``/invocations`` path:
 
 * JSON-serialized pandas DataFrames in the ``split`` orientation. For example,

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -1599,13 +1599,13 @@ You deploy MLflow model locally or generate a Docker image using the CLI interfa
 
 The REST API defines 4 endpoints:
 
-* /ping used for health check
+* `/ping` used for health check
 
-* /health (same as /ping)
+* `/health` (same as /ping)
 
-* /version used for getting the mlflow version
+* `/version` used for getting the mlflow version
 
-* /invocations used for scoring
+* `/invocations` used for scoring
 
 The REST API server accepts the following data formats as POST input to the ``/invocations`` path:
 

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -1599,13 +1599,13 @@ You deploy MLflow model locally or generate a Docker image using the CLI interfa
 
 The REST API defines 4 endpoints:
 
-* `/ping` used for health check
+* ``/ping`` used for health check
 
-* `/health` (same as /ping)
+* ``/health`` (same as /ping)
 
-* `/version` used for getting the mlflow version
+* ``/version`` used for getting the mlflow version
 
-* `/invocations` used for scoring
+* ``/invocations`` used for scoring
 
 The REST API server accepts the following data formats as POST input to the ``/invocations`` path:
 

--- a/mlflow/java/scoring/src/main/java/org/mlflow/sagemaker/ScoringServer.java
+++ b/mlflow/java/scoring/src/main/java/org/mlflow/sagemaker/ScoringServer.java
@@ -55,7 +55,8 @@ public class ScoringServer {
 
     ServletContextHandler rootContextHandler = new ServletContextHandler(null, "/");
     rootContextHandler.addServlet(new ServletHolder(new ScoringServer.PingServlet()), "/ping");
-    rootContextHandler.addServlet(new ServletHolder(new ScoringServer.VersionServlet()), "/version");
+    rootContextHandler.addServlet(new ServletHolder(
+        new ScoringServer.VersionServlet()), "/version");
     rootContextHandler.addServlet(
         new ServletHolder(new ScoringServer.InvocationsServlet(predictor)), "/invocations");
     this.server.setHandler(rootContextHandler);
@@ -171,7 +172,7 @@ public class ScoringServer {
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
       response.setStatus(HttpServletResponse.SC_OK);
-      response.getWriter().print("1.29.1.dev0");
+      response.getWriter().print("1.29.1-SNAPSHOT");
       response.getWriter().close();
     }
   }

--- a/mlflow/java/scoring/src/main/java/org/mlflow/sagemaker/ScoringServer.java
+++ b/mlflow/java/scoring/src/main/java/org/mlflow/sagemaker/ScoringServer.java
@@ -55,6 +55,7 @@ public class ScoringServer {
 
     ServletContextHandler rootContextHandler = new ServletContextHandler(null, "/");
     rootContextHandler.addServlet(new ServletHolder(new ScoringServer.PingServlet()), "/ping");
+    rootContextHandler.addServlet(new ServletHolder(new ScoringServer.VersionServlet()), "/version");
     rootContextHandler.addServlet(
         new ServletHolder(new ScoringServer.InvocationsServlet(predictor)), "/invocations");
     this.server.setHandler(rootContextHandler);
@@ -163,6 +164,15 @@ public class ScoringServer {
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) {
       response.setStatus(HttpServletResponse.SC_OK);
+    }
+  }
+
+  static class VersionServlet extends HttpServlet {
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+      response.setStatus(HttpServletResponse.SC_OK);
+      response.getWriter().print("1.29.1.dev0");
+      response.getWriter().close();
     }
   }
 

--- a/mlflow/java/scoring/src/test/java/org/mlflow/ScoringServerTest.java
+++ b/mlflow/java/scoring/src/test/java/org/mlflow/ScoringServerTest.java
@@ -68,6 +68,21 @@ public class ScoringServerTest {
   }
 
   @Test
+  public void testScoringServerWithValidPredictorRespondsToVersionCorrectly() throws IOException {
+    TestPredictor validPredictor = new TestPredictor(true);
+    ScoringServer server = new ScoringServer(validPredictor);
+    server.start();
+
+    String requestUrl = String.format("http://localhost:%d/version", server.getPort().get());
+    HttpGet getRequest = new HttpGet(requestUrl);
+    HttpResponse response = httpClient.execute(getRequest);
+    Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+    String responseBody = getHttpResponseBody(response);
+    Assert.assertEquals("1.29.1.dev0", responseBody);
+    server.stop();
+  }
+
+  @Test
   public void testConstructingScoringServerFromInvalidModelPathThrowsException() {
     String badModelPath = "/not/a/valid/path";
     try {

--- a/mlflow/java/scoring/src/test/java/org/mlflow/ScoringServerTest.java
+++ b/mlflow/java/scoring/src/test/java/org/mlflow/ScoringServerTest.java
@@ -78,7 +78,7 @@ public class ScoringServerTest {
     HttpResponse response = httpClient.execute(getRequest);
     Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
     String responseBody = getHttpResponseBody(response);
-    Assert.assertEquals("1.29.1.dev0", responseBody);
+    Assert.assertEquals("1.29.1-SNAPSHOT", responseBody);
     server.stop();
   }
 

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -6,9 +6,10 @@ The passed int model is expected to have function:
 Input, expected in text/csv or application/json format,
 is parsed into pandas.DataFrame and passed to the model.
 
-Defines three endpoints:
+Defines four endpoints:
     /ping used for health check
     /health (same as /ping)
+    /version used for getting the mlflow version
     /invocations used for scoring
 """
 from collections import OrderedDict
@@ -37,6 +38,7 @@ from mlflow.utils.proto_json_utils import (
     _get_jsonable_obj,
     parse_tf_serving_input,
 )
+from mlflow.version import VERSION
 
 try:
     from mlflow.pyfunc import load_model, PyFuncModel
@@ -230,6 +232,13 @@ def init(model: PyFuncModel):
         health = model is not None
         status = 200 if health else 404
         return flask.Response(response="\n", status=status, mimetype="application/json")
+
+    @app.route("/version", methods=["GET"])
+    def version():  # pylint: disable=unused-variable
+        """
+        Returns the current mlflow version.
+        """
+        return flask.Response(response=VERSION, status=200, mimetype="application/json")
 
     @app.route("/invocations", methods=["POST"])
     @catch_mlflow_exception

--- a/mlflow/pyfunc/scoring_server/client.py
+++ b/mlflow/pyfunc/scoring_server/client.py
@@ -15,6 +15,12 @@ class ScoringServerClient:
         if ping_status.status_code != 200:
             raise Exception(f"ping failed (error code {ping_status.status_code})")
 
+    def get_version(self):
+        resp_status = requests.get(url=self.url_prefix + "/version")
+        if resp_status.status_code != 200:
+            raise Exception(f"version failed (error code {resp_status.status_code})")
+        return resp_status.text
+
     def wait_server_ready(self, timeout=30, scoring_server_proc=None):
         begin_time = time.time()
 

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -212,7 +212,6 @@ def pyfunc_serve_and_score_model(
         scoring_cmd += extra_args
         validate_version = "--enable-mlserver" not in extra_args
     proc = _start_scoring_proc(cmd=scoring_cmd, env=env, stdout=stdout, stderr=stdout)
-    validate_version = "--enable-mlserver" not in extra_args
     return _evaluate_scoring_proc(
         proc, port, data, content_type, activity_polling_timeout_seconds, validate_version
     )

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -207,8 +207,10 @@ def pyfunc_serve_and_score_model(
         str(port),
         "--install-mlflow",
     ]
+    validate_version = True
     if extra_args is not None:
         scoring_cmd += extra_args
+        validate_version = "--enable-mlserver" not in extra_args
     proc = _start_scoring_proc(cmd=scoring_cmd, env=env, stdout=stdout, stderr=stdout)
     validate_version = "--enable-mlserver" not in extra_args
     return _evaluate_scoring_proc(

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -268,6 +268,12 @@ class RestEndpoint:
         if ping_status.status_code != 200:
             raise Exception("ping failed, server is not happy")
         _logger.info(f"server up, ping status {ping_status}")
+
+        resp_status = requests.get(url="http://localhost:%d/version" % self._port)
+        version = resp_status.text
+        _logger.info(f"mlflow server version {version}")
+        if version != mlflow.__version__:
+            raise Exception("version path is not returning correct mlflow version")
         return self
 
     def __exit__(self, tp, val, traceback):

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -210,7 +210,10 @@ def pyfunc_serve_and_score_model(
     if extra_args is not None:
         scoring_cmd += extra_args
     proc = _start_scoring_proc(cmd=scoring_cmd, env=env, stdout=stdout, stderr=stdout)
-    return _evaluate_scoring_proc(proc, port, data, content_type, activity_polling_timeout_seconds)
+    validate_version = "--enable-mlserver" not in extra_args
+    return _evaluate_scoring_proc(
+        proc, port, data, content_type, activity_polling_timeout_seconds, validate_version
+    )
 
 
 def _get_mlflow_home():
@@ -317,12 +320,16 @@ class RestEndpoint:
         return response
 
 
-def _evaluate_scoring_proc(proc, port, data, content_type, activity_polling_timeout_seconds=250):
+def _evaluate_scoring_proc(
+    proc, port, data, content_type, activity_polling_timeout_seconds=250, validate_version=True
+):
     """
     :param activity_polling_timeout_seconds: The amount of time, in seconds, to wait before
                                              declaring the scoring process to have failed.
     """
-    with RestEndpoint(proc, port, activity_polling_timeout_seconds) as endpoint:
+    with RestEndpoint(
+        proc, port, activity_polling_timeout_seconds, validate_version=validate_version
+    ) as endpoint:
         return endpoint.invoke(data, content_type)
 
 

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -518,7 +518,7 @@ def test_build_docker_without_model_uri(iris_data, sk_model, tmp_path):
 
 
 def _validate_with_rest_endpoint(scoring_proc, host_port, df, x, sk_model, enable_mlserver=False):
-    with RestEndpoint(proc=scoring_proc, port=host_port) as endpoint:
+    with RestEndpoint(proc=scoring_proc, port=host_port, validate_version=False) as endpoint:
         for content_type in [CONTENT_TYPE_JSON_SPLIT_ORIENTED, CONTENT_TYPE_CSV, CONTENT_TYPE_JSON]:
             scoring_response = endpoint.invoke(df, content_type)
             assert scoring_response.status_code == 200, (

--- a/tests/pyfunc/test_scoring_server.py
+++ b/tests/pyfunc/test_scoring_server.py
@@ -25,6 +25,7 @@ from mlflow.types import Schema, ColSpec, DataType
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils.proto_json_utils import NumpyEncoder
 from mlflow.utils import env_manager as _EnvManager
+from mlflow.version import VERSION
 
 from tests.helper_functions import pyfunc_serve_and_score_model, random_int, random_str
 
@@ -653,6 +654,9 @@ def test_scoring_server_client(sklearn_model, model_path):
         data = pd.DataFrame(sklearn_model.inference_data)
         result = client.invoke(data).to_numpy()[:, 0]
         np.testing.assert_allclose(result, expected_result, rtol=1e-5)
+
+        version = client.get_version()
+        assert version == VERSION
     finally:
         if server_proc is not None:
             os.kill(server_proc.pid, signal.SIGTERM)


### PR DESCRIPTION
Signed-off-by: Wendy Hu <wendy.hu@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

## What changes are proposed in this pull request?

This PR adds a `/version` path to the scoring server that returns the mlflow version

## How is this patch tested?
- unit tests
- started scoring server via `mlflow models serve` locally and ensured `curl localhost:8080/version` returned the expected result
```
$ curl localhost:8080/version
1.29.1.dev0
```
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Added a `/version` path to the scoring server that returns the mlflow version

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
