### PR TITLE
Support searching and sorting experiments by `creation_time` and `last_update_time`

### DIFF
--- a/docs/source/search-experiments.rst
+++ b/docs/source/search-experiments.rst
@@ -21,7 +21,7 @@ The following identifiers are supported:
 
 - ``attributes.name``: Experiment name
 - ``attributes.creation_time``: Experiment creation time
-- ``attributes.last_update_time``: Experiment last updated time
+- ``attributes.last_update_time``: Experiment last update time
 
     .. note::
 

--- a/docs/source/search-experiments.rst
+++ b/docs/source/search-experiments.rst
@@ -20,6 +20,8 @@ Identifier
 The following identifiers are supported:
 
 - ``attributes.name``: Experiment name
+- ``attributes.creation_time``: Experiment creation time
+- ``attributes.last_update_time``: Experiment last updated time
 
     .. note::
 
@@ -30,12 +32,21 @@ The following identifiers are supported:
 Comparator
 ^^^^^^^^^^
 
-The following comparators are supported:
+Comparators for string attributes:
 
 - ``=``: Equal
 - ``!=``: Not equal
 - ``LIKE``: Case-sensitive pattern match
 - ``ILIKE``: Case-insensitive pattern match
+
+Comparators for numeric attributes:
+
+- ``=``: Equal
+- ``!=``: Not equal
+- ``<``: Less than
+- ``<=``: Less than or equal to
+- ``>``: Greater than
+- ``>=``: Greater than or equal to
 
 Examples
 ^^^^^^^^

--- a/docs/source/search-experiments.rst
+++ b/docs/source/search-experiments.rst
@@ -32,7 +32,7 @@ The following identifiers are supported:
 Comparator
 ^^^^^^^^^^
 
-Comparators for string attributes:
+Comparators for string attributes and tags:
 
 - ``=``: Equal
 - ``!=``: Not equal

--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -58,26 +58,39 @@ class AbstractStore:
             supported.
 
             Identifiers
-              - ``name``: Experiment name.
+              - ``name``: Experiment name
+              - ``creation_time``: Experiment creation time
+              - ``last_update_time``: Experiment last update time
               - ``tags.<tag_key>``: Experiment tag. If ``tag_key`` contains
                 spaces, it must be wrapped with backticks (e.g., ``"tags.`extra key`"``).
 
-            Comparators
-              - ``=``: Equal to.
-              - ``!=``: Not equal to.
-              - ``LIKE``: Case-sensitive pattern match.
-              - ``ILIKE``: Case-insensitive pattern match.
+            Comparators for string attributes
+              - ``=``: Equal to
+              - ``!=``: Not equal to
+              - ``LIKE``: Case-sensitive pattern match
+              - ``ILIKE``: Case-insensitive pattern match
+
+            Comparators for numeric attributes
+              - ``=``: Equal to
+              - ``!=``: Not equal to
+              - ``<``: Less than
+              - ``<=``: Less than or equal to
+              - ``>``: Greater than
+              - ``>=``: Greater than or equal to
 
             Logical operators
               - ``AND``: Combines two sub-queries and returns True if both of them are True.
 
         :param order_by:
             List of columns to order by. The ``order_by`` column can contain an optional ``DESC`` or
-            ``ASC`` value (e.g., ``"name DESC"``). The default is ``ASC`` so ``"name"`` is
-            equivalent to ``"name ASC"``. The following identifiers are supported.
+            ``ASC`` value (e.g., ``"name DESC"``). The default ordering is ``ASC``, so ``"name"`` is
+            equivalent to ``"name ASC"``. If unspecified, defaults to ``["last_update_time DESC"]``,
+            which lists experiments updated most recently first. The following fields are supported:
 
-            - ``name``: Experiment name.
-            - ``experiment_id``: Experiment ID.
+            - ``name``: Experiment name
+            - ``experiment_id``: Experiment ID
+            - ``creation_time``: Experiment creation time
+            - ``last_update_time``: Experiment last update time
 
         :param page_token: Token specifying the next page of results. It should be obtained from
                            a ``search_experiments`` call.

--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -87,8 +87,8 @@ class AbstractStore:
             equivalent to ``"name ASC"``. If unspecified, defaults to ``["last_update_time DESC"]``,
             which lists experiments updated most recently first. The following fields are supported:
 
-            - ``name``: Experiment name
             - ``experiment_id``: Experiment ID
+            - ``name``: Experiment name
             - ``creation_time``: Experiment creation time
             - ``last_update_time``: Experiment last update time
 

--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -64,7 +64,7 @@ class AbstractStore:
               - ``tags.<tag_key>``: Experiment tag. If ``tag_key`` contains
                 spaces, it must be wrapped with backticks (e.g., ``"tags.`extra key`"``).
 
-            Comparators for string attributes
+            Comparators for string attributes and tags
               - ``=``: Equal to
               - ``!=``: Not equal to
               - ``LIKE``: Case-sensitive pattern match

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -326,7 +326,9 @@ class FileStore(AbstractStore):
                     f"Malformed experiment '{exp_id}'. Detailed error {e}", exc_info=True
                 )
         filtered = SearchExperimentsUtils.filter(experiments, filter_string)
-        sorted_experiments = SearchExperimentsUtils.sort(filtered, order_by)
+        sorted_experiments = SearchExperimentsUtils.sort(
+            filtered, order_by or ["last_update_time DESC"]
+        )
         experiments, next_page_token = SearchUtils.paginate(
             sorted_experiments, page_token, max_results
         )

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -1432,7 +1432,8 @@ def _get_search_experiments_filter_clauses(parsed_filters, dialect):
 def _get_search_experiments_order_by_clauses(order_by):
     order_by_clauses = []
     for (type_, key, ascending) in map(
-        SearchExperimentsUtils.parse_order_by_for_search_experiments, order_by or []
+        SearchExperimentsUtils.parse_order_by_for_search_experiments,
+        order_by or ["last_update_time DESC"],
     ):
         if type_ == "attribute":
             order_by_clauses.append((getattr(SqlExperiment, key), ascending))

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -186,11 +186,14 @@ class SqlAlchemyStore(AbstractStore):
         ToDo: Identify a less hacky mechanism to create default experiment 0
         """
         table = SqlExperiment.__tablename__
+        creation_time = get_current_time_millis()
         default_experiment = {
             SqlExperiment.experiment_id.name: int(SqlAlchemyStore.DEFAULT_EXPERIMENT_ID),
             SqlExperiment.name.name: Experiment.DEFAULT_EXPERIMENT_NAME,
             SqlExperiment.artifact_location.name: str(self._get_artifact_location(0)),
             SqlExperiment.lifecycle_stage.name: LifecycleStage.ACTIVE,
+            SqlExperiment.creation_time.name: creation_time,
+            SqlExperiment.last_update_time.name: creation_time,
         }
 
         def decorate(s):
@@ -1391,11 +1394,19 @@ def _get_search_experiments_filter_clauses(parsed_filters, dialect):
         comparator = f["comparator"]
         value = f["value"]
         if type_ == "attribute":
-            attr = getattr(SqlExperiment, key)
-            if comparator not in ("=", "!=", "LIKE", "ILIKE"):
+            if SearchExperimentsUtils.is_string_attribute(
+                type_, key, comparator
+            ) and comparator not in ("=", "!=", "LIKE", "ILIKE"):
                 raise MlflowException.invalid_parameter_value(
-                    f"Invalid comparator for attribute: {comparator}"
+                    f"Invalid comparator for string attribute: {comparator}"
                 )
+            if SearchExperimentsUtils.is_numeric_attribute(
+                type_, key, comparator
+            ) and comparator not in ("=", "!=", "<", "<=", ">", ">="):
+                raise MlflowException.invalid_parameter_value(
+                    f"Invalid comparator for numeric attribute: {comparator}"
+                )
+            attr = getattr(SqlExperiment, key)
             attr_filter = SearchUtils.get_sql_comparison_func(comparator, dialect)(attr, value)
             attribute_filters.append(attr_filter)
         elif type_ == "tag":

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -178,25 +178,25 @@ class TrackingServiceClient:
             supported.
 
             Identifiers
-              - ``name``: Experiment name.
-              - ``creation_time``: Experiment creation time.
-              - ``last_update_time``: Experiment last update time.
+              - ``name``: Experiment name
+              - ``creation_time``: Experiment creation time
+              - ``last_update_time``: Experiment last update time
               - ``tags.<tag_key>``: Experiment tag. If ``tag_key`` contains
                 spaces, it must be wrapped with backticks (e.g., ``"tags.`extra key`"``).
 
             Comparators for string attributes
-              - ``=``: Equal to.
-              - ``!=``: Not equal to.
-              - ``LIKE``: Case-sensitive pattern match.
-              - ``ILIKE``: Case-insensitive pattern match.
+              - ``=``: Equal to
+              - ``!=``: Not equal to
+              - ``LIKE``: Case-sensitive pattern match
+              - ``ILIKE``: Case-insensitive pattern match
 
             Comparators for numeric attributes
-              - ``=``: Equal to.
-              - ``!=``: Not equal to.
-              - ``<``: Less than.
-              - ``<=``: Less than or equal to.
-              - ``>``: Greater than.
-              - ``>=``: Greater than or equal to.
+              - ``=``: Equal to
+              - ``!=``: Not equal to
+              - ``<``: Less than
+              - ``<=``: Less than or equal to
+              - ``>``: Greater than
+              - ``>=``: Greater than or equal to
 
             Logical operators
               - ``AND``: Combines two sub-queries and returns True if both of them are True.
@@ -206,10 +206,10 @@ class TrackingServiceClient:
             ``ASC`` value (e.g., ``"name DESC"``). The default is ``ASC`` so ``"name"`` is
             equivalent to ``"name ASC"``. The following fields are supported.
 
-            - ``name``: Experiment name.
-            - ``creation_time``: Experiment creation time.
-            - ``last_update_time``: Experiment last update time.
-            - ``experiment_id``: Experiment ID.
+            - ``name``: Experiment name
+            - ``creation_time``: Experiment creation time
+            - ``last_update_time``: Experiment last update time
+            - ``experiment_id``: Experiment ID
 
         :param page_token: Token specifying the next page of results. It should be obtained from
                            a ``search_experiments`` call.

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -207,10 +207,10 @@ class TrackingServiceClient:
             equivalent to ``"name ASC"``. If unspecified, defaults to ``["last_update_time DESC"]``,
             which lists experiments updated most recently first. The following fields are supported:
 
+            - ``experiment_id``: Experiment ID
             - ``name``: Experiment name
             - ``creation_time``: Experiment creation time
             - ``last_update_time``: Experiment last update time
-            - ``experiment_id``: Experiment ID
 
         :param page_token: Token specifying the next page of results. It should be obtained from
                            a ``search_experiments`` call.

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -179,14 +179,24 @@ class TrackingServiceClient:
 
             Identifiers
               - ``name``: Experiment name.
+              - ``creation_time``: Experiment creation time.
+              - ``last_update_time``: Experiment last update time.
               - ``tags.<tag_key>``: Experiment tag. If ``tag_key`` contains
                 spaces, it must be wrapped with backticks (e.g., ``"tags.`extra key`"``).
 
-            Comparators
+            Comparators for string attributes
               - ``=``: Equal to.
               - ``!=``: Not equal to.
               - ``LIKE``: Case-sensitive pattern match.
               - ``ILIKE``: Case-insensitive pattern match.
+
+            Comparators for numeric attributes
+              - ``=``: Equal to.
+              - ``!=``: Not equal to.
+              - ``<``: Less than.
+              - ``<=``: Less than or equal to.
+              - ``>``: Greater than.
+              - ``>=``: Greater than or equal to.
 
             Logical operators
               - ``AND``: Combines two sub-queries and returns True if both of them are True.
@@ -197,6 +207,8 @@ class TrackingServiceClient:
             equivalent to ``"name ASC"``. The following fields are supported.
 
             - ``name``: Experiment name.
+            - ``creation_time``: Experiment creation time.
+            - ``last_update_time``: Experiment last update time.
             - ``experiment_id``: Experiment ID.
 
         :param page_token: Token specifying the next page of results. It should be obtained from

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -184,7 +184,7 @@ class TrackingServiceClient:
               - ``tags.<tag_key>``: Experiment tag. If ``tag_key`` contains
                 spaces, it must be wrapped with backticks (e.g., ``"tags.`extra key`"``).
 
-            Comparators for string attributes
+            Comparators for string attributes and tags
               - ``=``: Equal to
               - ``!=``: Not equal to
               - ``LIKE``: Case-sensitive pattern match

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -203,8 +203,9 @@ class TrackingServiceClient:
 
         :param order_by:
             List of columns to order by. The ``order_by`` column can contain an optional ``DESC`` or
-            ``ASC`` value (e.g., ``"name DESC"``). The default is ``ASC`` so ``"name"`` is
-            equivalent to ``"name ASC"``. The following fields are supported.
+            ``ASC`` value (e.g., ``"name DESC"``). The default ordering is ``ASC``, so ``"name"`` is
+            equivalent to ``"name ASC"``. If unspecified, defaults to ``["last_update_time DESC"]``,
+            which lists experiments updated most recently first. The following fields are supported:
 
             - ``name``: Experiment name
             - ``creation_time``: Experiment creation time

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -430,7 +430,7 @@ class MlflowClient:
               - ``tags.<tag_key>``: Experiment tag. If ``tag_key`` contains
                 spaces, it must be wrapped with backticks (e.g., ``"tags.`extra key`"``).
 
-            Comparators for string attributes
+            Comparators for string attributes and tags
               - ``=``: Equal to
               - ``!=``: Not equal to
               - ``LIKE``: Case-sensitive pattern match

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -449,13 +449,14 @@ class MlflowClient:
 
         :param order_by:
             List of columns to order by. The ``order_by`` column can contain an optional ``DESC`` or
-            ``ASC`` value (e.g., ``"name DESC"``). The default is ``ASC`` so ``"name"`` is
-            equivalent to ``"name ASC"``. The following identifiers are supported.
+            ``ASC`` value (e.g., ``"name DESC"``). The default ordering is ``ASC``, so ``"name"`` is
+            equivalent to ``"name ASC"``. If unspecified, defaults to ``["last_update_time DESC"]``,
+            which lists experiments updated most recently first. The following fields are supported:
 
-            - ``name``: Experiment name.
-            - ``experiment_id``: Experiment ID.
-            - ``creation_time``: Experiment creation time.
-            - ``last_update_time``: Experiment last update time.
+            - ``name``: Experiment name
+            - ``experiment_id``: Experiment ID
+            - ``creation_time``: Experiment creation time
+            - ``last_update_time``: Experiment last update time
 
         :param page_token: Token specifying the next page of results. It should be obtained from
                            a ``search_experiments`` call.

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -425,14 +425,24 @@ class MlflowClient:
 
             Identifiers
               - ``name``: Experiment name.
+              - ``creation_time``: Experiment creation time.
+              - ``last_update_time``: Experiment last update time.
               - ``tags.<tag_key>``: Experiment tag. If ``tag_key`` contains
                 spaces, it must be wrapped with backticks (e.g., ``"tags.`extra key`"``).
 
-            Comparators
+            Comparators for string attributes
               - ``=``: Equal to.
               - ``!=``: Not equal to.
               - ``LIKE``: Case-sensitive pattern match.
               - ``ILIKE``: Case-insensitive pattern match.
+
+            Comparators for numeric attributes
+              - ``=``: Equal to.
+              - ``!=``: Not equal to.
+              - ``<``: Less than.
+              - ``<=``: Less than or equal to.
+              - ``>``: Greater than.
+              - ``>=``: Greater than or equal to.
 
             Logical operators
               - ``AND``: Combines two sub-queries and returns True if both of them are True.
@@ -444,6 +454,8 @@ class MlflowClient:
 
             - ``name``: Experiment name.
             - ``experiment_id``: Experiment ID.
+            - ``creation_time``: Experiment creation time.
+            - ``last_update_time``: Experiment last update time.
 
         :param page_token: Token specifying the next page of results. It should be obtained from
                            a ``search_experiments`` call.

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -424,25 +424,25 @@ class MlflowClient:
             supported.
 
             Identifiers
-              - ``name``: Experiment name.
-              - ``creation_time``: Experiment creation time.
-              - ``last_update_time``: Experiment last update time.
+              - ``name``: Experiment name
+              - ``creation_time``: Experiment creation time
+              - ``last_update_time``: Experiment last update time
               - ``tags.<tag_key>``: Experiment tag. If ``tag_key`` contains
                 spaces, it must be wrapped with backticks (e.g., ``"tags.`extra key`"``).
 
             Comparators for string attributes
-              - ``=``: Equal to.
-              - ``!=``: Not equal to.
-              - ``LIKE``: Case-sensitive pattern match.
-              - ``ILIKE``: Case-insensitive pattern match.
+              - ``=``: Equal to
+              - ``!=``: Not equal to
+              - ``LIKE``: Case-sensitive pattern match
+              - ``ILIKE``: Case-insensitive pattern match
 
             Comparators for numeric attributes
-              - ``=``: Equal to.
-              - ``!=``: Not equal to.
-              - ``<``: Less than.
-              - ``<=``: Less than or equal to.
-              - ``>``: Greater than.
-              - ``>=``: Greater than or equal to.
+              - ``=``: Equal to
+              - ``!=``: Not equal to
+              - ``<``: Less than
+              - ``<=``: Less than or equal to
+              - ``>``: Greater than
+              - ``>=``: Greater than or equal to
 
             Logical operators
               - ``AND``: Combines two sub-queries and returns True if both of them are True.

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -453,8 +453,8 @@ class MlflowClient:
             equivalent to ``"name ASC"``. If unspecified, defaults to ``["last_update_time DESC"]``,
             which lists experiments updated most recently first. The following fields are supported:
 
-            - ``name``: Experiment name
             - ``experiment_id``: Experiment ID
+            - ``name``: Experiment name
             - ``creation_time``: Experiment creation time
             - ``last_update_time``: Experiment last update time
 

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1114,8 +1114,9 @@ def search_experiments(
 
     :param order_by:
         List of columns to order by. The ``order_by`` column can contain an optional ``DESC`` or
-        ``ASC`` value (e.g., ``"name DESC"``). The default is ``ASC`` so ``"name"`` is equivalent to
-        ``"name ASC"``. The following fields are supported.
+        ``ASC`` value (e.g., ``"name DESC"``). The default ordering is ``ASC``, so ``"name"`` is
+        equivalent to ``"name ASC"``. If unspecified, defaults to ``["last_update_time DESC"]``,
+        which lists experiments updated most recently first. The following fields are supported:
 
             - ``name``: Experiment name
             - ``experiment_id``: Experiment ID

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1095,7 +1095,7 @@ def search_experiments(
           - ``tags.<tag_key>``: Experiment tag. If ``tag_key`` contains
             spaces, it must be wrapped with backticks (e.g., ``"tags.`extra key`"``).
 
-        Comparators for string attributes
+        Comparators for string attributes and tags
             - ``=``: Equal to
             - ``!=``: Not equal to
             - ``LIKE``: Case-sensitive pattern match

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1089,25 +1089,25 @@ def search_experiments(
         experiments. The following identifiers, comparators, and logical operators are supported.
 
         Identifiers
-          - ``name``: Experiment name.
-          - ``creation_time``: Experiment creation time.
-          - ``last_update_time``: Experiment last update time.
+          - ``name``: Experiment name
+          - ``creation_time``: Experiment creation time
+          - ``last_update_time``: Experiment last update time
           - ``tags.<tag_key>``: Experiment tag. If ``tag_key`` contains
             spaces, it must be wrapped with backticks (e.g., ``"tags.`extra key`"``).
 
         Comparators for string attributes
-            - ``=``: Equal to.
-            - ``!=``: Not equal to.
-            - ``LIKE``: Case-sensitive pattern match.
-            - ``ILIKE``: Case-insensitive pattern match.
+            - ``=``: Equal to
+            - ``!=``: Not equal to
+            - ``LIKE``: Case-sensitive pattern match
+            - ``ILIKE``: Case-insensitive pattern match
 
         Comparators for numeric attributes
-            - ``=``: Equal to.
-            - ``!=``: Not equal to.
-            - ``<``: Less than.
-            - ``<=``: Less than or equal to.
-            - ``>``: Greater than.
-            - ``>=``: Greater than or equal to.
+            - ``=``: Equal to
+            - ``!=``: Not equal to
+            - ``<``: Less than
+            - ``<=``: Less than or equal to
+            - ``>``: Greater than
+            - ``>=``: Greater than or equal to
 
         Logical operators
           - ``AND``: Combines two sub-queries and returns True if both of them are True.
@@ -1117,10 +1117,10 @@ def search_experiments(
         ``ASC`` value (e.g., ``"name DESC"``). The default is ``ASC`` so ``"name"`` is equivalent to
         ``"name ASC"``. The following fields are supported.
 
-            - ``name``: Experiment name.
-            - ``experiment_id``: Experiment ID.
-            - ``creation_time``: Experiment creation time.
-            - ``last_update_time``: Experiment last update time.
+            - ``name``: Experiment name
+            - ``experiment_id``: Experiment ID
+            - ``creation_time``: Experiment creation time
+            - ``last_update_time``: Experiment last update time
 
     :return: A list of :py:class:`Experiment <mlflow.entities.Experiment>` objects.
 

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1090,14 +1090,24 @@ def search_experiments(
 
         Identifiers
           - ``name``: Experiment name.
+          - ``creation_time``: Experiment creation time.
+          - ``last_update_time``: Experiment last update time.
           - ``tags.<tag_key>``: Experiment tag. If ``tag_key`` contains
             spaces, it must be wrapped with backticks (e.g., ``"tags.`extra key`"``).
 
-        Comparators
-          - ``=``: Equal to.
-          - ``!=``: Not equal to.
-          - ``LIKE``: Case-sensitive pattern match.
-          - ``ILIKE``: Case-insensitive pattern match.
+        Comparators for string attributes
+            - ``=``: Equal to.
+            - ``!=``: Not equal to.
+            - ``LIKE``: Case-sensitive pattern match.
+            - ``ILIKE``: Case-insensitive pattern match.
+
+        Comparators for numeric attributes
+            - ``=``: Equal to.
+            - ``!=``: Not equal to.
+            - ``<``: Less than.
+            - ``<=``: Less than or equal to.
+            - ``>``: Greater than.
+            - ``>=``: Greater than or equal to.
 
         Logical operators
           - ``AND``: Combines two sub-queries and returns True if both of them are True.
@@ -1109,6 +1119,8 @@ def search_experiments(
 
             - ``name``: Experiment name.
             - ``experiment_id``: Experiment ID.
+            - ``creation_time``: Experiment creation time.
+            - ``last_update_time``: Experiment last update time.
 
     :return: A list of :py:class:`Experiment <mlflow.entities.Experiment>` objects.
 

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1118,8 +1118,8 @@ def search_experiments(
         equivalent to ``"name ASC"``. If unspecified, defaults to ``["last_update_time DESC"]``,
         which lists experiments updated most recently first. The following fields are supported:
 
-            - ``name``: Experiment name
             - ``experiment_id``: Experiment ID
+            - ``name``: Experiment name
             - ``creation_time``: Experiment creation time
             - ``last_update_time``: Experiment last update time
 

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -720,8 +720,9 @@ class SearchUtils:
 
 
 class SearchExperimentsUtils(SearchUtils):
-    VALID_SEARCH_ATTRIBUTE_KEYS = ("name",)
-    VALID_ORDER_BY_ATTRIBUTE_KEYS = ("name", "experiment_id")
+    VALID_SEARCH_ATTRIBUTE_KEYS = {"name", "creation_time", "last_update_time"}
+    VALID_ORDER_BY_ATTRIBUTE_KEYS = {"name", "experiment_id", "creation_time", "last_update_time"}
+    NUMERIC_ATTRIBUTES = {"creation_time", "last_update_time"}
 
     @classmethod
     def _invalid_statement_token_search_experiments(cls, token):
@@ -802,8 +803,11 @@ class SearchExperimentsUtils(SearchUtils):
         value = sed.get("value")
         comparator = sed.get("comparator").upper()
 
-        if cls.is_attribute(key_type, comparator):
+        if cls.is_string_attribute(key_type, key, comparator):
             lhs = getattr(experiment, key)
+        if cls.is_numeric_attribute(key_type, key, comparator):
+            lhs = getattr(experiment, key)
+            value = float(value)
         elif cls.is_tag(key_type, comparator):
             if key not in experiment.tags:
                 return False

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -805,7 +805,7 @@ class SearchExperimentsUtils(SearchUtils):
 
         if cls.is_string_attribute(key_type, key, comparator):
             lhs = getattr(experiment, key)
-        if cls.is_numeric_attribute(key_type, key, comparator):
+        elif cls.is_numeric_attribute(key_type, key, comparator):
             lhs = getattr(experiment, key)
             value = float(value)
         elif cls.is_tag(key_type, comparator):

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -222,7 +222,7 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
     def test_search_experiments_filter_by_time_attribute(self):
         self.initialize()
         # Sleep to ensure that the first experiment has a different creation_time than the default
-        # experiment
+        # experiment and eliminate flakiness.
         time.sleep(0.001)
         time_before_create1 = get_current_time_millis()
         exp_id1 = self.store.create_experiment("1")

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -264,6 +264,15 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         assert [e.experiment_id for e in experiments] == [exp_id1]
 
         experiments = self.store.search_experiments(
+            filter_string=f"last_update_time <= {get_current_time_millis()}"
+        )
+        assert [e.experiment_id for e in experiments] == [
+            exp_id2,
+            exp_id1,
+            self.store.DEFAULT_EXPERIMENT_ID,
+        ]
+
+        experiments = self.store.search_experiments(
             filter_string=f"last_update_time = {exp2.last_update_time}"
         )
         assert [e.experiment_id for e in experiments] == [exp_id2]

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -267,8 +267,8 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
             filter_string=f"last_update_time <= {get_current_time_millis()}"
         )
         assert [e.experiment_id for e in experiments] == [
-            exp_id2,
             exp_id1,
+            exp_id2,
             self.store.DEFAULT_EXPERIMENT_ID,
         ]
 

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -219,6 +219,55 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         )
         assert [e.name for e in experiments] == ["ab"]
 
+    def test_search_experiments_filter_by_time_attribute(self):
+        self.initialize()
+        # Sleep to ensure that the first experiment has a different creation_time than the default
+        # experiment
+        time.sleep(0.001)
+        time_before_create1 = get_current_time_millis()
+        exp_id1 = self.store.create_experiment("1")
+        exp1 = self.store.get_experiment(exp_id1)
+        time.sleep(0.001)
+        time_before_create2 = get_current_time_millis()
+        exp_id2 = self.store.create_experiment("2")
+        exp2 = self.store.get_experiment(exp_id2)
+
+        experiments = self.store.search_experiments(
+            filter_string=f"creation_time = {exp1.creation_time}"
+        )
+        assert [e.experiment_id for e in experiments] == [exp_id1]
+
+        experiments = self.store.search_experiments(
+            filter_string=f"creation_time != {exp1.creation_time}"
+        )
+        assert [e.experiment_id for e in experiments] == [exp_id2, self.store.DEFAULT_EXPERIMENT_ID]
+
+        experiments = self.store.search_experiments(
+            filter_string=f"creation_time >= {time_before_create1}"
+        )
+        assert [e.experiment_id for e in experiments] == [exp_id2, exp_id1]
+
+        experiments = self.store.search_experiments(
+            filter_string=f"creation_time < {time_before_create2}"
+        )
+        assert [e.experiment_id for e in experiments] == [exp_id1, self.store.DEFAULT_EXPERIMENT_ID]
+
+        now = get_current_time_millis()
+        experiments = self.store.search_experiments(filter_string=f"creation_time >= {now}")
+        assert experiments == []
+
+        time_before_rename = get_current_time_millis()
+        self.store.rename_experiment(exp_id1, "new_name")
+        experiments = self.store.search_experiments(
+            filter_string=f"last_update_time >= {time_before_rename}"
+        )
+        assert [e.experiment_id for e in experiments] == [exp_id1]
+
+        experiments = self.store.search_experiments(
+            filter_string=f"last_update_time = {exp2.last_update_time}"
+        )
+        assert [e.experiment_id for e in experiments] == [exp_id2]
+
     def test_search_experiments_filter_by_tag(self):
         self.initialize()
         experiments = [
@@ -280,6 +329,44 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
 
         experiments = self.store.search_experiments(order_by=["name", "experiment_id"])
         assert [e.name for e in experiments] == ["Default", "x", "y", "z"]
+
+    def test_search_experiments_order_by_time_attribute(self):
+        self.initialize()
+        # Sleep to ensure that the first experiment has a different creation_time than the default
+        # experiment and eliminate flakiness.
+        time.sleep(0.001)
+        exp_id1 = self.store.create_experiment("1")
+        time.sleep(0.001)
+        exp_id2 = self.store.create_experiment("2")
+
+        experiments = self.store.search_experiments(order_by=["creation_time"])
+        assert [e.experiment_id for e in experiments] == [
+            self.store.DEFAULT_EXPERIMENT_ID,
+            exp_id1,
+            exp_id2,
+        ]
+
+        experiments = self.store.search_experiments(order_by=["creation_time DESC"])
+        assert [e.experiment_id for e in experiments] == [
+            exp_id2,
+            exp_id1,
+            self.store.DEFAULT_EXPERIMENT_ID,
+        ]
+
+        experiments = self.store.search_experiments(order_by=["last_update_time"])
+        assert [e.experiment_id for e in experiments] == [
+            self.store.DEFAULT_EXPERIMENT_ID,
+            exp_id1,
+            exp_id2,
+        ]
+
+        self.store.rename_experiment(exp_id1, "new_name")
+        experiments = self.store.search_experiments(order_by=["last_update_time"])
+        assert [e.experiment_id for e in experiments] == [
+            self.store.DEFAULT_EXPERIMENT_ID,
+            exp_id2,
+            exp_id1,
+        ]
 
     def test_search_experiments_max_results(self):
         self.initialize()

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -531,7 +531,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
 
     def test_search_experiments_order_by_time_attribute(self):
         # Sleep to ensure that the first experiment has a different creation_time than the default
-        # experiment
+        # experiment and eliminate flakiness.
         time.sleep(0.001)
         exp_id1 = self.store.create_experiment("1")
         time.sleep(0.001)

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -462,6 +462,15 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         assert [e.experiment_id for e in experiments] == [exp_id1]
 
         experiments = self.store.search_experiments(
+            filter_string=f"last_update_time <= {get_current_time_millis()}"
+        )
+        assert [e.experiment_id for e in experiments] == [
+            exp_id2,
+            exp_id1,
+            self.store.DEFAULT_EXPERIMENT_ID,
+        ]
+
+        experiments = self.store.search_experiments(
             filter_string=f"last_update_time = {exp2.last_update_time}"
         )
         assert [e.experiment_id for e in experiments] == [exp_id2]

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -465,8 +465,8 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
             filter_string=f"last_update_time <= {get_current_time_millis()}"
         )
         assert [e.experiment_id for e in experiments] == [
-            exp_id2,
             exp_id1,
+            exp_id2,
             self.store.DEFAULT_EXPERIMENT_ID,
         ]
 

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -418,6 +418,54 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         )
         assert [e.name for e in experiments] == ["ab"]
 
+    def test_search_experiments_filter_by_time_attribute(self):
+        # Sleep to ensure that the first experiment has a different creation_time than the default
+        # experiment and eliminate flakiness.
+        time.sleep(0.001)
+        time_before_create1 = get_current_time_millis()
+        exp_id1 = self.store.create_experiment("1")
+        exp1 = self.store.get_experiment(exp_id1)
+        time.sleep(0.001)
+        time_before_create2 = get_current_time_millis()
+        exp_id2 = self.store.create_experiment("2")
+        exp2 = self.store.get_experiment(exp_id2)
+
+        experiments = self.store.search_experiments(
+            filter_string=f"creation_time = {exp1.creation_time}"
+        )
+        assert [e.experiment_id for e in experiments] == [exp_id1]
+
+        experiments = self.store.search_experiments(
+            filter_string=f"creation_time != {exp1.creation_time}"
+        )
+        assert [e.experiment_id for e in experiments] == [exp_id2, self.store.DEFAULT_EXPERIMENT_ID]
+
+        experiments = self.store.search_experiments(
+            filter_string=f"creation_time >= {time_before_create1}"
+        )
+        assert [e.experiment_id for e in experiments] == [exp_id2, exp_id1]
+
+        experiments = self.store.search_experiments(
+            filter_string=f"creation_time < {time_before_create2}"
+        )
+        assert [e.experiment_id for e in experiments] == [exp_id1, self.store.DEFAULT_EXPERIMENT_ID]
+
+        now = get_current_time_millis()
+        experiments = self.store.search_experiments(filter_string=f"creation_time >= {now}")
+        assert experiments == []
+
+        time_before_rename = get_current_time_millis()
+        self.store.rename_experiment(exp_id1, "new_name")
+        experiments = self.store.search_experiments(
+            filter_string=f"last_update_time >= {time_before_rename}"
+        )
+        assert [e.experiment_id for e in experiments] == [exp_id1]
+
+        experiments = self.store.search_experiments(
+            filter_string=f"last_update_time = {exp2.last_update_time}"
+        )
+        assert [e.experiment_id for e in experiments] == [exp_id2]
+
     def test_search_experiments_filter_by_tag(self):
         experiments = [
             ("exp1", [ExperimentTag("key1", "value"), ExperimentTag("key2", "value")]),
@@ -480,6 +528,43 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
 
         experiments = self.store.search_experiments(order_by=["name", "experiment_id"])
         assert [e.name for e in experiments] == ["Default", "x", "y", "z"]
+
+    def test_search_experiments_order_by_time_attribute(self):
+        # Sleep to ensure that the first experiment has a different creation_time than the default
+        # experiment
+        time.sleep(0.001)
+        exp_id1 = self.store.create_experiment("1")
+        time.sleep(0.001)
+        exp_id2 = self.store.create_experiment("2")
+
+        experiments = self.store.search_experiments(order_by=["creation_time"])
+        assert [e.experiment_id for e in experiments] == [
+            self.store.DEFAULT_EXPERIMENT_ID,
+            exp_id1,
+            exp_id2,
+        ]
+
+        experiments = self.store.search_experiments(order_by=["creation_time DESC"])
+        assert [e.experiment_id for e in experiments] == [
+            exp_id2,
+            exp_id1,
+            self.store.DEFAULT_EXPERIMENT_ID,
+        ]
+
+        experiments = self.store.search_experiments(order_by=["last_update_time"])
+        assert [e.experiment_id for e in experiments] == [
+            self.store.DEFAULT_EXPERIMENT_ID,
+            exp_id1,
+            exp_id2,
+        ]
+
+        self.store.rename_experiment(exp_id1, "new_name")
+        experiments = self.store.search_experiments(order_by=["last_update_time"])
+        assert [e.experiment_id for e in experiments] == [
+            self.store.DEFAULT_EXPERIMENT_ID,
+            exp_id2,
+            exp_id1,
+        ]
 
     def test_search_experiments_max_results(self):
         experiment_names = list(map(str, range(9)))

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -769,4 +769,4 @@ def test_search_experiments(mlflow_client):
     experiments = mlflow_client.search_experiments(view_type=ViewType.DELETED_ONLY)
     assert [e.name for e in experiments] == ["ab"]
     experiments = mlflow_client.search_experiments(view_type=ViewType.ALL)
-    assert [e.name for e in experiments] == ["Abc", "ab", "a", "Default"]
+    assert [e.name for e in experiments] == ["ab", "Abc", "a", "Default"]


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Support searching and sorting experiments by `creation_time` and `last_update_time`.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
