### PR TITLE
Run SQLAlchemy store tests with sqlalchemy 2.0.0b2

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -142,12 +142,7 @@ jobs:
         test $err = 0
     - name: Rebuild images with SQLAlchemy 2.x
       run: |
-        sed -i '/sqlalchemy.*/d' requirements/core-requirements.txt
-        # https://github.com/sqlalchemy/sqlalchemy/commit/f4214975a7deb5e13f8b6cf21e39697821396a7f
-        # is a patch for https://github.com/sqlalchemy/sqlalchemy/issues/8661. Tests that log a tag
-        # with a long value (e.g. `"a" * 5000`) fail because of this issue. Install sqlalchemy from
-        # this commit until a new 2.x version is published on PyPI.
-        echo 'sqlalchemy@git+https://github.com/sqlalchemy/sqlalchemy.git@f4214975a7deb5e13f8b6cf21e39697821396a7f' >> requirements/core-requirements.txt
+        sed -i 's/sqlalchemy.*/sqlalchemy==2.0.0b2/g' requirements/core-requirements.txt
         git diff
         ./tests/db/compose.sh build --build-arg DEPENDENCIES="$(python setup.py -q dependencies)"
     - name: Run tests

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -142,7 +142,7 @@ jobs:
         test $err = 0
     - name: Rebuild images with SQLAlchemy 2.x
       run: |
-        sed -i 's/sqlalchemy.*/sqlalchemy==2.0.0b2/g' requirements/core-requirements.txt
+        sed -i 's/sqlalchemy.*/sqlalchemy>=2.0.0b0/g' requirements/core-requirements.txt
         git diff
         ./tests/db/compose.sh build --build-arg DEPENDENCIES="$(python setup.py -q dependencies)"
     - name: Run tests

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -142,7 +142,7 @@ jobs:
         test $err = 0
     - name: Rebuild images with SQLAlchemy 2.x
       run: |
-        sed -i 's/sqlalchemy.*/sqlalchemy>=2.0.0b0/g' requirements/core-requirements.txt
+        sed -i 's/sqlalchemy.*/sqlalchemy>=2.0.0b2/g' requirements/core-requirements.txt
         git diff
         ./tests/db/compose.sh build --build-arg DEPENDENCIES="$(python setup.py -q dependencies)"
     - name: Run tests


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Run SQLAlchemy store tests with sqlalchemy 2.0.0b2.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
