### PR TITLE
Always profile target_col as the first column in split step

### DIFF
--- a/mlflow/pipelines/steps/split.py
+++ b/mlflow/pipelines/steps/split.py
@@ -198,11 +198,18 @@ class SplitStep(BaseStep):
         # drop rows which target value is missing
         raw_input_num_rows = len(input_df)
         # Make sure the target column is actually present in the input DF
-        if self.target_col not in input_df.columns:
+        input_cols = list(input_df.columns)
+        if self.target_col not in input_cols:
             raise MlflowException(
                 f"Target column '{self.target_col}' not found in ingested dataset.",
                 error_code=INVALID_PARAMETER_VALUE,
             )
+        # Swap the target column to be the first column in the input dataframe. The target column
+        # shall remain the first column for all derived datasets (e.g. training/validation/test).
+        idx0, idx1 = input_cols.index(self.target_col), 0
+        input_cols[idx0], input_cols[idx1] = input_cols[idx1], input_cols[idx0]
+        input_df = input_df[input_cols]
+
         input_df = input_df.dropna(how="any", subset=[self.target_col])
         self.num_dropped_rows = raw_input_num_rows - len(input_df)
 

--- a/mlflow/pipelines/steps/split.py
+++ b/mlflow/pipelines/steps/split.py
@@ -135,9 +135,8 @@ class SplitStep(BaseStep):
     def _build_profiles_and_card(self, train_df, validation_df, test_df) -> BaseCard:
         def _set_target_col_as_first(df, target_col):
             columns = list(df.columns)
-            idx0, idx1 = columns.index(target_col), 0
-            columns[idx0], columns[idx1] = columns[idx1], columns[idx0]
-            return df[columns]
+            col  = columns.pop(columns.index(target_col))
+            return df[[col] + columns]
 
         # Build card
         card = BaseCard(self.pipeline_name, self.name)

--- a/mlflow/pipelines/steps/split.py
+++ b/mlflow/pipelines/steps/split.py
@@ -135,7 +135,7 @@ class SplitStep(BaseStep):
     def _build_profiles_and_card(self, train_df, validation_df, test_df) -> BaseCard:
         def _set_target_col_as_first(df, target_col):
             columns = list(df.columns)
-            col  = columns.pop(columns.index(target_col))
+            col = columns.pop(columns.index(target_col))
             return df[[col] + columns]
 
         # Build card


### PR DESCRIPTION
Signed-off-by: Jin Zhang <jin.zhang@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?
We'd like to always show target column in data profiles irrespective of number of columns exist. See demo below:
<img width="999" alt="Screen Shot 2022-10-13 at 3 53 40 PM" src="https://user-images.githubusercontent.com/78067366/195725185-e56ca883-07c5-4930-b81b-a6143f390802.png">

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
