### PR TITLE
Moving back model_uri to predict

### DIFF
--- a/mlflow/pipelines/steps/predict.py
+++ b/mlflow/pipelines/steps/predict.py
@@ -226,8 +226,6 @@ class PredictStep(BaseStep):
             )
         step_config["register"] = pipeline_config.get("steps", {}).get("register", {})
         step_config["model_registry"] = pipeline_config.get("model_registry", {})
-        if pipeline_config.get("model_registry", {}).get("model_uri") is not None:
-            step_config["model_uri"] = pipeline_config.get("model_registry", {}).get("model_uri")
         if pipeline_config.get("model_registry", {}).get("registry_uri") is not None:
             step_config["registry_uri"] = pipeline_config.get("model_registry", {}).get(
                 "registry_uri"

--- a/tests/pipelines/test_predict_step.py
+++ b/tests/pipelines/test_predict_step.py
@@ -107,15 +107,13 @@ def test_predict_step_runs(
     pipeline_config = read_yaml(tmp_pipeline_root_path, _PIPELINE_CONFIG_FILE_NAME)
     pipeline_config.update(
         {
-            "model_registry": {
-                "model_uri": model_uri,
-            },
             "steps": {
                 "predict": {
                     "output": {
                         "using": "parquet",
                         "location": str(predict_step_output_dir.joinpath("output.parquet")),
-                    }
+                    },
+                    "model_uri": model_uri,
                 },
             },
         }
@@ -222,13 +220,14 @@ def test_predict_model_uri_takes_precendence_over_model_name(
     pipeline_config = read_yaml(tmp_pipeline_root_path, _PIPELINE_CONFIG_FILE_NAME)
     pipeline_config.update(
         {
-            "model_registry": {"model_name": register_step_rm_name, "model_uri": model_uri},
+            "model_registry": {"model_name": register_step_rm_name},
             "steps": {
                 "predict": {
                     "output": {
                         "using": "parquet",
                         "location": str(predict_step_output_dir.joinpath("output.parquet")),
-                    }
+                    },
+                    "model_uri": model_uri,
                 },
             },
         }
@@ -254,12 +253,12 @@ def test_predict_step_output_formats(
     pipeline_config = read_yaml(tmp_pipeline_root_path, _PIPELINE_CONFIG_FILE_NAME)
     pipeline_config.update(
         {
-            "model_registry": {"model_uri": model_uri},
             "steps": {
                 "predict": {
                     "output": {
                         "using": output_format,
-                    }
+                    },
+                    "model_uri": model_uri,
                 },
             },
         }
@@ -306,14 +305,14 @@ def test_predict_correctly_handles_save_modes(
     pipeline_config = read_yaml(tmp_pipeline_root_path, _PIPELINE_CONFIG_FILE_NAME)
     pipeline_config.update(
         {
-            "model_registry": {"model_uri": model_uri},
             "steps": {
                 "predict": {
                     "output": {
                         "using": using,
                         "location": output_path,
-                        "save_mode": save_mode,
-                    }
+                    },
+                    "model_uri": model_uri,
+                    "save_mode": save_mode,
                 },
             },
         }
@@ -331,13 +330,13 @@ def test_predict_correctly_handles_save_modes(
 def test_predict_throws_when_improperly_configured():
     for required_key in ["using", "location"]:
         pipeline_config = {
-            "model_registry": {"model_uri": "models:/taxi_fare_regressor/Production"},
             "steps": {
                 "predict": {
                     "output": {
                         "using": "parquet",
                         "location": "random/path",
-                    }
+                    },
+                    "model_uri": "models:/taxi_fare_regressor/Production",
                 },
             },
         }
@@ -353,13 +352,13 @@ def test_predict_throws_when_improperly_configured():
 
     predict_step = PredictStep.from_pipeline_config(
         pipeline_config={
-            "model_registry": {"model_uri": "my model"},
             "steps": {
                 "predict": {
                     "output": {
                         "using": "fancy_format",
                         "location": "random/path",
-                    }
+                    },
+                    "model_uri": "my model",
                 },
             },
         },
@@ -399,13 +398,13 @@ def test_predict_skips_profiling_when_specified(
         pipeline_config = read_yaml(tmp_pipeline_root_path, _PIPELINE_CONFIG_FILE_NAME)
         pipeline_config.update(
             {
-                "model_registry": {"model_uri": model_uri},
                 "steps": {
                     "predict": {
                         "output": {
                             "using": "parquet",
                             "location": str(predict_step_output_dir.joinpath("output.parquet")),
                         },
+                        "model_uri": model_uri,
                         "skip_data_profiling": True,
                     },
                 },
@@ -437,9 +436,7 @@ def test_predict_uses_registry_uri(
     mlflow.set_registry_uri("")
 
     pipeline_config = read_yaml(tmp_pipeline_root_path, _PIPELINE_CONFIG_FILE_NAME)
-    pipeline_config.update(
-        {"model_registry": {"registry_uri": str(registry_uri), "model_uri": model_uri}}
-    )
+    pipeline_config.update({"model_registry": {"registry_uri": str(registry_uri)}})
     pipeline_config.update(
         {
             "steps": {
@@ -447,7 +444,8 @@ def test_predict_uses_registry_uri(
                     "output": {
                         "using": "parquet",
                         "location": str(predict_step_output_dir.joinpath("output.parquet")),
-                    }
+                    },
+                    "model_uri": model_uri,
                 },
             },
         }


### PR DESCRIPTION
## What changes are proposed in this pull request?
Moving back model_uri to predict

## How is this patch tested?
- [x] Test passes

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
