### PR TITLE
Update documentation for serving 1.x models on 2.x release

### DIFF
--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -75,8 +75,8 @@ def serve(
         # split orientation input format for serializing a pandas DataFrame
         $ curl http://127.0.0.1:5000/invocations -H 'Content-Type: application/json' -d '{
             "dataframe_split": {"columns": ["a", "b"],
-                                "index":[0, 1, 2],
-                                "data":[[1, 2], [3, 4], [5, 6]]}
+                                "index": [0, 1, 2],
+                                "data": [[1, 2], [3, 4], [5, 6]]}
         }'
 
         # inputs format for List submission of array, tensor, or DataFrame data

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -49,14 +49,14 @@ def serve(
 
         Models built using MLflow 1.x will require adjustments to the endpoint request payload
         if executed in an environment that has MLflow 2.x installed. In 1.x, a request payload
-        was of the form {'columns': [str], 'data': [[...]]}. 2.x models require
+        was of the form `{'columns': [str], 'data': [[...]]}`. 2.x models require
         payloads that are defined by the structural defining keys of either `dataframe_split`,
         `instances`, `inputs` or `dataframe_records`. See the examples below for demonstrations
         of the changes in 2.x.
 
     .. note::
 
-        Requests made in pandas DataFrame structures can be made in either 'split' or `records'
+        Requests made in pandas DataFrame structures can be made in either `split` or `records`
         oriented formats.
         See https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_json.html for
         detailed information on orientation formats for converting a pandas DataFrame to json.

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -45,7 +45,21 @@ def serve(
     For information about the input data formats accepted by the webserver, see the following
     documentation: https://www.mlflow.org/docs/latest/models.html#built-in-deployment-tools.
 
-    You can make requests to ``POST /invocations`` in pandas split- or record-oriented formats.
+    .. warning::
+
+        Models built using MLflow 1.x will require adjustments to the endpoint request payload
+        if executed in an environment that has MLflow 2.x installed. In 1.x, a request payload
+        was of the form {<Optional>'columns': [str], 'data': [[<values>]]}. 2.x models require
+        payloads that contain the data referencing keys of *one of* `dataframe_split`,
+        `instances`, `inputs` or `dataframe_records`. See the examples below for demonstrations
+        of the changes in 2.x.
+
+    .. note::
+
+        Requests made in pandas DataFrame structures can be made in either 'split' or `records'
+        oriented formats.
+        See https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_json.html for
+        detailed information on orientation formats for converting a pandas DataFrame to json.
 
     Example:
 
@@ -53,10 +67,30 @@ def serve(
 
         $ mlflow models serve -m runs:/my-run-id/model-path &
 
+        # records orientation input format for serializing a pandas DataFrame
         $ curl http://127.0.0.1:5000/invocations -H 'Content-Type: application/json' -d '{
-            "columns": ["a", "b", "c"],
-            "data": [[1, 2, 3], [4, 5, 6]]
+            "dataframe_records": [{"a":1,"b":2},{"a":3,"b":4},{"a":5,"b":6}]
         }'
+
+        # split orientation input format for serializing a pandas DataFrame
+        $ curl http://127.0.0.1:5000/invocations -H 'Content-Type: application/json' -d '{
+            "dataframe_split": {"columns":["a","b"],"index":[0,1,2],"data":[[1,2],[3,4],[5,6]]}
+        }'
+
+        # inputs format for List submission of array, tensor, or DataFrame data
+        $ curl http://127.0.0.1:5000/invocations -H 'Content-Type: application/json' -d '{
+            "inputs": [[1,2],[3,4],[5,6]]
+        }'
+
+        #instances format for submission of Tensor data
+        curl http://127.0.0.1:5000/invocations -H 'Content-Type: application/json' -d '{
+            "instances": [
+                {"a": "t1", "b": [1, 2, 3]},
+                {"a": "t2", "b": [4, 5, 6]},
+                {"a": "t3", "b": [7, 8, 9]}
+            ]
+        }'
+        
     """
     env_manager = env_manager or _EnvManager.VIRTUALENV
     return get_flavor_backend(

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -49,8 +49,8 @@ def serve(
 
         Models built using MLflow 1.x will require adjustments to the endpoint request payload
         if executed in an environment that has MLflow 2.x installed. In 1.x, a request payload
-        was of the form {<Optional>'columns': [str], 'data': [[<values>]]}. 2.x models require
-        payloads that contain the data referencing keys of *one of* `dataframe_split`,
+        was of the form {'columns': [str], 'data': [[...]]}. 2.x models require
+        payloads that are defined by the structural defining keys of either `dataframe_split`,
         `instances`, `inputs` or `dataframe_records`. See the examples below for demonstrations
         of the changes in 2.x.
 
@@ -82,7 +82,7 @@ def serve(
             "inputs": [[1,2],[3,4],[5,6]]
         }'
 
-        #instances format for submission of Tensor data
+        # instances format for submission of Tensor data
         curl http://127.0.0.1:5000/invocations -H 'Content-Type: application/json' -d '{
             "instances": [
                 {"a": "t1", "b": [1, 2, 3]},
@@ -90,7 +90,7 @@ def serve(
                 {"a": "t3", "b": [7, 8, 9]}
             ]
         }'
-        
+
     """
     env_manager = env_manager or _EnvManager.VIRTUALENV
     return get_flavor_backend(

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -69,17 +69,19 @@ def serve(
 
         # records orientation input format for serializing a pandas DataFrame
         $ curl http://127.0.0.1:5000/invocations -H 'Content-Type: application/json' -d '{
-            "dataframe_records": [{"a":1,"b":2},{"a":3,"b":4},{"a":5,"b":6}]
+            "dataframe_records": [{"a":1, "b":2}, {"a":3, "b":4}, {"a":5, "b":6}]
         }'
 
         # split orientation input format for serializing a pandas DataFrame
         $ curl http://127.0.0.1:5000/invocations -H 'Content-Type: application/json' -d '{
-            "dataframe_split": {"columns":["a","b"],"index":[0,1,2],"data":[[1,2],[3,4],[5,6]]}
+            "dataframe_split": {"columns": ["a", "b"],
+                                "index":[0, 1, 2],
+                                "data":[[1, 2], [3, 4], [5, 6]]}
         }'
 
         # inputs format for List submission of array, tensor, or DataFrame data
         $ curl http://127.0.0.1:5000/invocations -H 'Content-Type: application/json' -d '{
-            "inputs": [[1,2],[3,4],[5,6]]
+            "inputs": [[1, 2], [3, 4], [5, 6]]
         }'
 
         # instances format for submission of Tensor data

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -49,10 +49,10 @@ def serve(
 
         Models built using MLflow 1.x will require adjustments to the endpoint request payload
         if executed in an environment that has MLflow 2.x installed. In 1.x, a request payload
-        was of the form `{'columns': [str], 'data': [[...]]}`. 2.x models require
-        payloads that are defined by the structural defining keys of either `dataframe_split`,
-        `instances`, `inputs` or `dataframe_records`. See the examples below for demonstrations
-        of the changes in 2.x.
+        was in the format: ``{'columns': [str], 'data': [[...]]}``. 2.x models require
+        payloads that are defined by the structural-defining keys of either ``dataframe_split``,
+        ``instances``, ``inputs`` or ``dataframe_records``. See the examples below for
+        demonstrations of the changes to the invocation API endpoint in 2.0.
 
     .. note::
 


### PR DESCRIPTION
Signed-off-by: Ben Wilson <benjamin.wilson@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Documentation updates in the pydoc strings for the cli serve function to illustrate and explain the differences in 2.x and how to correct serving exceptions that may arise. Also added additional formatting examples to curl request examples.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->
- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [X] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
