### PR TITLE
Imported experiment page column- and navigation-related fixes

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsTable.tsx
@@ -11,7 +11,7 @@ import { FormattedMessage } from 'react-intl';
 import { MLFlowAgGridLoader } from '../../../../../common/components/ag-grid/AgGridLoader';
 import { ExperimentRunsTableEmptyOverlay } from '../../../../../common/components/ExperimentRunsTableEmptyOverlay';
 import Utils from '../../../../../common/utils/Utils';
-import { ATTRIBUTE_COLUMN_SORT_KEY } from '../../../../constants';
+import { ATTRIBUTE_COLUMN_SORT_KEY, COLUMN_TYPES } from '../../../../constants';
 import {
   ExperimentEntity,
   UpdateExperimentSearchFacetsFn,
@@ -25,6 +25,7 @@ import {
   EXPERIMENTS_DEFAULT_COLUMN_SETUP,
   getFrameworkComponents,
   getRowId,
+  isCanonicalSortKeyOfType,
   useRunsColumnDefinitions,
 } from '../../utils/experimentPage.column-utils';
 import { RunRowType } from '../../utils/experimentPage.row-types';
@@ -285,6 +286,19 @@ export const ExperimentViewRunsTable = React.memo(
     const hasSelectedAllColumns =
       searchFacetsState.selectedColumns.length >= allAvailableColumnsCount;
 
+    // Count metrics and params columns that were not selected yet so it can be displayed in CTA
+    const moreAvailableParamsAndMetricsColumns = useMemo(() => {
+      const selectedMetricsAndParamsColumns = searchFacetsState.selectedColumns.filter(
+        (s) =>
+          isCanonicalSortKeyOfType(s, COLUMN_TYPES.METRICS) ||
+          isCanonicalSortKeyOfType(s, COLUMN_TYPES.PARAMS),
+      ).length;
+
+      const allMetricsAndParamsColumns = metricKeyList.length + paramKeyList.length;
+
+      return Math.max(0, allMetricsAndParamsColumns - selectedMetricsAndParamsColumns);
+    }, [metricKeyList.length, paramKeyList.length, searchFacetsState.selectedColumns]);
+
     return (
       <>
         <div css={styles.runsCount}>
@@ -326,6 +340,7 @@ export const ExperimentViewRunsTable = React.memo(
               isInitialized={Boolean(gridApi)}
               onClick={onAddColumnClicked}
               visible={!isLoading}
+              moreAvailableParamsAndMetricsColumnCount={moreAvailableParamsAndMetricsColumns}
             />
           )}
         </div>

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsTableAddColumnCTA.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsTableAddColumnCTA.tsx
@@ -30,6 +30,7 @@ interface ExperimentViewRunsTableAddColumnCTAProps {
   gridContainerElement: HTMLElement | null;
   isInitialized: boolean;
   visible?: boolean;
+  moreAvailableParamsAndMetricsColumnCount?: number;
 }
 
 /**
@@ -47,6 +48,7 @@ interface ExperimentViewRunsTableAddColumnCTAProps {
  *       isInitialized={gridInitialized}
  *       onAddColumnClicked={onAddColumnClicked}
  *       visible={!isLoading}
+ *       moreAvailableParamsAndMetricsColumnCount={3}
  *     />
  *   </div>
  * );
@@ -56,6 +58,7 @@ export const ExperimentViewRunsTableAddColumnCTA = ({
   gridContainerElement,
   isInitialized,
   visible,
+  moreAvailableParamsAndMetricsColumnCount = 0,
 }: ExperimentViewRunsTableAddColumnCTAProps) => {
   const ctaRef = useRef<HTMLDivElement>(null);
 
@@ -193,7 +196,10 @@ export const ExperimentViewRunsTableAddColumnCTA = ({
               <FormattedMessage
                 defaultMessage='Add metrics and parameters'
                 description='Label for a CTA button in experiment runs table which invokes column management dropdown'
-              />
+              />{' '}
+              {moreAvailableParamsAndMetricsColumnCount ? (
+                <>({moreAvailableParamsAndMetricsColumnCount})</>
+              ) : null}
             </div>
           </Button>
         </div>

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/contexts/GetExperimentRunsContext.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/contexts/GetExperimentRunsContext.tsx
@@ -108,14 +108,13 @@ export const GetExperimentRunsContextProvider = ({
   const [searchFacetsState, setSearchFacetsState] = useState<SearchExperimentRunsFacetsState>(
     () => {
       // useState() initialization function that restores current search facets state
-      const { queryString, state, isPristine } = restoreExperimentSearchFacetsState(
+      const { queryString, state } = restoreExperimentSearchFacetsState(
         history.location.search,
         experimentIdsHash,
       );
 
-      // If resulting query string is not a default one
-      // and it differs from the current one, replace it
-      if (!isPristine && history.location.search !== queryString) {
+      // If resulting query string differs from the current one, replace it.
+      if (history.location.search !== queryString) {
         history.replace(`${history.location.pathname}${queryString}`);
       }
       return state;

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/contexts/GetExperimentRunsContext.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/contexts/GetExperimentRunsContext.tsx
@@ -108,14 +108,15 @@ export const GetExperimentRunsContextProvider = ({
   const [searchFacetsState, setSearchFacetsState] = useState<SearchExperimentRunsFacetsState>(
     () => {
       // useState() initialization function that restores current search facets state
-      const { queryString, state } = restoreExperimentSearchFacetsState(
+      const { queryString, state, isPristine } = restoreExperimentSearchFacetsState(
         history.location.search,
         experimentIdsHash,
       );
 
-      // If query string differs from the current one, replace it
-      if (history.location.search !== queryString) {
-        history.push(`${history.location.pathname}${queryString}`);
+      // If resulting query string is not a default one
+      // and it differs from the current one, replace it
+      if (!isPristine && history.location.search !== queryString) {
+        history.replace(`${history.location.pathname}${queryString}`);
       }
       return state;
     },

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/models/SearchExperimentRunsFacetsState.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/models/SearchExperimentRunsFacetsState.ts
@@ -1,10 +1,19 @@
 import {
+  ATTRIBUTE_COLUMN_LABELS,
+  COLUMN_TYPES,
   DEFAULT_LIFECYCLE_FILTER,
   DEFAULT_MODEL_VERSION_FILTER,
   DEFAULT_ORDER_BY_ASC,
   DEFAULT_ORDER_BY_KEY,
   DEFAULT_START_TIME,
 } from '../../../constants';
+import { makeCanonicalSortKey } from '../utils/experimentPage.column-utils';
+
+const DEFAULT_SELECTED_COLUMNS = [
+  // "Source" and "Model" columns are visible by default
+  makeCanonicalSortKey(COLUMN_TYPES.ATTRIBUTES, ATTRIBUTE_COLUMN_LABELS.SOURCE),
+  makeCanonicalSortKey(COLUMN_TYPES.ATTRIBUTES, ATTRIBUTE_COLUMN_LABELS.MODELS),
+];
 
 /**
  * Defines persistable model respresenting sort and filter values
@@ -45,7 +54,7 @@ export class SearchExperimentRunsFacetsState {
   /**
    * Currently selected columns
    */
-  selectedColumns: string[] = [];
+  selectedColumns: string[] = [...DEFAULT_SELECTED_COLUMNS];
 
   /**
    * Object mapping run UUIDs (strings) to booleans, where a boolean value of true indicates that

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.column-utils.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.column-utils.ts
@@ -14,7 +14,7 @@ import { ExperimentNameCellRenderer } from '../components/runs/cells/ExperimentN
 import { ModelsCellRenderer } from '../components/runs/cells/ModelsCellRenderer';
 import { SourceCellRenderer } from '../components/runs/cells/SourceCellRenderer';
 import { VersionCellRenderer } from '../components/runs/cells/VersionCellRenderer';
-import { SearchExperimentRunsFacetsState } from '../models/SearchExperimentRunsFacetsState';
+import type { SearchExperimentRunsFacetsState } from '../models/SearchExperimentRunsFacetsState';
 import {
   EXPERIMENT_FIELD_PREFIX_METRIC,
   EXPERIMENT_FIELD_PREFIX_PARAM,

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/persistSearchFacets.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/persistSearchFacets.test.ts
@@ -73,8 +73,10 @@ describe('persistSearchFacet', () => {
       });
       const { state } = restoreExperimentSearchFacetsState('?searchFilter=urlfilter', 'id-key');
       expect(state.searchFilter).toEqual('urlfilter');
-      expect(state.orderByAsc).toEqual(true);
-      expect(state.orderByKey).toEqual('some-local-storage-sort-key');
+
+      // URL state (complemented with default values) should overshadow settings from the storage
+      expect(state.orderByAsc).not.toEqual(true);
+      expect(state.orderByKey).not.toEqual('some-local-storage-sort-key');
     });
 
     test('it should properly re-persist the local storage after merging', () => {

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/persistSearchFacets.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/persistSearchFacets.test.ts
@@ -104,6 +104,11 @@ describe('persistSearchFacet', () => {
       expect(state).toBeTruthy();
       expect(Utils.logErrorAndNotifyUser).toBeCalledTimes(1);
     });
+
+    test('it marks the calculated state as pristine if no changes are done', () => {
+      const { isPristine } = restoreExperimentSearchFacetsState('', 'id-key');
+      expect(isPristine).toEqual(true);
+    });
   });
 
   describe('persistExperimentSearchFacetsState', () => {
@@ -153,9 +158,18 @@ describe('persistSearchFacet', () => {
         '?experiments=foobar&somethingElse=abc',
       );
 
-      expect(queryString).toEqual(
-        '?experiments=foobar&searchFilter=some%20filter&orderByKey=order-key&orderByAsc=true&startTime=ALL&lifecycleFilter=Active&modelVersionFilter=All%20Runs',
-      );
+      let expectedQuery = '?experiments=foobar';
+      expectedQuery += `&searchFilter=${encodeURIComponent('some filter')}`;
+      expectedQuery += `&orderByKey=${encodeURIComponent('order-key')}`;
+      expectedQuery += `&orderByAsc=${encodeURIComponent('true')}`;
+      expectedQuery += `&startTime=${encodeURIComponent('ALL')}`;
+      expectedQuery += `&lifecycleFilter=${encodeURIComponent('Active')}`;
+      expectedQuery += `&modelVersionFilter=${encodeURIComponent('All Runs')}`;
+      expectedQuery += `&selectedColumns=${state.selectedColumns
+        .map((c) => encodeURIComponent(c))
+        .join(',')}`;
+
+      expect(queryString).toEqual(expectedQuery);
     });
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/persistSearchFacets.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/persistSearchFacets.ts
@@ -1,4 +1,4 @@
-import { isArray, isObject } from 'lodash';
+import { isArray, isEqual, isObject } from 'lodash';
 import QueryString, { IParseOptions } from 'qs';
 import LocalStorageUtils from '../../../../common/utils/LocalStorageUtils';
 import Utils from '../../../../common/utils/Utils';
@@ -27,10 +27,11 @@ const urlParserDecoder: IParseOptions['decoder'] = (str, defaultDecoder, _, type
 const mergeFacetsStates = (
   base: SearchExperimentRunsFacetsState,
   object: Partial<SearchExperimentRunsFacetsState>,
-): SearchExperimentRunsFacetsState => ({
-  ...base,
-  ...object,
-});
+): SearchExperimentRunsFacetsState =>
+  Object.assign(new SearchExperimentRunsFacetsState(), {
+    ...base,
+    ...object,
+  });
 
 /**
  * Performs basic checks on partial facets state model. Returns false if
@@ -143,6 +144,7 @@ export function restoreExperimentSearchFacetsState(locationSearch: string, idKey
 
   return {
     state: mergedFacetsState,
+    isPristine: isEqual(new SearchExperimentRunsFacetsState(), mergedFacetsState),
     queryString: createPersistedQueryString({ experiments, ...mergedFacetsState }),
   };
 }


### PR DESCRIPTION
Signed-off-by: Hubert Zub <hubert.zub@databricks.com>

## What changes are proposed in this pull request?

This PR aggregates and imports the following fixes:
- `fix: show source/models column in Experiment Page by default`

Displays "source" and "models" columns by default on the Experiment Page.
![image](https://user-images.githubusercontent.com/104438646/198957443-41749a4e-bede-446d-a463-482825922d19.png)

- `fix: remove unnecesary navigation action on experiment page`

After entering the experiment page from an experiment observatory, an additional navigation event occurs to ensure that all search facets are reflected in the URL query params. This fix introduces following adjustments:

the navigation does not occur if the facets set are default i.e. not changed by users/local settings
navigation uses history.replace instead of history.push so navigating backwards will behave properly (works in MFE, an iFrame version will still push due to routing limitations)

- `feat: display count of params and metrics to be added`

Displaying number of available metrics and params in the add column CTA on the experiment page
![image](https://user-images.githubusercontent.com/104438646/198957513-434cb446-bbe8-4011-986f-61e66d942442.png)

- `fix: un-stuck the back button on experiment page`

Due to a certain intricacy in query string handling (empty arrays not being serialized by qs package), the back navigation could get stuck on one particular entry. When navigating back to the state that included an empty state subtree (e.g. empty list of pinned rows), the application overwrote it with local-storage based values which created a loop in history.
With this change, URL-based search state is always complemented by default values. If URL state is not provided (e.g. navigation from experiment observatory), then local storage takes precedence.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->
- [X] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

Changes were manually tested on Chrome v106

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [X] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
