### PR TITLE
Fix NFS enablement check when Spark session is unavailable on Databricks workers

### DIFF
--- a/mlflow/utils/nfs_on_spark.py
+++ b/mlflow/utils/nfs_on_spark.py
@@ -24,10 +24,7 @@ def get_nfs_cache_root_dir():
     if is_in_databricks_runtime():
         spark_sess = _get_active_spark_session()
         nfs_enabled = spark_sess and (
-            spark_sess
-            .conf.get("spark.databricks.mlflow.nfs.enabled", "true")
-            .lower()
-            == "true"
+            spark_sess.conf.get("spark.databricks.mlflow.nfs.enabled", "true").lower() == "true"
         )
         if nfs_enabled:
             nfs_root_dir = "/local_disk0/.ephemeral_nfs"

--- a/mlflow/utils/nfs_on_spark.py
+++ b/mlflow/utils/nfs_on_spark.py
@@ -22,8 +22,9 @@ _NFS_CACHE_ROOT_DIR = None
 
 def get_nfs_cache_root_dir():
     if is_in_databricks_runtime():
-        nfs_enabled = (
-            _get_active_spark_session()
+        spark_sess = _get_active_spark_session()
+        nfs_enabled = spark_sess and (
+            spark_sess
             .conf.get("spark.databricks.mlflow.nfs.enabled", "true")
             .lower()
             == "true"


### PR DESCRIPTION
Signed-off-by: dbczumar <corey.zumar@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## What changes are proposed in this pull request?

Fix NFS enablement check when Spark session is unavailable on Databricks workers

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->
- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests (describe details, including test results, below)

Manually tested by running the following UDF code on Databricks with NFS disabled:

```

import mlflow
import pandas as pd
import tempfile
import os

class EnvRestoringTestModel(mlflow.pyfunc.PythonModel):
    def __init__(self, sklearn_version):
        self.sklearn_version = sklearn_version

    def predict(self, context, model_input):
        import sklearn
        if sklearn.__version__ != self.sklearn_version:
            raise RuntimeError(
                f"Expected sklearn {self.sklearn_version} but found sklearn {sklearn.__version__}"
            )
        return model_input.apply(lambda row: 1, axis=1)

infer_spark_df = spark.createDataFrame(pd.DataFrame(data=[[1, 2]], columns=["a", "b"])).repartition(1)
for sklearn_version in ["0.24.0"]:
  model_path = os.path.join(tempfile.mkdtemp(), "model")
  mlflow.pyfunc.save_model(
      path=model_path,
      python_model=EnvRestoringTestModel(sklearn_version),
      pip_requirements=[
          "pandas",
          "mlflow",
          f"scikit-learn=={sklearn_version}",
      ],
  )
  print(model_path)

  python_udf = mlflow.pyfunc.spark_udf(spark, model_path, env_manager="virtualenv")
  result = infer_spark_df.select(python_udf("a", "b").alias("result")).toPandas().result[0]
  assert result == 1
```

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [X] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
