### PR TITLE
Implements getModelVersion in the java client

### DIFF
--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -816,6 +816,24 @@ public class MlflowClient implements Serializable, Closeable {
   }
 
   /**
+   *
+   *   <pre>
+   *       import org.mlflow.api.proto.ModelRegistry.ModelVersion;
+   *       ModelVersion modelVersion = getModelVersion("model", "version");
+   *   </pre>
+   *
+   * @param modelName Name of the containing registered model. *
+   * @param version Version number as a string of the model version.
+   * @return a single model version
+   *        {@link org.mlflow.api.proto.ModelRegistry.ModelVersion}
+   */
+  public ModelVersion getModelVersion(String modelName, String version) {
+    String json = sendGet(mapper.makeGetModelVersion(modelName, version));
+    GetModelVersion.Response response = mapper.toGetModelVersionResponse(json);
+    return response.getModelVersion();
+  }
+
+  /**
    * Return the model URI containing for the given model version. The model URI can be used
    * to download the model version artifacts.
    *

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowProtobufMapper.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowProtobufMapper.java
@@ -160,7 +160,7 @@ class MlflowProtobufMapper {
     return print(builder);
   }
 
-  String makeGetModelVersionDetails(String modelName, String version) {
+  String makeGetModelVersion(String modelName, String version) {
     return print(GetModelVersion.newBuilder().setName(modelName).setVersion(version));
   }
 
@@ -230,6 +230,12 @@ class MlflowProtobufMapper {
 
   GetLatestVersions.Response toGetLatestVersionsResponse(String json) {
     GetLatestVersions.Response.Builder builder = GetLatestVersions.Response.newBuilder();
+    merge(json, builder);
+    return builder.build();
+  }
+
+  GetModelVersion.Response toGetModelVersionResponse(String json) {
+    GetModelVersion.Response.Builder builder = GetModelVersion.Response.newBuilder();
     merge(json, builder);
     return builder.build();
   }

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowProtobufMapper.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowProtobufMapper.java
@@ -160,8 +160,16 @@ class MlflowProtobufMapper {
     return print(builder);
   }
 
-  String makeGetModelVersion(String modelName, String version) {
-    return print(GetModelVersion.newBuilder().setName(modelName).setVersion(version));
+  String makeGetModelVersion(String modelName, String modelVersion) {
+    try {
+      return new URIBuilder("model-versions/get")
+          .addParameter("name", modelName)
+          .addParameter("version", modelVersion)
+          .build()
+          .toString();
+    } catch (URISyntaxException e) {
+      throw new MlflowClientException("Failed to construct request URI for get model version.", e);
+    }
   }
 
   String makeGetModelVersionDownloadUri(String modelName, String modelVersion) {

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/ModelRegistryMlflowClientTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/ModelRegistryMlflowClientTest.java
@@ -100,7 +100,7 @@ public class ModelRegistryMlflowClientTest {
     @Test
     public void testGetModelVersion() {
         ModelVersion modelVersion = client.getModelVersion(modelName, "1");
-        validateDetailedModelVersion(modelVersion, modelName, "None", "1");
+        validateDetailedModelVersion(modelVersion, modelName, "Staging", "1");
     }
 
     @Test(expectedExceptions = MlflowHttpException.class, expectedExceptionsMessageRegExp = ".*RESOURCE_DOES_NOT_EXIST.*")

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/ModelRegistryMlflowClientTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/ModelRegistryMlflowClientTest.java
@@ -65,9 +65,8 @@ public class ModelRegistryMlflowClientTest {
         client.sendPost("registered-models/create",
                 mapper.makeCreateModel(modelName));
 
-        String result = client.sendPost("model-versions/create",
+        client.sendPost("model-versions/create",
                 mapper.makeCreateModelVersion(modelName, runId, tempDir.getAbsolutePath()));
-        System.out.println("result: " + result);
     }
 
     @AfterTest

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/ModelRegistryMlflowClientTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/ModelRegistryMlflowClientTest.java
@@ -1,8 +1,18 @@
 package org.mlflow.tracking;
 
+import static org.mlflow.tracking.TestUtils.createExperimentName;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+
 import com.google.common.collect.Lists;
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.UUID;
 import org.apache.commons.io.FileUtils;
-import org.mlflow.api.proto.ModelRegistry;
 import org.mlflow.api.proto.ModelRegistry.ModelVersion;
 import org.mlflow.api.proto.Service.RunInfo;
 import org.mockito.Mockito;
@@ -12,18 +22,6 @@ import org.testng.Assert;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
-
-import java.io.File;
-import java.io.FilenameFilter;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.util.List;
-import java.util.UUID;
-
-import static org.mlflow.tracking.TestUtils.createExperimentName;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
 
 public class ModelRegistryMlflowClientTest {
     private static final Logger logger = LoggerFactory.getLogger(ModelRegistryMlflowClientTest.class);
@@ -67,8 +65,9 @@ public class ModelRegistryMlflowClientTest {
         client.sendPost("registered-models/create",
                 mapper.makeCreateModel(modelName));
 
-        client.sendPost("model-versions/create",
+        String result = client.sendPost("model-versions/create",
                 mapper.makeCreateModelVersion(modelName, runId, tempDir.getAbsolutePath()));
+        System.out.println("result: " + result);
     }
 
     @AfterTest
@@ -97,6 +96,17 @@ public class ModelRegistryMlflowClientTest {
         Assert.assertEquals(modelVersion.size(), 1);
         validateDetailedModelVersion(modelVersion.get(0),
                 modelName, "Staging", "1");
+    }
+
+    @Test
+    public void testGetModelVersion() {
+        ModelVersion modelVersion = client.getModelVersion(modelName, "1");
+        validateDetailedModelVersion(modelVersion, modelName, "None", "1");
+    }
+
+    @Test(expectedExceptions = MlflowHttpException.class, expectedExceptionsMessageRegExp = ".*RESOURCE_DOES_NOT_EXIST.*")
+    public void testGetModelVersion_NotFound() {
+        client.getModelVersion(modelName, "2");
     }
 
     @Test


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

Close https://github.com/mlflow/mlflow/issues/6603

## What changes are proposed in this pull request?

Adds support for the getModelVersion api but exposing it in the client and adding parsing support in the protobuf mapper.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [x] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
