### PR TITLE
Renaming estimator_spec to custom for training and custom_loader_method to loader_method for ingest

### DIFF
--- a/docs/source/recipes.rst
+++ b/docs/source/recipes.rst
@@ -385,7 +385,7 @@ The main components of the Recipe Template layout, which are common across all r
       transform:
         transformer_method: steps.transform.transformer_fn
       train:
-        using: estimator_spec
+        using: custom
         estimator_method: steps.train.estimator_fn
       evaluate:
         validation_criteria:

--- a/mlflow/recipes/dag_help_strings.py
+++ b/mlflow/recipes/dag_help_strings.py
@@ -19,7 +19,7 @@ recipe: "regression/v1"
 data:
   location: {{INGEST_DATA_LOCATION}}
   format: {{INGEST_DATA_FORMAT|default('parquet')}}
-  custom_loader_method: steps.ingest.load_file_as_dataframe
+  loader_method: steps.ingest.load_file_as_dataframe
 target_col: "fare_amount"
 steps:
   split:
@@ -45,12 +45,12 @@ metrics:
 """
 )
 
-INGEST_STEP_BASE = """The '{0}' step resolves the dataset specified by the '{1}' section in recipe.yaml and converts it to parquet format, leveraging the custom dataset parsing code defined in `steps/ingest.py` (and referred to by the 'custom_loader_method' attribute of the '{1}' section in recipe.yaml) if necessary. {2} An example recipe.yaml '{1}' configuration is shown below.
+INGEST_STEP_BASE = """The '{0}' step resolves the dataset specified by the '{1}' section in recipe.yaml and converts it to parquet format, leveraging the custom dataset parsing code defined in `steps/ingest.py` (and referred to by the 'loader_method' attribute of the '{1}' section in recipe.yaml) if necessary. {2} An example recipe.yaml '{1}' configuration is shown below.
 
 {1}:
   location: https://nyc-tlc.s3.amazonaws.com/trip+data/yellow_tripdata_2022-01.parquet
   format: {{{{INGEST_DATA_FORMAT|default('parquet')}}}}
-  custom_loader_method: steps.ingest.load_file_as_dataframe
+  loader_method: steps.ingest.load_file_as_dataframe
 """
 
 INGEST_STEP = format_help_string(
@@ -62,7 +62,7 @@ INGEST_STEP = format_help_string(
 )
 
 INGEST_USER_CODE = format_help_string(
-    """\"\"\"\nsteps/ingest.py defines customizable logic for parsing arbitrary dataset formats (i.e. formats that are not natively parsed by MLflow Recipes) via the `load_file_as_dataframe` function. Note that the Parquet, Delta, and Spark SQL dataset formats are natively parsed by MLflow Recipes, and you do not need to define custom logic for parsing them. An example `load_file_as_dataframe` implementation is displayed below (note that a different function name or module can be specified via the 'custom_loader_method' attribute of the 'data' section in recipe.yaml).\n\"\"\"\n
+    """\"\"\"\nsteps/ingest.py defines customizable logic for parsing arbitrary dataset formats (i.e. formats that are not natively parsed by MLflow Recipes) via the `load_file_as_dataframe` function. Note that the Parquet, Delta, and Spark SQL dataset formats are natively parsed by MLflow Recipes, and you do not need to define custom logic for parsing them. An example `load_file_as_dataframe` implementation is displayed below (note that a different function name or module can be specified via the 'loader_method' attribute of the 'data' section in recipe.yaml).\n\"\"\"\n
 def load_file_as_dataframe(
     file_path: str,
     file_format: str,

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -17,7 +17,7 @@ kaleido
 transformers
 # Required by tuning tests
 hyperopt
-# Required by pipelines tests
+# Required by recipes tests
 ipython
 # Required by automl tests
 flaml

--- a/tests/recipes/test_ingest_step.py
+++ b/tests/recipes/test_ingest_step.py
@@ -132,7 +132,7 @@ def test_ingests_csv_successfully(
                 "ingest": {
                     "using": "csv",
                     "location": dataset_path,
-                    "custom_loader_method": "steps.ingest.load_file_as_dataframe",
+                    "loader_method": "steps.ingest.load_file_as_dataframe",
                 }
             },
         },
@@ -160,7 +160,7 @@ def test_ingests_remote_http_datasets_with_multiple_files_successfully(tmp_path)
                         "https://archive.ics.uci.edu/ml/machine-learning-databases/wine-quality/winequality-red.csv",
                         "https://archive.ics.uci.edu/ml/machine-learning-databases/wine-quality/winequality-white.csv",
                     ],
-                    "custom_loader_method": "tests.recipes.test_ingest_step.custom_load_wine_csv",
+                    "loader_method": "tests.recipes.test_ingest_step.custom_load_wine_csv",
                 }
             },
         },
@@ -199,7 +199,7 @@ def test_ingests_custom_format_successfully(use_relative_path, multiple_files, p
                 "ingest": {
                     "using": "fooformat",
                     "location": str(dataset_path),
-                    "custom_loader_method": (
+                    "loader_method": (
                         "tests.recipes.test_ingest_step.custom_load_file_as_dataframe"
                     ),
                 }
@@ -213,7 +213,7 @@ def test_ingests_custom_format_successfully(use_relative_path, multiple_files, p
 
 
 @pytest.mark.usefixtures("enter_test_recipe_directory")
-def test_ingest_throws_for_custom_dataset_when_custom_loader_function_cannot_be_imported(
+def test_ingest_throws_for_custom_dataset_when_loader_function_cannot_be_imported(
     pandas_df, tmp_path
 ):
     dataset_path = tmp_path / "df.fooformat"
@@ -227,7 +227,7 @@ def test_ingest_throws_for_custom_dataset_when_custom_loader_function_cannot_be_
                     "ingest": {
                         "using": "fooformat",
                         "location": str(dataset_path),
-                        "custom_loader_method": ("non.existent.module.non.existent.method"),
+                        "loader_method": ("non.existent.module.non.existent.method"),
                     }
                 },
             },
@@ -236,7 +236,7 @@ def test_ingest_throws_for_custom_dataset_when_custom_loader_function_cannot_be_
 
 
 @pytest.mark.usefixtures("enter_test_recipe_directory")
-def test_ingest_throws_for_custom_dataset_when_custom_loader_function_not_implemented_for_format(
+def test_ingest_throws_for_custom_dataset_when_loader_function_not_implemented_for_format(
     pandas_df, tmp_path
 ):
     dataset_path = tmp_path / "df.fooformat"
@@ -252,7 +252,7 @@ def test_ingest_throws_for_custom_dataset_when_custom_loader_function_not_implem
                     "ingest": {
                         "using": "fooformat",
                         "location": str(dataset_path),
-                        "custom_loader_method": "steps.ingest.load_file_as_dataframe",
+                        "loader_method": "steps.ingest.load_file_as_dataframe",
                     }
                 },
             },
@@ -277,7 +277,7 @@ def test_ingest_throws_for_custom_dataset_when_custom_method_returns_array(panda
                     "ingest": {
                         "using": "fooformat",
                         "location": str(dataset_path),
-                        "custom_loader_method": (
+                        "loader_method": (
                             "tests.recipes.test_ingest_step.custom_load_file_as_array"
                         ),
                     }
@@ -288,7 +288,7 @@ def test_ingest_throws_for_custom_dataset_when_custom_method_returns_array(panda
 
 
 @pytest.mark.usefixtures("enter_test_recipe_directory")
-def test_ingest_throws_for_custom_dataset_when_custom_loader_function_throws_unexpectedly(
+def test_ingest_throws_for_custom_dataset_when_loader_function_throws_unexpectedly(
     pandas_df, tmp_path
 ):
     dataset_path = tmp_path / "df.fooformat"
@@ -297,8 +297,8 @@ def test_ingest_throws_for_custom_dataset_when_custom_loader_function_throws_une
     with mock.patch(
         "tests.recipes.test_ingest_step.custom_load_file_as_dataframe",
         side_effect=Exception("Failed to load!"),
-    ) as mock_custom_loader:
-        setattr(mock_custom_loader, "__name__", "custom_load_file_as_dataframe")
+    ) as mock_loader:
+        setattr(mock_loader, "__name__", "custom_load_file_as_dataframe")
         with pytest.raises(
             MlflowException, match="Unable to load data file at path.*using custom loader method"
         ):
@@ -309,7 +309,7 @@ def test_ingest_throws_for_custom_dataset_when_custom_loader_function_throws_une
                         "ingest": {
                             "using": "fooformat",
                             "location": str(dataset_path),
-                            "custom_loader_method": (
+                            "loader_method": (
                                 "tests.recipes.test_ingest_step.custom_load_file_as_dataframe"
                             ),
                         }
@@ -352,7 +352,7 @@ def test_ingests_remote_http_datasets_successfully(tmp_path):
                 "ingest": {
                     "using": "csv",
                     "location": dataset_url,
-                    "custom_loader_method": "steps.ingest.load_file_as_dataframe",
+                    "loader_method": "steps.ingest.load_file_as_dataframe",
                 }
             },
         },
@@ -731,14 +731,14 @@ def test_ingest_throws_when_required_dataset_config_keys_are_missing():
                 "ingest": {
                     "using": "csv",
                     "location": "my/dataset.csv",
-                    # Missing custom_loader_method
+                    # Missing loader_method
                 }
             },
         },
         recipe_root=os.getcwd(),
     )
     with pytest.raises(
-        MlflowException, match="The `custom_loader_method` configuration key must be specified"
+        MlflowException, match="The `loader_method` configuration key must be specified"
     ):
         ingest_step._validate_and_apply_step_config()
 

--- a/tests/recipes/test_train_step.py
+++ b/tests/recipes/test_train_step.py
@@ -104,7 +104,7 @@ def setup_train_step_with_tuning(
                 tracking_uri: {tracking_uri}
             steps:
                 train:
-                    using: estimator_spec
+                    using: custom
                     estimator_method: tests.recipes.test_train_step.estimator_fn
                     {estimator_params}
                     tuning:
@@ -140,7 +140,7 @@ def setup_train_step_with_tuning(
                 tracking_uri: {tracking_uri}
             steps:
                 train:
-                    using: estimator_spec
+                    using: custom
                     estimator_method: tests.recipes.test_train_step.estimator_fn
                     tuning:
                         enabled: false
@@ -171,7 +171,7 @@ def test_train_step(tmp_recipe_root_path):
                 tracking_uri: {tracking_uri}
             steps:
                 train:
-                    using: estimator_spec
+                    using: custom
                     estimator_method: tests.recipes.test_train_step.estimator_fn
                     tuning:
                         enabled: false
@@ -210,7 +210,7 @@ def test_train_step_imbalanced_data(tmp_recipe_root_path, capsys):
                 tracking_uri: {tracking_uri}
             steps:
                 train:
-                    using: estimator_spec
+                    using: custom
                     estimator_method: tests.recipes.test_train_step.classifier_estimator_fn
                     tuning:
                         enabled: false


### PR DESCRIPTION
## What changes are proposed in this pull request?
Renaming estimator_spec to custom for training and custom_loader_method to loader_method for ingest

## How is this patch tested?
- [x] test passes

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
