### PR TITLE
Improve documentation preview comment

### DIFF
--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -1,7 +1,7 @@
 name: Preview docs
 
 on:
-  pull_request_target:
+  pull_request:
 jobs:
   main:
     if: github.repository == 'mlflow/mlflow'
@@ -15,4 +15,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.MLFLOW_AUTOMATION_TOKEN }}
         run: |
-          python dev/preview_docs.py --commit-sha ${{ github.event.pull_request.head.sha }} --pull-number ${{ github.event.pull_request.number }}
+          python dev/preview_docs.py \
+            --commit-sha ${{ github.event.pull_request.head.sha }} \
+            --pull-number ${{ github.event.pull_request.number }} \
+            --workflow-run-id ${{ github.run_id }}

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -1,7 +1,7 @@
 name: Preview docs
 
 on:
-  pull_request:
+  pull_request_target:
 jobs:
   main:
     if: github.repository == 'mlflow/mlflow'

--- a/dev/preview_docs.py
+++ b/dev/preview_docs.py
@@ -93,7 +93,7 @@ def main():
     comment_body = f"""
 {marker}
 
-### Documentation preview for {args.commit_sha} will be available [here]({artifact_url}).
+### Documentation preview for {args.commit_sha} will be available [here]({artifact_url}) when [this CircleCI job]({job_url}) completes successfully.
 
 <details>
 <summary>More info</summary>
@@ -101,7 +101,6 @@ def main():
 - Ignore this comment if this PR does not change the documentation.
 - It takes a few minutes for the preview to be available.
 - The preview is updated when a new commit is pushed to this PR.
-- The preview was created by {job_url}.
 - This comment was created by {workflow_run_link}.
 
 </details>

--- a/dev/preview_docs.py
+++ b/dev/preview_docs.py
@@ -2,7 +2,6 @@ import os
 import requests
 import argparse
 import time
-from datetime import datetime
 from urllib.parse import urlparse
 
 
@@ -27,6 +26,7 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--commit-sha", required=True)
     parser.add_argument("--pull-number", required=True)
+    parser.add_argument("--workflow-run-id", required=True)
     args = parser.parse_args()
 
     token = os.environ.get("GITHUB_TOKEN")
@@ -38,6 +38,7 @@ def main():
     repo = "mlflow/mlflow"
     build_doc_job_name = "build_doc"
     job_id = None
+    workflow_run_link = f"https://github.com/{repo}/actions/runs/{args.workflow_run_id}"
     for _ in range(5):
         status = session.get(
             f"https://api.github.com/repos/{repo}/commits/{args.commit_sha}/status"
@@ -53,6 +54,24 @@ def main():
         time.sleep(3)
     else:
         print(f"Could not find {build_doc_job_name} job status")
+        comment = f"""
+### Failed to find a documentation preview link for {args.commit_sha}.
+
+<details>
+<summary>More info</summary>
+
+- If the `ci/circleci: {build_doc_job_name}` job status is successful, you can see the preview with the following steps:
+  1. Click `Details`.
+  2. Click `Artifacts`.
+  3. Click `docs/build/html/index.html`.
+- This comment was created by {workflow_run_link}.
+
+</details>
+"""
+        session.post(
+            f"https://api.github.com/repos/{repo}/issues/{args.pull_number}/comments",
+            json={"body": comment},
+        )
         return
 
     # Get the artifact URL of the top level index.html
@@ -74,16 +93,16 @@ def main():
     comment_body = f"""
 {marker}
 
-### Documentation preview will be available [here]({artifact_url}).
+### Documentation preview for {args.commit_sha} will be available [here]({artifact_url}).
 
 <details>
-<summary>Notes</summary>
+<summary>More info</summary>
 
 - Ignore this comment if this PR does not change the documentation.
 - It takes a few minutes for the preview to be available.
-- The preview is updated on every commit to this PR.
-- Job URL: {job_url}
-- Updated at: {datetime.now()}
+- The preview is updated when a new commit is pushed to this PR.
+- The preview was created by {job_url}.
+- This comment was created by {workflow_run_link}.
 
 </details>
 """

--- a/dev/preview_docs.py
+++ b/dev/preview_docs.py
@@ -55,7 +55,7 @@ def main():
     else:
         print(f"Could not find {build_doc_job_name} job status")
         comment = f"""
-### Failed to find a documentation preview for {args.commit_sha}.
+Failed to find a documentation preview for {args.commit_sha}.
 
 <details>
 <summary>More info</summary>
@@ -93,7 +93,7 @@ def main():
     comment_body = f"""
 {marker}
 
-### Documentation preview for {args.commit_sha} will be available [here]({artifact_url}) when [this CircleCI job]({job_url}) completes successfully.
+Documentation preview for {args.commit_sha} will be available [here]({artifact_url}) when [this CircleCI job]({job_url}) completes successfully.
 
 <details>
 <summary>More info</summary>

--- a/dev/preview_docs.py
+++ b/dev/preview_docs.py
@@ -55,7 +55,7 @@ def main():
     else:
         print(f"Could not find {build_doc_job_name} job status")
         comment = f"""
-### Failed to find a documentation preview link for {args.commit_sha}.
+### Failed to find a documentation preview for {args.commit_sha}.
 
 <details>
 <summary>More info</summary>


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

1. Include a commit SHA in the message.
2. Include the workflow run that created a preview comment in the message.
3. If the `build_doc` job status is not found, state "failed to find a preview link".

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->
- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
