### PR TITLE
feat: adjusted column order and icon sizes in experiment runs table

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsTable.tsx
@@ -6,6 +6,7 @@ import {
   SelectionChangedEvent,
 } from '@ag-grid-community/core';
 import { Theme } from '@emotion/react';
+import cx from 'classnames';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { MLFlowAgGridLoader } from '../../../../../common/components/ag-grid/AgGridLoader';
@@ -80,6 +81,8 @@ export const ExperimentViewRunsTable = React.memo(
     const [columnApi, setColumnApi] = useState<ColumnApi>();
     const prevSelectRunUuids = useRef<string[]>([]);
     const [runsCount, setRunsCount] = useState(runInfos.length);
+    // Flag indicating if there are any rows that can be expanded
+    const [expandersVisible, setExpandersVisible] = useState(false);
 
     const filteredTagKeys = useMemo(() => Utils.getVisibleTagKeyList(tagsList), [tagsList]);
 
@@ -211,7 +214,9 @@ export const ExperimentViewRunsTable = React.memo(
         runsPinned,
       });
       gridApi.setRowData(data);
+
       setRunsCount(data.length);
+      setExpandersVisible(data.some((row) => row.runDateAndNestInfo?.hasExpander));
     }, [
       gridApi,
       isLoading,
@@ -312,7 +317,9 @@ export const ExperimentViewRunsTable = React.memo(
         </div>
         <div
           ref={containerElement}
-          className='ag-theme-balham ag-grid-sticky'
+          className={cx('ag-theme-balham ag-grid-sticky', {
+            'ag-grid-expanders-visible': expandersVisible,
+          })}
           css={styles.agGridOverrides}
         >
           <MLFlowAgGridLoader

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/cells/DateCellRenderer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/cells/DateCellRenderer.tsx
@@ -1,4 +1,5 @@
 import { CheckCircleBorderIcon, ClockIcon, XCircleBorderIcon } from '@databricks/design-system';
+import { Theme } from '@emotion/react';
 import React from 'react';
 import Utils from '../../../../../../common/utils/Utils';
 import { RunRowDateAndNestInfo } from '../../../utils/experimentPage.row-types';
@@ -21,65 +22,33 @@ const getRunStatusIcon = (status: string) => {
     case 'SCHEDULED':
       return <ClockIcon />; // This one is the same color as the link
     default:
-      return <i />;
+      return null;
   }
 };
 
 export interface DateCellRendererProps {
   value: RunRowDateAndNestInfo;
-  onExpand: (runUuid: string, childrenIds?: string[]) => void;
 }
 
-const INDENT_PER_LEVEL = 18; // Pixels
-const BASIC_INDENT = 12; // Pixels
-
 export const DateCellRenderer = React.memo(
-  ({
-    value: {
-      startTime,
-      referenceTime,
-      runUuid,
-      runStatus,
-      isParent,
-      hasExpander,
-      expanderOpen,
-      childrenIds,
-      level,
-    },
-    onExpand,
-  }: DateCellRendererProps) => {
-    const isRenderingAsParent = !isNaN(level) && hasExpander;
-    const isRenderingAsChild = !isRenderingAsParent && !isNaN(level);
-
+  ({ value: { startTime, referenceTime, runStatus } }: DateCellRendererProps) => {
     return (
-      <div>
-        {isRenderingAsParent && (
-          // eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
-          <div
-            onClick={() => {
-              onExpand(runUuid, childrenIds);
-            }}
-            key={'Expander-' + runUuid}
-            css={(theme) => ({ paddingRight: theme.spacing.sm, display: 'inline' })}
-          >
-            <span style={{ paddingLeft: INDENT_PER_LEVEL * level }} />
-            <i
-              className={`ExperimentView-expander far fa-${expanderOpen ? 'minus' : 'plus'}-square`}
-              css={{ width: BASIC_INDENT }}
-            />
-          </div>
-        )}
-        {isRenderingAsChild && (
-          <span
-            style={{
-              paddingLeft: INDENT_PER_LEVEL * level + BASIC_INDENT,
-            }}
-          />
-        )}
-        <span css={{ paddingLeft: isParent ? 0 : 8 }} title={Utils.formatTimestamp(startTime)}>
-          {getRunStatusIcon(runStatus)} {Utils.timeSinceStr(startTime, referenceTime)}
-        </span>
-      </div>
+      <span css={styles.cellWrapper} title={Utils.formatTimestamp(startTime)}>
+        {getRunStatusIcon(runStatus)}
+        {Utils.timeSinceStr(startTime, referenceTime)}
+      </span>
     );
   },
 );
+
+const styles = {
+  cellWrapper: (theme: Theme) => ({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing.sm,
+    svg: {
+      width: 14,
+      height: 14,
+    },
+  }),
+};

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/cells/PinRowCellRenderer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/cells/PinRowCellRenderer.tsx
@@ -43,12 +43,12 @@ export const PinRowCellRenderer = React.memo(
 
 const styles = {
   pinWrapper: (theme: Theme) => ({
-    input: { width: 0 },
+    input: { width: 0, appearance: 'none' as const },
     cursor: 'pointer',
     display: 'inline-block',
     svg: {
-      width: 16,
-      height: 16,
+      width: 14,
+      height: 14,
       cursor: 'pointer',
       color: 'transparent',
     },

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/cells/RunNameCellRenderer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/cells/RunNameCellRenderer.tsx
@@ -1,19 +1,47 @@
 import { ICellRendererParams } from '@ag-grid-community/core';
+import { Button, MinusBoxIcon, PlusSquareIcon } from '@databricks/design-system';
 import { Theme } from '@emotion/react';
 import React from 'react';
 import { Link } from 'react-router-dom';
 import Routes from '../../../../../routes';
+import { RunRowType } from '../../../utils/experimentPage.row-types';
 
 export interface RunNameCellRendererProps extends ICellRendererParams {
-  value: string;
+  data: RunRowType;
+  onExpand: (runUuid: string, childrenIds?: string[]) => void;
 }
 
 export const RunNameCellRenderer = React.memo(
-  ({ value, data: { experimentId, runUuid } }: RunNameCellRendererProps) => (
-    <Link css={styles.link} to={Routes.getRunPageRoute(experimentId, runUuid)}>
-      {value}
-    </Link>
-  ),
+  ({
+    onExpand,
+    data: { runName, experimentId, runUuid, runDateAndNestInfo },
+  }: RunNameCellRendererProps) => {
+    const { hasExpander, expanderOpen, childrenIds, level } = runDateAndNestInfo || {};
+
+    const renderingAsParent = !isNaN(level) && hasExpander;
+
+    return (
+      <div css={styles.cellWrapper}>
+        <div css={styles.expanderWrapper}>
+          <div css={styles.nestLevel(level)}>
+            {renderingAsParent && (
+              <Button
+                css={styles.expanderButton}
+                size='small'
+                onClick={() => {
+                  onExpand(runUuid, childrenIds);
+                }}
+                key={'Expander-' + runUuid}
+                type='link'
+                icon={expanderOpen ? <MinusBoxIcon /> : <PlusSquareIcon />}
+              />
+            )}
+          </div>
+        </div>
+        <Link to={Routes.getRunPageRoute(experimentId, runUuid)}>{runName}</Link>
+      </div>
+    );
+  },
 );
 
 const styles = {
@@ -21,5 +49,26 @@ const styles = {
     display: 'inline-block',
     minWidth: theme.typography.fontSizeBase,
     minHeight: theme.typography.fontSizeBase,
+  }),
+  cellWrapper: {
+    display: 'flex',
+  },
+  expanderButton: {
+    svg: {
+      width: 12,
+      height: 12,
+    },
+  },
+  expanderWrapper: {
+    display: 'none',
+    '.ag-grid-expanders-visible &': {
+      display: 'block',
+    },
+  },
+
+  nestLevel: (level: number) => (theme: Theme) => ({
+    display: 'flex',
+    justifyContent: 'flex-end',
+    width: (level + 1) * theme.spacing.lg,
   }),
 };

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.column-utils.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.column-utils.ts
@@ -214,34 +214,17 @@ export const useRunsColumnDefinitions = ({
       resizable: false,
     });
 
-    // Date and expander selection column
-    columns.push({
-      headerName: ATTRIBUTE_COLUMN_LABELS.DATE,
-      headerTooltip: ATTRIBUTE_COLUMN_SORT_KEY.DATE,
-      pinned: 'left',
-      field: 'runDateAndNestInfo',
-      initialWidth: 150,
-      cellRenderer: 'DateCellRenderer',
-      cellRendererParams: { onExpand },
-      equals: (dateInfo1, dateInfo2) => isEqual(dateInfo1, dateInfo2),
-      sortable: true,
-      headerComponentParams: {
-        ...commonSortOrderProps,
-        canonicalSortKey: ATTRIBUTE_COLUMN_SORT_KEY.DATE,
-        getClassName: getHeaderClassName,
-      },
-      cellClass: getCellClassName,
-    });
-
-    // Run name column
+    // Run name and expander selection column
     columns.push({
       headerName: ATTRIBUTE_COLUMN_LABELS.RUN_NAME,
       colId: TAGS_TO_COLUMNS_MAP[ATTRIBUTE_COLUMN_SORT_KEY.RUN_NAME],
       headerTooltip: ATTRIBUTE_COLUMN_SORT_KEY.RUN_NAME,
       pinned: 'left',
-      field: 'runName',
       sortable: true,
+      field: 'runDateAndNestInfo',
       cellRenderer: 'RunNameCellRenderer',
+      cellRendererParams: { onExpand },
+      equals: isEqual,
       headerComponentParams: {
         ...commonSortOrderProps,
         canonicalSortKey: ATTRIBUTE_COLUMN_SORT_KEY.RUN_NAME,
@@ -249,6 +232,25 @@ export const useRunsColumnDefinitions = ({
       },
       cellClass: getCellClassName,
       initialWidth: 260,
+    });
+
+    // Date column
+    columns.push({
+      headerName: ATTRIBUTE_COLUMN_LABELS.DATE,
+      headerTooltip: ATTRIBUTE_COLUMN_SORT_KEY.DATE,
+      pinned: 'left',
+      sortable: true,
+      field: 'runDateAndNestInfo',
+      cellRenderer: 'DateCellRenderer',
+      cellRendererParams: { onExpand },
+      equals: isEqual,
+      headerComponentParams: {
+        ...commonSortOrderProps,
+        canonicalSortKey: ATTRIBUTE_COLUMN_SORT_KEY.DATE,
+        getClassName: getHeaderClassName,
+      },
+      cellClass: getCellClassName,
+      initialWidth: 150,
     });
 
     // Duration column


### PR DESCRIPTION
## What changes are proposed in this pull request?
feat: adjusted column order and icon sizes in experiment runs table

## How is this patch tested?
- [x] UI
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/5621432/201283998-50c6385b-eead-4d3c-b933-f54822644dc0.png">


## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
Updating column ordering in experiment runs table

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
