### PR TITLE
Adding validation for ingest and split step

### DIFF
--- a/tests/pipelines/test_ingest_step.py
+++ b/tests/pipelines/test_ingest_step.py
@@ -242,6 +242,30 @@ def test_ingest_throws_for_custom_dataset_when_custom_loader_function_not_implem
         ).run(output_directory=tmp_path)
 
 
+def custom_load_file_as_array(local_data_file_path, dataset_format):
+    return [local_data_file_path, dataset_format]
+
+
+@pytest.mark.usefixtures("enter_test_pipeline_directory")
+def test_ingest_throws_for_custom_dataset_when_custom_method_returns_array(pandas_df, tmp_path):
+    dataset_path = tmp_path / "df.fooformat"
+    pandas_df.to_csv(dataset_path, sep="#")
+
+    with pytest.raises(MlflowException, match="The `ingested_data` is not a DataFrame"):
+        IngestStep.from_pipeline_config(
+            pipeline_config={
+                "data": {
+                    "format": "fooformat",
+                    "location": str(dataset_path),
+                    "custom_loader_method": (
+                        "tests.pipelines.test_ingest_step.custom_load_file_as_array"
+                    ),
+                }
+            },
+            pipeline_root=os.getcwd(),
+        ).run(output_directory=tmp_path)
+
+
 @pytest.mark.usefixtures("enter_test_pipeline_directory")
 def test_ingest_throws_for_custom_dataset_when_custom_loader_function_throws_unexpectedly(
     pandas_df, tmp_path


### PR DESCRIPTION
## What changes are proposed in this pull request?
Adding validation for ingest and split step
Note: Others steps would be added in follow up PRs

## How is this patch tested?
- [x] Tested in notebook example

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
