### PR TITLE
Fix experiment search ordering bug and change default sort order

### DIFF
--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -285,7 +285,7 @@ class FileStore(AbstractStore):
                 )
         filtered = SearchExperimentsUtils.filter(experiments, filter_string)
         sorted_experiments = SearchExperimentsUtils.sort(
-            filtered, order_by or ["last_update_time DESC"]
+            filtered, order_by or ["creation_time DESC", "experiment_id ASC"]
         )
         experiments, next_page_token = SearchUtils.paginate(
             sorted_experiments, page_token, max_results

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -1366,7 +1366,7 @@ def _get_search_experiments_order_by_clauses(order_by):
     order_by_clauses = []
     for (type_, key, ascending) in map(
         SearchExperimentsUtils.parse_order_by_for_search_experiments,
-        order_by or ["last_update_time DESC"],
+        order_by or ["creation_time DESC", "experiment_id ASC"],
     ):
         if type_ == "attribute":
             order_by_clauses.append((getattr(SqlExperiment, key), ascending))

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -875,9 +875,7 @@ class SearchExperimentsUtils(SearchUtils):
             attr = getattr(experiment, key)
             return _Sorter(attr, ascending)
 
-        return lambda experiment: tuple(
-            _apply_sorter(experiment, k, asc) for (k, asc) in order_by
-        )
+        return lambda experiment: tuple(_apply_sorter(experiment, k, asc) for (k, asc) in order_by)
 
     @classmethod
     def sort(cls, experiments, order_by_list):  # pylint: disable=arguments-renamed

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -862,14 +862,17 @@ class SearchExperimentsUtils(SearchUtils):
                 return other.obj == self.obj
 
             def __lt__(self, other):
-                if self.obj is None:
-                    return False
-                elif other.obj is None:
-                    return True
-                elif self.ascending:
-                    return self.obj < other.obj
+                # if self.obj is None:
+                #     return True 
+                # elif other.obj is None:
+                #     return False
+                if self.ascending:
+                    return (self.obj is None, self.obj) < (other.obj is None, other.obj)
                 else:
-                    return other.obj < self.obj
+                    print((self.obj is None, self.obj))
+                    print((other.obj is None, other.obj))
+                    print((other.obj is None, other.obj) < (self.obj is None, self.obj))
+                    return (other.obj is None, other.obj) < (self.obj is None, self.obj)
 
         def _apply_sorter(experiment, key, ascending):
             attr = getattr(experiment, key)

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -852,23 +852,31 @@ class SearchExperimentsUtils(SearchUtils):
             order_by.append(("experiment_id", False))
 
         # https://stackoverflow.com/a/56842689
-        class _Reversor:
-            def __init__(self, obj):
+        class _Sorter:
+            def __init__(self, obj, ascending):
                 self.obj = obj
+                self.ascending = ascending
 
             # Only need < and == are needed for use as a key parameter in the sorted function
             def __eq__(self, other):
                 return other.obj == self.obj
 
             def __lt__(self, other):
-                return other.obj < self.obj
+                if self.obj is None:
+                    return False
+                elif other.obj is None:
+                    return True
+                elif self.ascending:
+                    return self.obj < other.obj
+                else:
+                    return other.obj < self.obj
 
-        def _apply_reversor(experiment, key, ascending):
+        def _apply_sorter(experiment, key, ascending):
             attr = getattr(experiment, key)
-            return attr if ascending else _Reversor(attr)
+            return _Sorter(attr, ascending)
 
         return lambda experiment: tuple(
-            _apply_reversor(experiment, k, asc) for (k, asc) in order_by
+            _apply_sorter(experiment, k, asc) for (k, asc) in order_by
         )
 
     @classmethod

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -862,17 +862,14 @@ class SearchExperimentsUtils(SearchUtils):
                 return other.obj == self.obj
 
             def __lt__(self, other):
-                # if self.obj is None:
-                #     return True 
-                # elif other.obj is None:
-                #     return False
-                if self.ascending:
-                    return (self.obj is None, self.obj) < (other.obj is None, other.obj)
+                if self.obj is None:
+                    return False
+                elif other.obj is None:
+                    return True
+                elif self.ascending:
+                    return self.obj < other.obj
                 else:
-                    print((self.obj is None, self.obj))
-                    print((other.obj is None, other.obj))
-                    print((other.obj is None, other.obj) < (self.obj is None, self.obj))
-                    return (other.obj is None, other.obj) < (self.obj is None, self.obj)
+                    return other.obj < self.obj
 
         def _apply_sorter(experiment, key, ascending):
             attr = getattr(experiment, key)

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -263,11 +263,11 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         experiments = self.store.search_experiments(
             filter_string=f"last_update_time <= {get_current_time_millis()}"
         )
-        assert [e.experiment_id for e in experiments] == [
+        assert {e.experiment_id for e in experiments} == {
             exp_id1,
             exp_id2,
             self.store.DEFAULT_EXPERIMENT_ID,
-        ]
+            }
 
         experiments = self.store.search_experiments(
             filter_string=f"last_update_time = {exp2.last_update_time}"

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -326,6 +326,9 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         time.sleep(0.05)
         self.create_experiments(experiment_names)
 
+        # Test the case where an experiment does not have a creation time by simulating a time of
+        # `None`. This is applicable to experiments created in older versions of MLflow where the
+        # `creation_time` attribute did not exist
         with mock.patch(
             "mlflow.store.tracking.file_store.get_current_time_millis",
             return_value=None,

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -267,7 +267,7 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
             exp_id1,
             exp_id2,
             self.store.DEFAULT_EXPERIMENT_ID,
-            }
+        }
 
         experiments = self.store.search_experiments(
             filter_string=f"last_update_time = {exp2.last_update_time}"

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -320,26 +320,33 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         )
         assert [e.name for e in experiments] == ["exp1"]
 
-    def test_search_experiments_order_by(self):
+    def test_search_experiments_order_by_foo(self):
         self.initialize()
         experiment_names = ["x", "y", "z"]
         time.sleep(0.05)
         self.create_experiments(experiment_names)
 
+        with mock.patch(
+            "mlflow.store.tracking.file_store.get_current_time_millis",
+            return_value=None,
+        ):
+            self.create_experiments(["n"])
+
         experiments = self.store.search_experiments(order_by=["name"])
-        assert [e.name for e in experiments] == ["Default", "x", "y", "z"]
+        assert [e.name for e in experiments] == ["Default", "n", "x", "y", "z"]
 
         experiments = self.store.search_experiments(order_by=["name ASC"])
-        assert [e.name for e in experiments] == ["Default", "x", "y", "z"]
+        assert [e.name for e in experiments] == ["Default", "n", "x", "y", "z"]
 
         experiments = self.store.search_experiments(order_by=["name DESC"])
-        assert [e.name for e in experiments] == ["z", "y", "x", "Default"]
+        assert [e.name for e in experiments] == ["z", "y", "x", "n", "Default"]
 
         experiments = self.store.search_experiments(order_by=["creation_time DESC"])
-        assert [e.name for e in experiments] == ["z", "y", "x", "Default"]
+        print("EINFO", [(e.name, e.last_update_time) for e in experiments])
+        assert [e.name for e in experiments] == ["z", "y", "x", "Default", "n"]
 
         experiments = self.store.search_experiments(order_by=["name", "last_update_time asc"])
-        assert [e.name for e in experiments] == ["Default", "x", "y", "z"]
+        assert [e.name for e in experiments] == ["Default", "x", "y", "z", "n"]
 
     def test_search_experiments_order_by_time_attribute(self):
         self.initialize()

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -320,7 +320,7 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         )
         assert [e.name for e in experiments] == ["exp1"]
 
-    def test_search_experiments_order_by_foo(self):
+    def test_search_experiments_order_by(self):
         self.initialize()
         experiment_names = ["x", "y", "z"]
         time.sleep(0.05)
@@ -342,11 +342,13 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         assert [e.name for e in experiments] == ["z", "y", "x", "n", "Default"]
 
         experiments = self.store.search_experiments(order_by=["creation_time DESC"])
-        print("EINFO", [(e.name, e.last_update_time) for e in experiments])
         assert [e.name for e in experiments] == ["z", "y", "x", "Default", "n"]
 
-        experiments = self.store.search_experiments(order_by=["name", "last_update_time asc"])
+        experiments = self.store.search_experiments(order_by=["creation_time ASC"])
         assert [e.name for e in experiments] == ["Default", "x", "y", "z", "n"]
+
+        experiments = self.store.search_experiments(order_by=["name", "last_update_time asc"])
+        assert [e.name for e in experiments] == ["Default", "n", "x", "y", "z"]
 
     def test_search_experiments_order_by_time_attribute(self):
         self.initialize()

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -398,11 +398,11 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         experiments = self.store.search_experiments(
             filter_string=f"last_update_time <= {get_current_time_millis()}"
         )
-        assert [e.experiment_id for e in experiments] == [
+        assert {e.experiment_id for e in experiments} == {
             exp_id1,
             exp_id2,
             self.store.DEFAULT_EXPERIMENT_ID,
-        ]
+        }
 
         experiments = self.store.search_experiments(
             filter_string=f"last_update_time = {exp2.last_update_time}"

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -842,4 +842,4 @@ def test_search_experiments(mlflow_client):
     experiments = mlflow_client.search_experiments(view_type=ViewType.DELETED_ONLY)
     assert [e.name for e in experiments] == ["ab"]
     experiments = mlflow_client.search_experiments(view_type=ViewType.ALL)
-    assert [e.name for e in experiments] == ["ab", "Abc", "a", "Default"]
+    assert [e.name for e in experiments] == ["Abc", "ab", "a", "Default"]


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## What changes are proposed in this pull request?

Fix experiment search ordering bug and change default sort order

## How is this patch tested?

New integration tests pending!

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->
- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
