### PR TITLE
Incorrect default headers passed to web client when no headers found

### DIFF
--- a/mlflow/store/artifact/databricks_models_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_models_artifact_repo.py
@@ -110,7 +110,7 @@ class DatabricksModelsArtifactRepository(ArtifactRepository):
                 "API request to get presigned uri to for file under path `%s` failed with"
                 " status code %s. Response body: %s" % (path, response.status_code, response.text)
             )
-        return json_response.get("signed_uri", None), json_response.get("headers", None)
+        return json_response.get("signed_uri", None), json_response.get("headers", {})
 
     def _extract_headers_from_signed_url(self, headers):
         filtered_headers = filter(lambda h: "name" in h and "value" in h, headers)

--- a/mlflow/store/artifact/databricks_models_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_models_artifact_repo.py
@@ -98,6 +98,7 @@ class DatabricksModelsArtifactRepository(ArtifactRepository):
             page_token = next_page_token
         return infos
 
+    # TODO: Change the implementation of this to match how databricks_artifact_repo.py handles this
     def _get_signed_download_uri(self, path=None):
         if not path:
             path = ""
@@ -110,6 +111,7 @@ class DatabricksModelsArtifactRepository(ArtifactRepository):
                 "API request to get presigned uri to for file under path `%s` failed with"
                 " status code %s. Response body: %s" % (path, response.status_code, response.text)
             )
+        # We must default the headers to be {} as that is the type expected back in the consumers
         return json_response.get("signed_uri", None), json_response.get("headers", {})
 
     def _extract_headers_from_signed_url(self, headers):

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -544,6 +544,8 @@ def download_file_using_http_uri(http_uri, download_path, chunk_size=100000000, 
     if headers is None:
         print("YOW! Resetting headers to {}!\n")
         headers = {}
+    else:
+        print("DOUBLE YOW!  Headers = " + str(headers))
     with cloud_storage_http_request("get", http_uri, stream=True, headers=headers) as response:
         augmented_raise_for_status(response)
         with open(download_path, "wb") as output_file:

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -540,12 +540,6 @@ def download_file_using_http_uri(http_uri, download_path, chunk_size=100000000, 
     Note : This function is meant to download files using presigned urls from various cloud
             providers.
     """
-    # We must convert the headers to an empty dict if none were passed in.
-    if headers is None:
-        print("YOW! Resetting headers to {}!\n")
-        headers = {}
-    else:
-        print("DOUBLE YOW!  Headers = " + str(headers))
     with cloud_storage_http_request("get", http_uri, stream=True, headers=headers) as response:
         augmented_raise_for_status(response)
         with open(download_path, "wb") as output_file:

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -532,7 +532,7 @@ def yield_file_in_chunks(file, chunk_size=100000000):
                 break
 
 
-def download_file_using_http_uri(http_uri, download_path, chunk_size=100000000, headers=None, **kwargs):
+def download_file_using_http_uri(http_uri, download_path, chunk_size=100000000, headers=None):
     """
     Downloads a file specified using the `http_uri` to a local `download_path`. This function
     uses a `chunk_size` to ensure an OOM error is not raised a large file is downloaded.
@@ -540,6 +540,7 @@ def download_file_using_http_uri(http_uri, download_path, chunk_size=100000000, 
     Note : This function is meant to download files using presigned urls from various cloud
             providers.
     """
+    kwargs = {}
     if headers is not None and len(headers) > 0:
         kwargs["headers"] = headers
     with cloud_storage_http_request("get", http_uri, stream=True, **kwargs) as response:

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -542,6 +542,7 @@ def download_file_using_http_uri(http_uri, download_path, chunk_size=100000000, 
     """
     # We must convert the headers to an empty dict if none were passed in.
     if headers is None:
+        print("YOW! Resetting headers to {}!\n")
         headers = {}
     with cloud_storage_http_request("get", http_uri, stream=True, headers=headers) as response:
         augmented_raise_for_status(response)

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -532,7 +532,7 @@ def yield_file_in_chunks(file, chunk_size=100000000):
                 break
 
 
-def download_file_using_http_uri(http_uri, download_path, chunk_size=100000000, headers=None):
+def download_file_using_http_uri(http_uri, download_path, chunk_size=100000000, headers=None, **kwargs):
     """
     Downloads a file specified using the `http_uri` to a local `download_path`. This function
     uses a `chunk_size` to ensure an OOM error is not raised a large file is downloaded.
@@ -540,7 +540,6 @@ def download_file_using_http_uri(http_uri, download_path, chunk_size=100000000, 
     Note : This function is meant to download files using presigned urls from various cloud
             providers.
     """
-    kwargs = {}
     if headers is not None and len(headers) > 0:
         kwargs["headers"] = headers
     with cloud_storage_http_request("get", http_uri, stream=True, **kwargs) as response:

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -540,7 +540,10 @@ def download_file_using_http_uri(http_uri, download_path, chunk_size=100000000, 
     Note : This function is meant to download files using presigned urls from various cloud
             providers.
     """
-    with cloud_storage_http_request("get", http_uri, stream=True, headers=headers) as response:
+    kwargs = {}
+    if headers is not None and len(headers) > 0:
+        kwargs["headers"] = headers
+    with cloud_storage_http_request("get", http_uri, stream=True, **kwargs) as response:
         augmented_raise_for_status(response)
         with open(download_path, "wb") as output_file:
             for chunk in response.iter_content(chunk_size=chunk_size):

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -540,6 +540,9 @@ def download_file_using_http_uri(http_uri, download_path, chunk_size=100000000, 
     Note : This function is meant to download files using presigned urls from various cloud
             providers.
     """
+    # We must convert the headers to an empty dict if none were passed in.
+    if headers is None:
+        headers = {}
     with cloud_storage_http_request("get", http_uri, stream=True, headers=headers) as response:
         augmented_raise_for_status(response)
         with open(download_path, "wb") as output_file:

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -540,10 +540,9 @@ def download_file_using_http_uri(http_uri, download_path, chunk_size=100000000, 
     Note : This function is meant to download files using presigned urls from various cloud
             providers.
     """
-    kwargs = {}
-    if headers is not None and len(headers) > 0:
-        kwargs["headers"] = headers
-    with cloud_storage_http_request("get", http_uri, stream=True, **kwargs) as response:
+    if headers is None:
+        headers = {}
+    with cloud_storage_http_request("get", http_uri, stream=True, headers=headers) as response:
         augmented_raise_for_status(response)
         with open(download_path, "wb") as output_file:
             for chunk in response.iter_content(chunk_size=chunk_size):


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Fixes a bug in the databricks_model_artifact_repository.py where an incorrect header type would be sent to the web client if no headers were present.

## How is this patch tested?

Manually tested the branch to validate it works.  This was caught by nightly master failing/DUST tests.
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
