### PR TITLE
Log roc_auc in multiclass classification

### DIFF
--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -233,15 +233,16 @@ def _get_multiclass_classifier_metrics(
         pos_label=None,
         sample_weights=sample_weights,
     )
-    metrics.update(
-        roc_auc=sk_metrics.roc_auc_score(
-            y_true=y_true,
-            y_score=y_proba,
-            sample_weight=sample_weights,
-            average=average,
-            multi_class="ovr",
+    if average in ("macro", "weighted") and y_proba is not None:
+        metrics.update(
+            roc_auc=sk_metrics.roc_auc_score(
+                y_true=y_true,
+                y_score=y_proba,
+                sample_weight=sample_weights,
+                average=average,
+                multi_class="ovr",
+            )
         )
-    )
     return metrics
 
 

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -224,7 +224,7 @@ def _get_multiclass_classifier_metrics(
     average="weighted",
     sample_weights=None,
 ):
-    return _get_common_classifier_metrics(
+    metrics = _get_common_classifier_metrics(
         y_true=y_true,
         y_pred=y_pred,
         y_proba=y_proba,
@@ -233,6 +233,16 @@ def _get_multiclass_classifier_metrics(
         pos_label=None,
         sample_weights=sample_weights,
     )
+    metrics.update(
+        roc_auc=sk_metrics.roc_auc_score(
+            y_true=y_true,
+            y_score=y_proba,
+            sample_weight=sample_weights,
+            average=average,
+            multi_class="ovr",
+        )
+    )
+    return metrics
 
 
 def _get_classifier_per_class_metrics_collection_df(y, y_pred, labels, sample_weights):

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -978,6 +978,7 @@ def test_get_multiclass_classifier_metrics(use_sample_weights):
             "log_loss": 0.7515668165194579,
             "precision_score": 0.8300395256916996,
             "recall_score": 0.8695652173913042,
+            "roc_auc": 0.8992673992673993,
         }
     else:
         expected_metrics = {
@@ -987,6 +988,7 @@ def test_get_multiclass_classifier_metrics(use_sample_weights):
             "log_loss": 1.1658691395263094,
             "precision_score": 0.3,
             "recall_score": 0.4,
+            "roc_auc": 0.5833333333333334,
         }
 
     metrics = _get_multiclass_classifier_metrics(


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Log roc_auc in multiclass classification.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

```
> python examples/evaluation/evaluate_on_multiclass_classifier.py

...
{
  'score': 0.39151515151515154,
  'example_count': 3300,
  'accuracy_score': 0.39151515151515154,
  'recall_score': 0.39151515151515154,
  'precision_score': 0.3859102905511945,
  'f1_score': 0.38687717099592833,
  'log_loss': 1.8034271705146117,
  👇👇👇👇👇👇👇
  'roc_auc': 0.8032521615065319,
}
```

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
