### PR TITLE
Update custom method to not include the module name

### DIFF
--- a/docs/source/recipes.rst
+++ b/docs/source/recipes.rst
@@ -383,10 +383,10 @@ The main components of the Recipe Template layout, which are common across all r
       split:
         split_ratios: {{SPLIT_RATIOS|default([0.75, 0.125, 0.125])}}
       transform:
-        transformer_method: steps.transform.transformer_fn
+        transformer_method: transformer_fn
       train:
         using: custom
-        estimator_method: steps.train.estimator_fn
+        estimator_method: estimator_fn
       evaluate:
         validation_criteria:
           - metric: root_mean_squared_error

--- a/mlflow/recipes/dag_help_strings.py
+++ b/mlflow/recipes/dag_help_strings.py
@@ -19,16 +19,16 @@ recipe: "regression/v1"
 data:
   location: {{INGEST_DATA_LOCATION}}
   format: {{INGEST_DATA_FORMAT|default('parquet')}}
-  loader_method: steps.ingest.load_file_as_dataframe
+  loader_method: load_file_as_dataframe
 target_col: "fare_amount"
 steps:
   split:
     split_ratios: {{SPLIT_RATIOS|default([0.75, 0.125, 0.125])}}
-    post_split_method: steps.split.process_splits
+    post_split_method: process_splits
   transform:
-    transformer_method: steps.transform.transformer_fn
+    transformer_method: transformer_fn
   train:
-    estimator_method: steps.train.estimator_fn
+    estimator_method: estimator_fn
   evaluate:
     validation_criteria:
       - metric: root_mean_squared_error
@@ -50,7 +50,7 @@ INGEST_STEP_BASE = """The '{0}' step resolves the dataset specified by the '{1}'
 {1}:
   location: https://nyc-tlc.s3.amazonaws.com/trip+data/yellow_tripdata_2022-01.parquet
   format: {{{{INGEST_DATA_FORMAT|default('parquet')}}}}
-  loader_method: steps.ingest.load_file_as_dataframe
+  loader_method: load_file_as_dataframe
 """
 
 INGEST_STEP = format_help_string(
@@ -89,7 +89,7 @@ SPLIT_STEP = format_help_string(
 steps:
   split:
     split_ratios: {{SPLIT_RATIOS|default([0.75, 0.125, 0.125])}}
-    post_split_method: steps.split.process_splits
+    post_split_method: process_splits
 """
 )
 
@@ -128,7 +128,7 @@ TRANSFORM_STEP = format_help_string(
 
 steps:
   transform:
-    transformer_method: steps.transform.transformer_fn
+    transformer_method: transformer_fn
 """
 )
 
@@ -154,7 +154,7 @@ TRAIN_STEP = format_help_string(
 
 steps:
   train:
-    estimator_method: steps.train.estimator_fn
+    estimator_method: estimator_fn
 
 metrics:
   custom:

--- a/mlflow/recipes/steps/ingest/datasets.py
+++ b/mlflow/recipes/steps/ingest/datasets.py
@@ -35,6 +35,8 @@ _logger = logging.getLogger(__name__)
 
 _DatasetType = TypeVar("_Dataset")
 
+_USER_DEFINED_INGEST_STEP_MODULE = "steps.ingest"
+
 
 class _Dataset:
     """
@@ -419,9 +421,8 @@ class CustomDataset(_PandasConvertibleDataset):
         :param location: The location of the dataset
                          (e.g. '/tmp/myfile.parquet', './mypath', 's3://mybucket/mypath', ...).
         :param dataset_format: The format of the dataset (e.g. 'csv', 'parquet', ...).
-        :param loader_method: The fully qualified name of the custom loader method used to
-                                     load and convert the dataset to parquet format, e.g.
-                                     `steps.ingest.load_file_as_dataframe`.
+        :param loader_method: The custom loader method used to load and convert the dataset
+                              to parquet format, e.g.`load_file_as_dataframe`.
         :param recipe_root: The absolute path of the associated recipe root directory on the
                               local filesystem.
         """
@@ -431,10 +432,7 @@ class CustomDataset(_PandasConvertibleDataset):
             recipe_root=recipe_root,
         )
         self.recipe_root = recipe_root
-        (
-            self.loader_module_name,
-            self.loader_method_name,
-        ) = loader_method.rsplit(".", 1)
+        self.loader_method = loader_method
 
     def _validate_user_code_output(self, func, *args):
         import pandas as pd
@@ -444,7 +442,8 @@ class CustomDataset(_PandasConvertibleDataset):
             raise MlflowException(
                 message=(
                     "The `ingested_data` is not a DataFrame, please make sure "
-                    f"'{self.loader_method_name}' returns a Pandas DataFrame object."
+                    f"'{_USER_DEFINED_INGEST_STEP_MODULE}.{self.loader_method}'"
+                    "returns a Pandas DataFrame object."
                 ),
                 error_code=INVALID_PARAMETER_VALUE,
             ) from None
@@ -454,14 +453,14 @@ class CustomDataset(_PandasConvertibleDataset):
         try:
             sys.path.append(self.recipe_root)
             loader_method = getattr(
-                importlib.import_module(self.loader_module_name),
-                self.loader_method_name,
+                importlib.import_module(_USER_DEFINED_INGEST_STEP_MODULE),
+                self.loader_method,
             )
         except Exception as e:
             raise MlflowException(
                 message=(
                     "Failed to import custom dataset loader function"
-                    f" '{self.loader_module_name}.{self.loader_method_name}' for"
+                    f" '{_USER_DEFINED_INGEST_STEP_MODULE}.{self.loader_method}' for"
                     f" ingesting dataset with format '{self.dataset_format}'.",
                 ),
                 error_code=BAD_REQUEST,

--- a/mlflow/recipes/steps/train.py
+++ b/mlflow/recipes/steps/train.py
@@ -57,6 +57,7 @@ from mlflow.utils.string_utils import strip_prefix
 
 _REBALANCING_CUTOFF = 5000
 _REBALANCING_DEFAULT_RATIO = 0.3
+_USER_DEFINED_TRAIN_STEP_MODULE = "steps.train"
 
 _logger = logging.getLogger(__name__)
 
@@ -480,11 +481,11 @@ class TrainStep(BaseStep):
             warnings.warn = original_warn
 
     def _get_user_defined_estimator(self, X_train, y_train, validation_df, run, output_directory):
-        train_module_name, estimator_method_name = self.step_config["estimator_method"].rsplit(
-            ".", 1
-        )
         sys.path.append(self.recipe_root)
-        estimator_fn = getattr(importlib.import_module(train_module_name), estimator_method_name)
+        estimator_fn = getattr(
+            importlib.import_module(_USER_DEFINED_TRAIN_STEP_MODULE),
+            self.step_config["estimator_method"],
+        )
         estimator_hardcoded_params = self.step_config["estimator_params"]
 
         # if using rebalancing pass in original class weights to preserve original distribution

--- a/mlflow/recipes/steps/transform.py
+++ b/mlflow/recipes/steps/transform.py
@@ -18,6 +18,8 @@ from mlflow.exceptions import MlflowException, INVALID_PARAMETER_VALUE
 
 _logger = logging.getLogger(__name__)
 
+_USER_DEFINED_TRANSFORM_STEP_MODULE = "steps.transform"
+
 
 def _generate_feature_names(num_features):
     max_length = len(str(num_features))
@@ -110,12 +112,8 @@ class TransformStep(BaseStep):
 
         method_config = self.step_config.get("transformer_method")
         if method_config:
-            (
-                transformer_module_name,
-                transformer_method_name,
-            ) = method_config.rsplit(".", 1)
             transformer_fn = getattr(
-                importlib.import_module(transformer_module_name), transformer_method_name
+                importlib.import_module(_USER_DEFINED_TRANSFORM_STEP_MODULE), method_config
             )
             transformer = _validate_user_code_output(transformer_fn)
         transformer = transformer if transformer else get_identity_transformer()

--- a/tests/recipes/test_execution_utils.py
+++ b/tests/recipes/test_execution_utils.py
@@ -93,7 +93,7 @@ def test_recipe(
             "target_col": "C",
             "steps": {
                 "transform": {
-                    "transformer_method": "steps.transform.transform_fn",
+                    "transformer_method": "transform_fn",
                 },
             },
         },

--- a/tests/recipes/test_ingest_step.py
+++ b/tests/recipes/test_ingest_step.py
@@ -132,7 +132,7 @@ def test_ingests_csv_successfully(
                 "ingest": {
                     "using": "csv",
                     "location": dataset_path,
-                    "loader_method": "steps.ingest.load_file_as_dataframe",
+                    "loader_method": "load_file_as_dataframe",
                 }
             },
         },
@@ -149,25 +149,29 @@ def custom_load_wine_csv(file_path, file_format):  # pylint: disable=unused-argu
 
 @pytest.mark.usefixtures("enter_test_recipe_directory")
 def test_ingests_remote_http_datasets_with_multiple_files_successfully(tmp_path):
-    IngestStep.from_recipe_config(
-        recipe_config={
-            "target_col": "density",
-            "steps": {
-                "ingest": {
-                    "skip_data_profiling": True,
-                    "using": "csv",
-                    "location": [
-                        "https://archive.ics.uci.edu/ml/machine-learning-databases/wine-quality/winequality-red.csv",
-                        "https://archive.ics.uci.edu/ml/machine-learning-databases/wine-quality/winequality-white.csv",
-                    ],
-                    "loader_method": "tests.recipes.test_ingest_step.custom_load_wine_csv",
-                }
+    with mock.patch(
+        "steps.ingest.load_file_as_dataframe",
+        custom_load_wine_csv,
+    ):
+        IngestStep.from_recipe_config(
+            recipe_config={
+                "target_col": "density",
+                "steps": {
+                    "ingest": {
+                        "skip_data_profiling": True,
+                        "using": "csv",
+                        "location": [
+                            "https://archive.ics.uci.edu/ml/machine-learning-databases/wine-quality/winequality-red.csv",
+                            "https://archive.ics.uci.edu/ml/machine-learning-databases/wine-quality/winequality-white.csv",
+                        ],
+                        "loader_method": "load_file_as_dataframe",
+                    }
+                },
             },
-        },
-        recipe_root=os.getcwd(),
-    ).run(output_directory=tmp_path)
-    reloaded_df = pd.read_parquet(str(tmp_path / "dataset.parquet"))
-    assert reloaded_df.count()[0] == 6497
+            recipe_root=os.getcwd(),
+        ).run(output_directory=tmp_path)
+        reloaded_df = pd.read_parquet(str(tmp_path / "dataset.parquet"))
+        assert reloaded_df.count()[0] == 6497
 
 
 def custom_load_file_as_dataframe(file_path, file_format):  # pylint: disable=unused-argument
@@ -192,24 +196,26 @@ def test_ingests_custom_format_successfully(use_relative_path, multiple_files, p
     if use_relative_path:
         dataset_path = os.path.relpath(dataset_path)
 
-    IngestStep.from_recipe_config(
-        recipe_config={
-            "target_col": "C",
-            "steps": {
-                "ingest": {
-                    "using": "fooformat",
-                    "location": str(dataset_path),
-                    "loader_method": (
-                        "tests.recipes.test_ingest_step.custom_load_file_as_dataframe"
-                    ),
-                }
+    with mock.patch(
+        "steps.ingest.load_file_as_dataframe",
+        custom_load_file_as_dataframe,
+    ):
+        IngestStep.from_recipe_config(
+            recipe_config={
+                "target_col": "C",
+                "steps": {
+                    "ingest": {
+                        "using": "fooformat",
+                        "location": str(dataset_path),
+                        "loader_method": "load_file_as_dataframe",
+                    }
+                },
             },
-        },
-        recipe_root=os.getcwd(),
-    ).run(output_directory=tmp_path)
+            recipe_root=os.getcwd(),
+        ).run(output_directory=tmp_path)
 
-    reloaded_df = pd.read_parquet(str(tmp_path / "dataset.parquet"))
-    pd.testing.assert_frame_equal(reloaded_df, pandas_df)
+        reloaded_df = pd.read_parquet(str(tmp_path / "dataset.parquet"))
+        pd.testing.assert_frame_equal(reloaded_df, pandas_df)
 
 
 @pytest.mark.usefixtures("enter_test_recipe_directory")
@@ -252,7 +258,7 @@ def test_ingest_throws_for_custom_dataset_when_loader_function_not_implemented_f
                     "ingest": {
                         "using": "fooformat",
                         "location": str(dataset_path),
-                        "loader_method": "steps.ingest.load_file_as_dataframe",
+                        "loader_method": "load_file_as_dataframe",
                     }
                 },
             },
@@ -268,23 +274,24 @@ def custom_load_file_as_array(local_data_file_path, dataset_format):
 def test_ingest_throws_for_custom_dataset_when_custom_method_returns_array(pandas_df, tmp_path):
     dataset_path = tmp_path / "df.fooformat"
     pandas_df.to_csv(dataset_path, sep="#")
-
-    with pytest.raises(MlflowException, match="The `ingested_data` is not a DataFrame"):
-        IngestStep.from_recipe_config(
-            recipe_config={
-                "target_col": "C",
-                "steps": {
-                    "ingest": {
-                        "using": "fooformat",
-                        "location": str(dataset_path),
-                        "loader_method": (
-                            "tests.recipes.test_ingest_step.custom_load_file_as_array"
-                        ),
-                    }
+    with mock.patch(
+        "steps.ingest.load_file_as_dataframe",
+        custom_load_file_as_array,
+    ):
+        with pytest.raises(MlflowException, match="The `ingested_data` is not a DataFrame"):
+            IngestStep.from_recipe_config(
+                recipe_config={
+                    "target_col": "C",
+                    "steps": {
+                        "ingest": {
+                            "using": "fooformat",
+                            "location": str(dataset_path),
+                            "loader_method": "load_file_as_dataframe",
+                        }
+                    },
                 },
-            },
-            recipe_root=os.getcwd(),
-        ).run(output_directory=tmp_path)
+                recipe_root=os.getcwd(),
+            ).run(output_directory=tmp_path)
 
 
 @pytest.mark.usefixtures("enter_test_recipe_directory")
@@ -295,10 +302,10 @@ def test_ingest_throws_for_custom_dataset_when_loader_function_throws_unexpected
     pandas_df.to_csv(dataset_path, sep="#")
 
     with mock.patch(
-        "tests.recipes.test_ingest_step.custom_load_file_as_dataframe",
+        "steps.ingest.load_file_as_dataframe",
         side_effect=Exception("Failed to load!"),
     ) as mock_loader:
-        setattr(mock_loader, "__name__", "custom_load_file_as_dataframe")
+        setattr(mock_loader, "__name__", "load_file_as_dataframe")
         with pytest.raises(
             MlflowException, match="Unable to load data file at path.*using custom loader method"
         ):
@@ -309,9 +316,7 @@ def test_ingest_throws_for_custom_dataset_when_loader_function_throws_unexpected
                         "ingest": {
                             "using": "fooformat",
                             "location": str(dataset_path),
-                            "loader_method": (
-                                "tests.recipes.test_ingest_step.custom_load_file_as_dataframe"
-                            ),
+                            "loader_method": "load_file_as_dataframe",
                         }
                     },
                 },
@@ -352,7 +357,7 @@ def test_ingests_remote_http_datasets_successfully(tmp_path):
                 "ingest": {
                     "using": "csv",
                     "location": dataset_url,
-                    "loader_method": "steps.ingest.load_file_as_dataframe",
+                    "loader_method": "load_file_as_dataframe",
                 }
             },
         },

--- a/tests/recipes/test_transform_step.py
+++ b/tests/recipes/test_transform_step.py
@@ -63,11 +63,13 @@ def set_up_transform_step(recipe_root: Path, transform_user_module):
 
 
 def test_transform_step_writes_onehot_encoded_dataframe_and_transformer_pkl(tmp_recipe_root_path):
+    from sklearn.preprocessing import StandardScaler
+
     with mock.patch.dict(
         os.environ, {_MLFLOW_RECIPES_EXECUTION_DIRECTORY_ENV_VAR: str(tmp_recipe_root_path)}
-    ):
+    ), mock.patch("steps.transform.transformer_fn", return_value=StandardScaler()):
         transform_step, transform_step_output_dir, _ = set_up_transform_step(
-            tmp_recipe_root_path, "sklearn.preprocessing.StandardScaler"
+            tmp_recipe_root_path, "transformer_fn"
         )
         transform_step.run(str(transform_step_output_dir))
 
@@ -106,7 +108,7 @@ def test_transform_empty_step(tmp_recipe_root_path):
         os.environ, {_MLFLOW_RECIPES_EXECUTION_DIRECTORY_ENV_VAR: str(tmp_recipe_root_path)}
     ), mock.patch("steps.transform.transformer_fn", return_value=None):
         transform_step, transform_step_output_dir, split_step_output_dir = set_up_transform_step(
-            tmp_recipe_root_path, "steps.transform.transformer_fn"
+            tmp_recipe_root_path, "transformer_fn"
         )
         transform_step.run(str(transform_step_output_dir))
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
Update custom method to not include the module name

## How is this patch tested?
- [x] Update recipe [example](https://github.com/mlflow/recipes-examples/pull/17) and [template](https://github.com/mlflow/recipes-regression-template/pull/11)

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
