### PR TITLE
Fix Facets Overview background

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
           name: Install dependencies
           command: |
             pip install -e .
-            pip install nbconvert ipykernel
+            pip install nbconvert ipykernel jupyterthemes
       - run:
           name: Run CLI
           working_directory: examples/recipes/regression
@@ -96,10 +96,16 @@ jobs:
             MLFLOW_RECIPES_PROFILE: local
           command: |
             jupyter nbconvert --to html --execute notebooks/jupyter.ipynb
+            # Run the notebook in a dark theme
+            jt -t monokai
+            jupyter nbconvert --to html --execute notebooks/jupyter.ipynb --output dark-jupyter
+
       - store_artifacts:
           path: ~/.mlflow/recipes
       - store_artifacts:
           path: examples/recipes/regression/notebooks/jupyter.html
+      - store_artifacts:
+          path: examples/recipes/regression/notebooks/dark-jupyter.html
 
 workflows:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
           name: Install dependencies
           command: |
             pip install -e .
-            pip install nbconvert ipykernel jupyterthemes
+            pip install nbconvert ipykernel
       - run:
           name: Run CLI
           working_directory: examples/recipes/regression
@@ -96,9 +96,7 @@ jobs:
             MLFLOW_RECIPES_PROFILE: local
           command: |
             jupyter nbconvert --to html --execute notebooks/jupyter.ipynb
-            # Run the notebook in a dark theme
-            jt -t monokai
-            jupyter nbconvert --to html --execute notebooks/jupyter.ipynb --output dark-jupyter
+            jupyter nbconvert --to html --execute notebooks/jupyter.ipynb --output dark-jupyter --HTMLExporter.theme=dark
 
       - store_artifacts:
           path: ~/.mlflow/recipes

--- a/mlflow/recipes/cards/pandas_renderer.py
+++ b/mlflow/recipes/cards/pandas_renderer.py
@@ -251,10 +251,12 @@ def construct_facets_html(
     polyfills_code = get_facets_polyfills()
 
     html_template = """
+        <div style="background-color: white">
         <script>{polyfills_code}</script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.3.3/webcomponents-lite.js"></script>
         <link rel="import" href="https://raw.githubusercontent.com/PAIR-code/facets/1.0.0/facets-dist/facets-jupyter.html" >
         <facets-overview id="facets" proto-input="{protostr}" compare-mode="{compare}"></facets-overview>
+        </div>
     """
     html = html_template.format(protostr=protostr, compare=compare, polyfills_code=polyfills_code)
     return html


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Fix Facets Overview background. See the images below.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->
- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

# Before

https://output.circle-artifacts.com/output/job/53769e0a-8ef1-462a-8f6f-4fbe01f1398c/artifacts/0/examples/recipes/regression/notebooks/dark-jupyter.html

<img width="1622" alt="image" src="https://user-images.githubusercontent.com/17039389/200275209-74b31894-e15c-45c0-9bfc-30235b8e2fe5.png">

# After

https://output.circle-artifacts.com/output/job/456b3418-edf3-4a3d-91be-28290f39a1f4/artifacts/0/examples/recipes/regression/notebooks/dark-jupyter.html

<img width="1703" alt="image" src="https://user-images.githubusercontent.com/17039389/200276983-28c82903-1438-4a66-8dc5-ebceea60d4c0.png">

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
