### PR TITLE
Adding predicted_training_data to the DAG

### DIFF
--- a/mlflow/pipelines/dag_help_strings.py
+++ b/mlflow/pipelines/dag_help_strings.py
@@ -181,6 +181,10 @@ MLFLOW_RUN = format_help_string(
     "The MLflow Tracking Run containing the model pipeline & its parameters, model performance metrics on the training & validation datasets, and lineage information about the current pipeline execution. The downstream 'evaluate' step logs performance metrics and model explanations from the test dataset to this MLflow Run."
 )
 
+PREDICTED_TRAINING_DATA = format_help_string(
+    "The predicted training dataset that is obtained by predicted training data using the fitted model."
+)
+
 CUSTOM_METRICS_USER_CODE = format_help_string(
     """\"\"\"\nsteps/custom_metrics.py defines customizable logic for specifying custom metrics to compute during model training and evaluation. Custom metric functions defined in `steps/custom_metrics.py` are referenced by the 'function' attributes of entries in the 'custom' subsection of the 'metrics' section in pipeline.yaml. For example:
 

--- a/mlflow/pipelines/pipeline.py
+++ b/mlflow/pipelines/pipeline.py
@@ -267,6 +267,10 @@ class _BasePipeline:
                     "help_string": dag_help_strings.MLFLOW_RUN,
                     "help_string_type": "text",
                 },
+                "predicted_training_data_help": {
+                    "help_string": dag_help_strings.PREDICTED_TRAINING_DATA,
+                    "help_string_type": "text",
+                },
                 "custom_metrics_user_code_help": {
                     "help_string": dag_help_strings.CUSTOM_METRICS_USER_CODE,
                     "help_string_type": "python",

--- a/mlflow/pipelines/resources/pipeline_dag_template.html
+++ b/mlflow/pipelines/resources/pipeline_dag_template.html
@@ -81,6 +81,7 @@
           transformer --> trainMLPStep
           trainMLPStep --> run{{run}}
           trainMLPStep --> model{{model}}
+          trainMLPStep --> predictedTrainingData[(predicted_training_data)]
 
           model --> evaluateMLPStep[["<font>evaluate</font>"]]
           splitData1 --> evaluateMLPStep
@@ -117,6 +118,7 @@
           click transformedParquet renderMoreInformation "{{transformed_training_and_validation_data_help}}"
           click run renderMoreInformation "{{mlflow_run_help}}"
           click model renderMoreInformation "{{fitted_model_help}}"
+          click predictedTrainingData renderMoreInformation "{{predicted_training_data_help}}"
           click transformer renderMoreInformation "{{fitted_transformer_help}}"
           click model_validation_status renderMoreInformation "{{model_validation_status_help}}"
           click registered_model_version renderMoreInformation "{{registered_model_version_help}}"

--- a/tests/pipelines/test_train_step.py
+++ b/tests/pipelines/test_train_step.py
@@ -105,7 +105,7 @@ def setup_train_step_with_tuning(
                             eta0:
                                 distribution: "normal"
                                 mu: 0.01
-                                sigma: 0.0001     
+                                sigma: 0.0001
             """.format(
                 tracking_uri=mlflow.get_tracking_uri(), estimator_params=estimator_params
             )
@@ -199,6 +199,7 @@ def test_train_steps_writes_model_pkl_and_card(tmp_pipeline_root_path, use_tunin
 
     assert (train_step_output_dir / "model/model.pkl").exists()
     assert (train_step_output_dir / "card.html").exists()
+    assert (train_step_output_dir / "predicted_training_data.parquet").exists()
 
 
 @pytest.mark.parametrize("use_tuning", [True, False])


### PR DESCRIPTION
## What changes are proposed in this pull request?
Adding predicted_training_data to the DAG

## How is this patch tested?
- [x] DAG
![image](https://user-images.githubusercontent.com/5621432/198155646-0ebe940e-7dfd-4105-b5e6-e0978621f870.png)
- [x] get_artifact:
![image](https://user-images.githubusercontent.com/5621432/198155696-6983fc8f-091c-4fdb-81da-2dc5223f76a1.png)


## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
Adding ability to inspect predicted training data

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
