### PR TITLE
Do not append `mlflow.runName` tag if it's already in tags

### DIFF
--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -608,7 +608,7 @@ class FileStore(AbstractStore):
         run_name_tag = _get_run_name_from_tags(tags)
         if run_name and run_name_tag:
             raise MlflowException(
-                "Both 'run_name' argument and 'mlflow.runName' tag (deprecated) are specified. "
+                "Both 'run_name' argument and 'mlflow.runName' tag are specified. "
                 "Remove 'mlflow.runName' tag.",
                 INVALID_PARAMETER_VALUE,
             )

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -604,7 +604,17 @@ class FileStore(AbstractStore):
                 "Could not create run under non-active experiment with ID %s." % experiment_id,
                 databricks_pb2.INVALID_STATE,
             )
-        run_name = run_name if run_name else _generate_random_name()
+        tags = tags or []
+        run_name_tag = _get_run_name_from_tags(tags)
+        if run_name and run_name_tag:
+            raise MlflowException(
+                "Both 'run_name' and 'mlflow.runName' tag (deprecated) are specified. "
+                "Remove 'mlflow.runName' tag.",
+                INVALID_PARAMETER_VALUE,
+            )
+        run_name = run_name or run_name_tag or _generate_random_name()
+        if not run_name_tag:
+            tags.append(RunTag(key=MLFLOW_RUN_NAME, value=run_name))
         run_uuid = uuid.uuid4().hex
         artifact_uri = self._get_artifact_dir(experiment_id, run_uuid)
         run_info = RunInfo(
@@ -628,8 +638,6 @@ class FileStore(AbstractStore):
         mkdir(run_dir, FileStore.METRICS_FOLDER_NAME)
         mkdir(run_dir, FileStore.PARAMS_FOLDER_NAME)
         mkdir(run_dir, FileStore.ARTIFACTS_FOLDER_NAME)
-        tags = tags or []
-        tags.append(RunTag(MLFLOW_RUN_NAME, run_name))
         for tag in tags:
             self.set_tag(run_uuid, tag)
         return self.get_run(run_id=run_uuid)

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -608,7 +608,7 @@ class FileStore(AbstractStore):
         run_name_tag = _get_run_name_from_tags(tags)
         if run_name and run_name_tag:
             raise MlflowException(
-                "Both 'run_name' and 'mlflow.runName' tag (deprecated) are specified. "
+                "Both 'run_name' argument and 'mlflow.runName' tag (deprecated) are specified. "
                 "Remove 'mlflow.runName' tag.",
                 INVALID_PARAMETER_VALUE,
             )

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -552,7 +552,7 @@ class SqlAlchemyStore(AbstractStore):
             run_name_tag = _get_run_name_from_tags(tags)
             if run_name and run_name_tag:
                 raise MlflowException(
-                    "Both 'run_name' and 'mlflow.runName' tag (deprecated) are specified. "
+                    "Both 'run_name' argument and 'mlflow.runName' tag (deprecated) are specified. "
                     "Remove 'mlflow.runName' tag.",
                     INVALID_PARAMETER_VALUE,
                 )

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -57,7 +57,7 @@ from mlflow.utils.validation import (
     _validate_param,
     _validate_experiment_name,
 )
-from mlflow.utils.mlflow_tags import MLFLOW_LOGGED_MODELS, MLFLOW_RUN_NAME
+from mlflow.utils.mlflow_tags import MLFLOW_LOGGED_MODELS, MLFLOW_RUN_NAME, _get_run_name_from_tags
 from mlflow.utils.time_utils import get_current_time_millis
 
 _logger = logging.getLogger(__name__)
@@ -548,7 +548,17 @@ class SqlAlchemyStore(AbstractStore):
             artifact_location = append_to_uri_path(
                 experiment.artifact_location, run_id, SqlAlchemyStore.ARTIFACTS_FOLDER_NAME
             )
-            run_name = run_name if run_name else _generate_random_name()
+            tags = tags or []
+            run_name_tag = _get_run_name_from_tags(tags)
+            if run_name and run_name_tag:
+                raise MlflowException(
+                    "Both 'run_name' and 'mlflow.runName' tag (deprecated) are specified. "
+                    "Remove 'mlflow.runName' tag.",
+                    INVALID_PARAMETER_VALUE,
+                )
+            run_name = run_name or run_name_tag or _generate_random_name()
+            if not run_name_tag:
+                tags.append(RunTag(key=MLFLOW_RUN_NAME, value=run_name))
             run = SqlRun(
                 name=run_name,
                 artifact_uri=artifact_location,
@@ -566,8 +576,6 @@ class SqlAlchemyStore(AbstractStore):
                 lifecycle_stage=LifecycleStage.ACTIVE,
             )
 
-            tags = tags or []
-            tags.append(RunTag(key=MLFLOW_RUN_NAME, value=run_name))
             run.tags = [SqlTag(key=tag.key, value=tag.value) for tag in tags]
             self._save_to_db(objs=run, session=session)
 

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -552,7 +552,7 @@ class SqlAlchemyStore(AbstractStore):
             run_name_tag = _get_run_name_from_tags(tags)
             if run_name and run_name_tag:
                 raise MlflowException(
-                    "Both 'run_name' argument and 'mlflow.runName' tag (deprecated) are specified. "
+                    "Both 'run_name' argument and 'mlflow.runName' tag are specified. "
                     "Remove 'mlflow.runName' tag.",
                     INVALID_PARAMETER_VALUE,
                 )

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -833,7 +833,7 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         with pytest.raises(
             MlflowException,
             match=re.escape(
-                "Both 'run_name' argument and 'mlflow.runName' tag (deprecated) are specified."
+                "Both 'run_name' argument and 'mlflow.runName' tag are specified."
             ),
         ):
             fs.create_run(

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -832,9 +832,7 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
 
         with pytest.raises(
             MlflowException,
-            match=re.escape(
-                "Both 'run_name' argument and 'mlflow.runName' tag are specified."
-            ),
+            match=re.escape("Both 'run_name' argument and 'mlflow.runName' tag are specified."),
         ):
             fs.create_run(
                 experiment_id=FileStore.DEFAULT_EXPERIMENT_ID,

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -832,7 +832,9 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
 
         with pytest.raises(
             MlflowException,
-            match=re.escape("Both 'run_name' and 'mlflow.runName' tag (deprecated) are specified."),
+            match=re.escape(
+                "Both 'run_name' argument and 'mlflow.runName' tag (deprecated) are specified."
+            ),
         ):
             fs.create_run(
                 experiment_id=FileStore.DEFAULT_EXPERIMENT_ID,

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -8,6 +8,7 @@ import time
 import unittest
 import uuid
 from pathlib import Path
+import re
 
 import pytest
 from unittest import mock
@@ -818,6 +819,28 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         run = fs.get_run(run.info.run_id)
         assert run.info.run_name == "my name"
         assert run.data.tags.get(MLFLOW_RUN_NAME) == "my name"
+
+        run_id = fs.create_run(
+            experiment_id=FileStore.DEFAULT_EXPERIMENT_ID,
+            user_id="user",
+            start_time=0,
+            run_name=None,
+            tags=[RunTag(MLFLOW_RUN_NAME, "test")],
+        ).info.run_id
+        run = fs.get_run(run_id)
+        assert run.info.run_name == "test"
+
+        with pytest.raises(
+            MlflowException,
+            match=re.escape("Both 'run_name' and 'mlflow.runName' tag (deprecated) are specified."),
+        ):
+            fs.create_run(
+                experiment_id=FileStore.DEFAULT_EXPERIMENT_ID,
+                user_id="user",
+                start_time=0,
+                run_name="test",
+                tags=[RunTag(MLFLOW_RUN_NAME, "test")],
+            )
 
     def _experiment_id_edit_func(self, old_dict):
         old_dict["experiment_id"] = int(old_dict["experiment_id"])

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -919,9 +919,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
 
         with pytest.raises(
             MlflowException,
-            match=re.escape(
-                "Both 'run_name' argument and 'mlflow.runName' tag are specified."
-            ),
+            match=re.escape("Both 'run_name' argument and 'mlflow.runName' tag are specified."),
         ):
             self.store.create_run(
                 experiment_id=experiment_id,

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -920,7 +920,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         with pytest.raises(
             MlflowException,
             match=re.escape(
-                "Both 'run_name' argument and 'mlflow.runName' tag (deprecated) are specified."
+                "Both 'run_name' argument and 'mlflow.runName' tag are specified."
             ),
         ):
             self.store.create_run(

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -919,7 +919,9 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
 
         with pytest.raises(
             MlflowException,
-            match=re.escape("Both 'run_name' and 'mlflow.runName' tag (deprecated) are specified."),
+            match=re.escape(
+                "Both 'run_name' argument and 'mlflow.runName' tag (deprecated) are specified."
+            ),
         ):
             self.store.create_run(
                 experiment_id=experiment_id,

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import tempfile
 import unittest
+import re
 
 import math
 import random
@@ -906,6 +907,27 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         run = self.store.get_run(run_id)
         self.assertEqual(run.info.run_name, configs["run_name"])
         self.assertEqual(run.data.tags.get(mlflow_tags.MLFLOW_RUN_NAME), configs["run_name"])
+        run_id = self.store.create_run(
+            experiment_id=experiment_id,
+            user_id="user",
+            start_time=0,
+            run_name=None,
+            tags=[RunTag(mlflow_tags.MLFLOW_RUN_NAME, "test")],
+        ).info.run_id
+        run = self.store.get_run(run_id)
+        assert run.info.run_name == "test"
+
+        with pytest.raises(
+            MlflowException,
+            match=re.escape("Both 'run_name' and 'mlflow.runName' tag (deprecated) are specified."),
+        ):
+            self.store.create_run(
+                experiment_id=experiment_id,
+                user_id="user",
+                start_time=0,
+                run_name="test",
+                tags=[RunTag(mlflow_tags.MLFLOW_RUN_NAME, "test")],
+            )
 
     def test_get_run_with_name(self):
         experiment_id = self._experiment_factory("test_get_run")


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Fix #7133

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
