### PR TITLE
Replace `assert expected == actual` to `assert actual == expected`

### DIFF
--- a/tests/autologging/test_autologging_utils.py
+++ b/tests/autologging/test_autologging_utils.py
@@ -905,10 +905,10 @@ def test_get_instance_method_first_arg_value():
         def f4(self, *args, **kwargs):
             pass
 
-    assert 3 == get_instance_method_first_arg_value(Test.f1, [3, 4], {})
-    assert 3 == get_instance_method_first_arg_value(Test.f1, [3], {"cd2": 4})
-    assert 3 == get_instance_method_first_arg_value(Test.f1, [], {"ab1": 3, "cd2": 4})
-    assert 3 == get_instance_method_first_arg_value(Test.f2, [3, 4], {})
+    assert get_instance_method_first_arg_value(Test.f1, [3, 4], {}) == 3
+    assert get_instance_method_first_arg_value(Test.f1, [3], {"cd2": 4}) == 3
+    assert get_instance_method_first_arg_value(Test.f1, [], {"ab1": 3, "cd2": 4}) == 3
+    assert get_instance_method_first_arg_value(Test.f2, [3, 4], {}) == 3
     with pytest.raises(AssertionError, match=""):
         get_instance_method_first_arg_value(Test.f3, [], {"ab1": 3, "cd2": 4})
     with pytest.raises(AssertionError, match=""):
@@ -917,6 +917,6 @@ def test_get_instance_method_first_arg_value():
 
 def test_get_method_call_arg_value():
     # suppose we call on a method defined like: `def f1(a, b=3, *, c=4, e=5)`
-    assert 2 == get_method_call_arg_value(1, "b", 3, [1, 2], {})
-    assert 3 == get_method_call_arg_value(1, "b", 3, [1], {})
-    assert 2 == get_method_call_arg_value(1, "b", 3, [1], {"b": 2})
+    assert get_method_call_arg_value(1, "b", 3, [1, 2], {}) == 2
+    assert get_method_call_arg_value(1, "b", 3, [1], {}) == 3
+    assert get_method_call_arg_value(1, "b", 3, [1], {"b": 2}) == 2

--- a/tests/entities/test_run_info.py
+++ b/tests/entities/test_run_info.py
@@ -146,7 +146,7 @@ class TestRunInfo(unittest.TestCase):
         )
 
     def test_searchable_attributes(self):
-        assert {
+        assert set(RunInfo.get_searchable_attributes()) == {
             "status",
             "artifact_uri",
             "start_time",
@@ -154,4 +154,4 @@ class TestRunInfo(unittest.TestCase):
             "end_time",
             "run_name",
             "run_id",
-        } == set(RunInfo.get_searchable_attributes())
+        }

--- a/tests/entities/test_run_status.py
+++ b/tests/entities/test_run_status.py
@@ -18,19 +18,19 @@ class TestRunStatus(unittest.TestCase):
 
     def test_status_mappings(self):
         # test enum to string mappings
-        assert "RUNNING" == RunStatus.to_string(RunStatus.RUNNING)
+        assert RunStatus.to_string(RunStatus.RUNNING) == "RUNNING"
         assert RunStatus.RUNNING == RunStatus.from_string("RUNNING")
 
-        assert "SCHEDULED" == RunStatus.to_string(RunStatus.SCHEDULED)
+        assert RunStatus.to_string(RunStatus.SCHEDULED) == "SCHEDULED"
         assert RunStatus.SCHEDULED == RunStatus.from_string("SCHEDULED")
 
-        assert "FINISHED" == RunStatus.to_string(RunStatus.FINISHED)
+        assert RunStatus.to_string(RunStatus.FINISHED) == "FINISHED"
         assert RunStatus.FINISHED == RunStatus.from_string("FINISHED")
 
-        assert "FAILED" == RunStatus.to_string(RunStatus.FAILED)
+        assert RunStatus.to_string(RunStatus.FAILED) == "FAILED"
         assert RunStatus.FAILED == RunStatus.from_string("FAILED")
 
-        assert "KILLED" == RunStatus.to_string(RunStatus.KILLED)
+        assert RunStatus.to_string(RunStatus.KILLED) == "KILLED"
         assert RunStatus.KILLED == RunStatus.from_string("KILLED")
 
         with pytest.raises(

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -116,7 +116,7 @@ def test_predict_with_old_mlflow_in_conda_and_with_orient_records(iris_data):
             ]
             + no_conda
         )
-        assert 0 == p.wait()
+        assert p.wait() == 0
         actual = pd.read_json(output_json_path, orient="records")
         actual = actual[actual.columns[0]].values
         expected = test_pyfunc.PyFuncTestModel(check_version=False).predict(df=pd.DataFrame(x))
@@ -273,7 +273,7 @@ def test_predict(iris_data, sk_model):
             + extra_options,
             env=env_with_tracking_uri,
         )
-        assert 0 == p.wait()
+        assert p.wait() == 0
         actual = pd.read_json(output_json_path, orient="records")
         actual = actual[actual.columns[0]].values
         expected = sk_model.predict(x)
@@ -297,7 +297,7 @@ def test_predict(iris_data, sk_model):
             + extra_options,
             env=env_with_tracking_uri,
         )
-        assert 0 == p.wait()
+        assert p.wait() == 0
         actual = pd.read_json(output_json_path, orient="records")
         actual = actual[actual.columns[0]].values
         expected = sk_model.predict(x)
@@ -321,7 +321,7 @@ def test_predict(iris_data, sk_model):
             + extra_options,
             env=env_with_tracking_uri,
         )
-        assert 0 == p.wait()
+        assert p.wait() == 0
         actual = pd.read_json(output_json_path, orient="records")
         actual = actual[actual.columns[0]].values
         expected = sk_model.predict(x)
@@ -338,7 +338,7 @@ def test_predict(iris_data, sk_model):
         )
         with open(input_json_path, "r") as f:
             stdout, _ = p.communicate(f.read())
-        assert 0 == p.wait()
+        assert p.wait() == 0
         actual = pd.read_json(StringIO(stdout), orient="records")
         actual = actual[actual.columns[0]].values
         expected = sk_model.predict(x)
@@ -365,7 +365,7 @@ def test_predict(iris_data, sk_model):
             + extra_options,
             env=env_with_tracking_uri,
         )
-        assert 0 == p.wait()
+        assert p.wait() == 0
         actual = pd.read_json(output_json_path, orient="records")
         actual = actual[actual.columns[0]].values
         expected = sk_model.predict(x)

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -1580,7 +1580,7 @@ def test_custom_metric_logs_artifacts_from_paths(
                 img_ext_qualified = "jpeg" if img_ext == "jpg" else img_ext
                 assert img.format.lower() == img_ext_qualified
                 assert img.size == (fig_x * fig_dpi, fig_y * fig_dpi)
-                assert (fig_dpi, fig_dpi) == pytest.approx(img.info.get("dpi"), 0.001)
+                assert pytest.approx(img.info.get("dpi"), 0.001) == (fig_dpi, fig_dpi)
 
     assert "test_json_artifact" in result.artifacts
     assert "test_json_artifact.json" in artifacts

--- a/tests/models/test_evaluation.py
+++ b/tests/models/test_evaluation.py
@@ -590,7 +590,7 @@ def test_gen_md5_for_arraylike_obj():
     list2 = list0[:-1] + [100]
     list3 = list0[:10] + [100] + list0[10:]
 
-    assert 4 == len({get_md5(list0), get_md5(list1), get_md5(list2), get_md5(list3)})
+    assert len({get_md5(list0), get_md5(list1), get_md5(list2), get_md5(list3)}) == 4
 
     list4 = list0[:10] + [99] + list0[10:]
     assert get_md5(list3) == get_md5(list4)

--- a/tests/projects/test_kubernetes.py
+++ b/tests/projects/test_kubernetes.py
@@ -20,7 +20,7 @@ def test_run_command_creation():  # pylint: disable=unused-argument
         '--comment-bis "bar foo"',
     ]
     command = kb._get_run_command(command)
-    assert [
+    assert command == [
         "python",
         "train.py",
         "--alpha",
@@ -31,7 +31,7 @@ def test_run_command_creation():  # pylint: disable=unused-argument
         "'foo bar'",
         "--comment-bis",
         "'bar foo'",
-    ] == command
+    ]
 
 
 def test_valid_kubernetes_job_spec():  # pylint: disable=unused-argument
@@ -73,7 +73,7 @@ def test_valid_kubernetes_job_spec():  # pylint: disable=unused-argument
     assert container_spec["name"] == project_name
     assert container_spec["image"] == image_tag + "@" + image_digest
     assert container_spec["command"] == command
-    assert 2 == len(container_spec["env"])
+    assert len(container_spec["env"]) == 2
     assert container_spec["env"][0]["name"] == "DUMMY"
     assert container_spec["env"][0]["value"] == "test_var"
     assert container_spec["env"][1]["name"] == "RUN_ID"

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -495,7 +495,7 @@ def test_pyfunc_cli_predict_command_without_conda_env_activation_succeeds(
         preexec_fn=os.setsid,
     )
     _, stderr = process.communicate()
-    assert 0 == process.wait(), "stderr = \n\n{}\n\n".format(stderr)
+    assert process.wait() == 0, "stderr = \n\n{}\n\n".format(stderr)
     with open(output_json_path, "r") as f:
         result_df = pd.DataFrame(data=json.load(f)["predictions"])
     np.testing.assert_array_equal(
@@ -544,7 +544,7 @@ def test_pyfunc_cli_predict_command_with_conda_env_activation_succeeds(
         preexec_fn=os.setsid,
     )
     stdout, stderr = process.communicate()
-    assert 0 == process.wait(), f"stdout = \n\n{stdout}\n\n stderr = \n\n{stderr}\n\n"
+    assert process.wait() == 0, f"stdout = \n\n{stdout}\n\n stderr = \n\n{stderr}\n\n"
     with open(output_json_path, "r") as f:
         result_df = pandas.DataFrame(json.load(f)["predictions"])
     np.testing.assert_array_equal(

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -680,7 +680,7 @@ class TestDatabricksArtifactRepository:
             call_endpoint_mock.side_effect = list_artifact_paginated_response_protos
             message_mock.return_value = None
             artifacts = databricks_artifact_repo.list_artifacts()
-            assert {"a.txt", "b", "c.txt", "d", "e.txt", "f"} == {file.path for file in artifacts}
+            assert {file.path for file in artifacts} == {"a.txt", "b", "c.txt", "d", "e.txt", "f"}
             calls = [
                 mock.call(ListArtifacts(run_id=MOCK_RUN_ID, path="")),
                 mock.call(ListArtifacts(run_id=MOCK_RUN_ID, path="", page_token="2")),

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -872,7 +872,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         )
 
         mvds = self.store.search_model_versions("run_id = '%s'" % run_id_1)
-        assert 1 == len(mvds)
+        assert len(mvds) == 1
         assert isinstance(mvds[0], ModelVersion)
         assert mvds[0].current_stage == "Production"
         assert mvds[0].run_id == run_id_1
@@ -1250,55 +1250,55 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
             order_by=["last_updated_timestamp ASC", "name DESC"],
             max_results=100,
         )
-        assert [rm2, rm1, rm4, rm3] == result
+        assert result == [rm2, rm1, rm4, rm3]
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=["timestamp ASC", "name   DESC"], max_results=100
         )
-        assert [rm2, rm1, rm4, rm3] == result
+        assert result == [rm2, rm1, rm4, rm3]
         # confirm that name ascending is the default, even if ties exist on other fields
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=[], max_results=100
         )
-        assert [rm1, rm2, rm3, rm4] == result
+        assert result == [rm1, rm2, rm3, rm4]
         # test default tiebreak with descending timestamps
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=["last_updated_timestamp DESC"], max_results=100
         )
-        assert [rm3, rm4, rm1, rm2] == result
+        assert result == [rm3, rm4, rm1, rm2]
         # test timestamp parsing
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=["timestamp\tASC"], max_results=100
         )
-        assert [rm1, rm2, rm3, rm4] == result
+        assert result == [rm1, rm2, rm3, rm4]
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=["timestamp\r\rASC"], max_results=100
         )
-        assert [rm1, rm2, rm3, rm4] == result
+        assert result == [rm1, rm2, rm3, rm4]
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=["timestamp\nASC"], max_results=100
         )
-        assert [rm1, rm2, rm3, rm4] == result
+        assert result == [rm1, rm2, rm3, rm4]
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=["timestamp  ASC"], max_results=100
         )
-        assert [rm1, rm2, rm3, rm4] == result
+        assert result == [rm1, rm2, rm3, rm4]
         # validate order by key is case-insensitive
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=["timestamp  asc"], max_results=100
         )
-        assert [rm1, rm2, rm3, rm4] == result
+        assert result == [rm1, rm2, rm3, rm4]
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=["timestamp  aSC"], max_results=100
         )
-        assert [rm1, rm2, rm3, rm4] == result
+        assert result == [rm1, rm2, rm3, rm4]
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=["timestamp  desc", "name desc"], max_results=100
         )
-        assert [rm4, rm3, rm2, rm1] == result
+        assert result == [rm4, rm3, rm2, rm1]
         result, _ = self._search_registered_models(
             query, page_token=None, order_by=["timestamp  deSc", "name deSc"], max_results=100
         )
-        assert [rm4, rm3, rm2, rm1] == result
+        assert result == [rm4, rm3, rm2, rm1]
 
     def test_search_registered_model_order_by_errors(self):
         query = "name LIKE 'RM%'"

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -1064,23 +1064,23 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
             [r1, r2],
         ) == sorted(self._search(fs, experiment_id, filter_str="tags.generic_tag = 'p_val'"))
         # test search returns appropriate run (same key different values per run)
-        assert [r1] == self._search(fs, experiment_id, filter_str="tags.generic_2 = 'some value'")
-        assert [r2] == self._search(fs, experiment_id, filter_str="tags.generic_2='another value'")
-        assert [] == self._search(fs, experiment_id, filter_str="tags.generic_tag = 'wrong_val'")
-        assert [] == self._search(fs, experiment_id, filter_str="tags.generic_tag != 'p_val'")
+        assert self._search(fs, experiment_id, filter_str="tags.generic_2 = 'some value'") == [r1]
+        assert self._search(fs, experiment_id, filter_str="tags.generic_2='another value'") == [r2]
+        assert self._search(fs, experiment_id, filter_str="tags.generic_tag = 'wrong_val'") == []
+        assert self._search(fs, experiment_id, filter_str="tags.generic_tag != 'p_val'") == []
         assert sorted([r1, r2],) == sorted(
             self._search(fs, experiment_id, filter_str="tags.generic_tag != 'wrong_val'"),
         )
         assert sorted([r1, r2],) == sorted(
             self._search(fs, experiment_id, filter_str="tags.generic_2 != 'wrong_val'"),
         )
-        assert [r1] == self._search(fs, experiment_id, filter_str="tags.p_a = 'abc'")
-        assert [r2] == self._search(fs, experiment_id, filter_str="tags.p_b = 'ABC'")
+        assert self._search(fs, experiment_id, filter_str="tags.p_a = 'abc'") == [r1]
+        assert self._search(fs, experiment_id, filter_str="tags.p_b = 'ABC'") == [r2]
 
-        assert [r2] == self._search(fs, experiment_id, filter_str="tags.generic_2 LIKE '%other%'")
-        assert [] == self._search(fs, experiment_id, filter_str="tags.generic_2 LIKE 'other%'")
-        assert [] == self._search(fs, experiment_id, filter_str="tags.generic_2 LIKE '%other'")
-        assert [r2] == self._search(fs, experiment_id, filter_str="tags.generic_2 ILIKE '%OTHER%'")
+        assert self._search(fs, experiment_id, filter_str="tags.generic_2 LIKE '%other%'") == [r2]
+        assert self._search(fs, experiment_id, filter_str="tags.generic_2 LIKE 'other%'") == []
+        assert self._search(fs, experiment_id, filter_str="tags.generic_2 LIKE '%other'") == []
+        assert self._search(fs, experiment_id, filter_str="tags.generic_2 ILIKE '%OTHER%'") == [r2]
 
     def test_search_with_max_results(self):
         fs = FileStore(self.test_root)

--- a/tests/tracking/test_model_registry.py
+++ b/tests/tracking/test_model_registry.py
@@ -117,18 +117,18 @@ def test_create_and_query_registered_model_flow(mlflow_client, backend_store_uri
     assert registered_model_detailed.latest_versions == []
     assert_is_between(start_time, end_time, registered_model_detailed.creation_timestamp)
     assert_is_between(start_time, end_time, registered_model_detailed.last_updated_timestamp)
-    assert [name] == [rm.name for rm in mlflow_client.search_registered_models() if rm.name == name]
-    assert [name] == [rm.name for rm in mlflow_client.search_registered_models() if rm.name == name]
-    assert [name] == [
+    assert [rm.name for rm in mlflow_client.search_registered_models() if rm.name == name] == [name]
+    assert [rm.name for rm in mlflow_client.search_registered_models() if rm.name == name] == [name]
+    assert [
         rm.name
         for rm in mlflow_client.search_registered_models(filter_string="")
         if rm.name == name
-    ]
-    assert [name] == [
+    ] == [name]
+    assert [
         rm.name
         for rm in mlflow_client.search_registered_models("name = 'CreateRMTest'")
         if rm.name == name
-    ]
+    ] == [name]
     # clean up test
     mlflow_client.delete_registered_model(name)
 
@@ -272,7 +272,7 @@ def test_delete_registered_model_flow(mlflow_client, backend_store_uri):
     assert_is_between(start_time_1, end_time_1, registered_model_detailed_1.creation_timestamp)
     assert_is_between(start_time_1, end_time_1, registered_model_detailed_1.last_updated_timestamp)
 
-    assert [name] == [rm.name for rm in mlflow_client.search_registered_models() if rm.name == name]
+    assert [rm.name for rm in mlflow_client.search_registered_models() if rm.name == name] == [name]
 
     # cannot create a model with same name
     with pytest.raises(MlflowException, match=r"Registered Model .+ already exists"):
@@ -289,7 +289,7 @@ def test_delete_registered_model_flow(mlflow_client, backend_store_uri):
         mlflow_client.rename_registered_model(name=name, new_name="something else")
 
     # list does not include deleted model
-    assert [] == [rm.name for rm in mlflow_client.search_registered_models() if rm.name == name]
+    assert [rm.name for rm in mlflow_client.search_registered_models() if rm.name == name] == []
 
     # recreate model with same name
     start_time_2 = get_current_time_millis()
@@ -300,7 +300,7 @@ def test_delete_registered_model_flow(mlflow_client, backend_store_uri):
     assert_is_between(start_time_2, end_time_2, registered_model_detailed_2.creation_timestamp)
     assert_is_between(start_time_2, end_time_2, registered_model_detailed_2.last_updated_timestamp)
 
-    assert [name] == [rm.name for rm in mlflow_client.search_registered_models() if rm.name == name]
+    assert [rm.name for rm in mlflow_client.search_registered_models() if rm.name == name] == [name]
 
 
 def test_set_delete_registered_model_tag_flow(mlflow_client, backend_store_uri):
@@ -339,26 +339,26 @@ def test_create_and_query_model_version_flow(mlflow_client, backend_store_uri):
         "another key": "some other value",
         "numeric value": "12345",
     }
-    assert [[mvd1]] == [
+    assert [
         rm.latest_versions for rm in mlflow_client.search_registered_models() if rm.name == name
-    ]
+    ] == [[mvd1]]
     mv2 = mlflow_client.create_model_version(name, "another_path/to/model", "run_id_1")
     assert mv2.version == "2"
     assert mv2.name == name
     mvd2 = mlflow_client.get_model_version(name, "2")
-    assert [[mvd2]] == [
+    assert [
         rm.latest_versions for rm in mlflow_client.search_registered_models() if rm.name == name
-    ]
+    ] == [[mvd2]]
     model_versions_by_name = mlflow_client.search_model_versions("name = '%s'" % name)
-    assert {"1", "2"} == {mv.version for mv in model_versions_by_name}
-    assert {name} == {mv.name for mv in model_versions_by_name}
+    assert {mv.version for mv in model_versions_by_name} == {"1", "2"}
+    assert {mv.name for mv in model_versions_by_name} == {name}
 
     mv3 = mlflow_client.create_model_version(name, "another_path/to/model", "run_id_2")
     assert mv3.version == "3"
-    assert [mvd1] == mlflow_client.search_model_versions("source_path = 'path/to/model'")
-    assert [mvd2, mvd1] == mlflow_client.search_model_versions("run_id = 'run_id_1'")
+    assert mlflow_client.search_model_versions("source_path = 'path/to/model'") == [mvd1]
+    assert mlflow_client.search_model_versions("run_id = 'run_id_1'") == [mvd2, mvd1]
 
-    assert "path/to/model" == mlflow_client.get_model_version_download_uri(name, "1")
+    assert mlflow_client.get_model_version_download_uri(name, "1") == "path/to/model"
 
 
 def test_get_model_version(mlflow_client, backend_store_uri):
@@ -399,16 +399,16 @@ def test_update_model_version_flow(mlflow_client, backend_store_uri):
     assert_is_between(start_time_0, end_time_0, rmd2.creation_timestamp)
     assert_is_between(start_time_1, end_time_1, rmd2.last_updated_timestamp)
 
-    assert [[mvd1]] == [
+    assert [
         rm.latest_versions for rm in mlflow_client.search_registered_models() if rm.name == name
-    ]
+    ] == [[mvd1]]
     mv2 = mlflow_client.create_model_version(name, "another_path/to/model", "run_id_1")
     assert mv2.version == "2"
     assert mv2.name == name
     mvd2 = mlflow_client.get_model_version(name, "2")
-    assert [[mvd2]] == [
+    assert [
         rm.latest_versions for rm in mlflow_client.search_registered_models() if rm.name == name
-    ]
+    ] == [[mvd2]]
 
     start_time_2 = get_current_time_millis()
     mlflow_client.transition_model_version_stage(name=name, version=1, stage="Staging")
@@ -425,9 +425,9 @@ def test_update_model_version_flow(mlflow_client, backend_store_uri):
     model_versions_detailed = [
         rm.latest_versions for rm in mlflow_client.search_registered_models() if rm.name == name
     ]
-    assert 1 == len(model_versions_detailed)
-    assert {"1", "2"} == {mvd.version for mvd in model_versions_detailed[0]}
-    assert {name} == {mvd.name for mvd in model_versions_detailed[0]}
+    assert len(model_versions_detailed) == 1
+    assert {mvd.version for mvd in model_versions_detailed[0]} == {"1", "2"}
+    assert {mvd.name for mvd in model_versions_detailed[0]} == {name}
 
     # update description
     start_time_3 = get_current_time_millis()
@@ -470,11 +470,11 @@ def test_latest_models(mlflow_client, backend_store_uri):
         latest = mlflow_client.get_latest_versions(name, stages)
         return {mvd.current_stage: mvd.version for mvd in latest}
 
-    assert {"None": "7"} == get_latest(["None"])
-    assert {"Staging": "6"} == get_latest(["Staging"])
-    assert {"None": "7", "Staging": "6"} == get_latest(["None", "Staging"])
-    assert {"Production": "4", "Staging": "6", "Archived": "3", "None": "7"} == get_latest(None)
-    assert {"Production": "4", "Staging": "6", "Archived": "3", "None": "7"} == get_latest([])
+    assert get_latest(["None"]) == {"None": "7"}
+    assert get_latest(["Staging"]) == {"Staging": "6"}
+    assert get_latest(["None", "Staging"]) == {"None": "7", "Staging": "6"}
+    assert get_latest(None) == {"Production": "4", "Staging": "6", "Archived": "3", "None": "7"}
+    assert get_latest([]) == {"Production": "4", "Staging": "6", "Archived": "3", "None": "7"}
 
 
 def test_delete_model_version_flow(mlflow_client, backend_store_uri):
@@ -509,17 +509,20 @@ def test_delete_model_version_flow(mlflow_client, backend_store_uri):
     model_versions_detailed = [
         rm.latest_versions for rm in mlflow_client.search_registered_models() if rm.name == name
     ]
-    assert 1 == len(model_versions_detailed)
-    assert "3" == model_versions_detailed[0][0].version
-    assert {"1", "2", "3"} == {
-        mv.version for mv in mlflow_client.search_model_versions("name = '%s'" % name)
+    assert len(model_versions_detailed) == 1
+    assert model_versions_detailed[0][0].version == "3"
+    assert {mv.version for mv in mlflow_client.search_model_versions("name = '%s'" % name)} == {
+        "1",
+        "2",
+        "3",
     }
 
     start_time_2 = get_current_time_millis()
     mlflow_client.delete_model_version(name, "1")
     end_time_2 = get_current_time_millis()
-    assert {"2", "3"} == {
-        mv.version for mv in mlflow_client.search_model_versions("name = '%s'" % name)
+    assert {mv.version for mv in mlflow_client.search_model_versions("name = '%s'" % name)} == {
+        "2",
+        "3",
     }
     rmd3 = mlflow_client.get_registered_model(name)
     # deleting model versions changes last_updated_timestamp for registered model
@@ -537,14 +540,15 @@ def test_delete_model_version_flow(mlflow_client, backend_store_uri):
         mlflow_client.transition_model_version_stage(name=name, version=1, stage="Staging")
 
     mlflow_client.delete_model_version(name, 3)
-    assert {"2"} == {mv.version for mv in mlflow_client.search_model_versions("name = '%s'" % name)}
+    assert {mv.version for mv in mlflow_client.search_model_versions("name = '%s'" % name)} == {"2"}
 
     # new model versions will not reuse existing version numbers
     mv4 = mlflow_client.create_model_version(name, "a/b/c", "run_id_2")
     assert mv4.version == "4"
     assert mv4.name == name
-    assert {"2", "4"} == {
-        mv.version for mv in mlflow_client.search_model_versions("name = '%s'" % name)
+    assert {mv.version for mv in mlflow_client.search_model_versions("name = '%s'" % name)} == {
+        "2",
+        "4",
     }
 
 

--- a/tests/utils/test_search_utils.py
+++ b/tests/utils/test_search_utils.py
@@ -476,9 +476,9 @@ def test_order_by_metric_with_nans_infs_nones():
     sorted_runs_asc = [x.info.run_id for x in SearchUtils.sort(runs, ["metrics.x asc"])]
     sorted_runs_desc = [x.info.run_id for x in SearchUtils.sort(runs, ["metrics.x desc"])]
     # asc
-    assert ["-inf", "-1000", "0", "1000", "inf", "nan", "None"] == sorted_runs_asc
+    assert sorted_runs_asc == ["-inf", "-1000", "0", "1000", "inf", "nan", "None"]
     # desc
-    assert ["inf", "1000", "0", "-1000", "-inf", "nan", "None"] == sorted_runs_desc
+    assert sorted_runs_desc == ["inf", "1000", "0", "-1000", "-inf", "nan", "None"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Signed-off-by: ayush_gitk <ayushsharmaa101@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

fixes #7248 
Currently the assert statements look like `assert expected == actual` .
This pr replaces it with `assert actual == expected`

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> 

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->
- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
