### PR TITLE
Do not notify user in UI on failed artifact fetch

### DIFF
--- a/mlflow/server/js/src/common/utils/ArtifactUtils.js
+++ b/mlflow/server/js/src/common/utils/ArtifactUtils.js
@@ -37,7 +37,7 @@ export function getArtifactContent(artifactLocation, isBinary = false) {
         fileReader.readAsText(blob);
       }
     } catch (error) {
-      Utils.logErrorAndNotifyUser(error);
+      console.error(error);
       reject(error);
     }
   });

--- a/mlflow/server/js/src/common/utils/ArtifactUtils.js
+++ b/mlflow/server/js/src/common/utils/ArtifactUtils.js
@@ -1,6 +1,5 @@
 import { ErrorWrapper } from './ErrorWrapper';
 import { getDefaultHeaders, HTTPMethods } from './FetchUtils';
-import Utils from './Utils';
 
 /**
  * Fetches the specified artifact, returning a Promise that resolves with


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->
Signed-off-by: Kevin Greer kevinegreer@gmail.com

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
Resolve #6984 

## What changes are proposed in this pull request?

If the UI fails to load an artifact, do not notify the user but instead just display the error in the console.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

Run the MLflow UI (follow the steps in the [contributing guide](https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.md#javascript-and-ui)). I used a fresh sqlite DB and used the Python SDK to create a single run with no artifacts, and then a model and model version.

```py
import mlflow
from mlflow.tracking import MlflowClient

tracking_uri = '<your-tracking-uri>'

client = MlflowClient(tracking_uri)
mlflow.set_experiment(experiment_id='<your-experiment-id>')

with mlflow.start_run() as run:
    artifact_uri = run.info.artifact_uri
    run_id = run.info.run_id

model_name = '<your-model-name>'
client.create_registered_model(model_name)
client.create_model_version(model_name, artifact_uri, run_id)
```

Before this change there was an error displayed in the model version page.

https://user-images.githubusercontent.com/7669871/194678161-2042bd8f-6773-4b0f-bb5a-ffdc10666a79.mov

After the error is still visible in the browser console and the server console, but no error is displayed in the web page

https://user-images.githubusercontent.com/7669871/194678178-fb6817b4-8cce-4275-90e0-4102d377ab7a.mov




## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

The UI will no longer display an error in the model version page if the version does not have an MLmodel file at the top level of its artifact directory.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
