### PR TITLE
Updating the source type to recipe

### DIFF
--- a/mlflow/entities/source_type.py
+++ b/mlflow/entities/source_type.py
@@ -8,7 +8,7 @@ class SourceType:
         "JOB": JOB,
         "PROJECT": PROJECT,
         "LOCAL": LOCAL,
-        "PIPELINE": RECIPE,
+        "RECIPE": RECIPE,
         "UNKNOWN": UNKNOWN,
     }
     SOURCETYPE_TO_STRING = {value: key for key, value in _STRING_TO_SOURCETYPE.items()}

--- a/tests/recipes/test_register_step.py
+++ b/tests/recipes/test_register_step.py
@@ -203,7 +203,7 @@ def weighted_mean_squared_error(eval_df, builtin_metrics):
     register_step.run(str(register_step_output_dir))
     registered_models = mlflow.tracking.MlflowClient().search_registered_models()
     latest_tag = registered_models[0].latest_versions[0].tags
-    assert latest_tag[MLFLOW_SOURCE_TYPE] == "PIPELINE"
+    assert latest_tag[MLFLOW_SOURCE_TYPE] == "RECIPE"
     assert latest_tag[MLFLOW_RECIPE_TEMPLATE_NAME] == "regression/v1"
 
 

--- a/tests/recipes/test_train_step.py
+++ b/tests/recipes/test_train_step.py
@@ -442,7 +442,7 @@ def test_train_steps_with_correct_tags(tmp_recipe_root_path, use_tuning):
         run_id = f.read()
 
     tags = MlflowClient().get_run(run_id).data.tags
-    assert tags[MLFLOW_SOURCE_TYPE] == "PIPELINE"
+    assert tags[MLFLOW_SOURCE_TYPE] == "RECIPE"
     assert tags[MLFLOW_RECIPE_TEMPLATE_NAME] == "regression/v1"
     assert tags[MLFLOW_RECIPE_STEP_NAME] == "train"
     assert tags[MLFLOW_RECIPE_PROFILE_NAME] == "test_profile"


### PR DESCRIPTION
## What changes are proposed in this pull request?
Updating the source type to recipe

## How is this patch tested?
- [x] Test passes

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
