### PR TITLE
Fix `SqlAlchemyStore` updating incorrect tag

### DIFF
--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -648,13 +648,13 @@ class SqlAlchemyStore(AbstractStore):
 
     def _try_get_run_tag(self, session, run_id, tagKey, eager=False):
         query_options = self._get_eager_run_query_options() if eager else []
-        tags = (
+        tag = (
             session.query(SqlTag)
             .options(*query_options)
-            .filter(SqlTag.run_uuid == run_id and SqlTag.key == tagKey)
-            .all()
+            .filter(SqlTag.run_uuid == run_id, SqlTag.key == tagKey)
+            .one_or_none()
         )
-        return None if not tags else tags[0]
+        return tag
 
     def get_run(self, run_id):
         with self.ManagedSessionMaker() as session:

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -648,13 +648,12 @@ class SqlAlchemyStore(AbstractStore):
 
     def _try_get_run_tag(self, session, run_id, tagKey, eager=False):
         query_options = self._get_eager_run_query_options() if eager else []
-        tag = (
+        return (
             session.query(SqlTag)
             .options(*query_options)
             .filter(SqlTag.run_uuid == run_id, SqlTag.key == tagKey)
             .one_or_none()
         )
-        return tag
 
     def get_run(self, run_id):
         with self.ManagedSessionMaker() as session:

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -2603,24 +2603,20 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
 
     def test_try_get_run_tag(self):
         run = self._run_factory()
-        self.store.set_tag(run.info.run_id, entities.RunTag("new tag key 1", "new tag value 1"))
-        self.store.set_tag(run.info.run_id, entities.RunTag("new tag key 2", "new tag value 2"))
-        self.store.set_tag(run.info.run_id, entities.RunTag("new tag key 3", "new tag value 3"))
+        self.store.set_tag(run.info.run_id, entities.RunTag("k1", "v1"))
+        self.store.set_tag(run.info.run_id, entities.RunTag("k2", "v2"))
+
         with self.store.ManagedSessionMaker() as session:
-            tag = self.store._try_get_run_tag(session, run.info.run_id, "new tag key 0")
+            tag = self.store._try_get_run_tag(session, run.info.run_id, "k0")
             self.assertIsNone(tag)
 
-            tag = self.store._try_get_run_tag(session, run.info.run_id, "new tag key 1")
-            self.assertEqual(tag.key, "new tag key 1")
-            self.assertEqual(tag.value, "new tag value 1")
+            tag = self.store._try_get_run_tag(session, run.info.run_id, "k1")
+            self.assertEqual(tag.key, "k1")
+            self.assertEqual(tag.value, "v1")
 
-            tag = self.store._try_get_run_tag(session, run.info.run_id, "new tag key 2")
-            self.assertEqual(tag.key, "new tag key 2")
-            self.assertEqual(tag.value, "new tag value 2")
-
-            tag = self.store._try_get_run_tag(session, run.info.run_id, "new tag key 3")
-            self.assertEqual(tag.key, "new tag key 3")
-            self.assertEqual(tag.value, "new tag value 3")
+            tag = self.store._try_get_run_tag(session, run.info.run_id, "k2")
+            self.assertEqual(tag.key, "k2")
+            self.assertEqual(tag.value, "v2")
 
 
 def test_sqlalchemy_store_behaves_as_expected_with_inmemory_sqlite_db():

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -2601,6 +2601,27 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         )
         assert len(run_results) == 2
 
+    def test_try_get_run_tag(self):
+        run = self._run_factory()
+        self.store.set_tag(run.info.run_id, entities.RunTag("new tag key 1", "new tag value 1"))
+        self.store.set_tag(run.info.run_id, entities.RunTag("new tag key 2", "new tag value 2"))
+        self.store.set_tag(run.info.run_id, entities.RunTag("new tag key 3", "new tag value 3"))
+        with self.store.ManagedSessionMaker() as session:
+            tag = self.store._try_get_run_tag(session, run.info.run_id, "new tag key 0")
+            self.assertIsNone(tag)
+
+            tag = self.store._try_get_run_tag(session, run.info.run_id, "new tag key 1")
+            self.assertEqual(tag.key, "new tag key 1")
+            self.assertEqual(tag.value, "new tag value 1")
+
+            tag = self.store._try_get_run_tag(session, run.info.run_id, "new tag key 2")
+            self.assertEqual(tag.key, "new tag key 2")
+            self.assertEqual(tag.value, "new tag value 2")
+
+            tag = self.store._try_get_run_tag(session, run.info.run_id, "new tag key 3")
+            self.assertEqual(tag.key, "new tag key 3")
+            self.assertEqual(tag.value, "new tag value 3")
+
 
 def test_sqlalchemy_store_behaves_as_expected_with_inmemory_sqlite_db():
     store = SqlAlchemyStore("sqlite:///:memory:", ARTIFACT_URI)


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
resolves #7014 

## What changes are proposed in this pull request?

Fix a bug where `SqlAlchemyStore` updates the wrong tag in `update_run_info()`

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [X] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

```shell
pytest tests/store/tracking/test_sqlalchemy_store.py::TestSqlAlchemyStore::test_try_get_run_tag
```

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [X] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
