### PR TITLE
Update MLflow artifact viewer to show correct recommendation when loa…

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.js
@@ -206,6 +206,58 @@ class ShowArtifactLoggedModelView extends Component {
     );
   }
 
+  renderPandasDataFramePrediction(modelPath) {
+    return (
+      <div css={styles.item}>
+        <Text>
+          <FormattedMessage
+            defaultMessage='Predict on a Pandas DataFrame:' // eslint-disable-next-line max-len
+            description='Section heading to display the code block on how we can use registered model to predict using pandas DataFrame'
+          />
+        </Text>
+        <Paragraph
+          dangerouslySetAntdProps={{
+            copyable: { text: this.pandasDataFrameCodeText(modelPath) },
+          }}
+        >
+          <pre style={{ wordBreak: 'break-all', whiteSpace: 'pre-wrap' }}>
+            <div className='code'>
+              <span className='code-keyword'>import</span> mlflow{`\n`}
+              logged_model = <span className='code-string'>{`'${modelPath}'`}</span>
+            </div>
+            <br />
+            <div className='code'>
+              <span className='code-comment'>
+                {'# '}
+                <FormattedMessage
+                  defaultMessage='Load model as a PyFuncModel.'
+                  description='Code comment which states how to load model using PyFuncModel'
+                />
+              </span>
+              {`\n`}
+              loaded_model = mlflow.pyfunc.load_model(logged_model)
+            </div>
+            <br />
+            <div className='code'>
+              <span className='code-comment'>
+                {'# '}
+                <FormattedMessage
+                  defaultMessage='Predict on a Pandas DataFrame.'
+                  // eslint-disable-next-line max-len
+                  description='Code comment which states on how we can predict using pandas DataFrame'
+                />
+              </span>
+              {`\n`}
+              <span className='code-keyword'>import</span> pandas{' '}
+              <span className='code-keyword'>as</span> pd{`\n`}
+              loaded_model.predict(pd.DataFrame(data))
+            </div>
+          </pre>
+        </Paragraph>
+      </div>
+    );
+  }
+
   renderPyfuncCodeSnippet() {
     if (this.state.loader_module === 'mlflow.spark') {
       return this.renderMlflowSparkCodeSnippet();
@@ -272,53 +324,7 @@ class ShowArtifactLoggedModelView extends Component {
               </pre>
             </Paragraph>
           </div>
-          <div css={styles.item}>
-            <Text>
-              <FormattedMessage
-                defaultMessage='Predict on a Pandas DataFrame:' // eslint-disable-next-line max-len
-                description='Section heading to display the code block on how we can use registered model to predict using pandas DataFrame'
-              />
-            </Text>
-            <Paragraph
-              dangerouslySetAntdProps={{
-                copyable: { text: this.pandasDataFrameCodeText(modelPath) },
-              }}
-            >
-              <pre style={{ wordBreak: 'break-all', whiteSpace: 'pre-wrap' }}>
-                <div className='code'>
-                  <span className='code-keyword'>import</span> mlflow{`\n`}
-                  logged_model = <span className='code-string'>{`'${modelPath}'`}</span>
-                </div>
-                <br />
-                <div className='code'>
-                  <span className='code-comment'>
-                    {'# '}
-                    <FormattedMessage
-                      defaultMessage='Load model as a PyFuncModel.'
-                      description='Code comment which states how to load model using PyFuncModel'
-                    />
-                  </span>
-                  {`\n`}
-                  loaded_model = mlflow.pyfunc.load_model(logged_model)
-                </div>
-                <br />
-                <div className='code'>
-                  <span className='code-comment'>
-                    {'# '}
-                    <FormattedMessage
-                      defaultMessage='Predict on a Pandas DataFrame.'
-                      // eslint-disable-next-line max-len
-                      description='Code comment which states on how we can predict using pandas DataFrame'
-                    />
-                  </span>
-                  {`\n`}
-                  <span className='code-keyword'>import</span> pandas{' '}
-                  <span className='code-keyword'>as</span> pd{`\n`}
-                  loaded_model.predict(pd.DataFrame(data))
-                </div>
-              </pre>
-            </Paragraph>
-          </div>
+          {this.renderPandasDataFramePrediction(modelPath)}
         </div>
       </>
     );
@@ -355,7 +361,7 @@ class ShowArtifactLoggedModelView extends Component {
                     <FormattedMessage
                       // eslint-disable-next-line max-len
                       defaultMessage='Load model'
-                      description='Code comment which states how to load model'
+                      description='Code comment which states how to load a SparkML model'
                     />
                   </span>
                   {`\n`}
@@ -368,7 +374,7 @@ class ShowArtifactLoggedModelView extends Component {
                     <FormattedMessage
                       defaultMessage='Perform inference via model.transform()'
                       // eslint-disable-next-line max-len
-                      description='Code comment which states on how we can perform inference'
+                      description='Code comment which states how we can perform SparkML inference'
                     />
                   </span>
                   {`\n`}
@@ -377,6 +383,7 @@ class ShowArtifactLoggedModelView extends Component {
               </pre>
             </Paragraph>
           </div>
+          {this.renderPandasDataFramePrediction(modelPath)}
         </div>
       </>
     );

--- a/mlflow/server/js/src/i18n/default/en.json
+++ b/mlflow/server/js/src/i18n/default/en.json
@@ -451,6 +451,10 @@
     "defaultMessage": "Show diff only",
     "description": "Toggle text that determines whether to show diff only in the model\n                      comparison page"
   },
+  "H8/czZ": {
+    "defaultMessage": "Load model",
+    "description": "Code comment which states how to load model"
+  },
   "HGG+BI": {
     "defaultMessage": "Y-axis Log Scale:",
     "description": "Label for the radio button to toggle the Log scale on the Y-axis of the metric graph for the experiment"
@@ -838,6 +842,10 @@
   "bSx/er": {
     "defaultMessage": "Parameters",
     "description": "Table title text for parameters table in the model comparison page"
+  },
+  "bUNg0K": {
+    "defaultMessage": "Perform inference via model.transform()",
+    "description": "Code comment which states on how we can perform inference"
   },
   "bhgG7S": {
     "defaultMessage": "Run Command",

--- a/mlflow/server/js/src/i18n/default/en.json
+++ b/mlflow/server/js/src/i18n/default/en.json
@@ -451,10 +451,6 @@
     "defaultMessage": "Show diff only",
     "description": "Toggle text that determines whether to show diff only in the model\n                      comparison page"
   },
-  "H8/czZ": {
-    "defaultMessage": "Load model",
-    "description": "Code comment which states how to load model"
-  },
   "HGG+BI": {
     "defaultMessage": "Y-axis Log Scale:",
     "description": "Label for the radio button to toggle the Log scale on the Y-axis of the metric graph for the experiment"
@@ -534,6 +530,10 @@
   "MatV9u": {
     "defaultMessage": "Create",
     "description": "Create button text for creating model in the model registry"
+  },
+  "NFUJyk": {
+    "defaultMessage": "Load model",
+    "description": "Code comment which states how to load a SparkML model"
   },
   "NJ1bYP": {
     "defaultMessage": "{fieldName} are identical",
@@ -767,6 +767,10 @@
     "defaultMessage": "Versions",
     "description": "Title text for the versions section under details tab on the\n                       model view page"
   },
+  "ZGrkWk": {
+    "defaultMessage": "Perform inference via model.transform()",
+    "description": "Code comment which states how we can perform SparkML inference"
+  },
   "ZYBoeF": {
     "defaultMessage": "Transition to",
     "description": "Text for activity description under confirmation modal for model\n             version stage transition"
@@ -842,10 +846,6 @@
   "bSx/er": {
     "defaultMessage": "Parameters",
     "description": "Table title text for parameters table in the model comparison page"
-  },
-  "bUNg0K": {
-    "defaultMessage": "Perform inference via model.transform()",
-    "description": "Code comment which states on how we can perform inference"
   },
   "bhgG7S": {
     "defaultMessage": "Run Command",


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

Spark models can’t be evaluated using Spark UDFs, so we shouldn’t show the spark udf code snippet if the model has the pyfunc flavor with loader module config mlflow.spark.

Before the change, it's showing
<img width="1663" alt="Screen Shot 2022-09-30 at 12 58 06 AM" src="https://user-images.githubusercontent.com/12734110/193221215-c6412f78-e364-46f4-abad-02cc9ea2d112.png">

After the change(made the same change in db repo and tested)
<img width="2035" alt="Screen Shot 2022-10-03 at 12 59 39 PM" src="https://user-images.githubusercontent.com/12734110/193668283-ecef603a-8089-4910-bb7d-102b3da18f6e.png">


And the recommendation can actually do inference and return value
<img width="1240" alt="Screen Shot 2022-09-30 at 12 49 12 AM" src="https://user-images.githubusercontent.com/12734110/193221510-64ffc78a-389a-4f92-a9a6-a7faf4160d9a.png">


## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->


## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
