### PR TITLE
write params yaml even if no tuning

### DIFF
--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -277,6 +277,9 @@ class TrainStep(BaseStep):
                 )
                 estimator = estimator_fn(best_estimator_params)
             elif len(estimator_hardcoded_params) > 0:
+                self._write_best_parameters_outputs(
+                    None, estimator_hardcoded_params, output_directory
+                )
                 estimator = estimator_fn(estimator_hardcoded_params)
             else:
                 estimator = estimator_fn()
@@ -627,19 +630,17 @@ class TrainStep(BaseStep):
             )
 
         # Tab 8: Best Parameters
-        if self.step_config["tuning_enabled"]:
+        best_parameters_yaml = os.path.join(output_directory, "best_parameters.yaml")
+        if os.path.exists(best_parameters_yaml):
             best_parameters_card_tab = card.add_tab(
                 "Best Parameters",
                 "{{ BEST_PARAMETERS }} ",
             )
-            best_parameters_yaml = os.path.join(output_directory, "best_parameters.yaml")
-            if os.path.exists(best_parameters_yaml):
-                best_hardcoded_parameters = open(best_parameters_yaml).read()
-                best_parameters_card_tab.add_html(
-                    "BEST_PARAMETERS",
-                    f"<b>Best parameters:</b><br>"
-                    f"<pre>{best_hardcoded_parameters}</pre><br><br>",
-                )
+            best_parameters = open(best_parameters_yaml).read()
+            best_parameters_card_tab.add_html(
+                "BEST_PARAMETERS",
+                f"<b>Best parameters:</b><br>" f"<pre>{best_parameters}</pre><br><br>",
+            )
 
         # Tab 9: HP trials
         if tuning_df is not None:
@@ -880,7 +881,7 @@ class TrainStep(BaseStep):
         else:
             best_hardcoded_params = {}
         best_combined_params = dict(estimator_hardcoded_params, **best_hp_params)
-        self._write_tuning_yaml_outputs(best_hp_params, best_hardcoded_params, output_directory)
+        self._write_best_parameters_outputs(best_hp_params, best_hardcoded_params, output_directory)
         return best_combined_params
 
     def _log_estimator_to_mlflow(self, estimator, X_train_sampled, on_worker=False):
@@ -911,7 +912,9 @@ class TrainStep(BaseStep):
         )
         return logged_estimator
 
-    def _write_tuning_yaml_outputs(self, best_hp_params, best_hardcoded_params, output_directory):
+    def _write_best_parameters_outputs(
+        self, best_hp_params, best_hardcoded_params, output_directory
+    ):
         best_parameters_path = os.path.join(output_directory, "best_parameters.yaml")
         if os.path.exists(best_parameters_path):
             os.remove(best_parameters_path)

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -278,7 +278,7 @@ class TrainStep(BaseStep):
                 estimator = estimator_fn(best_estimator_params)
             elif len(estimator_hardcoded_params) > 0:
                 self._write_best_parameters_outputs(
-                    None, estimator_hardcoded_params, output_directory
+                    {}, estimator_hardcoded_params, output_directory
                 )
                 estimator = estimator_fn(estimator_hardcoded_params)
             else:


### PR DESCRIPTION
Signed-off-by: Prithvi Kannan <prithvi.kannan@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Enable users who do "vanilla training" to move to HP tuning more easily by creating `best_parameter.yaml` and show a "Best Parameters" step card during training even if HP tuning is not used.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

Manual e2e test in notebook

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
