### PR TITLE
Add classification metrics

### DIFF
--- a/mlflow/pipelines/utils/metrics.py
+++ b/mlflow/pipelines/utils/metrics.py
@@ -37,11 +37,17 @@ class PipelineMetric:
 
 
 BUILTIN_CLASSIFICATION_PIPELINE_METRICS = [
-    PipelineMetric(name="mean_absolute_error", greater_is_better=False),
-    PipelineMetric(name="mean_squared_error", greater_is_better=False),
-    PipelineMetric(name="root_mean_squared_error", greater_is_better=False),
-    PipelineMetric(name="max_error", greater_is_better=False),
-    PipelineMetric(name="mean_absolute_percentage_error", greater_is_better=False),
+    PipelineMetric(name="true_negatives", greater_is_better=True),
+    PipelineMetric(name="false_positives", greater_is_better=False),
+    PipelineMetric(name="false_negatives", greater_is_better=False),
+    PipelineMetric(name="true_positives", greater_is_better=True),
+    PipelineMetric(name="recall", greater_is_better=True),
+    PipelineMetric(name="precision", greater_is_better=True),
+    PipelineMetric(name="f1_score", greater_is_better=True),
+    PipelineMetric(name="accuracy_score", greater_is_better=True),
+    PipelineMetric(name="log_loss", greater_is_better=False),
+    PipelineMetric(name="roc_auc", greater_is_better=True),
+    PipelineMetric(name="precision_recall_auc", greater_is_better=True),
 ]
 
 BUILTIN_REGRESSION_PIPELINE_METRICS = [
@@ -87,6 +93,8 @@ def _get_builtin_metrics(tmpl: str) -> str:
     """
     if tmpl == "regression/v1":
         return BUILTIN_REGRESSION_PIPELINE_METRICS
+    elif tmpl == "classification/v1":
+        return BUILTIN_CLASSIFICATION_PIPELINE_METRICS
     raise MlflowException(
         f"No builtin metrics for template kind {tmpl}",
         error_code=INVALID_PARAMETER_VALUE,

--- a/tests/pipelines/helper_functions.py
+++ b/tests/pipelines/helper_functions.py
@@ -166,6 +166,9 @@ class BaseStepImplemented(BaseStep):
     def _validate_and_apply_step_config(self):
         pass
 
+    def is_predict_step(self):
+        pass
+
 
 def list_all_artifacts(
     tracking_uri: str, run_id: str, path: str = None


### PR DESCRIPTION
Signed-off-by: Brian Barnes <brian.barnes@databricks.com>

## What changes are proposed in this pull request?

This PR adds metrics for evaluating classification models. The metric names must match the metrics supported my mlflow's evaluation service: https://www.mlflow.org/docs/latest/python_api/mlflow.html. As with the regression pipeline, the list of metrics supported in MLP is a subset of the metrics supported by mlflow - reviewer feedback is especially welcome regarding what metrics, if any, should be removed or added.

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [X] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
