### PR TITLE
Added /version endpoint for tracking server

### DIFF
--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -1251,7 +1251,8 @@ allow passing HTTP authentication to the tracking server:
     see :ref:`Artifact Stores <artifact-stores>`.
 
 Tracking Server versioning
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 The version of MLflow running on the server can be found by querying the ``/version`` endpoint.
 This can be used to check that the client-side version of MLflow is up-to-date with a remote tracking server prior to running experiments.
 For example:

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -1250,6 +1250,19 @@ allow passing HTTP authentication to the tracking server:
     For this reason, the client needs direct access to the artifact store. For instructions on setting up these credentials,
     see :ref:`Artifact Stores <artifact-stores>`.
 
+Tracking Server versioning
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The version of MLflow running on the server can be found by querying the ``/version`` endpoint.
+This can be used to check that the client-side version of MLflow is up-to-date with a remote tracking server prior to running experiments.
+For example:
+
+.. code-block:: python
+
+    import requests
+    import mlflow
+    response = requests.get("http://<mlflow-host>:<mlflow-port>/version")
+    assert response.text == mlflow.__version__ # Checking for a strict version match
+
 
 .. _system_tags:
 

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -1260,6 +1260,7 @@ For example:
 
     import requests
     import mlflow
+
     response = requests.get("http://<mlflow-host>:<mlflow-port>/version")
     assert response.text == mlflow.__version__ # Checking for a strict version match
 

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -13,6 +13,7 @@ from mlflow.server.handlers import (
     get_model_version_artifact_handler,
 )
 from mlflow.utils.process import _exec_cmd
+from mlflow.version import VERSION
 
 # NB: These are internal environment variables used for communication between
 # the cli and the forked gunicorn processes.
@@ -46,6 +47,12 @@ if os.getenv(PROMETHEUS_EXPORTER_ENV_VAR):
 @app.route("/health")
 def health():
     return "OK", 200
+
+
+# Provide an endpoint to query the version of mlflow running on the server
+@app.route("/version")
+def version():
+    return VERSION, 200
 
 
 # Serve the "get-artifact" route.

--- a/mlflow/server/prometheus_exporter.py
+++ b/mlflow/server/prometheus_exporter.py
@@ -12,7 +12,7 @@ def activate_prometheus_exporter(app):
         app,
         export_defaults=True,
         defaults_prefix="mlflow",
-        excluded_paths=["/health"],
+        excluded_paths=["/health", "/version"],
         group_by=mlflow_version,
     )
 

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -103,6 +103,13 @@ def test_health():
         assert response.get_data().decode() == "OK"
 
 
+def test_version():
+    with app.test_client() as c:
+        response = c.get("/version")
+        assert response.status_code == 200
+        assert response.get_data().decode() == mlflow.__version__
+
+
 def test_get_endpoints():
     endpoints = get_endpoints()
     create_experiment_endpoint = [e for e in endpoints if e[1] == _create_experiment]

--- a/tests/server/test_prometheus_exporter.py
+++ b/tests/server/test_prometheus_exporter.py
@@ -56,6 +56,13 @@ def test_metrics(app, test_client):
         metrics.registry.get_sample_value("mlflow_http_request_total", labels=success_labels) == 1
     )
 
+    # calling the version endpoint should not increment the counter
+    resp = test_client.get("/version")
+    assert resp.status_code == 200
+    assert (
+        metrics.registry.get_sample_value("mlflow_http_request_total", labels=success_labels) == 1
+    )
+
     # test metrics for failed responses
     failure_labels = {"method": "GET", "status": "404"}
     assert (


### PR DESCRIPTION
Signed-off-by: joncarter1 <jonathan.carter@magd.ox.ac.uk>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

(Partially*) fulfills https://github.com/mlflow/mlflow/issues/4594
** Closes https://github.com/mlflow/mlflow/issues/4120 

*This PR doesn't implement a method within the Python API. It would be nice to add this into the Python API in a future PR to avoid manual SSL certs/HTTP Auth set-up on the user side since MLflow already handles this under the hood.
**UI has displayed the server version for a few releases now. The additional REST API support of this PR should suffice to close this issue.

## What changes are proposed in this pull request?

This PR implements a ``/version`` endpoint on the tracking server which can be used to retrieve the running MLflow version programmatically. This can be useful as part of a check prior to starting an experiment run, to ensure that the client is up to date with the server. This is particularly useful in organisations where there is (any) distinction between users of the service and those responsible for its maintenance.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->
- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)


## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

Added a small section to the tracking server documentation with an example of querying the server version in Python.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [X] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
