### PR TITLE
Adding validation for transform step

### DIFF
--- a/mlflow/pipelines/steps/transform.py
+++ b/mlflow/pipelines/steps/transform.py
@@ -49,13 +49,17 @@ def _get_output_feature_names(transformer, num_features, input_features):
 def _validate_user_code_output(transformer_fn):
     transformer = transformer_fn()
     if transformer is not None and not (
-        hasattr(transformer, "fit")
-        and callable(getattr(transformer, "fit"))
-        and hasattr(transformer, "transform")
-        and callable(getattr(transformer, "transform"))
+        hasattr(transformer, "fit") and callable(getattr(transformer, "fit"))
     ):
         raise MlflowException(
-            message="The transformer provided doesn't have a fit and transform method."
+            message="The transformer provided doesn't have a fit method."
+        ) from None
+
+    if transformer is not None and not (
+        hasattr(transformer, "transform") and callable(getattr(transformer, "transform"))
+    ):
+        raise MlflowException(
+            message="The transformer provided doesn't have a transform method."
         ) from None
 
     return transformer

--- a/tests/pipelines/test_transform_step.py
+++ b/tests/pipelines/test_transform_step.py
@@ -136,12 +136,30 @@ def test_validate_method_validates_the_transformer():
     validated_transformer = _validate_user_code_output(correct_transformer)
     assert transformer == validated_transformer
 
-    class InCorrectTransformer:
+    class InCorrectFitTransformer:
         def pick(self):
             return "pick"
 
         def transform(self):
             return "transform"
+
+    inCorrectFitTransformer = InCorrectFitTransformer()
+
+    def incorrect__fit_transformer():
+        return inCorrectFitTransformer
+
+    with pytest.raises(
+        MlflowException,
+        match="The transformer provided doesn't have a fit method.",
+    ):
+        validated_transformer = _validate_user_code_output(incorrect__fit_transformer)
+
+    class InCorrectTransformer:
+        def pick(self):
+            return "pick"
+
+        def fit(self):
+            return "fit"
 
     inCorrectTransformer = InCorrectTransformer()
 
@@ -150,6 +168,6 @@ def test_validate_method_validates_the_transformer():
 
     with pytest.raises(
         MlflowException,
-        match="The transformer provided doesn't have a fit and transform method.",
+        match="The transformer provided doesn't have a transform method.",
     ):
         validated_transformer = _validate_user_code_output(incorrect_transformer)


### PR DESCRIPTION
## What changes are proposed in this pull request?
Adding validation for transform step

## How is this patch tested?
- [x] test added

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
