### PR TITLE
Added data profile tab comparing worst examples vs train dataset

### DIFF
--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -535,9 +535,9 @@ class TrainStep(BaseStep):
                     ["Train", train_df.reset_index(drop=True)],
                 ]
             )
-            card.add_tab("Data Profile (Worst vs Train)", "{{ WORST_EXAMPLES_COMP }}").add_pandas_profile(
-                "WORST_EXAMPLES_COMP", worst_prediction_profile
-            )
+            card.add_tab(
+                "Data Profile (Worst vs Train)", "{{ WORST_EXAMPLES_COMP }}"
+            ).add_pandas_profile("WORST_EXAMPLES_COMP", worst_prediction_profile)
 
         # Tab 7: Leaderboard
         if leaderboard_df is not None:

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -294,6 +294,7 @@ class TrainStep(BaseStep):
             run_id=run.info.run_id,
             model_uri=model_info.model_uri,
             worst_examples_df=worst_examples_df,
+            train_df=raw_train_df,
             output_directory=output_directory,
             leaderboard_df=leaderboard_df,
             tuning_df=tuning_df,
@@ -434,6 +435,7 @@ class TrainStep(BaseStep):
         run_id,
         model_uri,
         worst_examples_df,
+        train_df,
         output_directory,
         leaderboard_df=None,
         tuning_df=None,
@@ -525,7 +527,19 @@ class TrainStep(BaseStep):
             )
         )
 
-        # Tab 6: Leaderboard
+        # Tab 6: Worst predictions profile vs train profile.
+        if not self.skip_data_profiling:
+            worst_prediction_profile = get_pandas_data_profiles(
+                [
+                    ["Worst Predictions", worst_examples_df.reset_index(drop=True)],
+                    ["Train", train_df.reset_index(drop=True)],
+                ]
+            )
+            card.add_tab("Data Profile (Worst vs Train)", "{{ WORST_EXAMPLES_COMP }}").add_pandas_profile(
+                "WORST_EXAMPLES_COMP", worst_prediction_profile
+            )
+
+        # Tab 7: Leaderboard
         if leaderboard_df is not None:
             (
                 card.add_tab("Leaderboard", "{{ LEADERBOARD_TABLE }}").add_html(
@@ -533,7 +547,7 @@ class TrainStep(BaseStep):
                 )
             )
 
-        # Tab 7: Best Parameters
+        # Tab 8: Best Parameters
         if self.step_config["tuning_enabled"]:
             best_parameters_card_tab = card.add_tab(
                 "Best Parameters",
@@ -548,7 +562,7 @@ class TrainStep(BaseStep):
                     f"<pre>{best_hardcoded_parameters}</pre><br><br>",
                 )
 
-        # Tab 8: HP trials
+        # Tab 9: HP trials
         if tuning_df is not None:
             tuning_trials_card_tab = card.add_tab(
                 "Tuning Trials",
@@ -572,7 +586,7 @@ class TrainStep(BaseStep):
                 ),
             )
 
-        # Tab 9: Run summary.
+        # Tab 10: Run summary.
         run_card_tab = card.add_tab(
             "Run Summary",
             "{{ RUN_ID }} " + "{{ MODEL_URI }}" + "{{ EXE_DURATION }}" + "{{ LAST_UPDATE_TIME }}",


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Added data profile tab comparing worst examples vs train dataset in MLflow Pipelines train step card.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Manually tested. See attached screenshot.
<img width="1424" alt="Screen Shot 2022-10-06 at 4 31 20 PM" src="https://user-images.githubusercontent.com/78067366/194437035-c6cf608e-8dde-4738-8a7a-b78473cefb2a.png">


<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Added data profile tab comparing worst examples vs train dataset in the MLflow Pipelines train step card.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
