### PR TITLE
Move subgraph logic into base pipeline

### DIFF
--- a/mlflow/pipelines/pipeline.py
+++ b/mlflow/pipelines/pipeline.py
@@ -3,7 +3,7 @@ import logging
 
 from mlflow.exceptions import MlflowException
 from mlflow.pipelines.artifacts import Artifact
-from mlflow.pipelines.step import BaseStep, StepStatus
+from mlflow.pipelines.step import BaseStep, StepStatus, StepClass
 from mlflow.pipelines.utils import (
     get_pipeline_config,
     get_pipeline_name,
@@ -153,15 +153,18 @@ class _BasePipeline:
         return self._steps[step_names.index(step_name)]
 
     @experimental
-    @abc.abstractmethod
     def _get_subgraph_for_target_step(self, target_step: BaseStep) -> List[BaseStep]:
         """
         Return a list of step objects representing a connected DAG containing the target_step.
         The returned list should be a sublist of self._steps.
-
-        Concrete pipeline class should implement this method.
         """
-        pass
+        subgraph = []
+        if target_step.step_class == StepClass.UNKNOWN:
+            return subgraph
+        for step in self._steps:
+            if target_step.step_class() == step.step_class():
+                subgraph.append(step)
+        return subgraph
 
     @experimental
     @abc.abstractmethod

--- a/mlflow/pipelines/regression/v1/pipeline.py
+++ b/mlflow/pipelines/regression/v1/pipeline.py
@@ -142,7 +142,7 @@ from mlflow.pipelines.steps.evaluate import EvaluateStep
 from mlflow.pipelines.steps.predict import PredictStep
 from mlflow.pipelines.steps.register import RegisterStep
 from mlflow.pipelines.step import BaseStep
-from typing import List, Any, Optional
+from typing import Any, Optional
 from mlflow.pipelines.utils.execution import get_or_create_base_execution_directory
 from mlflow.utils.annotations import experimental
 
@@ -184,8 +184,7 @@ class RegressionPipeline(_BasePipeline):
         regression_pipeline.inspect(step="evaluate")
     """
 
-    _TRAIN_DAG_NAME = "train_dag"
-    _TRAIN_DAG_STEPS = (
+    _PIPELINE_STEPS = (
         # Training data ingestion DAG
         IngestStep,
         # Model training DAG
@@ -194,45 +193,15 @@ class RegressionPipeline(_BasePipeline):
         TrainStep,
         EvaluateStep,
         RegisterStep,
-    )
-
-    _SCORING_DAG_NAME = "scoring_dag"
-    _SCORING_DAG_STEPS = (
         # Batch scoring DAG
         IngestScoringStep,
         PredictStep,
     )
 
-    _PIPELINE_STEPS = _TRAIN_DAG_STEPS + _SCORING_DAG_STEPS
-
-    _STEPS_SUBGRAPH_MAP = dict()
-    for _step_class in _TRAIN_DAG_STEPS:
-        _STEPS_SUBGRAPH_MAP[_step_class] = _TRAIN_DAG_NAME
-    for _step_class in _SCORING_DAG_STEPS:
-        _STEPS_SUBGRAPH_MAP[_step_class] = _SCORING_DAG_NAME
-
-    _SUBGRAPH_INDICES_MAP = {
-        _TRAIN_DAG_NAME: (
-            _PIPELINE_STEPS.index(_TRAIN_DAG_STEPS[0]),
-            _PIPELINE_STEPS.index(_TRAIN_DAG_STEPS[-1]),
-        ),
-        _SCORING_DAG_NAME: (
-            _PIPELINE_STEPS.index(_SCORING_DAG_STEPS[0]),
-            _PIPELINE_STEPS.index(_SCORING_DAG_STEPS[-1]),
-        ),
-    }
-
     _DEFAULT_STEP_INDEX = _PIPELINE_STEPS.index(RegisterStep)
 
     def _get_step_classes(self):
         return self._PIPELINE_STEPS
-
-    def _get_subgraph_for_target_step(self, target_step: BaseStep) -> List[BaseStep]:
-        target_step_class = type(target_step)
-
-        subgraph_name = self._STEPS_SUBGRAPH_MAP[target_step_class]
-        s, e = self._SUBGRAPH_INDICES_MAP[subgraph_name]
-        return self._steps[s : e + 1]
 
     def _get_default_step(self) -> BaseStep:
         return self._steps[self._DEFAULT_STEP_INDEX]

--- a/mlflow/pipelines/step.py
+++ b/mlflow/pipelines/step.py
@@ -35,6 +35,19 @@ class StepStatus(Enum):
     FAILED = "FAILED"
 
 
+class StepClass(Enum):
+    """
+    Represents the class of a step.
+    """
+
+    # Indicates that the step class is unknown.
+    UNKNOWN = "UNKNOWN"
+    # Indicates that the step runs at training time.
+    TRAINING = "TRAINING"
+    # Indicates that the step runs at inference time.
+    PREDICTION = "PREDICTION"
+
+
 StepExecutionStateType = TypeVar("StepExecutionStateType", bound="StepExecutionState")
 
 
@@ -232,6 +245,14 @@ class BaseStep(metaclass=abc.ABCMeta):
         Returns the named artifacts produced by the step for the current class instance.
         """
         return {}
+
+    @experimental
+    @abc.abstractmethod
+    def step_class(self) -> StepClass:
+        """
+        Returns the step class.
+        """
+        pass
 
     @experimental
     def get_execution_state(self, output_directory: str) -> StepExecutionState:

--- a/mlflow/pipelines/steps/evaluate.py
+++ b/mlflow/pipelines/steps/evaluate.py
@@ -9,6 +9,7 @@ import mlflow
 from mlflow.exceptions import MlflowException
 from mlflow.pipelines.cards import BaseCard
 from mlflow.pipelines.step import BaseStep
+from mlflow.pipelines.step import StepClass
 from mlflow.pipelines.steps.train import TrainStep
 from mlflow.pipelines.utils.execution import get_step_output_path
 from mlflow.pipelines.utils.metrics import (
@@ -367,3 +368,6 @@ class EvaluateStep(BaseStep):
         environ = get_databricks_env_vars(tracking_uri=self.tracking_config.tracking_uri)
         environ.update(get_run_tags_env_vars(pipeline_root_path=self.pipeline_root))
         return environ
+
+    def step_class(self):
+        return StepClass.TRAINING

--- a/mlflow/pipelines/steps/ingest/__init__.py
+++ b/mlflow/pipelines/steps/ingest/__init__.py
@@ -7,6 +7,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.pipelines.artifacts import DataframeArtifact
 from mlflow.pipelines.cards import BaseCard
 from mlflow.pipelines.step import BaseStep
+from mlflow.pipelines.step import StepClass
 from mlflow.pipelines.utils.step import get_pandas_data_profiles
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.utils.file_utils import read_parquet_as_pandas_df
@@ -201,6 +202,9 @@ class IngestStep(BaseIngestStep):
             )
         ]
 
+    def step_class(self):
+        return StepClass.TRAINING
+
 
 class IngestScoringStep(BaseIngestStep):
     _DATASET_OUTPUT_NAME = "scoring-dataset.parquet"
@@ -231,3 +235,6 @@ class IngestScoringStep(BaseIngestStep):
                 IngestScoringStep._DATASET_OUTPUT_NAME,
             )
         ]
+
+    def step_class(self):
+        return StepClass.PREDICTION

--- a/mlflow/pipelines/steps/predict.py
+++ b/mlflow/pipelines/steps/predict.py
@@ -8,6 +8,7 @@ from mlflow.exceptions import MlflowException, BAD_REQUEST, INVALID_PARAMETER_VA
 from mlflow.pipelines.artifacts import DataframeArtifact
 from mlflow.pipelines.cards import BaseCard
 from mlflow.pipelines.step import BaseStep
+from mlflow.pipelines.step import StepClass
 from mlflow.pipelines.utils.execution import get_step_output_path
 from mlflow.pipelines.utils.step import get_pandas_data_profiles
 from mlflow.pipelines.utils.tracking import (
@@ -233,3 +234,6 @@ class PredictStep(BaseStep):
                 "scored_data", self.pipeline_root, self.name, _SCORED_OUTPUT_FILE_NAME
             )
         ]
+
+    def step_class(self):
+        return StepClass.PREDICTION

--- a/mlflow/pipelines/steps/register.py
+++ b/mlflow/pipelines/steps/register.py
@@ -8,6 +8,7 @@ from mlflow.exceptions import MlflowException, INVALID_PARAMETER_VALUE
 from mlflow.pipelines.artifacts import ModelVersionArtifact, RegisteredModelVersionInfo
 from mlflow.pipelines.cards import BaseCard
 from mlflow.pipelines.step import BaseStep
+from mlflow.pipelines.step import StepClass
 from mlflow.pipelines.steps.train import TrainStep
 from mlflow.pipelines.utils.execution import get_step_output_path
 from mlflow.pipelines.utils.tracking import (
@@ -192,3 +193,6 @@ class RegisterStep(BaseStep):
                 self.tracking_config.tracking_uri,
             )
         ]
+
+    def step_class(self):
+        return StepClass.TRAINING

--- a/mlflow/pipelines/steps/split.py
+++ b/mlflow/pipelines/steps/split.py
@@ -7,6 +7,7 @@ import sys
 from mlflow.pipelines.artifacts import DataframeArtifact
 from mlflow.pipelines.cards import BaseCard
 from mlflow.pipelines.step import BaseStep
+from mlflow.pipelines.step import StepClass
 from mlflow.pipelines.utils.execution import get_step_output_path
 from mlflow.pipelines.utils.step import get_pandas_data_profiles
 from mlflow.exceptions import MlflowException, INVALID_PARAMETER_VALUE
@@ -266,3 +267,6 @@ class SplitStep(BaseStep):
             ),
             DataframeArtifact("test_data", self.pipeline_root, self.name, _OUTPUT_TEST_FILE_NAME),
         ]
+
+    def step_class(self):
+        return StepClass.TRAINING

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -14,6 +14,7 @@ from mlflow.exceptions import MlflowException, INVALID_PARAMETER_VALUE, BAD_REQU
 from mlflow.pipelines.artifacts import ModelArtifact, RunArtifact, HyperParametersArtifact
 from mlflow.pipelines.cards import BaseCard
 from mlflow.pipelines.step import BaseStep
+from mlflow.pipelines.step import StepClass
 from mlflow.pipelines.utils.execution import (
     get_step_output_path,
     _MLFLOW_PIPELINES_EXECUTION_TARGET_STEP_NAME_ENV_VAR,
@@ -731,6 +732,9 @@ class TrainStep(BaseStep):
             RunArtifact("run", self.pipeline_root, self.name, self.tracking_config.tracking_uri),
             HyperParametersArtifact("best_parameters", self.pipeline_root, self.name),
         ]
+
+    def step_class(self):
+        return StepClass.TRAINING
 
     def _tune_and_get_best_estimator_params(
         self,

--- a/mlflow/pipelines/steps/transform.py
+++ b/mlflow/pipelines/steps/transform.py
@@ -10,6 +10,7 @@ from packaging.version import Version
 from mlflow.pipelines.artifacts import DataframeArtifact, TransformerArtifact
 from mlflow.pipelines.cards import BaseCard
 from mlflow.pipelines.step import BaseStep
+from mlflow.pipelines.step import StepClass
 from mlflow.pipelines.utils.execution import get_step_output_path
 from mlflow.pipelines.utils.step import get_pandas_data_profiles
 from mlflow.pipelines.utils.tracking import get_pipeline_tracking_config, TrackingConfig
@@ -223,3 +224,6 @@ class TransformStep(BaseStep):
                 "transformer", self.pipeline_root, self.name, self.tracking_config.tracking_uri
             ),
         ]
+
+    def step_class(self):
+        return StepClass.TRAINING

--- a/tests/pipelines/helper_functions.py
+++ b/tests/pipelines/helper_functions.py
@@ -166,7 +166,7 @@ class BaseStepImplemented(BaseStep):
     def _validate_and_apply_step_config(self):
         pass
 
-    def is_predict_step(self):
+    def step_class(self):
         pass
 
 


### PR DESCRIPTION
Signed-off-by: Brian Barnes <brian.barnes@databricks.com>

## What changes are proposed in this pull request?

This PR updates the `_get_subgraph_for_target` step implementation to decouple it from the regression pipeline and moves it into the base pipeline such that it is no longer abstract. This logic will be reused by the classification pipeline. To accomplish this change, each step is also updated to declare whether it runs at training time or inference time. 

## How is this patch tested?

Ran MLP regression template locally

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [X] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
