### PR TITLE
Remove references to mlflow.runName in docs

### DIFF
--- a/docs/source/search-runs.rst
+++ b/docs/source/search-runs.rst
@@ -111,13 +111,13 @@ You can search using the following run attributes contained in :py:class:`mlflow
 MLflow Tags
 ~~~~~~~~~~~
 
-You can search for MLflow tags by enclosing the tag name in double quotes or backticks. For example, to search by owner of an MLflow run, specify ``tags."mlflow.userId"`` or ``tags.`mlflow.userId```.
+You can search for MLflow tags by enclosing the tag name in double quotes or backticks. For example, to search by owner of an MLflow run, specify ``tags."mlflow.user"`` or ``tags.`mlflow.userId```.
 
 .. rubric:: Examples
 
 .. code-block:: sql
 
-  tags."mlflow.userId"
+  tags."mlflow.user"
 
 .. code-block:: sql
 

--- a/docs/source/search-runs.rst
+++ b/docs/source/search-runs.rst
@@ -111,13 +111,13 @@ You can search using the following run attributes contained in :py:class:`mlflow
 MLflow Tags
 ~~~~~~~~~~~
 
-You can search for MLflow tags by enclosing the tag name in double quotes or backticks. For example, to search for the name of an MLflow run, specify ``tags."mlflow.runName"`` or ``tags.`mlflow.runName```.
+You can search for MLflow tags by enclosing the tag name in double quotes or backticks. For example, to search by owner of an MLflow run, specify ``tags."mlflow.userId"`` or ``tags.`mlflow.userId```.
 
 .. rubric:: Examples
 
 .. code-block:: sql
 
-  tags."mlflow.runName"
+  tags."mlflow.userId"
 
 .. code-block:: sql
 

--- a/docs/source/search-runs.rst
+++ b/docs/source/search-runs.rst
@@ -111,7 +111,7 @@ You can search using the following run attributes contained in :py:class:`mlflow
 MLflow Tags
 ~~~~~~~~~~~
 
-You can search for MLflow tags by enclosing the tag name in double quotes or backticks. For example, to search by owner of an MLflow run, specify ``tags."mlflow.user"`` or ``tags.`mlflow.userId```.
+You can search for MLflow tags by enclosing the tag name in double quotes or backticks. For example, to search by owner of an MLflow run, specify ``tags."mlflow.user"`` or ``tags.`mlflow.user```.
 
 .. rubric:: Examples
 

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -1248,10 +1248,6 @@ internal use. The following tags are set automatically by MLflow, when appropria
 +-------------------------------+----------------------------------------------------------------------------------------+
 | Key                           | Description                                                                            |
 +===============================+========================================================================================+
-| ``mlflow.runName``            | Human readable name that identifies this run. This tag is set either by specifying     |
-|                               | the argument ``run_name`` when calling :py:func:`mlflow.start_run` or is automatically |
-|                               | generated with a random name if no ``run_name`` is set.                                |
-+-------------------------------+----------------------------------------------------------------------------------------+
 | ``mlflow.note.content``       | A descriptive note about this run. This reserved tag is not set automatically and can  |
 |                               | be overridden by the user to include additional information about the run. The content |
 |                               | is displayed on the run's page under the Notes section.                                |


### PR DESCRIPTION
Signed-off-by: Apurva Koti <apurva.koti@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Remove references to `mlflow.runName` reserved tag in the docs, to help direct users towards the `run_name` attribute in the future.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.
n/a
(screenshot taken before fixing `userId` to `user`)
<img width="1381" alt="image" src="https://user-images.githubusercontent.com/51172624/193348129-4b09aa64-128f-452b-a6e5-f69160805d09.png">

<img width="1335" alt="image" src="https://user-images.githubusercontent.com/51172624/193348224-7e05e06a-c626-4ab4-94bf-e659af916e1d.png">

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
