### PR TITLE
Add 'save_format' param to Keras autolog()

### DIFF
--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -22,7 +22,7 @@ from mlflow import pyfunc
 from mlflow.models import Model
 from mlflow.models.model import MLMODEL_FILE_NAME
 import mlflow.tracking
-from mlflow.exceptions import MlflowException
+from mlflow.exceptions import MlflowException, INVALID_PARAMETER_VALUE
 from mlflow.models.signature import ModelSignature
 from mlflow.models.utils import ModelInputExample, _save_example
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
@@ -687,9 +687,9 @@ def autolog(
 
     if save_format not in ["tf", "h5"]:
         raise MlflowException(
-            "Invalid value for `save_format` argument: {save_format}. "
+            f"Invalid value for `save_format` argument: {save_format}. "
             "Valid values for `save_format` are 'tf' or 'h5' only.",
-            INVALID_PARAMETER,
+            INVALID_PARAMETER_VALUE,
         )
 
     def getKerasCallback(metrics_logger):

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -671,7 +671,8 @@ def autolog(
                                   The registered model is created if it does not already exist.
     :param save_format: File format to save the model at the end of the training. Allowed
                         values are: ``tf`` for saving the model in ``SavedModel`` format
-                        or ``h5`` for saving the model in ``HDF5`` format.
+                        or ``h5`` for saving the model in ``HDF5`` format. Keras < 2.4.0 only
+                        supports ``HDF5`` format, so this parameter is ignored.
     """
     import keras
 
@@ -740,11 +741,16 @@ def autolog(
                     registered_model_name = get_autologging_config(
                         FLAVOR_NAME, "registered_model_name", None
                     )
+                    kwargs = (
+                        {}
+                        if Version(keras.__version__) < Version("2.4.0")
+                        else {"save_format": save_format}
+                    )
                     log_model(
                         self.model,
                         artifact_path="model",
                         registered_model_name=registered_model_name,
-                        save_format=save_format,
+                        **kwargs,
                     )
 
             # As of Keras 2.4.0, Keras Callback implementations must define the following

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -603,6 +603,7 @@ def autolog(
     disable_for_unsupported_versions=False,
     silent=False,
     registered_model_name=None,
+    save_format="tf",
 ):  # pylint: disable=unused-argument
     # pylint: disable=E0611
     """
@@ -668,6 +669,9 @@ def autolog(
     :param registered_model_name: If given, each time a model is trained, it is registered as a
                                   new model version of the registered model with this name.
                                   The registered model is created if it does not already exist.
+    :param save_format: File format to save the model at the end of the training. Allowed
+                        values are: ``tf`` for saving the model in ``SavedModel`` format
+                        or ``h5`` for saving the model in ``HDF5`` format.
     """
     import keras
 
@@ -679,6 +683,12 @@ def autolog(
             ),
             FutureWarning,
             stacklevel=2,
+        )
+
+    if save_format != "tf" and save_format != "h5":
+        raise Exception(
+            "Invalid value for `save_format` argument. "
+            "Valid values for `save_format` are `tf` or `h5` only."
         )
 
     def getKerasCallback(metrics_logger):
@@ -733,6 +743,7 @@ def autolog(
                         self.model,
                         artifact_path="model",
                         registered_model_name=registered_model_name,
+                        **{"save_format": save_format},
                     )
 
             # As of Keras 2.4.0, Keras Callback implementations must define the following

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -685,10 +685,11 @@ def autolog(
             stacklevel=2,
         )
 
-    if save_format != "tf" and save_format != "h5":
-        raise Exception(
-            "Invalid value for `save_format` argument. "
-            "Valid values for `save_format` are `tf` or `h5` only."
+    if save_format not in ["tf", "h5"]:
+        raise MlflowException(
+            "Invalid value for `save_format` argument: {save_format}. "
+            "Valid values for `save_format` are 'tf' or 'h5' only.",
+            INVALID_PARAMETER,
         )
 
     def getKerasCallback(metrics_logger):
@@ -743,7 +744,7 @@ def autolog(
                         self.model,
                         artifact_path="model",
                         registered_model_name=registered_model_name,
-                        **{"save_format": save_format},
+                        save_format=save_format,
                     )
 
             # As of Keras 2.4.0, Keras Callback implementations must define the following

--- a/tests/keras/test_keras_autolog.py
+++ b/tests/keras/test_keras_autolog.py
@@ -410,3 +410,20 @@ def test_autolog_registering_model(random_train_data, random_one_hot_labels):
 
         registered_model = MlflowClient().get_registered_model(registered_model_name)
         assert registered_model.name == registered_model_name
+
+
+def test_autolog_load_saved_hdf5_model(random_train_data, random_one_hot_labels):
+    mlflow.keras.autolog(save_format="h5")
+
+    data = random_train_data
+    labels = random_one_hot_labels
+
+    model = create_model()
+    with mlflow.start_run() as run:
+        model.fit(data, labels, epochs=10)
+        mlflow.keras.load_model("runs:/" + run.info.run_id + "/model")
+
+
+def test_autolog_invalid_model_save():
+    with pytest.raises(Exception, match="Invalid value for `save_format` argument."):
+        mlflow.keras.autolog(save_format="foo")


### PR DESCRIPTION
Signed-off-by: Bruno Alvisio <bruno.alvisio@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

Resolve https://github.com/mlflow/mlflow/issues/7024

## What changes are proposed in this pull request?

Allow configuring the format in which the model is saved in `keras.autolog()` 

## How is this patch tested?

Added test to load model in 'HDF5' format
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
