### PR TITLE
Replace deprecated sqlalchemy features that will be removed in sqlalchemy 2.0

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -144,6 +144,27 @@ jobs:
         done
 
         test $err = 0
+    - name: Rebuild images with SQLAlchemy 2.x
+      run: |
+        sed -i 's/sqlalchemy.*/sqlalchemy==2.0.0b2/g' requirements/core-requirements.txt
+        git diff
+        ./tests/db/compose.sh build --build-arg DEPENDENCIES="$(python setup.py -q dependencies)"
+    - name: Run tests
+      run: |
+        set +e
+        err=0
+        trap 'err=1' ERR
+
+        for service in $(./tests/db/compose.sh config --services | grep '^mlflow-')
+        do
+          # Set `--no-TTY` to show container logs on GitHub Actions:
+          ./tests/db/compose.sh run --rm --no-TTY $service pytest \
+            tests/store/tracking/test_sqlalchemy_store.py \
+            tests/store/model_registry/test_sqlalchemy_store.py \
+            tests/db
+        done
+
+        test $err = 0
     - name: Clean up
       run: |
         ./tests/db/compose.sh down --volumes --remove-orphans --rmi all

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -133,7 +133,7 @@ jobs:
         do
           # Set `--no-TTY` to show container logs on GitHub Actions:
           # https://github.com/actions/virtual-environments/issues/5022
-          ./tests/db/compose.sh run --rm --no-TTY $service pytest \
+          ./tests/db/compose.sh run --rm --no-TTY -e SQLALCHEMY_WARN_20=true $service pytest \
             tests/store/tracking/test_sqlalchemy_store.py \
             tests/store/model_registry/test_sqlalchemy_store.py \
             tests/db
@@ -143,42 +143,6 @@ jobs:
     - name: Clean up
       run: |
         ./tests/db/compose.sh down --volumes --remove-orphans --rmi all
-
-  ### REMOVE THIS JOS BEFORE MERGE ###
-  database-2:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        repository: ${{ github.event.inputs.repository }}
-        ref: ${{ github.event.inputs.ref }}
-        submodules: recursive
-    - name: Build
-      run: |
-        sed -i 's/sqlalchemy.*/sqlalchemy==2.0.0b1/g' requirements/core-requirements.txt
-        ./tests/db/compose.sh pull -q postgresql mysql mssql
-        ./tests/db/compose.sh build --build-arg DEPENDENCIES="$(python setup.py -q dependencies)"
-    - name: Run tests
-      run: |
-        set +e
-        err=0
-        trap 'err=1' ERR
-
-        for service in $(./tests/db/compose.sh config --services | grep '^mlflow-')
-        do
-          # Set `--no-TTY` to show container logs on GitHub Actions:
-          # https://github.com/actions/virtual-environments/issues/5022
-          ./tests/db/compose.sh run --rm --no-TTY $service pytest \
-            tests/store/tracking/test_sqlalchemy_store.py \
-            tests/store/model_registry/test_sqlalchemy_store.py \
-            tests/db
-        done
-
-        test $err = 0
-    - name: Clean up
-      run: |
-        ./tests/db/compose.sh down --volumes --remove-orphans --rmi all
-  ### REMOVE THIS JOS BEFORE MERGE ###
 
   java:
     runs-on: ubuntu-latest

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -134,7 +134,7 @@ jobs:
           # Set `--no-TTY` to show container logs on GitHub Actions:
           # https://github.com/actions/virtual-environments/issues/5022
           # Specify "filterwarnings=error::sqlalchemy.exc.RemovedIn20Warning"
-          # and "SQLALCHEMY_WARN_20=true" to avoid using deprecated SQLAlchemy features that will
+          # and "SQLALCHEMY_WARN_20=true" to prevent using deprecated SQLAlchemy features that will
           # be removed in 2.0.
           ./tests/db/compose.sh run --rm --no-TTY -e SQLALCHEMY_WARN_20=true $service pytest \
             --override-ini "filterwarnings=error::sqlalchemy.exc.RemovedIn20Warning"

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -145,7 +145,7 @@ jobs:
         ./tests/db/compose.sh down --volumes --remove-orphans --rmi all
 
   ### REMOVE THIS JOS BEFORE MERGE ###
-  database-2.0:
+  database-2:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -133,11 +133,7 @@ jobs:
         do
           # Set `--no-TTY` to show container logs on GitHub Actions:
           # https://github.com/actions/virtual-environments/issues/5022
-          # Specify "filterwarnings=error::sqlalchemy.exc.RemovedIn20Warning"
-          # and "SQLALCHEMY_WARN_20=true" to prevent using deprecated SQLAlchemy features that will
-          # be removed in 2.0.
-          ./tests/db/compose.sh run --rm --no-TTY -e SQLALCHEMY_WARN_20=true $service pytest \
-            --override-ini "filterwarnings=error::sqlalchemy.exc.RemovedIn20Warning" \
+          ./tests/db/compose.sh run --rm --no-TTY $service pytest \
             tests/store/tracking/test_sqlalchemy_store.py \
             tests/store/model_registry/test_sqlalchemy_store.py \
             tests/db

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -142,7 +142,7 @@ jobs:
         test $err = 0
     - name: Rebuild images with SQLAlchemy 2.x
       run: |
-        sed -i 's/sqlalchemy.*/sqlalchemy==2.0.0b2/g' requirements/core-requirements.txt
+        sed -i 's/sqlalchemy.*/sqlalchemy==2.0.0b1/g' requirements/core-requirements.txt
         git diff
         ./tests/db/compose.sh build --build-arg DEPENDENCIES="$(python setup.py -q dependencies)"
     - name: Run tests

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -142,7 +142,12 @@ jobs:
         test $err = 0
     - name: Rebuild images with SQLAlchemy 2.x
       run: |
-        sed -i 's/sqlalchemy.*/sqlalchemy==2.0.0b1/g' requirements/core-requirements.txt
+        sed -i '/sqlalchemy.*/d' requirements/core-requirements.txt
+        # https://github.com/sqlalchemy/sqlalchemy/commit/f4214975a7deb5e13f8b6cf21e39697821396a7f
+        # is a patch for https://github.com/sqlalchemy/sqlalchemy/issues/8661. Tests that log a tag
+        # with a long value (e.g. `"a" * 5000`) fail because of this issue. Install sqlalchemy from
+        # this commit until a new 2.x version is published on PyPI.
+        echo 'sqlalchemy@git+https://github.com/sqlalchemy/sqlalchemy.git@f4214975a7deb5e13f8b6cf21e39697821396a7f' >> requirements/core-requirements.txt
         git diff
         ./tests/db/compose.sh build --build-arg DEPENDENCIES="$(python setup.py -q dependencies)"
     - name: Run tests

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -137,7 +137,7 @@ jobs:
           # and "SQLALCHEMY_WARN_20=true" to prevent using deprecated SQLAlchemy features that will
           # be removed in 2.0.
           ./tests/db/compose.sh run --rm --no-TTY -e SQLALCHEMY_WARN_20=true $service pytest \
-            --override-ini "filterwarnings=error::sqlalchemy.exc.RemovedIn20Warning"
+            --override-ini "filterwarnings=error::sqlalchemy.exc.RemovedIn20Warning" \
             tests/store/tracking/test_sqlalchemy_store.py \
             tests/store/model_registry/test_sqlalchemy_store.py \
             tests/db

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -144,6 +144,42 @@ jobs:
       run: |
         ./tests/db/compose.sh down --volumes --remove-orphans --rmi all
 
+  ### REMOVE THIS JOS BEFORE MERGE ###
+  database-2.0:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        repository: ${{ github.event.inputs.repository }}
+        ref: ${{ github.event.inputs.ref }}
+        submodules: recursive
+    - name: Build
+      run: |
+        sed -i 's/sqlalchemy.*/sqlalchemy==2.0.0b1/g' requirements/core-requirements.txt
+        ./tests/db/compose.sh pull -q postgresql mysql mssql
+        ./tests/db/compose.sh build --build-arg DEPENDENCIES="$(python setup.py -q dependencies)"
+    - name: Run tests
+      run: |
+        set +e
+        err=0
+        trap 'err=1' ERR
+
+        for service in $(./tests/db/compose.sh config --services | grep '^mlflow-')
+        do
+          # Set `--no-TTY` to show container logs on GitHub Actions:
+          # https://github.com/actions/virtual-environments/issues/5022
+          ./tests/db/compose.sh run --rm --no-TTY $service pytest \
+            tests/store/tracking/test_sqlalchemy_store.py \
+            tests/store/model_registry/test_sqlalchemy_store.py \
+            tests/db
+        done
+
+        test $err = 0
+    - name: Clean up
+      run: |
+        ./tests/db/compose.sh down --volumes --remove-orphans --rmi all
+  ### REMOVE THIS JOS BEFORE MERGE ###
+
   java:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -133,7 +133,11 @@ jobs:
         do
           # Set `--no-TTY` to show container logs on GitHub Actions:
           # https://github.com/actions/virtual-environments/issues/5022
+          # Specify "filterwarnings=error::sqlalchemy.exc.RemovedIn20Warning"
+          # and "SQLALCHEMY_WARN_20=true" to avoid using deprecated SQLAlchemy features that will
+          # be removed in 2.0.
           ./tests/db/compose.sh run --rm --no-TTY -e SQLALCHEMY_WARN_20=true $service pytest \
+            --override-ini "filterwarnings=error::sqlalchemy.exc.RemovedIn20Warning"
             tests/store/tracking/test_sqlalchemy_store.py \
             tests/store/model_registry/test_sqlalchemy_store.py \
             tests/db

--- a/mlflow/store/db/base_sql_model.py
+++ b/mlflow/store/db/base_sql_model.py
@@ -1,3 +1,3 @@
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 Base = declarative_base()

--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -7,6 +7,7 @@ import logging
 from alembic.migration import MigrationContext  # pylint: disable=import-error
 from alembic.script import ScriptDirectory
 import sqlalchemy
+from sqlalchemy import sql
 
 # We need to import sqlalchemy.pool to convert poolclass string to class object
 from sqlalchemy.pool import (
@@ -91,9 +92,9 @@ def _get_managed_session_maker(SessionMaker, db_type):
         session = SessionMaker()
         try:
             if db_type == SQLITE:
-                session.execute("PRAGMA foreign_keys = ON;")
-                session.execute("PRAGMA busy_timeout = 20000;")
-                session.execute("PRAGMA case_sensitive_like = true;")
+                session.execute(sql.text("PRAGMA foreign_keys = ON;"))
+                session.execute(sql.text("PRAGMA busy_timeout = 20000;"))
+                session.execute(sql.text("PRAGMA case_sensitive_like = true;"))
             yield session
             session.commit()
         except MlflowException:

--- a/mlflow/store/db_migrations/env.py
+++ b/mlflow/store/db_migrations/env.py
@@ -61,15 +61,15 @@ def run_migrations_online():
     # for reference by the upgrade routine. For more information, see
     # https://alembic.sqlalchemy.org/en/latest/cookbook.html#sharing-a-
     # connection-with-a-series-of-migration-commands-and-environments
-    connectable = config.attributes.get("connection", None)
-    if connectable is None:
-        connectable = engine_from_config(
+    engine = config.attributes.get("connection", None).engine
+    if engine is None:
+        engine = engine_from_config(
             config.get_section(config.config_ini_section),
             prefix="sqlalchemy.",
             poolclass=pool.NullPool,
         )
 
-    with connectable.connect() as connection:
+    with engine.connect() as connection:
         context.configure(
             connection=connection, target_metadata=target_metadata, render_as_batch=True
         )

--- a/mlflow/store/db_migrations/env.py
+++ b/mlflow/store/db_migrations/env.py
@@ -61,13 +61,15 @@ def run_migrations_online():
     # for reference by the upgrade routine. For more information, see
     # https://alembic.sqlalchemy.org/en/latest/cookbook.html#sharing-a-
     # connection-with-a-series-of-migration-commands-and-environments
-    engine = config.attributes.get("connection", None).engine
-    if engine is None:
+    connection = config.attributes.get("connection")
+    if connection is None:
         engine = engine_from_config(
             config.get_section(config.config_ini_section),
             prefix="sqlalchemy.",
             poolclass=pool.NullPool,
         )
+    else:
+        engine = connection.engine
 
     with engine.connect() as connection:
         context.configure(

--- a/mlflow/store/db_migrations/versions/90e64c465722_migrate_user_column_to_tags.py
+++ b/mlflow/store/db_migrations/versions/90e64c465722_migrate_user_column_to_tags.py
@@ -8,8 +8,7 @@ Create Date: 2019-05-29 10:43:52.919427
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy import orm, Column, Integer, String, ForeignKey, PrimaryKeyConstraint
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import relationship, backref
+from sqlalchemy.orm import relationship, backref, declarative_base
 from mlflow.utils.mlflow_tags import MLFLOW_USER
 
 # revision identifiers, used by Alembic.

--- a/mlflow/store/tracking/dbmodels/initial_models.py
+++ b/mlflow/store/tracking/dbmodels/initial_models.py
@@ -20,7 +20,7 @@ from sqlalchemy import (
     BigInteger,
     PrimaryKeyConstraint,
 )
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 Base = declarative_base()
 

--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -289,7 +289,7 @@ class SqlTag(Base):
     """
     Tag key: `String` (limit 250 characters). *Primary Key* for ``tags`` table.
     """
-    value = Column(String(250), nullable=True)
+    value = Column(String(5000), nullable=True)
     """
     Value associated with tag: `String` (limit 250 characters). Could be *null*.
     """

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -9,6 +9,7 @@ from functools import reduce
 import math
 import sqlalchemy
 import sqlalchemy.sql.expression as sql
+from sqlalchemy import sql
 from sqlalchemy.future import select
 
 from mlflow.entities import RunTag
@@ -163,18 +164,18 @@ class SqlAlchemyStore(AbstractStore):
         if self.db_type == MYSQL:
             # config letting MySQL override default
             # to allow 0 value for experiment ID (auto increment column)
-            session.execute("SET @@SESSION.sql_mode='NO_AUTO_VALUE_ON_ZERO';")
+            session.execute(sql.text("SET @@SESSION.sql_mode='NO_AUTO_VALUE_ON_ZERO';"))
         if self.db_type == MSSQL:
             # config letting MSSQL override default
             # to allow any manual value inserted into IDENTITY column
-            session.execute("SET IDENTITY_INSERT experiments ON;")
+            session.execute(sql.text("SET IDENTITY_INSERT experiments ON;"))
 
     # DB helper methods to allow zero values for columns with auto increments
     def _unset_zero_value_insertion_for_autoincrement_column(self, session):
         if self.db_type == MYSQL:
-            session.execute("SET @@SESSION.sql_mode='';")
+            session.execute(sql.text("SET @@SESSION.sql_mode='';"))
         if self.db_type == MSSQL:
-            session.execute("SET IDENTITY_INSERT experiments OFF;")
+            session.execute(sql.text("SET IDENTITY_INSERT experiments OFF;"))
 
     def _create_default_experiment(self, session):
         """
@@ -209,7 +210,9 @@ class SqlAlchemyStore(AbstractStore):
         try:
             self._set_zero_value_insertion_for_autoincrement_column(session)
             session.execute(
-                "INSERT INTO {} ({}) VALUES ({});".format(table, ", ".join(columns), values)
+                sql.text(
+                    "INSERT INTO {} ({}) VALUES ({});".format(table, ", ".join(columns), values)
+                )
             )
         finally:
             self._unset_zero_value_insertion_for_autoincrement_column(session)
@@ -1370,22 +1373,18 @@ def _get_orderby_clauses(order_by_list, session):
             # avoid ambiguity
             if SearchUtils.is_metric(key_type, "="):
                 case = sql.case(
-                    [
-                        # Ideally the use of "IS" is preferred here but owing to sqlalchemy
-                        # translation in MSSQL we are forced to use "=" instead.
-                        # These 2 options are functionally identical / unchanged because
-                        # the column (is_nan) is not nullable. However it could become an issue
-                        # if this precondition changes in the future.
-                        (subquery.c.is_nan == sqlalchemy.true(), 1),
-                        (order_value.is_(None), 2),
-                    ],
+                    # Ideally the use of "IS" is preferred here but owing to sqlalchemy
+                    # translation in MSSQL we are forced to use "=" instead.
+                    # These 2 options are functionally identical / unchanged because
+                    # the column (is_nan) is not nullable. However it could become an issue
+                    # if this precondition changes in the future.
+                    (subquery.c.is_nan == sqlalchemy.true(), 1),
+                    (order_value.is_(None), 2),
                     else_=0,
                 ).label("clause_%s" % clause_id)
 
             else:  # other entities do not have an 'is_nan' field
-                case = sql.case([(order_value.is_(None), 1)], else_=0).label(
-                    "clause_%s" % clause_id
-                )
+                case = sql.case((order_value.is_(None), 1), else_=0).label("clause_%s" % clause_id)
             clauses.append(case.name)
             select_clauses.append(case)
             select_clauses.append(order_value)

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,6 +4,3 @@ filterwarnings =
   # Prevent deprecated numpy type aliases from being used
   error:^`np\.[a-z]+` is a deprecated alias for.+:DeprecationWarning:mlflow
   error:^`np\.[a-z]+` is a deprecated alias for.+:DeprecationWarning:tests
-  # Do not allow using deprecated SQLAlchemy features that will be removed in 2.0.
-  # To enable the warning, the `SQLALCHEMY_WARN_20` environment variable must be set.
-  error::sqlalchemy.exc.RemovedIn20Warning

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,9 @@
 [pytest]
 addopts = --cov=./mlflow --cov-report html --color=yes --durations=10 --showlocals --verbose
-# Prevent deprecated numpy type aliases from being used
 filterwarnings =
+  # Prevent deprecated numpy type aliases from being used
   error:^`np\.[a-z]+` is a deprecated alias for.+:DeprecationWarning:mlflow
   error:^`np\.[a-z]+` is a deprecated alias for.+:DeprecationWarning:tests
+  # Do not allow using deprecated SQLAlchemy features that will be removed in 2.0.
+  # To enable the warning, the `SQLALCHEMY_WARN_20` environment variable must be set.
+  error::sqlalchemy.exc.RemovedIn20Warning

--- a/tests/db/README.md
+++ b/tests/db/README.md
@@ -16,7 +16,8 @@ This directory contains files to test MLflow tracking operations using the follo
 
 ```bash
 # Build a service
-./tests/db/compose.sh build --build-arg DEPENDENCIES="$(python setup.py -q dependencies)" <service>
+service=mlflow-sqlite
+./tests/db/compose.sh build --build-arg DEPENDENCIES="$(python setup.py -q dependencies)" $service
 
 # Build all services
 ./tests/db/compose.sh build --build-arg DEPENDENCIES="$(python setup.py -q dependencies)"
@@ -26,7 +27,7 @@ This directory contains files to test MLflow tracking operations using the follo
 
 ```bash
 # Run a service (`pytest tests/db` is executed by default)
-./tests/db/compose.sh run --rm <service>
+./tests/db/compose.sh run --rm $service
 
 # Run all services
 for service in $(./tests/db/compose.sh config --services | grep '^mlflow-')
@@ -35,10 +36,10 @@ do
 done
 
 # Run tests
-./tests/db/compose.sh run --rm <service> pytest /path/to/directory/or/script
+./tests/db/compose.sh run --rm $service pytest /path/to/directory/or/script
 
 # Run a python script
-./tests/db/compose.sh run --rm <service> python /path/to/script
+./tests/db/compose.sh run --rm $service python /path/to/script
 ```
 
 ## Clean Up Services

--- a/tests/db/test_schema.py
+++ b/tests/db/test_schema.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from collections import namedtuple
 
 import pytest
+from packaging.version import Version
+import sqlalchemy
 from sqlalchemy.schema import MetaData, CreateTable
 from sqlalchemy import create_engine
 
@@ -125,6 +127,9 @@ def get_schema_update_command(dialect):
     return f"docker-compose -f {docker_compose_yml} run --rm mlflow-{dialect} python {this_script}"
 
 
+@pytest.mark.skipif(
+    Version(sqlalchemy.__version__) > Version("1.4"), reason="Use 1.4 for schema check"
+)
 def test_schema_is_up_to_date():
     initialize_database()
     tracking_uri = get_tracking_uri()

--- a/tests/db/test_schema.py
+++ b/tests/db/test_schema.py
@@ -25,8 +25,8 @@ def get_tracking_uri():
 
 def dump_schema(db_uri):
     engine = create_engine(db_uri)
-    created_tables_metadata = MetaData(bind=engine)
-    created_tables_metadata.reflect()
+    created_tables_metadata = MetaData()
+    created_tables_metadata.reflect(bind=engine)
     # Write out table schema as described in
     # https://docs.sqlalchemy.org/en/13/faq/metadata_schema.html#how-can-i-get-the-create-table-drop-table-output-as-a-string
     lines = []

--- a/tests/resources/db/initial_models.py
+++ b/tests/resources/db/initial_models.py
@@ -16,7 +16,7 @@ from sqlalchemy import (
     BigInteger,
     PrimaryKeyConstraint,
 )
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 Base = declarative_base()
 

--- a/tests/store/dump_schema.py
+++ b/tests/store/dump_schema.py
@@ -12,8 +12,8 @@ from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
 
 def dump_db_schema(db_url, dst_file):
     engine = sqlalchemy.create_engine(db_url)
-    created_tables_metadata = MetaData(bind=engine)
-    created_tables_metadata.reflect()
+    created_tables_metadata = MetaData()
+    created_tables_metadata.reflect(bind=engine)
     # Write out table schema as described in
     # https://docs.sqlalchemy.org/en/13/faq/
     # metadata_schema.html#how-can-i-get-the-create-table-drop-table-output-as-a-string

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -816,19 +816,14 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
 
     def test_run_data_model(self):
         with self.store.ManagedSessionMaker() as session:
-            m1 = models.SqlMetric(key="accuracy", value=0.89)
-            m2 = models.SqlMetric(key="recal", value=0.89)
-            p1 = models.SqlParam(key="loss", value="test param")
-            p2 = models.SqlParam(key="blue", value="test param")
+            run_id = uuid.uuid4().hex
+            run_data = models.SqlRun(run_uuid=run_id)
+            m1 = models.SqlMetric(run_uuid=run_id, key="accuracy", value=0.89)
+            m2 = models.SqlMetric(run_uuid=run_id, key="recal", value=0.89)
+            p1 = models.SqlParam(run_uuid=run_id, key="loss", value="test param")
+            p2 = models.SqlParam(run_uuid=run_id, key="blue", value="test param")
 
             session.add_all([m1, m2, p1, p2])
-
-            run_data = models.SqlRun(run_uuid=uuid.uuid4().hex)
-            run_data.params.append(p1)
-            run_data.params.append(p2)
-            run_data.metrics.append(m1)
-            run_data.metrics.append(m2)
-
             session.add(run_data)
             session.commit()
 

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -182,7 +182,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
                 # Reset experiment_id to start at 1
                 reset_experiment_id = self._get_query_to_reset_experiment_id()
                 if reset_experiment_id:
-                    session.execute(reset_experiment_id)
+                    session.execute(sqlalchemy.sql.text(reset_experiment_id))
         shutil.rmtree(ARTIFACT_URI)
 
     def _experiment_factory(self, names):

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -13,7 +13,6 @@ import uuid
 import json
 from concurrent.futures import ThreadPoolExecutor
 from unittest import mock
-from packaging.version import Version
 
 import mlflow.db
 import mlflow.store.db.base_sql_model
@@ -1238,15 +1237,9 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         longTag = entities.ExperimentTag("longTagKey", "a" * 5001)
         with pytest.raises(MlflowException, match="exceeded length limit of 5000"):
             self.store.set_experiment_tag(exp_id, longTag)
-        if not (
-            # TODO: Remove this condition once https://github.com/sqlalchemy/sqlalchemy/issues/8661
-            # is fixed.
-            self.store._get_dialect() == MSSQL
-            and Version(sqlalchemy.__version__) > Version("1.4")
-        ):
-            # test can set tags that are somewhat long
-            longTag = entities.ExperimentTag("longTagKey", "a" * 4999)
-            self.store.set_experiment_tag(exp_id, longTag)
+        # test can set tags that are somewhat long
+        longTag = entities.ExperimentTag("longTagKey", "a" * 4999)
+        self.store.set_experiment_tag(exp_id, longTag)
         # test cannot set tags on deleted experiments
         self.store.delete_experiment(exp_id)
         with pytest.raises(MlflowException, match="must be in the 'active' state"):

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -2528,12 +2528,11 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
             )
             current_run += 1
 
-        with self.store.engine.connect() as conn:
+        with self.store.engine.begin() as conn:
             conn.execute(sqlalchemy.insert(SqlParam), params_list)
             conn.execute(sqlalchemy.insert(SqlMetric), metrics_list)
             conn.execute(sqlalchemy.insert(SqlLatestMetric), latest_metrics_list)
             conn.execute(sqlalchemy.insert(SqlTag), tags_list)
-            conn.commit()
 
         return experiment_id, run_ids
 

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -2533,6 +2533,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
             conn.execute(sqlalchemy.insert(SqlMetric), metrics_list)
             conn.execute(sqlalchemy.insert(SqlLatestMetric), latest_metrics_list)
             conn.execute(sqlalchemy.insert(SqlTag), tags_list)
+            conn.commit()
 
         return experiment_id, run_ids
 


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

[SQLAlchemy 2.0.0b1](https://pypi.org/project/SQLAlchemy/2.0.0b1/) has been published on PyPI. Using this version, this PR replaces deprecated sqlalchemy features that will be removed in 2.0.


https://docs.sqlalchemy.org/en/14/changelog/migration_20.html#migrating-to-sqlalchemy-2-0 is also helpful.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [x] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
