### PR TITLE
Add descriptive MLflow 2.0 migration error message for invalid serving input formats

### DIFF
--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -77,7 +77,7 @@ SCORING_PROTOCOL_CHANGE_INFO = (
     " to 'mlflow==1.30.0'). If you are making a request using the MLflow client"
     " (e.g. via `mlflow.pyfunc.spark_udf()`), upgrade your MLflow client to a version >= 2.0 in"
     " order to use the new request format. For more information about the updated MLflow"
-    " Model scoring protocol in MLflow 2.0, see "
+    " Model scoring protocol in MLflow 2.0, see"
     " https://mlflow.org/docs/latest/models.html#deploy-mlflow-models."
 )
 

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -104,7 +104,7 @@ def infer_and_parse_json_input(json_input, schema: Schema = None):
         if len(format_keys) != 1:
             message = f"Received dictionary with input fields: {list(decoded_input.keys())}"
             raise MlflowException(
-                message=f"{REQUIRED_INPUT_FORMAT}. {message}.\n\n{SCORING_PROTOCOL_CHANGE_INFO}",
+                message=f"{REQUIRED_INPUT_FORMAT}. {message}. {SCORING_PROTOCOL_CHANGE_INFO}",
                 error_code=BAD_REQUEST,
             )
         input_format = format_keys.pop()
@@ -120,7 +120,7 @@ def infer_and_parse_json_input(json_input, schema: Schema = None):
     elif isinstance(decoded_input, list):
         message = "Received a list"
         raise MlflowException(
-            message=f"{REQUIRED_INPUT_FORMAT}. {message}.\n\n{SCORING_PROTOCOL_CHANGE_INFO}",
+            message=f"{REQUIRED_INPUT_FORMAT}. {message}. {SCORING_PROTOCOL_CHANGE_INFO}",
             error_code=BAD_REQUEST,
         )
     else:
@@ -241,8 +241,8 @@ def init(model: PyFuncModel):
             return flask.Response(
                 response=(
                     f"Unrecognized content type parameters: "
-                    f"{', '.join(unexpected_content_parameters)}."
-                    f"\n\n{SCORING_PROTOCOL_CHANGE_INFO}"
+                    f"{', '.join(unexpected_content_parameters)}. "
+                    f"{SCORING_PROTOCOL_CHANGE_INFO}"
                 ),
                 status=415,
                 mimetype="text/plain",

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -70,13 +70,13 @@ REQUIRED_INPUT_FORMAT = (
     f"The input must be a JSON dictionary with exactly one of the input fields {SUPPORTED_FORMATS}"
 )
 SCORING_PROTOCOL_CHANGE_INFO = (
-    f"IMPORTANT: If you're seeing this error, you may be querying an MLflow Model Server running"
-    f" version 2.0 or later from an MLflow client running an earlier version (for example, 1.30.0)."
-    f" To resolve the error, either upgrade your MLflow client to a version >= 2.0 or adjust your"
-    f" MLflow Model's requirements file to set the version of MLflow to the same version as the"
-    f" client (for example, change the 'mlflow' requirement string to 'mlflow==1.30.0'). For more"
-    f" information about the updated model scoring server protocol in MLflow 2.0, see "
-    f" https://mlflow.org/docs/latest/models.html#deploy-mlflow-models."
+    "IMPORTANT: If you're seeing this error, you may be querying an MLflow Model Server running"
+    " version 2.0 or later from an MLflow client running an earlier version (for example, 1.30.0)."
+    " To resolve the error, either upgrade your MLflow client to a version >= 2.0 or adjust your"
+    " MLflow Model's requirements file to set the version of MLflow to the same version as the"
+    " client (for example, change the 'mlflow' requirement string to 'mlflow==1.30.0'). For more"
+    " information about the updated model scoring server protocol in MLflow 2.0, see "
+    " https://mlflow.org/docs/latest/models.html#deploy-mlflow-models."
 )
 
 

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -70,12 +70,14 @@ REQUIRED_INPUT_FORMAT = (
     f"The input must be a JSON dictionary with exactly one of the input fields {SUPPORTED_FORMATS}"
 )
 SCORING_PROTOCOL_CHANGE_INFO = (
-    "IMPORTANT: If you're seeing this error, you may be querying an MLflow Model Server running"
-    " version 2.0 or later from an MLflow client running an earlier version (for example, 1.30.0)."
-    " To resolve the error, either upgrade your MLflow client to a version >= 2.0 or adjust your"
-    " MLflow Model's requirements file to set the version of MLflow to the same version as the"
-    " client (for example, change the 'mlflow' requirement string to 'mlflow==1.30.0'). For more"
-    " information about the updated model scoring server protocol in MLflow 2.0, see "
+    "IMPORTANT: The MLflow Model scoring protocol has changed in MLflow version 2.0. If you are"
+    " seeing this error, you are likely using an outdated scoring request format. To resolve the"
+    " error, either update your request format or adjust your MLflow Model's requirements file to"
+    " specify an older version of MLflow (for example, change the 'mlflow' requirement specifier"
+    " to 'mlflow==1.30.0'). If you are making a request using the MLflow client"
+    " (e.g. via `mlflow.pyfunc.spark_udf()`), upgrade your MLflow client to a version >= 2.0 in"
+    " order to use the new request format. For more information about the updated MLflow"
+    " Model Server scoring protocol in MLflow 2.0, see "
     " https://mlflow.org/docs/latest/models.html#deploy-mlflow-models."
 )
 

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -77,7 +77,7 @@ SCORING_PROTOCOL_CHANGE_INFO = (
     " to 'mlflow==1.30.0'). If you are making a request using the MLflow client"
     " (e.g. via `mlflow.pyfunc.spark_udf()`), upgrade your MLflow client to a version >= 2.0 in"
     " order to use the new request format. For more information about the updated MLflow"
-    " Model Server scoring protocol in MLflow 2.0, see "
+    " Model scoring protocol in MLflow 2.0, see "
     " https://mlflow.org/docs/latest/models.html#deploy-mlflow-models."
 )
 


### PR DESCRIPTION
Signed-off-by: dbczumar <corey.zumar@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Add descriptive MLflow 2.0 migration error message for invalid serving input formats

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->
- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [X] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
