### PR TITLE
Allow saving keras model in HDF5 format in TF autologging

### DIFF
--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -873,6 +873,8 @@ def autolog(
     registered_model_name=None,
     log_input_examples=False,
     log_model_signatures=True,
+    saved_model_kwargs=None,
+    keras_model_kwargs=None,
 ):  # pylint: disable=unused-argument
     # pylint: disable=E0611
     """
@@ -939,6 +941,8 @@ def autolog(
                                  (for single-output models) or a mapping from
                                  ``str`` -> ``np.ndarray`` (for multi-output models) is returned;
                                  when a signature is not present, a Pandas DataFrame is returned.
+    :param saved_model_kwargs: a dict of kwargs to pass to ``tensorflow.saved_model.save`` method.
+    :param keras_model_kwargs: a dict of kwargs to pass to ``keras_model.save`` method.
     """
     import tensorflow
 
@@ -1056,6 +1060,8 @@ def autolog(
             registered_model_name=get_autologging_config(
                 FLAVOR_NAME, "registered_model_name", None
             ),
+            saved_model_kwargs=saved_model_kwargs,
+            keras_model_kwargs=keras_model_kwargs,
         )
 
     class FitPatch(PatchFunction):

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -7,6 +7,7 @@ import sys
 from unittest.mock import patch
 import json
 import functools
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -1083,6 +1084,15 @@ def test_keras_autolog_infers_model_signature_correctly_with_keras_sequence(
             [{"type": "tensor", "tensor-spec": {"dtype": "float64", "shape": [-1, 4]}}],
             [{"type": "tensor", "tensor-spec": {"dtype": "float32", "shape": [-1, 3]}}],
         )
+
+
+def test_keras_autolog_load_saved_hdf5_model(keras_data_gen_sequence):
+    mlflow.tensorflow.autolog(keras_model_kwargs={"save_format": "h5"})
+    model = create_tf_keras_model()
+    with mlflow.start_run() as run:
+        model.fit(keras_data_gen_sequence)
+        mlflow.tensorflow.load_model(f"runs:/{run.info.run_id}/model")
+        assert Path(run.info.artifact_uri, "model", "data", "model.h5").exists()
 
 
 def test_keras_autolog_logs_model_signature_by_default(keras_data_gen_sequence):


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #7123, #7171

## What changes are proposed in this pull request?

In #7171, we ignored the conflicts caused by #7123 (on purpose since the TF/keras flavors already had lots of changes and adding additional changes was risky). This PR makes changes to allow saving keras models in HDF5 format in TF autologging.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
