### PR TITLE
Remove `set-output` and use `GITHUB_OUTPUT` when setting step outputs

### DIFF
--- a/.github/actions/cache-pip/action.yml
+++ b/.github/actions/cache-pip/action.yml
@@ -7,7 +7,7 @@ runs:
       id: get-cache-key-prefix
       shell: bash
       run: |
-        echo "::set-output name=prefix::$ImageOS-$ImageVersion"
+        echo "prefix=$ImageOS-$ImageVersion" >> $GITHUB_OUTPUT
     - uses: actions/cache@v2
       with:
         path: ~/.cache/pip

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -35,7 +35,7 @@ runs:
           echo "Invalid python version: '$python_version'. Must be one of ['3.7', '3.8']"
           exit 1
         fi
-        echo "::set-output name=version::$python_version"
+        echo "version=$python_version" >> $GITHUB_OUTPUT
     - uses: actions/setup-python@v3
       with:
         python-version: ${{ steps.get-python-version.outputs.version }}

--- a/.github/actions/update-requirements/action.yml
+++ b/.github/actions/update-requirements/action.yml
@@ -16,7 +16,7 @@ runs:
         python dev/update_requirements.py --requirements-yaml-location requirements/skinny-requirements.yaml
         python dev/update_requirements.py --requirements-yaml-location requirements/core-requirements.yaml
         if [ -z "$(git status --porcelain)" ]; then
-          echo "::set-output name=updated::false"
+          echo "updated=false" >> $GITHUB_OUTPUT
         else
           python dev/generate_requirements.py \
             --requirements-yaml-location requirements/skinny-requirements.yaml \
@@ -25,5 +25,5 @@ runs:
             --requirements-yaml-location requirements/core-requirements.yaml \
             --requirements-txt-output-location requirements/core-requirements.txt
           git diff --color=always
-          echo "::set-output name=updated::true"
+          echo "updated=true" >> $GITHUB_OUTPUT
         fi

--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -70,9 +70,9 @@ jobs:
           protos_changed=$([[ -z $(echo "$changed_files" | grep '^mlflow/protos') ]] && echo "false" || echo "true")
           py_changed=$([[ -z $(echo "$changed_files" | grep '\.py$') ]] && echo "false" || echo "true")
           ui_changed=$([[ -z $(echo "$changed_files" | grep '^mlflow/server/js') ]] && echo "false" || echo "true")
-          echo "::set-output name=protos_changed::$protos_changed"
-          echo "::set-output name=py_changed::$py_changed"
-          echo "::set-output name=ui_changed::$ui_changed"
+          echo "protos_changed=$protos_changed" >> $GITHUB_OUTPUT
+          echo "py_changed=$py_changed" >> $GITHUB_OUTPUT
+          echo "ui_changed=$ui_changed" >> $GITHUB_OUTPUT
 
   protos:
     # Generate a patch to update proto code.
@@ -97,7 +97,7 @@ jobs:
         run: |
           git diff --output=protos.diff
           has_diff=$([[ -z "$(cat protos.diff)" ]] && echo "false" || echo "true")
-          echo "::set-output name=has_diff::$has_diff"
+          echo "has_diff=$has_diff" >> $GITHUB_OUTPUT
       - uses: actions/upload-artifact@v3
         if: ${{ steps.check-diff.outputs.has_diff == 'true' }}
         with:
@@ -132,7 +132,7 @@ jobs:
         run: |
           git diff --output=python.diff
           has_diff=$([[ -z "$(cat python.diff)" ]] && echo "false" || echo "true")
-          echo "::set-output name=has_diff::$has_diff"
+          echo "has_diff=$has_diff" >> $GITHUB_OUTPUT
       - uses: actions/upload-artifact@v3
         if: ${{ steps.check-diff.outputs.has_diff == 'true' }}
         with:
@@ -171,7 +171,7 @@ jobs:
         run: |
           git diff --output=ui.diff
           has_diff=$([[ -z "$(cat ui.diff)" ]] && echo "false" || echo "true")
-          echo "::set-output name=has_diff::$has_diff"
+          echo "has_diff=$has_diff" >> $GITHUB_OUTPUT
       - uses: actions/upload-artifact@v3
         if: ${{ steps.check-diff.outputs.has_diff == 'true' }}
         with:

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -123,7 +123,7 @@ jobs:
           else
             java_version=11
           fi
-          echo "::set-output name=version::$java_version"
+          echo "version=$java_version" >> $GITHUB_OUTPUT
       - uses: ./.github/actions/setup-java
         with:
           java-version: ${{ steps.get-java-version.outputs.version }}
@@ -139,7 +139,7 @@ jobs:
           else
             python_version=$(python dev/get_minimum_required_python.py -p ${{ matrix.package }} -v ${{ matrix.version }} --python-versions "3.7,3.8")
           fi
-          echo "::set-output name=version::$python_version"
+          echo "version=$python_version" >> $GITHUB_OUTPUT
       - uses: ./.github/actions/setup-python
         with:
           python-version: ${{ steps.get-python-version.outputs.version }}
@@ -150,7 +150,7 @@ jobs:
         run: |
           date=$(date -u "+%Y%m%d")
           hash=$(echo -n "$INSTALL_COMMAND" | sha256sum)
-          echo "::set-output name=key::$ImageOS-$ImageVersion-wheels-$date-$hash"
+          echo "key=$ImageOS-$ImageVersion-wheels-$date-$hash" >> $GITHUB_OUTPUT
       - uses: actions/cache@v3
         # We only cache wheels that take long (> 10 min) to build
         if: ${{ contains('pyspark, catboost, scikit-learn', matrix.package) && matrix.version == 'dev' }}

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -61,7 +61,7 @@ jobs:
 
         echo -e "CHANGED_FILES:\nCHANGED_FILES"
         echo "EXAMPLES_CHANGED: $EXAMPLES_CHANGED"
-        echo "::set-output name=examples_changed::$EXAMPLES_CHANGED"
+        echo "examples_changed=$EXAMPLES_CHANGED" >> $GITHUB_OUTPUT
 
     - uses: ./.github/actions/setup-python
 
@@ -112,7 +112,7 @@ jobs:
 
         echo -e "CHANGED_FILES:\nCHANGED_FILES"
         echo "DOCKER_CHANGED: $DOCKER_CHANGED"
-        echo "::set-output name=docker_changed::$DOCKER_CHANGED"
+        echo "docker_changed=$DOCKER_CHANGED" >> $GITHUB_OUTPUT
 
     - name: Run docker tests
       if: ${{ github.event_name == 'schedule' || steps.check-diff.outputs.docker_changed == 'true' }}

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -42,7 +42,7 @@ jobs:
       run: |
         # `os_name` will be like "Ubuntu-20.04.1-LTS"
         os_name=$(lsb_release -ds | sed 's/\s/-/g')
-        echo "::set-output name=os-name::$os_name"
+        echo "os-name=$os_name" >> $GITHUB_OUTPUT
     - name: Cache R packages
       uses: actions/cache@v3
       with:

--- a/.github/workflows/test-package-build.yml
+++ b/.github/workflows/test-package-build.yml
@@ -87,10 +87,10 @@ jobs:
           wheel_path=$(find dist -type f -name "*.whl")
           wheel_name=$(basename $wheel_path)
           wheel_size=$(stat -c %s $wheel_path)
-          echo "::set-output name=sdist-path::${sdist_path}"
-          echo "::set-output name=wheel-path::${wheel_path}"
-          echo "::set-output name=wheel-name::${wheel_name}"
-          echo "::set-output name=wheel-size::${wheel_size}"
+          echo "sdist-path=${sdist_path}" >> $GITHUB_OUTPUT
+          echo "wheel-path=${wheel_path}" >> $GITHUB_OUTPUT
+          echo "wheel-name=${wheel_name}" >> $GITHUB_OUTPUT
+          echo "wheel-size=${wheel_size}" >> $GITHUB_OUTPUT
 
       - name: Run twine check
         run: |

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -440,9 +440,8 @@ class CustomEncoder(json.JSONEncoder):
 
 
 def set_action_output(name, value):
-    # `::set-output` is a special syntax for GitHub Actions to set an action's output parameter.
-    # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-output-parameter
-    print(f"::set-output name={name}::{value}")
+    with open(os.getenv("GITHUB_OUTPUT"), "a") as f:
+        f.write(f"{name}={value}")
 
 
 def main(args):


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

The `set-output` and `set-state` commands are deprecated now and will be removed in the future.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

This PR replaces them with a new recommended approach.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
