### PR TITLE
Use absolute path for default local file artifact path so it can be load from code in other directory than the current one

### DIFF
--- a/mlflow/store/tracking/__init__.py
+++ b/mlflow/store/tracking/__init__.py
@@ -5,11 +5,12 @@ artifacts like models, plots, images, etc.
 
 Several constants are used by multiple backend store implementations.
 """
+import os
 
 # Path to default location for backend when using local FileStore or ArtifactStore.
 # Also used as default location for artifacts, when not provided, in non local file based backends
 # (eg MySQL)
-DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH = "./mlruns"
+DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH = os.path.abspath("./mlruns")
 # Used for defining the artifacts uri (`--default-artifact-root`) for the tracking server when
 # configuring the server to use the option `--serve-artifacts` mode. This default can be
 # overridden by specifying an override to `--default-artifact-root` for the MLflow tracking server.

--- a/tests/tracking/_tracking_service/test_utils.py
+++ b/tests/tracking/_tracking_service/test_utils.py
@@ -145,7 +145,7 @@ def test_get_store_sqlalchemy_store(tmp_wkdir, db_type):
         store = _get_store()
         assert isinstance(store, SqlAlchemyStore)
         assert store.db_uri == uri
-        assert store.artifact_root_uri == "./mlruns"
+        assert store.artifact_root_uri == os.abs.path("./mlruns")
 
     mock_create_engine.assert_called_once_with(uri, pool_pre_ping=True)
 

--- a/tests/tracking/_tracking_service/test_utils.py
+++ b/tests/tracking/_tracking_service/test_utils.py
@@ -145,7 +145,7 @@ def test_get_store_sqlalchemy_store(tmp_wkdir, db_type):
         store = _get_store()
         assert isinstance(store, SqlAlchemyStore)
         assert store.db_uri == uri
-        assert store.artifact_root_uri == os.abs.path("./mlruns")
+        assert store.artifact_root_uri == os.path.abspath("./mlruns")
 
     mock_create_engine.assert_called_once_with(uri, pool_pre_ping=True)
 


### PR DESCRIPTION
Use absolute path for default local file artifact path so it can be load from code in other directory than the current one
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

Fix #2816

## What changes are proposed in this pull request?

Use absolute path for default local file artifact path so it can be load from code in other directory than the current one

## How is this patch tested?

- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
