### PR TITLE
Limiting the number of string values for a categorical dtype for profiling

### DIFF
--- a/mlflow/pipelines/cards/pandas_renderer.py
+++ b/mlflow/pipelines/cards/pandas_renderer.py
@@ -11,6 +11,9 @@ from mlflow.protos import facet_feature_statistics_pb2
 from mlflow.pipelines.cards import histogram_generator
 from mlflow.exceptions import MlflowException
 
+# Number of categorical strings values to be rendered as part of the histogram
+HISTOGRAM_CATEGORICAL_LEVELS_COUNT = 100
+
 
 def get_facet_type_from_numpy_type(dtype):
     """Converts a Numpy dtype to the FeatureNameStatistics.Type proto enum."""
@@ -139,12 +142,11 @@ def convert_to_dataset_feature_statistics(
             feat_stats = feat.string_stats
             strs = current_column_value.dropna()
 
-            histogram_categorical_levels_count = None
             feat_stats.avg_length = np.mean(np.vectorize(len)(strs))
             vals, counts = np.unique(strs, return_counts=True)
             feat_stats.unique = pandas_describe_key.get("unique", len(vals))
             sorted_vals = sorted(zip(counts, vals), reverse=True)
-            sorted_vals = sorted_vals[:histogram_categorical_levels_count]
+            sorted_vals = sorted_vals[:HISTOGRAM_CATEGORICAL_LEVELS_COUNT]
             for val_index, val in enumerate(sorted_vals):
                 try:
                     if sys.version_info.major < 3 or isinstance(val[1], (bytes, bytearray)):


### PR DESCRIPTION
## What changes are proposed in this pull request?
Limiting the number of string values for a categorical dtype for profiling
- Looked into this issue, found out that there are a few of categorical type columns with a lot of string values. So increase in the number of rows increases the categorical string values. 
- Found out that we only render top_k categorical, so changing it to 100 correctly renders the profile.

## How is this patch tested?
- [x] Screenshot

Previously: 
![image](https://user-images.githubusercontent.com/5621432/193102451-daa5a14d-309c-4907-8a88-259ac20d5e32.png)

Now: 
![image-20220929-160312](https://user-images.githubusercontent.com/5621432/193102558-1f4bd0bb-b56c-4425-801b-364a79fa79c1.png)


## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
