### PR TITLE
Fix error message for incorrect "using" field in recipes train step

### DIFF
--- a/examples/evaluation/evaluate_on_binary_classifier.py
+++ b/examples/evaluation/evaluate_on_binary_classifier.py
@@ -29,9 +29,6 @@ with mlflow.start_run() as run:
         targets="label",
         model_type="classifier",
         evaluators=["default"],
-        evaluator_config={
-            "default": {"metric_prefix": "val_"},
-        },
     )
 
 print(f"metrics:\n{result.metrics}")

--- a/examples/evaluation/evaluate_on_binary_classifier.py
+++ b/examples/evaluation/evaluate_on_binary_classifier.py
@@ -29,6 +29,9 @@ with mlflow.start_run() as run:
         targets="label",
         model_type="classifier",
         evaluators=["default"],
+        evaluator_config={
+            "default": {"metric_prefix": "val_"},
+        },
     )
 
 print(f"metrics:\n{result.metrics}")

--- a/mlflow/recipes/steps/train.py
+++ b/mlflow/recipes/steps/train.py
@@ -64,7 +64,7 @@ class TrainStep(BaseStep):
     PREDICTED_TRAINING_DATA_RELATIVE_PATH = "predicted_training_data.parquet"
     CONFIG_TYPE_ESTIMATOR_SPEC = "estimator_spec"
     CONFIG_TYPE_AUTOML = "automl/flaml"
-    SUPPORTED_CONFIG_TYPES = [TrainStep.CONFIG_TYPE_ESTIMATOR_SPEC, TrainStep.CONFIG_TYPE_AUTOML]
+    SUPPORTED_CONFIG_TYPES = [CONFIG_TYPE_ESTIMATOR_SPEC, CONFIG_TYPE_AUTOML]
 
     def __init__(self, step_config, recipe_root, recipe_config=None):
         super().__init__(step_config, recipe_root)


### PR DESCRIPTION
Signed-off-by: dbczumar <corey.zumar@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## What changes are proposed in this pull request?

Fix error message for incorrect "using" field (current message only says that `estimator_spec` is supported)

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->
- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [X] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
