### PR TITLE
Print command to run failed tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -100,8 +100,12 @@ def pytest_terminal_summary(
 ):  # pylint: disable=unused-argument
     yield
     failed_test_reports = terminalreporter.stats.get("failed", [])
-    if failed_test_reports and len(failed_test_reports) <= 50:
+    if failed_test_reports:
         terminalreporter.section("command to run failed tests")
-        ids = [repr(report.nodeid) for report in failed_test_reports]
+        if len(failed_test_reports) <= 30:
+            ids = [repr(report.nodeid) for report in failed_test_reports]
+        else:
+            # Use dict.fromkeys to preserve the order
+            ids = list(dict.fromkeys(report.fspath for report in failed_test_reports))
         terminalreporter.write(" ".join(["pytest"] + ids))
         terminalreporter.write("\n" * 2)

--- a/conftest.py
+++ b/conftest.py
@@ -92,3 +92,16 @@ def pytest_collection_modifyitems(session, config, items):  # pylint: disable=un
     # `before_request` on the application after the first request. To avoid this issue,
     # execute `tests.server.test_prometheus_exporter` first by reordering the test items.
     items.sort(key=lambda item: item.module.__name__ != "tests.server.test_prometheus_exporter")
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_terminal_summary(
+    terminalreporter, exitstatus, config
+):  # pylint: disable=unused-argument
+    yield
+    failed_test_reports = terminalreporter.stats.get("failed", [])
+    if failed_test_reports and len(failed_test_reports) <= 50:
+        terminalreporter.section("command to run failed tests")
+        ids = [repr(report.nodeid) for report in failed_test_reports]
+        terminalreporter.write(" ".join(["pytest"] + ids))
+        terminalreporter.write("\n" * 2)

--- a/conftest.py
+++ b/conftest.py
@@ -101,10 +101,11 @@ def pytest_terminal_summary(
     yield
     failed_test_reports = terminalreporter.stats.get("failed", [])
     if failed_test_reports:
-        terminalreporter.section("command to run failed tests")
         if len(failed_test_reports) <= 30:
+            terminalreporter.section("command to run failed test cases")
             ids = [repr(report.nodeid) for report in failed_test_reports]
         else:
+            terminalreporter.section("command to run failed test suites")
             # Use dict.fromkeys to preserve the order
             ids = list(dict.fromkeys(report.fspath for report in failed_test_reports))
         terminalreporter.write(" ".join(["pytest"] + ids))


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Print a command to run failed tests to quickly run tests failed on CI locally.

```
...
====================================================================================== slowest 10 durations ======================================================================================

(6 durations < 0.005s hidden.  Use -vv to show these durations.)
================================================================================== command to run failed tests ===================================================================================
pytest 'tests/utils/test_file_utils.py::test_make_tarfile' 'tests/utils/test_file_utils.py::test_read_and_write_parquet'

==================================================================================== short test summary info =====================================================================================
FAILED tests/utils/test_file_utils.py::test_make_tarfile - AssertionError: assert False
FAILED tests/utils/test_file_utils.py::test_read_and_write_parquet - Exception
```

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
