### PR TITLE
Remove useless `getattr` and `setattr`

### DIFF
--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -478,7 +478,7 @@ def autolog(
             except Exception as e:
                 input_example_info = InputExampleInfo(error_msg=str(e))
 
-            setattr(self, "input_example_info", input_example_info)
+            self.input_example_info = input_example_info
 
         original(self, *args, **kwargs)
 

--- a/mlflow/recipes/steps/train.py
+++ b/mlflow/recipes/steps/train.py
@@ -530,10 +530,9 @@ class TrainStep(BaseStep):
 
     def _resolve_estimator_plugin(self, plugin_str, X_train, y_train, output_directory):
         plugin_str = plugin_str.replace("/", ".")
-        estimator_fn = getattr(
-            importlib.import_module(f"mlflow.recipes.steps.{plugin_str}"),
-            "get_estimator_and_best_params",
-        )
+        estimator_fn = importlib.import_module(
+            f"mlflow.recipes.steps.{plugin_str}"
+        ).get_estimator_and_best_params
         estimator, best_parameters = estimator_fn(
             X_train,
             y_train,

--- a/mlflow/recipes/steps/transform.py
+++ b/mlflow/recipes/steps/transform.py
@@ -50,15 +50,13 @@ def _get_output_feature_names(transformer, num_features, input_features):
 
 def _validate_user_code_output(transformer_fn):
     transformer = transformer_fn()
-    if transformer is not None and not (
-        hasattr(transformer, "fit") and callable(getattr(transformer, "fit"))
-    ):
+    if transformer is not None and not (hasattr(transformer, "fit") and callable(transformer.fit)):
         raise MlflowException(
             message="The transformer provided doesn't have a fit method."
         ) from None
 
     if transformer is not None and not (
-        hasattr(transformer, "transform") and callable(getattr(transformer, "transform"))
+        hasattr(transformer, "transform") and callable(transformer.transform)
     ):
         raise MlflowException(
             message="The transformer provided doesn't have a transform method."

--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -255,7 +255,7 @@ def _get_pip_version():
     try:
         import pip
 
-        return getattr(pip, "__version__")
+        return pip.__version__
     except ImportError:
         return None
 

--- a/mlflow/xgboost/__init__.py
+++ b/mlflow/xgboost/__init__.py
@@ -441,7 +441,7 @@ def autolog(
             except Exception as e:
                 input_example_info = InputExampleInfo(error_msg=str(e))
 
-            setattr(self, "input_example_info", input_example_info)
+            self.input_example_info = input_example_info
 
         original(self, *args, **kwargs)
 

--- a/tests/recipes/test_ingest_step.py
+++ b/tests/recipes/test_ingest_step.py
@@ -305,7 +305,7 @@ def test_ingest_throws_for_custom_dataset_when_loader_function_throws_unexpected
         "steps.ingest.load_file_as_dataframe",
         side_effect=Exception("Failed to load!"),
     ) as mock_loader:
-        setattr(mock_loader, "__name__", "load_file_as_dataframe")
+        mock_loader.__name__ = "load_file_as_dataframe"
         with pytest.raises(
             MlflowException, match="Unable to load data file at path.*using custom loader method"
         ):


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

`getattr(obj, "attr")` and `setattr(obj, "attr", val)` are useless. We can just use `obj.attr` and `obj.attr = val`, which are more straightforward.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->
- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
