### PR TITLE
Speedup split step

### DIFF
--- a/mlflow/pipelines/steps/split.py
+++ b/mlflow/pipelines/steps/split.py
@@ -76,7 +76,7 @@ def _create_hash_buckets(input_df):
     pandarallel_start_time = time.time()
     pandarallel.initialize(progress_bar=False)
     hash_start_time = time.time()
-    hash_buckets = _hash_pandas_dataframe(input_df).parallel_apply(
+    hash_buckets = _hash_pandas_dataframe(input_df).parallel_map(
         lambda x: (x % _SPLIT_HASH_BUCKET_NUM) / _SPLIT_HASH_BUCKET_NUM
     )
     end_time = time.time()

--- a/mlflow/pipelines/steps/split.py
+++ b/mlflow/pipelines/steps/split.py
@@ -76,17 +76,21 @@ def _create_hash_buckets(input_df):
     pandarallel_start_time = time.time()
     pandarallel.initialize(progress_bar=False)
     hash_start_time = time.time()
-    hash_buckets = _hash_pandas_dataframe(input_df).parallel_map(
+    hashed_df = _hash_pandas_dataframe(input_df)
+    map_start_time = time.time()
+    hash_buckets = hashed_df.parallel_map(
         lambda x: (x % _SPLIT_HASH_BUCKET_NUM) / _SPLIT_HASH_BUCKET_NUM
     )
     end_time = time.time()
     execution_duration = end_time - hash_start_time
-    pandarallel_overhead = hash_start_time - pandarallel_start_time
     _logger.info(
         f"Creating hash buckets on input dataset containing {len(input_df)} "
         f"rows consumes {execution_duration} seconds."
     )
-    _logger.info(f"Pandarallel overhead: {pandarallel_overhead} second(s).")
+    _logger.info(f"Pandarallel overhead: {hash_start_time - pandarallel_start_time} second(s).")
+    _logger.info(f"_hash_pandas_dataframe time: {map_start_time - hash_start_time} second(s).")
+    _logger.info(f"parallel_map time: {end_time - map_start_time} second(s).")
+
     return hash_buckets
 
 

--- a/mlflow/pipelines/steps/split.py
+++ b/mlflow/pipelines/steps/split.py
@@ -76,7 +76,7 @@ def _create_hash_buckets(input_df):
         lambda x: (x % _SPLIT_HASH_BUCKET_NUM) / _SPLIT_HASH_BUCKET_NUM
     )
     execution_duration = time.time() - start_time
-    _logger.debug(
+    _logger.info(
         f"Creating hash buckets on input dataset containing {len(input_df)} "
         f"rows consumes {execution_duration} seconds."
     )

--- a/mlflow/pipelines/steps/split.py
+++ b/mlflow/pipelines/steps/split.py
@@ -74,22 +74,15 @@ def _create_hash_buckets(input_df):
     # Create hash bucket used for splitting dataset
     # Note: use `hash_pandas_object` instead of python builtin hash because it is stable
     # across different process runs / different python versions
-
-    pandarallel_start_time = time.time()
-    hash_start_time = time.time()
-    hashed_df = _hash_pandas_dataframe(input_df)
-    map_start_time = time.time()
-    hash_buckets = hashed_df.map(lambda x: (x % _SPLIT_HASH_BUCKET_NUM) / _SPLIT_HASH_BUCKET_NUM)
-    end_time = time.time()
-    execution_duration = end_time - hash_start_time
-    _logger.info(
+    start_time = time.time()
+    hash_buckets = _hash_pandas_dataframe(input_df).map(
+        lambda x: (x % _SPLIT_HASH_BUCKET_NUM) / _SPLIT_HASH_BUCKET_NUM
+    )
+    execution_duration = time.time() - start_time
+    _logger.debug(
         f"Creating hash buckets on input dataset containing {len(input_df)} "
         f"rows consumes {execution_duration} seconds."
     )
-    _logger.info(f"Pandarallel overhead: {hash_start_time - pandarallel_start_time} second(s).")
-    _logger.info(f"_hash_pandas_dataframe time: {map_start_time - hash_start_time} second(s).")
-    _logger.info(f"map time: {end_time - map_start_time} second(s).")
-
     return hash_buckets
 
 

--- a/mlflow/pipelines/steps/split.py
+++ b/mlflow/pipelines/steps/split.py
@@ -61,13 +61,34 @@ def _get_split_df(input_df, hash_buckets, split_ratios):
     return train_df, validation_df, test_df
 
 
+def _parallelize(data, func, num_of_processes=8):
+    import numpy as np
+    import pandas as pd
+    from multiprocessing import Pool
+
+    data_split = np.array_split(data, num_of_processes)
+    pool = Pool(num_of_processes)
+    data = pd.concat(pool.map(func, data_split))
+    pool.close()
+    pool.join()
+    return data
+
+
+def _run_on_subset(func, data_subset):
+    return data_subset.applymap(func)
+
+
+def _parallelize_on_rows(data, func, num_of_processes=8):
+    from functools import partial
+
+    return _parallelize(data, partial(_run_on_subset, func), num_of_processes)
+
+
 def _hash_pandas_dataframe(input_df):
     from pandas.util import hash_pandas_object
-    from pandarallel import pandarallel
 
-    pandarallel.initialize(progress_bar=False)
-
-    return hash_pandas_object(input_df.parallel_applymap(_make_elem_hashable))
+    hashed_input_df = _parallelize_on_rows(input_df, _make_elem_hashable)
+    return hash_pandas_object(hashed_input_df)
 
 
 def _create_hash_buckets(input_df):

--- a/tests/pipelines/test_split_step.py
+++ b/tests/pipelines/test_split_step.py
@@ -91,10 +91,7 @@ def test_hash_pandas_dataframe_deterministic():
         }
     )
     result = _hash_pandas_dataframe(pdf)
-    assert result.tolist() == [
-        2331111997514652279,
-        12302536142759575339,
-    ]
+    assert result.tolist() == [17628718130518205164, 1442560710956928490]
 
 
 def test_get_split_df():

--- a/tests/pipelines/test_split_step.py
+++ b/tests/pipelines/test_split_step.py
@@ -91,7 +91,7 @@ def test_hash_pandas_dataframe_deterministic():
         }
     )
     result = _hash_pandas_dataframe(pdf)
-    assert result.tolist() == [17628718130518205164, 1442560710956928490]
+    assert result.tolist() == [2331111997514652279, 12302536142759575339]
 
 
 def test_get_split_df():


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Parallelize hashing in the split step. Implemented with native python multiprocessing and pool. This function is still deterministic (See: [Pool.map ordering](https://stackoverflow.com/questions/41273960/python-3-does-pool-keep-the-original-order-of-data-passed-to-map))

Profiling
* Baseline (no parallel): `93.78527522087097 second(s).`
* Parallel with 2 workers: `59.39586281776428 second(s).`
* Parallel with 4 workers `28.890960931777954 second(s).`
 

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
