### PR TITLE
Changes to support ragged arrays in signature handling

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -311,9 +311,19 @@ missing values.
 Handling Date and Timestamp
 """""""""""""""""""""""""""
 For datetime values, Python has precision built into the type. For example, datetime values with
-day precision have NumPy type ``datetime64[D]``, while values with nanosecond precision have
+day precision have numpy type ``datetime64[D]``, while values with nanosecond precision have
 type ``datetime64[ns]``. Datetime precision is ignored for column-based model signature but is
 enforced for tensor-based signatures.
+
+Handling Ragged Arrays
+""""""""""""""""""""""
+Ragged arrays can be created in numpy and are produced with a shape of (-1,) and a dytpe of
+object. This will be handled by default when using ``infer_signature``, resulting in a
+signature containing ``Tensor('object', (-1,))``. A similar signature can be manually created
+containing a more detailed representation of a ragged array, for a more expressive signature,
+such as ``Tensor('object', (-1, -1, -1, 3))``. Enforcement will then be done on as much detail
+as possible given the signature provided, and will support ragged input arrays as well.
+
 
 .. _how-to-log-models-with-signatures:
 

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -321,7 +321,7 @@ Ragged arrays can be created in numpy and are produced with a shape of (-1,) and
 object. This will be handled by default when using ``infer_signature``, resulting in a
 signature containing ``Tensor('object', (-1,))``. A similar signature can be manually created
 containing a more detailed representation of a ragged array, for a more expressive signature,
-such as ``Tensor('object', (-1, -1, -1, 3))``. Enforcement will then be done on as much detail
+such as ``Tensor('float64', (-1, -1, -1, 3))``. Enforcement will then be done on as much detail
 as possible given the signature provided, and will support ragged input arrays as well.
 
 

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -297,6 +297,7 @@ def _enforce_tensor_spec(
     # representation of a ragged array. The second is for handling a more manual specification
     # of shape while support an input which is a ragged array.
     if len(expected_shape) == 1 and expected_shape[0] == -1 and expected_type == np.dtype("O"):
+        # Sample spec: Tensor('object', (-1,))
         return values
     if (
         len(expected_shape) > 1
@@ -304,6 +305,7 @@ def _enforce_tensor_spec(
         and len(actual_shape) == 1
         and actual_type == np.dtype("O")
     ):
+        # Sample spec: Tensor('object', (-1, -1, -1, 3))
         return values
 
     if len(expected_shape) != len(actual_shape):

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -293,9 +293,9 @@ def _enforce_tensor_spec(
     actual_shape = values.shape
     actual_type = values.dtype if isinstance(values, np.ndarray) else values.data.dtype
 
-    # This logic is for handling "ragged" arrays. The first check is for a standard numpy shape representation of
-    # a ragged array. The second is for handling a more manual specification of shape while support an input which
-    # is a ragged array.
+    # This logic is for handling "ragged" arrays. The first check is for a standard numpy shape
+    # representation of a ragged array. The second is for handling a more manual specification
+    # of shape while support an input which is a ragged array.
     if len(expected_shape) == 1 and expected_shape[0] == -1 and expected_type == np.dtype("O"):
         return values
     if (
@@ -321,8 +321,8 @@ def _enforce_tensor_spec(
                     actual_shape, expected_shape
                 )
             )
-    # Second clause provides support for signatures which support ragged arrays, but where the actual input
-    # isn't ragged
+    # Second clause provides support for signatures which support ragged arrays, but where the
+    # actual input isn't ragged
     if clean_tensor_type(actual_type) != expected_type and (
         -1 not in expected_shape[1:] or expected_type != np.dtype("O")
     ):

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -298,6 +298,7 @@ def _enforce_tensor_spec(
     # of shape while support an input which is a ragged array.
     if len(expected_shape) == 1 and expected_shape[0] == -1 and expected_type == np.dtype("O"):
         # Sample spec: Tensor('object', (-1,))
+        # Will pass on any provided input
         return values
     if (
         len(expected_shape) > 1
@@ -306,6 +307,7 @@ def _enforce_tensor_spec(
         and actual_type == np.dtype("O")
     ):
         # Sample spec: Tensor('object', (-1, -1, -1, 3))
+        # Will pass on inputs which are ragged arrays: shape==(x,), dtype=='object'
         return values
 
     if len(expected_shape) != len(actual_shape):

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -306,7 +306,7 @@ def _enforce_tensor_spec(
         and len(actual_shape) == 1
         and actual_type == np.dtype("O")
     ):
-        # Sample spec: Tensor('object', (-1, -1, -1, 3))
+        # Sample spec: Tensor('float64', (-1, -1, -1, 3))
         # Will pass on inputs which are ragged arrays: shape==(x,), dtype=='object'
         return values
 
@@ -325,11 +325,7 @@ def _enforce_tensor_spec(
                     actual_shape, expected_shape
                 )
             )
-    # Second clause provides support for signatures which support ragged arrays, but where the
-    # actual input isn't ragged
-    if clean_tensor_type(actual_type) != expected_type and (
-        -1 not in expected_shape[1:] or expected_type != np.dtype("O")
-    ):
+    if clean_tensor_type(actual_type) != expected_type:
         raise MlflowException(
             "dtype of input {0} does not match expected dtype {1}".format(
                 actual_type, expected_type

--- a/tests/types/test_schema.py
+++ b/tests/types/test_schema.py
@@ -516,7 +516,6 @@ def test_enforce_tensor_spec_variable_signature():
 
     standard_spec = _infer_schema(standard_array).inputs[0]
     assert standard_spec.shape == (-1, 2, 3)
-    assert standard_spec.type == np.dtype('int32')
 
     result_array = _enforce_tensor_spec(standard_array, standard_spec)
     np.testing.assert_array_equal(standard_array, result_array)

--- a/tests/types/test_schema.py
+++ b/tests/types/test_schema.py
@@ -1,5 +1,6 @@
 import json
 import math
+import re
 import numpy as np
 import pandas as pd
 import pytest
@@ -513,5 +514,8 @@ def test_enforce_tensor_spec_variable_signature():
     standard_spec = _infer_schema(standard_array).inputs[0]
     result_array = _enforce_tensor_spec(standard_array, standard_spec)
     np.testing.assert_array_equal(standard_array, result_array)
-    with pytest.raises(MlflowException):
+    with pytest.raises(
+        MlflowException,
+        match=re.escape(r"Shape of input (2,) does not match expected shape (-1, 2, 3)."),
+    ):
         _enforce_tensor_spec(ragged_array, standard_spec)

--- a/tests/types/test_schema.py
+++ b/tests/types/test_schema.py
@@ -500,6 +500,9 @@ def test_enforce_tensor_spec_variable_signature():
     ragged_array = np.array([[[1, 2, 3], [1, 2, 3]], [[1, 2, 3]]], dtype=object)
     inferred_schema = _infer_schema(ragged_array)
     inferred_spec = inferred_schema.inputs[0]
+    assert inferred_spec.shape == (-1,)
+    assert inferred_spec.type == np.dtype(object)
+
     result_array = _enforce_tensor_spec(standard_array, inferred_spec)
     np.testing.assert_array_equal(standard_array, result_array)
     result_array = _enforce_tensor_spec(ragged_array, inferred_spec)
@@ -512,6 +515,9 @@ def test_enforce_tensor_spec_variable_signature():
     np.testing.assert_array_equal(ragged_array, result_array)
 
     standard_spec = _infer_schema(standard_array).inputs[0]
+    assert standard_spec.shape == (-1, 2, 3)
+    assert standard_spec.type == np.dtype('int32')
+
     result_array = _enforce_tensor_spec(standard_array, standard_spec)
     np.testing.assert_array_equal(standard_array, result_array)
     with pytest.raises(

--- a/tests/types/test_schema.py
+++ b/tests/types/test_schema.py
@@ -496,7 +496,7 @@ def test_spark_type_mapping(pandas_df_with_all_types):
 
 
 def test_enforce_tensor_spec_variable_signature():
-    standard_array = np.array([[[1, 2, 3], [1, 2, 3]], [[1, 2, 3], [1, 2, 3]]])
+    standard_array = np.array([[[1, 2, 3], [1, 2, 3]], [[1, 2, 3], [1, 2, 3]]], dtype=np.int32)
     ragged_array = np.array([[[1, 2, 3], [1, 2, 3]], [[1, 2, 3]]], dtype=object)
     inferred_schema = _infer_schema(ragged_array)
     inferred_spec = inferred_schema.inputs[0]
@@ -508,7 +508,7 @@ def test_enforce_tensor_spec_variable_signature():
     result_array = _enforce_tensor_spec(ragged_array, inferred_spec)
     np.testing.assert_array_equal(ragged_array, result_array)
 
-    manual_spec = TensorSpec(np.dtype(object), (-1, -1, 3))
+    manual_spec = TensorSpec(np.dtype(np.int32), (-1, -1, 3))
     result_array = _enforce_tensor_spec(standard_array, manual_spec)
     np.testing.assert_array_equal(standard_array, result_array)
     result_array = _enforce_tensor_spec(ragged_array, manual_spec)


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR is to introduce/fix support for ragged arrays in signature handling. Because of the resulting nature of shape/type handling for ragged arrays, these changes are designed to loosen the handling of enforcement. There are three primary cases here:
- User uses `infer_signature` to create a signature using a ragged array. This results in a signature containing a (-1) shape and object type. In this situation, we simply pass the incoming array back, as we have no further way of validating.
- User manually creates a signature which contains -1 values in the shape. This means that the actual shape at this dimension can vary. In this case, we want to still make sure that the number of dimensions is the same, and that any non -1 values still match. However, since this type of signature can support ragged or non-ragged arrays as input, we don't want to fail if the expected type is "object" but the provided type is not.
- User provides either an inferred or non-inferred signature containing -1 values, and provides a ragged array as input. In this case we also simply pass the incoming array back, as we have no further way of validating.

Ultimately, this will lead to being able to support a broader range of models which have more customizable handling for their input logic.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

I've added a new test which exercises the new handling, as well as relying on existing tests.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Updates support for models which has a signature containing a -1. Loosens the support for input enforcement on these types of models at prediction time.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
