### PR TITLE
Add run_name when specified in start_run tags

### DIFF
--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -579,10 +579,10 @@ class FileStore(AbstractStore):
             )
         tags = tags or []
         run_name_tag = _get_run_name_from_tags(tags)
-        if run_name and run_name_tag:
+        if run_name and run_name_tag and run_name != run_name_tag:
             raise MlflowException(
-                "Both 'run_name' argument and 'mlflow.runName' tag are specified. "
-                "Remove 'mlflow.runName' tag.",
+                "Both 'run_name' argument and 'mlflow.runName' tag are specified, but with "
+                f"different values (run_name='{run_name}', mlflow.runName='{run_name_tag}').",
                 INVALID_PARAMETER_VALUE,
             )
         run_name = run_name or run_name_tag or _generate_random_name()

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -470,10 +470,10 @@ class SqlAlchemyStore(AbstractStore):
             )
             tags = tags or []
             run_name_tag = _get_run_name_from_tags(tags)
-            if run_name and run_name_tag:
+            if run_name and run_name_tag and (run_name != run_name_tag):
                 raise MlflowException(
-                    "Both 'run_name' argument and 'mlflow.runName' tag are specified. "
-                    "Remove 'mlflow.runName' tag.",
+                    "Both 'run_name' argument and 'mlflow.runName' tag are specified, but with "
+                    f"different values (run_name='{run_name}', mlflow.runName='{run_name_tag}').",
                     INVALID_PARAMETER_VALUE,
                 )
             run_name = run_name or run_name_tag or _generate_random_name()

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -33,6 +33,7 @@ from mlflow.utils.autologging_utils import (
 from mlflow.utils.import_hooks import register_post_import_hook
 from mlflow.utils.mlflow_tags import (
     MLFLOW_PARENT_RUN_ID,
+    MLFLOW_RUN_NAME,
     MLFLOW_RUN_NOTE,
     MLFLOW_EXPERIMENT_PRIMARY_METRIC_NAME,
     MLFLOW_EXPERIMENT_PRIMARY_METRIC_GREATER_IS_BETTER,
@@ -342,6 +343,8 @@ def start_run(
             user_specified_tags[MLFLOW_RUN_NOTE] = description
         if parent_run_id is not None:
             user_specified_tags[MLFLOW_PARENT_RUN_ID] = parent_run_id
+        if run_name:
+            user_specified_tags[MLFLOW_RUN_NAME] = run_name
 
         resolved_tags = context_registry.resolve_tags(user_specified_tags)
 

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -851,13 +851,16 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
 
         with pytest.raises(
             MlflowException,
-            match=re.escape("Both 'run_name' argument and 'mlflow.runName' tag are specified."),
+            match=re.escape(
+                "Both 'run_name' argument and 'mlflow.runName' tag are specified, but with "
+                "different values (run_name='my name', mlflow.runName='test')."
+            ),
         ):
             fs.create_run(
                 experiment_id=FileStore.DEFAULT_EXPERIMENT_ID,
                 user_id="user",
                 start_time=0,
-                run_name="test",
+                run_name="my name",
                 tags=[RunTag(MLFLOW_RUN_NAME, "test")],
             )
 

--- a/tests/store/tracking/test_rest_store.py
+++ b/tests/store/tracking/test_rest_store.py
@@ -148,6 +148,7 @@ class TestRestStore:
 
         user_name = "mock user"
         source_name = "rest test"
+        run_name = "my name"
 
         source_name_patch = mock.patch(
             "mlflow.tracking.context.default_context._get_source_name", return_value=source_name
@@ -163,17 +164,18 @@ class TestRestStore:
         ), mock.patch(
             "time.time", return_value=13579
         ), source_name_patch, source_type_patch:
-            with mlflow.start_run(experiment_id="43", run_name="my name"):
+            with mlflow.start_run(experiment_id="43", run_name=run_name):
                 cr_body = message_to_json(
                     CreateRun(
                         experiment_id="43",
                         user_id=user_name,
-                        run_name="my name",
+                        run_name=run_name,
                         start_time=13579000,
                         tags=[
                             ProtoRunTag(key="mlflow.source.name", value=source_name),
                             ProtoRunTag(key="mlflow.source.type", value="LOCAL"),
                             ProtoRunTag(key="mlflow.user", value=user_name),
+                            ProtoRunTag(key="mlflow.runName", value=run_name),
                         ],
                     )
                 )

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -853,14 +853,17 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
 
         with pytest.raises(
             MlflowException,
-            match=re.escape("Both 'run_name' argument and 'mlflow.runName' tag are specified."),
+            match=re.escape(
+                "Both 'run_name' argument and 'mlflow.runName' tag are specified, but with "
+                "different values (run_name='test', mlflow.runName='test_2').",
+            ),
         ):
             self.store.create_run(
                 experiment_id=experiment_id,
                 user_id="user",
                 start_time=0,
                 run_name="test",
-                tags=[RunTag(mlflow_tags.MLFLOW_RUN_NAME, "test")],
+                tags=[RunTag(mlflow_tags.MLFLOW_RUN_NAME, "test_2")],
             )
 
     def test_get_run_with_name(self):

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -454,12 +454,14 @@ def test_start_run_defaults(empty_active_run_stack):  # pylint: disable=unused-a
     source_version_patch = mock.patch(
         "mlflow.tracking.context.git_context._get_source_version", return_value=mock_source_version
     )
+    run_name = "my name"
 
     expected_tags = {
         mlflow_tags.MLFLOW_USER: mock_user,
         mlflow_tags.MLFLOW_SOURCE_NAME: mock_source_name,
         mlflow_tags.MLFLOW_SOURCE_TYPE: SourceType.to_string(SourceType.NOTEBOOK),
         mlflow_tags.MLFLOW_GIT_COMMIT: mock_source_version,
+        mlflow_tags.MLFLOW_RUN_NAME: run_name,
     }
 
     create_run_patch = mock.patch.object(MlflowClient, "create_run")
@@ -472,7 +474,7 @@ def test_start_run_defaults(empty_active_run_stack):  # pylint: disable=unused-a
         source_version_patch,
         create_run_patch,
     ):
-        active_run = start_run(run_name="my name")
+        active_run = start_run(run_name=run_name)
         MlflowClient.create_run.assert_called_once_with(
             experiment_id=mock_experiment_id, tags=expected_tags, run_name="my name"
         )


### PR DESCRIPTION
Signed-off-by: Thomas Coquereau <thomas.coquereau@klm.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
Resolve #7217 

## What changes are proposed in this pull request?

Set the MLFLOW_RUN_NAME in user_specified_tags when specified by the user in the parameters in the function `start_run`.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->
I edited an existing test to include the run_name in the expected tags, but I am unsure if that covers it. I wasn't able to run the unit tests locally `./dev/run-python-tests.sh` outputs `pytest: error: unrecognized arguments: --cov=./mlflow --cov-report tests`
- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
