### PR TITLE
enable `superfluous-parens / C0325` rule and fixed the pylint errors

### DIFF
--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -906,7 +906,7 @@ def _backported_all_estimators(type_filter=None):
     IS_PYPY = platform.python_implementation() == "PyPy"
 
     def is_abstract(c):
-        if not (hasattr(c, "__abstractmethods__")):
+        if not hasattr(c, "__abstractmethods__"):
             return False
         if not len(c.__abstractmethods__):
             return False

--- a/pylintrc
+++ b/pylintrc
@@ -206,8 +206,7 @@ enable=c-extension-no-member,
        singleton-comparison,
        use-dict-literal,
        use-list-literal,
-       unnecessary-lambda-assignment,
-       superfluous-parens
+       unnecessary-lambda-assignment
        
 
 [REPORTS]

--- a/pylintrc
+++ b/pylintrc
@@ -147,7 +147,6 @@ disable=print-statement,
         use-maxsplit-arg,
         consider-using-enumerate,
         unused-argument,
-        superfluous-parens,
         c-extension-no-member,
         disallowed-name,
         wrong-import-position,
@@ -207,7 +206,8 @@ enable=c-extension-no-member,
        singleton-comparison,
        use-dict-literal,
        use-list-literal,
-       unnecessary-lambda-assignment
+       unnecessary-lambda-assignment,
+       superfluous-parens
        
 
 [REPORTS]

--- a/tests/autologging/test_autologging_behaviors_unit.py
+++ b/tests/autologging/test_autologging_behaviors_unit.py
@@ -101,13 +101,13 @@ def test_autologging_warnings_are_redirected_as_expected(
         'MLflow autologging encountered a warning: "%s:5: Warning: preamble MLflow warning"',
         'MLflow autologging encountered a warning: "%s:10: Warning: postamble MLflow warning"',
     ]:
-        assert (item % mlflow.__file__) in stream.getvalue()
+        assert item % mlflow.__file__ in stream.getvalue()
     for item in [
         'MLflow autologging encountered a warning: "%s:7: UserWarning: preamble numpy warning"',
         'MLflow autologging encountered a warning: "%s:14: Warning: postamble numpy warning"',
         'MLflow autologging encountered a warning: "%s:30: Warning: enablement warning numpy"',
     ]:
-        assert (item % np.__file__) in stream.getvalue()
+        assert item % np.__file__ in stream.getvalue()
 
 
 def test_autologging_event_logging_and_warnings_respect_silent_mode(

--- a/tests/models/test_artifacts.py
+++ b/tests/models/test_artifacts.py
@@ -80,7 +80,7 @@ def test_infer_artifact_type_and_ext(is_file, artifact, artifact_type, ext, tmp_
     inferred_from_path, inferred_type, inferred_ext = _infer_artifact_type_and_ext(
         f"{ext}_{artifact_type.__name__}_artifact", artifact_representation, cm_fn_tuple
     )
-    assert not (is_file ^ inferred_from_path)
+    assert not is_file ^ inferred_from_path
     assert inferred_type is artifact_type
     assert inferred_ext == f".{ext}"
 


### PR DESCRIPTION
Signed-off-by: ayush_gitk <ayushsharmaa101@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> Solve a part of #7205

## What changes are proposed in this pull request?

enable [`superfluous-parens / C0325`](https://pylint.pycqa.org/en/latest/user_guide/messages/convention/superfluous-parens.html) and fixed the pylint errors generated

(Please fill in changes proposed in this fix)

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->
- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
