### PR TITLE
Fix for git tags

### DIFF
--- a/mlflow/projects/utils.py
+++ b/mlflow/projects/utils.py
@@ -209,10 +209,7 @@ def _fetch_git_repo(uri, version, dst_dir):
         origin = repo.create_remote("origin", uri)
     if version is not None:
         try:
-            origin.fetch(refspec=version, depth=GIT_FETCH_DEPTH)
-            cmd = ["git", "fetch", "--tags"]
-            g = git.cmd.Git(dst_dir)
-            g.execute(cmd)
+            origin.fetch(refspec=version, depth=GIT_FETCH_DEPTH, tags=True)
             repo.git.checkout(version)
         except git.exc.GitCommandError as e:
             raise ExecutionException(

--- a/mlflow/projects/utils.py
+++ b/mlflow/projects/utils.py
@@ -210,6 +210,9 @@ def _fetch_git_repo(uri, version, dst_dir):
     if version is not None:
         try:
             origin.fetch(refspec=version, depth=GIT_FETCH_DEPTH)
+            cmd = ["git", "fetch", "--tags"]
+            g = git.cmd.Git(dst_dir)
+            g.execute(cmd)
             repo.git.checkout(version)
         except git.exc.GitCommandError as e:
             raise ExecutionException(


### PR DESCRIPTION
Signed-off-by: avikantsrivastava <asdavikant@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
Fix https://github.com/mlflow/mlflow/issues/6821

## What changes are proposed in this pull request?

Git tags were not being fetched by default during a git fetch operation here https://github.com/mlflow/mlflow/blob/5ddfe9a1b48e065540094d83125040d3273c48fa/mlflow/projects/utils.py#L211

I have added a command to explicitly fetch the tags 
```git fetch --tags```

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->
I ran the example project with the tags, which was earlier failing (as mentioned in the issue https://github.com/mlflow/mlflow/issues/6821)

With the fix, it is working as expected, attaching logs here
```bash
mlflow run git@github.com:graelo/mlflow-example.git -v "1.0.0"
```
```
(mlflow-dev) (base) aesthetixell@aesthetixell-pc:~/Desktop/Working/open_source/mlflow$ mlflow run git@github.com:graelo/mlflow-example.git -v "1.0.0"
2022/10/13 12:42:42 INFO mlflow.projects.utils: === Fetching project from git@github.com:graelo/mlflow-example.git into /tmp/tmpl0su6459 ===
2022/10/13 12:42:49 INFO mlflow.utils.conda: Conda environment mlflow-2b6b69a3ea30872171ff71aee564367746fae613 already exists.
2022/10/13 12:42:49 INFO mlflow.projects.utils: === Created directory /tmp/tmphvt0alup for downloading remote URIs passed to arguments of type 'path' ===
2022/10/13 12:42:49 INFO mlflow.projects.backend.local: === Running command 'source /home/aesthetixell/miniconda3/bin/../etc/profile.d/conda.sh && conda activate mlflow-2b6b69a3ea30872171ff71aee564367746fae613 1>&2 && python train.py 0.5 0.1' in run with ID 'bf4deb8de7954652abbac9df1d78dc63' === 
Elasticnet model (alpha=0.500000, l1_ratio=0.100000):
  RMSE: 0.7947931019036528
  MAE: 0.6189130834228137
  R2: 0.1841166871822183
2022/10/13 12:42:53 INFO mlflow.projects: === Run (ID 'bf4deb8de7954652abbac9df1d78dc63') succeeded ===
```

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [x] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
