### PR TITLE
Augment predict step to read register step model version output

### DIFF
--- a/mlflow/pipelines/dag_help_strings.py
+++ b/mlflow/pipelines/dag_help_strings.py
@@ -262,7 +262,7 @@ INGESTED_SCORING_DATA = format_help_string(
 )
 
 PREDICT_STEP = format_help_string(
-    """The 'predict' step uses the model registered by the 'register' step to score the ingested dataset produced by the 'ingest_scoring' step and writes the resulting dataset to the specified output format and location. Namely, it uses the latest version of the registered model specified by the `model_name` attribute of the pipeline.yaml 'register' step definition. To fix a specific model for use in the 'predict' step, provide its model URI as the 'model_uri' attribute of the pipeline.yaml 'predict' step definition. An example pipeline.yaml 'predict' step definition is shown below.
+    """The 'predict' step uses the model registered by the 'register' step to score the ingested dataset produced by the 'ingest_scoring' step and writes the resulting dataset to the specified output format and location. To get model for scoring, it reads the register step model version artifact. If the register step was cleared, it uses the latest version of the registered model specified by the `model_name` attribute of the pipeline.yaml 'register' step definition. To fix a specific model for use in the 'predict' step, provide its model URI as the 'model_uri' attribute of the pipeline.yaml 'predict' step definition. An example pipeline.yaml 'predict' step definition is shown below.
 steps:
   predict:
     model_uri: "models:/taxi_fare_regressor/Production" # optional

--- a/mlflow/pipelines/steps/register.py
+++ b/mlflow/pipelines/steps/register.py
@@ -23,6 +23,8 @@ from mlflow.utils.mlflow_tags import MLFLOW_SOURCE_TYPE, MLFLOW_PIPELINE_TEMPLAT
 
 _logger = logging.getLogger(__name__)
 
+_REGISTERED_MV_INFO_FILE = "registered_model_version.json"
+
 
 class RegisterStep(BaseStep):
     def __init__(self, step_config: Dict[str, Any], pipeline_root: str):
@@ -85,7 +87,7 @@ class RegisterStep(BaseStep):
                 name=self.register_model_name, version=self.version
             )
             registered_model_info.to_json(
-                path=str(Path(output_directory) / "registered_model_version.json")
+                path=str(Path(output_directory) / _REGISTERED_MV_INFO_FILE)
             )
         else:
             raise MlflowException(

--- a/tests/pipelines/helper_functions.py
+++ b/tests/pipelines/helper_functions.py
@@ -69,15 +69,8 @@ def train_and_log_model(is_dummy=False):
 def train_log_and_register_model(model_name, is_dummy=False):
     run_id, _ = train_and_log_model(is_dummy)
     runs_uri = "runs:/{}/train/model".format(run_id)
-    model_version = mlflow.register_model(runs_uri, model_name)
-    client = mlflow.tracking.MlflowClient()
-    client.transition_model_version_stage(
-        name=model_name,
-        version=model_version.version,
-        stage="Production",
-        archive_existing_versions=True,
-    )
-    return "models:/{model_name}/Production".format(model_name=model_name)
+    mv = mlflow.register_model(runs_uri, model_name)
+    return f"models:/{mv.name}/{mv.version}"
 
 
 ## Fixtures

--- a/tests/pipelines/test_predict_step.py
+++ b/tests/pipelines/test_predict_step.py
@@ -171,7 +171,7 @@ def test_predict_step_uses_register_step_output(
     train_log_and_register_model(register_step_rm_name, is_dummy=True)
     train_log_and_register_model(register_step_rm_name)
 
-    # Make the first version the output of the register step
+    # Write v1 to the output directory of the register step
     register_step_output_dir = tmp_pipeline_exec_path.joinpath("steps", "register", "outputs")
     register_step_output_dir.mkdir(parents=True)
     registered_model_info = RegisteredModelVersionInfo(name=register_step_rm_name, version=1)

--- a/tests/pipelines/test_predict_step.py
+++ b/tests/pipelines/test_predict_step.py
@@ -9,8 +9,10 @@ from unittest import mock
 
 import mlflow
 from mlflow.exceptions import MlflowException
+from mlflow.pipelines.artifacts import RegisteredModelVersionInfo
 from mlflow.pipelines.utils import _PIPELINE_CONFIG_FILE_NAME
 from mlflow.pipelines.steps.predict import PredictStep, _INPUT_FILE_NAME, _SCORED_OUTPUT_FILE_NAME
+from mlflow.pipelines.steps.register import _REGISTERED_MV_INFO_FILE
 from mlflow.utils.file_utils import read_yaml
 
 # pylint: disable=unused-import
@@ -155,6 +157,45 @@ def test_predict_step_uses_register_step_model_name(
     )
     predict_step.run(str(predict_step_output_dir))
 
+    prediction_assertions(predict_step_output_dir, "parquet", "output", spark_session)
+
+
+def test_predict_step_uses_register_step_output(
+    tmp_pipeline_root_path: Path,
+    tmp_pipeline_exec_path: Path,
+    predict_step_output_dir: Path,
+    spark_session,
+):
+    # Create two versions for a registered_model. v1 is a dummy model. v2 is a normal model.
+    register_step_rm_name = "register_step_model_" + get_random_id()
+    train_log_and_register_model(register_step_rm_name, is_dummy=True)
+    train_log_and_register_model(register_step_rm_name)
+
+    # Make the first version the output of the register step
+    register_step_output_dir = tmp_pipeline_exec_path.joinpath("steps", "register", "outputs")
+    register_step_output_dir.mkdir(parents=True)
+    registered_model_info = RegisteredModelVersionInfo(name=register_step_rm_name, version=1)
+    registered_model_info.to_json(path=str(register_step_output_dir / _REGISTERED_MV_INFO_FILE))
+
+    pipeline_config = read_yaml(tmp_pipeline_root_path, _PIPELINE_CONFIG_FILE_NAME)
+    pipeline_config.update(
+        {
+            "steps": {
+                "register": {"model_name": register_step_rm_name},
+                "predict": {
+                    "output_format": "parquet",
+                    "output_location": str(predict_step_output_dir.joinpath("output.parquet")),
+                },
+            }
+        }
+    )
+    predict_step = PredictStep.from_pipeline_config(
+        pipeline_config,
+        str(tmp_pipeline_root_path),
+    )
+    predict_step.run(str(predict_step_output_dir))
+
+    # These assertions will only pass if the dummy model was used for scoring
     prediction_assertions(predict_step_output_dir, "parquet", "output", spark_session)
 
 

--- a/tests/pipelines/test_register_step.py
+++ b/tests/pipelines/test_register_step.py
@@ -5,7 +5,7 @@ import mlflow
 from mlflow.utils.file_utils import read_yaml
 from mlflow.pipelines.utils import _PIPELINE_CONFIG_FILE_NAME
 from mlflow.pipelines.steps.evaluate import EvaluateStep
-from mlflow.pipelines.steps.register import RegisterStep
+from mlflow.pipelines.steps.register import RegisterStep, _REGISTERED_MV_INFO_FILE
 from mlflow.exceptions import MlflowException
 
 # pylint: disable=unused-import
@@ -96,6 +96,8 @@ def weighted_mean_squared_error(eval_df, builtin_metrics):
         model_validation_status_path = evaluate_step_output_dir.joinpath("model_validation_status")
         assert model_validation_status_path.exists()
         assert model_validation_status_path.read_text() == "VALIDATED"
+        mv_info_file_path = register_step_output_dir.joinpath(_REGISTERED_MV_INFO_FILE)
+        assert mv_info_file_path.exists()
         assert len(mlflow.tracking.MlflowClient().list_registered_models()) == 1
 
 
@@ -139,6 +141,8 @@ steps:
         model_validation_status_path = evaluate_step_output_dir.joinpath("model_validation_status")
         assert model_validation_status_path.exists()
         assert model_validation_status_path.read_text() == "UNKNOWN"
+        mv_info_file_path = register_step_output_dir.joinpath(_REGISTERED_MV_INFO_FILE)
+        assert mv_info_file_path.exists()
         assert len(mlflow.tracking.MlflowClient().list_registered_models()) == 1
 
 


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

As title.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
