### PR TITLE
fix: fixed profile cards rendering with URL polyfill

### DIFF
--- a/mlflow/pipelines/cards/pandas_renderer.py
+++ b/mlflow/pipelines/cards/pandas_renderer.py
@@ -234,7 +234,7 @@ def get_facets_polyfills() -> str:
      * })();
     */
     """
-    return '<script>!function(){let t=window.URL;window.URL=function(n,e){return"string"==typeof e&&e.startsWith("blob:")?new URL(e):new t(n,e)}}();</script>'  # pylint: disable=line-too-long
+    return '!function(){let t=window.URL;window.URL=function(n,e){return"string"==typeof e&&e.startsWith("blob:")?new URL(e):new t(n,e)}}();'  # pylint: disable=line-too-long
 
 
 def construct_facets_html(
@@ -252,7 +252,7 @@ def construct_facets_html(
     polyfills_code = get_facets_polyfills()
 
     html_template = """
-        {polyfills_code}
+        <script>{polyfills_code}</script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.3.3/webcomponents-lite.js"></script>
         <link rel="import" href="https://raw.githubusercontent.com/PAIR-code/facets/1.0.0/facets-dist/facets-jupyter.html" >
         <facets-overview id="facets" proto-input="{protostr}" compare-mode="{compare}"></facets-overview>

--- a/mlflow/pipelines/cards/pandas_renderer.py
+++ b/mlflow/pipelines/cards/pandas_renderer.py
@@ -212,6 +212,31 @@ def convert_to_comparison_proto(
     return feature_stats_list
 
 
+def get_facets_polyfills() -> str:
+    """
+     * A JS polyfill/monkey-patching function that fixes issue where objectURL passed as a
+     * "base" argument to the URL constructor ends up in a "invalid URL" exception.
+     *
+     * Polymer is using parent's URL in its internal asset URL resolution system, while MLFLow
+     * artifact rendering engine uses object URLs to display iframed artifacts code. This ends up
+     * in object URL being used in `new URL()` constructor which needs to be patched.
+     *
+     * Original function code:
+     *
+     * (function patchURLConstructor() {
+     *     const _originalURLConstructor = window.URL;
+     *     window.URL = function (url, base) {
+     *         if (typeof base === "string" && base.startsWith("blob:")) {
+     *             return new URL(base);
+     *         }
+     *         return new _originalURLConstructor(url, base);
+     *     };
+     * })();
+    */
+    """
+    return '<script>!function(){let t=window.URL;window.URL=function(n,e){return"string"==typeof e&&e.startsWith("blob:")?new URL(e):new t(n,e)}}();</script>'  # pylint: disable=line-too-long
+
+
 def construct_facets_html(
     proto: facet_feature_statistics_pb2.DatasetFeatureStatisticsList, compare: bool = False
 ) -> str:
@@ -224,12 +249,15 @@ def construct_facets_html(
     """
     # facets_html_bundle = _get_facets_html_bundle()
     protostr = base64.b64encode(proto.SerializeToString()).decode("utf-8")
+    polyfills_code = get_facets_polyfills()
+
     html_template = """
+        {polyfills_code}
         <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.3.3/webcomponents-lite.js"></script>
         <link rel="import" href="https://raw.githubusercontent.com/PAIR-code/facets/1.0.0/facets-dist/facets-jupyter.html" >
         <facets-overview id="facets" proto-input="{protostr}" compare-mode="{compare}"></facets-overview>
     """
-    html = html_template.format(protostr=protostr, compare=compare)
+    html = html_template.format(protostr=protostr, compare=compare, polyfills_code=polyfills_code)
     return html
 
 

--- a/mlflow/pipelines/cards/pandas_renderer.py
+++ b/mlflow/pipelines/cards/pandas_renderer.py
@@ -214,25 +214,24 @@ def convert_to_comparison_proto(
 
 def get_facets_polyfills() -> str:
     """
-     * A JS polyfill/monkey-patching function that fixes issue where objectURL passed as a
-     * "base" argument to the URL constructor ends up in a "invalid URL" exception.
-     *
-     * Polymer is using parent's URL in its internal asset URL resolution system, while MLFLow
-     * artifact rendering engine uses object URLs to display iframed artifacts code. This ends up
-     * in object URL being used in `new URL()` constructor which needs to be patched.
-     *
-     * Original function code:
-     *
-     * (function patchURLConstructor() {
-     *     const _originalURLConstructor = window.URL;
-     *     window.URL = function (url, base) {
-     *         if (typeof base === "string" && base.startsWith("blob:")) {
-     *             return new URL(base);
-     *         }
-     *         return new _originalURLConstructor(url, base);
-     *     };
-     * })();
-    */
+    A JS polyfill/monkey-patching function that fixes issue where objectURL passed as a
+    "base" argument to the URL constructor ends up in a "invalid URL" exception.
+
+    Polymer is using parent's URL in its internal asset URL resolution system, while MLFLow
+    artifact rendering engine uses object URLs to display iframed artifacts code. This ends up
+    in object URL being used in `new URL()` constructor which needs to be patched.
+
+    Original function code:
+
+    (function patchURLConstructor() {
+        const _originalURLConstructor = window.URL;
+        window.URL = function (url, base) {
+            if (typeof base === "string" && base.startsWith("blob:")) {
+                return new URL(base);
+            }
+            return new _originalURLConstructor(url, base);
+        };
+    })();
     """
     return '!function(){let t=window.URL;window.URL=function(n,e){return"string"==typeof e&&e.startsWith("blob:")?new URL(e):new t(n,e)}}();'  # pylint: disable=line-too-long
 


### PR DESCRIPTION
Signed-off-by: Hubert Zub <hubert.zub@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## What changes are proposed in this pull request?

Pandas profile card failed to render in ML/Databricks because MLFlow uses `objectURL`s in artifact iframe renderer, which is incompatible with Polymer renderer that tries to use parent's baseURL in `new URL()` which caused an unrecoverable exception (it's not possible to use objectURLs as a `base` parameter of URL constructor). This PR introduces a conditional polyfill to Polymer's `window.URL` constructor which fixes this issue.

![Screen Shot 2022-10-25 at 16 59 45](https://user-images.githubusercontent.com/104438646/197809602-c21804f6-9dfb-4967-a606-918afa75db84.png)

## How is this patch tested?

- Manual tests using Chrome v105 on [mlp-regression-example](https://github.com/mlflow/mlp-regression-example) repo

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [X] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [X] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
