### PR TITLE
Set `metric_prefix` in MLP steps

### DIFF
--- a/mlflow/pipelines/steps/evaluate.py
+++ b/mlflow/pipelines/steps/evaluate.py
@@ -30,6 +30,7 @@ from mlflow.projects.utils import get_databricks_env_vars
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.tracking.fluent import _get_experiment_id, _set_experiment_primary_metric
 from mlflow.utils.databricks_utils import get_databricks_run_url
+from mlflow.utils.string_utils import strip_prefix
 
 _logger = logging.getLogger(__name__)
 
@@ -223,7 +224,10 @@ class EvaluateStep(BaseStep):
                         evaluator_config=evaluator_config,
                     )
                     eval_result.save(os.path.join(output_directory, f"eval_{dataset_name}"))
-                    eval_metrics[dataset_name] = eval_result.metrics
+                    eval_metrics[dataset_name] = {
+                        strip_prefix(k, evaluator_config["metric_prefix"]): v
+                        for k, v in eval_result.metrics.items()
+                    }
 
                 validation_results = self._validate_model(eval_metrics, output_directory)
 

--- a/mlflow/pipelines/steps/evaluate.py
+++ b/mlflow/pipelines/steps/evaluate.py
@@ -198,7 +198,7 @@ class EvaluateStep(BaseStep):
                             "explainability_algorithm": "kernel",
                             "explainability_nsamples": 10,
                             "pos_label": self.positive_class,
-                            "metric_prefix": "validation_",
+                            "metric_prefix": "val_",
                         },
                     ),
                     (

--- a/mlflow/pipelines/steps/evaluate.py
+++ b/mlflow/pipelines/steps/evaluate.py
@@ -184,7 +184,7 @@ class EvaluateStep(BaseStep):
             ].greater_is_better
 
             _set_experiment_primary_metric(
-                exp_id, f"{self.primary_metric}_on_data_test", primary_metric_greater_is_better
+                exp_id, f"test_{self.primary_metric}", primary_metric_greater_is_better
             )
 
             with mlflow.start_run(run_id=run_id):
@@ -197,12 +197,17 @@ class EvaluateStep(BaseStep):
                             "explainability_algorithm": "kernel",
                             "explainability_nsamples": 10,
                             "pos_label": self.positive_class,
+                            "metric_prefix": "validation_",
                         },
                     ),
                     (
                         "test",
                         test_df,
-                        {"log_model_explainability": False, "pos_label": self.positive_class},
+                        {
+                            "log_model_explainability": False,
+                            "pos_label": self.positive_class,
+                            "metric_prefix": "test_",
+                        },
                     ),
                 ):
                     eval_result = mlflow.evaluate(

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -343,6 +343,7 @@ class TrainStep(BaseStep):
                         evaluator_config={
                             "log_model_explainability": False,
                             "pos_label": self.positive_class,
+                            "metric_prefix": f"{dataset_name}_",
                         },
                     )
                     eval_result.save(os.path.join(output_directory, f"eval_{dataset_name}"))

--- a/mlflow/pipelines/steps/train.py
+++ b/mlflow/pipelines/steps/train.py
@@ -327,11 +327,10 @@ class TrainStep(BaseStep):
                 )
 
                 eval_metrics = {}
-                for dataset_name, dataset in {
-                    "training": train_df,
-                    "validation": validation_df,
+                for dataset_name, (dataset, metric_prefix) in {
+                    "training": (train_df, "training_"),
+                    "validation": (validation_df, "val_"),
                 }.items():
-                    metric_prefix = f"{dataset_name}_"
                     eval_result = mlflow.evaluate(
                         model=logged_estimator.model_uri,
                         data=dataset,

--- a/tests/pipelines/test_evaluate_step.py
+++ b/tests/pipelines/test_evaluate_step.py
@@ -257,7 +257,7 @@ def one(eval_df, builtin_metrics):
     with pytest.raises(MlflowException, match="Failed to load custom metric functions") as exc:
         evaluate_step.run(str(evaluate_step_output_dir))
     assert isinstance(exc.value.__cause__, AttributeError)
-    assert "test_weighted_mean_squared_error" in str(exc.value.__cause__)
+    assert "weighted_mean_squared_error" in str(exc.value.__cause__)
 
 
 @pytest.mark.usefixtures("clear_custom_metrics_module_cache", "tmp_pipeline_exec_path")

--- a/tests/pipelines/test_evaluate_step.py
+++ b/tests/pipelines/test_evaluate_step.py
@@ -103,7 +103,7 @@ def weighted_mean_squared_error(eval_df, builtin_metrics):
     logged_metrics = (
         mlflow.tracking.MlflowClient().get_run(mlflow.last_active_run().info.run_id).data.metrics
     )
-    assert "weighted_mean_squared_error" in logged_metrics
+    assert "test_weighted_mean_squared_error" in logged_metrics
     model_validation_status_path = evaluate_step_output_dir.joinpath("model_validation_status")
     assert model_validation_status_path.exists()
     expected_status = "REJECTED" if mae_threshold < 0 else "VALIDATED"
@@ -178,8 +178,8 @@ steps:
     logged_metrics = (
         mlflow.tracking.MlflowClient().get_run(mlflow.last_active_run().info.run_id).data.metrics
     )
-    assert "mean_squared_error" in logged_metrics
-    assert "root_mean_squared_error" in logged_metrics
+    assert "test_mean_squared_error" in logged_metrics
+    assert "test_root_mean_squared_error" in logged_metrics
     model_validation_status_path = evaluate_step_output_dir.joinpath("model_validation_status")
     assert model_validation_status_path.exists()
     assert model_validation_status_path.read_text() == "UNKNOWN"
@@ -257,7 +257,7 @@ def one(eval_df, builtin_metrics):
     with pytest.raises(MlflowException, match="Failed to load custom metric functions") as exc:
         evaluate_step.run(str(evaluate_step_output_dir))
     assert isinstance(exc.value.__cause__, AttributeError)
-    assert "weighted_mean_squared_error" in str(exc.value.__cause__)
+    assert "test_weighted_mean_squared_error" in str(exc.value.__cause__)
 
 
 @pytest.mark.usefixtures("clear_custom_metrics_module_cache", "tmp_pipeline_exec_path")
@@ -354,10 +354,10 @@ def root_mean_squared_error(eval_df, builtin_metrics):
     logged_metrics = (
         mlflow.tracking.MlflowClient().get_run(mlflow.last_active_run().info.run_id).data.metrics
     )
-    assert "root_mean_squared_error" in logged_metrics
-    assert logged_metrics["root_mean_squared_error"] == 1
-    assert "mean_absolute_error" in logged_metrics
-    assert logged_metrics["mean_absolute_error"] == 1
+    assert "test_root_mean_squared_error" in logged_metrics
+    assert logged_metrics["test_root_mean_squared_error"] == 1
+    assert "test_mean_absolute_error" in logged_metrics
+    assert logged_metrics["test_mean_absolute_error"] == 1
     model_validation_status_path = evaluate_step_output_dir.joinpath("model_validation_status")
     assert model_validation_status_path.exists()
     assert model_validation_status_path.read_text() == "VALIDATED"

--- a/tests/pipelines/test_pipeline.py
+++ b/tests/pipelines/test_pipeline.py
@@ -148,7 +148,7 @@ def test_pipelines_log_to_expected_mlflow_backend_with_expected_run_tags_once_on
     assert logged_run.info.artifact_uri == path_to_local_file_uri(
         str((pathlib.Path(artifact_location) / logged_run.info.run_id / "artifacts").resolve())
     )
-    assert "r2_score" in logged_run.data.metrics
+    assert "test_r2_score" in logged_run.data.metrics
     artifacts = MlflowClient(tracking_uri).list_artifacts(
         run_id=logged_run.info.run_id, path="train"
     )

--- a/tests/pipelines/test_train_step.py
+++ b/tests/pipelines/test_train_step.py
@@ -380,9 +380,9 @@ def test_tuning_param_equal(tuning_param, logged_param):
 @pytest.mark.parametrize(
     ("automl", "primary_metric", "generate_custom_metrics"),
     [
-        (False, "root_mean_squared_error", False),
-        (True, "root_mean_squared_error", False),
-        (True, "weighted_mean_squared_error", True),
+        (False, "test_root_mean_squared_error", False),
+        (True, "test_root_mean_squared_error", False),
+        (True, "test_weighted_mean_squared_error", True),
     ],
 )
 def test_automl(tmp_pipeline_root_path, automl, primary_metric, generate_custom_metrics):

--- a/tests/pipelines/test_train_step.py
+++ b/tests/pipelines/test_train_step.py
@@ -136,6 +136,42 @@ def setup_train_step_with_tuning(
     return train_step
 
 
+def test_train_step(tmp_pipeline_root_path):
+    with mock.patch.dict(
+        os.environ, {_MLFLOW_PIPELINES_EXECUTION_DIRECTORY_ENV_VAR: str(tmp_pipeline_root_path)}
+    ):
+        train_step_output_dir = setup_train_dataset(tmp_pipeline_root_path)
+        pipeline_yaml = tmp_pipeline_root_path.joinpath(_PIPELINE_CONFIG_FILE_NAME)
+        pipeline_yaml.write_text(
+            """
+            template: "regression/v1"
+            target_col: "y"
+            profile: "test_profile"
+            run_args:
+                step: "train"
+            experiment:
+                name: "demo"
+                tracking_uri: {tracking_uri}
+            steps:
+                train:
+                    using: estimator_spec
+                    estimator_method: tests.pipelines.test_train_step.estimator_fn
+                    tuning:
+                        enabled: false
+            """.format(
+                tracking_uri=mlflow.get_tracking_uri()
+            )
+        )
+        pipeline_config = read_yaml(tmp_pipeline_root_path, _PIPELINE_CONFIG_FILE_NAME)
+        train_step = TrainStep.from_pipeline_config(pipeline_config, str(tmp_pipeline_root_path))
+        train_step.run(str(train_step_output_dir))
+
+    run_id = train_step_output_dir.joinpath("run_id").read_text()
+    metrics = MlflowClient().get_run(run_id).data.metrics
+    assert "val_mean_squared_error" in metrics
+    assert "training_mean_squared_error" in metrics
+
+
 def setup_train_step_with_automl(
     pipeline_root: Path,
     primary_metric: str = "root_mean_squared_error",

--- a/tests/pipelines/test_train_step.py
+++ b/tests/pipelines/test_train_step.py
@@ -427,4 +427,4 @@ def weighted_mean_squared_error(eval_df, builtin_metrics):
             run_id = f.read()
 
         metrics = MlflowClient().get_run(run_id).data.metrics
-        assert primary_metric in metrics
+        assert f"training_{primary_metric}" in metrics

--- a/tests/pipelines/test_train_step.py
+++ b/tests/pipelines/test_train_step.py
@@ -380,9 +380,9 @@ def test_tuning_param_equal(tuning_param, logged_param):
 @pytest.mark.parametrize(
     ("automl", "primary_metric", "generate_custom_metrics"),
     [
-        (False, "test_root_mean_squared_error", False),
-        (True, "test_root_mean_squared_error", False),
-        (True, "test_weighted_mean_squared_error", True),
+        (False, "root_mean_squared_error", False),
+        (True, "root_mean_squared_error", False),
+        (True, "weighted_mean_squared_error", True),
     ],
 )
 def test_automl(tmp_pipeline_root_path, automl, primary_metric, generate_custom_metrics):


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

We removed the `dataset_name` argument for `mlflow.evaluate` recently. To differentiate metrics logged during MLP execution, `metric_prefix` needs to be specified in each step.   

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->
- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

### Before

<img width="659" alt="Screen Shot 2022-10-31 at 12 30 27" src="https://user-images.githubusercontent.com/17039389/198925370-25de0076-5046-4e4a-aa53-bcf7fbc62397.png">

- Metrics prefixed with `training_` come from autologging.
- Other metrics come from `mlflow.evaluate`. They are overwritten every time `mlflow.evaluate` is called.

### After

<img width="659" alt="Screen Shot 2022-10-31 at 12 28 06" src="https://user-images.githubusercontent.com/17039389/198925361-752c4411-9461-4805-b62b-b5cd3eae4dd0.png">

- Each `mlflow.evaluate` call generates a different set of metics.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
