### PR TITLE
Introduce pipeline helper objects to abstract template-specific logic from step implementations

### DIFF
--- a/mlflow/pipelines/helpers.py
+++ b/mlflow/pipelines/helpers.py
@@ -1,0 +1,111 @@
+from abc import ABC, abstractmethod
+
+from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
+
+from typing import Optional
+
+
+class PipelineHelper(ABC):
+    @abstractmethod
+    def error_fn(self):
+        """
+        :return: The error function for the template type.
+        """
+        pass
+
+    @abstractmethod
+    def builtin_metrics(self):
+        """
+        :return: The builtin metrics for the mlflow evaluation service for the template type.
+        """
+        pass
+
+    @abstractmethod
+    def model_type(self):
+        """
+        :return: A model type literal compatible with the mlflow evaluation service."""
+        pass
+
+    @classmethod
+    def from_template(cls, tmpl):
+        """
+        Factory method for initializing pipeline helpers based on the template type.
+
+        :return: A `PipelineHelper` instance for the given template type.
+        """
+        if tmpl == "regression/v1":
+            return RegressionHelper()
+        if tmpl == "classification/v1":
+            return ClassificationHelper()
+        raise MlflowException(
+            f"No such for template {tmpl}",
+            error_code=INVALID_PARAMETER_VALUE,
+        )
+
+
+class RegressionHelper(PipelineHelper):
+    def error_fn(self):
+        return lambda predictions, targets: predictions - targets
+
+    def builtin_metrics(self):
+        return [
+            PipelineMetric(name="mean_absolute_error", greater_is_better=False),
+            PipelineMetric(name="mean_squared_error", greater_is_better=False),
+            PipelineMetric(name="root_mean_squared_error", greater_is_better=False),
+            PipelineMetric(name="max_error", greater_is_better=False),
+            PipelineMetric(name="mean_absolute_percentage_error", greater_is_better=False),
+        ]
+
+    def model_type(self):
+        return "regressor"
+
+
+class ClassificationHelper(PipelineHelper):
+    def error_fn(self):
+        return lambda predictions, targets: predictions != targets
+
+    def builtin_metrics(self):
+        return [
+            PipelineMetric(name="true_negatives", greater_is_better=True),
+            PipelineMetric(name="false_positives", greater_is_better=False),
+            PipelineMetric(name="false_negatives", greater_is_better=False),
+            PipelineMetric(name="true_positives", greater_is_better=True),
+            PipelineMetric(name="recall", greater_is_better=True),
+            PipelineMetric(name="precision", greater_is_better=True),
+            PipelineMetric(name="f1_score", greater_is_better=True),
+            PipelineMetric(name="accuracy_score", greater_is_better=True),
+            PipelineMetric(name="log_loss", greater_is_better=False),
+            PipelineMetric(name="roc_auc", greater_is_better=True),
+            PipelineMetric(name="precision_recall_auc", greater_is_better=True),
+        ]
+
+    def model_type(self):
+        return "classifier"
+
+
+class PipelineMetric:
+
+    _KEY_METRIC_NAME = "name"
+    _KEY_METRIC_GREATER_IS_BETTER = "greater_is_better"
+    _KEY_CUSTOM_FUNCTION = "function"
+
+    def __init__(self, name: str, greater_is_better: bool, custom_function: Optional[str] = None):
+        self.name = name
+        self.greater_is_better = greater_is_better
+        self.custom_function = custom_function
+
+    @classmethod
+    def from_custom_metric_dict(cls, custom_metric_dict):
+        metric_name = custom_metric_dict.get(PipelineMetric._KEY_METRIC_NAME)
+        greater_is_better = custom_metric_dict.get(PipelineMetric._KEY_METRIC_GREATER_IS_BETTER)
+        custom_function = custom_metric_dict.get(PipelineMetric._KEY_CUSTOM_FUNCTION)
+        if (metric_name, greater_is_better, custom_function).count(None) > 0:
+            raise MlflowException(
+                f"Invalid custom metric definition: {custom_metric_dict}",
+                error_code=INVALID_PARAMETER_VALUE,
+            )
+
+        return cls(
+            name=metric_name, greater_is_better=greater_is_better, custom_function=custom_function
+        )

--- a/mlflow/pipelines/utils/metrics.py
+++ b/mlflow/pipelines/utils/metrics.py
@@ -1,107 +1,15 @@
 import logging
 import importlib
 import sys
-from typing import List, Dict, Optional
+from typing import List, Dict
 
 from mlflow.exceptions import MlflowException, BAD_REQUEST
-from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
+from mlflow.pipelines.helpers import PipelineHelper, PipelineMetric
 
 _logger = logging.getLogger(__name__)
 
 
-class PipelineMetric:
-
-    _KEY_METRIC_NAME = "name"
-    _KEY_METRIC_GREATER_IS_BETTER = "greater_is_better"
-    _KEY_CUSTOM_FUNCTION = "function"
-
-    def __init__(self, name: str, greater_is_better: bool, custom_function: Optional[str] = None):
-        self.name = name
-        self.greater_is_better = greater_is_better
-        self.custom_function = custom_function
-
-    @classmethod
-    def from_custom_metric_dict(cls, custom_metric_dict):
-        metric_name = custom_metric_dict.get(PipelineMetric._KEY_METRIC_NAME)
-        greater_is_better = custom_metric_dict.get(PipelineMetric._KEY_METRIC_GREATER_IS_BETTER)
-        custom_function = custom_metric_dict.get(PipelineMetric._KEY_CUSTOM_FUNCTION)
-        if (metric_name, greater_is_better, custom_function).count(None) > 0:
-            raise MlflowException(
-                f"Invalid custom metric definition: {custom_metric_dict}",
-                error_code=INVALID_PARAMETER_VALUE,
-            )
-
-        return cls(
-            name=metric_name, greater_is_better=greater_is_better, custom_function=custom_function
-        )
-
-
-BUILTIN_CLASSIFICATION_PIPELINE_METRICS = [
-    PipelineMetric(name="true_negatives", greater_is_better=True),
-    PipelineMetric(name="false_positives", greater_is_better=False),
-    PipelineMetric(name="false_negatives", greater_is_better=False),
-    PipelineMetric(name="true_positives", greater_is_better=True),
-    PipelineMetric(name="recall", greater_is_better=True),
-    PipelineMetric(name="precision", greater_is_better=True),
-    PipelineMetric(name="f1_score", greater_is_better=True),
-    PipelineMetric(name="accuracy_score", greater_is_better=True),
-    PipelineMetric(name="log_loss", greater_is_better=False),
-    PipelineMetric(name="roc_auc", greater_is_better=True),
-    PipelineMetric(name="precision_recall_auc", greater_is_better=True),
-]
-
-BUILTIN_REGRESSION_PIPELINE_METRICS = [
-    PipelineMetric(name="mean_absolute_error", greater_is_better=False),
-    PipelineMetric(name="mean_squared_error", greater_is_better=False),
-    PipelineMetric(name="root_mean_squared_error", greater_is_better=False),
-    PipelineMetric(name="max_error", greater_is_better=False),
-    PipelineMetric(name="mean_absolute_percentage_error", greater_is_better=False),
-]
-
-
-def _get_error_fn(tmpl: str):
-    """
-    :param tmpl: The template kind, e.g. `regression/v1`.
-    :return: The error function for the provided template.
-    """
-    if tmpl == "regression/v1":
-        return lambda predictions, targets: predictions - targets
-    raise MlflowException(
-        f"No error function for template kind {tmpl}",
-        error_code=INVALID_PARAMETER_VALUE,
-    )
-
-
-def _get_model_type_from_template(tmpl: str) -> str:
-    """
-    :param tmpl: The template kind, e.g. `regression/v1`.
-    :return: A model type literal compatible with the mlflow evaluation service, e.g. regressor.
-    """
-    if tmpl == "regression/v1":
-        return "regressor"
-    raise MlflowException(
-        f"No model type for template kind {tmpl}",
-        error_code=INVALID_PARAMETER_VALUE,
-    )
-
-
-def _get_builtin_metrics(tmpl: str) -> str:
-    """
-    :param tmpl: The template kind, e.g. `regression/v1`.
-    :return: The builtin metrics for the mlflow evaluation service for the model type for
-    this template.
-    """
-    if tmpl == "regression/v1":
-        return BUILTIN_REGRESSION_PIPELINE_METRICS
-    elif tmpl == "classification/v1":
-        return BUILTIN_CLASSIFICATION_PIPELINE_METRICS
-    raise MlflowException(
-        f"No builtin metrics for template kind {tmpl}",
-        error_code=INVALID_PARAMETER_VALUE,
-    )
-
-
-def _get_custom_metrics(step_config: Dict) -> List[Dict]:
+def _get_custom_metrics(step_config: Dict, pipeline_helper: PipelineHelper) -> List[Dict]:
     """
     :param: Configuration dictionary for the train or evaluate step.
     :return: A list of custom metrics defined in the specified configuration dictionary,
@@ -112,9 +20,7 @@ def _get_custom_metrics(step_config: Dict) -> List[Dict]:
         PipelineMetric.from_custom_metric_dict(metric_dict) for metric_dict in custom_metric_dicts
     ]
     custom_metric_names = {metric.name for metric in custom_metrics}
-    builtin_metric_names = {
-        metric.name for metric in _get_builtin_metrics(step_config.get("template_name"))
-    }
+    builtin_metric_names = {metric.name for metric in pipeline_helper.builtin_metrics()}
     overridden_builtin_metrics = custom_metric_names.intersection(builtin_metric_names)
     if overridden_builtin_metrics:
         _logger.warning(


### PR DESCRIPTION
Signed-off-by: Brian Barnes <brian.barnes@databricks.com>

## What changes are proposed in this pull request?

This PR introduces an interface for template-specific logic required by step implementations. This interface is expected to grow in the immediate future, as steps currently implement a nontrival amount of logic that is specific to regression (step cards in particular). The idea here is that steps are agnostic to the template in which they run (evidenced by removing the `template` field from TrainStep and EvaluateStep) and the pipeline helper factory method is the only place in which we switch on the template type. 

## How is this patch tested?

Locally using mlp-regression-example

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Click the `Details` link on the `Preview docs` check.
2. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
