### PR TITLE
Handle read-only model mounts during virtualenv creation

### DIFF
--- a/mlflow/utils/virtualenv.py
+++ b/mlflow/utils/virtualenv.py
@@ -243,13 +243,13 @@ def _create_virtualenv(
             # in it correctly. To do this, we must first symlink or copy the model directory's
             # contents to a temporary location for compatibility with deployment tools that store
             # models in a read-only mount
-            model_dir = t.path("model")
+            tmp_model_dir = t.path("model")
+            os.makedirs(tmp_model_dir)
             try:
-                os.makedirs(model_dir)
                 for model_item in os.listdir(local_model_path):
                     os.symlink(
                         src=os.path.join(local_model_path, model_item),
-                        dst=os.path.join(model_dir, model_item),
+                        dst=os.path.join(tmp_model_dir, model_item),
                     )
             except Exception as e:
                 _logger.warning(
@@ -257,15 +257,36 @@ def _create_virtualenv(
                     " Copying instead. Exception: %s",
                     e,
                 )
-                shutil.rmtree(model_dir)
-                shutil.copytree(local_model_path, model_dir)
+                shutil.rmtree(tmp_model_dir)
+                _copy_model_to_writeable_destination(local_model_path, tmp_model_dir)
 
             tmp_req_file = f"requirements.{uuid.uuid4().hex}.txt"
-            Path(model_dir).joinpath(tmp_req_file).write_text("\n".join(deps))
+            Path(tmp_model_dir).joinpath(tmp_req_file).write_text("\n".join(deps))
             cmd = _join_commands(activate_cmd, f"python -m pip install --quiet -r {tmp_req_file}")
-            _exec_cmd(cmd, capture_output=capture_output, cwd=model_dir, extra_env=extra_env)
+            _exec_cmd(cmd, capture_output=capture_output, cwd=tmp_model_dir, extra_env=extra_env)
 
     return activate_cmd
+
+
+def _copy_model_to_writeable_destination(model_src, dst):
+    """
+    Copies the specified `model_src` directory, which may be read-only, to the writeable `dst`
+    directory.
+    """
+    os.makedirs(dst, exist_ok=True)
+    for model_item in os.listdir(model_src):
+        # Copy individual files and subdirectories, rather than using `shutil.copytree()`
+        # because `shutil.copytree()` will apply the permissions from the source directory,
+        # which may be read-only
+        if os.path.isdir(model_item):
+            copy_fn = shutil.copytree
+        else:
+            copy_fn = shutil.copy2
+
+        copy_fn(
+            src=os.path.join(model_src, model_item),
+            dst=os.path.join(dst, model_item),
+        )
 
 
 def _get_virtualenv_extra_env_vars(env_root_dir=None):

--- a/mlflow/utils/virtualenv.py
+++ b/mlflow/utils/virtualenv.py
@@ -244,8 +244,8 @@ def _create_virtualenv(
             # contents to a temporary location for compatibility with deployment tools that store
             # models in a read-only mount
             model_dir = t.path("model")
-            os.makedirs(model_dir)
             try:
+                os.makedirs(model_dir)
                 for model_item in os.listdir(local_model_path):
                     os.symlink(model_item, os.path.join(model_dir, model_item))
             except Exception as e:

--- a/mlflow/utils/virtualenv.py
+++ b/mlflow/utils/virtualenv.py
@@ -258,7 +258,7 @@ def _create_virtualenv(
                 shutil.copytree(local_model_path, model_dir)
 
             tmp_req_file = f"requirements.{uuid.uuid4().hex}.txt"
-            t.path(tmp_req_file).write_text("\n".join(deps))
+            Path(model_dir).joinpath(tmp_req_file).write_text("\n".join(deps))
             cmd = _join_commands(activate_cmd, f"python -m pip install --quiet -r {tmp_req_file}")
             _exec_cmd(cmd, capture_output=capture_output, cwd=local_model_path, extra_env=extra_env)
 

--- a/mlflow/utils/virtualenv.py
+++ b/mlflow/utils/virtualenv.py
@@ -255,8 +255,7 @@ def _create_virtualenv(
                     e
                 )
                 shutil.rmtree(model_dir)
-                os.makedirs(model_dir)
-                shutil.copytree(local_model_path, t.path())
+                shutil.copytree(local_model_path, model_dir)
 
             tmp_req_file = f"requirements.{uuid.uuid4().hex}.txt"
             t.path(tmp_req_file).write_text("\n".join(deps))

--- a/mlflow/utils/virtualenv.py
+++ b/mlflow/utils/virtualenv.py
@@ -255,7 +255,7 @@ def _create_virtualenv(
                 _logger.warning(
                     "Failed to symlink model directory during dependency installation"
                     " Copying instead. Exception: %s",
-                    e
+                    e,
                 )
                 shutil.rmtree(model_dir)
                 shutil.copytree(local_model_path, model_dir)

--- a/mlflow/utils/virtualenv.py
+++ b/mlflow/utils/virtualenv.py
@@ -247,7 +247,10 @@ def _create_virtualenv(
             try:
                 os.makedirs(model_dir)
                 for model_item in os.listdir(local_model_path):
-                    os.symlink(model_item, os.path.join(model_dir, model_item))
+                    os.symlink(
+                        src=os.path.join(local_model_path, model_item),
+                        dst=os.path.join(model_dir, model_item),
+                    )
             except Exception as e:
                 _logger.warning(
                     "Failed to symlink model directory during dependency installation"
@@ -260,7 +263,7 @@ def _create_virtualenv(
             tmp_req_file = f"requirements.{uuid.uuid4().hex}.txt"
             Path(model_dir).joinpath(tmp_req_file).write_text("\n".join(deps))
             cmd = _join_commands(activate_cmd, f"python -m pip install --quiet -r {tmp_req_file}")
-            _exec_cmd(cmd, capture_output=capture_output, cwd=local_model_path, extra_env=extra_env)
+            _exec_cmd(cmd, capture_output=capture_output, cwd=model_dir, extra_env=extra_env)
 
     return activate_cmd
 

--- a/tests/projects/test_virtualenv_projects.py
+++ b/tests/projects/test_virtualenv_projects.py
@@ -26,8 +26,7 @@ def use_dev_mlflow_for_projects():
 
     conda_env = read_yaml(TEST_VIRTUALENV_CONDA_PROJECT_DIR, "conda.yaml")
     conda_pip_dependencies = [
-        item for item in conda_env["dependencies"] if isinstance(item, dict)
-        and "pip" in item
+        item for item in conda_env["dependencies"] if isinstance(item, dict) and "pip" in item
     ][0]["pip"]
     if "mlflow" in conda_pip_dependencies:
         conda_pip_dependencies.remove("mlflow")

--- a/tests/pyfunc/test_virtualenv.py
+++ b/tests/pyfunc/test_virtualenv.py
@@ -2,7 +2,7 @@ import os
 import sys
 from collections import namedtuple
 from pathlib import Path
-from stat import S_IREAD, S_IRUSR, S_IRGRP, S_IROTH, S_IXUSR, S_IXGRP, S_IXOTH
+from stat import S_IRUSR, S_IRGRP, S_IROTH, S_IXUSR, S_IXGRP, S_IXOTH
 
 import pytest
 import numpy as np
@@ -72,7 +72,7 @@ def test_serve_and_score_read_only_model_directory(sklearn_model, tmp_path):
     mlflow.sklearn.save_model(sklearn_model.model, path=model_path)
     os.chmod(
         model_path,
-        S_IRUSR|S_IRGRP|S_IROTH|S_IXUSR|S_IXGRP|S_IXOTH,
+        S_IRUSR | S_IRGRP | S_IROTH | S_IXUSR | S_IXGRP | S_IXOTH,
     )
 
     scores = serve_and_score(model_path, sklearn_model.X_pred)

--- a/tests/pyfunc/test_virtualenv.py
+++ b/tests/pyfunc/test_virtualenv.py
@@ -68,8 +68,7 @@ def test_restore_environment_with_virtualenv(sklearn_model):
 
 
 @use_temp_mlflow_env_root
-@pytest.mark.parametrize("simulate_symlink_fail", [False, True])
-def test_serve_and_score_read_only_model_directory(sklearn_model, tmp_path, simulate_symlink_fail):
+def test_serve_and_score_read_only_model_directory(sklearn_model, tmp_path):
     model_path = str(tmp_path / "model")
     mlflow.sklearn.save_model(sklearn_model.model, path=model_path)
     os.chmod(
@@ -77,12 +76,7 @@ def test_serve_and_score_read_only_model_directory(sklearn_model, tmp_path, simu
         S_IRUSR | S_IRGRP | S_IROTH | S_IXUSR | S_IXGRP | S_IXOTH,
     )
 
-    if simulate_symlink_fail:
-        with mock.patch("os.symlink", side_effect=Exception("Symlink failed!")):
-            scores = serve_and_score(model_path, sklearn_model.X_pred)
-    else:
-        scores = serve_and_score(model_path, sklearn_model.X_pred)
-
+    scores = serve_and_score(model_path, sklearn_model.X_pred)
     np.testing.assert_array_almost_equal(scores, sklearn_model.y_pred)
 
 

--- a/tests/pyfunc/test_virtualenv.py
+++ b/tests/pyfunc/test_virtualenv.py
@@ -2,7 +2,7 @@ import os
 import sys
 from collections import namedtuple
 from pathlib import Path
-from stat import S_IREAD, S_IRUSR, S_IRGRP, S_IROTH
+from stat import S_IREAD, S_IRUSR, S_IRGRP, S_IROTH, S_IXUSR, S_IXGRP, S_IXOTH
 
 import pytest
 import numpy as np
@@ -70,7 +70,10 @@ def test_restore_environment_with_virtualenv(sklearn_model):
 def test_serve_and_score_read_only_model_directory(sklearn_model, tmp_path):
     model_path = str(tmp_path / "model")
     mlflow.sklearn.save_model(sklearn_model.model, path=model_path)
-    os.chmod(model_path, S_IRUSR|S_IREAD|S_IRGRP|S_IROTH)
+    os.chmod(
+        model_path,
+        S_IRUSR|S_IRGRP|S_IROTH|S_IXUSR|S_IXGRP|S_IXOTH,
+    )
 
     scores = serve_and_score(model_path, sklearn_model.X_pred)
     np.testing.assert_array_almost_equal(scores, sklearn_model.y_pred)

--- a/tests/pyfunc/test_virtualenv.py
+++ b/tests/pyfunc/test_virtualenv.py
@@ -3,7 +3,6 @@ import sys
 from collections import namedtuple
 from pathlib import Path
 from stat import S_IRUSR, S_IRGRP, S_IROTH, S_IXUSR, S_IXGRP, S_IXOTH
-from unittest import mock
 
 import pytest
 import numpy as np

--- a/tests/pyfunc/test_virtualenv.py
+++ b/tests/pyfunc/test_virtualenv.py
@@ -2,7 +2,7 @@ import os
 import sys
 from collections import namedtuple
 from pathlib import Path
-from stat import S_IREAD, S_IRGRP, S_IROTH
+from stat import S_IREAD, S_IRUSR, S_IRGRP, S_IROTH
 
 import pytest
 import numpy as np
@@ -70,11 +70,7 @@ def test_restore_environment_with_virtualenv(sklearn_model):
 def test_serve_and_score_read_only_model_directory(sklearn_model, tmp_path):
     model_path = str(tmp_path / "model")
     mlflow.sklearn.save_model(sklearn_model.model, path=model_path)
-    os.chmod(model_path, S_IREAD|S_IRGRP|S_IROTH)
-    for dirpath, _, filenames in os.walk(model_path):
-        os.chmod(dirpath, S_IREAD|S_IRGRP|S_IROTH)
-        for filename in filenames:
-            os.chmod(os.path.join(dirpath, filename), S_IREAD|S_IRGRP|S_IROTH)
+    os.chmod(model_path, S_IRUSR|S_IREAD|S_IRGRP|S_IROTH)
 
     scores = serve_and_score(model_path, sklearn_model.X_pred)
     np.testing.assert_array_almost_equal(scores, sklearn_model.y_pred)

--- a/tests/resources/example_virtualenv_conda_project/conda.yaml
+++ b/tests/resources/example_virtualenv_conda_project/conda.yaml
@@ -6,5 +6,5 @@ dependencies:
   - numpy
   - pip
   - pip:
-      - ../../..
+      - ~/mlflow
       - scikit-learn==1.0.2

--- a/tests/resources/example_virtualenv_conda_project/conda.yaml
+++ b/tests/resources/example_virtualenv_conda_project/conda.yaml
@@ -1,3 +1,4 @@
+name: virtualenv-conda
 channels:
   - conda-forge
 dependencies:
@@ -7,4 +8,3 @@ dependencies:
   - pip:
     - mlflow
     - scikit-learn==1.0.2
-name: virtualenv-conda

--- a/tests/resources/example_virtualenv_conda_project/conda.yaml
+++ b/tests/resources/example_virtualenv_conda_project/conda.yaml
@@ -1,10 +1,10 @@
-name: virtualenv-conda
 channels:
-  - conda-forge
+- conda-forge
 dependencies:
-  - python=3.8.13
-  - numpy
-  - pip
-  - pip:
-      - ~/mlflow
-      - scikit-learn==1.0.2
+- python=3.8.13
+- numpy
+- pip
+- pip:
+  - mlflow
+  - scikit-learn==1.0.2
+name: virtualenv-conda

--- a/tests/resources/example_virtualenv_conda_project/conda.yaml
+++ b/tests/resources/example_virtualenv_conda_project/conda.yaml
@@ -1,10 +1,10 @@
 channels:
-- conda-forge
+  - conda-forge
 dependencies:
-- python=3.8.13
-- numpy
-- pip
-- pip:
-  - mlflow
-  - scikit-learn==1.0.2
+  - python=3.8.13
+  - numpy
+  - pip
+  - pip:
+    - mlflow
+    - scikit-learn==1.0.2
 name: virtualenv-conda

--- a/tests/resources/example_virtualenv_project/requirements.txt
+++ b/tests/resources/example_virtualenv_project/requirements.txt
@@ -1,2 +1,2 @@
-mlflow
+~/mlflow
 scikit-learn==1.0.2

--- a/tests/resources/example_virtualenv_project/requirements.txt
+++ b/tests/resources/example_virtualenv_project/requirements.txt
@@ -1,2 +1,2 @@
-../../..
+mlflow
 scikit-learn==1.0.2

--- a/tests/resources/example_virtualenv_project/requirements.txt
+++ b/tests/resources/example_virtualenv_project/requirements.txt
@@ -1,2 +1,2 @@
-~/mlflow
+mlflow
 scikit-learn==1.0.2


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## What changes are proposed in this pull request?

Handle read-only model mounts during virtualenv creation

## How is this patch tested?

Added unit tests. Also manually tested the case where symlinking fails.

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

Handle read-only model mounts during virtualenv creation

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
