### PR TITLE
FLAML classifier metrics

### DIFF
--- a/mlflow/recipes/steps/automl/flaml.py
+++ b/mlflow/recipes/steps/automl/flaml.py
@@ -11,7 +11,7 @@ from mlflow.models.evaluation.default_evaluator import (
     _get_regressor_metrics,
     _get_binary_classifier_metrics,
 )
-from mlflow.recipes.utils.metrics import RecipeMetric, _load_custom_metrics, _load_sklearn_metrics
+from mlflow.recipes.utils.metrics import RecipeMetric, _load_custom_metrics
 
 _logger = logging.getLogger(__name__)
 

--- a/mlflow/recipes/steps/automl/flaml.py
+++ b/mlflow/recipes/steps/automl/flaml.py
@@ -28,13 +28,6 @@ _MLFLOW_TO_FLAML_METRICS = {
 
 _MLFLOW_TO_SKLEARN_METRICS = ["recall_score", "precision_score"]
 
-_MLFLOW_TO_CONFUSION_METRICS = {
-    "true_negatives": 0,
-    "false_positives": 1,
-    "false_negatives": 2,
-    "true_positives": 3,
-}
-
 
 def get_estimator_and_best_params(
     X,

--- a/mlflow/recipes/steps/automl/flaml.py
+++ b/mlflow/recipes/steps/automl/flaml.py
@@ -56,7 +56,7 @@ def _create_custom_metric_flaml(
         )
         res_df = pd.DataFrame()
         res_df["prediction"] = y_pred
-        res_df["target"] = y
+        res_df["target"] = y if task == "classification" else y.values
         return eval_metric.eval_fn(res_df, builtin_metrics)
 
     # pylint: disable=keyword-arg-before-vararg

--- a/mlflow/recipes/steps/automl/flaml.py
+++ b/mlflow/recipes/steps/automl/flaml.py
@@ -19,6 +19,7 @@ _MLFLOW_TO_FLAML_METRICS = {
     "root_mean_squared_error": "rmse",
     "r2_score": "r2",
     "mean_absolute_percentage_error": "mape",
+    "f1_score": "f1",
 }
 
 

--- a/mlflow/recipes/steps/automl/flaml.py
+++ b/mlflow/recipes/steps/automl/flaml.py
@@ -83,6 +83,8 @@ def _create_custom_metric_flaml(
 
 
 def _create_sklearn_metric_flaml(metric_name: str, coeff: int) -> callable:
+    # pylint: disable=keyword-arg-before-vararg
+    # pylint: disable=unused-argument
     def sklearn_metric(
         X_val,
         y_val,

--- a/mlflow/recipes/steps/automl/flaml.py
+++ b/mlflow/recipes/steps/automl/flaml.py
@@ -20,6 +20,7 @@ _MLFLOW_TO_FLAML_METRICS = {
     "r2_score": "r2",
     "mean_absolute_percentage_error": "mape",
     "f1_score": "f1",
+    "accuracy_score": "accuracy",
 }
 
 

--- a/mlflow/recipes/steps/automl/flaml.py
+++ b/mlflow/recipes/steps/automl/flaml.py
@@ -26,7 +26,8 @@ _MLFLOW_TO_FLAML_METRICS = {
     "accuracy_score": "accuracy",
 }
 
-_MLFLOW_TO_SKLEARN_METRICS = ["recall_score", "precision_score"]
+# metrics that are not supported natively in FLAML
+_SKLEARN_METRICS = ["recall_score", "precision_score"]
 
 
 def get_estimator_and_best_params(
@@ -127,7 +128,7 @@ def _create_model_automl(
     try:
         if primary_metric in _MLFLOW_TO_FLAML_METRICS and primary_metric in evaluation_metrics:
             metric = _MLFLOW_TO_FLAML_METRICS[primary_metric]
-        elif primary_metric in _MLFLOW_TO_SKLEARN_METRICS and primary_metric in evaluation_metrics:
+        elif primary_metric in _SKLEARN_METRICS and primary_metric in evaluation_metrics:
             metric = _create_sklearn_metric_flaml(
                 primary_metric, -1 if evaluation_metrics[primary_metric].greater_is_better else 1
             )

--- a/mlflow/recipes/steps/automl/flaml.py
+++ b/mlflow/recipes/steps/automl/flaml.py
@@ -7,8 +7,11 @@ from sklearn.base import BaseEstimator
 import mlflow
 from mlflow import MlflowException
 from mlflow.models import EvaluationMetric
-from mlflow.models.evaluation.default_evaluator import _get_regressor_metrics
-from mlflow.recipes.utils.metrics import RecipeMetric, _load_custom_metrics
+from mlflow.models.evaluation.default_evaluator import (
+    _get_regressor_metrics,
+    _get_binary_classifier_metrics,
+)
+from mlflow.recipes.utils.metrics import RecipeMetric, _load_custom_metrics, _load_sklearn_metrics
 
 _logger = logging.getLogger(__name__)
 
@@ -21,6 +24,15 @@ _MLFLOW_TO_FLAML_METRICS = {
     "mean_absolute_percentage_error": "mape",
     "f1_score": "f1",
     "accuracy_score": "accuracy",
+}
+
+_MLFLOW_TO_SKLEARN_METRICS = ["recall_score", "precision_score"]
+
+_MLFLOW_TO_CONFUSION_METRICS = {
+    "true_negatives": 0,
+    "false_positives": 1,
+    "false_negatives": 2,
+    "true_positives": 3,
 }
 
 
@@ -39,14 +51,18 @@ def get_estimator_and_best_params(
 
 
 def _create_custom_metric_flaml(
-    metric_name: str, coeff: int, eval_metric: EvaluationMetric
+    task: str, metric_name: str, coeff: int, eval_metric: EvaluationMetric
 ) -> callable:
     def calc_metric(X, y, estimator) -> Dict[str, float]:
         y_pred = estimator.predict(X)
-        builtin_metrics = _get_regressor_metrics(y, y_pred, sample_weights=None)
+        builtin_metrics = (
+            _get_regressor_metrics(y, y_pred, sample_weights=None)
+            if task == "regression"
+            else _get_binary_classifier_metrics(y_true=y, y_pred=y_pred)
+        )
         res_df = pd.DataFrame()
         res_df["prediction"] = y_pred
-        res_df["target"] = y.values
+        res_df["target"] = y
         return eval_metric.eval_fn(res_df, builtin_metrics)
 
     # pylint: disable=keyword-arg-before-vararg
@@ -73,6 +89,32 @@ def _create_custom_metric_flaml(
     return custom_metric
 
 
+def _create_sklearn_metric_flaml(metric_name: str, coeff: int) -> callable:
+    def sklearn_metric(
+        X_val,
+        y_val,
+        estimator,
+        labels,
+        X_train,
+        y_train,
+        weight_val=None,
+        weight_train=None,
+        *args,
+    ):
+        import importlib
+
+        custom_metrics_mod = importlib.import_module("sklearn.metrics")
+        eval_fn = getattr(custom_metrics_mod, metric_name)
+        val_metric = coeff * eval_fn(y_val, estimator.predict(X_val))
+        train_metric = coeff * eval_fn(y_train, estimator.predict(X_train))
+        return val_metric, {
+            f"{metric_name}_train": train_metric,
+            f"{metric_name}_val": val_metric,
+        }
+
+    return sklearn_metric
+
+
 def _create_model_automl(
     X,
     y,
@@ -90,8 +132,13 @@ def _create_model_automl(
     try:
         if primary_metric in _MLFLOW_TO_FLAML_METRICS and primary_metric in evaluation_metrics:
             metric = _MLFLOW_TO_FLAML_METRICS[primary_metric]
+        elif primary_metric in _MLFLOW_TO_SKLEARN_METRICS and primary_metric in evaluation_metrics:
+            metric = _create_sklearn_metric_flaml(
+                primary_metric, -1 if evaluation_metrics[primary_metric].greater_is_better else 1
+            )
         elif primary_metric in evaluation_metrics:
             metric = _create_custom_metric_flaml(
+                task,
                 primary_metric,
                 -1 if evaluation_metrics[primary_metric].greater_is_better else 1,
                 _load_custom_metrics(recipe_root, [evaluation_metrics[primary_metric]])[0],


### PR DESCRIPTION
Signed-off-by: Prithvi Kannan <prithvi.kannan@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

https://github.com/mlflow/mlflow/pull/6959

## What changes are proposed in this pull request?

Adding classifier metrics to the `_MLFLOW_TO_FLAML_METRICS` mapping. This unblocks users who want to use automl training for classification problems.

FLAML only supports `f1_score` and `accuracy` natively. We have built adapters for `recall_score` and `precision_score`, since we support those as primary metrics.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->
- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)


<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

E2E test with the wine dataset classification example using automl/flaml in the train step.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
