### PR TITLE
standardize pytest assertion ordering

### DIFF
--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -1549,34 +1549,35 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         run = self._create_run(fs)
         run_id = run.info.run_id
 
-        self.assertEqual("name", run.info.run_name)
-        self.assertEqual("name", run.data.tags.get(MLFLOW_RUN_NAME))
+        self.assertEqual(run.info.run_name, "name")
+        self.assertEqual(run.data.tags.get(MLFLOW_RUN_NAME), "name")
 
         fs.update_run_info(run_id, RunStatus.FINISHED, 100, "new name")
         run = fs.get_run(run_id)
-        self.assertEqual("new name", run.info.run_name)
-        self.assertEqual("new name", run.data.tags.get(MLFLOW_RUN_NAME))
+        self.assertEqual(run.info.run_name, "new name")
+        self.assertEqual(run.data.tags.get(MLFLOW_RUN_NAME), "new name")
 
         fs.update_run_info(run_id, RunStatus.FINISHED, 100, None)
         run = fs.get_run(run_id)
-        self.assertEqual("new name", run.info.run_name)
-        self.assertEqual("new name", run.data.tags.get(MLFLOW_RUN_NAME))
+        self.assertEqual(run.info.run_name, "new name")
+        self.assertEqual(run.data.tags.get(MLFLOW_RUN_NAME), "new name")
 
         fs.delete_tag(run_id, MLFLOW_RUN_NAME)
         run = fs.get_run(run_id)
-        self.assertEqual("new name", run.info.run_name)
-        self.assertEqual(None, run.data.tags.get(MLFLOW_RUN_NAME))
+        self.assertEqual(run.info.run_name, "new name")
+        self.assertEqual(run.data.tags.get(MLFLOW_RUN_NAME), None)
 
         fs.update_run_info(run_id, RunStatus.FINISHED, 100, "another name")
         run = fs.get_run(run_id)
-        self.assertEqual("another name", run.data.tags.get(MLFLOW_RUN_NAME))
+        self.assertEqual(run.data.tags.get(MLFLOW_RUN_NAME), "another name")
+        self.assertEqual(run.info.run_name, "another name")
 
         fs.set_tag(run_id, RunTag(MLFLOW_RUN_NAME, "yet another name"))
         run = fs.get_run(run_id)
-        self.assertEqual("yet another name", run.info.run_name)
-        self.assertEqual("yet another name", run.data.tags.get(MLFLOW_RUN_NAME))
+        self.assertEqual(run.info.run_name, "yet another name")
+        self.assertEqual(run.data.tags.get(MLFLOW_RUN_NAME), "yet another name")
 
         fs.log_batch(run_id, metrics=[], params=[], tags=[RunTag(MLFLOW_RUN_NAME, "batch name")])
         run = fs.get_run(run_id)
-        self.assertEqual("batch name", run.info.run_name)
-        self.assertEqual("batch name", run.data.tags.get(MLFLOW_RUN_NAME))
+        self.assertEqual(run.info.run_name, "batch name")
+        self.assertEqual(run.data.tags.get(MLFLOW_RUN_NAME), "batch name")

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -1275,30 +1275,32 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
 
         run_id = self.store.create_run(**configs).info.run_id
         run = self.store.get_run(run_id)
-        self.assertEqual(configs["run_name"], run.info.run_name)
+        self.assertEqual(run.info.run_name, configs["run_name"])
 
         self.store.update_run_info(run_id, RunStatus.FINISHED, 1000, "new name")
         run = self.store.get_run(run_id)
-        self.assertEqual("new name", run.info.run_name)
-        self.assertEqual("new name", run.data.tags.get(mlflow_tags.MLFLOW_RUN_NAME))
+        self.assertEqual(run.info.run_name, "new name")
+        self.assertEqual(run.data.tags.get(mlflow_tags.MLFLOW_RUN_NAME), "new name")
 
         self.store.update_run_info(run_id, RunStatus.FINISHED, 1000, None)
         run = self.store.get_run(run_id)
-        self.assertEqual("new name", run.info.run_name)
-        self.assertEqual("new name", run.data.tags.get(mlflow_tags.MLFLOW_RUN_NAME))
+        self.assertEqual(run.info.run_name, "new name")
+        self.assertEqual(run.data.tags.get(mlflow_tags.MLFLOW_RUN_NAME), "new name")
 
         self.store.delete_tag(run_id, mlflow_tags.MLFLOW_RUN_NAME)
         run = self.store.get_run(run_id)
-        self.assertEqual(None, run.data.tags.get(mlflow_tags.MLFLOW_RUN_NAME))
+        self.assertEqual(run.info.run_name, "new name")
+        self.assertEqual(run.data.tags.get(mlflow_tags.MLFLOW_RUN_NAME), None)
 
         self.store.update_run_info(run_id, RunStatus.FINISHED, 1000, "newer name")
         run = self.store.get_run(run_id)
-        self.assertEqual("newer name", run.data.tags.get(mlflow_tags.MLFLOW_RUN_NAME))
+        self.assertEqual(run.info.run_name, "newer name")
+        self.assertEqual(run.data.tags.get(mlflow_tags.MLFLOW_RUN_NAME), "newer name")
 
         self.store.set_tag(run_id, entities.RunTag(mlflow_tags.MLFLOW_RUN_NAME, "newest name"))
         run = self.store.get_run(run_id)
         self.assertEqual(run.data.tags.get(mlflow_tags.MLFLOW_RUN_NAME), "newest name")
-        self.assertEqual("newest name", run.info.run_name)
+        self.assertEqual(run.info.run_name, "newest name")
 
         self.store.log_batch(
             run_id,
@@ -1308,7 +1310,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         )
         run = self.store.get_run(run_id)
         self.assertEqual(run.data.tags.get(mlflow_tags.MLFLOW_RUN_NAME), "batch name")
-        self.assertEqual("batch name", run.info.run_name)
+        self.assertEqual(run.info.run_name, "batch name")
 
     def test_restore_experiment(self):
         experiment_id = self._experiment_factory("helloexp")


### PR DESCRIPTION
Signed-off-by: Ben Wilson <benjamin.wilson@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#6971 

## What changes are proposed in this pull request?

Standardize assertion ordering to PEP and add in additional assertions to provide better coverage.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [X] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
