### PR TITLE
Throw exception if not all required step files are present

### DIFF
--- a/mlflow/pipelines/utils/execution.py
+++ b/mlflow/pipelines/utils/execution.py
@@ -412,7 +412,10 @@ def _create_makefile(pipeline_root_path, execution_directory_path, template) -> 
         ]:
             required_file_path = os.path.join(steps_folder_path, required_file)
             if not os.path.exists(required_file_path):
-                with open(required_file_path, "w"):
+                try:
+                    with open(required_file_path, "w"):
+                        pass
+                except OSError:
                     pass
             if not os.path.exists(required_file_path):
                 raise ValueError(

--- a/mlflow/pipelines/utils/execution.py
+++ b/mlflow/pipelines/utils/execution.py
@@ -400,6 +400,9 @@ def _create_makefile(pipeline_root_path, execution_directory_path, template) -> 
 
     if template == "regression/v1":
         makefile_to_use = _REGRESSION_MAKEFILE_FORMAT_STRING
+        steps_folder_path = os.path.join(pipeline_root_path, "steps")
+        if not os.path.exists(steps_folder_path):
+            os.mkdir(steps_folder_path)
         for required_file in [
             "ingest.py",
             "split.py",
@@ -407,7 +410,10 @@ def _create_makefile(pipeline_root_path, execution_directory_path, template) -> 
             "transform.py",
             "custom_metrics.py",
         ]:
-            required_file_path = os.path.join(pipeline_root_path, "steps", required_file)
+            required_file_path = os.path.join(steps_folder_path, required_file)
+            if not os.path.exists(required_file_path):
+                with open(required_file_path, "w") as _:
+                    pass
             if not os.path.exists(required_file_path):
                 raise ValueError(
                     f"Can not find required file {required_file_path} from steps folder. "

--- a/mlflow/pipelines/utils/execution.py
+++ b/mlflow/pipelines/utils/execution.py
@@ -400,6 +400,19 @@ def _create_makefile(pipeline_root_path, execution_directory_path, template) -> 
 
     if template == "regression/v1":
         makefile_to_use = _REGRESSION_MAKEFILE_FORMAT_STRING
+        for required_file in [
+            "ingest.py",
+            "split.py",
+            "train.py",
+            "transform.py",
+            "custom_metrics.py",
+        ]:
+            required_file_path = os.path.join(pipeline_root_path, "steps", required_file)
+            if not os.path.exists(required_file_path):
+                raise ValueError(
+                    f"Can not find required file {required_file_path} from steps folder. "
+                    "Please create empty python file if the step is not used."
+                )
     else:
         raise ValueError(f"Invalid template: {template}")
 

--- a/mlflow/pipelines/utils/execution.py
+++ b/mlflow/pipelines/utils/execution.py
@@ -413,8 +413,8 @@ def _create_makefile(pipeline_root_path, execution_directory_path, template) -> 
             required_file_path = os.path.join(steps_folder_path, required_file)
             if not os.path.exists(required_file_path):
                 try:
-                    with open(required_file_path, "w"):
-                        pass
+                    with open(required_file_path, "w") as f:
+                        f.write("# Created by MLflow Pipeliens\n")
                 except OSError:
                     pass
             if not os.path.exists(required_file_path):

--- a/mlflow/pipelines/utils/execution.py
+++ b/mlflow/pipelines/utils/execution.py
@@ -412,7 +412,7 @@ def _create_makefile(pipeline_root_path, execution_directory_path, template) -> 
         ]:
             required_file_path = os.path.join(steps_folder_path, required_file)
             if not os.path.exists(required_file_path):
-                with open(required_file_path, "w") as _:
+                with open(required_file_path, "w"):
                     pass
             if not os.path.exists(required_file_path):
                 raise ValueError(

--- a/tests/pipelines/test_execution_utils.py
+++ b/tests/pipelines/test_execution_utils.py
@@ -122,7 +122,7 @@ def test_create_required_step_files(tmp_path):
             "steps/transform.py",
             "steps/custom_metrics.py",
         ]:
-            assert not check_exist ^ (tmp_path / required_file).exists()
+            assert (tmp_path / required_file).exists() is check_exist
 
     test_step = TestStep()
     check_required_files(False)

--- a/tests/pipelines/test_execution_utils.py
+++ b/tests/pipelines/test_execution_utils.py
@@ -104,6 +104,34 @@ def clean_test_pipeline(enter_test_pipeline_directory):  # pylint: disable=unuse
         Pipeline(profile="local").clean()
 
 
+def test_create_required_step_files(tmp_path):
+    class TestStep(BaseStepImplemented):
+        def __init__(self):  # pylint: disable=super-init-not-called
+            pass
+
+        @property
+        def name(self):
+            return "test_step"
+
+    def check_required_files(check_exist):
+        for required_file in [
+            "steps",
+            "steps/ingest.py",
+            "steps/split.py",
+            "steps/train.py",
+            "steps/transform.py",
+            "steps/custom_metrics.py",
+        ]:
+            assert not check_exist ^ (tmp_path / required_file).exists()
+
+    test_step = TestStep()
+    check_required_files(False)
+    _get_or_create_execution_directory(
+        pipeline_root_path=tmp_path, pipeline_steps=[test_step], template="regression/v1"
+    )
+    check_required_files(True)
+
+
 def test_get_or_create_execution_directory_is_idempotent(tmp_path):
     class TestStep(BaseStepImplemented):
         def __init__(self):  # pylint: disable=super-init-not-called


### PR DESCRIPTION
Signed-off-by: Mingyu Li <mingyu.li@databricks.com>

As title. Please not that the exception will be thrown from the first step command, which is ingest.
This should be fine because it's checking all files required by the pipeline. User will have to add the required file sooner or later.

## Test
Tested by unit test test_create_required_step_files





<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [X] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
