### PR TITLE
Replace `get_account_id` with `DEFAULT_ACCOUNT_ID`

### DIFF
--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -17,8 +17,6 @@ matplotlib
 shap>=0.40
 plotly
 kaleido
-# The latest flask version requires werkzeug>=2.2.0
-werkzeug>=2.2.0
 # Required by mlflow.keras / mlflow.pytorch tests.
 transformers
 # Required by tuning tests

--- a/tests/sagemaker/mock/__init__.py
+++ b/tests/sagemaker/mock/__init__.py
@@ -1079,4 +1079,4 @@ class TransformJobDescription:
 # Create a SageMaker backend for EC2 region: "us-west-2"
 sagemaker_backends = BackendDict(SageMakerBackend, "sagemaker")
 
-mock_sagemaker = base_decorator(sagemaker_backends)
+mock_sagemaker = base_decorator(sagemaker_backends)[DEFAULT_ACCOUNT_ID]

--- a/tests/sagemaker/mock/__init__.py
+++ b/tests/sagemaker/mock/__init__.py
@@ -1079,4 +1079,4 @@ class TransformJobDescription:
 # Create a SageMaker backend for EC2 region: "us-west-2"
 sagemaker_backends = BackendDict(SageMakerBackend, "sagemaker")
 
-mock_sagemaker = base_decorator(sagemaker_backends)[DEFAULT_ACCOUNT_ID]
+mock_sagemaker = base_decorator(sagemaker_backends)

--- a/tests/sagemaker/mock/__init__.py
+++ b/tests/sagemaker/mock/__init__.py
@@ -20,7 +20,7 @@ class SageMakerResponse(BaseResponse):
 
     @property
     def sagemaker_backend(self):
-        return sagemaker_backends[self.region]
+        return sagemaker_backends[DEFAULT_ACCOUNT_ID][self.region]
 
     @property
     def request_params(self):

--- a/tests/sagemaker/mock/__init__.py
+++ b/tests/sagemaker/mock/__init__.py
@@ -3,7 +3,7 @@ import json
 from collections import namedtuple
 from datetime import datetime
 
-from moto.core import get_account_id
+from moto.core import DEFAULT_ACCOUNT_ID
 from moto.core import BaseBackend, BaseModel
 from moto.core.responses import BaseResponse
 from moto.core.models import base_decorator
@@ -305,7 +305,7 @@ class SageMakerBackend(BaseBackend):
         :return: A SageMaker ARN prefix that can be prepended to a resource name.
         """
         return SageMakerBackend.BASE_SAGEMAKER_ARN.format(
-            region_name=region_name, account_id=get_account_id()
+            region_name=region_name, account_id=DEFAULT_ACCOUNT_ID
         )
 
     def create_endpoint_config(self, config_name, production_variants, tags, region_name):

--- a/tests/sagemaker/test_batch_deployment.py
+++ b/tests/sagemaker/test_batch_deployment.py
@@ -9,6 +9,7 @@ import botocore
 import numpy as np
 from click.testing import CliRunner
 from sklearn.linear_model import LogisticRegression
+from moto.core import DEFAULT_ACCOUNT_ID
 
 import mlflow
 import mlflow.pyfunc
@@ -52,7 +53,7 @@ def sagemaker_client():
 
 
 def get_sagemaker_backend(region_name):
-    return mock_sagemaker.backends[region_name]
+    return mock_sagemaker.backends[DEFAULT_ACCOUNT_ID][region_name]
 
 
 def mock_sagemaker_aws_services(fn):

--- a/tests/sagemaker/test_deployment.py
+++ b/tests/sagemaker/test_deployment.py
@@ -9,6 +9,7 @@ import botocore
 import numpy as np
 from click.testing import CliRunner
 from sklearn.linear_model import LogisticRegression
+from moto.core import DEFAULT_ACCOUNT_ID
 
 import mlflow
 import mlflow.pyfunc
@@ -53,7 +54,7 @@ def sagemaker_client():
 
 
 def get_sagemaker_backend(region_name):
-    return mock_sagemaker.backends[region_name]
+    return mock_sagemaker.backends[DEFAULT_ACCOUNT_ID][region_name]
 
 
 def mock_sagemaker_aws_services(fn):

--- a/tests/sagemaker/test_sagemaker_deployment_client.py
+++ b/tests/sagemaker/test_sagemaker_deployment_client.py
@@ -11,6 +11,7 @@ import numpy as np
 import pandas as pd
 from click.testing import CliRunner
 from sklearn.linear_model import LogisticRegression
+from moto.core import DEFAULT_ACCOUNT_ID
 
 import mlflow
 import mlflow.pyfunc
@@ -79,7 +80,7 @@ def create_sagemaker_deployment_through_cli(app_name, model_uri, region_name, en
 
 
 def get_sagemaker_backend(region_name):
-    return mock_sagemaker.backends[region_name]
+    return mock_sagemaker.backends[DEFAULT_ACCOUNT_ID][region_name]
 
 
 def mock_sagemaker_aws_services(fn):


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Fix the following error caused by the latest moto release:

https://github.com/mlflow/mlflow/actions/runs/3285573946/jobs/5412798232#step:6:29

```
__________ ERROR collecting tests/sagemaker/test_batch_deployment.py ___________
ImportError while importing test module '/home/runner/work/mlflow/mlflow/tests/sagemaker/test_batch_deployment.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/sagemaker/test_batch_deployment.py:[30](https://github.com/mlflow/mlflow/actions/runs/3285573946/jobs/5412798232#step:6:31): in <module>
    from tests.sagemaker.mock import mock_sagemaker, TransformJob, TransformJobOperation
tests/sagemaker/mock/__init__.py:6: in <module>
    from moto.core import get_account_id
E   ImportError: cannot import name 'get_account_id' from 'moto.core' (/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/moto/core/__init__.py)
```

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
