### PR TITLE
Fix package repository URL and unpin Ubuntu in R workflow

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -19,8 +19,7 @@ env:
 
 jobs:
   r:
-    # TODO: Change this to 'ubuntu-latest' once https://github.com/mlflow/mlflow/issues/7222 is fixed
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: github.event_name != 'schedule' || github.repository == 'mlflow/mlflow'
     defaults:
       run:

--- a/mlflow/R/mlflow/.Rprofile
+++ b/mlflow/R/mlflow/.Rprofile
@@ -1,6 +1,6 @@
 # https://packagemanager.rstudio.com provides pre-compiled package binaries for Linux
 # that can be installed significantly faster than uncompiled package sources.
-if (Sys.which("lst_release") != "") {
+if (Sys.which("lsb_release") != "") {
     ubuntu_codename <- tolower(system("lsb_release -cs", intern = TRUE))
     repo_name <- sprintf("https://packagemanager.rstudio.com/cran/__linux__/%s/latest", ubuntu_code_name)
     options(repos = c(REPO_NAME = repo_name))

--- a/mlflow/R/mlflow/.Rprofile
+++ b/mlflow/R/mlflow/.Rprofile
@@ -1,3 +1,3 @@
 # https://packagemanager.rstudio.com provides pre-compiled package binaries for Linux
 # that can be installed significantly faster than uncompiled package sources.
-options(repos = c(REPO_NAME = "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"))
+options(repos = c(REPO_NAME = "https://packagemanager.rstudio.com/cran/__linux__/jammy/latest"))

--- a/mlflow/R/mlflow/.Rprofile
+++ b/mlflow/R/mlflow/.Rprofile
@@ -1,3 +1,5 @@
 # https://packagemanager.rstudio.com provides pre-compiled package binaries for Linux
 # that can be installed significantly faster than uncompiled package sources.
-options(repos = c(REPO_NAME = "https://packagemanager.rstudio.com/cran/__linux__/jammy/latest"))
+ubuntu_code_name <- tolower(gsub(" .*", "", system("lsb_release -cs", intern = TRUE)))
+repo_name <- sprintf("https://packagemanager.rstudio.com/cran/__linux__/%s/latest", ubuntu_code_name)
+options(repos = c(REPO_NAME = repo_name))

--- a/mlflow/R/mlflow/.Rprofile
+++ b/mlflow/R/mlflow/.Rprofile
@@ -2,6 +2,6 @@
 # that can be installed significantly faster than uncompiled package sources.
 if (Sys.which("lsb_release") != "") {
     ubuntu_codename <- tolower(system("lsb_release -cs", intern = TRUE))
-    repo_name <- sprintf("https://packagemanager.rstudio.com/cran/__linux__/%s/latest", ubuntu_code_name)
+    repo_name <- sprintf("https://packagemanager.rstudio.com/cran/__linux__/%s/latest", ubuntu_codename)
     options(repos = c(REPO_NAME = repo_name))
 }

--- a/mlflow/R/mlflow/.Rprofile
+++ b/mlflow/R/mlflow/.Rprofile
@@ -1,7 +1,7 @@
 # https://packagemanager.rstudio.com provides pre-compiled package binaries for Linux
 # that can be installed significantly faster than uncompiled package sources.
 if (Sys.which("lst_release") != "") {
-    ubuntu_code_name <- tolower(gsub(" .*", "", system("lsb_release -cs", intern = TRUE)))
+    ubuntu_codename <- tolower(system("lsb_release -cs", intern = TRUE))
     repo_name <- sprintf("https://packagemanager.rstudio.com/cran/__linux__/%s/latest", ubuntu_code_name)
     options(repos = c(REPO_NAME = repo_name))
 }

--- a/mlflow/R/mlflow/.Rprofile
+++ b/mlflow/R/mlflow/.Rprofile
@@ -1,5 +1,7 @@
 # https://packagemanager.rstudio.com provides pre-compiled package binaries for Linux
 # that can be installed significantly faster than uncompiled package sources.
-ubuntu_code_name <- tolower(gsub(" .*", "", system("lsb_release -cs", intern = TRUE)))
-repo_name <- sprintf("https://packagemanager.rstudio.com/cran/__linux__/%s/latest", ubuntu_code_name)
-options(repos = c(REPO_NAME = repo_name))
+if (Sys.which("lst_release") != "") {
+    ubuntu_code_name <- tolower(gsub(" .*", "", system("lsb_release -cs", intern = TRUE)))
+    repo_name <- sprintf("https://packagemanager.rstudio.com/cran/__linux__/%s/latest", ubuntu_code_name)
+    options(repos = c(REPO_NAME = repo_name))
+}


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #7222

## What changes are proposed in this pull request?

Changed the package repository URL to `https://packagemanager.rstudio.com/cran/__linux__/jammy/latest` and unpin Ubuntu.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->
- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
