### PR TITLE
Added parameter for model_format in models/xgboost

### DIFF
--- a/mlflow/xgboost/__init__.py
+++ b/mlflow/xgboost/__init__.py
@@ -96,6 +96,7 @@ def get_default_conda_env():
 def save_model(
     xgb_model,
     path,
+    model_format="xgb",
     conda_env=None,
     code_paths=None,
     mlflow_model=None,
@@ -110,6 +111,7 @@ def save_model(
     :param xgb_model: XGBoost model (an instance of `xgboost.Booster`_ or
                       models that implement the `scikit-learn API`_) to be saved.
     :param path: Local path where the model is to be saved.
+    :param model_format: File format in which the model is to be saved.
     :param conda_env: {{ conda_env }}
     :param code_paths: A list of local filesystem paths to Python file dependencies (or directories
                        containing file dependencies). These files are *prepended* to the system
@@ -151,7 +153,7 @@ def save_model(
         mlflow_model.signature = signature
     if input_example is not None:
         _save_example(mlflow_model, input_example, path)
-    model_data_subpath = "model.xgb"
+    model_data_subpath = f"model.{model_format}"
     model_data_path = os.path.join(path, model_data_subpath)
 
     # Save an XGBoost model
@@ -211,6 +213,7 @@ def save_model(
 def log_model(
     xgb_model,
     artifact_path,
+    model_format=None,
     conda_env=None,
     code_paths=None,
     registered_model_name=None,
@@ -227,6 +230,7 @@ def log_model(
     :param xgb_model: XGBoost model (an instance of `xgboost.Booster`_ or
                       models that implement the `scikit-learn API`_) to be saved.
     :param artifact_path: Run-relative artifact path.
+    :param model_format: File format in which the model is to be saved.
     :param conda_env: {{ conda_env }}
     :param code_paths: A list of local filesystem paths to Python file dependencies (or directories
                        containing file dependencies). These files are *prepended* to the system
@@ -267,6 +271,7 @@ def log_model(
         flavor=mlflow.xgboost,
         registered_model_name=registered_model_name,
         xgb_model=xgb_model,
+        model_format=model_format,
         conda_env=conda_env,
         code_paths=code_paths,
         signature=signature,

--- a/mlflow/xgboost/__init__.py
+++ b/mlflow/xgboost/__init__.py
@@ -96,7 +96,6 @@ def get_default_conda_env():
 def save_model(
     xgb_model,
     path,
-    model_format="xgb",
     conda_env=None,
     code_paths=None,
     mlflow_model=None,
@@ -104,6 +103,7 @@ def save_model(
     input_example: ModelInputExample = None,
     pip_requirements=None,
     extra_pip_requirements=None,
+    model_format="xgb",
 ):
     """
     Save an XGBoost model to a path on the local file system.
@@ -111,7 +111,6 @@ def save_model(
     :param xgb_model: XGBoost model (an instance of `xgboost.Booster`_ or
                       models that implement the `scikit-learn API`_) to be saved.
     :param path: Local path where the model is to be saved.
-    :param model_format: File format in which the model is to be saved.
     :param conda_env: {{ conda_env }}
     :param code_paths: A list of local filesystem paths to Python file dependencies (or directories
                        containing file dependencies). These files are *prepended* to the system
@@ -138,6 +137,7 @@ def save_model(
                           base64-encoded.
     :param pip_requirements: {{ pip_requirements }}
     :param extra_pip_requirements: {{ extra_pip_requirements }}
+    :param model_format: File format in which the model is to be saved.
     """
     import xgboost as xgb
 
@@ -171,6 +171,7 @@ def save_model(
         xgb_version=xgb.__version__,
         data=model_data_subpath,
         model_class=xgb_model_class,
+        model_format=model_format,
         code=code_dir_subpath,
     )
     mlflow_model.save(os.path.join(path, MLMODEL_FILE_NAME))
@@ -213,7 +214,6 @@ def save_model(
 def log_model(
     xgb_model,
     artifact_path,
-    model_format=None,
     conda_env=None,
     code_paths=None,
     registered_model_name=None,
@@ -222,6 +222,7 @@ def log_model(
     await_registration_for=DEFAULT_AWAIT_MAX_SLEEP_SECONDS,
     pip_requirements=None,
     extra_pip_requirements=None,
+    model_format=None,
     **kwargs,
 ):
     """
@@ -230,7 +231,6 @@ def log_model(
     :param xgb_model: XGBoost model (an instance of `xgboost.Booster`_ or
                       models that implement the `scikit-learn API`_) to be saved.
     :param artifact_path: Run-relative artifact path.
-    :param model_format: File format in which the model is to be saved.
     :param conda_env: {{ conda_env }}
     :param code_paths: A list of local filesystem paths to Python file dependencies (or directories
                        containing file dependencies). These files are *prepended* to the system
@@ -262,6 +262,7 @@ def log_model(
                             waits for five minutes. Specify 0 or None to skip waiting.
     :param pip_requirements: {{ pip_requirements }}
     :param extra_pip_requirements: {{ extra_pip_requirements }}
+    :param model_format: File format in which the model is to be saved.
     :param kwargs: kwargs to pass to `xgboost.Booster.save_model`_ method.
     :return: A :py:class:`ModelInfo <mlflow.models.model.ModelInfo>` instance that contains the
              metadata of the logged model.

--- a/tests/xgboost/test_xgboost_model_export.py
+++ b/tests/xgboost/test_xgboost_model_export.py
@@ -519,3 +519,14 @@ def test_log_model_with_code_paths(xgb_model):
         _compare_logged_code_paths(__file__, model_uri, mlflow.xgboost.FLAVOR_NAME)
         mlflow.xgboost.load_model(model_uri=model_uri)
         add_mock.assert_called()
+
+
+@pytest.mark.parametrize("model_format", ["xgb", "json", "ubj"])
+def test_log_model_with_model_format(xgb_model, model_format):
+    with mlflow.start_run():
+        model_info = mlflow.xgboost.log_model(xgb_model.model, "model", model_format=model_format)
+        loaded_model = mlflow.xgboost.load_model(model_info.model_uri)
+        np.testing.assert_array_almost_equal(
+            xgb_model.model.predict(xgb_model.inference_dmatrix),
+            loaded_model.predict(xgb_model.inference_dmatrix),
+        )


### PR DESCRIPTION
Signed-off-by: avikantsrivastava <asdavikant@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
Resolve #6626

## What changes are proposed in this pull request?

- I have added a new parameter called `model_format` in `mlflow.xgboost.save_model` and `mlflow.xgboost.log_model` which specifies the save format of xgboost model (json or xgb).
- I have passed it as a **kwargs to `Model.log` so it will be automatically picked up by `save_model` as a param
- The value defaults to `.xgb` incase it is not provided

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->
Still testing on examples

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
