### PR TITLE
Implement classification pipeline

### DIFF
--- a/docs/source/python_api/mlflow.pipelines.rst
+++ b/docs/source/python_api/mlflow.pipelines.rst
@@ -18,3 +18,12 @@ Regression Pipeline
 .. autoclass:: mlflow.pipelines.regression.v1.pipeline.RegressionPipeline()
     :members:
     :undoc-members:
+
+Classification Pipeline
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: mlflow.pipelines.classification.v1.pipeline
+
+.. autoclass:: mlflow.pipelines.classification.v1.pipeline.ClassificationPipeline()
+    :members:
+    :undoc-members:

--- a/mlflow/pipelines/classification/v1/__init__.py
+++ b/mlflow/pipelines/classification/v1/__init__.py
@@ -1,0 +1,5 @@
+from mlflow.pipelines.classification.v1.pipeline import (
+    ClassificationPipeline as PipelineImpl,
+)
+
+__all__ = ["PipelineImpl"]

--- a/mlflow/pipelines/classification/v1/pipeline.py
+++ b/mlflow/pipelines/classification/v1/pipeline.py
@@ -1,0 +1,395 @@
+"""
+.. _mlflow-classification-pipeline:
+
+The MLflow Classification Pipeline is an MLflow Pipeline for developing binary classification
+models. Multiclass classifiers are currently not supported.
+The classification pipeline is designed for developing models using scikit-learn and
+frameworks that integrate with scikit-learn, such as the ``XGBClassifier`` API from XGBoost.
+The :py:class:`ClassificationPipeline API Documentation <ClassificationPipeline>` provides
+instructions for executing the pipeline and inspecting its results.
+
+The training pipeline contains the following sequential steps:
+
+**ingest** -> **split** -> **transform** -> **train** -> **evaluate** -> **register**
+
+The batch scoring pipeline contains the following sequential steps:
+
+**ingest_scoring** -> **predict**
+
+The pipeline steps are defined as follows:
+
+   - **ingest**
+      - The **ingest** step resolves the dataset specified by the |'data' section in pipeline.yaml|
+        and converts it to parquet format, leveraging the custom dataset parsing code defined in
+        |steps/ingest.py| if necessary. Subsequent steps convert this dataset into training,
+        validation, & test sets and use them to develop a model.
+
+        .. note::
+            If you make changes to the dataset referenced by the **ingest** step (e.g. by adding
+            new records or columns), you must manually re-run the **ingest** step in order to
+            use the updated dataset in the pipeline. The **ingest** step does *not* automatically
+            detect changes in the dataset.
+
+        .. note::
+            `target_col` must have a cardinality of two and `positive_class` must be specified.
+
+   .. _mlflow-classification-pipeline-split-step:
+
+   - **split**
+      - The **split** step splits the ingested dataset produced by the **ingest** step into
+        a training dataset for model training, a validation dataset for model performance
+        evaluation  & tuning, and a test dataset for model performance evaluation. The fraction
+        of records allocated to each dataset is defined by the ``split_ratios`` attribute of the
+        |'split' step definition in pipeline.yaml|. The **split** step also preprocesses the
+        datasets using logic defined in |steps/split.py|. Subsequent steps use these datasets
+        to develop a model and measure its performance.
+
+   - **transform**
+      - The **transform** step uses the training dataset created by **split** to fit
+        a transformer that performs the transformations defined in |steps/transform.py|. The
+        transformer is then applied to the training dataset and the validation dataset, creating
+        transformed datasets that are used by subsequent steps for estimator training and model
+        performance evaluation.
+
+   .. _mlflow-classification-pipeline-train-step:
+
+   - **train**
+      - The **train** step uses the transformed training dataset output from the **transform**
+        step to fit an estimator with the type and parameters defined in |steps/train.py|. The
+        estimator is then joined with the fitted transformer output from the **transform** step
+        to create a model pipeline. Finally, this model pipeline is evaluated against the
+        transformed training and validation datasets to compute performance metrics; custom
+        metrics are computed according to definitions in |steps/custom_metrics.py| and the
+        |'metrics' section of pipeline.yaml|. The model pipeline and its associated parameters,
+        performance metrics, and lineage information are logged to MLflow Tracking, producing
+        an MLflow Run.
+
+            .. note::
+                The **train** step supports hyperparameter tuning with hyperopt by adding 
+                configurations in the 
+                |'tuning' section of the 'train' step definition in pipeline.yaml|. 
+
+   - **evaluate**
+      - The **evaluate** step evaluates the model pipeline created by the **train** step on
+        the test dataset output from the **split** step, computing performance metrics and
+        model explanations. Performance metrics are compared against configured thresholds to
+        compute a ``model_validation_status``, which indicates whether or not a model is good
+        enough to be registered to the MLflow Model Registry by the subsequent **register**
+        step. Custom performance metrics are computed according to definitions in
+        |steps/custom_metrics.py| and the |'metrics' section of pipeline.yaml|. Model
+        performance thresholds are defined in the
+        |'validation_criteria' section of the 'evaluate' step definition in pipeline.yaml|. Model
+        performance metrics and explanations are logged to the same MLflow Tracking Run used by
+        the **train** step.
+
+   - **register**
+      - The **register** step checks the ``model_validation_status`` output of the preceding
+        **evaluate** step and, if model validation was successful
+        (as indicated by the ``'VALIDATED'`` status), registers the model pipeline created by
+        the **train** step to the MLflow Model Registry. If the ``model_validation_status`` does
+        not indicate that the model passed validation checks (i.e. its value is ``'REJECTED'``),
+        the model pipeline is not registered to the MLflow Model Registry.
+        If the model pipeline is registered to the MLflow Model Registry, a
+        ``registered_model_version`` is produced containing the model name and the model version.
+
+            .. note::
+                The model validation status check can be disabled by specifying
+                ``allow_non_validated_model: true`` in the
+                |'register' step definition of pipeline.yaml|, in which case the model pipeline is
+                always registered with the MLflow Model Registry when the **register** step is
+                executed.
+
+   - **ingest_scoring**
+      - The **ingest_scoring** step resolves the dataset specified by the 
+        |'data/scoring' section in pipeline.yaml| and converts it to parquet format, leveraging 
+        the custom dataset parsing code defined in |steps/ingest.py| if necessary. 
+    
+            .. note::
+                If you make changes to the dataset referenced by the **ingest_scoring** step 
+                (e.g. by adding new records or columns), you must manually re-run the 
+                **ingest_scoring** step in order to use the updated dataset in the pipeline. 
+                The **ingest_scoring** step does *not* automatically detect changes in the dataset.
+    
+   - **predict**
+      - The **predict** step uses the ingested dataset for scoring created by the
+        **ingest_scoring** step and applies the specified model to the dataset.
+
+            .. note::
+                In Databricks, the **predict** step writes the output parquet/delta files to
+                DBFS.
+"""
+
+import logging
+from typing import Any, Optional
+
+from mlflow.pipelines.pipeline import _BasePipeline
+from mlflow.pipelines.steps.ingest import IngestStep, IngestScoringStep
+from mlflow.pipelines.steps.split import SplitStep
+from mlflow.pipelines.steps.transform import TransformStep
+from mlflow.pipelines.steps.train import TrainStep
+from mlflow.pipelines.steps.evaluate import EvaluateStep
+from mlflow.pipelines.steps.predict import PredictStep
+from mlflow.pipelines.steps.register import RegisterStep
+from mlflow.pipelines.step import BaseStep
+from mlflow.utils.annotations import experimental
+
+_logger = logging.getLogger(__name__)
+
+
+@experimental
+class ClassificationPipeline(_BasePipeline):
+    """
+    A pipeline for developing high-quality classification models. The pipeline is designed for
+    developing models using scikit-learn and frameworks that integrate with scikit-learn,
+    such as the ``XGBClassifier`` API from XGBoost.
+    The training pipeline contains the following sequential steps:
+
+    **ingest** -> **split** -> **transform** -> **train** -> **evaluate** -> **register**
+
+    while the batch scoring pipeline contains this set of sequential steps:
+
+    **ingest_scoring** -> **predict**
+
+    .. code-block:: python
+        :caption: Example
+
+        import os
+        from mlflow.pipelines import Pipeline
+
+        os.chdir("~/mlp-classification-template")
+        classification_pipeline = Pipeline(profile="local")
+        # Display a visual overview of the pipeline graph
+        classification_pipeline.inspect()
+        # Run the full pipeline
+        classification_pipeline.run()
+        # Display a summary of results from the 'train' step, including the trained model
+        # and associated performance metrics computed from the training & validation datasets
+        classification_pipeline.inspect(step="train")
+        # Display a summary of results from the 'evaluate' step, including model explanations
+        # computed from the validation dataset and metrics computed from the test dataset
+        classification_pipeline.inspect(step="evaluate")
+    """
+
+    _PIPELINE_STEPS = (
+        # Training data ingestion DAG
+        IngestStep,
+        # Model training DAG
+        SplitStep,
+        TransformStep,
+        TrainStep,
+        EvaluateStep,
+        RegisterStep,
+        # Batch scoring DAG
+        IngestScoringStep,
+        PredictStep,
+    )
+
+    _DEFAULT_STEP_INDEX = _PIPELINE_STEPS.index(RegisterStep)
+
+    def _get_step_classes(self):
+        return self._PIPELINE_STEPS
+
+    def _get_default_step(self) -> BaseStep:
+        return self._steps[self._DEFAULT_STEP_INDEX]
+
+    def run(self, step: str = None) -> None:
+        """
+        Runs the full pipeline or a particular pipeline step, producing outputs and displaying a
+        summary of results upon completion. Step outputs are cached from previous executions, and
+        steps are only re-executed if configuration or code changes have been made to the step or
+        to any of its dependent steps (e.g. changes to the pipeline's ``pipeline.yaml`` file or
+        ``steps/ingest.py`` file) since the previous execution.
+
+        :param step: String name of the step to run within the classification pipeline. The step and
+                     its dependencies are executed sequentially. If a step is not specified, the
+                     entire pipeline is executed. Supported steps, in their order of execution, are:
+
+                     - ``"ingest"``: resolves the dataset specified by the ``data/training`` section
+                       in the pipeline's configuration file (``pipeline.yaml``) and converts it to
+                       parquet format.
+
+                     - ``"ingest_scoring"``: resolves the dataset specified by the ``data/scoring``
+                       section in the pipeline's configuration file (``pipeline.yaml``) and converts
+                       it to parquet format.
+
+                     - ``"split"``: splits the ingested dataset produced by the **ingest** step into
+                       a training dataset for model training, a validation dataset for model
+                       performance evaluation & tuning, and a test dataset for model performance
+                       evaluation.
+
+                     - ``"transform"``: uses the training dataset created by the **split** step to
+                       fit a transformer that performs the transformations defined in the
+                       pipeline's ``steps/transform.py`` file. Then, applies the transformer to the
+                       training dataset and the validation dataset, creating transformed datasets
+                       that are used by subsequent steps for estimator training and model
+                       performance evaluation.
+
+                     - ``"train"``: uses the transformed training dataset output from the
+                       **transform** step to fit an estimator with the type and parameters defined
+                       in in the pipeline's ``steps/train.py`` file. Then, joins the estimator with
+                       the fitted transformer output from the **transform** step to create a model
+                       pipeline. Finally, evaluates the model pipeline against the transformed
+                       training and validation datasets to compute performance metrics.
+
+                     - ``"evaluate"``: evaluates the model pipeline created by the **train** step
+                       on the validation and test dataset outputs from the **split** step, computing
+                       performance metrics and model explanations. Then, compares performance
+                       metrics against thresholds configured in the pipeline's ``pipeline.yaml``
+                       configuration file to compute a ``model_validation_status``, which indicates
+                       whether or not the model is good enough to be registered to the MLflow Model
+                       Registry by the subsequent **register** step.
+
+                     - ``"register"``: checks the ``model_validation_status`` output of the
+                       preceding **evaluate** step and, if model validation was successful (as
+                       indicated by the ``'VALIDATED'`` status), registers the model pipeline
+                       created by the **train** step to the MLflow Model Registry.
+
+                     - ``"predict"``: uses the ingested dataset for scoring created by the
+                       **ingest_scoring** step and applies the specified model to the dataset.
+
+        .. code-block:: python
+            :caption: Example
+
+            import os
+            from mlflow.pipelines import Pipeline
+
+            os.chdir("~/mlp-classification-template")
+            classification_pipeline = Pipeline(profile="local")
+            # Run the 'train' step and preceding steps
+            classification_pipeline.run(step="train")
+            # Run the 'register' step and preceding steps; the 'train' step and all steps
+            # prior to 'train' are not re-executed because their outputs are already cached
+            classification_pipeline.run(step="register")
+            # Run all pipeline steps; equivalent to running 'register'; no steps are re-executed
+            # because the outputs of all steps are already cached
+            classification_pipeline.run()
+        """
+        return super().run(step=step)
+
+    @experimental
+    def get_artifact(self, artifact_name: str) -> Optional[Any]:
+        """
+        Reads an artifact from the pipeline's outputs. Supported artifact names can be obtained by
+        examining the pipeline graph visualization displayed by
+        :py:func:`ClassificationPipeline.inspect()`.
+
+        :param artifact_name: The string name of the artifact. Supported artifact values are:
+
+                         - ``"ingested_data"``: returns the ingested dataset created in the
+                           **ingest** step as a pandas DataFrame.
+
+                         - ``"training_data"``: returns the training dataset created in the
+                           **split** step as a pandas DataFrame.
+
+                         - ``"validation_data"``: returns the validation dataset created in the
+                           **split** step as a pandas DataFrame.
+
+                         - ``"test_data"``: returns the test dataset created in the **split** step
+                           as a pandas DataFrame.
+
+                         - ``"ingested_scoring_data"``: returns the scoring dataset created in the
+                           **ingest_scoring** step as a pandas DataFrame.
+
+                         - ``"transformed_training_data"``: returns the transformed training dataset
+                           created in the **transform** step as a pandas DataFrame.
+
+                         - ``"transformed_validation_data"``: returns the transformed validation
+                           dataset created in the **transform** step as a pandas DataFrame.
+
+                         - ``"model"``: returns the MLflow Model pipeline created in the **train**
+                           step as a :py:class:`PyFuncModel <mlflow.pyfunc.PyFuncModel>` instance.
+
+                         - ``"transformer"``: returns the scikit-learn transformer created in the
+                           **transform** step.
+
+                         - ``"run"``: returns the
+                           :py:class:`MLflow Tracking Run <mlflow.entities.Run>` containing the
+                           model pipeline created in the **train** step and its associated
+                           parameters, as well as performance metrics and model explanations created
+                           during the **train** and **evaluate** steps.
+
+                         - ``"registered_model_version``": returns the MLflow Model Registry
+                           :py:class:`ModelVersion <mlflow.entities.model_registry.ModelVersion>`
+                           created by the **register** step.
+
+                         - ``"scored_data"``: returns the scored dataset created in the
+                           **predict** step as a pandas DataFrame.
+
+        :return: An object representation of the artifact corresponding to the specified name,
+                 as described in the ``artifact_name`` parameter docstring. If the artifact is
+                 not present because its corresponding step has not been executed or its output
+                 cache has been cleaned, ``None`` is returned.
+
+        .. code-block:: python
+            :caption: Example
+
+            import os
+            import pandas as pd
+            from mlflow.pipelines import Pipeline
+            from mlflow.pyfunc import PyFuncModel
+
+            os.chdir("~/mlp-classification-template")
+            classification_pipeline = Pipeline(profile="local")
+            classification_pipeline.run()
+            train_df: pd.DataFrame = classification_pipeline.get_artifact("training_data")
+            trained_model: PyFuncModel = classification_pipeline.get_artifact("model")
+        """
+        return super().get_artifact(artifact_name=artifact_name)
+
+    def clean(self, step: str = None) -> None:
+        """
+        Removes all pipeline outputs from the cache, or removes the cached outputs of a particular
+        pipeline step if specified. After cached outputs are cleaned for a particular step, the
+        step will be re-executed in its entirety the next time it is run.
+
+        :param step: String name of the step to clean within the pipeline. If not specified,
+                     cached outputs are removed for all pipeline steps.
+
+        .. code-block:: python
+            :caption: Example
+
+            import os
+            from mlflow.pipelines import Pipeline
+
+            os.chdir("~/mlp-classification-template")
+            classification_pipeline = Pipeline(profile="local")
+            # Run the 'train' step and preceding steps
+            classification_pipeline.run(step="train")
+            # Clean the cache of the 'transform' step
+            classification_pipeline.clean(step="transform")
+            # Run the 'split' step; outputs are still cached because 'split' precedes
+            # 'transform' & 'train'
+            classification_pipeline.run(step="split")
+            # Run the 'train' step again; the 'transform' and 'train' steps are re-executed because:
+            # 1. the cache of the preceding 'transform' step was cleaned and 2. 'train' occurs after
+            # 'transform'. The 'ingest' and 'split' steps are not re-executed because their outputs
+            # are still cached
+            classification_pipeline.run(step="train")
+        """
+        super().clean(step=step)
+
+    def inspect(self, step: str = None) -> None:
+        """
+        Displays a visual overview of the pipeline graph, or displays a summary of results from
+        a particular pipeline step if specified. If the specified step has not been executed,
+        nothing is displayed.
+
+        :param step: String name of the pipeline step for which to display a results summary. If
+                     unspecified, a visual overview of the pipeline graph is displayed.
+
+        .. code-block:: python
+            :caption: Example
+
+            import os
+            from mlflow.pipelines import Pipeline
+
+            os.chdir("~/mlp-classification-template")
+            classification_pipeline = Pipeline(profile="local")
+            # Display a visual overview of the pipeline graph.
+            classification_pipeline.inspect()
+            # Run the 'train' pipeline step
+            classification_pipeline.run(step="train")
+            # Display a summary of results from the preceding 'transform' step
+            classification_pipeline.inspect(step="transform")
+        """
+        super().inspect(step=step)

--- a/mlflow/pipelines/pipeline.py
+++ b/mlflow/pipelines/pipeline.py
@@ -21,7 +21,7 @@ from mlflow.pipelines.utils.step import display_html
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, INTERNAL_ERROR, BAD_REQUEST
 from mlflow.utils.annotations import experimental
 from mlflow.utils.class_utils import _get_class_from_string
-from typing import List
+from typing import List, Union
 
 _logger = logging.getLogger(__name__)
 
@@ -355,6 +355,7 @@ class _BasePipeline:
         )
 
 
+from mlflow.pipelines.classification.v1.pipeline import ClassificationPipeline
 from mlflow.pipelines.regression.v1.pipeline import RegressionPipeline
 
 
@@ -377,7 +378,7 @@ class Pipeline:
     """
 
     @experimental
-    def __new__(cls, profile: str) -> RegressionPipeline:
+    def __new__(cls, profile: str) -> Union[RegressionPipeline, ClassificationPipeline]:
         """
         Creates an instance of an MLflow Pipeline for a particular ML problem or MLOps task based
         on the current working directory and supplied configuration. The current working directory

--- a/mlflow/pipelines/steps/evaluate.py
+++ b/mlflow/pipelines/steps/evaluate.py
@@ -60,6 +60,12 @@ class EvaluateStep(BaseStep):
                 "Missing template_name config in pipeline config.",
                 error_code=INVALID_PARAMETER_VALUE,
             )
+        if "positive_class" not in self.step_config and self.template == "classification/v1":
+            raise MlflowException(
+                "`positive_class` must be specified for classification/v1 templates.",
+                error_code=INVALID_PARAMETER_VALUE,
+            )
+        self.positive_class = self.step_config.get("positive_class")
         self.model_validation_status = "UNKNOWN"
         self.primary_metric = _get_primary_metric(self.step_config)
         self.user_defined_custom_metrics = {
@@ -187,9 +193,17 @@ class EvaluateStep(BaseStep):
                     (
                         "validation",
                         validation_df,
-                        {"explainability_algorithm": "kernel", "explainability_nsamples": 10},
+                        {
+                            "explainability_algorithm": "kernel",
+                            "explainability_nsamples": 10,
+                            "pos_label": self.positive_class,
+                        },
                     ),
-                    ("test", test_df, {"log_model_explainability": False}),
+                    (
+                        "test",
+                        test_df,
+                        {"log_model_explainability": False, "pos_label": self.positive_class},
+                    ),
                 ):
                     eval_result = mlflow.evaluate(
                         model=model_uri,
@@ -378,6 +392,8 @@ class EvaluateStep(BaseStep):
         if pipeline_config.get("steps", {}).get("evaluate", {}) is not None:
             step_config.update(pipeline_config.get("steps", {}).get("evaluate", {}))
         step_config["target_col"] = pipeline_config.get("target_col")
+        if "positive_class" in pipeline_config:
+            step_config["positive_class"] = pipeline_config.get("positive_class")
         step_config["metrics"] = pipeline_config.get("metrics")
         step_config["template_name"] = pipeline_config.get("template")
         step_config.update(

--- a/mlflow/pipelines/steps/ingest/__init__.py
+++ b/mlflow/pipelines/steps/ingest/__init__.py
@@ -40,11 +40,6 @@ class BaseIngestStep(BaseStep, metaclass=abc.ABCMeta):
     ]
 
     def _validate_and_apply_step_config(self):
-        if len(self.step_config) == 0:
-            raise MlflowException(
-                message="The `data` section of pipeline.yaml must be specified",
-                error_code=INVALID_PARAMETER_VALUE,
-            )
         dataset_format = self.step_config.get("format")
         if not dataset_format:
             raise MlflowException(
@@ -54,6 +49,22 @@ class BaseIngestStep(BaseStep, metaclass=abc.ABCMeta):
                 ),
                 error_code=INVALID_PARAMETER_VALUE,
             )
+        if self.step_class() == StepClass.TRAINING:
+            self.target_col = self.step_config.get("target_col")
+            if self.target_col is None:
+                raise MlflowException(
+                    "Missing target_col config in pipeline config.",
+                    error_code=INVALID_PARAMETER_VALUE,
+                )
+            if (
+                "positive_class" not in self.step_config
+                and self.step_config["template_name"] == "classification/v1"
+            ):
+                raise MlflowException(
+                    "`positive_class` must be specified for classification/v1 templates.",
+                    error_code=INVALID_PARAMETER_VALUE,
+                )
+            self.positive_class = self.step_config.get("positive_class")
         for dataset_class in BaseIngestStep._SUPPORTED_DATASETS:
             if dataset_class.handles_format(dataset_format):
                 self.dataset = dataset_class.from_config(
@@ -77,6 +88,21 @@ class BaseIngestStep(BaseStep, metaclass=abc.ABCMeta):
         _logger.debug("Successfully stored data in parquet format at '%s'", dataset_dst_path)
 
         ingested_df = read_parquet_as_pandas_df(data_parquet_path=dataset_dst_path)
+        if self.step_class() == StepClass.TRAINING:
+            if self.target_col not in ingested_df.columns:
+                raise MlflowException(
+                    f"Target column '{self.target_col}' not found in ingested dataset.",
+                    error_code=INVALID_PARAMETER_VALUE,
+                )
+            if self.positive_class is not None:
+                cardinality = ingested_df[self.target_col].nunique()
+                if cardinality != 2:
+                    raise MlflowException(
+                        f"Target column '{self.target_col}' must have a cardinality of 2,"
+                        f"found '{cardinality}'.",
+                        error_code=INVALID_PARAMETER_VALUE,
+                    )
+
         ingested_dataset_profile = None
         if not self.skip_data_profiling:
             _logger.debug("Profiling ingested dataset")
@@ -186,8 +212,16 @@ class IngestStep(BaseIngestStep):
     def from_pipeline_config(cls, pipeline_config: Dict[str, Any], pipeline_root: str):
         data_config = pipeline_config.get("data", {})
         ingest_config = pipeline_config.get("steps", {}).get("ingest", {})
+        target_config = {"target_col": pipeline_config.get("target_col")}
+        if "positive_class" in pipeline_config:
+            target_config["positive_class"] = pipeline_config.get("positive_class")
         return cls(
-            step_config={**data_config, **ingest_config},
+            step_config={
+                **data_config,
+                **ingest_config,
+                **target_config,
+                **{"template_name": pipeline_config.get("template")},
+            },
             pipeline_root=pipeline_root,
         )
 

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -135,6 +135,12 @@ class TrainStep(BaseStep):
                 "Missing template_name config in pipeline config.",
                 error_code=INVALID_PARAMETER_VALUE,
             )
+        if "positive_class" not in self.step_config and self.template == "classification/v1":
+            raise MlflowException(
+                "`positive_class` must be specified for classification/v1 templates.",
+                error_code=INVALID_PARAMETER_VALUE,
+            )
+        self.positive_class = self.step_config.get("positive_class")
         self.skip_data_profiling = self.step_config.get("skip_data_profiling", False)
         if (
             "estimator_method" not in self.step_config
@@ -330,6 +336,7 @@ class TrainStep(BaseStep):
                         ),
                         evaluator_config={
                             "log_model_explainability": False,
+                            "pos_label": self.positive_class,
                         },
                     )
                     eval_result.save(os.path.join(output_directory, f"eval_{dataset_name}"))
@@ -806,6 +813,8 @@ class TrainStep(BaseStep):
         step_config["template_name"] = pipeline_config.get("template")
         step_config["profile"] = pipeline_config.get("profile")
         step_config["target_col"] = pipeline_config.get("target_col")
+        if "positive_class" in pipeline_config:
+            step_config["positive_class"] = pipeline_config.get("positive_class")
         step_config.update(
             get_pipeline_tracking_config(
                 pipeline_root_path=pipeline_root,

--- a/mlflow/pipelines/utils/execution.py
+++ b/mlflow/pipelines/utils/execution.py
@@ -398,8 +398,8 @@ def _create_makefile(pipeline_root_path, execution_directory_path, template) -> 
     """
     makefile_path = os.path.join(execution_directory_path, "Makefile")
 
-    if template == "regression/v1":
-        makefile_to_use = _REGRESSION_MAKEFILE_FORMAT_STRING
+    if template == "regression/v1" or template == "classification/v1":
+        makefile_to_use = _MAKEFILE_FORMAT_STRING
         steps_folder_path = os.path.join(pipeline_root_path, "steps")
         if not os.path.exists(steps_folder_path):
             os.mkdir(steps_folder_path)
@@ -514,7 +514,7 @@ class _MakefilePathFormat:
 # Makefile contents for cache-aware pipeline execution. These contents include variable placeholders
 # that need to be formatted (substituted) with the pipeline root directory in order to produce a
 # valid Makefile
-_REGRESSION_MAKEFILE_FORMAT_STRING = r"""
+_MAKEFILE_FORMAT_STRING = r"""
 # Define `ingest` as a target with no dependencies to ensure that it runs whenever a user explicitly
 # invokes the MLflow Pipelines ingest step, allowing them to reingest data on-demand
 ingest:

--- a/mlflow/pipelines/utils/metrics.py
+++ b/mlflow/pipelines/utils/metrics.py
@@ -41,13 +41,10 @@ BUILTIN_CLASSIFICATION_PIPELINE_METRICS = [
     PipelineMetric(name="false_positives", greater_is_better=False),
     PipelineMetric(name="false_negatives", greater_is_better=False),
     PipelineMetric(name="true_positives", greater_is_better=True),
-    PipelineMetric(name="recall", greater_is_better=True),
-    PipelineMetric(name="precision", greater_is_better=True),
+    PipelineMetric(name="recall_score", greater_is_better=True),
+    PipelineMetric(name="precision_score", greater_is_better=True),
     PipelineMetric(name="f1_score", greater_is_better=True),
     PipelineMetric(name="accuracy_score", greater_is_better=True),
-    PipelineMetric(name="log_loss", greater_is_better=False),
-    PipelineMetric(name="roc_auc", greater_is_better=True),
-    PipelineMetric(name="precision_recall_auc", greater_is_better=True),
 ]
 
 BUILTIN_REGRESSION_PIPELINE_METRICS = [
@@ -66,6 +63,8 @@ def _get_error_fn(tmpl: str):
     """
     if tmpl == "regression/v1":
         return lambda predictions, targets: predictions - targets
+    if tmpl == "classification/v1":
+        return lambda predictions, targets: predictions != targets
     raise MlflowException(
         f"No error function for template kind {tmpl}",
         error_code=INVALID_PARAMETER_VALUE,
@@ -79,6 +78,8 @@ def _get_model_type_from_template(tmpl: str) -> str:
     """
     if tmpl == "regression/v1":
         return "regressor"
+    if tmpl == "classification/v1":
+        return "classifier"
     raise MlflowException(
         f"No model type for template kind {tmpl}",
         error_code=INVALID_PARAMETER_VALUE,

--- a/tests/pipelines/test_execution_utils.py
+++ b/tests/pipelines/test_execution_utils.py
@@ -51,10 +51,11 @@ def test_pipeline(
     pandas_df.to_parquet(dataset_path)
     ingest_step = IngestStep.from_pipeline_config(
         pipeline_config={
+            "target_col": "C",
             "data": {
                 "format": "parquet",
                 "location": str(dataset_path),
-            }
+            },
         },
         pipeline_root=os.getcwd(),
     )
@@ -321,10 +322,11 @@ def test_run_pipeline_step_maintains_execution_status_correctly(pandas_df, tmp_p
 
     ingest_step_good = IngestStep.from_pipeline_config(
         pipeline_config={
+            "target_col": "C",
             "data": {
                 "format": "parquet",
                 "location": str(dataset_path),
-            }
+            },
         },
         pipeline_root=os.getcwd(),
     )
@@ -340,10 +342,11 @@ def test_run_pipeline_step_maintains_execution_status_correctly(pandas_df, tmp_p
 
     ingest_step_bad = IngestStep.from_pipeline_config(
         pipeline_config={
+            "target_col": "C",
             "data": {
                 "format": "parquet",
                 "location": "badlocation",
-            }
+            },
         },
         pipeline_root=os.getcwd(),
     )
@@ -364,10 +367,11 @@ def test_run_pipeline_step_returns_expected_result(test_pipeline):
 
     ingest_step_bad = IngestStep.from_pipeline_config(
         pipeline_config={
+            "target_col": "C",
             "data": {
                 "format": "parquet",
                 "location": "badlocation",
-            }
+            },
         },
         pipeline_root=os.getcwd(),
     )
@@ -522,10 +526,11 @@ def test_run_pipeline_step_failure_clears_downstream_step_state(test_pipeline):
 
     ingest_step_bad = IngestStep.from_pipeline_config(
         pipeline_config={
+            "target_col": "C",
             "data": {
                 "format": "parquet",
                 "location": "badlocation",
-            }
+            },
         },
         pipeline_root=os.getcwd(),
     )

--- a/tests/pipelines/test_ingest_step.py
+++ b/tests/pipelines/test_ingest_step.py
@@ -80,10 +80,11 @@ def test_ingests_parquet_successfully(use_relative_path, multiple_files, pandas_
 
     IngestStep.from_pipeline_config(
         pipeline_config={
+            "target_col": "C",
             "data": {
                 "format": "parquet",
                 "location": str(dataset_path),
-            }
+            },
         },
         pipeline_root=os.getcwd(),
     ).run(output_directory=tmp_path)
@@ -124,11 +125,12 @@ def test_ingests_csv_successfully(
 
     IngestStep.from_pipeline_config(
         pipeline_config={
+            "target_col": "C",
             "data": {
                 "format": "csv",
                 "location": dataset_path,
                 "custom_loader_method": "steps.ingest.load_file_as_dataframe",
-            }
+            },
         },
         pipeline_root=os.getcwd(),
     ).run(output_directory=tmp_path)
@@ -145,6 +147,7 @@ def custom_load_wine_csv(file_path, file_format):  # pylint: disable=unused-argu
 def test_ingests_remote_http_datasets_with_multiple_files_successfully(tmp_path):
     IngestStep.from_pipeline_config(
         pipeline_config={
+            "target_col": "density",
             "data": {
                 "format": "csv",
                 "location": [
@@ -185,13 +188,14 @@ def test_ingests_custom_format_successfully(use_relative_path, multiple_files, p
 
     IngestStep.from_pipeline_config(
         pipeline_config={
+            "target_col": "C",
             "data": {
                 "format": "fooformat",
                 "location": str(dataset_path),
                 "custom_loader_method": (
                     "tests.pipelines.test_ingest_step.custom_load_file_as_dataframe"
                 ),
-            }
+            },
         },
         pipeline_root=os.getcwd(),
     ).run(output_directory=tmp_path)
@@ -210,11 +214,12 @@ def test_ingest_throws_for_custom_dataset_when_custom_loader_function_cannot_be_
     with pytest.raises(MlflowException, match="Failed to import custom dataset loader function"):
         IngestStep.from_pipeline_config(
             pipeline_config={
+                "target_col": "C",
                 "data": {
                     "format": "fooformat",
                     "location": str(dataset_path),
                     "custom_loader_method": "non.existent.module.non.existent.method",
-                }
+                },
             },
             pipeline_root=os.getcwd(),
         ).run(output_directory=tmp_path)
@@ -232,11 +237,12 @@ def test_ingest_throws_for_custom_dataset_when_custom_loader_function_not_implem
     ):
         IngestStep.from_pipeline_config(
             pipeline_config={
+                "target_col": "C",
                 "data": {
                     "format": "fooformat",
                     "location": str(dataset_path),
                     "custom_loader_method": "steps.ingest.load_file_as_dataframe",
-                }
+                },
             },
             pipeline_root=os.getcwd(),
         ).run(output_directory=tmp_path)
@@ -254,13 +260,14 @@ def test_ingest_throws_for_custom_dataset_when_custom_method_returns_array(panda
     with pytest.raises(MlflowException, match="The `ingested_data` is not a DataFrame"):
         IngestStep.from_pipeline_config(
             pipeline_config={
+                "target_col": "C",
                 "data": {
                     "format": "fooformat",
                     "location": str(dataset_path),
                     "custom_loader_method": (
                         "tests.pipelines.test_ingest_step.custom_load_file_as_array"
                     ),
-                }
+                },
             },
             pipeline_root=os.getcwd(),
         ).run(output_directory=tmp_path)
@@ -283,13 +290,14 @@ def test_ingest_throws_for_custom_dataset_when_custom_loader_function_throws_une
         ):
             IngestStep.from_pipeline_config(
                 pipeline_config={
+                    "target_col": "C",
                     "data": {
                         "format": "fooformat",
                         "location": str(dataset_path),
                         "custom_loader_method": (
                             "tests.pipelines.test_ingest_step.custom_load_file_as_dataframe"
                         ),
-                    }
+                    },
                 },
                 pipeline_root=os.getcwd(),
             ).run(output_directory=tmp_path)
@@ -303,10 +311,11 @@ def test_ingests_remote_s3_datasets_successfully(mock_s3_bucket, pandas_df, tmp_
 
     IngestStep.from_pipeline_config(
         pipeline_config={
+            "target_col": "C",
             "data": {
                 "format": "parquet",
                 "location": f"s3://{mock_s3_bucket}/df.parquet",
-            }
+            },
         },
         pipeline_root=os.getcwd(),
     ).run(output_directory=tmp_path)
@@ -320,11 +329,12 @@ def test_ingests_remote_http_datasets_successfully(tmp_path):
     dataset_url = "https://raw.githubusercontent.com/mlflow/mlflow/594a08f2a49c5754bb65d76cd719c15c5b8266e9/examples/sklearn_elasticnet_wine/wine-quality.csv"
     IngestStep.from_pipeline_config(
         pipeline_config={
+            "target_col": "density",
             "data": {
                 "format": "csv",
                 "location": dataset_url,
                 "custom_loader_method": "steps.ingest.load_file_as_dataframe",
-            }
+            },
         },
         pipeline_root=os.getcwd(),
     ).run(output_directory=tmp_path)
@@ -339,10 +349,11 @@ def test_ingests_spark_sql_successfully(spark_df, tmp_path):
 
     IngestStep.from_pipeline_config(
         pipeline_config={
+            "target_col": "label",
             "data": {
                 "format": "spark_sql",
                 "sql": "SELECT * FROM test_table ORDER BY id",
-            }
+            },
         },
         pipeline_root=os.getcwd(),
     ).run(output_directory=tmp_path)
@@ -365,7 +376,10 @@ def test_ingests_spark_sql_location_successfully(spark_df, tmp_path):
     spark_df.write.mode("overwrite").saveAsTable("test_table")
 
     IngestStep.from_pipeline_config(
-        pipeline_config={"data": {"format": "spark_sql", "location": "test_table"}},
+        pipeline_config={
+            "target_col": "label",
+            "data": {"format": "spark_sql", "location": "test_table"},
+        },
         pipeline_root=os.getcwd(),
     ).run(output_directory=tmp_path)
 
@@ -392,10 +406,11 @@ def test_ingests_delta_successfully(use_relative_path, spark_df, tmp_path):
 
     IngestStep.from_pipeline_config(
         pipeline_config={
+            "target_col": "label",
             "data": {
                 "format": "delta",
                 "location": str(dataset_path),
-            }
+            },
         },
         pipeline_root=os.getcwd(),
     ).run(output_directory=tmp_path)
@@ -429,11 +444,12 @@ def test_ingests_delta_with_table_version_successfully(spark_session, spark_df, 
 
     IngestStep.from_pipeline_config(
         pipeline_config={
+            "target_col": "label",
             "data": {
                 "format": "delta",
                 "location": str(dataset_path),
                 "version": version,
-            }
+            },
         },
         pipeline_root=os.getcwd(),
     ).run(output_directory=tmp_path)
@@ -483,11 +499,12 @@ def test_ingests_delta_with_timestamp_successfully(
 
     IngestStep.from_pipeline_config(
         pipeline_config={
+            "target_col": "label",
             "data": {
                 "format": "delta",
                 "location": str(dataset_path),
                 "timestamp": timestamps[timestamp_idx],
-            }
+            },
         },
         pipeline_root=os.getcwd(),
     ).run(output_directory=tmp_path)
@@ -521,10 +538,11 @@ def test_ingest_directory_ignores_files_that_do_not_match_dataset_format(pandas_
 
     IngestStep.from_pipeline_config(
         pipeline_config={
+            "target_col": "C",
             "data": {
                 "format": "parquet",
                 "location": str(dataset_path),
-            }
+            },
         },
         pipeline_root=os.getcwd(),
     ).run(output_directory=tmp_path)
@@ -540,10 +558,11 @@ def test_ingest_produces_expected_step_card(pandas_df, tmp_path):
 
     IngestStep.from_pipeline_config(
         pipeline_config={
+            "target_col": "C",
             "data": {
                 "format": "parquet",
                 "location": str(dataset_path),
-            }
+            },
         },
         pipeline_root=os.getcwd(),
     ).run(output_directory=tmp_path)
@@ -572,10 +591,11 @@ def test_ingest_throws_when_spark_unavailable_for_spark_based_dataset(spark_df, 
     ):
         IngestStep.from_pipeline_config(
             pipeline_config={
+                "target_col": "C",
                 "data": {
                     "format": "delta",
                     "location": str(dataset_path),
-                }
+                },
             },
             pipeline_root=os.getcwd(),
         ).run(output_directory=tmp_path)
@@ -592,10 +612,11 @@ def test_ingest_makes_spark_session_if_not_available_for_spark_based_dataset(spa
         _get_active_spark_session.return_value = None
         IngestStep.from_pipeline_config(
             pipeline_config={
+                "target_col": "label",
                 "data": {
                     "format": "delta",
                     "location": str(dataset_path),
-                }
+                },
             },
             pipeline_root=os.getcwd(),
         ).run(output_directory=tmp_path)
@@ -605,9 +626,10 @@ def test_ingest_makes_spark_session_if_not_available_for_spark_based_dataset(spa
 def test_ingest_throws_when_dataset_format_unspecified():
     ingest_step = IngestStep.from_pipeline_config(
         pipeline_config={
+            "target_col": "C",
             "data": {
                 "location": "my_location",
-            }
+            },
         },
         pipeline_root=os.getcwd(),
     )
@@ -621,7 +643,7 @@ def test_ingest_throws_when_data_section_unspecified():
         pipeline_config={},
         pipeline_root=os.getcwd(),
     )
-    with pytest.raises(MlflowException, match="The `data` section.*must be specified"):
+    with pytest.raises(MlflowException, match="Dataset format must be specified"):
         ingest_step._validate_and_apply_step_config()
 
 
@@ -629,10 +651,11 @@ def test_ingest_throws_when_data_section_unspecified():
 def test_ingest_throws_when_required_dataset_config_keys_are_missing():
     ingest_step = IngestStep.from_pipeline_config(
         pipeline_config={
+            "target_col": "C",
             "data": {
                 "format": "parquet",
                 # Missing location
-            }
+            },
         },
         pipeline_root=os.getcwd(),
     )
@@ -641,10 +664,11 @@ def test_ingest_throws_when_required_dataset_config_keys_are_missing():
 
     ingest_step = IngestStep.from_pipeline_config(
         pipeline_config={
+            "target_col": "C",
             "data": {
                 "format": "spark_sql",
                 # Missing sql and location
-            }
+            },
         },
         pipeline_root=os.getcwd(),
     )
@@ -659,11 +683,12 @@ def test_ingest_throws_when_required_dataset_config_keys_are_missing():
 
     ingest_step = IngestStep.from_pipeline_config(
         pipeline_config={
+            "target_col": "C",
             "data": {
                 "format": "csv",
                 "location": "my/dataset.csv",
                 # Missing custom_loader_method
-            }
+            },
         },
         pipeline_root=os.getcwd(),
     )
@@ -683,11 +708,12 @@ def test_ingest_throws_when_dataset_files_have_wrong_format(pandas_df, tmp_path)
     ):
         IngestStep.from_pipeline_config(
             pipeline_config={
+                "target_col": "C",
                 "data": {
                     # Intentionally use an incorrect format that doesn't match the dataset
                     "format": "parquet",
                     "location": str(dataset_path),
-                }
+                },
             },
             pipeline_root=os.getcwd(),
         ).run(output_directory=tmp_path)
@@ -704,11 +730,12 @@ def test_ingest_throws_when_dataset_files_have_wrong_format(pandas_df, tmp_path)
     ):
         IngestStep.from_pipeline_config(
             pipeline_config={
+                "target_col": "C",
                 "data": {
                     # Intentionally use an incorrect format that doesn't match the dataset
                     "format": "parquet",
                     "location": str(dataset_path),
-                }
+                },
             },
             pipeline_root=os.getcwd(),
         ).run(output_directory=tmp_path)
@@ -722,6 +749,7 @@ def test_ingest_skips_profiling_when_specified(pandas_df, tmp_path):
     with mock.patch("mlflow.pipelines.utils.step.get_pandas_data_profiles") as mock_profiling:
         IngestStep.from_pipeline_config(
             pipeline_config={
+                "target_col": "C",
                 "data": {
                     "format": "parquet",
                     "location": str(dataset_path),

--- a/tests/pipelines/test_pipeline.py
+++ b/tests/pipelines/test_pipeline.py
@@ -17,7 +17,7 @@ from mlflow.pipelines.step import BaseStep
 from mlflow.pipelines.utils.execution import (
     get_step_output_path,
     _get_execution_directory_basename,
-    _REGRESSION_MAKEFILE_FORMAT_STRING,
+    _MAKEFILE_FORMAT_STRING,
 )
 from mlflow.tracking.client import MlflowClient
 from mlflow.tracking.context.registry import resolve_tags
@@ -338,9 +338,9 @@ def test_print_cached_steps_and_running_steps(capsys):
 
 @pytest.mark.usefixtures("enter_pipeline_example_directory")
 def test_make_dry_run_error_does_not_print_cached_steps_messages(capsys):
-    malformed_makefile = _REGRESSION_MAKEFILE_FORMAT_STRING + "non_existing_cmd"
+    malformed_makefile = _MAKEFILE_FORMAT_STRING + "non_existing_cmd"
     with mock.patch(
-        "mlflow.pipelines.utils.execution._REGRESSION_MAKEFILE_FORMAT_STRING",
+        "mlflow.pipelines.utils.execution._MAKEFILE_FORMAT_STRING",
         new=malformed_makefile,
     ):
         p = Pipeline(profile="local")
@@ -362,13 +362,13 @@ def test_make_dry_run_error_does_not_print_cached_steps_messages(capsys):
 @pytest.mark.usefixtures("enter_pipeline_example_directory")
 def test_makefile_with_runtime_error_print_cached_steps_messages(capsys):
     split = "# Run MLP step: split"
-    tokens = _REGRESSION_MAKEFILE_FORMAT_STRING.split(split)
+    tokens = _MAKEFILE_FORMAT_STRING.split(split)
     assert len(tokens) == 2
     tokens[1] = "\n\tnon-existing-cmd" + tokens[1]
     malformed_makefile_rte = split.join(tokens)
 
     with mock.patch(
-        "mlflow.pipelines.utils.execution._REGRESSION_MAKEFILE_FORMAT_STRING",
+        "mlflow.pipelines.utils.execution._MAKEFILE_FORMAT_STRING",
         new=malformed_makefile_rte,
     ):
         p = Pipeline(profile="local")


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## What changes are proposed in this pull request?

This PR introduces a pipeline implementation for building classification models and updates associated utility methods that perform logic conditioned on the template type. Note that the classification pipeline implementation is currently identical to the regression pipeline implementation, this is expected to change as we add additional facilities such as a rebalancing step. A few other notes:
- This PR also adds support for declaring the `positive_class` and threads this value through the mlflow evaluation service.
- This PR updates builtin metrics name which are inconsistent with the metrics supported by the mlflow evaluation service. I _think_ the [docs](https://www.mlflow.org/docs/latest/python_api/mlflow.html) may need to be updated.
- The worst_examples function doesn't work that well, the current error function returns True if the prediction is correct and false otherwise (rather than using the probability of the prediction to compute the error). I think this is OK for the first version in the interest of getting customer feedback ASAP, but please challenge me on this!

Importantly, I have not disabled this behind a feature flag, users will be able to build classification pipelines once this is released. If reviewers would prefer to disable this until we have a template + example repo, I'd be happy to do so.

## How is this patch tested?

Locally + Databricks using the Iris dataset.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
