### PR TITLE
Replace unittest assertmethods with plain assert

### DIFF
--- a/tests/entities/model_registry/test_model_version.py
+++ b/tests/entities/model_registry/test_model_version.py
@@ -26,19 +26,19 @@ class TestModelVersion(unittest.TestCase):
         status_message,
         tags,
     ):
-        self.assertIsInstance(model_version, ModelVersion)
-        self.assertEqual(model_version.name, name)
-        self.assertEqual(model_version.version, version)
-        self.assertEqual(model_version.creation_timestamp, creation_timestamp)
-        self.assertEqual(model_version.last_updated_timestamp, last_updated_timestamp)
-        self.assertEqual(model_version.description, description)
-        self.assertEqual(model_version.user_id, user_id)
-        self.assertEqual(model_version.current_stage, current_stage)
-        self.assertEqual(model_version.source, source)
-        self.assertEqual(model_version.run_id, run_id)
-        self.assertEqual(model_version.status, status)
-        self.assertEqual(model_version.status_message, status_message)
-        self.assertEqual(model_version.tags, tags)
+        assert isinstance(model_version, ModelVersion)
+        assert model_version.name == name
+        assert model_version.version == version
+        assert model_version.creation_timestamp == creation_timestamp
+        assert model_version.last_updated_timestamp == last_updated_timestamp
+        assert model_version.description == description
+        assert model_version.user_id == user_id
+        assert model_version.current_stage == current_stage
+        assert model_version.source == source
+        assert model_version.run_id == run_id
+        assert model_version.status == status
+        assert model_version.status_message == status_message
+        assert model_version.tags == tags
 
     def test_creation_and_hydration(self):
         name = random_str()
@@ -94,15 +94,15 @@ class TestModelVersion(unittest.TestCase):
             "tags": {tag.key: tag.value for tag in (tags or [])},
         }
         model_version_as_dict = dict(mvd)
-        self.assertEqual(model_version_as_dict, expected_dict)
+        assert model_version_as_dict == expected_dict
 
         proto = mvd.to_proto()
-        self.assertEqual(proto.name, name)
-        self.assertEqual(proto.version, "5")
-        self.assertEqual(proto.status, ModelVersionStatus.from_string("READY"))
-        self.assertEqual(proto.status_message, "Model version #5 is ready to use.")
-        self.assertEqual({tag.key for tag in proto.tags}, {"key", "randomKey"})
-        self.assertEqual({tag.value for tag in proto.tags}, {"value", "not a random value"})
+        assert proto.name == name
+        assert proto.version == "5"
+        assert proto.status == ModelVersionStatus.from_string("READY")
+        assert proto.status_message == "Model version #5 is ready to use."
+        assert {tag.key for tag in proto.tags} == {"key", "randomKey"}
+        assert {tag.value for tag in proto.tags} == {"value", "not a random value"}
         mvd_2 = ModelVersion.from_proto(proto)
         self._check(
             mvd_2,

--- a/tests/entities/model_registry/test_registered_model.py
+++ b/tests/entities/model_registry/test_registered_model.py
@@ -17,14 +17,14 @@ class TestRegisteredModel(unittest.TestCase):
         latest_versions,
         tags,
     ):
-        self.assertIsInstance(registered_model, RegisteredModel)
-        self.assertEqual(registered_model.name, name)
-        self.assertEqual(registered_model.creation_timestamp, creation_timestamp)
-        self.assertEqual(registered_model.last_updated_timestamp, last_updated_timestamp)
-        self.assertEqual(registered_model.description, description)
-        self.assertEqual(registered_model.last_updated_timestamp, last_updated_timestamp)
-        self.assertEqual(registered_model.latest_versions, latest_versions)
-        self.assertEqual(registered_model.tags, tags)
+        assert isinstance(registered_model, RegisteredModel)
+        assert registered_model.name == name
+        assert registered_model.creation_timestamp == creation_timestamp
+        assert registered_model.last_updated_timestamp == last_updated_timestamp
+        assert registered_model.description == description
+        assert registered_model.last_updated_timestamp == last_updated_timestamp
+        assert registered_model.latest_versions == latest_versions
+        assert registered_model.tags == tags
 
     def test_creation_and_hydration(self):
         name = random_str()
@@ -40,13 +40,13 @@ class TestRegisteredModel(unittest.TestCase):
             "latest_versions": [],
             "tags": {},
         }
-        self.assertEqual(dict(rmd_1), as_dict)
+        assert dict(rmd_1) == as_dict
 
         proto = rmd_1.to_proto()
-        self.assertEqual(proto.name, name)
-        self.assertEqual(proto.creation_timestamp, 1)
-        self.assertEqual(proto.last_updated_timestamp, 2)
-        self.assertEqual(proto.description, description)
+        assert proto.name == name
+        assert proto.creation_timestamp == 1
+        assert proto.last_updated_timestamp == 2
+        assert proto.description == description
         rmd_2 = RegisteredModel.from_proto(proto)
         self._check(rmd_2, name, 1, 2, description, [], {})
         as_dict["tags"] = []
@@ -91,26 +91,17 @@ class TestRegisteredModel(unittest.TestCase):
         }
         rmd_1 = RegisteredModel.from_dictionary(as_dict)
         as_dict["tags"] = {}
-        self.assertEqual(dict(rmd_1), as_dict)
+        assert dict(rmd_1) == as_dict
 
         proto = rmd_1.to_proto()
-        self.assertEqual(proto.creation_timestamp, 1)
-        self.assertEqual(proto.last_updated_timestamp, 4000)
-        self.assertEqual({mvd.version for mvd in proto.latest_versions}, {"1", "4"})
-        self.assertEqual({mvd.name for mvd in proto.latest_versions}, {name})
-        self.assertEqual(
-            {mvd.current_stage for mvd in proto.latest_versions},
-            {"Production", "Staging"},
-        )
-        self.assertEqual(
-            {mvd.last_updated_timestamp for mvd in proto.latest_versions},
-            {2000, 2002},
-        )
+        assert proto.creation_timestamp == 1
+        assert proto.last_updated_timestamp == 4000
+        assert {mvd.version for mvd in proto.latest_versions} == {"1", "4"}
+        assert {mvd.name for mvd in proto.latest_versions} == {name}
+        assert {mvd.current_stage for mvd in proto.latest_versions} == {"Production", "Staging"}
+        assert {mvd.last_updated_timestamp for mvd in proto.latest_versions} == {2000, 2002}
 
-        self.assertEqual(
-            {mvd.creation_timestamp for mvd in proto.latest_versions},
-            {1300, 1000},
-        )
+        assert {mvd.creation_timestamp for mvd in proto.latest_versions} == {1300, 1000}
 
     def test_with_tags(self):
         name = random_str()
@@ -127,18 +118,12 @@ class TestRegisteredModel(unittest.TestCase):
         }
         rmd_1 = RegisteredModel.from_dictionary(as_dict)
         as_dict["tags"] = {tag.key: tag.value for tag in (tags or [])}
-        self.assertEqual(dict(rmd_1), as_dict)
+        assert dict(rmd_1) == as_dict
         proto = rmd_1.to_proto()
-        self.assertEqual(proto.creation_timestamp, 1)
-        self.assertEqual(proto.last_updated_timestamp, 4000)
-        self.assertEqual(
-            {tag.key for tag in proto.tags},
-            {"key", "randomKey"},
-        )
-        self.assertEqual(
-            {tag.value for tag in proto.tags},
-            {"value", "not a random value"},
-        )
+        assert proto.creation_timestamp == 1
+        assert proto.last_updated_timestamp == 4000
+        assert {tag.key for tag in proto.tags} == {"key", "randomKey"}
+        assert {tag.value for tag in proto.tags} == {"value", "not a random value"}
 
     def test_string_repr(self):
         rmd = RegisteredModel(

--- a/tests/entities/test_experiment.py
+++ b/tests/entities/test_experiment.py
@@ -7,13 +7,13 @@ from tests.helper_functions import random_int, random_file
 
 class TestExperiment(unittest.TestCase):
     def _check(self, exp, exp_id, name, location, lifecyle_stage, creation_time, last_update_time):
-        self.assertIsInstance(exp, Experiment)
-        self.assertEqual(exp.experiment_id, exp_id)
-        self.assertEqual(exp.name, name)
-        self.assertEqual(exp.artifact_location, location)
-        self.assertEqual(exp.lifecycle_stage, lifecyle_stage)
-        self.assertEqual(exp.creation_time, creation_time)
-        self.assertEqual(exp.last_update_time, last_update_time)
+        assert isinstance(exp, Experiment)
+        assert exp.experiment_id == exp_id
+        assert exp.name == name
+        assert exp.artifact_location == location
+        assert exp.lifecycle_stage == lifecyle_stage
+        assert exp.creation_time == creation_time
+        assert exp.last_update_time == last_update_time
 
     def test_creation_and_hydration(self):
         exp_id = str(random_int())
@@ -42,7 +42,7 @@ class TestExperiment(unittest.TestCase):
             "creation_time": creation_time,
             "last_update_time": last_update_time,
         }
-        self.assertEqual(dict(exp), as_dict)
+        assert dict(exp) == as_dict
 
         proto = exp.to_proto()
         exp2 = Experiment.from_proto(proto)

--- a/tests/entities/test_file_info.py
+++ b/tests/entities/test_file_info.py
@@ -6,10 +6,10 @@ from tests.helper_functions import random_str, random_int
 
 class TestFileInfo(unittest.TestCase):
     def _check(self, fi, path, is_dir, size_in_bytes):
-        self.assertIsInstance(fi, FileInfo)
-        self.assertEqual(fi.path, path)
-        self.assertEqual(fi.is_dir, is_dir)
-        self.assertEqual(fi.file_size, size_in_bytes)
+        assert isinstance(fi, FileInfo)
+        assert fi.path == path
+        assert fi.is_dir == is_dir
+        assert fi.file_size == size_in_bytes
 
     def test_creation_and_hydration(self):
         path = random_str(random_int(10, 50))
@@ -19,7 +19,7 @@ class TestFileInfo(unittest.TestCase):
         self._check(fi1, path, is_dir, size_in_bytes)
 
         as_dict = {"path": path, "is_dir": is_dir, "file_size": size_in_bytes}
-        self.assertEqual(dict(fi1), as_dict)
+        assert dict(fi1) == as_dict
 
         proto = fi1.to_proto()
         fi2 = FileInfo.from_proto(proto)

--- a/tests/entities/test_param.py
+++ b/tests/entities/test_param.py
@@ -6,9 +6,9 @@ from tests.helper_functions import random_str, random_int
 
 class TestParam(unittest.TestCase):
     def _check(self, param, key, value):
-        self.assertIsInstance(param, Param)
-        self.assertEqual(param.key, key)
-        self.assertEqual(param.value, value)
+        assert isinstance(param, Param)
+        assert param.key == key
+        assert param.value == value
 
     def test_creation_and_hydration(self):
         key = random_str(random_int(10, 25))  # random string on size in range [10, 25]
@@ -18,7 +18,7 @@ class TestParam(unittest.TestCase):
         self._check(param, key, value)
 
         as_dict = {"key": key, "value": value}
-        self.assertEqual(dict(param), as_dict)
+        assert dict(param) == as_dict
 
         proto = param.to_proto()
         param2 = Param.from_proto(proto)

--- a/tests/entities/test_run.py
+++ b/tests/entities/test_run.py
@@ -53,24 +53,21 @@ class TestRun(TestRunInfo, TestRunData):
             "lifecycle_stage": lifecycle_stage,
             "artifact_uri": artifact_uri,
         }
-        self.assertEqual(
-            run1.to_dictionary(),
-            {
-                "info": expected_info_dict,
-                "data": {
-                    "metrics": {m.key: m.value for m in metrics},
-                    "params": {p.key: p.value for p in params},
-                    "tags": {t.key: t.value for t in tags},
-                },
+        assert run1.to_dictionary() == {
+            "info": expected_info_dict,
+            "data": {
+                "metrics": {m.key: m.value for m in metrics},
+                "params": {p.key: p.value for p in params},
+                "tags": {t.key: t.value for t in tags},
             },
-        )
+        }
 
         proto = run1.to_proto()
         run2 = Run.from_proto(proto)
         self._check_run(run2, run_info, metrics, params, tags)
 
         run3 = Run(run_info, None)
-        self.assertEqual(run3.to_dictionary(), {"info": expected_info_dict})
+        assert run3.to_dictionary() == {"info": expected_info_dict}
 
     def test_string_repr(self):
         run_info = RunInfo(

--- a/tests/entities/test_run_data.py
+++ b/tests/entities/test_run_data.py
@@ -7,33 +7,21 @@ from tests.helper_functions import random_str, random_int
 
 class TestRunData(unittest.TestCase):
     def _check_metrics(self, metric_objs, metrics_dict, expected_metrics):
-        self.assertEqual(
-            {m.key for m in metric_objs},
-            {m.key for m in expected_metrics},
-        )
-        self.assertEqual(
-            {m.value for m in metric_objs},
-            {m.value for m in expected_metrics},
-        )
-        self.assertEqual(
-            {m.timestamp for m in metric_objs},
-            {m.timestamp for m in expected_metrics},
-        )
-        self.assertEqual(
-            {m.step for m in metric_objs},
-            {m.step for m in expected_metrics},
-        )
+        assert {m.key for m in metric_objs} == {m.key for m in expected_metrics}
+        assert {m.value for m in metric_objs} == {m.value for m in expected_metrics}
+        assert {m.timestamp for m in metric_objs} == {m.timestamp for m in expected_metrics}
+        assert {m.step for m in metric_objs} == {m.step for m in expected_metrics}
         assert len(metrics_dict) == len(expected_metrics)
         assert metrics_dict == {m.key: m.value for m in expected_metrics}
 
     def _check_params(self, params_dict, expected_params):
-        self.assertEqual(params_dict, {p.key: p.value for p in expected_params})
+        assert params_dict == {p.key: p.value for p in expected_params}
 
     def _check_tags(self, tags_dict, expected_tags):
-        self.assertEqual(tags_dict, {t.key: t.value for t in expected_tags})
+        assert tags_dict == {t.key: t.value for t in expected_tags}
 
     def _check(self, rd, metrics, params, tags):
-        self.assertIsInstance(rd, RunData)
+        assert isinstance(rd, RunData)
         self._check_metrics(rd._metric_objs, rd.metrics, metrics)
         self._check_params(rd.params, params)
         self._check_tags(rd.tags, tags)
@@ -62,7 +50,7 @@ class TestRunData(unittest.TestCase):
             "params": {p.key: p.value for p in params},
             "tags": {t.key: t.value for t in tags},
         }
-        self.assertEqual(dict(rd1), as_dict)
+        assert dict(rd1) == as_dict
         proto = rd1.to_proto()
         rd2 = RunData.from_proto(proto)
         self._check(rd2, metrics, params, tags)

--- a/tests/entities/test_run_info.py
+++ b/tests/entities/test_run_info.py
@@ -19,16 +19,16 @@ class TestRunInfo(unittest.TestCase):
         lifecycle_stage,
         artifact_uri,
     ):
-        self.assertIsInstance(ri, RunInfo)
-        self.assertEqual(ri.run_uuid, run_id)
-        self.assertEqual(ri.run_id, run_id)
-        self.assertEqual(ri.experiment_id, experiment_id)
-        self.assertEqual(ri.user_id, user_id)
-        self.assertEqual(ri.status, status)
-        self.assertEqual(ri.start_time, start_time)
-        self.assertEqual(ri.end_time, end_time)
-        self.assertEqual(ri.lifecycle_stage, lifecycle_stage)
-        self.assertEqual(ri.artifact_uri, artifact_uri)
+        assert isinstance(ri, RunInfo)
+        assert ri.run_uuid == run_id
+        assert ri.run_id == run_id
+        assert ri.experiment_id == experiment_id
+        assert ri.user_id == user_id
+        assert ri.status == status
+        assert ri.start_time == start_time
+        assert ri.end_time == end_time
+        assert ri.lifecycle_stage == lifecycle_stage
+        assert ri.artifact_uri == artifact_uri
 
     @staticmethod
     def _create():
@@ -102,7 +102,7 @@ class TestRunInfo(unittest.TestCase):
             "lifecycle_stage": lifecycle_stage,
             "artifact_uri": artifact_uri,
         }
-        self.assertEqual(dict(ri1), as_dict)
+        assert dict(ri1) == as_dict
 
         proto = ri1.to_proto()
         ri2 = RunInfo.from_proto(proto)
@@ -146,7 +146,12 @@ class TestRunInfo(unittest.TestCase):
         )
 
     def test_searchable_attributes(self):
-        self.assertSequenceEqual(
-            {"status", "artifact_uri", "start_time", "user_id", "end_time", "run_name", "run_id"},
-            set(RunInfo.get_searchable_attributes()),
-        )
+        assert {
+            "status",
+            "artifact_uri",
+            "start_time",
+            "user_id",
+            "end_time",
+            "run_name",
+            "run_id",
+        } == set(RunInfo.get_searchable_attributes())

--- a/tests/entities/test_run_status.py
+++ b/tests/entities/test_run_status.py
@@ -14,24 +14,24 @@ class TestRunStatus(unittest.TestCase):
             RunStatus.FAILED,
             RunStatus.KILLED,
         }
-        self.assertSequenceEqual(all_statuses, set(RunStatus.all_status()))
+        assert all_statuses == set(RunStatus.all_status())
 
     def test_status_mappings(self):
         # test enum to string mappings
-        self.assertEqual("RUNNING", RunStatus.to_string(RunStatus.RUNNING))
-        self.assertEqual(RunStatus.RUNNING, RunStatus.from_string("RUNNING"))
+        assert "RUNNING" == RunStatus.to_string(RunStatus.RUNNING)
+        assert RunStatus.RUNNING == RunStatus.from_string("RUNNING")
 
-        self.assertEqual("SCHEDULED", RunStatus.to_string(RunStatus.SCHEDULED))
-        self.assertEqual(RunStatus.SCHEDULED, RunStatus.from_string("SCHEDULED"))
+        assert "SCHEDULED" == RunStatus.to_string(RunStatus.SCHEDULED)
+        assert RunStatus.SCHEDULED == RunStatus.from_string("SCHEDULED")
 
-        self.assertEqual("FINISHED", RunStatus.to_string(RunStatus.FINISHED))
-        self.assertEqual(RunStatus.FINISHED, RunStatus.from_string("FINISHED"))
+        assert "FINISHED" == RunStatus.to_string(RunStatus.FINISHED)
+        assert RunStatus.FINISHED == RunStatus.from_string("FINISHED")
 
-        self.assertEqual("FAILED", RunStatus.to_string(RunStatus.FAILED))
-        self.assertEqual(RunStatus.FAILED, RunStatus.from_string("FAILED"))
+        assert "FAILED" == RunStatus.to_string(RunStatus.FAILED)
+        assert RunStatus.FAILED == RunStatus.from_string("FAILED")
 
-        self.assertEqual("KILLED", RunStatus.to_string(RunStatus.KILLED))
-        self.assertEqual(RunStatus.KILLED, RunStatus.from_string("KILLED"))
+        assert "KILLED" == RunStatus.to_string(RunStatus.KILLED)
+        assert RunStatus.KILLED == RunStatus.from_string("KILLED")
 
         with pytest.raises(
             Exception, match=r"Could not get string corresponding to run status -120"

--- a/tests/recipes/cards/test_histogram_generator.py
+++ b/tests/recipes/cards/test_histogram_generator.py
@@ -1,6 +1,7 @@
 """
 Unit tests for histogram_generator.py
 """
+import pytest
 import unittest
 
 from mlflow.protos import facet_feature_statistics_pb2
@@ -19,14 +20,20 @@ class HistogramGeneratorTestCase(unittest.TestCase):
         """
         Helper function to assert the actual histogram is almost equal to the expected histogram.
         """
-        self.assertEqual(expected.type, actual.type)
-        self.assertEqual(len(expected.buckets), len(actual.buckets))
+        assert expected.type == actual.type
+        assert len(expected.buckets) == len(actual.buckets)
         for i in range(len(expected.buckets)):
             actual_bucket = actual.buckets[i]
             expected_bucket = expected.buckets[i]
-            self.assertAlmostEqual(actual_bucket.low_value, expected_bucket.low_value, 2)
-            self.assertAlmostEqual(actual_bucket.high_value, expected_bucket.high_value, 2)
-            self.assertAlmostEqual(actual_bucket.sample_count, expected_bucket.sample_count, 2)
+            assert actual_bucket.low_value == pytest.approx(
+                expected_bucket.low_value,
+            )
+            assert actual_bucket.high_value == pytest.approx(
+                expected_bucket.high_value,
+            )
+            assert actual_bucket.sample_count == pytest.approx(
+                expected_bucket.sample_count,
+            )
 
 
 class EqualHeightHistogramGeneratorTestCase(HistogramGeneratorTestCase):
@@ -39,18 +46,20 @@ class EqualHeightHistogramGeneratorTestCase(HistogramGeneratorTestCase):
         Tests generate_equal_height_histogram returns None when quantiles is invalid.
         """
         # Empty quantiles is invalid.
-        self.assertIsNone(
-            histogram_generator.generate_equal_height_histogram(quantiles=[], num_buckets=5)
+        assert (
+            histogram_generator.generate_equal_height_histogram(quantiles=[], num_buckets=5) is None
         )
         # Quantiles which has less than 3 elements is invalid.
-        self.assertIsNone(
+        assert (
             histogram_generator.generate_equal_height_histogram(quantiles=[1, 2], num_buckets=1)
+            is None
         )
         # When (len(quantiles) - 1) % num_buckets != 0, quantiles is considered as invalid.
-        self.assertIsNone(
+        assert (
             histogram_generator.generate_equal_height_histogram(
                 quantiles=[1, 2, 3, 4, 5], num_buckets=3
             )
+            is None
         )
 
     def test_valid_quantiles(self):

--- a/tests/recipes/cards/test_histogram_generator.py
+++ b/tests/recipes/cards/test_histogram_generator.py
@@ -25,14 +25,10 @@ class HistogramGeneratorTestCase(unittest.TestCase):
         for i in range(len(expected.buckets)):
             actual_bucket = actual.buckets[i]
             expected_bucket = expected.buckets[i]
-            assert actual_bucket.low_value == pytest.approx(
-                expected_bucket.low_value,
-            )
-            assert actual_bucket.high_value == pytest.approx(
-                expected_bucket.high_value,
-            )
+            assert actual_bucket.low_value == pytest.approx(expected_bucket.low_value, rel=1e-3)
+            assert actual_bucket.high_value == pytest.approx(expected_bucket.high_value, rel=1e-3)
             assert actual_bucket.sample_count == pytest.approx(
-                expected_bucket.sample_count,
+                expected_bucket.sample_count, rel=1e-3
             )
 
 

--- a/tests/recipes/cards/test_histogram_generator.py
+++ b/tests/recipes/cards/test_histogram_generator.py
@@ -25,10 +25,10 @@ class HistogramGeneratorTestCase(unittest.TestCase):
         for i in range(len(expected.buckets)):
             actual_bucket = actual.buckets[i]
             expected_bucket = expected.buckets[i]
-            assert actual_bucket.low_value == pytest.approx(expected_bucket.low_value, rel=1e-3)
-            assert actual_bucket.high_value == pytest.approx(expected_bucket.high_value, rel=1e-3)
+            assert actual_bucket.low_value == pytest.approx(expected_bucket.low_value, rel=1e-2)
+            assert actual_bucket.high_value == pytest.approx(expected_bucket.high_value, rel=1e-2)
             assert actual_bucket.sample_count == pytest.approx(
-                expected_bucket.sample_count, rel=1e-3
+                expected_bucket.sample_count, rel=1e-2
             )
 
 

--- a/tests/store/db/test_utils.py
+++ b/tests/store/db/test_utils.py
@@ -75,7 +75,7 @@ class TestCreateSqlAlchemyEngineWithRetry(TestCase):
                         mock_create_sqlalchemy_engine.assert_called_once_with("mydb://host:port/")
                         mock_sqlalchemy_inspect.assert_called_once()
                         mock_sleep.assert_not_called()
-                        self.assertEqual(engine, "Engine")
+                        assert engine == "Engine"
 
     def test_create_sqlalchemy_engine_with_retry_success_after_third_call(self):
         with mock.patch.dict(os.environ, {}):
@@ -91,7 +91,7 @@ class TestCreateSqlAlchemyEngineWithRetry(TestCase):
                             mock_create_sqlalchemy_engine.mock_calls
                             == [mock.call("mydb://host:port/")] * 3
                         )
-                        self.assertEqual(engine, "Engine")
+                        assert engine == "Engine"
 
     def test_create_sqlalchemy_engine_with_retry_fail(self):
         with mock.patch.dict(os.environ, {}), mock.patch(

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -89,8 +89,8 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
     def test_create_registered_model(self):
         name = random_str() + "abCD"
         rm1 = self._rm_maker(name)
-        self.assertEqual(rm1.name, name)
-        self.assertEqual(rm1.description, None)
+        assert rm1.name == name
+        assert rm1.description == None
 
         # error on duplicate
         with pytest.raises(
@@ -102,7 +102,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         # slightly different name is ok
         for name2 in [name + "extra", name + name]:
             rm2 = self._rm_maker(name2)
-            self.assertEqual(rm2.name, name2)
+            assert rm2.name == name2
 
         # test create model with tags
         name2 = random_str() + "tags"
@@ -112,20 +112,20 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         ]
         rm2 = self._rm_maker(name2, tags)
         rmd2 = self.store.get_registered_model(name2)
-        self.assertEqual(rm2.name, name2)
-        self.assertEqual(rm2.tags, {tag.key: tag.value for tag in tags})
-        self.assertEqual(rmd2.name, name2)
-        self.assertEqual(rmd2.tags, {tag.key: tag.value for tag in tags})
+        assert rm2.name == name2
+        assert rm2.tags == {tag.key: tag.value for tag in tags}
+        assert rmd2.name == name2
+        assert rmd2.tags == {tag.key: tag.value for tag in tags}
 
         # create with description
         name3 = random_str() + "-description"
         description = "the best model ever"
         rm3 = self._rm_maker(name3, description=description)
         rmd3 = self.store.get_registered_model(name3)
-        self.assertEqual(rm3.name, name3)
-        self.assertEqual(rm3.description, description)
-        self.assertEqual(rmd3.name, name3)
-        self.assertEqual(rmd3.description, description)
+        assert rm3.name == name3
+        assert rm3.description == description
+        assert rmd3.name == name3
+        assert rmd3.description == description
 
         # invalid model name will fail
         with pytest.raises(
@@ -149,28 +149,28 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         with mock.patch("time.time") as mock_time:
             mock_time.return_value = 1234
             rm = self._rm_maker(name, tags)
-            self.assertEqual(rm.name, name)
+            assert rm.name == name
         rmd = self.store.get_registered_model(name=name)
-        self.assertEqual(rmd.name, name)
-        self.assertEqual(rmd.creation_timestamp, 1234000)
-        self.assertEqual(rmd.last_updated_timestamp, 1234000)
-        self.assertEqual(rmd.description, None)
-        self.assertEqual(rmd.latest_versions, [])
-        self.assertEqual(rmd.tags, {tag.key: tag.value for tag in tags})
+        assert rmd.name == name
+        assert rmd.creation_timestamp == 1234000
+        assert rmd.last_updated_timestamp == 1234000
+        assert rmd.description == None
+        assert rmd.latest_versions == []
+        assert rmd.tags == {tag.key: tag.value for tag in tags}
 
     def test_update_registered_model(self):
         name = "model_for_update_RM"
         rm1 = self._rm_maker(name)
         rmd1 = self.store.get_registered_model(name=name)
-        self.assertEqual(rm1.name, name)
-        self.assertEqual(rmd1.description, None)
+        assert rm1.name == name
+        assert rmd1.description == None
 
         # update description
         rm2 = self.store.update_registered_model(name=name, description="test model")
         rmd2 = self.store.get_registered_model(name=name)
-        self.assertEqual(rm2.name, "model_for_update_RM")
-        self.assertEqual(rmd2.name, "model_for_update_RM")
-        self.assertEqual(rmd2.description, "test model")
+        assert rm2.name == "model_for_update_RM"
+        assert rmd2.name == "model_for_update_RM"
+        assert rmd2.description == "test model"
 
     def test_rename_registered_model(self):
         original_name = "original name"
@@ -181,18 +181,18 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         rm = self.store.get_registered_model(original_name)
         mv1 = self.store.get_model_version(original_name, 1)
         mv2 = self.store.get_model_version(original_name, 2)
-        self.assertEqual(rm.name, original_name)
-        self.assertEqual(mv1.name, original_name)
-        self.assertEqual(mv2.name, original_name)
+        assert rm.name == original_name
+        assert mv1.name == original_name
+        assert mv2.name == original_name
 
         # test renaming registered model also updates its model versions
         self.store.rename_registered_model(original_name, new_name)
         rm = self.store.get_registered_model(new_name)
         mv1 = self.store.get_model_version(new_name, 1)
         mv2 = self.store.get_model_version(new_name, 2)
-        self.assertEqual(rm.name, new_name)
-        self.assertEqual(mv1.name, new_name)
-        self.assertEqual(mv2.name, new_name)
+        assert rm.name == new_name
+        assert mv1.name == new_name
+        assert mv2.name == new_name
 
         # test accessing the model with the old name will fail
         with pytest.raises(
@@ -227,8 +227,8 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self._mv_maker(name)
         rm1 = self.store.get_registered_model(name=name)
         mv1 = self.store.get_model_version(name, 1)
-        self.assertEqual(rm1.name, name)
-        self.assertEqual(mv1.name, name)
+        assert rm1.name == name
+        assert mv1.name == name
 
         # delete model
         self.store.delete_registered_model(name=name)
@@ -265,87 +265,75 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         name = "test_for_latest_versions"
         self._rm_maker(name)
         rmd1 = self.store.get_registered_model(name=name)
-        self.assertEqual(rmd1.latest_versions, [])
+        assert rmd1.latest_versions == []
 
         mv1 = self._mv_maker(name)
-        self.assertEqual(mv1.version, 1)
+        assert mv1.version == 1
         rmd2 = self.store.get_registered_model(name=name)
-        self.assertEqual(self._extract_latest_by_stage(rmd2.latest_versions), {"None": 1})
+        assert self._extract_latest_by_stage(rmd2.latest_versions) == {"None": 1}
 
         # add a bunch more
         mv2 = self._mv_maker(name)
-        self.assertEqual(mv2.version, 2)
+        assert mv2.version == 2
         self.store.transition_model_version_stage(
             name=mv2.name, version=mv2.version, stage="Production", archive_existing_versions=False
         )
 
         mv3 = self._mv_maker(name)
-        self.assertEqual(mv3.version, 3)
+        assert mv3.version == 3
         self.store.transition_model_version_stage(
             name=mv3.name, version=mv3.version, stage="Production", archive_existing_versions=False
         )
         mv4 = self._mv_maker(name)
-        self.assertEqual(mv4.version, 4)
+        assert mv4.version == 4
         self.store.transition_model_version_stage(
             name=mv4.name, version=mv4.version, stage="Staging", archive_existing_versions=False
         )
 
         # test that correct latest versions are returned for each stage
         rmd4 = self.store.get_registered_model(name=name)
-        self.assertEqual(
-            self._extract_latest_by_stage(rmd4.latest_versions),
-            {"None": 1, "Production": 3, "Staging": 4},
-        )
-        self.assertEqual(
-            self._extract_latest_by_stage(self.store.get_latest_versions(name=name, stages=None)),
-            {"None": 1, "Production": 3, "Staging": 4},
-        )
-        self.assertEqual(
-            self._extract_latest_by_stage(self.store.get_latest_versions(name=name, stages=[])),
-            {"None": 1, "Production": 3, "Staging": 4},
-        )
-        self.assertEqual(
-            self._extract_latest_by_stage(
-                self.store.get_latest_versions(name=name, stages=["Production"])
-            ),
-            {"Production": 3},
-        )
-        self.assertEqual(
-            self._extract_latest_by_stage(
-                self.store.get_latest_versions(name=name, stages=["production"])
-            ),
-            {"Production": 3},
-        )  # The stages are case insensitive.
-        self.assertEqual(
-            self._extract_latest_by_stage(
-                self.store.get_latest_versions(name=name, stages=["pROduction"])
-            ),
-            {"Production": 3},
-        )  # The stages are case insensitive.
-        self.assertEqual(
-            self._extract_latest_by_stage(
-                self.store.get_latest_versions(name=name, stages=["None", "Production"])
-            ),
-            {"None": 1, "Production": 3},
-        )
+        assert self._extract_latest_by_stage(rmd4.latest_versions) == {
+            "None": 1,
+            "Production": 3,
+            "Staging": 4,
+        }
+        assert self._extract_latest_by_stage(
+            self.store.get_latest_versions(name=name, stages=None)
+        ) == {"None": 1, "Production": 3, "Staging": 4}
+        assert self._extract_latest_by_stage(
+            self.store.get_latest_versions(name=name, stages=[])
+        ) == {"None": 1, "Production": 3, "Staging": 4}
+        assert self._extract_latest_by_stage(
+            self.store.get_latest_versions(name=name, stages=["Production"])
+        ) == {"Production": 3}
+        assert self._extract_latest_by_stage(
+            self.store.get_latest_versions(name=name, stages=["production"])
+        ) == {
+            "Production": 3
+        }  # The stages are case insensitive.
+        assert self._extract_latest_by_stage(
+            self.store.get_latest_versions(name=name, stages=["pROduction"])
+        ) == {
+            "Production": 3
+        }  # The stages are case insensitive.
+        assert self._extract_latest_by_stage(
+            self.store.get_latest_versions(name=name, stages=["None", "Production"])
+        ) == {"None": 1, "Production": 3}
 
         # delete latest Production, and should point to previous one
         self.store.delete_model_version(name=mv3.name, version=mv3.version)
         rmd5 = self.store.get_registered_model(name=name)
-        self.assertEqual(
-            self._extract_latest_by_stage(rmd5.latest_versions),
-            {"None": 1, "Production": 2, "Staging": 4},
-        )
-        self.assertEqual(
-            self._extract_latest_by_stage(self.store.get_latest_versions(name=name, stages=None)),
-            {"None": 1, "Production": 2, "Staging": 4},
-        )
-        self.assertEqual(
-            self._extract_latest_by_stage(
-                self.store.get_latest_versions(name=name, stages=["Production"])
-            ),
-            {"Production": 2},
-        )
+        assert self._extract_latest_by_stage(rmd5.latest_versions) == {
+            "None": 1,
+            "Production": 2,
+            "Staging": 4,
+        }
+        assert self._extract_latest_by_stage(
+            self.store.get_latest_versions(name=name, stages=None)
+        ) == {"None": 1, "Production": 2, "Staging": 4}
+        assert self._extract_latest_by_stage(
+            self.store.get_latest_versions(name=name, stages=["Production"])
+        ) == {"Production": 2}
 
     def test_set_registered_model_tag(self):
         name1 = "SetRegisteredModelTag_TestMod"
@@ -360,17 +348,17 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self.store.set_registered_model_tag(name1, new_tag)
         rm1 = self.store.get_registered_model(name=name1)
         all_tags = initial_tags + [new_tag]
-        self.assertEqual(rm1.tags, {tag.key: tag.value for tag in all_tags})
+        assert rm1.tags == {tag.key: tag.value for tag in all_tags}
 
         # test overriding a tag with the same key
         overriding_tag = RegisteredModelTag("key", "overriding")
         self.store.set_registered_model_tag(name1, overriding_tag)
         all_tags = [tag for tag in all_tags if tag.key != "key"] + [overriding_tag]
         rm1 = self.store.get_registered_model(name=name1)
-        self.assertEqual(rm1.tags, {tag.key: tag.value for tag in all_tags})
+        assert rm1.tags == {tag.key: tag.value for tag in all_tags}
         # does not affect other models with the same key
         rm2 = self.store.get_registered_model(name=name2)
-        self.assertEqual(rm2.tags, {tag.key: tag.value for tag in initial_tags})
+        assert rm2.tags == {tag.key: tag.value for tag in initial_tags}
 
         # can not set tag on deleted (non-existed) registered model
         self.store.delete_registered_model(name1)
@@ -416,19 +404,19 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self.store.set_registered_model_tag(name1, new_tag)
         self.store.delete_registered_model_tag(name1, "randomTag")
         rm1 = self.store.get_registered_model(name=name1)
-        self.assertEqual(rm1.tags, {tag.key: tag.value for tag in initial_tags})
+        assert rm1.tags == {tag.key: tag.value for tag in initial_tags}
 
         # testing deleting a key does not affect other models with the same key
         self.store.delete_registered_model_tag(name1, "key")
         rm1 = self.store.get_registered_model(name=name1)
         rm2 = self.store.get_registered_model(name=name2)
-        self.assertEqual(rm1.tags, {"anotherKey": "some other value"})
-        self.assertEqual(rm2.tags, {tag.key: tag.value for tag in initial_tags})
+        assert rm1.tags == {"anotherKey": "some other value"}
+        assert rm2.tags == {tag.key: tag.value for tag in initial_tags}
 
         # delete tag that is already deleted does nothing
         self.store.delete_registered_model_tag(name1, "key")
         rm1 = self.store.get_registered_model(name=name1)
-        self.assertEqual(rm1.tags, {"anotherKey": "some other value"})
+        assert rm1.tags == {"anotherKey": "some other value"}
 
         # can not delete tag on deleted (non-existed) registered model
         self.store.delete_registered_model(name1)
@@ -455,91 +443,91 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         with mock.patch("time.time") as mock_time:
             mock_time.return_value = 456778
             mv1 = self._mv_maker(name, "a/b/CD", run_id)
-            self.assertEqual(mv1.name, name)
-            self.assertEqual(mv1.version, 1)
+            assert mv1.name == name
+            assert mv1.version == 1
 
         mvd1 = self.store.get_model_version(mv1.name, mv1.version)
-        self.assertEqual(mvd1.name, name)
-        self.assertEqual(mvd1.version, 1)
-        self.assertEqual(mvd1.current_stage, "None")
-        self.assertEqual(mvd1.creation_timestamp, 456778000)
-        self.assertEqual(mvd1.last_updated_timestamp, 456778000)
-        self.assertEqual(mvd1.description, None)
-        self.assertEqual(mvd1.source, "a/b/CD")
-        self.assertEqual(mvd1.run_id, run_id)
-        self.assertEqual(mvd1.status, "READY")
-        self.assertEqual(mvd1.status_message, None)
-        self.assertEqual(mvd1.tags, {})
+        assert mvd1.name == name
+        assert mvd1.version == 1
+        assert mvd1.current_stage == "None"
+        assert mvd1.creation_timestamp == 456778000
+        assert mvd1.last_updated_timestamp == 456778000
+        assert mvd1.description == None
+        assert mvd1.source == "a/b/CD"
+        assert mvd1.run_id == run_id
+        assert mvd1.status == "READY"
+        assert mvd1.status_message == None
+        assert mvd1.tags == {}
 
         # new model versions for same name autoincrement versions
         mv2 = self._mv_maker(name)
         mvd2 = self.store.get_model_version(name=mv2.name, version=mv2.version)
-        self.assertEqual(mv2.version, 2)
-        self.assertEqual(mvd2.version, 2)
+        assert mv2.version == 2
+        assert mvd2.version == 2
 
         # create model version with tags return model version entity with tags
         tags = [ModelVersionTag("key", "value"), ModelVersionTag("anotherKey", "some other value")]
         mv3 = self._mv_maker(name, tags=tags)
         mvd3 = self.store.get_model_version(name=mv3.name, version=mv3.version)
-        self.assertEqual(mv3.version, 3)
-        self.assertEqual(mv3.tags, {tag.key: tag.value for tag in tags})
-        self.assertEqual(mvd3.version, 3)
-        self.assertEqual(mvd3.tags, {tag.key: tag.value for tag in tags})
+        assert mv3.version == 3
+        assert mv3.tags == {tag.key: tag.value for tag in tags}
+        assert mvd3.version == 3
+        assert mvd3.tags == {tag.key: tag.value for tag in tags}
 
         # create model versions with runLink
         run_link = "http://localhost:3000/path/to/run/"
         mv4 = self._mv_maker(name, run_link=run_link)
         mvd4 = self.store.get_model_version(name, mv4.version)
-        self.assertEqual(mv4.version, 4)
-        self.assertEqual(mv4.run_link, run_link)
-        self.assertEqual(mvd4.version, 4)
-        self.assertEqual(mvd4.run_link, run_link)
+        assert mv4.version == 4
+        assert mv4.run_link == run_link
+        assert mvd4.version == 4
+        assert mvd4.run_link == run_link
 
         # create model version with description
         description = "the best model ever"
         mv5 = self._mv_maker(name, description=description)
         mvd5 = self.store.get_model_version(name, mv5.version)
-        self.assertEqual(mv5.version, 5)
-        self.assertEqual(mv5.description, description)
-        self.assertEqual(mvd5.version, 5)
-        self.assertEqual(mvd5.description, description)
+        assert mv5.version == 5
+        assert mv5.description == description
+        assert mvd5.version == 5
+        assert mvd5.description == description
 
         # create model version without runId
         mv6 = self._mv_maker(name, run_id=None)
         mvd6 = self.store.get_model_version(name, mv6.version)
-        self.assertEqual(mv6.version, 6)
-        self.assertEqual(mv6.run_id, None)
-        self.assertEqual(mvd6.version, 6)
-        self.assertEqual(mvd6.run_id, None)
+        assert mv6.version == 6
+        assert mv6.run_id == None
+        assert mvd6.version == 6
+        assert mvd6.run_id == None
 
     def test_update_model_version(self):
         name = "test_for_update_MV"
         self._rm_maker(name)
         mv1 = self._mv_maker(name)
         mvd1 = self.store.get_model_version(name=mv1.name, version=mv1.version)
-        self.assertEqual(mvd1.name, name)
-        self.assertEqual(mvd1.version, 1)
-        self.assertEqual(mvd1.current_stage, "None")
+        assert mvd1.name == name
+        assert mvd1.version == 1
+        assert mvd1.current_stage == "None"
 
         # update stage
         self.store.transition_model_version_stage(
             name=mv1.name, version=mv1.version, stage="Production", archive_existing_versions=False
         )
         mvd2 = self.store.get_model_version(name=mv1.name, version=mv1.version)
-        self.assertEqual(mvd2.name, name)
-        self.assertEqual(mvd2.version, 1)
-        self.assertEqual(mvd2.current_stage, "Production")
-        self.assertEqual(mvd2.description, None)
+        assert mvd2.name == name
+        assert mvd2.version == 1
+        assert mvd2.current_stage == "Production"
+        assert mvd2.description == None
 
         # update description
         self.store.update_model_version(
             name=mv1.name, version=mv1.version, description="test model version"
         )
         mvd3 = self.store.get_model_version(name=mv1.name, version=mv1.version)
-        self.assertEqual(mvd3.name, name)
-        self.assertEqual(mvd3.version, 1)
-        self.assertEqual(mvd3.current_stage, "Production")
-        self.assertEqual(mvd3.description, "test model version")
+        assert mvd3.name == name
+        assert mvd3.version == 1
+        assert mvd3.current_stage == "Production"
+        assert mvd3.description == "test model version"
 
         # only valid stages can be set
         with pytest.raises(
@@ -563,7 +551,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
                 archive_existing_versions=False,
             )
             mvd5 = self.store.get_model_version(name=mv1.name, version=mv1.version)
-            self.assertEqual(mvd5.current_stage, "Staging")
+            assert mvd5.current_stage == "Staging"
 
     def test_transition_model_version_stage_when_archive_existing_versions_is_false(self):
         name = "model"
@@ -585,9 +573,9 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         mvd2 = self.store.get_model_version(name=name, version=mv2.version)
         mvd3 = self.store.get_model_version(name=name, version=mv3.version)
 
-        self.assertEqual(mvd1.current_stage, "Staging")
-        self.assertEqual(mvd2.current_stage, "Production")
-        self.assertEqual(mvd3.current_stage, "Staging")
+        assert mvd1.current_stage == "Staging"
+        assert mvd2.current_stage == "Production"
+        assert mvd3.current_stage == "Staging"
 
         self.store.transition_model_version_stage(name, mv3.version, "Production", False)
 
@@ -595,9 +583,9 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         mvd2 = self.store.get_model_version(name=name, version=mv2.version)
         mvd3 = self.store.get_model_version(name=name, version=mv3.version)
 
-        self.assertEqual(mvd1.current_stage, "Staging")
-        self.assertEqual(mvd2.current_stage, "Production")
-        self.assertEqual(mvd3.current_stage, "Production")
+        assert mvd1.current_stage == "Staging"
+        assert mvd2.current_stage == "Production"
+        assert mvd3.current_stage == "Production"
 
     def test_transition_model_version_stage_when_archive_existing_versions_is_true(self):
         name = "model"
@@ -625,10 +613,10 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         mvd2 = self.store.get_model_version(name=name, version=mv2.version)
         mvd3 = self.store.get_model_version(name=name, version=mv3.version)
 
-        self.assertEqual(mvd1.current_stage, "Archived")
-        self.assertEqual(mvd2.current_stage, "Production")
-        self.assertEqual(mvd3.current_stage, "Staging")
-        self.assertEqual(mvd1.last_updated_timestamp, mvd3.last_updated_timestamp)
+        assert mvd1.current_stage == "Archived"
+        assert mvd2.current_stage == "Production"
+        assert mvd3.current_stage == "Staging"
+        assert mvd1.last_updated_timestamp == mvd3.last_updated_timestamp
 
         self.store.transition_model_version_stage(name, mv3.version, "Production", True)
 
@@ -636,10 +624,10 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         mvd2 = self.store.get_model_version(name=name, version=mv2.version)
         mvd3 = self.store.get_model_version(name=name, version=mv3.version)
 
-        self.assertEqual(mvd1.current_stage, "Archived")
-        self.assertEqual(mvd2.current_stage, "Archived")
-        self.assertEqual(mvd3.current_stage, "Production")
-        self.assertEqual(mvd2.last_updated_timestamp, mvd3.last_updated_timestamp)
+        assert mvd1.current_stage == "Archived"
+        assert mvd2.current_stage == "Archived"
+        assert mvd3.current_stage == "Production"
+        assert mvd2.last_updated_timestamp == mvd3.last_updated_timestamp
 
         for uncanonical_stage_name in ["STAGING", "staging", "StAgInG"]:
             self.store.transition_model_version_stage(mv1.name, mv1.version, "Staging", False)
@@ -652,8 +640,8 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
 
             mvd1 = self.store.get_model_version(name=mv1.name, version=mv1.version)
             mvd2 = self.store.get_model_version(name=mv2.name, version=mv2.version)
-            self.assertEqual(mvd1.current_stage, "Archived")
-            self.assertEqual(mvd2.current_stage, "Staging")
+            assert mvd1.current_stage == "Archived"
+            assert mvd2.current_stage == "Staging"
 
     def test_delete_model_version(self):
         name = "test_for_delete_MV"
@@ -664,7 +652,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self._rm_maker(name)
         mv = self._mv_maker(name, tags=initial_tags)
         mvd = self.store.get_model_version(name=mv.name, version=mv.version)
-        self.assertEqual(mvd.name, name)
+        assert mvd.name == name
 
         self.store.delete_model_version(name=mv.name, version=mv.version)
 
@@ -700,18 +688,18 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self._rm_maker(name)
         mv = self._mv_maker(name, source=source, run_id=run_id, run_link=run_link)
         mvd = self.store.get_model_version(name=name, version=mv.version)
-        self.assertEqual(mvd.run_link, run_link)
-        self.assertEqual(mvd.run_id, run_id)
-        self.assertEqual(mvd.source, source)
+        assert mvd.run_link == run_link
+        assert mvd.run_id == run_id
+        assert mvd.source == source
         # delete the MV now
         self.store.delete_model_version(name, mv.version)
         # verify that the relevant fields are redacted
         mvd_deleted = self.store._get_sql_model_version_including_deleted(
             name=name, version=mv.version
         )
-        self.assertIn("REDACTED", mvd_deleted.run_link)
-        self.assertIn("REDACTED", mvd_deleted.source)
-        self.assertIn("REDACTED", mvd_deleted.run_id)
+        assert "REDACTED" in mvd_deleted.run_link
+        assert "REDACTED" in mvd_deleted.source
+        assert "REDACTED" in mvd_deleted.run_id
 
     def test_get_model_version_download_uri(self):
         name = "test_for_update_MV"
@@ -719,12 +707,13 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         source_path = "path/to/source"
         mv = self._mv_maker(name, source=source_path, run_id=uuid.uuid4().hex)
         mvd1 = self.store.get_model_version(name=mv.name, version=mv.version)
-        self.assertEqual(mvd1.name, name)
-        self.assertEqual(mvd1.source, source_path)
+        assert mvd1.name == name
+        assert mvd1.source == source_path
 
         # download location points to source
-        self.assertEqual(
-            self.store.get_model_version_download_uri(name=mv.name, version=mv.version), source_path
+        assert (
+            self.store.get_model_version_download_uri(name=mv.name, version=mv.version)
+            == source_path
         )
 
         # download URI does not change even if model version is updated
@@ -735,9 +724,10 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
             name=mv.name, version=mv.version, description="Test for Path"
         )
         mvd2 = self.store.get_model_version(name=mv.name, version=mv.version)
-        self.assertEqual(mvd2.source, source_path)
-        self.assertEqual(
-            self.store.get_model_version_download_uri(name=mv.name, version=mv.version), source_path
+        assert mvd2.source == source_path
+        assert (
+            self.store.get_model_version_download_uri(name=mv.name, version=mv.version)
+            == source_path
         )
 
         # cannot retrieve download URI for deleted model versions
@@ -757,43 +747,34 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         run_id_2 = uuid.uuid4().hex
         run_id_3 = uuid.uuid4().hex
         mv1 = self._mv_maker(name=name, source="A/B", run_id=run_id_1)
-        self.assertEqual(mv1.version, 1)
+        assert mv1.version == 1
         mv2 = self._mv_maker(name=name, source="A/C", run_id=run_id_2)
-        self.assertEqual(mv2.version, 2)
+        assert mv2.version == 2
         mv3 = self._mv_maker(name=name, source="A/D", run_id=run_id_2)
-        self.assertEqual(mv3.version, 3)
+        assert mv3.version == 3
         mv4 = self._mv_maker(name=name, source="A/D", run_id=run_id_3)
-        self.assertEqual(mv4.version, 4)
+        assert mv4.version == 4
 
         def search_versions(filter_string):
             return [mvd.version for mvd in self.store.search_model_versions(filter_string)]
 
         # search using name should return all 4 versions
-        self.assertEqual(set(search_versions("name='%s'" % name)), {1, 2, 3, 4})
+        assert set(search_versions("name='%s'" % name)) == {1, 2, 3, 4}
 
         # search using run_id_1 should return version 1
-        self.assertEqual(set(search_versions("run_id='%s'" % run_id_1)), {1})
+        assert set(search_versions("run_id='%s'" % run_id_1)) == {1}
 
         # search using run_id_2 should return versions 2 and 3
-        self.assertEqual(set(search_versions("run_id='%s'" % run_id_2)), {2, 3})
+        assert set(search_versions("run_id='%s'" % run_id_2)) == {2, 3}
 
         # search using the IN operator should return all versions
-        self.assertEqual(
-            set(search_versions(f"run_id IN ('{run_id_1}','{run_id_2}')")),
-            {1, 2, 3},
-        )
+        assert set(search_versions(f"run_id IN ('{run_id_1}','{run_id_2}')")) == {1, 2, 3}
 
         # search IN operator is case sensitive
-        self.assertEqual(
-            set(search_versions(f"run_id IN ('{run_id_1.upper()}','{run_id_2}')")),
-            {2, 3},
-        )
+        assert set(search_versions(f"run_id IN ('{run_id_1.upper()}','{run_id_2}')")) == {2, 3}
 
         # search IN operator with right-hand side value containing whitespaces
-        self.assertEqual(
-            set(search_versions(f"run_id IN ('{run_id_1}', '{run_id_2}')")),
-            {1, 2, 3},
-        )
+        assert set(search_versions(f"run_id IN ('{run_id_1}', '{run_id_2}')")) == {1, 2, 3}
 
         # search using the IN operator with bad lists should return exceptions
         with pytest.raises(
@@ -807,15 +788,9 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
             search_versions("run_id IN (1,2,3)")
         assert exception_context.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
-        self.assertEqual(
-            set(search_versions(f"run_id LIKE '{run_id_2[:30]}%'")),
-            {2, 3},
-        )
+        assert set(search_versions(f"run_id LIKE '{run_id_2[:30]}%'")) == {2, 3}
 
-        self.assertEqual(
-            set(search_versions(f"run_id ILIKE '{run_id_2[:30].upper()}%'")),
-            {2, 3},
-        )
+        assert set(search_versions(f"run_id ILIKE '{run_id_2[:30].upper()}%'")) == {2, 3}
 
         # search using the IN operator with empty lists should return exceptions
         with pytest.raises(
@@ -871,22 +846,22 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         assert exception_context.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
         # search using source_path "A/D" should return version 3 and 4
-        self.assertEqual(set(search_versions("source_path = 'A/D'")), {3, 4})
+        assert set(search_versions("source_path = 'A/D'")) == {3, 4}
 
         # search using source_path "A" should not return anything
-        self.assertEqual(len(search_versions("source_path = 'A'")), 0)
-        self.assertEqual(len(search_versions("source_path = 'A/'")), 0)
-        self.assertEqual(len(search_versions("source_path = ''")), 0)
+        assert len(search_versions("source_path = 'A'")) == 0
+        assert len(search_versions("source_path = 'A/'")) == 0
+        assert len(search_versions("source_path = ''")) == 0
 
         # delete mv4. search should not return version 4
         self.store.delete_model_version(name=mv4.name, version=mv4.version)
-        self.assertEqual(set(search_versions("")), {1, 2, 3})
+        assert set(search_versions("")) == {1, 2, 3}
 
-        self.assertEqual(set(search_versions(None)), {1, 2, 3})
+        assert set(search_versions(None)) == {1, 2, 3}
 
-        self.assertEqual(set(search_versions("name='%s'" % name)), {1, 2, 3})
+        assert set(search_versions("name='%s'" % name)) == {1, 2, 3}
 
-        self.assertEqual(set(search_versions("source_path = 'A/D'")), {3})
+        assert set(search_versions("source_path = 'A/D'")) == {3}
 
         self.store.transition_model_version_stage(
             name=mv1.name, version=mv1.version, stage="production", archive_existing_versions=False
@@ -965,66 +940,66 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
 
         # search with no filter should return all registered models
         rms, _ = self._search_registered_models(None)
-        self.assertEqual(rms, names)
+        assert rms == names
 
         # equality search using name should return exactly the 1 name
         rms, _ = self._search_registered_models("name='{}'".format(names[0]))
-        self.assertEqual(rms, [names[0]])
+        assert rms == [names[0]]
 
         # equality search using name that is not valid should return nothing
         rms, _ = self._search_registered_models("name='{}'".format(names[0] + "cats"))
-        self.assertEqual(rms, [])
+        assert rms == []
 
         # case-sensitive prefix search using LIKE should return all the RMs
         rms, _ = self._search_registered_models("name LIKE '{}%'".format(prefix))
-        self.assertEqual(rms, names)
+        assert rms == names
 
         # case-sensitive prefix search using LIKE with surrounding % should return all the RMs
         rms, _ = self._search_registered_models("name LIKE '%RM%'")
-        self.assertEqual(rms, names)
+        assert rms == names
 
         # case-sensitive prefix search using LIKE with surrounding % should return all the RMs
         # _e% matches test_for_search_ , so all RMs should match
         rms, _ = self._search_registered_models("name LIKE '_e%'")
-        self.assertEqual(rms, names)
+        assert rms == names
 
         # case-sensitive prefix search using LIKE should return just rm4
         rms, _ = self._search_registered_models("name LIKE '{}%'".format(prefix + "RM4A"))
-        self.assertEqual(rms, [names[4]])
+        assert rms == [names[4]]
 
         # case-sensitive prefix search using LIKE should return no models if no match
         rms, _ = self._search_registered_models("name LIKE '{}%'".format(prefix + "cats"))
-        self.assertEqual(rms, [])
+        assert rms == []
 
         # confirm that LIKE is not case-sensitive
         rms, _ = self._search_registered_models("name lIkE '%blah%'")
-        self.assertEqual(rms, [])
+        assert rms == []
 
         rms, _ = self._search_registered_models("name like '{}%'".format(prefix + "RM4A"))
-        self.assertEqual(rms, [names[4]])
+        assert rms == [names[4]]
 
         # case-insensitive prefix search using ILIKE should return both rm5 and rm6
         rms, _ = self._search_registered_models("name ILIKE '{}%'".format(prefix + "RM4A"))
-        self.assertEqual(rms, names[4:])
+        assert rms == names[4:]
 
         # case-insensitive postfix search with ILIKE
         rms, _ = self._search_registered_models("name ILIKE '%RM4a%'")
-        self.assertEqual(rms, names[4:])
+        assert rms == names[4:]
 
         # case-insensitive prefix search using ILIKE should return both rm5 and rm6
         rms, _ = self._search_registered_models("name ILIKE '{}%'".format(prefix + "cats"))
-        self.assertEqual(rms, [])
+        assert rms == []
 
         # confirm that ILIKE is not case-sensitive
         rms, _ = self._search_registered_models("name iLike '%blah%'")
-        self.assertEqual(rms, [])
+        assert rms == []
 
         # confirm that ILIKE works for empty query
         rms, _ = self._search_registered_models("name iLike '%%'")
-        self.assertEqual(rms, names)
+        assert rms == names
 
         rms, _ = self._search_registered_models("name ilike '%RM4a%'")
-        self.assertEqual(rms, names[4:])
+        assert rms == names[4:]
 
         # cannot search by invalid comparator types
         with pytest.raises(
@@ -1058,20 +1033,21 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
 
         # delete last registered model. search should not return the first 5
         self.store.delete_registered_model(name=names[-1])
-        self.assertEqual(self._search_registered_models(None, max_results=1000), (names[:-1], None))
+        assert self._search_registered_models(None, max_results=1000) == (names[:-1], None)
 
         # equality search using name should return no names
-        self.assertEqual(self._search_registered_models("name='{}'".format(names[-1])), ([], None))
+        assert self._search_registered_models("name='{}'".format(names[-1])) == ([], None)
 
         # case-sensitive prefix search using LIKE should return all the RMs
-        self.assertEqual(
-            self._search_registered_models("name LIKE '{}%'".format(prefix)), (names[0:5], None)
+        assert self._search_registered_models("name LIKE '{}%'".format(prefix)) == (
+            names[0:5],
+            None,
         )
 
         # case-insensitive prefix search using ILIKE should return both rm5 and rm6
-        self.assertEqual(
-            self._search_registered_models("name ILIKE '{}%'".format(prefix + "RM4A")),
-            ([names[4]], None),
+        assert self._search_registered_models("name ILIKE '{}%'".format(prefix + "RM4A")) == (
+            [names[4]],
+            None,
         )
 
     def test_search_registered_models_by_tag(self):
@@ -1120,11 +1096,11 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
     def test_parse_search_registered_models_order_by(self):
         # test that "registered_models.name ASC" is returned by default
         parsed = SqlAlchemyStore._parse_search_registered_models_order_by([])
-        self.assertEqual([str(x) for x in parsed], ["registered_models.name ASC"])
+        assert [str(x) for x in parsed] == ["registered_models.name ASC"]
 
         # test that the given 'name' replaces the default one ('registered_models.name ASC')
         parsed = SqlAlchemyStore._parse_search_registered_models_order_by(["name DESC"])
-        self.assertEqual([str(x) for x in parsed], ["registered_models.name DESC"])
+        assert [str(x) for x in parsed] == ["registered_models.name DESC"]
 
         # test that an exception is raised when order_by contains duplicate fields
         msg = "`order_by` contains duplicate fields:"
@@ -1162,26 +1138,26 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         while token:
             result, token = self._search_registered_models(query, page_token=token, max_results=5)
             returned_rms.extend(result)
-        self.assertEqual(rms, returned_rms)
+        assert rms == returned_rms
 
         # test that pagination will return all valid results in sorted order
         # by name ascending
         result, token1 = self._search_registered_models(query, max_results=5)
-        self.assertNotEqual(token1, None)
-        self.assertEqual(result, rms[0:5])
+        assert token1 != None
+        assert result == rms[0:5]
 
         result, token2 = self._search_registered_models(query, page_token=token1, max_results=10)
-        self.assertNotEqual(token2, None)
-        self.assertEqual(result, rms[5:15])
+        assert token2 != None
+        assert result == rms[5:15]
 
         result, token3 = self._search_registered_models(query, page_token=token2, max_results=20)
-        self.assertNotEqual(token3, None)
-        self.assertEqual(result, rms[15:35])
+        assert token3 != None
+        assert result == rms[15:35]
 
         result, token4 = self._search_registered_models(query, page_token=token3, max_results=100)
         # assert that page token is None
-        self.assertEqual(token4, None)
-        self.assertEqual(result, rms[35:])
+        assert token4 == None
+        assert result == rms[35:]
 
         # test that providing a completely invalid page token throws
         with pytest.raises(
@@ -1220,42 +1196,42 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
             )
             returned_rms.extend(result)
         # name descending should be the opposite order of the current order
-        self.assertEqual(rms[::-1], returned_rms)
+        assert rms[::-1] == returned_rms
         # last_updated_timestamp descending should have the newest RMs first
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=["last_updated_timestamp DESC"], max_results=100
         )
-        self.assertEqual(rms[::-1], result)
+        assert rms[::-1] == result
         # timestamp returns same result as last_updated_timestamp
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=["timestamp DESC"], max_results=100
         )
-        self.assertEqual(rms[::-1], result)
+        assert rms[::-1] == result
         # last_updated_timestamp ascending should have the oldest RMs first
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=["last_updated_timestamp ASC"], max_results=100
         )
-        self.assertEqual(rms, result)
+        assert rms == result
         # timestamp returns same result as last_updated_timestamp
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=["timestamp ASC"], max_results=100
         )
-        self.assertEqual(rms, result)
+        assert rms == result
         # timestamp returns same result as last_updated_timestamp
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=["timestamp"], max_results=100
         )
-        self.assertEqual(rms, result)
+        assert rms == result
         # name ascending should have the original order
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=["name ASC"], max_results=100
         )
-        self.assertEqual(rms, result)
+        assert rms == result
         # test that no ASC/DESC defaults to ASC
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=["last_updated_timestamp"], max_results=100
         )
-        self.assertEqual(rms, result)
+        assert rms == result
         with mock.patch(
             "mlflow.store.model_registry.sqlalchemy_store.get_current_time_millis", return_value=1
         ):
@@ -1274,55 +1250,55 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
             order_by=["last_updated_timestamp ASC", "name DESC"],
             max_results=100,
         )
-        self.assertEqual([rm2, rm1, rm4, rm3], result)
+        assert [rm2, rm1, rm4, rm3] == result
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=["timestamp ASC", "name   DESC"], max_results=100
         )
-        self.assertEqual([rm2, rm1, rm4, rm3], result)
+        assert [rm2, rm1, rm4, rm3] == result
         # confirm that name ascending is the default, even if ties exist on other fields
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=[], max_results=100
         )
-        self.assertEqual([rm1, rm2, rm3, rm4], result)
+        assert [rm1, rm2, rm3, rm4] == result
         # test default tiebreak with descending timestamps
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=["last_updated_timestamp DESC"], max_results=100
         )
-        self.assertEqual([rm3, rm4, rm1, rm2], result)
+        assert [rm3, rm4, rm1, rm2] == result
         # test timestamp parsing
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=["timestamp\tASC"], max_results=100
         )
-        self.assertEqual([rm1, rm2, rm3, rm4], result)
+        assert [rm1, rm2, rm3, rm4] == result
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=["timestamp\r\rASC"], max_results=100
         )
-        self.assertEqual([rm1, rm2, rm3, rm4], result)
+        assert [rm1, rm2, rm3, rm4] == result
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=["timestamp\nASC"], max_results=100
         )
-        self.assertEqual([rm1, rm2, rm3, rm4], result)
+        assert [rm1, rm2, rm3, rm4] == result
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=["timestamp  ASC"], max_results=100
         )
-        self.assertEqual([rm1, rm2, rm3, rm4], result)
+        assert [rm1, rm2, rm3, rm4] == result
         # validate order by key is case-insensitive
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=["timestamp  asc"], max_results=100
         )
-        self.assertEqual([rm1, rm2, rm3, rm4], result)
+        assert [rm1, rm2, rm3, rm4] == result
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=["timestamp  aSC"], max_results=100
         )
-        self.assertEqual([rm1, rm2, rm3, rm4], result)
+        assert [rm1, rm2, rm3, rm4] == result
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=["timestamp  desc", "name desc"], max_results=100
         )
-        self.assertEqual([rm4, rm3, rm2, rm1], result)
+        assert [rm4, rm3, rm2, rm1] == result
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=["timestamp  deSc", "name deSc"], max_results=100
         )
-        self.assertEqual([rm4, rm3, rm2, rm1], result)
+        assert [rm4, rm3, rm2, rm1] == result
 
     def test_search_registered_model_order_by_errors(self):
         query = "name LIKE 'RM%'"
@@ -1368,19 +1344,19 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self.store.set_model_version_tag(name1, 1, new_tag)
         all_tags = initial_tags + [new_tag]
         rm1mv1 = self.store.get_model_version(name1, 1)
-        self.assertEqual(rm1mv1.tags, {tag.key: tag.value for tag in all_tags})
+        assert rm1mv1.tags == {tag.key: tag.value for tag in all_tags}
 
         # test overriding a tag with the same key
         overriding_tag = ModelVersionTag("key", "overriding")
         self.store.set_model_version_tag(name1, 1, overriding_tag)
         all_tags = [tag for tag in all_tags if tag.key != "key"] + [overriding_tag]
         rm1mv1 = self.store.get_model_version(name1, 1)
-        self.assertEqual(rm1mv1.tags, {tag.key: tag.value for tag in all_tags})
+        assert rm1mv1.tags == {tag.key: tag.value for tag in all_tags}
         # does not affect other model versions with the same key
         rm1mv2 = self.store.get_model_version(name1, 2)
         rm2mv1 = self.store.get_model_version(name2, 1)
-        self.assertEqual(rm1mv2.tags, {tag.key: tag.value for tag in initial_tags})
-        self.assertEqual(rm2mv1.tags, {tag.key: tag.value for tag in initial_tags})
+        assert rm1mv2.tags == {tag.key: tag.value for tag in initial_tags}
+        assert rm2mv1.tags == {tag.key: tag.value for tag in initial_tags}
 
         # can not set tag on deleted (non-existed) model version
         self.store.delete_model_version(name1, 2)
@@ -1437,21 +1413,21 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self.store.set_model_version_tag(name1, 1, new_tag)
         self.store.delete_model_version_tag(name1, 1, "randomTag")
         rm1mv1 = self.store.get_model_version(name1, 1)
-        self.assertEqual(rm1mv1.tags, {tag.key: tag.value for tag in initial_tags})
+        assert rm1mv1.tags == {tag.key: tag.value for tag in initial_tags}
 
         # testing deleting a key does not affect other model versions with the same key
         self.store.delete_model_version_tag(name1, 1, "key")
         rm1mv1 = self.store.get_model_version(name1, 1)
         rm1mv2 = self.store.get_model_version(name1, 2)
         rm2mv1 = self.store.get_model_version(name2, 1)
-        self.assertEqual(rm1mv1.tags, {"anotherKey": "some other value"})
-        self.assertEqual(rm1mv2.tags, {tag.key: tag.value for tag in initial_tags})
-        self.assertEqual(rm2mv1.tags, {tag.key: tag.value for tag in initial_tags})
+        assert rm1mv1.tags == {"anotherKey": "some other value"}
+        assert rm1mv2.tags == {tag.key: tag.value for tag in initial_tags}
+        assert rm2mv1.tags == {tag.key: tag.value for tag in initial_tags}
 
         # delete tag that is already deleted does nothing
         self.store.delete_model_version_tag(name1, 1, "key")
         rm1mv1 = self.store.get_model_version(name1, 1)
-        self.assertEqual(rm1mv1.tags, {"anotherKey": "some other value"})
+        assert rm1mv1.tags == {"anotherKey": "some other value"}
 
         # can not delete tag on deleted (non-existed) model version
         self.store.delete_model_version(name2, 1)

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -171,7 +171,7 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
             return FileStore.DEFAULT_EXPERIMENT_ID in ids
 
         file_store = FileStore(self.test_root)
-        self.assertTrue(_is_default_in_experiments(ViewType.ACTIVE_ONLY))
+        assert _is_default_in_experiments(ViewType.ACTIVE_ONLY)
 
         # Ensure experiment deletion of default id raises
         with pytest.raises(MlflowException, match="Cannot delete the default experiment"):
@@ -431,9 +431,9 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
 
     def _verify_experiment(self, fs, exp_id):
         exp = fs.get_experiment(exp_id)
-        self.assertEqual(exp.experiment_id, exp_id)
-        self.assertEqual(exp.name, self.exp_data[exp_id]["name"])
-        self.assertEqual(exp.artifact_location, self.exp_data[exp_id]["artifact_location"])
+        assert exp.experiment_id == exp_id
+        assert exp.name == self.exp_data[exp_id]["name"]
+        assert exp.artifact_location == self.exp_data[exp_id]["artifact_location"]
 
     def test_get_experiment(self):
         fs = FileStore(self.test_root)
@@ -481,15 +481,15 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         for exp_id in self.experiments:
             name = self.exp_data[exp_id]["name"]
             exp = fs.get_experiment_by_name(name)
-            self.assertEqual(exp.experiment_id, exp_id)
-            self.assertEqual(exp.name, self.exp_data[exp_id]["name"])
-            self.assertEqual(exp.artifact_location, self.exp_data[exp_id]["artifact_location"])
+            assert exp.experiment_id == exp_id
+            assert exp.name == self.exp_data[exp_id]["name"]
+            assert exp.artifact_location == self.exp_data[exp_id]["artifact_location"]
 
         # test that fake experiments dont exist.
         # look up experiments with names of length 15 since created ones are of length 10
         for exp_names in set(random_str(15) for x in range(20)):
             exp = fs.get_experiment_by_name(exp_names)
-            self.assertIsNone(exp)
+            assert exp is None
 
     def test_create_additional_experiment_generates_random_fixed_length_id(self):
         fs = FileStore(self.test_root)
@@ -499,7 +499,7 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         fs.create_experiment(random_str())
         fs._create_experiment_with_id.assert_called_once()
         experiment_id = fs._create_experiment_with_id.call_args[0][1]
-        self.assertEqual(len(experiment_id), _EXPERIMENT_ID_FIXED_WIDTH)
+        assert len(experiment_id) == _EXPERIMENT_ID_FIXED_WIDTH
 
     def test_create_experiment(self):
         fs = FileStore(self.test_root)
@@ -513,21 +513,20 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         time_before_create = get_current_time_millis()
         created_id = fs.create_experiment(name)
         # test that newly created experiment id is random but of a fixed length
-        self.assertEqual(len(created_id), _EXPERIMENT_ID_FIXED_WIDTH)
+        assert len(created_id) == _EXPERIMENT_ID_FIXED_WIDTH
 
         # get the new experiment (by id) and verify (by name)
         exp1 = fs.get_experiment(created_id)
-        self.assertEqual(exp1.name, name)
-        self.assertEqual(
-            exp1.artifact_location,
-            path_to_local_file_uri(posixpath.join(self.test_root, created_id)),
+        assert exp1.name == name
+        assert exp1.artifact_location == path_to_local_file_uri(
+            posixpath.join(self.test_root, created_id)
         )
         assert exp1.creation_time >= time_before_create
         assert exp1.last_update_time == exp1.creation_time
 
         # get the new experiment (by name) and verify (by id)
         exp2 = fs.get_experiment_by_name(name)
-        self.assertEqual(exp2.experiment_id, created_id)
+        assert exp2.experiment_id == created_id
         assert exp2.creation_time == exp1.creation_time
         assert exp2.last_update_time == exp1.last_update_time
 
@@ -568,9 +567,7 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
                 fs = FileStore(tmp.path(), artifact_root_uri)
                 exp_id = fs.create_experiment("exp")
                 exp = fs.get_experiment(exp_id)
-                self.assertEqual(
-                    exp.artifact_location, expected_artifact_uri_format.format(e=exp_id)
-                )
+                assert exp.artifact_location == expected_artifact_uri_format.format(e=exp_id)
 
     def test_create_experiment_with_tags_works_correctly(self):
         fs = FileStore(self.test_root)
@@ -610,30 +607,30 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         )
         assert exp_id in self._extract_ids(fs.search_experiments(view_type=ViewType.DELETED_ONLY))
         assert exp_id in self._extract_ids(fs.search_experiments(view_type=ViewType.ALL))
-        self.assertEqual(fs.get_experiment(exp_id).lifecycle_stage, LifecycleStage.DELETED)
+        assert fs.get_experiment(exp_id).lifecycle_stage == LifecycleStage.DELETED
 
         deleted_exp1 = fs.get_experiment(exp_id)
         assert deleted_exp1.last_update_time > exp1.last_update_time
-        self.assertEqual(deleted_exp1.lifecycle_stage, LifecycleStage.DELETED)
+        assert deleted_exp1.lifecycle_stage == LifecycleStage.DELETED
 
         # restore it
         exp1 = fs.get_experiment(exp_id)
         time.sleep(0.01)
         fs.restore_experiment(exp_id)
         restored_1 = fs.get_experiment(exp_id)
-        self.assertEqual(restored_1.experiment_id, exp_id)
-        self.assertEqual(restored_1.name, exp_name)
+        assert restored_1.experiment_id == exp_id
+        assert restored_1.name == exp_name
         assert restored_1.last_update_time > exp1.last_update_time
 
         restored_2 = fs.get_experiment_by_name(exp_name)
-        self.assertEqual(restored_2.experiment_id, exp_id)
-        self.assertEqual(restored_2.name, exp_name)
+        assert restored_2.experiment_id == exp_id
+        assert restored_2.name == exp_name
         assert exp_id in self._extract_ids(fs.search_experiments(view_type=ViewType.ACTIVE_ONLY))
         assert exp_id not in self._extract_ids(
             fs.search_experiments(view_type=ViewType.DELETED_ONLY)
         )
         assert exp_id in self._extract_ids(fs.search_experiments(view_type=ViewType.ALL))
-        self.assertEqual(fs.get_experiment(exp_id).lifecycle_stage, LifecycleStage.ACTIVE)
+        assert fs.get_experiment(exp_id).lifecycle_stage == LifecycleStage.ACTIVE
 
     def test_rename_experiment(self):
         fs = FileStore(self.test_root)
@@ -654,10 +651,10 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
 
         exp_name = fs.get_experiment(exp_id).name
         new_name = exp_name + "!!!"
-        self.assertNotEqual(exp_name, new_name)
-        self.assertEqual(fs.get_experiment(exp_id).name, exp_name)
+        assert exp_name != new_name
+        assert fs.get_experiment(exp_id).name == exp_name
         fs.rename_experiment(exp_id, new_name)
-        self.assertEqual(fs.get_experiment(exp_id).name, new_name)
+        assert fs.get_experiment(exp_id).name == new_name
 
         # Ensure that we cannot rename deleted experiments.
         fs.delete_experiment(exp_id)
@@ -666,21 +663,21 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         ) as e:
             fs.rename_experiment(exp_id, exp_name)
         assert "non-active lifecycle" in str(e.value)
-        self.assertEqual(fs.get_experiment(exp_id).name, new_name)
+        assert fs.get_experiment(exp_id).name == new_name
 
         # Restore the experiment, and confirm that we can now rename it.
         exp1 = fs.get_experiment(exp_id)
         time.sleep(0.01)
         fs.restore_experiment(exp_id)
         restored_exp1 = fs.get_experiment(exp_id)
-        self.assertEqual(restored_exp1.name, new_name)
+        assert restored_exp1.name == new_name
         assert restored_exp1.last_update_time > exp1.last_update_time
 
         exp1 = fs.get_experiment(exp_id)
         time.sleep(0.01)
         fs.rename_experiment(exp_id, exp_name)
         renamed_exp1 = fs.get_experiment(exp_id)
-        self.assertEqual(renamed_exp1.name, exp_name)
+        assert renamed_exp1.name == exp_name
         assert renamed_exp1.last_update_time > exp1.last_update_time
 
     def test_delete_restore_run(self):
@@ -770,9 +767,8 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
                 run = fs.create_run(
                     experiment_id=exp_id, user_id="user", start_time=0, tags=[], run_name="name"
                 )
-                self.assertEqual(
-                    run.info.artifact_uri,
-                    expected_artifact_uri_format.format(e=exp_id, r=run.info.run_id),
+                assert run.info.artifact_uri == expected_artifact_uri_format.format(
+                    e=exp_id, r=run.info.run_id
                 )
 
     def test_create_run_in_deleted_experiment(self):
@@ -878,7 +874,7 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         # key without actually deleting it from self.run_data
         _run_info = run_info.copy()
         _run_info.pop("deleted_time", None)
-        self.assertEqual(_run_info, dict(run.info))
+        assert _run_info == dict(run.info)
 
     def test_get_run(self):
         fs = FileStore(self.test_root)
@@ -1005,8 +1001,8 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
                 metrics_dict = run_info.pop("metrics")
                 for metric in metrics:
                     expected_timestamp, expected_value = max(metrics_dict[metric.key])
-                    self.assertEqual(metric.timestamp, expected_timestamp)
-                    self.assertEqual(metric.value, expected_value)
+                    assert metric.timestamp == expected_timestamp
+                    assert metric.value == expected_value
 
     def test_get_metric_history(self):
         fs = FileStore(self.test_root)
@@ -1020,9 +1016,9 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
                     sorted_values = sorted(values, reverse=True)
                     for metric in metric_history:
                         timestamp, metric_value = sorted_values.pop()
-                        self.assertEqual(metric.timestamp, timestamp)
-                        self.assertEqual(metric.key, metric_name)
-                        self.assertEqual(metric.value, metric_value)
+                        assert metric.timestamp == timestamp
+                        assert metric.key == metric_name
+                        assert metric.value == metric_value
 
     def _search(
         self,
@@ -1061,45 +1057,27 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         fs.set_tag(r2, RunTag("p_b", "ABC"))
 
         # test search returns both runs
-        self.assertCountEqual(
-            [r1, r2], self._search(fs, experiment_id, filter_str="tags.generic_tag = 'p_val'")
-        )
-        # test search returns appropriate run (same key different values per run)
-        self.assertCountEqual(
-            [r1], self._search(fs, experiment_id, filter_str="tags.generic_2 = 'some value'")
-        )
-        self.assertCountEqual(
-            [r2], self._search(fs, experiment_id, filter_str="tags.generic_2='another value'")
-        )
-        self.assertCountEqual(
-            [], self._search(fs, experiment_id, filter_str="tags.generic_tag = 'wrong_val'")
-        )
-        self.assertCountEqual(
-            [], self._search(fs, experiment_id, filter_str="tags.generic_tag != 'p_val'")
-        )
-        self.assertCountEqual(
+        assert sorted(
             [r1, r2],
+        ) == sorted(self._search(fs, experiment_id, filter_str="tags.generic_tag = 'p_val'"))
+        # test search returns appropriate run (same key different values per run)
+        assert [r1] == self._search(fs, experiment_id, filter_str="tags.generic_2 = 'some value'")
+        assert [r2] == self._search(fs, experiment_id, filter_str="tags.generic_2='another value'")
+        assert [] == self._search(fs, experiment_id, filter_str="tags.generic_tag = 'wrong_val'")
+        assert [] == self._search(fs, experiment_id, filter_str="tags.generic_tag != 'p_val'")
+        assert sorted([r1, r2],) == sorted(
             self._search(fs, experiment_id, filter_str="tags.generic_tag != 'wrong_val'"),
         )
-        self.assertCountEqual(
-            [r1, r2],
+        assert sorted([r1, r2],) == sorted(
             self._search(fs, experiment_id, filter_str="tags.generic_2 != 'wrong_val'"),
         )
-        self.assertCountEqual([r1], self._search(fs, experiment_id, filter_str="tags.p_a = 'abc'"))
-        self.assertCountEqual([r2], self._search(fs, experiment_id, filter_str="tags.p_b = 'ABC'"))
+        assert [r1] == self._search(fs, experiment_id, filter_str="tags.p_a = 'abc'")
+        assert [r2] == self._search(fs, experiment_id, filter_str="tags.p_b = 'ABC'")
 
-        self.assertCountEqual(
-            [r2], self._search(fs, experiment_id, filter_str="tags.generic_2 LIKE '%other%'")
-        )
-        self.assertCountEqual(
-            [], self._search(fs, experiment_id, filter_str="tags.generic_2 LIKE 'other%'")
-        )
-        self.assertCountEqual(
-            [], self._search(fs, experiment_id, filter_str="tags.generic_2 LIKE '%other'")
-        )
-        self.assertCountEqual(
-            [r2], self._search(fs, experiment_id, filter_str="tags.generic_2 ILIKE '%OTHER%'")
-        )
+        assert [r2] == self._search(fs, experiment_id, filter_str="tags.generic_2 LIKE '%other%'")
+        assert [] == self._search(fs, experiment_id, filter_str="tags.generic_2 LIKE 'other%'")
+        assert [] == self._search(fs, experiment_id, filter_str="tags.generic_2 LIKE '%other'")
+        assert [r2] == self._search(fs, experiment_id, filter_str="tags.generic_2 ILIKE '%OTHER%'")
 
     def test_search_with_max_results(self):
         fs = FileStore(self.test_root)
@@ -1684,35 +1662,35 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         run = self._create_run(fs)
         run_id = run.info.run_id
 
-        self.assertEqual(run.info.run_name, "name")
-        self.assertEqual(run.data.tags.get(MLFLOW_RUN_NAME), "name")
+        assert run.info.run_name == "name"
+        assert run.data.tags.get(MLFLOW_RUN_NAME) == "name"
 
         fs.update_run_info(run_id, RunStatus.FINISHED, 100, "new name")
         run = fs.get_run(run_id)
-        self.assertEqual(run.info.run_name, "new name")
-        self.assertEqual(run.data.tags.get(MLFLOW_RUN_NAME), "new name")
+        assert run.info.run_name == "new name"
+        assert run.data.tags.get(MLFLOW_RUN_NAME) == "new name"
 
         fs.update_run_info(run_id, RunStatus.FINISHED, 100, None)
         run = fs.get_run(run_id)
-        self.assertEqual(run.info.run_name, "new name")
-        self.assertEqual(run.data.tags.get(MLFLOW_RUN_NAME), "new name")
+        assert run.info.run_name == "new name"
+        assert run.data.tags.get(MLFLOW_RUN_NAME) == "new name"
 
         fs.delete_tag(run_id, MLFLOW_RUN_NAME)
         run = fs.get_run(run_id)
-        self.assertEqual(run.info.run_name, "new name")
-        self.assertEqual(run.data.tags.get(MLFLOW_RUN_NAME), None)
+        assert run.info.run_name == "new name"
+        assert run.data.tags.get(MLFLOW_RUN_NAME) == None
 
         fs.update_run_info(run_id, RunStatus.FINISHED, 100, "another name")
         run = fs.get_run(run_id)
-        self.assertEqual(run.data.tags.get(MLFLOW_RUN_NAME), "another name")
-        self.assertEqual(run.info.run_name, "another name")
+        assert run.data.tags.get(MLFLOW_RUN_NAME) == "another name"
+        assert run.info.run_name == "another name"
 
         fs.set_tag(run_id, RunTag(MLFLOW_RUN_NAME, "yet another name"))
         run = fs.get_run(run_id)
-        self.assertEqual(run.info.run_name, "yet another name")
-        self.assertEqual(run.data.tags.get(MLFLOW_RUN_NAME), "yet another name")
+        assert run.info.run_name == "yet another name"
+        assert run.data.tags.get(MLFLOW_RUN_NAME) == "yet another name"
 
         fs.log_batch(run_id, metrics=[], params=[], tags=[RunTag(MLFLOW_RUN_NAME, "batch name")])
         run = fs.get_run(run_id)
-        self.assertEqual(run.info.run_name, "batch name")
-        self.assertEqual(run.data.tags.get(MLFLOW_RUN_NAME), "batch name")
+        assert run.info.run_name == "batch name"
+        assert run.data.tags.get(MLFLOW_RUN_NAME) == "batch name"

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -97,12 +97,12 @@ class TestParseDbUri(unittest.TestCase):
             # try the driver-less version, which will revert SQLAlchemy to the default driver
             uri = "%s://..." % target_db_type
             parsed_db_type = extract_db_type_from_uri(uri)
-            self.assertEqual(target_db_type, parsed_db_type)
+            assert target_db_type == parsed_db_type
             # try each of the popular drivers (per SQLAlchemy's dialect pages)
             for driver in drivers:
                 uri = "%s+%s://..." % (target_db_type, driver)
                 parsed_db_type = extract_db_type_from_uri(uri)
-                self.assertEqual(target_db_type, parsed_db_type)
+                assert target_db_type == parsed_db_type
 
     def _db_uri_error(self, db_uris, expected_message_regex):
         for db_uri in db_uris:
@@ -192,30 +192,30 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
 
     def test_default_experiment(self):
         experiments = self.store.search_experiments()
-        self.assertEqual(len(experiments), 1)
+        assert len(experiments) == 1
 
         first = experiments[0]
-        self.assertEqual(first.experiment_id, "0")
-        self.assertEqual(first.name, "Default")
+        assert first.experiment_id == "0"
+        assert first.name == "Default"
 
     def test_default_experiment_lifecycle(self):
         default_experiment = self.store.get_experiment(experiment_id=0)
-        self.assertEqual(default_experiment.name, Experiment.DEFAULT_EXPERIMENT_NAME)
-        self.assertEqual(default_experiment.lifecycle_stage, entities.LifecycleStage.ACTIVE)
+        assert default_experiment.name == Experiment.DEFAULT_EXPERIMENT_NAME
+        assert default_experiment.lifecycle_stage == entities.LifecycleStage.ACTIVE
 
         self._experiment_factory("aNothEr")
         all_experiments = [e.name for e in self.store.search_experiments()]
-        self.assertCountEqual({"aNothEr", "Default"}, set(all_experiments))
+        assert {"aNothEr", "Default"} == set(all_experiments)
 
         self.store.delete_experiment(0)
 
-        self.assertCountEqual(["aNothEr"], [e.name for e in self.store.search_experiments()])
+        assert ["aNothEr"] == [e.name for e in self.store.search_experiments()]
         another = self.store.get_experiment(1)
-        self.assertEqual("aNothEr", another.name)
+        assert "aNothEr" == another.name
 
         default_experiment = self.store.get_experiment(experiment_id=0)
-        self.assertEqual(default_experiment.name, Experiment.DEFAULT_EXPERIMENT_NAME)
-        self.assertEqual(default_experiment.lifecycle_stage, entities.LifecycleStage.DELETED)
+        assert default_experiment.name == Experiment.DEFAULT_EXPERIMENT_NAME
+        assert default_experiment.lifecycle_stage == entities.LifecycleStage.DELETED
 
         # destroy SqlStore and make a new one
         del self.store
@@ -223,16 +223,16 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
 
         # test that default experiment is not reactivated
         default_experiment = self.store.get_experiment(experiment_id=0)
-        self.assertEqual(default_experiment.name, Experiment.DEFAULT_EXPERIMENT_NAME)
-        self.assertEqual(default_experiment.lifecycle_stage, entities.LifecycleStage.DELETED)
+        assert default_experiment.name == Experiment.DEFAULT_EXPERIMENT_NAME
+        assert default_experiment.lifecycle_stage == entities.LifecycleStage.DELETED
 
-        self.assertCountEqual(["aNothEr"], [e.name for e in self.store.search_experiments()])
+        assert ["aNothEr"] == [e.name for e in self.store.search_experiments()]
         all_experiments = [e.name for e in self.store.search_experiments(ViewType.ALL)]
-        self.assertCountEqual({"aNothEr", "Default"}, set(all_experiments))
+        assert {"aNothEr", "Default"} == set(all_experiments)
 
         # ensure that experiment ID dor active experiment is unchanged
         another = self.store.get_experiment(1)
-        self.assertEqual("aNothEr", another.name)
+        assert "aNothEr" == another.name
 
     def test_raise_duplicate_experiments(self):
         with pytest.raises(Exception, match=r"Experiment\(name=.+\) already exists"):
@@ -246,7 +246,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         experiments = self._experiment_factory(["morty", "rick", "rick and morty"])
 
         all_experiments = self.store.search_experiments()
-        self.assertEqual(len(all_experiments), len(experiments) + 1)  # default
+        assert len(all_experiments) == len(experiments) + 1  # default
 
         exp_id = experiments[0]
         exp = self.store.get_experiment(exp_id)
@@ -254,9 +254,9 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         self.store.delete_experiment(exp_id)
 
         updated_exp = self.store.get_experiment(exp_id)
-        self.assertEqual(updated_exp.lifecycle_stage, entities.LifecycleStage.DELETED)
+        assert updated_exp.lifecycle_stage == entities.LifecycleStage.DELETED
 
-        self.assertEqual(len(self.store.search_experiments()), len(all_experiments) - 1)
+        assert len(self.store.search_experiments()) == len(all_experiments) - 1
         assert updated_exp.last_update_time > exp.last_update_time
 
     def test_delete_restore_experiment_with_runs(self):
@@ -270,7 +270,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         self.store.delete_experiment(experiment_id)
 
         updated_exp = self.store.get_experiment(experiment_id)
-        self.assertEqual(updated_exp.lifecycle_stage, entities.LifecycleStage.DELETED)
+        assert updated_exp.lifecycle_stage == entities.LifecycleStage.DELETED
 
         deleted_run_list = self.store.search_runs(
             experiment_ids=[experiment_id],
@@ -278,9 +278,9 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
             run_view_type=ViewType.DELETED_ONLY,
         )
 
-        self.assertEqual(len(deleted_run_list), 2)
+        assert len(deleted_run_list) == 2
         for deleted_run in deleted_run_list:
-            self.assertEqual(deleted_run.info.lifecycle_stage, entities.LifecycleStage.DELETED)
+            assert deleted_run.info.lifecycle_stage == entities.LifecycleStage.DELETED
             assert deleted_run.info.experiment_id in experiment_id
             assert deleted_run.info.run_id in run_ids
             with self.store.ManagedSessionMaker() as session:
@@ -291,7 +291,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         self.store.restore_experiment(experiment_id)
 
         updated_exp = self.store.get_experiment(experiment_id)
-        self.assertEqual(updated_exp.lifecycle_stage, entities.LifecycleStage.ACTIVE)
+        assert updated_exp.lifecycle_stage == entities.LifecycleStage.ACTIVE
 
         restored_run_list = self.store.search_runs(
             experiment_ids=[experiment_id],
@@ -299,9 +299,9 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
             run_view_type=ViewType.ACTIVE_ONLY,
         )
 
-        self.assertEqual(len(restored_run_list), 2)
+        assert len(restored_run_list) == 2
         for restored_run in restored_run_list:
-            self.assertEqual(restored_run.info.lifecycle_stage, entities.LifecycleStage.ACTIVE)
+            assert restored_run.info.lifecycle_stage == entities.LifecycleStage.ACTIVE
             with self.store.ManagedSessionMaker() as session:
                 assert self.store._get_run(session, restored_run.info.run_id).deleted_time is None
             assert restored_run.info.experiment_id in experiment_id
@@ -311,13 +311,13 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         name = "goku"
         experiment_id = self._experiment_factory(name)
         actual = self.store.get_experiment(experiment_id)
-        self.assertEqual(actual.name, name)
-        self.assertEqual(actual.experiment_id, experiment_id)
+        assert actual.name == name
+        assert actual.experiment_id == experiment_id
 
         actual_by_name = self.store.get_experiment_by_name(name)
-        self.assertEqual(actual_by_name.name, name)
-        self.assertEqual(actual_by_name.experiment_id, experiment_id)
-        self.assertEqual(self.store.get_experiment_by_name("idontexist"), None)
+        assert actual_by_name.name == name
+        assert actual_by_name.experiment_id == experiment_id
+        assert self.store.get_experiment_by_name("idontexist") == None
 
     def test_search_experiments_view_type(self):
         experiment_names = ["a", "b"]
@@ -547,21 +547,21 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
     def test_create_experiments(self):
         with self.store.ManagedSessionMaker() as session:
             result = session.query(models.SqlExperiment).all()
-            self.assertEqual(len(result), 1)
+            assert len(result) == 1
         time_before_create = get_current_time_millis()
         experiment_id = self.store.create_experiment(name="test exp")
-        self.assertEqual(experiment_id, "1")
+        assert experiment_id == "1"
         with self.store.ManagedSessionMaker() as session:
             result = session.query(models.SqlExperiment).all()
-            self.assertEqual(len(result), 2)
+            assert len(result) == 2
 
             test_exp = session.query(models.SqlExperiment).filter_by(name="test exp").first()
-            self.assertEqual(str(test_exp.experiment_id), experiment_id)
-            self.assertEqual(test_exp.name, "test exp")
+            assert str(test_exp.experiment_id) == experiment_id
+            assert test_exp.name == "test exp"
 
         actual = self.store.get_experiment(experiment_id)
-        self.assertEqual(actual.experiment_id, experiment_id)
-        self.assertEqual(actual.name, "test exp")
+        assert actual.experiment_id == experiment_id
+        assert actual.name == "test exp"
         assert actual.creation_time >= time_before_create
         assert actual.last_update_time == actual.creation_time
 
@@ -609,9 +609,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
                     )
                     exp_id = store.create_experiment(name="exp")
                     exp = store.get_experiment(exp_id)
-                    self.assertEqual(
-                        exp.artifact_location, expected_artifact_uri_format.format(e=exp_id)
-                    )
+                    assert exp.artifact_location == expected_artifact_uri_format.format(e=exp_id)
 
     def test_create_experiment_with_tags_works_correctly(self):
         experiment_id = self.store.create_experiment(
@@ -675,9 +673,8 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
                     run = store.create_run(
                         experiment_id=exp_id, user_id="user", start_time=0, tags=[], run_name="name"
                     )
-                    self.assertEqual(
-                        run.info.artifact_uri,
-                        expected_artifact_uri_format.format(e=exp_id, r=run.info.run_id),
+                    assert run.info.artifact_uri == expected_artifact_uri_format.format(
+                        e=exp_id, r=run.info.run_id
                     )
 
     def test_run_tag_model(self):
@@ -693,9 +690,9 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
             added_tags = [
                 tag for tag in session.query(models.SqlTag).all() if tag.key == new_tag.key
             ]
-            self.assertEqual(len(added_tags), 1)
+            assert len(added_tags) == 1
             added_tag = added_tags[0].to_mlflow_entity()
-            self.assertEqual(added_tag.value, new_tag.value)
+            assert added_tag.value == new_tag.value
 
     def test_metric_model(self):
         # Create a run whose UUID we can reference when creating metric models.
@@ -708,11 +705,11 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
             session.add(new_metric)
             session.commit()
             metrics = session.query(models.SqlMetric).all()
-            self.assertEqual(len(metrics), 1)
+            assert len(metrics) == 1
 
             added_metric = metrics[0].to_mlflow_entity()
-            self.assertEqual(added_metric.value, new_metric.value)
-            self.assertEqual(added_metric.key, new_metric.key)
+            assert added_metric.value == new_metric.value
+            assert added_metric.key == new_metric.key
 
     def test_param_model(self):
         # Create a run whose UUID we can reference when creating parameter models.
@@ -727,11 +724,11 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
             session.add(new_param)
             session.commit()
             params = session.query(models.SqlParam).all()
-            self.assertEqual(len(params), 1)
+            assert len(params) == 1
 
             added_param = params[0].to_mlflow_entity()
-            self.assertEqual(added_param.value, new_param.value)
-            self.assertEqual(added_param.key, new_param.key)
+            assert added_param.value == new_param.value
+            assert added_param.key == new_param.key
 
     def test_run_needs_uuid(self):
         regex = {
@@ -764,9 +761,9 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
 
             run_datums = session.query(models.SqlRun).all()
             actual = run_datums[0]
-            self.assertEqual(len(run_datums), 1)
-            self.assertEqual(len(actual.params), 2)
-            self.assertEqual(len(actual.metrics), 2)
+            assert len(run_datums) == 1
+            assert len(actual.params) == 2
+            assert len(actual.metrics) == 2
 
     def test_run_info(self):
         experiment_id = self._experiment_factory("test exp")
@@ -794,9 +791,9 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
 
             v2 = getattr(run.info, k)
             if k == "source_type":
-                self.assertEqual(v, SourceType.to_string(v2))
+                assert v == SourceType.to_string(v2)
             else:
-                self.assertEqual(v, v2)
+                assert v == v2
 
     def _get_run_configs(self, experiment_id=None, tags=None, start_time=None):
         return {
@@ -825,22 +822,22 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
 
         actual = self.store.create_run(**expected)
 
-        self.assertEqual(actual.info.experiment_id, experiment_id)
-        self.assertEqual(actual.info.user_id, expected["user_id"])
-        self.assertEqual(actual.info.run_name, expected["run_name"])
-        self.assertEqual(actual.info.start_time, expected["start_time"])
+        assert actual.info.experiment_id == experiment_id
+        assert actual.info.user_id == expected["user_id"]
+        assert actual.info.run_name == expected["run_name"]
+        assert actual.info.start_time == expected["start_time"]
 
-        self.assertEqual(len(actual.data.tags), len(tags))
+        assert len(actual.data.tags) == len(tags)
         expected_tags = {tag.key: tag.value for tag in tags}
-        self.assertEqual(actual.data.tags, expected_tags)
+        assert actual.data.tags == expected_tags
 
     def test_create_run_sets_name(self):
         experiment_id = self._experiment_factory("test_create_run_run_name")
         configs = self._get_run_configs(experiment_id=experiment_id)
         run_id = self.store.create_run(**configs).info.run_id
         run = self.store.get_run(run_id)
-        self.assertEqual(run.info.run_name, configs["run_name"])
-        self.assertEqual(run.data.tags.get(mlflow_tags.MLFLOW_RUN_NAME), configs["run_name"])
+        assert run.info.run_name == configs["run_name"]
+        assert run.data.tags.get(mlflow_tags.MLFLOW_RUN_NAME) == configs["run_name"]
         run_id = self.store.create_run(
             experiment_id=experiment_id,
             user_id="user",
@@ -871,8 +868,8 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
 
         run = self.store.get_run(run_id)
 
-        self.assertEqual(run.info.experiment_id, experiment_id)
-        self.assertEqual(run.info.run_name, configs["run_name"])
+        assert run.info.experiment_id == experiment_id
+        assert run.info.run_name == configs["run_name"]
 
         no_run_configs = {
             "experiment_id": experiment_id,
@@ -905,12 +902,12 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         run.to_proto()
 
         # Verify attributes of the Python run entity
-        self.assertIsInstance(run.info, entities.RunInfo)
-        self.assertIsInstance(run.data, entities.RunData)
+        assert isinstance(run.info, entities.RunInfo)
+        assert isinstance(run.data, entities.RunData)
 
-        self.assertEqual(run.data.metrics, {"my-metric": 3.4})
-        self.assertEqual(run.data.params, {"my-param": "param-val"})
-        self.assertEqual(run.data.tags["my-tag"], "tag-val")
+        assert run.data.metrics == {"my-metric": 3.4}
+        assert run.data.params == {"my-param": "param-val"}
+        assert run.data.tags["my-tag"] == "tag-val"
 
         # Get the parent experiment of the run, verify it can be converted to protobuf
         exp = self.store.get_experiment(run.info.experiment_id)
@@ -923,13 +920,13 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
 
         with self.store.ManagedSessionMaker() as session:
             actual = session.query(models.SqlRun).filter_by(run_uuid=run.info.run_id).first()
-            self.assertEqual(actual.lifecycle_stage, entities.LifecycleStage.DELETED)
+            assert actual.lifecycle_stage == entities.LifecycleStage.DELETED
             assert (
                 actual.deleted_time is not None
             )  # deleted time should be updated and thus not None anymore
 
             deleted_run = self.store.get_run(run.info.run_id)
-            self.assertEqual(actual.run_uuid, deleted_run.info.run_id)
+            assert actual.run_uuid == deleted_run.info.run_id
 
     def test_hard_delete_run(self):
         run = self._run_factory()
@@ -944,26 +941,26 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
 
         with self.store.ManagedSessionMaker() as session:
             actual_run = session.query(models.SqlRun).filter_by(run_uuid=run.info.run_id).first()
-            self.assertEqual(None, actual_run)
+            assert None == actual_run
             actual_metric = (
                 session.query(models.SqlMetric).filter_by(run_uuid=run.info.run_id).first()
             )
-            self.assertEqual(None, actual_metric)
+            assert None == actual_metric
             actual_param = (
                 session.query(models.SqlParam).filter_by(run_uuid=run.info.run_id).first()
             )
-            self.assertEqual(None, actual_param)
+            assert None == actual_param
             actual_tag = session.query(models.SqlTag).filter_by(run_uuid=run.info.run_id).first()
-            self.assertEqual(None, actual_tag)
+            assert None == actual_tag
 
     def test_get_deleted_runs(self):
         run = self._run_factory()
         deleted_run_ids = self.store._get_deleted_runs()
-        self.assertEqual([], deleted_run_ids)
+        assert [] == deleted_run_ids
 
         self.store.delete_run(run.info.run_uuid)
         deleted_run_ids = self.store._get_deleted_runs()
-        self.assertEqual([run.info.run_uuid], deleted_run_ids)
+        assert [run.info.run_uuid] == deleted_run_ids
 
     def test_log_metric(self):
         run = self._run_factory()
@@ -989,8 +986,8 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         # MLflow RunData contains only the last reported values for metrics.
         with self.store.ManagedSessionMaker() as session:
             sql_run_metrics = self.store._get_run(session, run.info.run_id).metrics
-            self.assertEqual(5, len(sql_run_metrics))
-            self.assertEqual(4, len(run.data.metrics))
+            assert 5 == len(sql_run_metrics)
+            assert 4 == len(run.data.metrics)
             assert math.isnan(run.data.metrics["NaN"])
             assert run.data.metrics["PosInf"] == 1.7976931348623157e308
             assert run.data.metrics["NegInf"] == -1.7976931348623157e308
@@ -1109,7 +1106,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         self.store.log_param(run.info.run_id, param2)
 
         run = self.store.get_run(run.info.run_id)
-        self.assertEqual(2, len(run.data.params))
+        assert 2 == len(run.data.params)
         assert tkey in run.data.params and run.data.params[tkey] == tval
 
     def test_log_param_uniqueness(self):
@@ -1135,7 +1132,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         self.store.log_param(run.info.run_id, param2)
 
         run = self.store.get_run(run.info.run_id)
-        self.assertEqual(2, len(run.data.params))
+        assert 2 == len(run.data.params)
         assert tkey in run.data.params and run.data.params[tkey] == tval
 
     def test_log_null_param(self):
@@ -1272,8 +1269,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
 
         actual = self.store.get_metric_history(run.info.run_id, key)
 
-        self.assertCountEqual(
-            [(m.key, m.value, m.timestamp) for m in expected],
+        assert sorted([(m.key, m.value, m.timestamp) for m in expected],) == sorted(
             [(m.key, m.value, m.timestamp) for m in actual],
         )
 
@@ -1286,7 +1282,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
 
         renamed_experiment = self.store.get_experiment(experiment_id)
 
-        self.assertEqual(renamed_experiment.name, new_name)
+        assert renamed_experiment.name == new_name
         assert renamed_experiment.last_update_time > experiment.last_update_time
 
     def test_update_run_info(self):
@@ -1297,8 +1293,8 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
             actual = self.store.update_run_info(
                 run.info.run_id, RunStatus.from_string(new_status_string), endtime, None
             )
-            self.assertEqual(actual.status, new_status_string)
-            self.assertEqual(actual.end_time, endtime)
+            assert actual.status == new_status_string
+            assert actual.end_time == endtime
 
     def test_update_run_name(self):
         experiment_id = self._experiment_factory("test_update_run_name")
@@ -1306,37 +1302,37 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
 
         run_id = self.store.create_run(**configs).info.run_id
         run = self.store.get_run(run_id)
-        self.assertEqual(run.info.run_name, configs["run_name"])
+        assert run.info.run_name == configs["run_name"]
 
         self.store.update_run_info(run_id, RunStatus.FINISHED, 1000, "new name")
         run = self.store.get_run(run_id)
-        self.assertEqual(run.info.run_name, "new name")
-        self.assertEqual(run.data.tags.get(mlflow_tags.MLFLOW_RUN_NAME), "new name")
+        assert run.info.run_name == "new name"
+        assert run.data.tags.get(mlflow_tags.MLFLOW_RUN_NAME) == "new name"
 
         self.store.update_run_info(run_id, RunStatus.FINISHED, 1000, None)
         run = self.store.get_run(run_id)
-        self.assertEqual(run.info.run_name, "new name")
-        self.assertEqual(run.data.tags.get(mlflow_tags.MLFLOW_RUN_NAME), "new name")
+        assert run.info.run_name == "new name"
+        assert run.data.tags.get(mlflow_tags.MLFLOW_RUN_NAME) == "new name"
 
         self.store.update_run_info(run_id, RunStatus.FINISHED, 1000, "")
         run = self.store.get_run(run_id)
-        self.assertEqual(run.info.run_name, "new name")
-        self.assertEqual(run.data.tags.get(mlflow_tags.MLFLOW_RUN_NAME), "new name")
+        assert run.info.run_name == "new name"
+        assert run.data.tags.get(mlflow_tags.MLFLOW_RUN_NAME) == "new name"
 
         self.store.delete_tag(run_id, mlflow_tags.MLFLOW_RUN_NAME)
         run = self.store.get_run(run_id)
-        self.assertEqual(run.info.run_name, "new name")
-        self.assertEqual(run.data.tags.get(mlflow_tags.MLFLOW_RUN_NAME), None)
+        assert run.info.run_name == "new name"
+        assert run.data.tags.get(mlflow_tags.MLFLOW_RUN_NAME) == None
 
         self.store.update_run_info(run_id, RunStatus.FINISHED, 1000, "newer name")
         run = self.store.get_run(run_id)
-        self.assertEqual(run.info.run_name, "newer name")
-        self.assertEqual(run.data.tags.get(mlflow_tags.MLFLOW_RUN_NAME), "newer name")
+        assert run.info.run_name == "newer name"
+        assert run.data.tags.get(mlflow_tags.MLFLOW_RUN_NAME) == "newer name"
 
         self.store.set_tag(run_id, entities.RunTag(mlflow_tags.MLFLOW_RUN_NAME, "newest name"))
         run = self.store.get_run(run_id)
-        self.assertEqual(run.data.tags.get(mlflow_tags.MLFLOW_RUN_NAME), "newest name")
-        self.assertEqual(run.info.run_name, "newest name")
+        assert run.data.tags.get(mlflow_tags.MLFLOW_RUN_NAME) == "newest name"
+        assert run.info.run_name == "newest name"
 
         self.store.log_batch(
             run_id,
@@ -1345,30 +1341,30 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
             tags=[entities.RunTag(mlflow_tags.MLFLOW_RUN_NAME, "batch name")],
         )
         run = self.store.get_run(run_id)
-        self.assertEqual(run.data.tags.get(mlflow_tags.MLFLOW_RUN_NAME), "batch name")
-        self.assertEqual(run.info.run_name, "batch name")
+        assert run.data.tags.get(mlflow_tags.MLFLOW_RUN_NAME) == "batch name"
+        assert run.info.run_name == "batch name"
 
     def test_restore_experiment(self):
         experiment_id = self._experiment_factory("helloexp")
         exp = self.store.get_experiment(experiment_id)
-        self.assertEqual(exp.lifecycle_stage, entities.LifecycleStage.ACTIVE)
+        assert exp.lifecycle_stage == entities.LifecycleStage.ACTIVE
 
         experiment_id = exp.experiment_id
         self.store.delete_experiment(experiment_id)
 
         deleted = self.store.get_experiment(experiment_id)
-        self.assertEqual(deleted.experiment_id, experiment_id)
-        self.assertEqual(deleted.lifecycle_stage, entities.LifecycleStage.DELETED)
+        assert deleted.experiment_id == experiment_id
+        assert deleted.lifecycle_stage == entities.LifecycleStage.DELETED
         time.sleep(0.01)
         self.store.restore_experiment(exp.experiment_id)
         restored = self.store.get_experiment(exp.experiment_id)
-        self.assertEqual(restored.experiment_id, experiment_id)
-        self.assertEqual(restored.lifecycle_stage, entities.LifecycleStage.ACTIVE)
+        assert restored.experiment_id == experiment_id
+        assert restored.lifecycle_stage == entities.LifecycleStage.ACTIVE
         assert restored.last_update_time > deleted.last_update_time
 
     def test_delete_restore_run(self):
         run = self._run_factory()
-        self.assertEqual(run.info.lifecycle_stage, entities.LifecycleStage.ACTIVE)
+        assert run.info.lifecycle_stage == entities.LifecycleStage.ACTIVE
 
         # Verify that active runs can be restored (run restoration is idempotent)
         self.store.restore_run(run.info.run_id)
@@ -1378,16 +1374,16 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         self.store.delete_run(run.info.run_id)
 
         deleted = self.store.get_run(run.info.run_id)
-        self.assertEqual(deleted.info.run_id, run.info.run_id)
-        self.assertEqual(deleted.info.lifecycle_stage, entities.LifecycleStage.DELETED)
+        assert deleted.info.run_id == run.info.run_id
+        assert deleted.info.lifecycle_stage == entities.LifecycleStage.DELETED
         with self.store.ManagedSessionMaker() as session:
             assert self.store._get_run(session, deleted.info.run_id).deleted_time is not None
         # Verify that restoration of a deleted run is idempotent
         self.store.restore_run(run.info.run_id)
         self.store.restore_run(run.info.run_id)
         restored = self.store.get_run(run.info.run_id)
-        self.assertEqual(restored.info.run_id, run.info.run_id)
-        self.assertEqual(restored.info.lifecycle_stage, entities.LifecycleStage.ACTIVE)
+        assert restored.info.run_id == run.info.run_id
+        assert restored.info.lifecycle_stage == entities.LifecycleStage.ACTIVE
         with self.store.ManagedSessionMaker() as session:
             assert self.store._get_run(session, restored.info.run_id).deleted_time is None
 
@@ -1396,9 +1392,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         run_id = self._run_factory(self._get_run_configs(experiment_id=exp)).info.run_id
 
         self.store.delete_run(run_id)
-        self.assertEqual(
-            self.store.get_run(run_id).info.lifecycle_stage, entities.LifecycleStage.DELETED
-        )
+        assert self.store.get_run(run_id).info.lifecycle_stage == entities.LifecycleStage.DELETED
         with pytest.raises(MlflowException, match=r"The run .+ must be in the 'active' state"):
             self.store.log_param(run_id, entities.Param("p1345", "v1"))
 
@@ -1410,23 +1404,21 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
 
         # restore this run and try again
         self.store.restore_run(run_id)
-        self.assertEqual(
-            self.store.get_run(run_id).info.lifecycle_stage, entities.LifecycleStage.ACTIVE
-        )
+        assert self.store.get_run(run_id).info.lifecycle_stage == entities.LifecycleStage.ACTIVE
         self.store.log_param(run_id, entities.Param("p1345", "v22"))
         self.store.log_metric(run_id, entities.Metric("m1345", 34.0, 85, 1))  # earlier timestamp
         self.store.set_tag(run_id, entities.RunTag("t1345", "tv44"))
 
         run = self.store.get_run(run_id)
-        self.assertEqual(run.data.params, {"p1345": "v22"})
-        self.assertEqual(run.data.metrics, {"m1345": 34.0})
+        assert run.data.params == {"p1345": "v22"}
+        assert run.data.metrics == {"m1345": 34.0}
         metric_history = self.store.get_metric_history(run_id, "m1345")
-        self.assertEqual(len(metric_history), 1)
+        assert len(metric_history) == 1
         metric_obj = metric_history[0]
-        self.assertEqual(metric_obj.key, "m1345")
-        self.assertEqual(metric_obj.value, 34.0)
-        self.assertEqual(metric_obj.timestamp, 85)
-        self.assertEqual(metric_obj.step, 1)
+        assert metric_obj.key == "m1345"
+        assert metric_obj.value == 34.0
+        assert metric_obj.timestamp == 85
+        assert metric_obj.step == 1
         assert {("t1345", "tv44")} <= set(run.data.tags.items())
 
     # Tests for Search API
@@ -1481,38 +1473,74 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
             create_and_log_run(names)
 
         # asc/asc
-        self.assertListEqual(
-            ["-inf/4", "-1000/5", "0/6", "0/7", "1000/8", "inf/3", "nan/2", "None/1"],
-            self.get_ordered_runs(["metrics.x asc", "metrics.y asc"], experiment_id),
-        )
+        assert [
+            "-inf/4",
+            "-1000/5",
+            "0/6",
+            "0/7",
+            "1000/8",
+            "inf/3",
+            "nan/2",
+            "None/1",
+        ] == self.get_ordered_runs(["metrics.x asc", "metrics.y asc"], experiment_id)
 
-        self.assertListEqual(
-            ["-inf/4", "-1000/5", "0/6", "0/7", "1000/8", "inf/3", "nan/2", "None/1"],
-            self.get_ordered_runs(["metrics.x asc", "tag.metric asc"], experiment_id),
-        )
+        assert [
+            "-inf/4",
+            "-1000/5",
+            "0/6",
+            "0/7",
+            "1000/8",
+            "inf/3",
+            "nan/2",
+            "None/1",
+        ] == self.get_ordered_runs(["metrics.x asc", "tag.metric asc"], experiment_id)
 
         # asc/desc
-        self.assertListEqual(
-            ["-inf/4", "-1000/5", "0/7", "0/6", "1000/8", "inf/3", "nan/2", "None/1"],
-            self.get_ordered_runs(["metrics.x asc", "metrics.y desc"], experiment_id),
-        )
+        assert [
+            "-inf/4",
+            "-1000/5",
+            "0/7",
+            "0/6",
+            "1000/8",
+            "inf/3",
+            "nan/2",
+            "None/1",
+        ] == self.get_ordered_runs(["metrics.x asc", "metrics.y desc"], experiment_id)
 
-        self.assertListEqual(
-            ["-inf/4", "-1000/5", "0/7", "0/6", "1000/8", "inf/3", "nan/2", "None/1"],
-            self.get_ordered_runs(["metrics.x asc", "tag.metric desc"], experiment_id),
-        )
+        assert [
+            "-inf/4",
+            "-1000/5",
+            "0/7",
+            "0/6",
+            "1000/8",
+            "inf/3",
+            "nan/2",
+            "None/1",
+        ] == self.get_ordered_runs(["metrics.x asc", "tag.metric desc"], experiment_id)
 
         # desc / asc
-        self.assertListEqual(
-            ["inf/3", "1000/8", "0/6", "0/7", "-1000/5", "-inf/4", "nan/2", "None/1"],
-            self.get_ordered_runs(["metrics.x desc", "metrics.y asc"], experiment_id),
-        )
+        assert [
+            "inf/3",
+            "1000/8",
+            "0/6",
+            "0/7",
+            "-1000/5",
+            "-inf/4",
+            "nan/2",
+            "None/1",
+        ] == self.get_ordered_runs(["metrics.x desc", "metrics.y asc"], experiment_id)
 
         # desc / desc
-        self.assertListEqual(
-            ["inf/3", "1000/8", "0/7", "0/6", "-1000/5", "-inf/4", "nan/2", "None/1"],
-            self.get_ordered_runs(["metrics.x desc", "param.metric desc"], experiment_id),
-        )
+        assert [
+            "inf/3",
+            "1000/8",
+            "0/7",
+            "0/6",
+            "-1000/5",
+            "-inf/4",
+            "nan/2",
+            "None/1",
+        ] == self.get_ordered_runs(["metrics.x desc", "param.metric desc"], experiment_id)
 
     def test_order_by_attributes(self):
         experiment_id = self.store.create_experiment("order_by_attributes")
@@ -1535,44 +1563,51 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
             start_time += 1
 
         # asc
-        self.assertListEqual(
-            ["-123", "123", "234", "456", "789", "None"],
-            self.get_ordered_runs(["attribute.end_time asc"], experiment_id),
+        assert ["-123", "123", "234", "456", "789", "None"] == self.get_ordered_runs(
+            ["attribute.end_time asc"], experiment_id
         )
 
         # desc
-        self.assertListEqual(
-            ["789", "456", "234", "123", "-123", "None"],
-            self.get_ordered_runs(["attribute.end_time desc"], experiment_id),
+        assert ["789", "456", "234", "123", "-123", "None"] == self.get_ordered_runs(
+            ["attribute.end_time desc"], experiment_id
         )
 
         # Sort priority correctly handled
-        self.assertListEqual(
-            ["234", "None", "456", "-123", "789", "123"],
-            self.get_ordered_runs(
-                ["attribute.start_time asc", "attribute.end_time desc"], experiment_id
-            ),
+        assert ["234", "None", "456", "-123", "789", "123"] == self.get_ordered_runs(
+            ["attribute.start_time asc", "attribute.end_time desc"], experiment_id
         )
 
     def test_search_vanilla(self):
         exp = self._experiment_factory("search_vanilla")
         runs = [self._run_factory(self._get_run_configs(exp)).info.run_id for r in range(3)]
 
-        self.assertCountEqual(runs, self._search(exp, run_view_type=ViewType.ALL))
-        self.assertCountEqual(runs, self._search(exp, run_view_type=ViewType.ACTIVE_ONLY))
-        self.assertCountEqual([], self._search(exp, run_view_type=ViewType.DELETED_ONLY))
+        assert sorted(
+            runs,
+        ) == sorted(self._search(exp, run_view_type=ViewType.ALL))
+        assert sorted(
+            runs,
+        ) == sorted(self._search(exp, run_view_type=ViewType.ACTIVE_ONLY))
+        assert [] == self._search(exp, run_view_type=ViewType.DELETED_ONLY)
 
         first = runs[0]
 
         self.store.delete_run(first)
-        self.assertCountEqual(runs, self._search(exp, run_view_type=ViewType.ALL))
-        self.assertCountEqual(runs[1:], self._search(exp, run_view_type=ViewType.ACTIVE_ONLY))
-        self.assertCountEqual([first], self._search(exp, run_view_type=ViewType.DELETED_ONLY))
+        assert sorted(
+            runs,
+        ) == sorted(self._search(exp, run_view_type=ViewType.ALL))
+        assert sorted(
+            runs[1:],
+        ) == sorted(self._search(exp, run_view_type=ViewType.ACTIVE_ONLY))
+        assert [first] == self._search(exp, run_view_type=ViewType.DELETED_ONLY)
 
         self.store.restore_run(first)
-        self.assertCountEqual(runs, self._search(exp, run_view_type=ViewType.ALL))
-        self.assertCountEqual(runs, self._search(exp, run_view_type=ViewType.ACTIVE_ONLY))
-        self.assertCountEqual([], self._search(exp, run_view_type=ViewType.DELETED_ONLY))
+        assert sorted(
+            runs,
+        ) == sorted(self._search(exp, run_view_type=ViewType.ALL))
+        assert sorted(
+            runs,
+        ) == sorted(self._search(exp, run_view_type=ViewType.ACTIVE_ONLY))
+        assert [] == self._search(exp, run_view_type=ViewType.DELETED_ONLY)
 
     def test_search_params(self):
         experiment_id = self._experiment_factory("search_params")
@@ -1590,54 +1625,60 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
 
         # test search returns both runs
         filter_string = "params.generic_param = 'p_val'"
-        self.assertCountEqual([r1, r2], self._search(experiment_id, filter_string))
+        assert sorted(
+            [r1, r2],
+        ) == sorted(self._search(experiment_id, filter_string))
 
         # test search returns appropriate run (same key different values per run)
         filter_string = "params.generic_2 = 'some value'"
-        self.assertCountEqual([r1], self._search(experiment_id, filter_string))
+        assert [r1] == self._search(experiment_id, filter_string)
         filter_string = "params.generic_2 = 'another value'"
-        self.assertCountEqual([r2], self._search(experiment_id, filter_string))
+        assert [r2] == self._search(experiment_id, filter_string)
 
         filter_string = "params.generic_param = 'wrong_val'"
-        self.assertCountEqual([], self._search(experiment_id, filter_string))
+        assert [] == self._search(experiment_id, filter_string)
 
         filter_string = "params.generic_param != 'p_val'"
-        self.assertCountEqual([], self._search(experiment_id, filter_string))
+        assert [] == self._search(experiment_id, filter_string)
 
         filter_string = "params.generic_param != 'wrong_val'"
-        self.assertCountEqual([r1, r2], self._search(experiment_id, filter_string))
+        assert sorted(
+            [r1, r2],
+        ) == sorted(self._search(experiment_id, filter_string))
         filter_string = "params.generic_2 != 'wrong_val'"
-        self.assertCountEqual([r1, r2], self._search(experiment_id, filter_string))
+        assert sorted(
+            [r1, r2],
+        ) == sorted(self._search(experiment_id, filter_string))
 
         filter_string = "params.p_a = 'abc'"
-        self.assertCountEqual([r1], self._search(experiment_id, filter_string))
+        assert [r1] == self._search(experiment_id, filter_string)
 
         filter_string = "params.p_a = 'ABC'"
-        self.assertCountEqual([], self._search(experiment_id, filter_string))
+        assert [] == self._search(experiment_id, filter_string)
 
         filter_string = "params.p_a != 'ABC'"
-        self.assertCountEqual([r1], self._search(experiment_id, filter_string))
+        assert [r1] == self._search(experiment_id, filter_string)
 
         filter_string = "params.p_b = 'ABC'"
-        self.assertCountEqual([r2], self._search(experiment_id, filter_string))
+        assert [r2] == self._search(experiment_id, filter_string)
 
         filter_string = "params.generic_2 LIKE '%other%'"
-        self.assertCountEqual([r2], self._search(experiment_id, filter_string))
+        assert [r2] == self._search(experiment_id, filter_string)
 
         filter_string = "params.generic_2 LIKE 'other%'"
-        self.assertCountEqual([], self._search(experiment_id, filter_string))
+        assert [] == self._search(experiment_id, filter_string)
 
         filter_string = "params.generic_2 LIKE '%other'"
-        self.assertCountEqual([], self._search(experiment_id, filter_string))
+        assert [] == self._search(experiment_id, filter_string)
 
         filter_string = "params.generic_2 LIKE 'other'"
-        self.assertCountEqual([], self._search(experiment_id, filter_string))
+        assert [] == self._search(experiment_id, filter_string)
 
         filter_string = "params.generic_2 LIKE '%Other%'"
-        self.assertCountEqual([], self._search(experiment_id, filter_string))
+        assert [] == self._search(experiment_id, filter_string)
 
         filter_string = "params.generic_2 ILIKE '%Other%'"
-        self.assertCountEqual([r2], self._search(experiment_id, filter_string))
+        assert [r2] == self._search(experiment_id, filter_string)
 
     def test_search_tags(self):
         experiment_id = self._experiment_factory("search_tags")
@@ -1654,71 +1695,39 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         self.store.set_tag(r2, entities.RunTag("p_b", "ABC"))
 
         # test search returns both runs
-        self.assertCountEqual(
-            [r1, r2], self._search(experiment_id, filter_string="tags.generic_tag = 'p_val'")
-        )
-        self.assertCountEqual(
-            [], self._search(experiment_id, filter_string="tags.generic_tag = 'P_VAL'")
-        )
-        self.assertCountEqual(
-            [r1, r2], self._search(experiment_id, filter_string="tags.generic_tag != 'P_VAL'")
-        )
-        # test search returns appropriate run (same key different values per run)
-        self.assertCountEqual(
-            [r1], self._search(experiment_id, filter_string="tags.generic_2 = 'some value'")
-        )
-        self.assertCountEqual(
-            [r2],
-            self._search(experiment_id, filter_string="tags.generic_2 = 'another value'"),
-        )
-        self.assertCountEqual(
-            [], self._search(experiment_id, filter_string="tags.generic_tag = 'wrong_val'")
-        )
-        self.assertCountEqual(
-            [], self._search(experiment_id, filter_string="tags.generic_tag != 'p_val'")
-        )
-        self.assertCountEqual(
+        assert sorted(
             [r1, r2],
+        ) == sorted(self._search(experiment_id, filter_string="tags.generic_tag = 'p_val'"))
+        assert [] == self._search(experiment_id, filter_string="tags.generic_tag = 'P_VAL'")
+        assert sorted(
+            [r1, r2],
+        ) == sorted(self._search(experiment_id, filter_string="tags.generic_tag != 'P_VAL'"))
+        # test search returns appropriate run (same key different values per run)
+        assert [r1] == self._search(experiment_id, filter_string="tags.generic_2 = 'some value'")
+        assert [r2] == self._search(experiment_id, filter_string="tags.generic_2 = 'another value'")
+        assert [] == self._search(experiment_id, filter_string="tags.generic_tag = 'wrong_val'")
+        assert [] == self._search(experiment_id, filter_string="tags.generic_tag != 'p_val'")
+        assert sorted([r1, r2],) == sorted(
             self._search(experiment_id, filter_string="tags.generic_tag != 'wrong_val'"),
         )
-        self.assertCountEqual(
-            [r1, r2],
+        assert sorted([r1, r2],) == sorted(
             self._search(experiment_id, filter_string="tags.generic_2 != 'wrong_val'"),
         )
-        self.assertCountEqual([r1], self._search(experiment_id, filter_string="tags.p_a = 'abc'"))
-        self.assertCountEqual([r2], self._search(experiment_id, filter_string="tags.p_b = 'ABC'"))
-        self.assertCountEqual(
-            [r2], self._search(experiment_id, filter_string="tags.generic_2 LIKE '%other%'")
+        assert [r1] == self._search(experiment_id, filter_string="tags.p_a = 'abc'")
+        assert [r2] == self._search(experiment_id, filter_string="tags.p_b = 'ABC'")
+        assert [r2] == self._search(experiment_id, filter_string="tags.generic_2 LIKE '%other%'")
+        assert [] == self._search(experiment_id, filter_string="tags.generic_2 LIKE '%Other%'")
+        assert [] == self._search(experiment_id, filter_string="tags.generic_2 LIKE 'other%'")
+        assert [] == self._search(experiment_id, filter_string="tags.generic_2 LIKE '%other'")
+        assert [] == self._search(experiment_id, filter_string="tags.generic_2 LIKE 'other'")
+        assert [r2] == self._search(experiment_id, filter_string="tags.generic_2 ILIKE '%Other%'")
+        assert [r2] == self._search(
+            experiment_id,
+            filter_string="tags.generic_2 ILIKE '%Other%' and tags.generic_tag = 'p_val'",
         )
-        self.assertCountEqual(
-            [], self._search(experiment_id, filter_string="tags.generic_2 LIKE '%Other%'")
-        )
-        self.assertCountEqual(
-            [], self._search(experiment_id, filter_string="tags.generic_2 LIKE 'other%'")
-        )
-        self.assertCountEqual(
-            [], self._search(experiment_id, filter_string="tags.generic_2 LIKE '%other'")
-        )
-        self.assertCountEqual(
-            [], self._search(experiment_id, filter_string="tags.generic_2 LIKE 'other'")
-        )
-        self.assertCountEqual(
-            [r2], self._search(experiment_id, filter_string="tags.generic_2 ILIKE '%Other%'")
-        )
-        self.assertCountEqual(
-            [r2],
-            self._search(
-                experiment_id,
-                filter_string="tags.generic_2 ILIKE '%Other%' and tags.generic_tag = 'p_val'",
-            ),
-        )
-        self.assertCountEqual(
-            [r2],
-            self._search(
-                experiment_id,
-                filter_string="tags.generic_2 ILIKE '%Other%' and "
-                "tags.generic_tag ILIKE 'p_val'",
-            ),
+        assert [r2] == self._search(
+            experiment_id,
+            filter_string="tags.generic_2 ILIKE '%Other%' and " "tags.generic_tag ILIKE 'p_val'",
         )
 
     def test_search_metrics(self):
@@ -1739,65 +1748,81 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         self.store.log_metric(r2, entities.Metric("m_b", 8.0, 3, 0))
 
         filter_string = "metrics.common = 1.0"
-        self.assertCountEqual([r1, r2], self._search(experiment_id, filter_string))
+        assert sorted(
+            [r1, r2],
+        ) == sorted(self._search(experiment_id, filter_string))
 
         filter_string = "metrics.common > 0.0"
-        self.assertCountEqual([r1, r2], self._search(experiment_id, filter_string))
+        assert sorted(
+            [r1, r2],
+        ) == sorted(self._search(experiment_id, filter_string))
 
         filter_string = "metrics.common >= 0.0"
-        self.assertCountEqual([r1, r2], self._search(experiment_id, filter_string))
+        assert sorted(
+            [r1, r2],
+        ) == sorted(self._search(experiment_id, filter_string))
 
         filter_string = "metrics.common < 4.0"
-        self.assertCountEqual([r1, r2], self._search(experiment_id, filter_string))
+        assert sorted(
+            [r1, r2],
+        ) == sorted(self._search(experiment_id, filter_string))
 
         filter_string = "metrics.common <= 4.0"
-        self.assertCountEqual([r1, r2], self._search(experiment_id, filter_string))
+        assert sorted(
+            [r1, r2],
+        ) == sorted(self._search(experiment_id, filter_string))
 
         filter_string = "metrics.common != 1.0"
-        self.assertCountEqual([], self._search(experiment_id, filter_string))
+        assert [] == self._search(experiment_id, filter_string)
 
         filter_string = "metrics.common >= 3.0"
-        self.assertCountEqual([], self._search(experiment_id, filter_string))
+        assert [] == self._search(experiment_id, filter_string)
 
         filter_string = "metrics.common <= 0.75"
-        self.assertCountEqual([], self._search(experiment_id, filter_string))
+        assert [] == self._search(experiment_id, filter_string)
 
         # tests for same metric name across runs with different values and timestamps
         filter_string = "metrics.measure_a > 0.0"
-        self.assertCountEqual([r1, r2], self._search(experiment_id, filter_string))
+        assert sorted(
+            [r1, r2],
+        ) == sorted(self._search(experiment_id, filter_string))
 
         filter_string = "metrics.measure_a < 50.0"
-        self.assertCountEqual([r1], self._search(experiment_id, filter_string))
+        assert [r1] == self._search(experiment_id, filter_string)
 
         filter_string = "metrics.measure_a < 1000.0"
-        self.assertCountEqual([r1, r2], self._search(experiment_id, filter_string))
+        assert sorted(
+            [r1, r2],
+        ) == sorted(self._search(experiment_id, filter_string))
 
         filter_string = "metrics.measure_a != -12.0"
-        self.assertCountEqual([r1, r2], self._search(experiment_id, filter_string))
+        assert sorted(
+            [r1, r2],
+        ) == sorted(self._search(experiment_id, filter_string))
 
         filter_string = "metrics.measure_a > 50.0"
-        self.assertCountEqual([r2], self._search(experiment_id, filter_string))
+        assert [r2] == self._search(experiment_id, filter_string)
 
         filter_string = "metrics.measure_a = 1.0"
-        self.assertCountEqual([r1], self._search(experiment_id, filter_string))
+        assert [r1] == self._search(experiment_id, filter_string)
 
         filter_string = "metrics.measure_a = 400.0"
-        self.assertCountEqual([r2], self._search(experiment_id, filter_string))
+        assert [r2] == self._search(experiment_id, filter_string)
 
         # test search with unique metric keys
         filter_string = "metrics.m_a > 1.0"
-        self.assertCountEqual([r1], self._search(experiment_id, filter_string))
+        assert [r1] == self._search(experiment_id, filter_string)
 
         filter_string = "metrics.m_b > 1.0"
-        self.assertCountEqual([r2], self._search(experiment_id, filter_string))
+        assert [r2] == self._search(experiment_id, filter_string)
 
         # there is a recorded metric this threshold but not last timestamp
         filter_string = "metrics.m_b > 5.0"
-        self.assertCountEqual([], self._search(experiment_id, filter_string))
+        assert [] == self._search(experiment_id, filter_string)
 
         # metrics matches last reported timestamp for 'm_b'
         filter_string = "metrics.m_b = 4.0"
-        self.assertCountEqual([r2], self._search(experiment_id, filter_string))
+        assert [r2] == self._search(experiment_id, filter_string)
 
     def test_search_attrs(self):
         e1 = self._experiment_factory("search_attributes_1")
@@ -1807,74 +1832,86 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         r2 = self._run_factory(self._get_run_configs(experiment_id=e2)).info.run_id
 
         filter_string = ""
-        self.assertCountEqual([r1, r2], self._search([e1, e2], filter_string))
+        assert sorted(
+            [r1, r2],
+        ) == sorted(self._search([e1, e2], filter_string))
 
         filter_string = "attribute.status != 'blah'"
-        self.assertCountEqual([r1, r2], self._search([e1, e2], filter_string))
+        assert sorted(
+            [r1, r2],
+        ) == sorted(self._search([e1, e2], filter_string))
 
         filter_string = "attribute.status = '{}'".format(RunStatus.to_string(RunStatus.RUNNING))
-        self.assertCountEqual([r1, r2], self._search([e1, e2], filter_string))
+        assert sorted(
+            [r1, r2],
+        ) == sorted(self._search([e1, e2], filter_string))
 
         # change status for one of the runs
         self.store.update_run_info(r2, RunStatus.FAILED, 300, None)
 
         filter_string = "attribute.status = 'RUNNING'"
-        self.assertCountEqual([r1], self._search([e1, e2], filter_string))
+        assert [r1] == self._search([e1, e2], filter_string)
 
         filter_string = "attribute.status = 'FAILED'"
-        self.assertCountEqual([r2], self._search([e1, e2], filter_string))
+        assert [r2] == self._search([e1, e2], filter_string)
 
         filter_string = "attribute.status != 'SCHEDULED'"
-        self.assertCountEqual([r1, r2], self._search([e1, e2], filter_string))
+        assert sorted(
+            [r1, r2],
+        ) == sorted(self._search([e1, e2], filter_string))
 
         filter_string = "attribute.status = 'SCHEDULED'"
-        self.assertCountEqual([], self._search([e1, e2], filter_string))
+        assert [] == self._search([e1, e2], filter_string)
 
         filter_string = "attribute.status = 'KILLED'"
-        self.assertCountEqual([], self._search([e1, e2], filter_string))
+        assert [] == self._search([e1, e2], filter_string)
 
         filter_string = "attr.artifact_uri = '{}/{}/{}/artifacts'".format(ARTIFACT_URI, e1, r1)
-        self.assertCountEqual([r1], self._search([e1, e2], filter_string))
+        assert [r1] == self._search([e1, e2], filter_string)
 
         filter_string = "attr.artifact_uri = '{}/{}/{}/artifacts'".format(
             ARTIFACT_URI, e1.upper(), r1.upper()
         )
-        self.assertCountEqual([], self._search([e1, e2], filter_string))
+        assert [] == self._search([e1, e2], filter_string)
 
         filter_string = "attr.artifact_uri != '{}/{}/{}/artifacts'".format(
             ARTIFACT_URI, e1.upper(), r1.upper()
         )
-        self.assertCountEqual([r1, r2], self._search([e1, e2], filter_string))
+        assert sorted(
+            [r1, r2],
+        ) == sorted(self._search([e1, e2], filter_string))
 
         filter_string = "attr.artifact_uri = '{}/{}/{}/artifacts'".format(ARTIFACT_URI, e2, r1)
-        self.assertCountEqual([], self._search([e1, e2], filter_string))
+        assert [] == self._search([e1, e2], filter_string)
 
         filter_string = "attribute.artifact_uri = 'random_artifact_path'"
-        self.assertCountEqual([], self._search([e1, e2], filter_string))
+        assert [] == self._search([e1, e2], filter_string)
 
         filter_string = "attribute.artifact_uri != 'random_artifact_path'"
-        self.assertCountEqual([r1, r2], self._search([e1, e2], filter_string))
+        assert sorted(
+            [r1, r2],
+        ) == sorted(self._search([e1, e2], filter_string))
 
         filter_string = "attribute.artifact_uri LIKE '%{}%'".format(r1)
-        self.assertCountEqual([r1], self._search([e1, e2], filter_string))
+        assert [r1] == self._search([e1, e2], filter_string)
 
         filter_string = "attribute.artifact_uri LIKE '%{}%'".format(r1[:16])
-        self.assertCountEqual([r1], self._search([e1, e2], filter_string))
+        assert [r1] == self._search([e1, e2], filter_string)
 
         filter_string = "attribute.artifact_uri LIKE '%{}%'".format(r1[-16:])
-        self.assertCountEqual([r1], self._search([e1, e2], filter_string))
+        assert [r1] == self._search([e1, e2], filter_string)
 
         filter_string = "attribute.artifact_uri LIKE '%{}%'".format(r1.upper())
-        self.assertCountEqual([], self._search([e1, e2], filter_string))
+        assert [] == self._search([e1, e2], filter_string)
 
         filter_string = "attribute.artifact_uri ILIKE '%{}%'".format(r1.upper())
-        self.assertCountEqual([r1], self._search([e1, e2], filter_string))
+        assert [r1] == self._search([e1, e2], filter_string)
 
         filter_string = "attribute.artifact_uri ILIKE '%{}%'".format(r1[:16].upper())
-        self.assertCountEqual([r1], self._search([e1, e2], filter_string))
+        assert [r1] == self._search([e1, e2], filter_string)
 
         filter_string = "attribute.artifact_uri ILIKE '%{}%'".format(r1[-16:].upper())
-        self.assertCountEqual([r1], self._search([e1, e2], filter_string))
+        assert [r1] == self._search([e1, e2], filter_string)
 
         for (k, v) in {"experiment_id": e1, "lifecycle_stage": "ACTIVE"}.items():
             with pytest.raises(MlflowException, match=r"Invalid attribute key '.+' specified"):
@@ -1900,43 +1937,45 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         self.store.log_metric(r2, entities.Metric("m_b", 8.0, 3, 0))
 
         filter_string = "params.generic_param = 'p_val' and metrics.common = 1.0"
-        self.assertCountEqual([r1, r2], self._search(experiment_id, filter_string))
+        assert sorted(
+            [r1, r2],
+        ) == sorted(self._search(experiment_id, filter_string))
 
         # all params and metrics match
         filter_string = (
             "params.generic_param = 'p_val' and metrics.common = 1.0 and metrics.m_a > 1.0"
         )
-        self.assertCountEqual([r1], self._search(experiment_id, filter_string))
+        assert [r1] == self._search(experiment_id, filter_string)
 
         filter_string = (
             "params.generic_param = 'p_val' and metrics.common = 1.0 "
             "and metrics.m_a > 1.0 and params.p_a LIKE 'a%'"
         )
-        self.assertCountEqual([r1], self._search(experiment_id, filter_string))
+        assert [r1] == self._search(experiment_id, filter_string)
 
         filter_string = (
             "params.generic_param = 'p_val' and metrics.common = 1.0 "
             "and metrics.m_a > 1.0 and params.p_a LIKE 'A%'"
         )
-        self.assertCountEqual([], self._search(experiment_id, filter_string))
+        assert [] == self._search(experiment_id, filter_string)
 
         filter_string = (
             "params.generic_param = 'p_val' and metrics.common = 1.0 "
             "and metrics.m_a > 1.0 and params.p_a ILIKE 'A%'"
         )
-        self.assertCountEqual([r1], self._search(experiment_id, filter_string))
+        assert [r1] == self._search(experiment_id, filter_string)
 
         # test with mismatch param
         filter_string = (
             "params.random_bad_name = 'p_val' and metrics.common = 1.0 and metrics.m_a > 1.0"
         )
-        self.assertCountEqual([], self._search(experiment_id, filter_string))
+        assert [] == self._search(experiment_id, filter_string)
 
         # test with mismatch metric
         filter_string = (
             "params.generic_param = 'p_val' and metrics.common = 1.0 and metrics.m_a > 100.0"
         )
-        self.assertCountEqual([], self._search(experiment_id, filter_string))
+        assert [] == self._search(experiment_id, filter_string)
 
     def test_search_with_max_results(self):
         exp = self._experiment_factory("search_with_max_results")
@@ -2302,8 +2341,8 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         # MLflow RunData contains only the last reported values for metrics.
         with self.store.ManagedSessionMaker() as session:
             sql_run_metrics = self.store._get_run(session, run.info.run_id).metrics
-            self.assertEqual(5, len(sql_run_metrics))
-            self.assertEqual(4, len(run.data.metrics))
+            assert 5 == len(sql_run_metrics)
+            assert 4 == len(run.data.metrics)
             assert math.isnan(run.data.metrics["NaN"])
             assert run.data.metrics["PosInf"] == 1.7976931348623157e308
             assert run.data.metrics["NegInf"] == -1.7976931348623157e308
@@ -2519,9 +2558,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         run_results = self.store.search_runs([experiment_id], None, ViewType.ALL, max_results=100)
         assert len(run_results) == 100
         # runs are sorted by desc start_time
-        self.assertListEqual(
-            [run.info.run_id for run in run_results], list(reversed(run_ids[900:]))
-        )
+        assert [run.info.run_id for run in run_results] == list(reversed(run_ids[900:]))
 
     def test_search_runs_correctly_filters_large_data(self):
         experiment_id, _ = self._generate_large_data(1000)
@@ -2577,15 +2614,15 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
 
         with self.store.ManagedSessionMaker() as session:
             tag = self.store._try_get_run_tag(session, run.info.run_id, "k0")
-            self.assertIsNone(tag)
+            assert tag is None
 
             tag = self.store._try_get_run_tag(session, run.info.run_id, "k1")
-            self.assertEqual(tag.key, "k1")
-            self.assertEqual(tag.value, "v1")
+            assert tag.key == "k1"
+            assert tag.value == "v1"
 
             tag = self.store._try_get_run_tag(session, run.info.run_id, "k2")
-            self.assertEqual(tag.key, "k2")
-            self.assertEqual(tag.value, "v2")
+            assert tag.key == "k2"
+            assert tag.value == "v2"
 
 
 def test_sqlalchemy_store_behaves_as_expected_with_inmemory_sqlite_db():


### PR DESCRIPTION
Signed-off-by: ayush_gitk <ayushsharmaa101@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs
fixes #7185 

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve -->

## What changes are proposed in this pull request?

All unittest `assertmethods` are replaced with plain `assert`

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->
- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
