### PR TITLE
Adding a using option of custom in transform step

### DIFF
--- a/docs/source/recipes.rst
+++ b/docs/source/recipes.rst
@@ -406,6 +406,7 @@ The main components of the Recipe Template layout, which are common across all r
       split:
         split_ratios: {{SPLIT_RATIOS|default([0.75, 0.125, 0.125])}}
       transform:
+        using: custom
         transformer_method: transformer_fn
       train:
         using: custom

--- a/mlflow/recipes/dag_help_strings.py
+++ b/mlflow/recipes/dag_help_strings.py
@@ -23,6 +23,7 @@ steps:
     split_ratios: {{SPLIT_RATIOS|default([0.75, 0.125, 0.125])}}
     post_split_filter_method: create_dataset_filter
   transform:
+    using: custom
     transformer_method: transformer_fn
   train:
     using: custom
@@ -128,6 +129,7 @@ TRANSFORM_STEP = format_help_string(
 
 steps:
   transform:
+    using: custom
     transformer_method: transformer_fn
 """
 )
@@ -154,6 +156,7 @@ TRAIN_STEP = format_help_string(
 
 steps:
   train:
+    using: custom
     estimator_method: estimator_fn
 
 custom_metrics:

--- a/mlflow/recipes/steps/transform.py
+++ b/mlflow/recipes/steps/transform.py
@@ -79,6 +79,15 @@ class TransformStep(BaseStep):
                 "Missing target_col config in recipe config.",
                 error_code=INVALID_PARAMETER_VALUE,
             )
+        if "using" in self.step_config:
+            if self.step_config["using"] not in ["custom"]:
+                raise MlflowException(
+                    f"Invalid transform step configuration value {self.step_config['using']} for "
+                    f"key 'using'. Supported values are: ['custom']",
+                    error_code=INVALID_PARAMETER_VALUE,
+                )
+        else:
+            self.step_config["using"] = "custom"
         self.run_end_time = None
         self.execution_duration = None
         self.skip_data_profiling = self.step_config.get("skip_data_profiling", False)
@@ -110,8 +119,15 @@ class TransformStep(BaseStep):
 
             return Pipeline(steps=[("identity", FunctionTransformer())])
 
+        if "transformer_method" not in self.step_config and self.step_config["using"] == "custom":
+            raise MlflowException(
+                "Missing 'transformer_method' configuration in the transform step, "
+                "which is using 'custom'.",
+                error_code=INVALID_PARAMETER_VALUE,
+            )
         method_config = self.step_config.get("transformer_method")
-        if method_config:
+        transformer = None
+        if method_config and self.step_config["using"] == "custom":
             transformer_fn = getattr(
                 importlib.import_module(_USER_DEFINED_TRANSFORM_STEP_MODULE), method_config
             )

--- a/tests/recipes/test_execution_utils.py
+++ b/tests/recipes/test_execution_utils.py
@@ -93,6 +93,7 @@ def test_recipe(
             "target_col": "C",
             "steps": {
                 "transform": {
+                    "using": "custom",
                     "transformer_method": "transform_fn",
                 },
             },

--- a/tests/recipes/test_transform_step.py
+++ b/tests/recipes/test_transform_step.py
@@ -50,6 +50,7 @@ def set_up_transform_step(recipe_root: Path, transform_user_module):
           tracking_uri: {tracking_uri}
         steps:
           transform:
+            using: custom
             transformer_method: {transform_user_module}
         """.format(
             tracking_uri=mlflow.get_tracking_uri(),


### PR DESCRIPTION
## What changes are proposed in this pull request?
Adding a using option of custom in transform step

## How is this patch tested?
- [x] The change is backwards compatible. So tests should pass
- [ ] Update example and template repo with documentation 

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
