### PR TITLE
Fix SageMaker deployment client predict API and add tests

### DIFF
--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -2628,7 +2628,7 @@ class SageMakerDeploymentClient(BaseDeploymentClient):
                 "sagemaker-runtime", region_name=self.region_name, **assume_role_credentials
             )
             if isinstance(inputs, pd.DataFrame):
-                body = (json.dumps({"dataframe_split": inputs.to_dict(orient="split")}),)
+                body = json.dumps({"dataframe_split": inputs.to_dict(orient="split")})
             else:
                 body = json.dumps({"instances": _get_jsonable_obj(inputs)})
             response = sage_client.invoke_endpoint(

--- a/tests/sagemaker/test_sagemaker_deployment_client.py
+++ b/tests/sagemaker/test_sagemaker_deployment_client.py
@@ -1361,9 +1361,9 @@ def test_predict_with_dataframe_input_output(sagemaker_deployment_client):
 
     def mock_invoke_endpoint(self, operation_name, operation_kwargs):
         if operation_name == "InvokeEndpoint":
-            assert operation_kwargs['Body'] == json.dumps({
-                "dataframe_split": input_df.to_dict(orient="split")
-            })
+            assert operation_kwargs["Body"] == json.dumps(
+                {"dataframe_split": input_df.to_dict(orient="split")}
+            )
             output_json = json.dumps({"predictions": output_df.to_dict(orient="records")})
             result = dict(Body=BytesIO(bytes(output_json, encoding="utf-8")))
         else:
@@ -1382,9 +1382,7 @@ def test_predict_with_array_input_output(sagemaker_deployment_client):
 
     def mock_invoke_endpoint(self, operation_name, operation_kwargs):
         if operation_name == "InvokeEndpoint":
-            assert operation_kwargs['Body'] == json.dumps({
-                "instances": list(range(10))
-            })
+            assert operation_kwargs["Body"] == json.dumps({"instances": list(range(10))})
             result = dict(Body=BytesIO(b'{ "predictions": [1,2,3]}'))
         else:
             result = boto_caller(self, operation_name, operation_kwargs)

--- a/tests/sagemaker/test_sagemaker_deployment_client.py
+++ b/tests/sagemaker/test_sagemaker_deployment_client.py
@@ -1355,11 +1355,15 @@ def test_deploy_cli_list_sagemaker_deployments(pretrained_model, sagemaker_clien
 
 @mock_sagemaker_aws_services
 def test_predict_with_dataframe_input_output(sagemaker_deployment_client):
+    input_df = pd.DataFrame(data=[[1, 2]], columns=["a", "b"])
     output_df = pd.DataFrame({"1": ["2", ".", "3"]})
     boto_caller = botocore.client.BaseClient._make_api_call
 
     def mock_invoke_endpoint(self, operation_name, operation_kwargs):
         if operation_name == "InvokeEndpoint":
+            assert operation_kwargs['Body'] == json.dumps({
+                "dataframe_split": input_df.to_dict(orient="split")
+            })
             output_json = json.dumps({"predictions": output_df.to_dict(orient="records")})
             result = dict(Body=BytesIO(bytes(output_json, encoding="utf-8")))
         else:
@@ -1367,8 +1371,7 @@ def test_predict_with_dataframe_input_output(sagemaker_deployment_client):
         return result
 
     with mock.patch("botocore.client.BaseClient._make_api_call", new=mock_invoke_endpoint):
-        df = pd.DataFrame(data=[[1, 2]], columns=["a", "b"])
-        result = sagemaker_deployment_client.predict("test", df).get_predictions()
+        result = sagemaker_deployment_client.predict("test", input_df).get_predictions()
         assert isinstance(result, pd.DataFrame)
         pd.testing.assert_frame_equal(result, output_df)
 
@@ -1379,6 +1382,9 @@ def test_predict_with_array_input_output(sagemaker_deployment_client):
 
     def mock_invoke_endpoint(self, operation_name, operation_kwargs):
         if operation_name == "InvokeEndpoint":
+            assert operation_kwargs['Body'] == json.dumps({
+                "instances": list(range(10))
+            })
             result = dict(Body=BytesIO(b'{ "predictions": [1,2,3]}'))
         else:
             result = boto_caller(self, operation_name, operation_kwargs)


### PR DESCRIPTION
Signed-off-by: dbczumar <corey.zumar@databricks.com>

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Fix SageMaker deployment client predict API and add tests

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->
- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

Fix SageMaker deployment client predict API and add tests

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [X] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
