### PR TITLE
Add inline example of PyTorch pyfunc usage

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -704,7 +704,7 @@ via :py:func:`mlflow.pyfunc.load_model()`.
     logging multiple copies of the same model.
 
 PyTorch pyfunc usage
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~
 
 For a minimal PyTorch model, an example configuration for the pyfunc predict() method is:
 
@@ -716,16 +716,7 @@ For a minimal PyTorch model, an example configuration for the pyfunc predict() m
     from torch import nn
 
 
-    class Net(nn.Module):
-        def __init__(self):
-            super().__init__()
-            self.l1 = nn.Linear(6, 1)
-
-        def forward(self, x):
-            return self.l1(x)
-
-
-    net = Net()
+    net = nn.Linear(6, 1)
     loss_function = nn.L1Loss()
     optimizer = torch.optim.Adam(net.parameters(), lr=1e-4)
 
@@ -743,11 +734,12 @@ For a minimal PyTorch model, an example configuration for the pyfunc predict() m
         optimizer.step()
 
     with mlflow.start_run() as run:
-        mlflow.pytorch.save_model(net, "net")
+        model_info = mlflow.pytorch.log_model(net, "model")
 
-    pytorch_pyfunc = mlflow.pyfunc.load_model(model_uri="net")
+    pytorch_pyfunc = mlflow.pyfunc.load_model(model_uri=model_info.model_uri)
 
-    predictions = pytorch_pyfunc.predict(np.array([3.4, -1.2, 4.8, 7.1, 9.4, -6.9], np.float32))
+    predictions = pytorch_pyfunc.predict(torch.randn(6).numpy())
+    print(predictions)
 
 For more information, see :py:mod:`mlflow.pytorch`.
 

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -703,6 +703,52 @@ via :py:func:`mlflow.pyfunc.load_model()`.
     In case of multi gpu training, ensure to save the model only with global rank 0 gpu. This avoids
     logging multiple copies of the same model.
 
+PyTorch pyfunc usage
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For a minimal PyTorch model, an example configuration for the pyfunc predict() method is:
+
+.. code-block:: py
+    
+    import numpy as np
+    import mlflow
+    import torch
+    from torch import nn
+
+
+    class Net(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.l1 = nn.Linear(6, 1)
+
+        def forward(self, x):
+            return self.l1(x)
+
+
+    net = Net()
+    loss_function = nn.L1Loss()
+    optimizer = torch.optim.Adam(net.parameters(), lr=1e-4)
+
+    X = torch.randn(6)
+    y = torch.randn(1)
+
+    epochs = 5
+    for epoch in range(epochs):
+        optimizer.zero_grad()
+        outputs = net(X)
+
+        loss = loss_function(outputs, y)
+        loss.backward()
+
+        optimizer.step()
+
+    with mlflow.start_run() as run:
+        mlflow.pytorch.save_model(net, "net")
+
+    pytorch_pyfunc = mlflow.pyfunc.load_model(model_uri="net")
+
+    predictions = pytorch_pyfunc.predict(np.array([3.4, -1.2, 4.8, 7.1, 9.4, -6.9], np.float32))
+
 For more information, see :py:mod:`mlflow.pytorch`.
 
 Scikit-learn (``sklearn``)


### PR DESCRIPTION
Signed-off-by: Gonzalo Mellizo-Soto <gmellizosoto@gmail.com>

## Related Issues/PRs

Contributes to #6099 

## What changes are proposed in this pull request?

This PR adds an inline usage example to the PyTorch model flavour.

## How is this patch tested?

- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

Adds usage example to the PyTorch model flavour

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [X] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
