### PR TITLE
Fix code path resolution on Spark model loading

### DIFF
--- a/examples/evaluation/evaluate_on_regressor.py
+++ b/examples/evaluation/evaluate_on_regressor.py
@@ -20,7 +20,7 @@ with mlflow.start_run() as run:
         X_test,
         targets=y_test,
         model_type="regressor",
-        dataset_name="california_housing",
+        # dataset_name="california_housing",
         evaluators="default",
         feature_names=california_housing_data.feature_names,
         evaluator_config={"explainability_nsamples": 1000},

--- a/examples/evaluation/evaluate_on_regressor.py
+++ b/examples/evaluation/evaluate_on_regressor.py
@@ -20,7 +20,7 @@ with mlflow.start_run() as run:
         X_test,
         targets=y_test,
         model_type="regressor",
-        # dataset_name="california_housing",
+        dataset_name="california_housing",
         evaluators="default",
         feature_names=california_housing_data.feature_names,
         evaluator_config={"explainability_nsamples": 1000},

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -800,7 +800,9 @@ def load_model(model_uri, dfs_tmpdir=None, dst_path=None):
     sparkml_model_uri = append_to_uri_path(model_uri, flavor_conf["model_data"])
     local_sparkml_model_path = os.path.join(local_mlflow_model_path, flavor_conf["model_data"])
     return _load_model(
-        model_uri=sparkml_model_uri, dfs_tmpdir_base=dfs_tmpdir, local_model_path=local_sparkml_model_path
+        model_uri=sparkml_model_uri,
+        dfs_tmpdir_base=dfs_tmpdir,
+        local_model_path=local_sparkml_model_path,
     )
 
 

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -797,9 +797,10 @@ def load_model(model_uri, dfs_tmpdir=None, dst_path=None):
         ):
             return PipelineModel.load(mlflowdbfs_path)
 
+    sparkml_model_uri = append_to_uri_path(model_uri, flavor_conf["model_data"])
     local_sparkml_model_path = os.path.join(local_mlflow_model_path, flavor_conf["model_data"])
     return _load_model(
-        model_uri=model_uri, dfs_tmpdir_base=dfs_tmpdir, local_model_path=local_sparkml_model_path
+        model_uri=sparkml_model_uri, dfs_tmpdir_base=dfs_tmpdir, local_model_path=local_sparkml_model_path
     )
 
 

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -781,9 +781,10 @@ def load_model(model_uri, dfs_tmpdir=None, dst_path=None):
     root_uri, artifact_path = _get_root_uri_and_artifact_path(model_uri)
 
     flavor_conf = _get_flavor_configuration_from_uri(model_uri, FLAVOR_NAME)
-    model_uri = append_to_uri_path(model_uri, flavor_conf["model_data"])
-    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
-    _add_code_from_conf_to_system_path(local_model_path, flavor_conf)
+    local_mlflow_model_path = _download_artifact_from_uri(
+        artifact_uri=model_uri, output_path=dst_path
+    )
+    _add_code_from_conf_to_system_path(local_mlflow_model_path, flavor_conf)
 
     if _should_use_mlflowdbfs(model_uri):
         from pyspark.ml.pipeline import PipelineModel
@@ -796,8 +797,9 @@ def load_model(model_uri, dfs_tmpdir=None, dst_path=None):
         ):
             return PipelineModel.load(mlflowdbfs_path)
 
+    local_sparkml_model_path = os.path.join(local_mlflow_model_path, flavor_conf["model_data"])
     return _load_model(
-        model_uri=model_uri, dfs_tmpdir_base=dfs_tmpdir, local_model_path=local_model_path
+        model_uri=model_uri, dfs_tmpdir_base=dfs_tmpdir, local_model_path=local_sparkml_model_path
     )
 
 

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -23,6 +23,7 @@ from mlflow import spark as sparkm
 from mlflow.environment_variables import MLFLOW_DFS_TMP
 from mlflow.models import Model, infer_signature
 from mlflow.models.utils import _read_example
+from mlflow.spark import _add_code_from_conf_to_system_path
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.environment import _mlflow_conda_env
@@ -823,7 +824,8 @@ def test_shutil_copytree_without_file_permissions(tmpdir):
 def test_log_model_with_code_paths(spark_model_iris):
     artifact_path = "model"
     with mlflow.start_run(), mock.patch(
-        "mlflow.spark._add_code_from_conf_to_system_path"
+        "mlflow.spark._add_code_from_conf_to_system_path",
+        wraps=_add_code_from_conf_to_system_path,
     ) as add_mock:
         sparkm.log_model(
             spark_model=spark_model_iris.model, artifact_path=artifact_path, code_paths=[__file__]


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

Fixes #6450

## What changes are proposed in this pull request?

Fix code path resolution during SparkML model loading

## How is this patch tested?

Updated integration tests

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

Fix a code path resolution when loading SparkML models with `mlflow.spark.load_model()`.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
