### PR TITLE
Make each MLP step declare its own output

### DIFF
--- a/mlflow/pipelines/artifacts.py
+++ b/mlflow/pipelines/artifacts.py
@@ -1,0 +1,200 @@
+from abc import ABC, abstractmethod
+import json
+import logging
+import os
+
+import mlflow
+from mlflow.pipelines.utils.execution import get_step_output_path
+from mlflow.tracking import MlflowClient
+from mlflow.tracking._tracking_service.utils import _use_tracking_uri
+
+_logger = logging.getLogger(__name__)
+
+
+class Artifact(ABC):
+    @abstractmethod
+    def name(self):
+        pass
+
+    @abstractmethod
+    def path(self):
+        pass
+
+    @abstractmethod
+    def load(self):
+        pass
+
+
+class DataframeArtifact(Artifact):
+    def __init__(self, name, pipeline_root, step_name, rel_path=""):
+        self._name = name
+        self._path = get_step_output_path(pipeline_root, step_name, rel_path)
+        self._step_name = step_name
+
+    def name(self):
+        return self._name
+
+    def path(self):
+        return self._path
+
+    def load(self):
+        import pandas as pd
+
+        if os.path.exists(self._path):
+            return pd.read_parquet(self._path)
+        log_artifact_not_found_warning(self._name, self._step_name)
+        return None
+
+
+class ModelArtifact(Artifact):
+    def __init__(self, name, pipeline_root, step_name, tracking_uri):
+        self._name = name
+        self._path = get_step_output_path(pipeline_root, step_name, "model/model.pkl")
+        self._pipeline_root = pipeline_root
+        self._step_name = step_name
+        self._tracking_uri = tracking_uri
+
+    def name(self):
+        return self._name
+
+    def path(self):
+        return self._path
+
+    def load(self):
+        run_id = read_run_id(self._pipeline_root)
+        if run_id:
+            with _use_tracking_uri(self._tracking_uri, self._pipeline_root):
+                return mlflow.pyfunc.load_model(f"runs:/{run_id}/{self._step_name}/model")
+        log_artifact_not_found_warning(self._name, self._step_name)
+        return None
+
+
+class TransformerArtifact(Artifact):
+    def __init__(self, name, pipeline_root, step_name, tracking_uri):
+        self._name = name
+        self._path = get_step_output_path(pipeline_root, step_name, "transformer.pkl")
+        self._pipeline_root = pipeline_root
+        self._step_name = step_name
+        self._tracking_uri = tracking_uri
+
+    def name(self):
+        return self._name
+
+    def path(self):
+        return self._path
+
+    def load(self):
+        run_id = read_run_id(self._pipeline_root)
+        if run_id:
+            with _use_tracking_uri(self._tracking_uri, self._pipeline_root):
+                return mlflow.sklearn.load_model(f"runs:/{run_id}/{self._step_name}/transformer")
+        log_artifact_not_found_warning(self._name, self._step_name)
+        return None
+
+
+class RunArtifact(Artifact):
+    def __init__(self, name, pipeline_root, step_name, tracking_uri):
+        self._name = name
+        self._path = get_step_output_path(pipeline_root, step_name, "run_id")
+        self._pipeline_root = pipeline_root
+        self._step_name = step_name
+        self._tracking_uri = tracking_uri
+
+    def name(self):
+        return self._name
+
+    def path(self):
+        return self._path
+
+    def load(self):
+        run_id = read_run_id(self._pipeline_root)
+        if run_id:
+            with _use_tracking_uri(self._tracking_uri, self._pipeline_root):
+                return MlflowClient().get_run(run_id)
+        log_artifact_not_found_warning(self._name, self._step_name)
+        return None
+
+
+class ModelVersionArtifact(Artifact):
+    def __init__(self, name, pipeline_root, step_name, tracking_uri):
+        self._name = name
+        self._path = get_step_output_path(pipeline_root, step_name, "registered_model_version.json")
+        self._pipeline_root = pipeline_root
+        self._step_name = step_name
+        self._tracking_uri = tracking_uri
+
+    def name(self):
+        return self._name
+
+    def path(self):
+        return self._path
+
+    def load(self):
+        if os.path.exists(self._path):
+            registered_model_info = RegisteredModelVersionInfo.from_json(path=self._path)
+            with _use_tracking_uri(self._tracking_uri, self._pipeline_root):
+                return MlflowClient().get_model_version(
+                    name=registered_model_info.name, version=registered_model_info.version
+                )
+        log_artifact_not_found_warning(self._name, self._step_name)
+        return None
+
+
+class HyperParametersArtifact(Artifact):
+    def __init__(self, name, pipeline_root, step_name):
+        self._name = name
+        self._path = get_step_output_path(pipeline_root, step_name, "best_parameters.yaml")
+
+    def name(self):
+        return self._name
+
+    def path(self):
+        return self._path
+
+    def load(self):
+        if os.path.exists(self._path):
+            return open(self._path).read()
+
+
+def log_artifact_not_found_warning(artifact_name, step_name):
+    _logger.warning(
+        f"The artifact with name '{artifact_name}' was not found."
+        f" Re-run the '{step_name}' step to generate it."
+    )
+
+
+def read_run_id(pipeline_root):
+    run_id_file_path = get_step_output_path(pipeline_root, "train", "run_id")
+    if os.path.exists(run_id_file_path):
+        with open(run_id_file_path, "r") as f:
+            return f.read().strip()
+    return None
+
+
+class RegisteredModelVersionInfo:
+    _KEY_REGISTERED_MODEL_NAME = "registered_model_name"
+    _KEY_REGISTERED_MODEL_VERSION = "registered_model_version"
+
+    def __init__(self, name: str, version: int):
+        self.name = name
+        self.version = version
+
+    def to_json(self, path):
+        registered_model_info_dict = {
+            RegisteredModelVersionInfo._KEY_REGISTERED_MODEL_NAME: self.name,
+            RegisteredModelVersionInfo._KEY_REGISTERED_MODEL_VERSION: self.version,
+        }
+        with open(path, "w") as f:
+            json.dump(registered_model_info_dict, f)
+
+    @classmethod
+    def from_json(cls, path):
+        with open(path, "r") as f:
+            registered_model_info_dict = json.load(f)
+
+        return cls(
+            name=registered_model_info_dict[RegisteredModelVersionInfo._KEY_REGISTERED_MODEL_NAME],
+            version=registered_model_info_dict[
+                RegisteredModelVersionInfo._KEY_REGISTERED_MODEL_VERSION
+            ],
+        )

--- a/mlflow/pipelines/cli.py
+++ b/mlflow/pipelines/cli.py
@@ -110,5 +110,5 @@ def get_artifact(profile, artifact):
     """
     Get the location of an artifact output from the pipeline.
     """
-    artifact_location = Pipeline(profile=profile)._get_artifact_path(artifact)
+    artifact_location = Pipeline(profile=profile)._get_artifact(artifact).path()
     click.echo(artifact_location)

--- a/mlflow/pipelines/regression/v1/pipeline.py
+++ b/mlflow/pipelines/regression/v1/pipeline.py
@@ -133,30 +133,17 @@ import os
 import logging
 
 from mlflow.pipelines.regression.v1 import dag_help_strings
-from mlflow.tracking.client import MlflowClient
 from mlflow.pipelines.pipeline import _BasePipeline
 from mlflow.pipelines.steps.ingest import IngestStep, IngestScoringStep
-from mlflow.pipelines.steps.split import (
-    SplitStep,
-    _OUTPUT_TRAIN_FILE_NAME,
-    _OUTPUT_VALIDATION_FILE_NAME,
-    _OUTPUT_TEST_FILE_NAME,
-)
+from mlflow.pipelines.steps.split import SplitStep
 from mlflow.pipelines.steps.transform import TransformStep
 from mlflow.pipelines.steps.train import TrainStep
 from mlflow.pipelines.steps.evaluate import EvaluateStep
-from mlflow.pipelines.steps.predict import (
-    PredictStep,
-    _SCORED_OUTPUT_FILE_NAME,
-)
-from mlflow.pipelines.steps.register import RegisterStep, RegisteredModelVersionInfo
+from mlflow.pipelines.steps.predict import PredictStep
+from mlflow.pipelines.steps.register import RegisterStep
 from mlflow.pipelines.step import BaseStep
 from typing import List, Any, Optional
-from mlflow.pipelines.utils import get_pipeline_root_path
 from mlflow.pipelines.utils.execution import get_or_create_base_execution_directory
-from mlflow.pipelines.utils.execution import get_step_output_path
-from mlflow.exceptions import MlflowException, INVALID_PARAMETER_VALUE
-from mlflow.tracking._tracking_service.utils import _use_tracking_uri
 from mlflow.utils.annotations import experimental
 
 _logger = logging.getLogger(__name__)
@@ -501,196 +488,7 @@ class RegressionPipeline(_BasePipeline):
             train_df: pd.DataFrame = regression_pipeline.get_artifact("training_data")
             trained_model: PyFuncModel = regression_pipeline.get_artifact("model")
         """
-        import mlflow.pyfunc
-
-        (
-            ingest_step,
-            split_step,
-            transform_step,
-            train_step,
-            _,
-            register_step,
-            ingest_scoring_step,
-            predict_step,
-        ) = self._steps
-
-        def log_artifact_not_found_warning(artifact_name, step_name):
-            _logger.warning(
-                f"The artifact with name '{artifact_name}' was not found."
-                f" Re-run the '{step_name}' step to generate it."
-            )
-
-        def read_run_id():
-            train_output_dir = get_step_output_path(self._pipeline_root_path, train_step.name, "")
-            run_id_file_path = os.path.join(train_output_dir, "run_id")
-            if os.path.exists(run_id_file_path):
-                with open(run_id_file_path, "r") as f:
-                    return f.read().strip()
-            else:
-                return None
-
-        train_step_tracking_uri = train_step.tracking_config.tracking_uri
-        pipeline_root_path = get_pipeline_root_path()
-
-        def read_dataframe_from_path(artifact_path, step_name):
-            import pandas as pd
-
-            if os.path.exists(artifact_path):
-                return pd.read_parquet(artifact_path)
-            else:
-                log_artifact_not_found_warning(artifact_name, step_name)
-                return None
-
-        artifact_path = self._get_artifact_path(
-            artifact_name
-        )  # path may or may not exist, error handling is in this function
-
-        if artifact_name == "ingested_data":
-            return read_dataframe_from_path(artifact_path, ingest_step.name)
-
-        elif artifact_name == "training_data":
-            return read_dataframe_from_path(artifact_path, split_step.name)
-
-        elif artifact_name == "validation_data":
-            return read_dataframe_from_path(artifact_path, split_step.name)
-
-        elif artifact_name == "test_data":
-            return read_dataframe_from_path(artifact_path, split_step.name)
-
-        elif artifact_name == "transformed_training_data":
-            return read_dataframe_from_path(artifact_path, transform_step.name)
-
-        elif artifact_name == "transformed_validation_data":
-            return read_dataframe_from_path(artifact_path, transform_step.name)
-
-        elif artifact_name == "model":
-            run_id = read_run_id()
-            if run_id:
-                with _use_tracking_uri(train_step_tracking_uri, pipeline_root_path):
-                    return mlflow.pyfunc.load_model(f"runs:/{run_id}/{train_step.name}/model")
-            else:
-                log_artifact_not_found_warning("model", train_step.name)
-                return None
-
-        elif artifact_name == "transformer":
-            run_id = read_run_id()
-            if run_id:
-                with _use_tracking_uri(train_step_tracking_uri, pipeline_root_path):
-                    return mlflow.sklearn.load_model(
-                        f"runs:/{run_id}/{transform_step.name}/transformer"
-                    )
-            else:
-                log_artifact_not_found_warning("transformer", train_step.name)
-                return None
-
-        elif artifact_name == "run":
-            run_id = read_run_id()
-            if run_id:
-                with _use_tracking_uri(train_step_tracking_uri, pipeline_root_path):
-                    return MlflowClient().get_run(run_id)
-            else:
-                log_artifact_not_found_warning("mlflow run", train_step.name)
-                return None
-
-        elif artifact_name == "registered_model_version":
-            if os.path.exists(artifact_path):
-                registered_model_info = RegisteredModelVersionInfo.from_json(path=artifact_path)
-                with _use_tracking_uri(train_step_tracking_uri, pipeline_root_path):
-                    return MlflowClient().get_model_version(
-                        name=registered_model_info.name, version=registered_model_info.version
-                    )
-            else:
-                log_artifact_not_found_warning("registered_model_version", register_step.name)
-                return None
-
-        elif artifact_name == "ingested_scoring_data":
-            return read_dataframe_from_path(artifact_path, ingest_scoring_step.name)
-
-        elif artifact_name == "scored_data":
-            return read_dataframe_from_path(artifact_path, predict_step.name)
-
-        elif artifact_name == "best_parameters":
-            if os.path.exists(artifact_path):
-                return open(artifact_path).read()
-
-        else:
-            raise MlflowException(
-                f"The artifact with name '{artifact_name}' is not supported.",
-                error_code=INVALID_PARAMETER_VALUE,
-            )
-
-    def _get_artifact_path(self, artifact_name: str) -> Optional[str]:
-        """
-        Returns a path to an artifact, which may or may not exist depending on whether or not the
-        corresponding pipeline step has been run.
-        """
-        (
-            ingest_step,
-            split_step,
-            transform_step,
-            train_step,
-            _,
-            register_step,
-            ingest_scoring_step,
-            predict_step,
-        ) = self._steps
-
-        if artifact_name == "ingested_data":
-            ingest_output_dir = get_step_output_path(self._pipeline_root_path, ingest_step.name, "")
-            return os.path.join(ingest_output_dir, IngestStep._DATASET_OUTPUT_NAME)
-        elif artifact_name == "training_data":
-            split_output_dir = get_step_output_path(self._pipeline_root_path, split_step.name, "")
-            return os.path.join(split_output_dir, _OUTPUT_TRAIN_FILE_NAME)
-        elif artifact_name == "validation_data":
-            split_output_dir = get_step_output_path(self._pipeline_root_path, split_step.name, "")
-            return os.path.join(split_output_dir, _OUTPUT_VALIDATION_FILE_NAME)
-        elif artifact_name == "test_data":
-            split_output_dir = get_step_output_path(self._pipeline_root_path, split_step.name, "")
-            return os.path.join(split_output_dir, _OUTPUT_TEST_FILE_NAME)
-        elif artifact_name == "transformed_training_data":
-            transform_output_dir = get_step_output_path(
-                self._pipeline_root_path, transform_step.name, ""
-            )
-            return os.path.join(transform_output_dir, "transformed_training_data.parquet")
-        elif artifact_name == "transformed_validation_data":
-            transform_output_dir = get_step_output_path(
-                self._pipeline_root_path, transform_step.name, ""
-            )
-            return os.path.join(transform_output_dir, "transformed_validation_data.parquet")
-        elif artifact_name == "model":
-            train_output_dir = get_step_output_path(self._pipeline_root_path, train_step.name, "")
-            return os.path.join(train_output_dir, "model", "model.pkl")
-        elif artifact_name == "transformer":
-            transform_output_dir = get_step_output_path(
-                self._pipeline_root_path, transform_step.name, ""
-            )
-            return os.path.join(transform_output_dir, "transformer.pkl")
-        elif artifact_name == "run":
-            train_output_dir = get_step_output_path(self._pipeline_root_path, train_step.name, "")
-            return os.path.join(train_output_dir, "run_id")
-        elif artifact_name == "registered_model_version":
-            register_output_dir = get_step_output_path(
-                self._pipeline_root_path, register_step.name, ""
-            )
-            return os.path.join(register_output_dir, "registered_model_version.json")
-        elif artifact_name == "ingested_scoring_data":
-            ingest_scoring_output_dir = get_step_output_path(
-                self._pipeline_root_path, ingest_scoring_step.name, ""
-            )
-            return os.path.join(ingest_scoring_output_dir, IngestScoringStep._DATASET_OUTPUT_NAME)
-        elif artifact_name == "scored_data":
-            predict_output_dir = get_step_output_path(
-                self._pipeline_root_path, predict_step.name, ""
-            )
-            return os.path.join(predict_output_dir, _SCORED_OUTPUT_FILE_NAME)
-        elif artifact_name == "best_parameters":
-            train_output_dir = get_step_output_path(self._pipeline_root_path, train_step.name, "")
-            return os.path.join(train_output_dir, "best_parameters.yaml")
-        else:
-            raise MlflowException(
-                f"The artifact with name '{artifact_name}' is not supported.",
-                error_code=INVALID_PARAMETER_VALUE,
-            )
+        return super().get_artifact(artifact_name=artifact_name)
 
     def clean(self, step: str = None) -> None:
         """

--- a/mlflow/pipelines/step.py
+++ b/mlflow/pipelines/step.py
@@ -8,7 +8,7 @@ import traceback
 import yaml
 
 from enum import Enum
-from typing import TypeVar, Dict, Any
+from typing import TypeVar, Dict, Any, List
 from mlflow.pipelines.cards import BaseCard, CARD_PICKLE_NAME, FailureCard, CARD_HTML_NAME
 from mlflow.pipelines.utils import get_pipeline_name
 from mlflow.pipelines.utils.step import display_html
@@ -223,6 +223,13 @@ class BaseStep(metaclass=abc.ABCMeta):
         """
         Returns environment variables associated with step that should be set when the
         step is executed.
+        """
+        return {}
+
+    @experimental
+    def get_artifacts(self) -> List[Any]:
+        """
+        Returns the named artifacts produced by the step for the current class instance.
         """
         return {}
 

--- a/mlflow/pipelines/steps/ingest/__init__.py
+++ b/mlflow/pipelines/steps/ingest/__init__.py
@@ -4,6 +4,7 @@ import os
 
 from pathlib import Path
 from mlflow.exceptions import MlflowException
+from mlflow.pipelines.artifacts import DataframeArtifact
 from mlflow.pipelines.cards import BaseCard
 from mlflow.pipelines.step import BaseStep
 from mlflow.pipelines.utils.step import get_pandas_data_profiles
@@ -193,6 +194,13 @@ class IngestStep(BaseIngestStep):
     def name(self) -> str:
         return "ingest"
 
+    def get_artifacts(self):
+        return [
+            DataframeArtifact(
+                "ingested_data", self.pipeline_root, self.name, IngestStep._DATASET_OUTPUT_NAME
+            )
+        ]
+
 
 class IngestScoringStep(BaseIngestStep):
     _DATASET_OUTPUT_NAME = "scoring-dataset.parquet"
@@ -213,3 +221,13 @@ class IngestScoringStep(BaseIngestStep):
     @property
     def name(self) -> str:
         return "ingest_scoring"
+
+    def get_artifacts(self):
+        return [
+            DataframeArtifact(
+                "ingested_scoring_data",
+                self.pipeline_root,
+                self.name,
+                IngestScoringStep._DATASET_OUTPUT_NAME,
+            )
+        ]

--- a/mlflow/pipelines/steps/predict.py
+++ b/mlflow/pipelines/steps/predict.py
@@ -5,6 +5,7 @@ from typing import Dict, Any
 
 import mlflow
 from mlflow.exceptions import MlflowException, BAD_REQUEST, INVALID_PARAMETER_VALUE
+from mlflow.pipelines.artifacts import DataframeArtifact
 from mlflow.pipelines.cards import BaseCard
 from mlflow.pipelines.step import BaseStep
 from mlflow.pipelines.utils.execution import get_step_output_path
@@ -212,3 +213,10 @@ class PredictStep(BaseStep):
     @property
     def environment(self):
         return get_databricks_env_vars(tracking_uri=self.tracking_config.tracking_uri)
+
+    def get_artifacts(self):
+        return [
+            DataframeArtifact(
+                "scored_data", self.pipeline_root, self.name, _SCORED_OUTPUT_FILE_NAME
+            )
+        ]

--- a/mlflow/pipelines/steps/split.py
+++ b/mlflow/pipelines/steps/split.py
@@ -4,6 +4,7 @@ import time
 import importlib
 import sys
 
+from mlflow.pipelines.artifacts import DataframeArtifact
 from mlflow.pipelines.cards import BaseCard
 from mlflow.pipelines.step import BaseStep
 from mlflow.pipelines.utils.execution import get_step_output_path
@@ -223,3 +224,14 @@ class SplitStep(BaseStep):
     @property
     def name(self):
         return "split"
+
+    def get_artifacts(self):
+        return [
+            DataframeArtifact(
+                "training_data", self.pipeline_root, self.name, _OUTPUT_TRAIN_FILE_NAME
+            ),
+            DataframeArtifact(
+                "validation_data", self.pipeline_root, self.name, _OUTPUT_VALIDATION_FILE_NAME
+            ),
+            DataframeArtifact("test_data", self.pipeline_root, self.name, _OUTPUT_TEST_FILE_NAME),
+        ]

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -11,6 +11,7 @@ import cloudpickle
 import mlflow
 from mlflow.entities import SourceType, ViewType
 from mlflow.exceptions import MlflowException, INVALID_PARAMETER_VALUE, BAD_REQUEST
+from mlflow.pipelines.artifacts import ModelArtifact, RunArtifact, HyperParametersArtifact
 from mlflow.pipelines.cards import BaseCard
 from mlflow.pipelines.step import BaseStep
 from mlflow.pipelines.utils.execution import (
@@ -721,6 +722,15 @@ class TrainStep(BaseStep):
         environ = get_databricks_env_vars(tracking_uri=self.tracking_config.tracking_uri)
         environ.update(get_run_tags_env_vars(pipeline_root_path=self.pipeline_root))
         return environ
+
+    def get_artifacts(self):
+        return [
+            ModelArtifact(
+                "model", self.pipeline_root, self.name, self.tracking_config.tracking_uri
+            ),
+            RunArtifact("run", self.pipeline_root, self.name, self.tracking_config.tracking_uri),
+            HyperParametersArtifact("best_parameters", self.pipeline_root, self.name),
+        ]
 
     def _tune_and_get_best_estimator_params(
         self,

--- a/tests/pipelines/test_pipeline.py
+++ b/tests/pipelines/test_pipeline.py
@@ -281,12 +281,7 @@ def test_pipeline_get_artifacts():
         pipeline.get_artifact("abcde")
 
     pipeline.clean()
-    with mock.patch("mlflow.pipelines.regression.v1.pipeline._logger.warning") as mock_warning:
-        pipeline.get_artifact("ingested_data")
-        mock_warning.assert_called_once_with(
-            "The artifact with name 'ingested_data' was not found."
-            " Re-run the 'ingest' step to generate it."
-        )
+    assert not pipeline.get_artifact("ingested_data")
 
 
 def test_generate_worst_examples_dataframe():


### PR DESCRIPTION
Signed-off-by: Brian Barnes <brian.barnes@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## What changes are proposed in this pull request?

This PR makes each pipeline step declare its own output and introduces a generic implementation of `get_artifact` that iterates through the steps for a given pipeline to identify and return the request artifact. This will facilitate better code reuse as we introduce additional templates. See also: [the open-closed principle](https://en.wikipedia.org/wiki/Open%E2%80%93closed_principle).

## How is this patch tested?

[MLP regression template](https://github.com/mlflow/mlp-regression-template) executed locally.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
