### PR TITLE
environment variables support for timeout

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -176,7 +176,7 @@ MLFLOW_REQUIREMENTS_INFERENCE_TIMEOUT = _EnvironmentVariable(
     "MLFLOW_REQUIREMENTS_INFERENCE_TIMEOUT", int, 120
 )
 
-#: Configuring the scoring server request timeout via environment variable
+#: Specifies the MLflow Model Scoring server request timeout in seconds
 #: (default: ``60``)
 MLFLOW_SCORING_SERVER_REQUEST_TIMEOUT = _EnvironmentVariable(
     "MLFLOW_SCORING_SERVER_REQUEST_TIMEOUT", int, 60

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -175,3 +175,9 @@ MLFLOW_SQLALCHEMYSTORE_POOLCLASS = _EnvironmentVariable(
 MLFLOW_REQUIREMENTS_INFERENCE_TIMEOUT = _EnvironmentVariable(
     "MLFLOW_REQUIREMENTS_INFERENCE_TIMEOUT", int, 120
 )
+
+#: Configuring the scoring server request timeout via environment variable
+#: (default: ``60``)
+MLFLOW_SCORING_SERVER_REQUEST_TIMEOUT = _EnvironmentVariable(
+    "MLFLOW_SCORING_SERVER_REQUEST_TIMEOUT", int, 60
+)

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -573,7 +573,7 @@ def _load_model_or_server(model_uri: str, env_manager: str):
         model_uri=local_path,
         port=server_port,
         host="127.0.0.1",
-        timeout=60,
+        timeout=MLFLOW_SCORING_SERVER_REQUEST_TIMEOUT.get(),
         enable_mlserver=False,
         synchronous=False,
         stdout=subprocess.PIPE,

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -225,6 +225,7 @@ import yaml
 
 import mlflow
 import mlflow.pyfunc.model
+from mlflow.environment_variables import MLFLOW_SCORING_SERVER_REQUEST_TIMEOUT
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model, ModelSignature, ModelInputExample
 from mlflow.models.model import MLMODEL_FILE_NAME
@@ -1076,7 +1077,7 @@ def spark_udf(spark, model_uri, result_type="double", env_manager="local"):
                 model_uri=local_model_path_on_executor,
                 port=server_port,
                 host="127.0.0.1",
-                timeout=60,
+                timeout=MLFLOW_SCORING_SERVER_REQUEST_TIMEOUT.get(),
                 enable_mlserver=False,
                 synchronous=False,
                 stdout=subprocess.PIPE,

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -6,6 +6,7 @@ import posixpath
 import sys
 import warnings
 
+from mlflow.environment_variables import MLFLOW_SCORING_SERVER_REQUEST_TIMEOUT
 from mlflow.models import FlavorBackend
 from mlflow.models.docker_utils import (
     _build_image,
@@ -158,6 +159,7 @@ class PyFuncBackend(FlavorBackend):
         Serve pyfunc model locally.
         """
         local_path = _download_artifact_from_uri(model_uri)
+        timeout = timeout or MLFLOW_SCORING_SERVER_REQUEST_TIMEOUT.get()
 
         server_implementation = mlserver if enable_mlserver else scoring_server
         command, command_env = server_implementation.get_cmd(

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -6,7 +6,7 @@ import posixpath
 import sys
 import warnings
 
-from mlflow.environment_variables import MLFLOW_SCORING_SERVER_REQUEST_TIMEOUT
+
 from mlflow.models import FlavorBackend
 from mlflow.models.docker_utils import (
     _build_image,
@@ -159,7 +159,6 @@ class PyFuncBackend(FlavorBackend):
         Serve pyfunc model locally.
         """
         local_path = _download_artifact_from_uri(model_uri)
-        timeout = timeout or MLFLOW_SCORING_SERVER_REQUEST_TIMEOUT.get()
 
         server_implementation = mlserver if enable_mlserver else scoring_server
         command, command_env = server_implementation.get_cmd(

--- a/mlflow/pyfunc/mlserver.py
+++ b/mlflow/pyfunc/mlserver.py
@@ -1,6 +1,9 @@
+import logging
 import os
 
 from typing import Tuple, Dict
+
+_logger = logging.getLogger(__name__)
 
 MLServerMLflowRuntime = "mlserver_mlflow.MLflowRuntime"
 MLServerDefaultModelName = "mlflow-model"
@@ -20,7 +23,7 @@ def get_cmd(
         cmd_env["MLSERVER_HOST"] = host
 
     if timeout:
-        raise Exception("Timeout is not yet supported in MLServer.")
+        _logger.warning("Timeout is not yet supported in MLServer.")
 
     cmd_env["MLSERVER_MODEL_NAME"] = MLServerDefaultModelName
 

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
     from mlflow.pyfunc import load_pyfunc as load_model
 from mlflow.protos.databricks_pb2 import BAD_REQUEST
 from mlflow.server.handlers import catch_mlflow_exception
-
+from mlflow.environment_variables import MLFLOW_SCORING_SERVER_REQUEST_TIMEOUT
 from io import StringIO
 
 _SERVER_MODEL_PATH = "__pyfunc_model_path__"
@@ -365,7 +365,7 @@ def get_cmd(
     model_uri: str, port: int = None, host: int = None, timeout: int = None, nworkers: int = None
 ) -> Tuple[str, Dict[str, str]]:
     local_uri = path_to_local_file_uri(model_uri)
-    timeout = timeout or 60
+    timeout = timeout or MLFLOW_SCORING_SERVER_REQUEST_TIMEOUT.get()
     # NB: Absolute windows paths do not work with mlflow apis, use file uri to ensure
     # platform compatibility.
     if os.name != "nt":

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -23,6 +23,8 @@ import pandas as pd
 import sys
 import traceback
 
+from mlflow.environment_variables import MLFLOW_SCORING_SERVER_REQUEST_TIMEOUT
+
 # NB: We need to be careful what we import form mlflow here. Scoring server is used from within
 # model's conda environment. The version of mlflow doing the serving (outside) and the version of
 # mlflow in the model's conda environment (inside) can differ. We should therefore keep mlflow
@@ -364,6 +366,7 @@ def get_cmd(
     model_uri: str, port: int = None, host: int = None, timeout: int = None, nworkers: int = None
 ) -> Tuple[str, Dict[str, str]]:
     local_uri = path_to_local_file_uri(model_uri)
+    timeout = timeout or MLFLOW_SCORING_SERVER_REQUEST_TIMEOUT.get()
     # NB: Absolute windows paths do not work with mlflow apis, use file uri to ensure
     # platform compatibility.
     if os.name != "nt":

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -46,7 +46,6 @@ except ImportError:
     from mlflow.pyfunc import load_pyfunc as load_model
 from mlflow.protos.databricks_pb2 import BAD_REQUEST
 from mlflow.server.handlers import catch_mlflow_exception
-from mlflow.environment_variables import MLFLOW_SCORING_SERVER_REQUEST_TIMEOUT
 from io import StringIO
 
 _SERVER_MODEL_PATH = "__pyfunc_model_path__"
@@ -365,7 +364,6 @@ def get_cmd(
     model_uri: str, port: int = None, host: int = None, timeout: int = None, nworkers: int = None
 ) -> Tuple[str, Dict[str, str]]:
     local_uri = path_to_local_file_uri(model_uri)
-    timeout = timeout or MLFLOW_SCORING_SERVER_REQUEST_TIMEOUT.get()
     # NB: Absolute windows paths do not work with mlflow apis, use file uri to ensure
     # platform compatibility.
     if os.name != "nt":

--- a/mlflow/rfunc/backend.py
+++ b/mlflow/rfunc/backend.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import re
 import subprocess
@@ -5,6 +6,8 @@ import subprocess
 from mlflow.models import FlavorBackend
 from mlflow.utils.string_utils import quote
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
+
+_logger = logging.getLogger(__name__)
 
 
 class RFuncBackend(FlavorBackend):
@@ -64,7 +67,7 @@ class RFuncBackend(FlavorBackend):
             raise Exception("The MLServer inference server is not yet supported in the R backend.")
 
         if timeout:
-            raise Exception("Timeout is not yet supported in the R backend.")
+            _logger.warning("Timeout is not yet supported in the R backend.")
 
         if not synchronous:
             raise Exception("RBackend does not support call with synchronous=False")

--- a/mlflow/utils/cli_args.py
+++ b/mlflow/utils/cli_args.py
@@ -156,7 +156,11 @@ PORT = click.option(
 )
 
 TIMEOUT = click.option(
-    "--timeout", "-t", help="Timeout in seconds to serve a request (default: 60)."
+    "--timeout",
+    "-t",
+    envvar="MLFLOW_SCORING_SERVER_REQUEST_TIMEOUT",
+    default=60,
+    help="Timeout in seconds to serve a request (default: 60).",
 )
 
 # We use None to disambiguate manually selecting "4"

--- a/tests/pyfunc/test_mlserver.py
+++ b/tests/pyfunc/test_mlserver.py
@@ -40,16 +40,3 @@ def test_get_cmd(params: dict, expected: dict):
         **expected,
         **os.environ.copy(),
     }
-
-
-@pytest.mark.parametrize(
-    ("params", "expected"),
-    [
-        ({"port": 5000, "timeout": 70}, "Timeout is not yet supported in MLServer."),
-    ],
-)
-def test_raise_error_mlserver_timeout(params: dict, expected: str):
-    model_uri = "/foo/bar"
-
-    with pytest.raises(Exception, match=expected):
-        get_cmd(model_uri=model_uri, **params)


### PR DESCRIPTION
Signed-off-by: alonisser <alonisser@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#6970 

## What changes are proposed in this pull request?

Add environment variable under mlflow.environment_variables and reference it in the scoring server

## How is this patch tested?

Not sure on how to test this, I've looked at the current tests and I didn't see a relevant example. 
<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.
Allow user to configure via environment variable in the deployed mlflow model the scoring server timeout

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [X] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
