### PR TITLE
Enable `singleton-comparison` rule

### DIFF
--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -378,5 +378,5 @@ def _validate_model_version_or_stage_exists(version, stage):
 
 
 def _validate_tag_value(value):
-    if value == None:
+    if value is None:
         raise MlflowException("Tag value cannot be None", INVALID_PARAMETER_VALUE)

--- a/pylintrc
+++ b/pylintrc
@@ -182,7 +182,8 @@ enable=c-extension-no-member,
        consider-merging-isinstance,
        consider-using-dict-items,
        unnecessary-comprehension,
-       consider-using-set-comprehension
+       consider-using-set-comprehension,
+       singleton-comparison
 
 [REPORTS]
 

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -1857,7 +1857,7 @@ def test_evaluation_binary_classification_with_pos_label(pos_label):
     y = y.head(len(X))
     if pos_label == 2:
         y = [2 if trg == 1 else trg for trg in y]
-    elif pos_label == None:
+    elif pos_label is None:
         # Use a different positive class other than the 1 to verify
         # that an unspecified `pos_label` doesn't cause problems
         # for binary classification tasks with nonstandard labels

--- a/tests/recipes/test_cli.py
+++ b/tests/recipes/test_cli.py
@@ -70,7 +70,7 @@ def test_recipes_get_artifact_works():
         env={_RECIPE_PROFILE_ENV_VAR: "local"},
     )
     assert result.exit_code == 0
-    assert result.output != None
+    assert result.output is not None
 
 
 @pytest.mark.usefixtures("enter_recipe_example_directory", "clean_up_recipe")

--- a/tests/recipes/test_execution_utils.py
+++ b/tests/recipes/test_execution_utils.py
@@ -182,7 +182,7 @@ def test_get_or_create_execution_directory_is_idempotent(tmp_path):
     # Verify that the directory exists but is empty due to short circuiting after
     # failed Makefile creation
     assert execution_dir_path_1.exists()
-    assert next(execution_dir_path_1.iterdir(), None) == None
+    assert next(execution_dir_path_1.iterdir(), None) is None
 
     # Re-create the execution directory and verify that all expected contents are present
     execution_dir_path_3 = pathlib.Path(

--- a/tests/recipes/test_transform_step.py
+++ b/tests/recipes/test_transform_step.py
@@ -116,7 +116,7 @@ def test_transform_empty_step(tmp_recipe_root_path):
     )
     train_split = pd.read_parquet(split_step_output_dir / "train.parquet")
 
-    assert train_transformed.equals(train_split) == True
+    assert train_transformed.equals(train_split) is True
     assert os.path.exists(transform_step_output_dir / "transformer.pkl")
 
 

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -90,7 +90,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         name = random_str() + "abCD"
         rm1 = self._rm_maker(name)
         assert rm1.name == name
-        assert rm1.description == None
+        assert rm1.description is None
 
         # error on duplicate
         with pytest.raises(
@@ -154,7 +154,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         assert rmd.name == name
         assert rmd.creation_timestamp == 1234000
         assert rmd.last_updated_timestamp == 1234000
-        assert rmd.description == None
+        assert rmd.description is None
         assert rmd.latest_versions == []
         assert rmd.tags == {tag.key: tag.value for tag in tags}
 
@@ -163,7 +163,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         rm1 = self._rm_maker(name)
         rmd1 = self.store.get_registered_model(name=name)
         assert rm1.name == name
-        assert rmd1.description == None
+        assert rmd1.description is None
 
         # update description
         rm2 = self.store.update_registered_model(name=name, description="test model")
@@ -452,11 +452,11 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         assert mvd1.current_stage == "None"
         assert mvd1.creation_timestamp == 456778000
         assert mvd1.last_updated_timestamp == 456778000
-        assert mvd1.description == None
+        assert mvd1.description is None
         assert mvd1.source == "a/b/CD"
         assert mvd1.run_id == run_id
         assert mvd1.status == "READY"
-        assert mvd1.status_message == None
+        assert mvd1.status_message is None
         assert mvd1.tags == {}
 
         # new model versions for same name autoincrement versions
@@ -496,9 +496,9 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         mv6 = self._mv_maker(name, run_id=None)
         mvd6 = self.store.get_model_version(name, mv6.version)
         assert mv6.version == 6
-        assert mv6.run_id == None
+        assert mv6.run_id is None
         assert mvd6.version == 6
-        assert mvd6.run_id == None
+        assert mvd6.run_id is None
 
     def test_update_model_version(self):
         name = "test_for_update_MV"
@@ -517,7 +517,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         assert mvd2.name == name
         assert mvd2.version == 1
         assert mvd2.current_stage == "Production"
-        assert mvd2.description == None
+        assert mvd2.description is None
 
         # update description
         self.store.update_model_version(
@@ -1143,20 +1143,20 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         # test that pagination will return all valid results in sorted order
         # by name ascending
         result, token1 = self._search_registered_models(query, max_results=5)
-        assert token1 != None
+        assert token1 is not None
         assert result == rms[0:5]
 
         result, token2 = self._search_registered_models(query, page_token=token1, max_results=10)
-        assert token2 != None
+        assert token2 is not None
         assert result == rms[5:15]
 
         result, token3 = self._search_registered_models(query, page_token=token2, max_results=20)
-        assert token3 != None
+        assert token3 is not None
         assert result == rms[15:35]
 
         result, token4 = self._search_registered_models(query, page_token=token3, max_results=100)
         # assert that page token is None
-        assert token4 == None
+        assert token4 is None
         assert result == rms[35:]
 
         # test that providing a completely invalid page token throws

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -1681,7 +1681,7 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         fs.delete_tag(run_id, MLFLOW_RUN_NAME)
         run = fs.get_run(run_id)
         assert run.info.run_name == "new name"
-        assert run.data.tags.get(MLFLOW_RUN_NAME) == None
+        assert run.data.tags.get(MLFLOW_RUN_NAME) is None
 
         fs.update_run_info(run_id, RunStatus.FINISHED, 100, "another name")
         run = fs.get_run(run_id)

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -317,7 +317,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         actual_by_name = self.store.get_experiment_by_name(name)
         assert actual_by_name.name == name
         assert actual_by_name.experiment_id == experiment_id
-        assert self.store.get_experiment_by_name("idontexist") == None
+        assert self.store.get_experiment_by_name("idontexist") is None
 
     def test_search_experiments_view_type(self):
         experiment_names = ["a", "b"]
@@ -944,17 +944,17 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
 
         with self.store.ManagedSessionMaker() as session:
             actual_run = session.query(models.SqlRun).filter_by(run_uuid=run.info.run_id).first()
-            assert actual_run == None
+            assert actual_run is None
             actual_metric = (
                 session.query(models.SqlMetric).filter_by(run_uuid=run.info.run_id).first()
             )
-            assert actual_metric == None
+            assert actual_metric is None
             actual_param = (
                 session.query(models.SqlParam).filter_by(run_uuid=run.info.run_id).first()
             )
-            assert actual_param == None
+            assert actual_param is None
             actual_tag = session.query(models.SqlTag).filter_by(run_uuid=run.info.run_id).first()
-            assert actual_tag == None
+            assert actual_tag is None
 
     def test_get_deleted_runs(self):
         run = self._run_factory()
@@ -1325,7 +1325,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         self.store.delete_tag(run_id, mlflow_tags.MLFLOW_RUN_NAME)
         run = self.store.get_run(run_id)
         assert run.info.run_name == "new name"
-        assert run.data.tags.get(mlflow_tags.MLFLOW_RUN_NAME) == None
+        assert run.data.tags.get(mlflow_tags.MLFLOW_RUN_NAME) is None
 
         self.store.update_run_info(run_id, RunStatus.FINISHED, 1000, "newer name")
         run = self.store.get_run(run_id)

--- a/tests/tracking/default_experiment/test_databricks_job_experiment_provider.py
+++ b/tests/tracking/default_experiment/test_databricks_job_experiment_provider.py
@@ -21,7 +21,7 @@ def test_databricks_job_default_experiment_in_context():
     ) as get_job_type_info:
         in_job_mock.return_value = True
         get_job_type_info.return_value = "NORMAL"
-        assert DatabricksJobExperimentProvider().in_context() == True
+        assert DatabricksJobExperimentProvider().in_context() is True
 
 
 def test_databricks_job_default_experiment_in_context_with_not_in_databricks_job():
@@ -32,7 +32,7 @@ def test_databricks_job_default_experiment_in_context_with_not_in_databricks_job
     ) as get_job_type_info:
         in_job_mock.return_value = False
         get_job_type_info.return_value = "NORMAL"
-        assert DatabricksJobExperimentProvider().in_context() == False
+        assert DatabricksJobExperimentProvider().in_context() is False
 
 
 def test_databricks_job_default_experiment_in_context_with_ephemeral_job_type():
@@ -43,7 +43,7 @@ def test_databricks_job_default_experiment_in_context_with_ephemeral_job_type():
     ) as get_job_type_info:
         in_job_mock.return_value = True
         get_job_type_info.return_value = "EPHEMERAL"
-        assert DatabricksJobExperimentProvider().in_context() == False
+        assert DatabricksJobExperimentProvider().in_context() is False
 
 
 def test_databricks_job_default_experiment_id():


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Enable `singleton-comparison` rule.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->
- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
