### PR TITLE
Adding support for UC tables in ingest step

### DIFF
--- a/mlflow/pipelines/steps/ingest/datasets.py
+++ b/mlflow/pipelines/steps/ingest/datasets.py
@@ -583,7 +583,7 @@ class SparkSqlDataset(_SparkDatasetMixin, _Dataset):
     (e.g. `SELECT * FROM my_spark_table`).
     """
 
-    def __init__(self, sql: str, dataset_format: str):
+    def __init__(self, sql: str, location: str, dataset_format: str):
         """
         :param sql: The Spark SQL query string that defines the dataset
                     (e.g. 'SELECT * FROM my_spark_table').
@@ -591,17 +591,28 @@ class SparkSqlDataset(_SparkDatasetMixin, _Dataset):
         """
         super().__init__(dataset_format=dataset_format)
         self.sql = sql
+        self.location = location
 
     def resolve_to_parquet(self, dst_path: str):
+        if self.location is None and self.sql is None:
+            raise MlflowException(
+                "Either location or sql configuration key must be specified for "
+                "dataset with format spark_sql"
+            ) from None
         spark_session = self._get_or_create_spark_session()
-        spark_df = spark_session.sql(self.sql)
+        spark_df = None
+        if self.location is not None:
+            spark_df = spark_session.table(self.location)
+        if self.sql is not None:
+            spark_df = spark_session.sql(self.sql)
         pandas_df = spark_df.toPandas()
         write_pandas_df_as_parquet(df=pandas_df, data_parquet_path=dst_path)
 
     @classmethod
     def _from_config(cls, dataset_config: Dict[str, Any], pipeline_root: str) -> _DatasetType:
         return cls(
-            sql=cls._get_required_config(dataset_config=dataset_config, key="sql"),
+            sql=dataset_config.get("sql"),
+            location=dataset_config.get("location"),
             dataset_format=cls._get_required_config(dataset_config=dataset_config, key="format"),
         )
 

--- a/mlflow/pipelines/steps/ingest/datasets.py
+++ b/mlflow/pipelines/steps/ingest/datasets.py
@@ -587,6 +587,8 @@ class SparkSqlDataset(_SparkDatasetMixin, _Dataset):
         """
         :param sql: The Spark SQL query string that defines the dataset
                     (e.g. 'SELECT * FROM my_spark_table').
+        :param location: The location of the dataset
+                    (e.g. 'catalog.schema.table', 'schema.table', 'table').
         :param dataset_format: The format of the dataset (e.g. 'csv', 'parquet', ...).
         """
         super().__init__(dataset_format=dataset_format)
@@ -601,10 +603,10 @@ class SparkSqlDataset(_SparkDatasetMixin, _Dataset):
             ) from None
         spark_session = self._get_or_create_spark_session()
         spark_df = None
-        if self.location is not None:
-            spark_df = spark_session.table(self.location)
         if self.sql is not None:
             spark_df = spark_session.sql(self.sql)
+        elif self.location is not None:
+            spark_df = spark_session.table(self.location)
         pandas_df = spark_df.toPandas()
         write_pandas_df_as_parquet(df=pandas_df, data_parquet_path=dst_path)
 

--- a/tests/pipelines/test_ingest_step.py
+++ b/tests/pipelines/test_ingest_step.py
@@ -336,6 +336,28 @@ def test_ingests_spark_sql_successfully(spark_df, tmp_path):
     pd.testing.assert_frame_equal(reloaded_df, spark_to_pandas_df)
 
 
+@pytest.mark.usefixtures("enter_test_pipeline_directory")
+def test_ingests_spark_sql_location_successfully(spark_df, tmp_path):
+    spark_df.write.mode("overwrite").saveAsTable("test_table")
+
+    IngestStep.from_pipeline_config(
+        pipeline_config={"data": {"format": "spark_sql", "location": "test_table"}},
+        pipeline_root=os.getcwd(),
+    ).run(output_directory=tmp_path)
+
+    # Spark DataFrames are not ingested with a consistent row order, as doing so would incur a
+    # substantial performance cost. Accordingly, we sort the ingested DataFrame and the original
+    # DataFrame on the `id` column and reset the DataFrame index to achieve a consistent ordering
+    # before testing their equivalence
+    reloaded_df = (
+        pd.read_parquet(str(tmp_path / "dataset.parquet"))
+        .sort_values(by="id")
+        .reset_index(drop=True)
+    )
+    spark_to_pandas_df = spark_df.toPandas().sort_values(by="id").reset_index(drop=True)
+    pd.testing.assert_frame_equal(reloaded_df, spark_to_pandas_df)
+
+
 @pytest.mark.parametrize("use_relative_path", [False, True])
 @pytest.mark.usefixtures("enter_test_pipeline_directory")
 def test_ingests_delta_successfully(use_relative_path, spark_df, tmp_path):
@@ -597,13 +619,19 @@ def test_ingest_throws_when_required_dataset_config_keys_are_missing():
         pipeline_config={
             "data": {
                 "format": "spark_sql",
-                # Missing sql
+                # Missing sql and location
             }
         },
         pipeline_root=os.getcwd(),
     )
-    with pytest.raises(MlflowException, match="The `sql` configuration key must be specified"):
-        ingest_step._validate_and_apply_step_config()
+
+    ingest_step._validate_and_apply_step_config()
+    with pytest.raises(
+        MlflowException,
+        match="Either location or sql configuration key must be specified for "
+        "dataset with format spark_sql",
+    ):
+        ingest_step._run("output-directory")
 
     ingest_step = IngestStep.from_pipeline_config(
         pipeline_config={


### PR DESCRIPTION
## What changes are proposed in this pull request?
Adding support for UC tables in ingest step

## How is this patch tested?
- [x] notebook

![image](https://user-images.githubusercontent.com/5621432/194965218-1f94b3f6-d003-400a-8767-68b52f0eaa71.png)

![image](https://user-images.githubusercontent.com/5621432/194965273-d1afd2de-acec-4f45-bf0c-e8f91a17fb0b.png)

![image](https://user-images.githubusercontent.com/5621432/194965318-7e22ee1c-2988-4722-8a41-ba7d4e96d076.png)


## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Adding support to ingest data using spark table

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
