### PR TITLE
Fix flaky tests in `tests/test_cli.py`

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35,7 +35,7 @@ def test_mlflow_server_command(command):
     cmd = ["mlflow", command, "--port", str(port)]
     process = subprocess.Popen(cmd)
     try:
-        _await_server_up_or_die(port, timeout=10)
+        _await_server_up_or_die(port, timeout=20)
         resp = requests.get(f"http://localhost:{port}/health")
         augmented_raise_for_status(resp)
         assert resp.text == "OK"
@@ -433,7 +433,7 @@ def test_mlflow_tracking_disabled_in_artifacts_only_mode():
     port = get_safe_port()
     cmd = ["mlflow", "server", "--port", str(port), "--artifacts-only"]
     process = subprocess.Popen(cmd)
-    _await_server_up_or_die(port, timeout=10)
+    _await_server_up_or_die(port, timeout=20)
     resp = requests.get(f"http://localhost:{port}/api/2.0/mlflow/experiments/search")
     assert (
         "Endpoint: /api/2.0/mlflow/experiments/search disabled due to the mlflow server running "
@@ -448,7 +448,7 @@ def test_mlflow_artifact_list_in_artifacts_only_mode():
     cmd = ["mlflow", "server", "--port", str(port), "--artifacts-only"]
     process = subprocess.Popen(cmd)
     try:
-        _await_server_up_or_die(port, timeout=10)
+        _await_server_up_or_die(port, timeout=20)
         resp = requests.get(f"http://localhost:{port}/api/2.0/mlflow-artifacts/artifacts")
         augmented_raise_for_status(resp)
         assert resp.status_code == 200
@@ -463,7 +463,7 @@ def test_mlflow_artifact_service_unavailable_when_no_server_artifacts_is_specifi
     cmd = ["mlflow", "server", "--port", str(port), "--no-serve-artifacts"]
     process = subprocess.Popen(cmd)
     try:
-        _await_server_up_or_die(port, timeout=10)
+        _await_server_up_or_die(port, timeout=20)
         endpoint = "/api/2.0/mlflow-artifacts/artifacts"
         resp = requests.get(f"http://localhost:{port}{endpoint}")
         assert (


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Several tests in `tests/test_cli.py` are flaky on Windows. This PR fixes them by increase timeout.

https://github.com/mlflow/mlflow/actions/runs/3365638593/jobs/5581293555#step:8:1925

```
2022/11/01 00:25:56 INFO tests.tracking.integration_test_utils: Awaiting server to be up on 127.0.0.1:61977
2022/11/01 00:25:58 INFO tests.tracking.integration_test_utils: Server not yet up, waiting...
2022/11/01 00:26:01 INFO tests.tracking.integration_test_utils: Server not yet up, waiting...
2022/11/01 00:26:03 INFO tests.tracking.integration_test_utils: Server not yet up, waiting...
2022/11/01 00:26:06 INFO tests.tracking.integration_test_utils: Server not yet up, waiting...
```

https://github.com/mlflow/mlflow/actions/runs/3365635828/jobs/5581288313#step:8:1921

```
---------------------------- Captured stderr call -----------------------------
2022/11/01 00:04:18 INFO tests.tracking.integration_test_utils: Awaiting server to be up on 127.0.0.1:50646
2022/11/01 00:04:20 INFO tests.tracking.integration_test_utils: Server not yet up, waiting...
2022/11/01 00:04:22 INFO tests.tracking.integration_test_utils: Server not yet up, waiting...
2022/11/01 00:04:25 INFO tests.tracking.integration_test_utils: Server not yet up, waiting...
2022/11/01 00:04:27 INFO tests.tracking.integration_test_utils: Server not yet up, waiting...
INFO:waitress:Serving on http://127.0.0.1:50646/
👆👆👆👆👆 server started running after the final attempt, 10 seconds is too short
```


## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->
- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
