### PR TITLE
Do not allow contributors to autoformat

### DIFF
--- a/.github/workflows/autoformat.js
+++ b/.github/workflows/autoformat.js
@@ -59,7 +59,7 @@ const updateStatus = async (context, github, sha, needs) => {
   await createCommitStatus(context, github, sha, state);
 };
 
-const isMlflowMaintainer = async (commentAuthorAssociation) => {
+const isMlflowMaintainer = (commentAuthorAssociation) => {
   return ['OWNER', 'MEMBER', 'COLLABORATOR'].includes(commentAuthorAssociation);
 };
 

--- a/.github/workflows/autoformat.js
+++ b/.github/workflows/autoformat.js
@@ -59,7 +59,12 @@ const updateStatus = async (context, github, sha, needs) => {
   await createCommitStatus(context, github, sha, state);
 };
 
+const isMlflowMaintainer = async (commentAuthorAssociation) => {
+  return ['OWNER', 'MEMBER', 'COLLABORATOR'].includes(commentAuthorAssociation);
+};
+
 module.exports = {
+  isMlflowOrgMemberOrCollaborator,
   shouldAutoformat,
   getPullInformation,
   createReaction,

--- a/.github/workflows/autoformat.js
+++ b/.github/workflows/autoformat.js
@@ -64,7 +64,7 @@ const isMlflowMaintainer = (commentAuthorAssociation) => {
 };
 
 module.exports = {
-  isMlflowOrgMemberOrCollaborator,
+  isMlflowMaintainer,
   shouldAutoformat,
   getPullInformation,
   createReaction,

--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -34,11 +34,16 @@ jobs:
         id: create-status
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.MLFLOW_AUTOMATION_TOKEN }}
           script: |
             core.debug(JSON.stringify(context, null, 2));
             const autoformat = require('./.github/workflows/autoformat.js');
-            const shouldAutoformat = autoformat.shouldAutoformat(context.payload.comment);
+            const { comment } = context.payload;
+            const isMaintainer = autoformat.isMaintainer(comment.author_association);
+            if (!isMaintainer) {
+              core.setFailed("Only MLflow maintainers can trigger this workflow.");
+            }
+            const shouldAutoformat = autoformat.shouldAutoformat(comment);
             if (shouldAutoformat) {
               await autoformat.createReaction(context, github);
               await autoformat.createStatus(context, github, core);

--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -34,7 +34,7 @@ jobs:
         id: create-status
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.MLFLOW_AUTOMATION_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             core.debug(JSON.stringify(context, null, 2));
             const autoformat = require('./.github/workflows/autoformat.js');

--- a/dev/black.sh
+++ b/dev/black.sh
@@ -6,7 +6,7 @@ if [ -z "${GITHUB_ACTIONS}" ]; then
   black --check . "$@"
 else
   black --check "$@" > .black-output 2>&1
-  sed 's/^would reformat \(.*\)/\1: This file is unformatted. Run `black .` or comment `@mlflow-automation autoformat` on the PR to format./' .black-output
+  sed 's/^would reformat \(.*\)/\1: This file is unformatted. Run `black .` or comment `@mlflow-automation autoformat` on the PR if you are an MLflow maintainer./' .black-output
 fi
 
 test $err = 0

--- a/dev/black.sh
+++ b/dev/black.sh
@@ -6,7 +6,7 @@ if [ -z "${GITHUB_ACTIONS}" ]; then
   black --check . "$@"
 else
   black --check "$@" > .black-output 2>&1
-  sed 's/^would reformat \(.*\)/\1: This file is unformatted. Run `black .` or comment `@mlflow-automation autoformat` on the PR if you are an MLflow maintainer./' .black-output
+  sed 's/^would reformat \(.*\)/\1: This file is unformatted. Run `black .` or comment `@mlflow-automation autoformat` on the PR if you'\''re an MLflow maintainer./' .black-output
 fi
 
 test $err = 0


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->
- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
