### PR TITLE
Fix preview-docs workflow

### DIFF
--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -1,18 +1,17 @@
 name: Preview docs
 
-on: [status]
+on:
+  pull_request:
 jobs:
   main:
-    if: "github.event.context == 'ci/circleci: build_doc'"
+    if: github.repository == 'mlflow/mlflow'
     runs-on: ubuntu-latest
     steps:
-      - uses: larsoner/circleci-artifacts-redirector-action@0.3.1
-        id: create-link
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-path: 0/docs/build/html/index.html
-          circleci-jobs: build_doc
-          job-title: Preview docs
-      - name: Check URL
+      - name: Install dependencies
         run: |
-          curl --fail ${{ steps.create-link.outputs.url }}
+          pip install requests
+      - name: Create preview link
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python dev/preview_docs.py --ref ${{ github.sha }} --issue-number ${{ github.event.pull_request.number }}

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -15,4 +15,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          python dev/preview_docs.py --ref ${{ github.sha }} --issue-number ${{ github.event.pull_request.number }}
+          python dev/preview_docs.py --ref ${{ github.event.pull_request.head.sha }} --issue-number ${{ github.event.pull_request.number }}

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -13,6 +13,6 @@ jobs:
           pip install requests
       - name: Create preview link
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.MLFLOW_AUTOMATION_TOKEN }}
         run: |
           python dev/preview_docs.py --ref ${{ github.event.pull_request.head.sha }} --issue-number ${{ github.event.pull_request.number }}

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -7,6 +7,7 @@ jobs:
     if: github.repository == 'mlflow/mlflow'
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - name: Install dependencies
         run: |
           pip install requests

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -15,4 +15,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.MLFLOW_AUTOMATION_TOKEN }}
         run: |
-          python dev/preview_docs.py --ref ${{ github.event.pull_request.head.sha }} --issue-number ${{ github.event.pull_request.number }}
+          python dev/preview_docs.py --commit-sha ${{ github.event.pull_request.head.sha }} --pull-number ${{ github.event.pull_request.number }}

--- a/dev/preview_docs.py
+++ b/dev/preview_docs.py
@@ -2,6 +2,7 @@ import os
 import requests
 import argparse
 import time
+from datetime import datetime
 from urllib.parse import urlparse
 
 
@@ -65,6 +66,7 @@ def main():
 - It takes a few minutes for the preview to be available.
 - The preview is updated on every commit to the PR.
 - Job URL: {job_url}
+- Updated at: {datetime.now()}
 
 </details>
 """

--- a/dev/preview_docs.py
+++ b/dev/preview_docs.py
@@ -24,9 +24,8 @@ def main():
         resp = session.get(f"https://api.github.com/repos/{repo}/commits/{args.ref}/status")
         resp.raise_for_status()
         build_doc_status = next(
-            filter(
-                lambda s: s["context"].endswith(build_doc_job_name), resp.json()["statuses"], None
-            )
+            filter(lambda s: s["context"].endswith(build_doc_job_name), resp.json()["statuses"]),
+            None,
         )
         if build_doc_status:
             job_id = urlparse(build_doc_status["target_url"]).path.split("/")[-1]

--- a/dev/preview_docs.py
+++ b/dev/preview_docs.py
@@ -59,9 +59,11 @@ def main():
 ### Documentation preview will be available [here]({artifact_url}).
 
 <details>
-<summary>Details</summary>
+<summary>Notes</summary>
 
-Job URL: {job_url}
+- It takes a few minutes for the preview to be available.
+- The preview is updated on every commit to the PR.
+- Job URL: {job_url}
 
 </details>
 """

--- a/dev/preview_docs.py
+++ b/dev/preview_docs.py
@@ -6,6 +6,23 @@ from datetime import datetime
 from urllib.parse import urlparse
 
 
+class Session(requests.Session):
+    def get(self, *args, **kwargs):
+        resp = super().get(*args, **kwargs)
+        resp.raise_for_status()
+        return resp.json()
+
+    def post(self, *args, **kwargs):
+        resp = super().post(*args, **kwargs)
+        resp.raise_for_status()
+        return resp.json()
+
+    def patch(self, *args, **kwargs):
+        resp = super().patch(*args, **kwargs)
+        resp.raise_for_status()
+        return resp.json()
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--commit-sha", required=True)
@@ -14,7 +31,7 @@ def main():
 
     token = os.environ.get("GITHUB_TOKEN")
     headers = {"Authorization": f"token {token}"}
-    session = requests.Session()
+    session = Session()
     session.headers.update(headers)
 
     # Get the ID of the build_doc job
@@ -22,10 +39,11 @@ def main():
     build_doc_job_name = "build_doc"
     job_id = None
     for _ in range(5):
-        resp = session.get(f"https://api.github.com/repos/{repo}/commits/{args.commit_sha}/status")
-        resp.raise_for_status()
+        status = session.get(
+            f"https://api.github.com/repos/{repo}/commits/{args.commit_sha}/status"
+        )
         build_doc_status = next(
-            filter(lambda s: s["context"].endswith(build_doc_job_name), resp.json()["statuses"]),
+            filter(lambda s: s["context"].endswith(build_doc_job_name), status["statuses"]),
             None,
         )
         if build_doc_status:
@@ -38,23 +56,21 @@ def main():
         return
 
     # Get the artifact URL of the top level index.html
-    resp = session.get(f"https://circleci.com/api/v2/project/gh/{repo}/job/{job_id}")
-    resp.raise_for_status()
-    job_data = resp.json()
-    job_url = job_data["web_url"]
-    workflow_id = job_data["latest_workflow"]["id"]
-    resp = session.get(f"https://circleci.com/api/v2/workflow/{workflow_id}/job")
-    resp.raise_for_status()
-    workflow_job = next(filter(lambda s: s["name"] == build_doc_job_name, resp.json()["items"]))
-    workflow_job_id = workflow_job["id"]
-    artifact_url = f"https://output.circle-artifacts.com/output/job/{workflow_job_id}/artifacts/0/docs/build/html/index.html"
+    job = session.get(f"https://circleci.com/api/v2/project/gh/{repo}/job/{job_id}")
+    job_url = job["web_url"]
+    workflow_id = job["latest_workflow"]["id"]
+    workflow = session.get(f"https://circleci.com/api/v2/workflow/{workflow_id}/job")
+    build_doc_job = next(filter(lambda s: s["name"] == build_doc_job_name, workflow["items"]))
+    build_doc_job_id = build_doc_job["id"]
+    artifact_url = f"https://output.circle-artifacts.com/output/job/{build_doc_job_id}/artifacts/0/docs/build/html/index.html"
     print(f"Artifact URL: {artifact_url}")
 
     # Post the artifact URL as a comment
-    resp = session.get(f"https://api.github.com/repos/{repo}/issues/{args.pull_number}/comments")
-    resp.raise_for_status()
+    comments = session.get(
+        f"https://api.github.com/repos/{repo}/issues/{args.pull_number}/comments"
+    )
     marker = "<!-- documentation preview -->"
-    preview_docs_comment = next(filter(lambda c: marker in c["body"], resp.json()), None)
+    preview_docs_comment = next(filter(lambda c: marker in c["body"], comments), None)
     comment_body = f"""
 {marker}
 
@@ -72,15 +88,13 @@ def main():
 """
     if preview_docs_comment is None:
         print("Creating comment")
-        resp = session.post(
+        session.post(
             f"https://api.github.com/repos/{repo}/issues/{args.pull_number}/comments",
             json={"body": comment_body},
         )
-        resp.raise_for_status()
     else:
         print("Updating comment")
-        resp = session.patch(preview_docs_comment["url"], json={"body": comment_body})
-        resp.raise_for_status()
+        session.patch(preview_docs_comment["url"], json={"body": comment_body})
 
 
 if __name__ == "__main__":

--- a/dev/preview_docs.py
+++ b/dev/preview_docs.py
@@ -23,7 +23,6 @@ def main():
     for _ in range(5):
         resp = session.get(f"https://api.github.com/repos/{repo}/commits/{args.ref}/status")
         resp.raise_for_status()
-        print(resp.json()["statuses"])
         build_doc_status = next(
             filter(lambda s: s["context"].endswith(build_doc_job_name), resp.json()["statuses"]),
             None,

--- a/dev/preview_docs.py
+++ b/dev/preview_docs.py
@@ -56,6 +56,7 @@ def main():
     preview_docs_comment = next(filter(lambda c: marker in c["body"], resp.json()), None)
     comment_body = f"""
 {marker}
+
 ### Documentation preview will be available [here]({artifact_url}).
 
 <details>

--- a/dev/preview_docs.py
+++ b/dev/preview_docs.py
@@ -23,6 +23,7 @@ def main():
     for _ in range(5):
         resp = session.get(f"https://api.github.com/repos/{repo}/commits/{args.ref}/status")
         resp.raise_for_status()
+        print(resp.json()["statuses"])
         build_doc_status = next(
             filter(lambda s: s["context"].endswith(build_doc_job_name), resp.json()["statuses"]),
             None,

--- a/dev/preview_docs.py
+++ b/dev/preview_docs.py
@@ -8,8 +8,8 @@ from urllib.parse import urlparse
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--ref", required=True)
-    parser.add_argument("--issue-number", required=True)
+    parser.add_argument("--commit-sha", required=True)
+    parser.add_argument("--pull-number", required=True)
     args = parser.parse_args()
 
     token = os.environ.get("GITHUB_TOKEN")
@@ -22,7 +22,7 @@ def main():
     build_doc_job_name = "build_doc"
     job_id = None
     for _ in range(5):
-        resp = session.get(f"https://api.github.com/repos/{repo}/commits/{args.ref}/status")
+        resp = session.get(f"https://api.github.com/repos/{repo}/commits/{args.commit_sha}/status")
         resp.raise_for_status()
         build_doc_status = next(
             filter(lambda s: s["context"].endswith(build_doc_job_name), resp.json()["statuses"]),
@@ -51,7 +51,7 @@ def main():
     print(f"Artifact URL: {artifact_url}")
 
     # Post the artifact URL as a comment
-    resp = session.get(f"https://api.github.com/repos/{repo}/issues/{args.issue_number}/comments")
+    resp = session.get(f"https://api.github.com/repos/{repo}/issues/{args.pull_number}/comments")
     resp.raise_for_status()
     marker = "<!-- documentation preview -->"
     preview_docs_comment = next(filter(lambda c: marker in c["body"], resp.json()), None)
@@ -73,7 +73,7 @@ def main():
     if preview_docs_comment is None:
         print("Creating comment")
         resp = session.post(
-            f"https://api.github.com/repos/{repo}/issues/{args.issue_number}/comments",
+            f"https://api.github.com/repos/{repo}/issues/{args.pull_number}/comments",
             json={"body": comment_body},
         )
         resp.raise_for_status()

--- a/dev/preview_docs.py
+++ b/dev/preview_docs.py
@@ -1,0 +1,71 @@
+import os
+import requests
+import argparse
+import time
+from urllib.parse import urlparse
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ref", required=True)
+    parser.add_argument("--issue-number", required=True)
+    args = parser.parse_args()
+
+    token = os.environ.get("GITHUB_TOKEN")
+    headers = {"Authorization": f"token {token}"}
+    session = requests.Session()
+    session.headers.update(headers)
+
+    # Get the ID of the build_doc job
+    repo = "mlflow/mlflow"
+    build_doc_job_name = "build_doc"
+    job_id = None
+    for _ in range(5):
+        resp = session.get(f"https://api.github.com/repos/{repo}/commits/{args.ref}/status")
+        resp.raise_for_status()
+        build_doc_status = next(
+            filter(
+                lambda s: s["context"].endswith(build_doc_job_name), resp.json()["statuses"], None
+            )
+        )
+        if build_doc_status:
+            job_id = urlparse(build_doc_status["target_url"]).path.split("/")[-1]
+            break
+        print(f"Waiting for {build_doc_job_name} job status to be available...")
+        time.sleep(3)
+    else:
+        print(f"Could not find {build_doc_job_name} job status")
+        return
+
+    # Get the artifact URL of the top level index.html
+    resp = session.get(f"https://circleci.com/api/v2/project/gh/{repo}/job/{job_id}")
+    resp.raise_for_status()
+    workflow_id = resp.json()["latest_workflow"]["id"]
+    resp = session.get(f"https://circleci.com/api/v2/workflow/{workflow_id}/job")
+    resp.raise_for_status()
+    workflow_job = next(filter(lambda s: s["name"] == build_doc_job_name, resp.json()["items"]))
+    workflow_job_id = workflow_job["id"]
+    artifact_url = f"https://output.circle-artifacts.com/output/job/{workflow_job_id}/artifacts/0/docs/build/html/index.html"
+    print(f"Artifact URL: {artifact_url}")
+
+    # Post the artifact URL as a comment
+    resp = session.get(f"https://api.github.com/repos/{repo}/issues/{args.issue_number}/comments")
+    resp.raise_for_status()
+    marker = "<!-- documentation preview -->"
+    preview_docs_comment = next(filter(lambda c: marker in c["body"], resp.json()), None)
+    comment_body = f"{marker}\n### Documentation preview will be available [here]({artifact_url})."
+    if preview_docs_comment is None:
+        print("Creating comment")
+        resp = session.post(
+            f"https://api.github.com/repos/{repo}/issues/{args.issue_number}/comments",
+            json={"body": comment_body},
+        )
+        resp.raise_for_status()
+    else:
+        print("Updating comment")
+        resp = session.patch(preview_docs_comment["url"], json={"body": comment_body})
+        resp.raise_for_status()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

The existing preview-docs workflow generates a lot of redundant workflow runs as shown below:

https://github.com/mlflow/mlflow/actions/workflows/preview-docs.yml?query=created%3A%3E2022-09-01+event%3Astatus

<img width="872" alt="image" src="https://user-images.githubusercontent.com/17039389/193544419-fd3e73af-9918-4bec-a863-7fd8d20d97a4.png">

This is actually not harmful but makes it difficult to explore workflow runs. This PR fixes this issue.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
