### PR TITLE
Add support for run_name synchronization when setting run name tag

### DIFF
--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -573,7 +573,7 @@ class FileStore(AbstractStore):
         check_run_is_active(run_info)
         new_info = run_info._copy_with_overrides(run_status, end_time, run_name=run_name)
         if run_name is not None:
-            self.set_tag(run_id, RunTag(MLFLOW_RUN_NAME, run_name))
+            self._set_run_tag(run_info, RunTag(MLFLOW_RUN_NAME, run_name))
         self._overwrite_run_info(new_info)
         return new_info
 
@@ -953,6 +953,9 @@ class FileStore(AbstractStore):
         run_info = self._get_run_info(run_id)
         check_run_is_active(run_info)
         self._set_run_tag(run_info, tag)
+        if tag.key == MLFLOW_RUN_NAME:
+            run_status = RunStatus.from_string(run_info.status)
+            self.update_run_info(run_id, run_status, run_info.end_time, tag.value)
 
     def _set_run_tag(self, run_info, tag):
         tag_path = self._get_tag_path(run_info.experiment_id, run_info.run_id, tag.key)
@@ -997,6 +1000,11 @@ class FileStore(AbstractStore):
             for metric in metrics:
                 self._log_run_metric(run_info, metric)
             for tag in tags:
+                # NB: If the tag run name value is set, update the run info to assure
+                # synchronization.
+                if tag.key == MLFLOW_RUN_NAME:
+                    run_status = RunStatus.from_string(run_info.status)
+                    self.update_run_info(run_id, run_status, run_info.end_time, tag.value)
                 self._set_run_tag(run_info, tag)
         except Exception as e:
             raise MlflowException(e, INTERNAL_ERROR)

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -1490,3 +1490,40 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
             )
         assert e.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
         self._verify_logged(fs, run.info.run_id, metrics=[], params=[], tags=[])
+
+    def test_update_run_name(self):
+        fs = FileStore(self.test_root)
+        run = self._create_run(fs)
+        run_id = run.info.run_id
+
+        self.assertEqual("name", run.info.run_name)
+        self.assertEqual("name", run.data.tags.get(MLFLOW_RUN_NAME))
+
+        fs.update_run_info(run_id, RunStatus.FINISHED, 100, "new name")
+        run = fs.get_run(run_id)
+        self.assertEqual("new name", run.info.run_name)
+        self.assertEqual("new name", run.data.tags.get(MLFLOW_RUN_NAME))
+
+        fs.update_run_info(run_id, RunStatus.FINISHED, 100, None)
+        run = fs.get_run(run_id)
+        self.assertEqual("new name", run.info.run_name)
+        self.assertEqual("new name", run.data.tags.get(MLFLOW_RUN_NAME))
+
+        fs.delete_tag(run_id, MLFLOW_RUN_NAME)
+        run = fs.get_run(run_id)
+        self.assertEqual("new name", run.info.run_name)
+        self.assertEqual(None, run.data.tags.get(MLFLOW_RUN_NAME))
+
+        fs.update_run_info(run_id, RunStatus.FINISHED, 100, "another name")
+        run = fs.get_run(run_id)
+        self.assertEqual("another name", run.data.tags.get(MLFLOW_RUN_NAME))
+
+        fs.set_tag(run_id, RunTag(MLFLOW_RUN_NAME, "yet another name"))
+        run = fs.get_run(run_id)
+        self.assertEqual("yet another name", run.info.run_name)
+        self.assertEqual("yet another name", run.data.tags.get(MLFLOW_RUN_NAME))
+
+        fs.log_batch(run_id, metrics=[], params=[], tags=[RunTag(MLFLOW_RUN_NAME, "batch name")])
+        run = fs.get_run(run_id)
+        self.assertEqual("batch name", run.info.run_name)
+        self.assertEqual("batch name", run.data.tags.get(MLFLOW_RUN_NAME))


### PR DESCRIPTION
Signed-off-by: Ben Wilson <benjamin.wilson@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Ensuring that run_name run info attribute remains in sync with tag reserved run name value. Whenever the reserved tag name (legacy version) is set, the run info `run_name` attribute is set with the new tag value.

## How is this patch tested?

Added to sqlalchemy store run_name mutation validation and created a similar test in filestore

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [X] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Run name will maintain a synchronized state between the `run.info.run_name` attribute and the `run.data.tags[mlflow.runName]` value set in tags.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
