### PR TITLE
Refactoring pipeline config to update to new spec

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "examples/pipelines/sklearn_regression_example"]
 	path = examples/pipelines/sklearn_regression_example
 	url = https://github.com/mlflow/mlp-regression-example.git
+	branch = sunish-pipeline-2.0

--- a/mlflow/pipelines/steps/evaluate.py
+++ b/mlflow/pipelines/steps/evaluate.py
@@ -450,7 +450,10 @@ class EvaluateStep(BaseStep):
         step_config["target_col"] = pipeline_config.get("target_col")
         if "positive_class" in pipeline_config:
             step_config["positive_class"] = pipeline_config.get("positive_class")
-        step_config["metrics"] = pipeline_config.get("metrics")
+        if pipeline_config.get("custom_metrics") is not None:
+            step_config["custom_metrics"] = pipeline_config["custom_metrics"]
+        if pipeline_config.get("primary_metric") is not None:
+            step_config["primary_metric"] = pipeline_config["primary_metric"]
         step_config["template_name"] = pipeline_config.get("template")
         step_config.update(
             get_pipeline_tracking_config(

--- a/mlflow/pipelines/steps/ingest/__init__.py
+++ b/mlflow/pipelines/steps/ingest/__init__.py
@@ -40,11 +40,11 @@ class BaseIngestStep(BaseStep, metaclass=abc.ABCMeta):
     ]
 
     def _validate_and_apply_step_config(self):
-        dataset_format = self.step_config.get("format")
+        dataset_format = self.step_config.get("using")
         if not dataset_format:
             raise MlflowException(
                 message=(
-                    "Dataset format must be specified via the `format` key within the `data`"
+                    "Dataset format must be specified via the `using` key within the `ingest`"
                     " section of pipeline.yaml"
                 ),
                 error_code=INVALID_PARAMETER_VALUE,
@@ -211,15 +211,12 @@ class IngestStep(BaseIngestStep):
 
     @classmethod
     def from_pipeline_config(cls, pipeline_config: Dict[str, Any], pipeline_root: str):
-
-        data_config = pipeline_config.get("data", {})
         ingest_config = pipeline_config.get("steps", {}).get("ingest", {})
         target_config = {"target_col": pipeline_config.get("target_col")}
         if "positive_class" in pipeline_config:
             target_config["positive_class"] = pipeline_config.get("positive_class")
         return cls(
             step_config={
-                **data_config,
                 **ingest_config,
                 **target_config,
                 **{"template_name": pipeline_config.get("template")},
@@ -251,10 +248,9 @@ class IngestScoringStep(BaseIngestStep):
 
     @classmethod
     def from_pipeline_config(cls, pipeline_config: Dict[str, Any], pipeline_root: str):
-        data_config = pipeline_config.get("data_scoring", {})
-        ingest_config = pipeline_config.get("steps", {}).get("ingest", {})
+        step_config = pipeline_config.get("steps", {}).get("register", {})
         return cls(
-            step_config={**data_config, **ingest_config},
+            step_config=step_config,
             pipeline_root=pipeline_root,
         )
 

--- a/mlflow/pipelines/steps/ingest/__init__.py
+++ b/mlflow/pipelines/steps/ingest/__init__.py
@@ -248,7 +248,7 @@ class IngestScoringStep(BaseIngestStep):
 
     @classmethod
     def from_pipeline_config(cls, pipeline_config: Dict[str, Any], pipeline_root: str):
-        step_config = pipeline_config.get("steps", {}).get("register", {})
+        step_config = pipeline_config.get("steps", {}).get("ingest_scoring", {})
         return cls(
             step_config=step_config,
             pipeline_root=pipeline_root,

--- a/mlflow/pipelines/steps/ingest/datasets.py
+++ b/mlflow/pipelines/steps/ingest/datasets.py
@@ -69,9 +69,9 @@ class _Dataset:
                               local filesystem.
         :return: A `_Dataset` instance representing the configured dataset.
         """
-        if not cls.handles_format(dataset_config.get("format")):
+        if not cls.handles_format(dataset_config.get("using")):
             raise MlflowException(
-                f"Invalid format {dataset_config.get('format')} for dataset {cls}",
+                f"Invalid format {dataset_config.get('using')} for dataset {cls}",
                 error_code=INVALID_PARAMETER_VALUE,
             )
         return cls._from_config(dataset_config, pipeline_root)
@@ -121,7 +121,7 @@ class _Dataset:
         except KeyError:
             raise MlflowException(
                 f"The `{key}` configuration key must be specified for dataset with"
-                f" format '{dataset_config.get('format')}'"
+                f" using '{dataset_config.get('using')}' format"
             ) from None
 
 
@@ -167,7 +167,7 @@ class _LocationBasedDataset(_Dataset):
         return cls(
             location=cls._get_required_config(dataset_config=dataset_config, key="location"),
             pipeline_root=pipeline_root,
-            dataset_format=cls._get_required_config(dataset_config=dataset_config, key="format"),
+            dataset_format=cls._get_required_config(dataset_config=dataset_config, key="using"),
         )
 
     @staticmethod
@@ -498,7 +498,7 @@ class CustomDataset(_PandasConvertibleDataset):
     def _from_config(cls, dataset_config: Dict[str, Any], pipeline_root: str) -> _DatasetType:
         return cls(
             location=cls._get_required_config(dataset_config=dataset_config, key="location"),
-            dataset_format=cls._get_required_config(dataset_config=dataset_config, key="format"),
+            dataset_format=cls._get_required_config(dataset_config=dataset_config, key="using"),
             custom_loader_method=cls._get_required_config(
                 dataset_config=dataset_config, key="custom_loader_method"
             ),
@@ -589,7 +589,7 @@ class DeltaTableDataset(_SparkDatasetMixin, _LocationBasedDataset):
         return cls(
             location=cls._get_required_config(dataset_config=dataset_config, key="location"),
             pipeline_root=pipeline_root,
-            dataset_format=cls._get_required_config(dataset_config=dataset_config, key="format"),
+            dataset_format=cls._get_required_config(dataset_config=dataset_config, key="using"),
             version=dataset_config.get("version"),
             timestamp=dataset_config.get("timestamp"),
         )
@@ -633,7 +633,7 @@ class SparkSqlDataset(_SparkDatasetMixin, _Dataset):
         return cls(
             sql=dataset_config.get("sql"),
             location=dataset_config.get("location"),
-            dataset_format=cls._get_required_config(dataset_config=dataset_config, key="format"),
+            dataset_format=cls._get_required_config(dataset_config=dataset_config, key="using"),
         )
 
     @staticmethod

--- a/mlflow/pipelines/steps/predict.py
+++ b/mlflow/pipelines/steps/predict.py
@@ -44,7 +44,7 @@ class PredictStep(BaseStep):
         self.tracking_config = TrackingConfig.from_dict(self.step_config)
 
     def _validate_and_apply_step_config(self):
-        required_configuration_keys = ["using", "output_location"]
+        required_configuration_keys = ["using", "location"]
         for key in required_configuration_keys:
             if key not in self.step_config:
                 raise MlflowException(
@@ -142,7 +142,7 @@ class PredictStep(BaseStep):
 
         # check if output location is already populated for non-delta output formats
         output_format = self.step_config["using"]
-        output_location = self.step_config["output_location"]
+        output_location = self.step_config["location"]
         output_populated = False
         if self.save_mode in ["default", "error", "errorifexists"]:
             if output_format == "parquet" or output_format == "delta":
@@ -220,6 +220,10 @@ class PredictStep(BaseStep):
         step_config = {}
         if pipeline_config.get("steps", {}).get("predict", {}) is not None:
             step_config.update(pipeline_config.get("steps", {}).get("predict", {}))
+        if pipeline_config.get("steps", {}).get("predict", {}).get("output", {}) is not None:
+            step_config.update(
+                pipeline_config.get("steps", {}).get("predict", {}).get("output", {})
+            )
         step_config["register"] = pipeline_config.get("steps", {}).get("register", {})
         step_config["model_registry"] = pipeline_config.get("model_registry", {})
         if pipeline_config.get("model_registry", {}).get("model_uri") is not None:

--- a/mlflow/pipelines/steps/predict.py
+++ b/mlflow/pipelines/steps/predict.py
@@ -44,27 +44,26 @@ class PredictStep(BaseStep):
         self.tracking_config = TrackingConfig.from_dict(self.step_config)
 
     def _validate_and_apply_step_config(self):
-        required_configuration_keys = ["output_format", "output_location"]
+        required_configuration_keys = ["using", "output_location"]
         for key in required_configuration_keys:
             if key not in self.step_config:
                 raise MlflowException(
                     f"The `{key}` configuration key must be specified for the predict step.",
                     error_code=INVALID_PARAMETER_VALUE,
                 )
-        if self.step_config["output_format"] not in {"parquet", "delta", "table"}:
+        if self.step_config["using"] not in {"parquet", "delta", "table"}:
             raise MlflowException(
-                "Invalid `output_format` in predict step configuration.",
+                "Invalid `using` in predict step configuration.",
                 error_code=INVALID_PARAMETER_VALUE,
             )
         if "model_uri" not in self.step_config:
             try:
-                register_config = self.step_config["register"]
+                register_config = self.step_config["model_registry"]
                 model_name = register_config["model_name"]
             except KeyError:
                 raise MlflowException(
-                    "No model specified for batch scoring: predict step does not have `model_uri` "
-                    "configuration key and register step does not have `model_name` configuration "
-                    " key.",
+                    "No model specified for batch scoring: model_registry does not have "
+                    "`model_uri` and does not have `model_name` configuration key.",
                     error_code=INVALID_PARAMETER_VALUE,
                 )
             else:
@@ -142,7 +141,7 @@ class PredictStep(BaseStep):
             ) from e
 
         # check if output location is already populated for non-delta output formats
-        output_format = self.step_config["output_format"]
+        output_format = self.step_config["using"]
         output_location = self.step_config["output_location"]
         output_populated = False
         if self.save_mode in ["default", "error", "errorifexists"]:
@@ -157,9 +156,9 @@ class PredictStep(BaseStep):
         if output_populated:
             raise MlflowException(
                 message=(
-                    f"Output location `{output_location}` of format `{output_format}` is already "
-                    "populated. To overwrite, please change the spark `save_mode` in the predict "
-                    "step configuration."
+                    f"Output location `{output_location}` using format `{output_format}` is "
+                    "already populated. To overwrite, please change the spark `save_mode` in "
+                    "the predict step configuration."
                 ),
                 error_code=BAD_REQUEST,
             )
@@ -222,7 +221,14 @@ class PredictStep(BaseStep):
         if pipeline_config.get("steps", {}).get("predict", {}) is not None:
             step_config.update(pipeline_config.get("steps", {}).get("predict", {}))
         step_config["register"] = pipeline_config.get("steps", {}).get("register", {})
-        step_config["registry_uri"] = pipeline_config.get("model_registry", {}).get("uri", None)
+        step_config["model_registry"] = pipeline_config.get("model_registry", {})
+        if pipeline_config.get("model_registry", {}).get("model_uri") is not None:
+            step_config["model_uri"] = pipeline_config.get("model_registry", {}).get("model_uri")
+        if pipeline_config.get("model_registry", {}).get("registry_uri") is not None:
+            step_config["registry_uri"] = pipeline_config.get("model_registry", {}).get(
+                "registry_uri"
+            )
+
         step_config.update(
             get_pipeline_tracking_config(
                 pipeline_root_path=pipeline_root,

--- a/mlflow/pipelines/steps/register.py
+++ b/mlflow/pipelines/steps/register.py
@@ -169,7 +169,12 @@ class RegisterStep(BaseStep):
         if pipeline_config.get("steps", {}).get("register") is not None:
             step_config.update(pipeline_config.get("steps", {}).get("register"))
         step_config["template_name"] = pipeline_config.get("template")
-        step_config["registry_uri"] = pipeline_config.get("model_registry", {}).get("uri", None)
+        if pipeline_config.get("model_registry", {}).get("registry_uri") is not None:
+            step_config["registry_uri"] = pipeline_config.get("model_registry", {}).get(
+                "registry_uri"
+            )
+        if pipeline_config.get("model_registry", {}).get("model_name") is not None:
+            step_config["model_name"] = pipeline_config.get("model_registry", {}).get("model_name")
         step_config.update(
             get_pipeline_tracking_config(
                 pipeline_root_path=pipeline_root,

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -817,7 +817,10 @@ class TrainStep(BaseStep):
         step_config = {}
         if pipeline_config.get("steps", {}).get("train", {}) is not None:
             step_config.update(pipeline_config.get("steps", {}).get("train", {}))
-        step_config["metrics"] = pipeline_config.get("metrics")
+        if pipeline_config.get("custom_metrics") is not None:
+            step_config["custom_metrics"] = pipeline_config["custom_metrics"]
+        if pipeline_config.get("primary_metric") is not None:
+            step_config["primary_metric"] = pipeline_config["primary_metric"]
         step_config["template_name"] = pipeline_config.get("template")
         step_config["profile"] = pipeline_config.get("profile")
         step_config["target_col"] = pipeline_config.get("target_col")

--- a/mlflow/pipelines/utils/metrics.py
+++ b/mlflow/pipelines/utils/metrics.py
@@ -108,7 +108,7 @@ def _get_custom_metrics(step_config: Dict) -> List[Dict]:
     :return: A list of custom metrics defined in the specified configuration dictionary,
              or an empty list of the configuration dictionary does not define any custom metrics.
     """
-    custom_metric_dicts = (step_config.get("metrics") or {}).get("custom", [])
+    custom_metric_dicts = step_config.get("custom_metrics", [])
     custom_metrics = [
         PipelineMetric.from_custom_metric_dict(metric_dict) for metric_dict in custom_metric_dicts
     ]
@@ -149,4 +149,4 @@ def _load_custom_metric_functions(
 
 
 def _get_primary_metric(step_config):
-    return (step_config.get("metrics") or {}).get("primary", "root_mean_squared_error")
+    return step_config.get("primary_metric", "root_mean_squared_error")

--- a/tests/pipelines/test_evaluate_step.py
+++ b/tests/pipelines/test_evaluate_step.py
@@ -73,11 +73,10 @@ steps:
         threshold: {mae_threshold}
       - metric: weighted_mean_squared_error
         threshold: 1_000_000
-metrics:
-  custom:
-    - name: weighted_mean_squared_error
-      function: weighted_mean_squared_error
-      greater_is_better: False
+custom_metrics:
+  - name: weighted_mean_squared_error
+    function: weighted_mean_squared_error
+    greater_is_better: False
 """.format(
             tracking_uri=mlflow.get_tracking_uri(),
             mae_threshold=mae_threshold,
@@ -238,11 +237,10 @@ steps:
     validation_criteria:
       - metric: weighted_mean_squared_error
         threshold: 100
-metrics:
-  custom:
-    - name: weighted_mean_squared_error
-      function: weighted_mean_squared_error
-      greater_is_better: False
+custom_metrics:
+  - name: weighted_mean_squared_error
+    function: weighted_mean_squared_error
+    greater_is_better: False
 """.format(
             tracking_uri=mlflow.get_tracking_uri()
         )
@@ -281,11 +279,10 @@ steps:
     validation_criteria:
       - metric: weighted_mean_squared_error
         threshold: 100
-metrics:
-  custom:
-    - name: weighted_mean_squared_error
-      function: weighted_mean_squared_error
-      greater_is_better: False
+custom_metrics:
+  - name: weighted_mean_squared_error
+    function: weighted_mean_squared_error
+    greater_is_better: False
 """.format(
             tracking_uri=mlflow.get_tracking_uri()
         )
@@ -324,14 +321,13 @@ steps:
         threshold: 10
       - metric: mean_absolute_error
         threshold: 10
-metrics:
-  custom:
-    - name: mean_absolute_error
-      function: mean_absolute_error
-      greater_is_better: False
-    - name: root_mean_squared_error
-      function: root_mean_squared_error
-      greater_is_better: False
+custom_metrics:
+  - name: mean_absolute_error
+    function: mean_absolute_error
+    greater_is_better: False
+  - name: root_mean_squared_error
+    function: root_mean_squared_error
+    greater_is_better: False
 """.format(
             tracking_uri=mlflow.get_tracking_uri()
         )

--- a/tests/pipelines/test_evaluate_step.py
+++ b/tests/pipelines/test_evaluate_step.py
@@ -126,6 +126,7 @@ def test_evaluate_produces_expected_step_card(
 template: "classification/v1"
 positive_class: "Iris-setosa"
 target_col: "y"
+primary_metric: "f1_score"
 experiment:
   tracking_uri: {tracking_uri}
 steps:
@@ -133,8 +134,6 @@ steps:
     validation_criteria:
       - metric: f1_score
         threshold: 10
-metrics:
-  primary: "f1_score"
 """.format(
             tracking_uri=mlflow.get_tracking_uri(),
         )

--- a/tests/pipelines/test_execution_utils.py
+++ b/tests/pipelines/test_execution_utils.py
@@ -52,9 +52,11 @@ def test_pipeline(
     ingest_step = IngestStep.from_pipeline_config(
         pipeline_config={
             "target_col": "C",
-            "data": {
-                "format": "parquet",
-                "location": str(dataset_path),
+            "steps": {
+                "ingest": {
+                    "using": "parquet",
+                    "location": str(dataset_path),
+                }
             },
         },
         pipeline_root=os.getcwd(),
@@ -323,9 +325,11 @@ def test_run_pipeline_step_maintains_execution_status_correctly(pandas_df, tmp_p
     ingest_step_good = IngestStep.from_pipeline_config(
         pipeline_config={
             "target_col": "C",
-            "data": {
-                "format": "parquet",
-                "location": str(dataset_path),
+            "steps": {
+                "ingest": {
+                    "using": "parquet",
+                    "location": str(dataset_path),
+                }
             },
         },
         pipeline_root=os.getcwd(),
@@ -345,9 +349,11 @@ def test_run_pipeline_step_maintains_execution_status_correctly(pandas_df, tmp_p
     ingest_step_bad = IngestStep.from_pipeline_config(
         pipeline_config={
             "target_col": "C",
-            "data": {
-                "format": "parquet",
-                "location": "badlocation",
+            "steps": {
+                "ingest": {
+                    "using": "parquet",
+                    "location": "badlocation",
+                }
             },
         },
         pipeline_root=os.getcwd(),
@@ -371,9 +377,11 @@ def test_run_pipeline_step_returns_expected_result(test_pipeline):
     ingest_step_bad = IngestStep.from_pipeline_config(
         pipeline_config={
             "target_col": "C",
-            "data": {
-                "format": "parquet",
-                "location": "badlocation",
+            "steps": {
+                "ingest": {
+                    "using": "parquet",
+                    "location": "badlocation",
+                }
             },
         },
         pipeline_root=os.getcwd(),
@@ -530,9 +538,11 @@ def test_run_pipeline_step_failure_clears_downstream_step_state(test_pipeline):
     ingest_step_bad = IngestStep.from_pipeline_config(
         pipeline_config={
             "target_col": "C",
-            "data": {
-                "format": "parquet",
-                "location": "badlocation",
+            "steps": {
+                "ingest": {
+                    "using": "parquet",
+                    "location": "badlocation",
+                }
             },
         },
         pipeline_root=os.getcwd(),

--- a/tests/pipelines/test_ingest_step.py
+++ b/tests/pipelines/test_ingest_step.py
@@ -81,9 +81,11 @@ def test_ingests_parquet_successfully(use_relative_path, multiple_files, pandas_
     IngestStep.from_pipeline_config(
         pipeline_config={
             "target_col": "C",
-            "data": {
-                "format": "parquet",
-                "location": str(dataset_path),
+            "steps": {
+                "ingest": {
+                    "using": "parquet",
+                    "location": str(dataset_path),
+                }
             },
         },
         pipeline_root=os.getcwd(),
@@ -126,10 +128,12 @@ def test_ingests_csv_successfully(
     IngestStep.from_pipeline_config(
         pipeline_config={
             "target_col": "C",
-            "data": {
-                "format": "csv",
-                "location": dataset_path,
-                "custom_loader_method": "steps.ingest.load_file_as_dataframe",
+            "steps": {
+                "ingest": {
+                    "using": "csv",
+                    "location": dataset_path,
+                    "custom_loader_method": "steps.ingest.load_file_as_dataframe",
+                }
             },
         },
         pipeline_root=os.getcwd(),
@@ -148,15 +152,17 @@ def test_ingests_remote_http_datasets_with_multiple_files_successfully(tmp_path)
     IngestStep.from_pipeline_config(
         pipeline_config={
             "target_col": "density",
-            "data": {
-                "format": "csv",
-                "location": [
-                    "https://archive.ics.uci.edu/ml/machine-learning-databases/wine-quality/winequality-red.csv",
-                    "https://archive.ics.uci.edu/ml/machine-learning-databases/wine-quality/winequality-white.csv",
-                ],
-                "custom_loader_method": "tests.pipelines.test_ingest_step.custom_load_wine_csv",
+            "steps": {
+                "ingest": {
+                    "skip_data_profiling": True,
+                    "using": "csv",
+                    "location": [
+                        "https://archive.ics.uci.edu/ml/machine-learning-databases/wine-quality/winequality-red.csv",
+                        "https://archive.ics.uci.edu/ml/machine-learning-databases/wine-quality/winequality-white.csv",
+                    ],
+                    "custom_loader_method": "tests.pipelines.test_ingest_step.custom_load_wine_csv",
+                }
             },
-            "steps": {"ingest": {"skip_data_profiling": True}},
         },
         pipeline_root=os.getcwd(),
     ).run(output_directory=tmp_path)
@@ -189,12 +195,14 @@ def test_ingests_custom_format_successfully(use_relative_path, multiple_files, p
     IngestStep.from_pipeline_config(
         pipeline_config={
             "target_col": "C",
-            "data": {
-                "format": "fooformat",
-                "location": str(dataset_path),
-                "custom_loader_method": (
-                    "tests.pipelines.test_ingest_step.custom_load_file_as_dataframe"
-                ),
+            "steps": {
+                "ingest": {
+                    "using": "fooformat",
+                    "location": str(dataset_path),
+                    "custom_loader_method": (
+                        "tests.pipelines.test_ingest_step.custom_load_file_as_dataframe"
+                    ),
+                }
             },
         },
         pipeline_root=os.getcwd(),
@@ -215,10 +223,12 @@ def test_ingest_throws_for_custom_dataset_when_custom_loader_function_cannot_be_
         IngestStep.from_pipeline_config(
             pipeline_config={
                 "target_col": "C",
-                "data": {
-                    "format": "fooformat",
-                    "location": str(dataset_path),
-                    "custom_loader_method": "non.existent.module.non.existent.method",
+                "steps": {
+                    "ingest": {
+                        "using": "fooformat",
+                        "location": str(dataset_path),
+                        "custom_loader_method": ("non.existent.module.non.existent.method"),
+                    }
                 },
             },
             pipeline_root=os.getcwd(),
@@ -238,10 +248,12 @@ def test_ingest_throws_for_custom_dataset_when_custom_loader_function_not_implem
         IngestStep.from_pipeline_config(
             pipeline_config={
                 "target_col": "C",
-                "data": {
-                    "format": "fooformat",
-                    "location": str(dataset_path),
-                    "custom_loader_method": "steps.ingest.load_file_as_dataframe",
+                "steps": {
+                    "ingest": {
+                        "using": "fooformat",
+                        "location": str(dataset_path),
+                        "custom_loader_method": "steps.ingest.load_file_as_dataframe",
+                    }
                 },
             },
             pipeline_root=os.getcwd(),
@@ -261,12 +273,14 @@ def test_ingest_throws_for_custom_dataset_when_custom_method_returns_array(panda
         IngestStep.from_pipeline_config(
             pipeline_config={
                 "target_col": "C",
-                "data": {
-                    "format": "fooformat",
-                    "location": str(dataset_path),
-                    "custom_loader_method": (
-                        "tests.pipelines.test_ingest_step.custom_load_file_as_array"
-                    ),
+                "steps": {
+                    "ingest": {
+                        "using": "fooformat",
+                        "location": str(dataset_path),
+                        "custom_loader_method": (
+                            "tests.pipelines.test_ingest_step.custom_load_file_as_array"
+                        ),
+                    }
                 },
             },
             pipeline_root=os.getcwd(),
@@ -291,12 +305,14 @@ def test_ingest_throws_for_custom_dataset_when_custom_loader_function_throws_une
             IngestStep.from_pipeline_config(
                 pipeline_config={
                     "target_col": "C",
-                    "data": {
-                        "format": "fooformat",
-                        "location": str(dataset_path),
-                        "custom_loader_method": (
-                            "tests.pipelines.test_ingest_step.custom_load_file_as_dataframe"
-                        ),
+                    "steps": {
+                        "ingest": {
+                            "using": "fooformat",
+                            "location": str(dataset_path),
+                            "custom_loader_method": (
+                                "tests.pipelines.test_ingest_step.custom_load_file_as_dataframe"
+                            ),
+                        }
                     },
                 },
                 pipeline_root=os.getcwd(),
@@ -312,9 +328,11 @@ def test_ingests_remote_s3_datasets_successfully(mock_s3_bucket, pandas_df, tmp_
     IngestStep.from_pipeline_config(
         pipeline_config={
             "target_col": "C",
-            "data": {
-                "format": "parquet",
-                "location": f"s3://{mock_s3_bucket}/df.parquet",
+            "steps": {
+                "ingest": {
+                    "using": "parquet",
+                    "location": f"s3://{mock_s3_bucket}/df.parquet",
+                }
             },
         },
         pipeline_root=os.getcwd(),
@@ -330,10 +348,12 @@ def test_ingests_remote_http_datasets_successfully(tmp_path):
     IngestStep.from_pipeline_config(
         pipeline_config={
             "target_col": "density",
-            "data": {
-                "format": "csv",
-                "location": dataset_url,
-                "custom_loader_method": "steps.ingest.load_file_as_dataframe",
+            "steps": {
+                "ingest": {
+                    "using": "csv",
+                    "location": dataset_url,
+                    "custom_loader_method": "steps.ingest.load_file_as_dataframe",
+                }
             },
         },
         pipeline_root=os.getcwd(),
@@ -350,9 +370,11 @@ def test_ingests_spark_sql_successfully(spark_df, tmp_path):
     IngestStep.from_pipeline_config(
         pipeline_config={
             "target_col": "label",
-            "data": {
-                "format": "spark_sql",
-                "sql": "SELECT * FROM test_table ORDER BY id",
+            "steps": {
+                "ingest": {
+                    "using": "spark_sql",
+                    "sql": "SELECT * FROM test_table ORDER BY id",
+                }
             },
         },
         pipeline_root=os.getcwd(),
@@ -378,7 +400,7 @@ def test_ingests_spark_sql_location_successfully(spark_df, tmp_path):
     IngestStep.from_pipeline_config(
         pipeline_config={
             "target_col": "label",
-            "data": {"format": "spark_sql", "location": "test_table"},
+            "steps": {"ingest": {"using": "spark_sql", "location": "test_table"}},
         },
         pipeline_root=os.getcwd(),
     ).run(output_directory=tmp_path)
@@ -407,9 +429,11 @@ def test_ingests_delta_successfully(use_relative_path, spark_df, tmp_path):
     IngestStep.from_pipeline_config(
         pipeline_config={
             "target_col": "label",
-            "data": {
-                "format": "delta",
-                "location": str(dataset_path),
+            "steps": {
+                "ingest": {
+                    "using": "delta",
+                    "location": str(dataset_path),
+                }
             },
         },
         pipeline_root=os.getcwd(),
@@ -445,10 +469,12 @@ def test_ingests_delta_with_table_version_successfully(spark_session, spark_df, 
     IngestStep.from_pipeline_config(
         pipeline_config={
             "target_col": "label",
-            "data": {
-                "format": "delta",
-                "location": str(dataset_path),
-                "version": version,
+            "steps": {
+                "ingest": {
+                    "using": "delta",
+                    "location": str(dataset_path),
+                    "version": version,
+                }
             },
         },
         pipeline_root=os.getcwd(),
@@ -500,10 +526,12 @@ def test_ingests_delta_with_timestamp_successfully(
     IngestStep.from_pipeline_config(
         pipeline_config={
             "target_col": "label",
-            "data": {
-                "format": "delta",
-                "location": str(dataset_path),
-                "timestamp": timestamps[timestamp_idx],
+            "steps": {
+                "ingest": {
+                    "using": "delta",
+                    "location": str(dataset_path),
+                    "timestamp": timestamps[timestamp_idx],
+                }
             },
         },
         pipeline_root=os.getcwd(),
@@ -539,9 +567,11 @@ def test_ingest_directory_ignores_files_that_do_not_match_dataset_format(pandas_
     IngestStep.from_pipeline_config(
         pipeline_config={
             "target_col": "C",
-            "data": {
-                "format": "parquet",
-                "location": str(dataset_path),
+            "steps": {
+                "ingest": {
+                    "using": "parquet",
+                    "location": str(dataset_path),
+                }
             },
         },
         pipeline_root=os.getcwd(),
@@ -559,9 +589,11 @@ def test_ingest_produces_expected_step_card(pandas_df, tmp_path):
     IngestStep.from_pipeline_config(
         pipeline_config={
             "target_col": "C",
-            "data": {
-                "format": "parquet",
-                "location": str(dataset_path),
+            "steps": {
+                "ingest": {
+                    "using": "parquet",
+                    "location": str(dataset_path),
+                }
             },
         },
         pipeline_root=os.getcwd(),
@@ -592,9 +624,11 @@ def test_ingest_throws_when_spark_unavailable_for_spark_based_dataset(spark_df, 
         IngestStep.from_pipeline_config(
             pipeline_config={
                 "target_col": "C",
-                "data": {
-                    "format": "delta",
-                    "location": str(dataset_path),
+                "steps": {
+                    "ingest": {
+                        "using": "delta",
+                        "location": str(dataset_path),
+                    }
                 },
             },
             pipeline_root=os.getcwd(),
@@ -614,9 +648,11 @@ def test_ingest_makes_spark_session_if_not_available_for_spark_based_dataset(spa
         IngestStep.from_pipeline_config(
             pipeline_config={
                 "target_col": "label",
-                "data": {
-                    "format": "delta",
-                    "location": str(dataset_path),
+                "steps": {
+                    "ingest": {
+                        "using": "delta",
+                        "location": str(dataset_path),
+                    }
                 },
             },
             pipeline_root=os.getcwd(),
@@ -628,8 +664,10 @@ def test_ingest_throws_when_dataset_format_unspecified():
     ingest_step = IngestStep.from_pipeline_config(
         pipeline_config={
             "target_col": "C",
-            "data": {
-                "location": "my_location",
+            "steps": {
+                "ingest": {
+                    "location": "my_location",
+                }
             },
         },
         pipeline_root=os.getcwd(),
@@ -653,9 +691,11 @@ def test_ingest_throws_when_required_dataset_config_keys_are_missing():
     ingest_step = IngestStep.from_pipeline_config(
         pipeline_config={
             "target_col": "C",
-            "data": {
-                "format": "parquet",
-                # Missing location
+            "steps": {
+                "ingest": {
+                    "using": "parquet",
+                    # Missing location
+                }
             },
         },
         pipeline_root=os.getcwd(),
@@ -666,9 +706,11 @@ def test_ingest_throws_when_required_dataset_config_keys_are_missing():
     ingest_step = IngestStep.from_pipeline_config(
         pipeline_config={
             "target_col": "C",
-            "data": {
-                "format": "spark_sql",
-                # Missing sql and location
+            "steps": {
+                "ingest": {
+                    "using": "spark_sql",
+                    # Missing sql and location
+                }
             },
         },
         pipeline_root=os.getcwd(),
@@ -685,10 +727,12 @@ def test_ingest_throws_when_required_dataset_config_keys_are_missing():
     ingest_step = IngestStep.from_pipeline_config(
         pipeline_config={
             "target_col": "C",
-            "data": {
-                "format": "csv",
-                "location": "my/dataset.csv",
-                # Missing custom_loader_method
+            "steps": {
+                "ingest": {
+                    "using": "csv",
+                    "location": "my/dataset.csv",
+                    # Missing custom_loader_method
+                }
             },
         },
         pipeline_root=os.getcwd(),
@@ -710,10 +754,12 @@ def test_ingest_throws_when_dataset_files_have_wrong_format(pandas_df, tmp_path)
         IngestStep.from_pipeline_config(
             pipeline_config={
                 "target_col": "C",
-                "data": {
-                    # Intentionally use an incorrect format that doesn't match the dataset
-                    "format": "parquet",
-                    "location": str(dataset_path),
+                "steps": {
+                    "ingest": {
+                        # Intentionally use an incorrect format that doesn't match the dataset
+                        "using": "parquet",
+                        "location": str(dataset_path),
+                    }
                 },
             },
             pipeline_root=os.getcwd(),
@@ -732,10 +778,12 @@ def test_ingest_throws_when_dataset_files_have_wrong_format(pandas_df, tmp_path)
         IngestStep.from_pipeline_config(
             pipeline_config={
                 "target_col": "C",
-                "data": {
-                    # Intentionally use an incorrect format that doesn't match the dataset
-                    "format": "parquet",
-                    "location": str(dataset_path),
+                "steps": {
+                    "ingest": {
+                        # Intentionally use an incorrect format that doesn't match the dataset
+                        "using": "parquet",
+                        "location": str(dataset_path),
+                    }
                 },
             },
             pipeline_root=os.getcwd(),
@@ -751,11 +799,13 @@ def test_ingest_skips_profiling_when_specified(pandas_df, tmp_path):
         IngestStep.from_pipeline_config(
             pipeline_config={
                 "target_col": "C",
-                "data": {
-                    "format": "parquet",
-                    "location": str(dataset_path),
+                "steps": {
+                    "ingest": {
+                        "using": "parquet",
+                        "location": str(dataset_path),
+                        "skip_data_profiling": True,
+                    }
                 },
-                "steps": {"ingest": {"skip_data_profiling": True}},
             },
             pipeline_root=os.getcwd(),
         ).run(output_directory=tmp_path)

--- a/tests/pipelines/test_pipeline.py
+++ b/tests/pipelines/test_pipeline.py
@@ -204,7 +204,7 @@ def test_pipelines_run_throws_exception_and_produces_failure_card_when_step_fail
     with open(profile_path, "r") as f:
         profile_contents = yaml.safe_load(f)
 
-    profile_contents["INGEST_DATA_LOCATION"] = "a bad location"
+    profile_contents["INGEST_STEP_CONFIG"] = {"using": "parquet", "location": "a bad location"}
 
     with open(profile_path, "w") as f:
         yaml.safe_dump(profile_contents, f)

--- a/tests/pipelines/test_pipeline.py
+++ b/tests/pipelines/test_pipeline.py
@@ -204,7 +204,7 @@ def test_pipelines_run_throws_exception_and_produces_failure_card_when_step_fail
     with open(profile_path, "r") as f:
         profile_contents = yaml.safe_load(f)
 
-    profile_contents["INGEST_STEP_CONFIG"] = {"using": "parquet", "location": "a bad location"}
+    profile_contents["INGEST_CONFIG"] = {"using": "parquet", "location": "a bad location"}
 
     with open(profile_path, "w") as f:
         yaml.safe_dump(profile_contents, f)

--- a/tests/pipelines/test_predict_step.py
+++ b/tests/pipelines/test_predict_step.py
@@ -417,10 +417,11 @@ def test_predict_uses_registry_uri(
     mlflow.set_registry_uri("")
 
     pipeline_config = read_yaml(tmp_pipeline_root_path, _PIPELINE_CONFIG_FILE_NAME)
-    pipeline_config.update({"model_registry": {"uri": str(registry_uri)}})
+    pipeline_config.update(
+        {"model_registry": {"registry_uri": str(registry_uri), "model_uri": model_uri}}
+    )
     pipeline_config.update(
         {
-            "model_registry": {"model_uri": model_uri},
             "steps": {
                 "predict": {
                     "using": "parquet",

--- a/tests/pipelines/test_predict_step.py
+++ b/tests/pipelines/test_predict_step.py
@@ -112,8 +112,10 @@ def test_predict_step_runs(
             },
             "steps": {
                 "predict": {
-                    "using": "parquet",
-                    "output_location": str(predict_step_output_dir.joinpath("output.parquet")),
+                    "output": {
+                        "using": "parquet",
+                        "location": str(predict_step_output_dir.joinpath("output.parquet")),
+                    }
                 },
             },
         }
@@ -147,8 +149,10 @@ def test_predict_step_uses_register_step_model_name(
             "model_registry": {"model_name": rm_name},
             "steps": {
                 "predict": {
-                    "using": "parquet",
-                    "output_location": str(predict_step_output_dir.joinpath("output.parquet")),
+                    "output": {
+                        "using": "parquet",
+                        "location": str(predict_step_output_dir.joinpath("output.parquet")),
+                    }
                 },
             },
         }
@@ -185,8 +189,10 @@ def test_predict_step_uses_register_step_output(
             "model_registry": {"model_name": register_step_rm_name},
             "steps": {
                 "predict": {
-                    "using": "parquet",
-                    "output_location": str(predict_step_output_dir.joinpath("output.parquet")),
+                    "output": {
+                        "using": "parquet",
+                        "location": str(predict_step_output_dir.joinpath("output.parquet")),
+                    }
                 },
             },
         }
@@ -219,8 +225,10 @@ def test_predict_model_uri_takes_precendence_over_model_name(
             "model_registry": {"model_name": register_step_rm_name, "model_uri": model_uri},
             "steps": {
                 "predict": {
-                    "using": "parquet",
-                    "output_location": str(predict_step_output_dir.joinpath("output.parquet")),
+                    "output": {
+                        "using": "parquet",
+                        "location": str(predict_step_output_dir.joinpath("output.parquet")),
+                    }
                 },
             },
         }
@@ -249,16 +257,18 @@ def test_predict_step_output_formats(
             "model_registry": {"model_uri": model_uri},
             "steps": {
                 "predict": {
-                    "using": output_format,
+                    "output": {
+                        "using": output_format,
+                    }
                 },
             },
         }
     )
     if output_format == "table":
-        pipeline_config["steps"]["predict"]["output_location"] = output_name
+        pipeline_config["steps"]["predict"]["output"]["location"] = output_name
     else:
         file_name = "{}.{}".format(output_name, output_format)
-        pipeline_config["steps"]["predict"]["output_location"] = str(
+        pipeline_config["steps"]["predict"]["output"]["location"] = str(
             predict_step_output_dir / file_name
         )
     predict_step = PredictStep.from_pipeline_config(pipeline_config, str(tmp_pipeline_root_path))
@@ -266,13 +276,13 @@ def test_predict_step_output_formats(
     prediction_assertions(predict_step_output_dir, output_format, output_name, spark_session)
 
 
-@pytest.mark.parametrize("output_format", ["parquet", "delta", "table"])
+@pytest.mark.parametrize("using", ["parquet", "delta", "table"])
 @pytest.mark.parametrize("save_mode", ["default", "overwrite"])
 def test_predict_correctly_handles_save_modes(
     tmp_pipeline_root_path: Path,
     predict_step_output_dir: Path,
     spark_session,
-    output_format: str,
+    using: str,
     save_mode: str,
 ):
     rm_name = "model_" + get_random_id()
@@ -285,13 +295,13 @@ def test_predict_correctly_handles_save_modes(
         ],
         ["age", "sex", "bmi", "bp", "s1", "s2", "s3", "s4", "s5", "s6", "prediction"],
     )
-    if output_format == "table":
+    if using == "table":
         output_path = get_random_id()
         sdf.write.format("delta").saveAsTable(output_path)
     else:
-        output_file = "output_{}.{}".format(get_random_id(), output_format)
+        output_file = "output_{}.{}".format(get_random_id(), using)
         output_path = str(predict_step_output_dir / output_file)
-        sdf.coalesce(1).write.format(output_format).save(output_path)
+        sdf.coalesce(1).write.format(using).save(output_path)
 
     pipeline_config = read_yaml(tmp_pipeline_root_path, _PIPELINE_CONFIG_FILE_NAME)
     pipeline_config.update(
@@ -299,9 +309,11 @@ def test_predict_correctly_handles_save_modes(
             "model_registry": {"model_uri": model_uri},
             "steps": {
                 "predict": {
-                    "using": output_format,
-                    "output_location": output_path,
-                    "save_mode": save_mode,
+                    "output": {
+                        "using": using,
+                        "location": output_path,
+                        "save_mode": save_mode,
+                    }
                 },
             },
         }
@@ -317,17 +329,19 @@ def test_predict_correctly_handles_save_modes(
 
 @pytest.mark.usefixtures("enter_test_pipeline_directory")
 def test_predict_throws_when_improperly_configured():
-    for required_key in ["using", "output_location"]:
+    for required_key in ["using", "location"]:
         pipeline_config = {
             "model_registry": {"model_uri": "models:/taxi_fare_regressor/Production"},
             "steps": {
                 "predict": {
-                    "using": "parquet",
-                    "output_location": "random/path",
+                    "output": {
+                        "using": "parquet",
+                        "location": "random/path",
+                    }
                 },
             },
         }
-        pipeline_config["steps"]["predict"].pop(required_key)
+        pipeline_config["steps"]["predict"]["output"].pop(required_key)
         predict_step = PredictStep.from_pipeline_config(
             pipeline_config=pipeline_config,
             pipeline_root=os.getcwd(),
@@ -342,8 +356,10 @@ def test_predict_throws_when_improperly_configured():
             "model_registry": {"model_uri": "my model"},
             "steps": {
                 "predict": {
-                    "using": "fancy_format",
-                    "output_location": "random/path",
+                    "output": {
+                        "using": "fancy_format",
+                        "location": "random/path",
+                    }
                 },
             },
         },
@@ -358,8 +374,10 @@ def test_predict_throws_when_no_model_is_specified():
     pipeline_config = {
         "steps": {
             "predict": {
-                "using": "parquet",
-                "output_location": "random/path",
+                "output": {
+                    "using": "parquet",
+                    "location": "random/path",
+                }
             }
         }
     }
@@ -384,8 +402,10 @@ def test_predict_skips_profiling_when_specified(
                 "model_registry": {"model_uri": model_uri},
                 "steps": {
                     "predict": {
-                        "using": "parquet",
-                        "output_location": str(predict_step_output_dir.joinpath("output.parquet")),
+                        "output": {
+                            "using": "parquet",
+                            "location": str(predict_step_output_dir.joinpath("output.parquet")),
+                        },
                         "skip_data_profiling": True,
                     },
                 },
@@ -424,8 +444,10 @@ def test_predict_uses_registry_uri(
         {
             "steps": {
                 "predict": {
-                    "using": "parquet",
-                    "output_location": str(predict_step_output_dir.joinpath("output.parquet")),
+                    "output": {
+                        "using": "parquet",
+                        "location": str(predict_step_output_dir.joinpath("output.parquet")),
+                    }
                 },
             },
         }

--- a/tests/pipelines/test_register_step.py
+++ b/tests/pipelines/test_register_step.py
@@ -44,6 +44,8 @@ template: "regression/v1"
 target_col: "y"
 experiment:
   tracking_uri: {tracking_uri}
+model_registry:
+  model_name: "demo_model"
 steps:
   evaluate:
     validation_criteria:
@@ -54,13 +56,11 @@ steps:
       - metric: weighted_mean_squared_error
         threshold: 1_000_000
   register:
-    model_name: "demo_model"
     {allow_non_validated_model}
-metrics:
-  custom:
-    - name: weighted_mean_squared_error
-      function: weighted_mean_squared_error
-      greater_is_better: False
+custom_metrics:
+  - name: weighted_mean_squared_error
+    function: weighted_mean_squared_error
+    greater_is_better: False
 """.format(
             tracking_uri=mlflow.get_tracking_uri(),
             mae_threshold=mae_threshold,
@@ -116,10 +116,11 @@ template: "regression/v1"
 target_col: "y"
 experiment:
   tracking_uri: {tracking_uri}
+model_registry:
+  model_name: "demo_model"
 steps:
   evaluate:
   register:
-    model_name: "demo_model"
     {allow_non_validated_model}
 """.format(
             tracking_uri=mlflow.get_tracking_uri(),
@@ -158,6 +159,8 @@ def test_usage_tracking_correctly_added(
         """
 template: "regression/v1"
 target_col: "y"
+model_registry:
+  model_name: "demo_model"
 experiment:
   tracking_uri: {tracking_uri}
 steps:
@@ -169,13 +172,10 @@ steps:
         threshold: 1_000_000
       - metric: weighted_mean_squared_error
         threshold: 1_000_000
-  register:
-    model_name: "demo_model"
-metrics:
-  custom:
-    - name: weighted_mean_squared_error
-      function: weighted_mean_squared_error
-      greater_is_better: False
+custom_metrics:
+  - name: weighted_mean_squared_error
+    function: weighted_mean_squared_error
+    greater_is_better: False
 """.format(
             tracking_uri=mlflow.get_tracking_uri(),
         )
@@ -224,7 +224,8 @@ target_col: "y"
 experiment:
   tracking_uri: {tracking_uri}
 model_registry:
-  uri: {registry_uri}
+  registry_uri: {registry_uri}
+  model_name: "demo_model"
 steps:
   evaluate:
     validation_criteria:
@@ -234,13 +235,10 @@ steps:
         threshold: 1_000_000
       - metric: weighted_mean_squared_error
         threshold: 1_000_000
-  register:
-    model_name: "demo_model"
-metrics:
-  custom:
-    - name: weighted_mean_squared_error
-      function: weighted_mean_squared_error
-      greater_is_better: False
+custom_metrics:
+  - name: weighted_mean_squared_error
+    function: weighted_mean_squared_error
+    greater_is_better: False
 """.format(
             tracking_uri=mlflow.get_tracking_uri(),
             registry_uri=registry_uri,
@@ -287,13 +285,13 @@ template: "regression/v1"
 target_col: "y"
 experiment:
   tracking_uri: {tracking_uri}
+model_registry:
+  model_name: "demo_model"
 steps:
   evaluate:
     validation_criteria:
       - metric: root_mean_squared_error
         threshold: 1_000_000
-  register:
-    model_name: "demo_model"
 """.format(
             tracking_uri=mlflow.get_tracking_uri()
         )

--- a/tests/pipelines/test_tracking_utils.py
+++ b/tests/pipelines/test_tracking_utils.py
@@ -43,9 +43,9 @@ def test_get_pipeline_tracking_config_returns_expected_config(
 
     profile_contents = {
         "experiment": {},
-        "INGEST_DATA_LOCATION": None,
-        "INGEST_SCORING_DATA_LOCATION": None,
-        "SCORED_OUTPUT_DATA_LOCATION": None,
+        "INGEST_STEP_CONFIG": None,
+        "REGISTER_STEP_CONFIG": None,
+        "PREDICT_STEP_CONFIG": None,
     }
     if tracking_uri is not None:
         profile_contents["experiment"]["tracking_uri"] = tracking_uri
@@ -97,9 +97,9 @@ def test_get_pipeline_tracking_config_returns_expected_config_on_databricks(
 
         profile_contents = {
             "experiment": {},
-            "INGEST_DATA_LOCATION": None,
-            "INGEST_SCORING_DATA_LOCATION": None,
-            "SCORED_OUTPUT_DATA_LOCATION": None,
+            "INGEST_STEP_CONFIG": None,
+            "REGISTER_STEP_CONFIG": None,
+            "PREDICT_STEP_CONFIG": None,
         }
         if tracking_uri is not None:
             profile_contents["experiment"]["tracking_uri"] = tracking_uri

--- a/tests/pipelines/test_tracking_utils.py
+++ b/tests/pipelines/test_tracking_utils.py
@@ -45,7 +45,7 @@ def test_get_pipeline_tracking_config_returns_expected_config(
         "experiment": {},
         "INGEST_CONFIG": None,
         "INGEST_SCORING_CONFIG": None,
-        "PREDICT_CONFIG": None,
+        "PREDICT_OUTPUT_CONFIG": None,
     }
     if tracking_uri is not None:
         profile_contents["experiment"]["tracking_uri"] = tracking_uri
@@ -99,7 +99,7 @@ def test_get_pipeline_tracking_config_returns_expected_config_on_databricks(
             "experiment": {},
             "INGEST_CONFIG": None,
             "INGEST_SCORING_CONFIG": None,
-            "PREDICT_CONFIG": None,
+            "PREDICT_OUTPUT_CONFIG": None,
         }
         if tracking_uri is not None:
             profile_contents["experiment"]["tracking_uri"] = tracking_uri

--- a/tests/pipelines/test_tracking_utils.py
+++ b/tests/pipelines/test_tracking_utils.py
@@ -43,9 +43,9 @@ def test_get_pipeline_tracking_config_returns_expected_config(
 
     profile_contents = {
         "experiment": {},
-        "INGEST_STEP_CONFIG": None,
-        "REGISTER_STEP_CONFIG": None,
-        "PREDICT_STEP_CONFIG": None,
+        "INGEST_CONFIG": None,
+        "INGEST_SCORING_CONFIG": None,
+        "PREDICT_CONFIG": None,
     }
     if tracking_uri is not None:
         profile_contents["experiment"]["tracking_uri"] = tracking_uri
@@ -97,9 +97,9 @@ def test_get_pipeline_tracking_config_returns_expected_config_on_databricks(
 
         profile_contents = {
             "experiment": {},
-            "INGEST_STEP_CONFIG": None,
-            "REGISTER_STEP_CONFIG": None,
-            "PREDICT_STEP_CONFIG": None,
+            "INGEST_CONFIG": None,
+            "INGEST_SCORING_CONFIG": None,
+            "PREDICT_CONFIG": None,
         }
         if tracking_uri is not None:
             profile_contents["experiment"]["tracking_uri"] = tracking_uri

--- a/tests/pipelines/test_train_step.py
+++ b/tests/pipelines/test_train_step.py
@@ -144,15 +144,15 @@ def setup_train_step_with_automl(
     pipeline_yaml = pipeline_root.joinpath(_PIPELINE_CONFIG_FILE_NAME)
 
     custom_metric = """
-    custom:
-      - name: weighted_mean_squared_error
-        function: weighted_mean_squared_error
-        greater_is_better: False
+    - name: weighted_mean_squared_error
+      function: weighted_mean_squared_error
+      greater_is_better: False
             """
     pipeline_yaml.write_text(
         f"""
   template: regression/v1
   target_col: y
+  primary_metric: { primary_metric }
   profile: test_profile
   run_args:
     step: train
@@ -168,9 +168,8 @@ def setup_train_step_with_automl(
           - xgboost
           - rf
           - lgbm
-  metrics:
+  custom_metrics:
     { custom_metric if generate_custom_metrics else "" }
-    primary: { primary_metric }
         """
     )
     pipeline_config = read_yaml(pipeline_root, _PIPELINE_CONFIG_FILE_NAME)


### PR DESCRIPTION
## What changes are proposed in this pull request?
Refactoring pipeline config to update to new spec

## How is this patch tested?
- [x] Ran a notebook using this branch: https://github.com/mlflow/mlp-regression-example/tree/sunish-pipeline-2.0
- [x] Test passes 

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
Refactoring pipeline config to update to new spec for MLP

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [x] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
