### PR TITLE
Set positive label default to None for mlflow.evaluate() and infer pos label

### DIFF
--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -932,8 +932,8 @@ def evaluate(
         - **log_metrics_with_dataset_info**: A boolean value specifying whether or not to include
           information about the evaluation dataset in the name of each metric logged to MLflow
           Tracking during evaluation, default value is True.
-        - **pos_label**: The positive label to use when computing classification metrics such as
-          precision, recall, f1, etc. for binary classification models (default: ``1``). For
+        - **pos_label**: If specified, the positive label to use when computing classification
+          metrics such as precision, recall, f1, etc. for binary classification models. For
           multiclass classification and regression models, this parameter will be ignored.
         - **average**: The averaging method to use when computing classification metrics such as
           precision, recall, f1, etc. for multiclass classification models

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1070,6 +1070,8 @@ class DefaultEvaluator(ModelEvaluator):
                         self.label_list, np.where(self.label_list == self.pos_label)
                     )
                     self.label_list = np.append(self.label_list, self.pos_label)
+                else:
+                    self.pos_label = self.label_list[-1]
                 _logger.info(
                     "The evaluation dataset is inferred as binary dataset, positive label is "
                     f"{self.label_list[1]}, negative label is {self.label_list[0]}."
@@ -1208,7 +1210,7 @@ class DefaultEvaluator(ModelEvaluator):
         self.feature_names = dataset.feature_names
         self.custom_metrics = custom_metrics
         self.y = dataset.labels_data
-        self.pos_label = self.evaluator_config.get("pos_label", 1)
+        self.pos_label = self.evaluator_config.get("pos_label")
         self.sample_weights = self.evaluator_config.get("sample_weights")
 
         inferred_model_type = _infer_model_type_by_labels(self.y)

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1070,7 +1070,7 @@ class DefaultEvaluator(ModelEvaluator):
                         self.label_list, np.where(self.label_list == self.pos_label)
                     )
                     self.label_list = np.append(self.label_list, self.pos_label)
-                else:
+                elif self.pos_label is None:
                     self.pos_label = self.label_list[-1]
                 _logger.info(
                     "The evaluation dataset is inferred as binary dataset, positive label is "

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -1916,13 +1916,19 @@ def test_evaluation_with_env_restoration(
     }
 
 
-@pytest.mark.parametrize("pos_label", [None, 0, 1, 2])
+@pytest.mark.parametrize("pos_label", [None])
+# @pytest.mark.parametrize("pos_label", [None, 0, 1, 2])
 def test_evaluation_binary_classification_with_pos_label(pos_label):
     X, y = load_breast_cancer(as_frame=True, return_X_y=True)
     X = X.iloc[:, :4].head(100)
     y = y.head(len(X))
     if pos_label == 2:
         y = [2 if trg == 1 else trg for trg in y]
+    elif pos_label == None:
+        # Use a different positive class other than the 1 to verify
+        # that an unspecified `pos_label` doesn't cause problems
+        # for binary classification tasks with nonstandard labels
+        y = [10 if trg == 1 else trg for trg in y]
     with mlflow.start_run():
         model = LogisticRegression()
         model.fit(X, y)
@@ -1937,7 +1943,7 @@ def test_evaluation_binary_classification_with_pos_label(pos_label):
             evaluator_config=None if pos_label is None else {"pos_label": pos_label},
         )
         y_pred = model.predict(X)
-        pl = 1 if pos_label is None else pos_label
+        pl = 10 if pos_label is None else pos_label
         precision = precision_score(y, y_pred, pos_label=pl)
         recall = recall_score(y, y_pred, pos_label=pl)
         f1 = f1_score(y, y_pred, pos_label=pl)

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -1916,8 +1916,7 @@ def test_evaluation_with_env_restoration(
     }
 
 
-@pytest.mark.parametrize("pos_label", [None])
-# @pytest.mark.parametrize("pos_label", [None, 0, 1, 2])
+@pytest.mark.parametrize("pos_label", [None, 0, 1, 2])
 def test_evaluation_binary_classification_with_pos_label(pos_label):
     X, y = load_breast_cancer(as_frame=True, return_X_y=True)
     X = X.iloc[:, :4].head(100)


### PR DESCRIPTION
Signed-off-by: dbczumar <corey.zumar@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## What changes are proposed in this pull request?

Set positive label default to None for mlflow.evaluate() and infer pos label

## How is this patch tested?

Edited integration tests

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

Set positive label default to None for mlflow.evaluate() and infer pos label

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
