### PR TITLE
Upgrade `actions/github-script` to v6

### DIFF
--- a/.github/workflows/autoformat.js
+++ b/.github/workflows/autoformat.js
@@ -2,7 +2,7 @@ const createCommitStatus = async (context, github, sha, state) => {
   const { workflow, runId } = context;
   const { owner, repo } = context.repo;
   const target_url = `https://github.com/${owner}/${repo}/actions/runs/${runId}`;
-  await github.repos.createCommitStatus({
+  await github.rest.repos.createCommitStatus({
     owner,
     repo,
     sha,
@@ -20,7 +20,7 @@ const shouldAutoformat = (comment) => {
 const getPullInformation = async (context, github) => {
   const { owner, repo } = context.repo;
   const pull_number = context.issue.number;
-  const pr = await github.pulls.get({ owner, repo, pull_number });
+  const pr = await github.rest.pulls.get({ owner, repo, pull_number });
   const {
     sha,
     ref,
@@ -37,7 +37,7 @@ const getPullInformation = async (context, github) => {
 const createReaction = async (context, github) => {
   const { owner, repo } = context.repo;
   const { id: comment_id } = context.payload.comment;
-  await github.reactions.createForIssueComment({
+  await github.rest.reactions.createForIssueComment({
     owner,
     repo,
     comment_id,

--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Create status
         id: create-status
-        uses: actions/github-script@v4
+        uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -229,7 +229,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Update status
-        uses: actions/github-script@v4
+        uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/closing-pr.js
+++ b/.github/workflows/closing-pr.js
@@ -68,7 +68,7 @@ module.exports = async ({ context, github }) => {
   const { body } = context.payload.pull_request;
   getIssuesToClose(body).forEach(async (issue_number) => {
     const { owner, repo } = context.repo;
-    await github.issues.addLabels({
+    await github.rest.issues.addLabels({
       owner,
       repo,
       issue_number,

--- a/.github/workflows/closing-pr.yml
+++ b/.github/workflows/closing-pr.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-      - uses: actions/github-script@v4
+      - uses: actions/github-script@v6
         with:
           script: |
             const script = require(

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -65,7 +65,7 @@ jobs:
                 only_latest: false,
               };
             }
-            const labels = await github.issues.listLabelsOnIssue({
+            const labels = await github.rest.issues.listLabelsOnIssue({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -55,7 +55,7 @@ jobs:
           pip install -r dev/requirements.txt
           pip install pytest pytest-cov
       - name: Check labels
-        uses: actions/github-script@v4
+        uses: actions/github-script@v6
         id: check-labels
         with:
           script: |

--- a/.github/workflows/notify-dco-failure.js
+++ b/.github/workflows/notify-dco-failure.js
@@ -13,7 +13,7 @@ module.exports = async ({ context, github }) => {
     const numAttempts = backoffs.length;
     for (const [index, backoff] of backoffs.entries()) {
       await sleep(backoff * 1000);
-      const resp = await github.checks.listForRef({
+      const resp = await github.rest.checks.listForRef({
         owner,
         repo,
         ref,
@@ -39,7 +39,7 @@ module.exports = async ({ context, github }) => {
       "See https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.md#sign-your-work for more ",
       "details.",
     ].join("");
-    await github.issues.createComment({
+    await github.rest.issues.createComment({
       owner,
       repo,
       issue_number,

--- a/.github/workflows/notify-dco-failure.yml
+++ b/.github/workflows/notify-dco-failure.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-      - uses: actions/github-script@v4
+      - uses: actions/github-script@v6
         with:
           script: |
             const script = require(

--- a/.github/workflows/release-note-category.js
+++ b/.github/workflows/release-note-category.js
@@ -12,7 +12,7 @@ module.exports = async ({ core, context, github }) => {
   }
 
   // Fetch release note category labels
-  const labelsForRepoResp = await github.issues.listLabelsForRepo({
+  const labelsForRepoResp = await github.rest.issues.listLabelsForRepo({
     owner,
     repo,
     per_page: 100, // the default value is 30, which is too small to fetch all labels
@@ -29,7 +29,7 @@ module.exports = async ({ core, context, github }) => {
     for (const [index, backoff] of backoffs.entries()) {
       console.log(`Attempt ${index + 1}/${backoffs.length}`);
       await new Promise(r => setTimeout(r, backoff * 1000));
-      const listLabelsOnIssueResp = await github.issues.listLabelsOnIssue({
+      const listLabelsOnIssueResp = await github.rest.issues.listLabelsOnIssue({
         owner,
         repo,
         issue_number,

--- a/.github/workflows/release-note-category.yml
+++ b/.github/workflows/release-note-category.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           submodules: recursive
       - name: Validate
-        uses: actions/github-script@v3
+        uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/test-package-build.yml
+++ b/.github/workflows/test-package-build.yml
@@ -115,7 +115,7 @@ jobs:
           path: ${{ steps.build-dist.outputs.wheel-path }}
 
       - name: Remove old wheels
-        uses: actions/github-script@v3
+        uses: actions/github-script@v6
         if: github.event_name == 'push'
         env:
           WHEEL_SIZE: ${{ steps.build-dist.outputs.wheel-size }}
@@ -125,7 +125,7 @@ jobs:
             const { owner, repo } = context.repo;
 
             // For some reason, the newly-uploaded wheel in the previous step is not included.
-            const artifactsResp = await github.actions.listArtifactsForRepo({
+            const artifactsResp = await github.rest.actions.listArtifactsForRepo({
               owner,
               repo,
             });
@@ -151,7 +151,7 @@ jobs:
 
             // Delete old wheels
             const promises = wheels.slice(index).map(({ id: artifact_id }) =>
-              github.actions.deleteArtifact({
+              github.rest.actions.deleteArtifact({
                 owner,
                 repo,
                 artifact_id,


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #7073

## What changes are proposed in this pull request?

Upgrade `actions/github-script` to v6 to remove warnings for `set-output`.

https://github.com/mlflow/mlflow/actions/runs/3273802975

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
