### PR TITLE
Fixes #6028: Don't add /code subdirectories to sys.path

### DIFF
--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -78,23 +78,6 @@ def _get_flavor_configuration_from_ml_model_file(ml_model_file, flavor_name):
     return model_conf.flavors[flavor_name]
 
 
-def _get_code_dirs(src_code_path, dst_code_path=None):
-    """
-    Obtains the names of the subdirectories contained under the specified source code
-    path and joins them with the specified destination code path.
-    :param src_code_path: The path of the source code directory for which to list subdirectories.
-    :param dst_code_path: The destination directory path to which subdirectory names should be
-                          joined.
-    """
-    if not dst_code_path:
-        dst_code_path = src_code_path
-    return [
-        (os.path.join(dst_code_path, x))
-        for x in os.listdir(src_code_path)
-        if os.path.isdir(os.path.join(src_code_path, x)) and not x == "__pycache__"
-    ]
-
-
 def _validate_code_paths(code_paths):
     if code_paths is not None:
         if not isinstance(code_paths, list):
@@ -122,7 +105,7 @@ def _validate_and_copy_code_paths(code_paths, path, default_subpath="code"):
 
 
 def _add_code_to_system_path(code_path):
-    sys.path = [code_path] + _get_code_dirs(code_path) + sys.path
+    sys.path = [code_path] + sys.path
     # Delete cached modules so they will get reloaded anew from the correct code path
     # Otherwise python will use the cached modules
     modules = [

--- a/tests/utils/test_resources/dummy_package/base.py
+++ b/tests/utils/test_resources/dummy_package/base.py
@@ -1,0 +1,3 @@
+# This call should import the **system** operator, not the dummy_package.operator
+# module that is adjacent to this file
+import operator  # pylint: disable=W0611

--- a/tests/utils/test_resources/dummy_package/operator.py
+++ b/tests/utils/test_resources/dummy_package/operator.py
@@ -1,0 +1,5 @@
+# This module is meant to test shadowing of the built-in operator module
+raise Exception(
+    "This package should not have been imported!"
+    "This means that the sys.path was not configured correctly"
+)


### PR DESCRIPTION
## Related Issues/PRs

https://github.com/mlflow/mlflow/issues/6028

## What changes are proposed in this pull request?

MLflow was not only adding `<model>/code` to the PYTHONPATH, but also all of the directories underneath `<model>/code` which caused unexpected import conflict errors with built-ins and 3rd-party libraries.

This change makes it so that only `<model>/code` is placed on the system path, as users are expected to import from the top-level directories directly themselves.

More details, including minimal reproducible example, can be found in issue \#6028


## How is this patch tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)


## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Users of the `pyfunc` flavor of MLflow models may have had to deal with odd import conflicts with built-in and 3rd-party libraries resulting from incorrect handling of the `sys.path`. This change alters the path configuration logic to no longer place top-level directories on the `sys.path`.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
