### PR TITLE
Update `tests/db/schemas/mssql.sql`

### DIFF
--- a/tests/db/schemas/mssql.sql
+++ b/tests/db/schemas/mssql.sql
@@ -30,7 +30,7 @@ CREATE TABLE experiment_tags (
 	value VARCHAR(5000) COLLATE "SQL_Latin1_General_CP1_CI_AS",
 	experiment_id INTEGER NOT NULL,
 	CONSTRAINT experiment_tag_pk PRIMARY KEY (key, experiment_id),
-	CONSTRAINT "FK__experimen__exper__4E88ABD4" FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
+	CONSTRAINT "FK__experimen__exper__4F7CD00D" FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
 )
 
 
@@ -48,7 +48,7 @@ CREATE TABLE model_versions (
 	status_message VARCHAR(500) COLLATE "SQL_Latin1_General_CP1_CI_AS",
 	run_link VARCHAR(500) COLLATE "SQL_Latin1_General_CP1_CI_AS",
 	CONSTRAINT model_version_pk PRIMARY KEY (name, version),
-	CONSTRAINT "FK__model_vers__name__571DF1D5" FOREIGN KEY(name) REFERENCES registered_models (name) ON UPDATE CASCADE
+	CONSTRAINT "FK__model_vers__name__5812160E" FOREIGN KEY(name) REFERENCES registered_models (name) ON UPDATE CASCADE
 )
 
 
@@ -57,7 +57,7 @@ CREATE TABLE registered_model_tags (
 	value VARCHAR(5000) COLLATE "SQL_Latin1_General_CP1_CI_AS",
 	name VARCHAR(256) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	CONSTRAINT registered_model_tag_pk PRIMARY KEY (key, name),
-	CONSTRAINT "FK__registered__name__5AEE82B9" FOREIGN KEY(name) REFERENCES registered_models (name) ON UPDATE CASCADE
+	CONSTRAINT "FK__registered__name__5BE2A6F2" FOREIGN KEY(name) REFERENCES registered_models (name) ON UPDATE CASCADE
 )
 
 
@@ -77,7 +77,7 @@ CREATE TABLE runs (
 	experiment_id INTEGER,
 	deleted_time BIGINT,
 	CONSTRAINT run_pk PRIMARY KEY (run_uuid),
-	CONSTRAINT "FK__runs__experiment__3D5E1FD2" FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
+	CONSTRAINT "FK__runs__experiment__3E52440B" FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
 )
 
 
@@ -89,7 +89,7 @@ CREATE TABLE latest_metrics (
 	is_nan BIT NOT NULL,
 	run_uuid VARCHAR(32) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	CONSTRAINT latest_metric_pk PRIMARY KEY (key, run_uuid),
-	CONSTRAINT "FK__latest_me__run_u__5165187F" FOREIGN KEY(run_uuid) REFERENCES runs (run_uuid)
+	CONSTRAINT "FK__latest_me__run_u__52593CB8" FOREIGN KEY(run_uuid) REFERENCES runs (run_uuid)
 )
 
 
@@ -101,7 +101,7 @@ CREATE TABLE metrics (
 	step BIGINT DEFAULT ('0') NOT NULL,
 	is_nan BIT DEFAULT ('0') NOT NULL,
 	CONSTRAINT metric_pk PRIMARY KEY (key, timestamp, step, run_uuid, value, is_nan),
-	CONSTRAINT "FK__metrics__run_uui__4316F928" FOREIGN KEY(run_uuid) REFERENCES runs (run_uuid)
+	CONSTRAINT "FK__metrics__run_uui__440B1D61" FOREIGN KEY(run_uuid) REFERENCES runs (run_uuid)
 )
 
 
@@ -111,7 +111,7 @@ CREATE TABLE model_version_tags (
 	name VARCHAR(256) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	version INTEGER NOT NULL,
 	CONSTRAINT model_version_tag_pk PRIMARY KEY (key, name, version),
-	CONSTRAINT "FK__model_version_ta__5DCAEF64" FOREIGN KEY(name, version) REFERENCES model_versions (name, version) ON UPDATE CASCADE
+	CONSTRAINT "FK__model_version_ta__5EBF139D" FOREIGN KEY(name, version) REFERENCES model_versions (name, version) ON UPDATE CASCADE
 )
 
 
@@ -120,7 +120,7 @@ CREATE TABLE params (
 	value VARCHAR(500) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	run_uuid VARCHAR(32) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	CONSTRAINT param_pk PRIMARY KEY (key, run_uuid),
-	CONSTRAINT "FK__params__run_uuid__45F365D3" FOREIGN KEY(run_uuid) REFERENCES runs (run_uuid)
+	CONSTRAINT "FK__params__run_uuid__46E78A0C" FOREIGN KEY(run_uuid) REFERENCES runs (run_uuid)
 )
 
 
@@ -129,5 +129,5 @@ CREATE TABLE tags (
 	value VARCHAR(5000) COLLATE "SQL_Latin1_General_CP1_CI_AS",
 	run_uuid VARCHAR(32) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	CONSTRAINT tag_pk PRIMARY KEY (key, run_uuid),
-	CONSTRAINT "FK__tags__run_uuid__403A8C7D" FOREIGN KEY(run_uuid) REFERENCES runs (run_uuid)
+	CONSTRAINT "FK__tags__run_uuid__412EB0B6" FOREIGN KEY(run_uuid) REFERENCES runs (run_uuid)
 )


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Update `tests/db/schemas/mssql.sql` to fix the database check failure:

https://github.com/mlflow/mlflow/actions/runs/3154847458/jobs/5132896589#step:4:303

```
__________________________ test_schema_is_up_to_date ___________________________

    def test_schema_is_up_to_date():
        initialize_database()
        tracking_uri = get_tracking_uri()
        schema_path = get_schema_path(tracking_uri)
        existing_schema = schema_path.read_text()
        latest_schema = dump_schema(tracking_uri)
        dialect = get_database_dialect(tracking_uri)
        update_command = get_schema_update_command(dialect)
        message = (
            f"{schema_path.relative_to(Path.cwd())} is not up-to-date. "
            f"Please run this command to update it: {update_command}"
        )
>       assert schema_equal(existing_schema, latest_schema), message
E       AssertionError: tests/db/schemas/mssql.sql is not up-to-date. Please run this command to update it: docker-compose -f tests/db/docker-compose.yml run --rm mlflow-mssql python tests/db/test_schema.py
E       assert False
E        +  where False = schema_equal('\nCREATE TABLE alembic_version (\n\tversion_num VARCHAR(32) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,\n\tCONSTRAINT alembic_version_pkc PRIMARY KEY (version_num)\n)\n\n\nCREATE TABLE experiments (\n\texperiment_id INTEGER GENERATED BY DEFAULT AS IDENTITY (INCREMENT BY 1 START WITH 1),\n\tname VARCHAR(256) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,\n\tartifact_location VARCHAR(256) COLLATE "SQL_Latin1_General_CP1_CI_AS",\n\tlifecycle_stage VARCHAR(32) COLLATE "SQL_Latin1_General_CP1_CI_AS",\n\tcreation_time BIGINT,\n\tlast_update_time BIGINT,\n\tCONSTRAINT experiment_pk PRIMARY KEY (experiment_id)\n)\n\n\nCREATE TABLE registered_models (\n\tname VARCHAR(256) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,\n\tcreation_time BIGINT,\n\tlast_updated_time BIGINT,\n\tdescription VARCHAR(5000) COLLATE "SQL_Latin1_General_CP1_CI_AS",\n\tCONSTRAINT registered_model_pk PRIMARY KEY (name)\n)\n\n\nCREATE TABLE experiment_tags (\n\tkey VARCHAR(250) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,\n\tvalue VARCHAR(5000) COLLATE "SQL_Latin1_General_CP1_CI_AS",\n\texperiment_id INTEGER NOT NULL,\n\tCONSTRAINT experiment_tag_pk PRIMARY KEY (key, experiment_id),\n\tCONSTRAINT "FK__ex...ARCHAR(250) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,\n\tvalue VARCHAR(5000) COLLATE "SQL_Latin1_General_CP1_CI_AS",\n\tname VARCHAR(256) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,\n\tversion INTEGER NOT NULL,\n\tCONSTRAINT model_version_tag_pk PRIMARY KEY (key, name, version),\n\tCONSTRAINT "FK__model_version_ta__5DCAEF64" FOREIGN KEY(name, version) REFERENCES model_versions (name, version) ON UPDATE CASCADE\n)\n\n\nCREATE TABLE params (\n\tkey VARCHAR(250) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,\n\tvalue VARCHAR(500) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,\n\trun_uuid VARCHAR(32) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,\n\tCONSTRAINT param_pk PRIMARY KEY (key, run_uuid),\n\tCONSTRAINT "FK__params__run_uuid__45F365D3" FOREIGN KEY(run_uuid) REFERENCES runs (run_uuid)\n)\n\n\nCREATE TABLE tags (\n\tkey VARCHAR(250) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,\n\tvalue VARCHAR(5000) COLLATE "SQL_Latin1_General_CP1_CI_AS",\n\trun_uuid VARCHAR(32) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,\n\tCONSTRAINT tag_pk PRIMARY KEY (key, run_uuid),\n\tCONSTRAINT "FK__tags__run_uuid__403A8C7D" FOREIGN KEY(run_uuid) REFERENCES runs (run_uuid)\n)\n', '\nCREATE TABLE alembic_version (\n\tversion_num VARCHAR(32) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,\n\tCONSTRAINT alembic_version_pkc PRIMARY KEY (version_num)\n)\n\n\nCREATE TABLE experiments (\n\texperiment_id INTEGER GENERATED BY DEFAULT AS IDENTITY (INCREMENT BY 1 START WITH 1),\n\tname VARCHAR(256) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,\n\tartifact_location VARCHAR(256) COLLATE "SQL_Latin1_General_CP1_CI_AS",\n\tlifecycle_stage VARCHAR(32) COLLATE "SQL_Latin1_General_CP1_CI_AS",\n\tcreation_time BIGINT,\n\tlast_update_time BIGINT,\n\tCONSTRAINT experiment_pk PRIMARY KEY (experiment_id)\n)\n\n\nCREATE TABLE registered_models (\n\tname VARCHAR(256) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,\n\tcreation_time BIGINT,\n\tlast_updated_time BIGINT,\n\tdescription VARCHAR(5000) COLLATE "SQL_Latin1_General_CP1_CI_AS",\n\tCONSTRAINT registered_model_pk PRIMARY KEY (name)\n)\n\n\nCREATE TABLE experiment_tags (\n\tkey VARCHAR(250) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,\n\tvalue VARCHAR(5000) COLLATE "SQL_Latin1_General_CP1_CI_AS",\n\texperiment_id INTEGER NOT NULL,\n\tCONSTRAINT experiment_tag_pk PRIMARY KEY (key, experiment_id),\n\tCONSTRAINT "FK__ex...ARCHAR(250) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,\n\tvalue VARCHAR(5000) COLLATE "SQL_Latin1_General_CP1_CI_AS",\n\tname VARCHAR(256) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,\n\tversion INTEGER NOT NULL,\n\tCONSTRAINT model_version_tag_pk PRIMARY KEY (key, name, version),\n\tCONSTRAINT "FK__model_version_ta__5EBF139D" FOREIGN KEY(name, version) REFERENCES model_versions (name, version) ON UPDATE CASCADE\n)\n\n\nCREATE TABLE params (\n\tkey VARCHAR(250) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,\n\tvalue VARCHAR(500) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,\n\trun_uuid VARCHAR(32) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,\n\tCONSTRAINT param_pk PRIMARY KEY (key, run_uuid),\n\tCONSTRAINT "FK__params__run_uuid__46E78A0C" FOREIGN KEY(run_uuid) REFERENCES runs (run_uuid)\n)\n\n\nCREATE TABLE tags (\n\tkey VARCHAR(250) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,\n\tvalue VARCHAR(5000) COLLATE "SQL_Latin1_General_CP1_CI_AS",\n\trun_uuid VARCHAR(32) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,\n\tCONSTRAINT tag_pk PRIMARY KEY (key, run_uuid),\n\tCONSTRAINT "FK__tags__run_uuid__412EB0B6" FOREIGN KEY(run_uuid) REFERENCES runs (run_uuid)\n)\n')
```

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
