### PR TITLE
Prevent nested xgboost / lightgbm model being autologged

### DIFF
--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -671,11 +671,11 @@ def autolog(
         return model
 
     def train(_log_models, original, *args, **kwargs):
-        with _SklearnTrainingSession(clazz="lightgbm.train", allow_children=False) as t:
-            if t.should_log():
-                return train_impl(_log_models, original, *args, **kwargs)
-            else:
-                return original(*args, **kwargs)
+        topmost_sklearn_session = _SklearnTrainingSession.get_topmost_session()
+        if topmost_sklearn_session is not None and topmost_sklearn_session.should_log():
+            return train_impl(_log_models, original, *args, **kwargs)
+        else:
+            return original(*args, **kwargs)
 
     safe_patch(FLAVOR_NAME, lightgbm.Dataset, "__init__", __init__)
     safe_patch(

--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -673,7 +673,7 @@ def autolog(
     def train(_log_models, original, *args, **kwargs):
         topmost_sklearn_session = _SklearnTrainingSession.get_topmost_session()
         if topmost_sklearn_session is None or (
-                topmost_sklearn_session is not None and topmost_sklearn_session.should_log()
+                topmost_sklearn_session is not None and topmost_sklearn_session.should_log_without_reentrance()
         ):
             return train_impl(_log_models, original, *args, **kwargs)
         else:

--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -671,11 +671,11 @@ def autolog(
         return model
 
     def train(_log_models, original, *args, **kwargs):
-        current_sklearn_session = _SklearnTrainingSession.get_current_session()
-        if current_sklearn_session is None or current_sklearn_session.should_log():
-            return train_impl(_log_models, original, *args, **kwargs)
-        else:
-            return original(*args, **kwargs)
+        with _SklearnTrainingSession(estimator=lightgbm.train, allow_children=False) as t:
+            if t.should_log():
+                return train_impl(_log_models, original, *args, **kwargs)
+            else:
+                return original(*args, **kwargs)
 
     safe_patch(FLAVOR_NAME, lightgbm.Dataset, "__init__", __init__)
     safe_patch(

--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -673,8 +673,7 @@ def autolog(
     def train(_log_models, original, *args, **kwargs):
         current_sklearn_session = _SklearnTrainingSession.get_current_session()
         if current_sklearn_session is None or (
-            current_sklearn_session is not None
-            and current_sklearn_session.should_log_without_reentrance()
+            current_sklearn_session is not None and current_sklearn_session.should_log()
         ):
             return train_impl(_log_models, original, *args, **kwargs)
         else:

--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -672,7 +672,9 @@ def autolog(
 
     def train(_log_models, original, *args, **kwargs):
         topmost_sklearn_session = _SklearnTrainingSession.get_topmost_session()
-        if topmost_sklearn_session is not None and topmost_sklearn_session.should_log():
+        if topmost_sklearn_session is None or (
+                topmost_sklearn_session is not None and topmost_sklearn_session.should_log()
+        ):
             return train_impl(_log_models, original, *args, **kwargs)
         else:
             return original(*args, **kwargs)

--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -671,9 +671,10 @@ def autolog(
         return model
 
     def train(_log_models, original, *args, **kwargs):
-        topmost_sklearn_session = _SklearnTrainingSession.get_topmost_session()
-        if topmost_sklearn_session is None or (
-                topmost_sklearn_session is not None and topmost_sklearn_session.should_log_without_reentrance()
+        current_sklearn_session = _SklearnTrainingSession.get_current_session()
+        if current_sklearn_session is None or (
+            current_sklearn_session is not None
+            and current_sklearn_session.should_log_without_reentrance()
         ):
             return train_impl(_log_models, original, *args, **kwargs)
         else:

--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -672,9 +672,7 @@ def autolog(
 
     def train(_log_models, original, *args, **kwargs):
         current_sklearn_session = _SklearnTrainingSession.get_current_session()
-        if current_sklearn_session is None or (
-            current_sklearn_session is not None and current_sklearn_session.should_log()
-        ):
+        if current_sklearn_session is None or current_sklearn_session.should_log():
             return train_impl(_log_models, original, *args, **kwargs)
         else:
             return original(*args, **kwargs)

--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -69,6 +69,7 @@ from mlflow.utils.autologging_utils import (
     MlflowAutologgingQueueingClient,
 )
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
+from mlflow.sklearn import _SklearnTrainingSession
 
 FLAVOR_NAME = "lightgbm"
 
@@ -482,7 +483,7 @@ def autolog(
 
         original(self, *args, **kwargs)
 
-    def train(_log_models, original, *args, **kwargs):
+    def train_impl(_log_models, original, *args, **kwargs):
         def record_eval_results(eval_results, metrics_logger):
             """
             Create a callback function that records evaluation results.
@@ -668,6 +669,13 @@ def autolog(
             early_stopping_logging_operations.await_completion()
 
         return model
+
+    def train(_log_models, original, *args, **kwargs):
+        with _SklearnTrainingSession(clazz="lightgbm.train", allow_children=False) as t:
+            if t.should_log():
+                return train_impl(_log_models, original, *args, **kwargs)
+            else:
+                return original(*args, **kwargs)
 
     safe_patch(FLAVOR_NAME, lightgbm.Dataset, "__init__", __init__)
     safe_patch(

--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -1094,8 +1094,8 @@ def autolog(
             log_post_training_metrics
             and _AUTOLOGGING_METRICS_MANAGER.should_log_post_training_metrics()
         )
-        with _SparkTrainingSession.init(estimator=self, allow_children=False) as t:
-            if t.should_log():
+        with _SparkTrainingSession(estimator=self, allow_children=False) as t:
+            if t.should_enable_patch():
                 with _AUTOLOGGING_METRICS_MANAGER.disable_log_post_training_metrics():
                     fit_result = fit_mlflow(original, self, *args, **kwargs)
                 # In some cases the `fit_result` may be an iterator of spark models.

--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -1094,7 +1094,7 @@ def autolog(
             log_post_training_metrics
             and _AUTOLOGGING_METRICS_MANAGER.should_log_post_training_metrics()
         )
-        with _SparkTrainingSession(clazz=self.__class__, allow_children=False) as t:
+        with _SparkTrainingSession.init(estimator=self, allow_children=False) as t:
             if t.should_log():
                 with _AUTOLOGGING_METRICS_MANAGER.disable_log_post_training_metrics():
                     fit_result = fit_mlflow(original, self, *args, **kwargs)

--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -1095,7 +1095,7 @@ def autolog(
             and _AUTOLOGGING_METRICS_MANAGER.should_log_post_training_metrics()
         )
         with _SparkTrainingSession(estimator=self, allow_children=False) as t:
-            if t.should_log():
+            if t.should_log() and not t.is_current_estimator_nested_call():
                 with _AUTOLOGGING_METRICS_MANAGER.disable_log_post_training_metrics():
                     fit_result = fit_mlflow(original, self, *args, **kwargs)
                 # In some cases the `fit_result` may be an iterator of spark models.

--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -1095,7 +1095,7 @@ def autolog(
             and _AUTOLOGGING_METRICS_MANAGER.should_log_post_training_metrics()
         )
         with _SparkTrainingSession(estimator=self, allow_children=False) as t:
-            if t.should_enable_patch():
+            if t.should_log():
                 with _AUTOLOGGING_METRICS_MANAGER.disable_log_post_training_metrics():
                     fit_result = fit_mlflow(original, self, *args, **kwargs)
                 # In some cases the `fit_result` may be an iterator of spark models.

--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -1095,7 +1095,7 @@ def autolog(
             and _AUTOLOGGING_METRICS_MANAGER.should_log_post_training_metrics()
         )
         with _SparkTrainingSession(estimator=self, allow_children=False) as t:
-            if t.should_log() and not t.is_current_estimator_nested_call():
+            if t.should_log():
                 with _AUTOLOGGING_METRICS_MANAGER.disable_log_post_training_metrics():
                     fit_result = fit_mlflow(original, self, *args, **kwargs)
                 # In some cases the `fit_result` may be an iterator of spark models.

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -1544,8 +1544,8 @@ def _autolog(
             and _AUTOLOGGING_METRICS_MANAGER.should_log_post_training_metrics()
         )
 
-        with _SklearnTrainingSession.init(estimator=self, allow_children=False) as t:
-            if t.should_log():
+        with _SklearnTrainingSession(estimator=self, allow_children=False) as t:
+            if t.should_enable_patch():
                 # In `fit_mlflow` call, it will also call metric API for computing training metrics
                 # so we need temporarily disable the post_training_metrics patching.
                 with _AUTOLOGGING_METRICS_MANAGER.disable_log_post_training_metrics():

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -1545,7 +1545,7 @@ def _autolog(
         )
 
         with _SklearnTrainingSession(estimator=self, allow_children=False) as t:
-            if t.should_enable_patch():
+            if t.should_log() and not t.is_current_estimator_nested_call():
                 # In `fit_mlflow` call, it will also call metric API for computing training metrics
                 # so we need temporarily disable the post_training_metrics patching.
                 with _AUTOLOGGING_METRICS_MANAGER.disable_log_post_training_metrics():

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -1528,24 +1528,30 @@ def _autolog(
                     )
                     _logger.warning(msg)
 
-    def patched_fit(fit_impl, original, self, *args, **kwargs):
+    def patched_fit(fit_impl, allow_children_patch, original, self, *args, **kwargs):
         """
         Autologging patch function to be applied to a sklearn model class that defines a `fit`
         method and inherits from `BaseEstimator` (thereby defining the `get_params()` method)
 
-        :param clazz: The scikit-learn model class to which this patch function is being applied for
-                      autologging (e.g., `sklearn.linear_model.LogisticRegression`)
-        :param func_name: The function name on the specified `clazz` that this patch is overriding
-                          for autologging (e.g., specify "fit" in order to indicate that
-                          `sklearn.linear_model.LogisticRegression.fit()` is being patched)
+        :param fit_impl: The patched fit function implementation, the function should be defined as
+                         `fit_mlflow(original, self, *args, **kwargs)`, the `original` argument
+                          refers to the original `EstimatorClass.fit` method, the `self` argument
+                          refers to the estimator instance being patched, the `*args` and
+                          `**kwargs` are arguments passed to the original fit method.
+
+        :param allow_children_patch: Whether to allow children sklearn session logging or not.
+        :param original: the original `EstimatorClass.fit` method to be patched.
+        :param self: the estimator instance being patched.
+        :param args: positional arguments to be passed to the original fit method.
+        :param kwargs: keyword arguments to be passed to the original fit method.
         """
         should_log_post_training_metrics = (
             log_post_training_metrics
             and _AUTOLOGGING_METRICS_MANAGER.should_log_post_training_metrics()
         )
 
-        with _SklearnTrainingSession(estimator=self, allow_children=False) as t:
-            if t.should_log() and not t.is_current_estimator_nested_call():
+        with _SklearnTrainingSession(estimator=self, allow_children=allow_children_patch) as t:
+            if t.should_log():
                 # In `fit_mlflow` call, it will also call metric API for computing training metrics
                 # so we need temporarily disable the post_training_metrics patching.
                 with _AUTOLOGGING_METRICS_MANAGER.disable_log_post_training_metrics():
@@ -1709,12 +1715,15 @@ def _autolog(
     if flavor_name == mlflow.xgboost.FLAVOR_NAME:
         estimators_to_patch = _gen_xgboost_sklearn_estimators_to_patch()
         patched_fit_impl = fit_mlflow_xgboost_and_lightgbm
+        allow_children_patch = True
     elif flavor_name == mlflow.lightgbm.FLAVOR_NAME:
         estimators_to_patch = _gen_lightgbm_sklearn_estimators_to_patch()
         patched_fit_impl = fit_mlflow_xgboost_and_lightgbm
+        allow_children_patch = True
     else:
         estimators_to_patch = _gen_estimators_to_patch()
         patched_fit_impl = fit_mlflow
+        allow_children_patch = False
 
     for class_def in estimators_to_patch:
         # Patch fitting methods
@@ -1723,7 +1732,7 @@ def _autolog(
                 flavor_name,
                 class_def,
                 func_name,
-                functools.partial(patched_fit, patched_fit_impl),
+                functools.partial(patched_fit, patched_fit_impl, allow_children_patch),
                 manage_run=True,
             )
 

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -1544,7 +1544,7 @@ def _autolog(
             and _AUTOLOGGING_METRICS_MANAGER.should_log_post_training_metrics()
         )
 
-        with _SklearnTrainingSession(clazz=self.__class__, allow_children=False) as t:
+        with _SklearnTrainingSession.init(estimator=self, allow_children=False) as t:
             if t.should_log():
                 # In `fit_mlflow` call, it will also call metric API for computing training metrics
                 # so we need temporarily disable the post_training_metrics patching.

--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -559,11 +559,10 @@ def _get_new_training_session_class():
             if self._parent is None:
                 return True
 
-            session = self
-            while session._parent is not None and session._parent.estimator is session.estimator:
-                session = session._parent
-
-            return session.should_enable_patch()
+            if self._parent.estimator is self.estimator:
+                return self._parent.should_log()
+            else:
+                return self.should_enable_patch()
 
         @staticmethod
         def is_active():

--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -543,22 +543,16 @@ def _get_new_training_session_class():
             Returns True when at least one of the following conditions satisfies:
 
             1. This session is the root session.
-            2. For the first session that has the same estimator with current session,
-               its parent session allows autologging.
+            2. The parent session allows autologging and its estimator differs from this session's
+               estimator.
             """
             for training_session in _TrainingSession._session_stack:
                 if training_session is self:
                     break
                 elif training_session.estimator is self.estimator:
-                    return training_session.should_log()
+                    return False
 
             return self._parent is None or self._parent.allow_children
-
-        def is_current_estimator_nested_call(self):
-            """
-            Check whether it is a session has the same estiamtor with parent session
-            """
-            return self._parent is not None and self.estimator is self._parent.estimator
 
         @staticmethod
         def is_active():

--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -552,9 +552,8 @@ def _get_new_training_session_class():
 
         def should_log(self):
             """
-            Look through the session stack above for all sessions that have the same estiamtor wiht
-            current session, return the `should_enable_patch` result on root session that has the
-            same estiamtor.
+            Finds the first session created by the current estimator and returns
+            `first_session.should_enable_patch()`.
             """
             if self._parent is None:
                 return True

--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -554,6 +554,13 @@ def _get_new_training_session_class():
         def is_active():
             return len(_TrainingSession._session_stack) != 0
 
+        @staticmethod
+        def get_topmost_session():
+            if _TrainingSession.is_active():
+                return _TrainingSession._session_stack[-1]
+            else:
+                return None
+
     return _TrainingSession
 
 

--- a/mlflow/xgboost/__init__.py
+++ b/mlflow/xgboost/__init__.py
@@ -707,9 +707,10 @@ def autolog(
         return model
 
     def train(_log_models, original, *args, **kwargs):
-        topmost_sklearn_session = _SklearnTrainingSession.get_topmost_session()
-        if topmost_sklearn_session is None or (
-                topmost_sklearn_session is not None and topmost_sklearn_session.should_log_without_reentrance()
+        current_sklearn_session = _SklearnTrainingSession.get_current_session()
+        if current_sklearn_session is None or (
+            current_sklearn_session is not None
+            and current_sklearn_session.should_log_without_reentrance()
         ):
             return train_impl(_log_models, original, *args, **kwargs)
         else:

--- a/mlflow/xgboost/__init__.py
+++ b/mlflow/xgboost/__init__.py
@@ -707,11 +707,11 @@ def autolog(
         return model
 
     def train(_log_models, original, *args, **kwargs):
-        with _SklearnTrainingSession(clazz="xgboost.train", allow_children=False) as t:
-            if t.should_log():
-                return train_impl(_log_models, original, *args, **kwargs)
-            else:
-                return original(*args, **kwargs)
+        topmost_sklearn_session = _SklearnTrainingSession.get_topmost_session()
+        if topmost_sklearn_session is not None and topmost_sklearn_session.should_log():
+            return train_impl(_log_models, original, *args, **kwargs)
+        else:
+            return original(*args, **kwargs)
 
     safe_patch(FLAVOR_NAME, xgboost, "train", functools.partial(train, log_models), manage_run=True)
     # The `train()` method logs XGBoost models as Booster objects. When using XGBoost

--- a/mlflow/xgboost/__init__.py
+++ b/mlflow/xgboost/__init__.py
@@ -708,9 +708,7 @@ def autolog(
 
     def train(_log_models, original, *args, **kwargs):
         current_sklearn_session = _SklearnTrainingSession.get_current_session()
-        if current_sklearn_session is None or (
-            current_sklearn_session is not None and current_sklearn_session.should_log()
-        ):
+        if current_sklearn_session is None or current_sklearn_session.should_log():
             return train_impl(_log_models, original, *args, **kwargs)
         else:
             return original(*args, **kwargs)

--- a/mlflow/xgboost/__init__.py
+++ b/mlflow/xgboost/__init__.py
@@ -709,8 +709,7 @@ def autolog(
     def train(_log_models, original, *args, **kwargs):
         current_sklearn_session = _SklearnTrainingSession.get_current_session()
         if current_sklearn_session is None or (
-            current_sklearn_session is not None
-            and current_sklearn_session.should_log_without_reentrance()
+            current_sklearn_session is not None and current_sklearn_session.should_log()
         ):
             return train_impl(_log_models, original, *args, **kwargs)
         else:

--- a/mlflow/xgboost/__init__.py
+++ b/mlflow/xgboost/__init__.py
@@ -709,7 +709,7 @@ def autolog(
     def train(_log_models, original, *args, **kwargs):
         topmost_sklearn_session = _SklearnTrainingSession.get_topmost_session()
         if topmost_sklearn_session is None or (
-                topmost_sklearn_session is not None and topmost_sklearn_session.should_log()
+                topmost_sklearn_session is not None and topmost_sklearn_session.should_log_without_reentrance()
         ):
             return train_impl(_log_models, original, *args, **kwargs)
         else:

--- a/mlflow/xgboost/__init__.py
+++ b/mlflow/xgboost/__init__.py
@@ -708,7 +708,9 @@ def autolog(
 
     def train(_log_models, original, *args, **kwargs):
         topmost_sklearn_session = _SklearnTrainingSession.get_topmost_session()
-        if topmost_sklearn_session is not None and topmost_sklearn_session.should_log():
+        if topmost_sklearn_session is None or (
+                topmost_sklearn_session is not None and topmost_sklearn_session.should_log()
+        ):
             return train_impl(_log_models, original, *args, **kwargs)
         else:
             return original(*args, **kwargs)

--- a/tests/autologging/test_training_session.py
+++ b/tests/autologging/test_training_session.py
@@ -114,9 +114,7 @@ def test_should_log_returns_false_when_parrent_session_has_the_same_estimator():
 
                 assert p.should_log()
                 assert c1.should_log()
-                assert not c1.is_current_estimator_nested_call()
                 assert c2.should_log()
-                assert c2.is_current_estimator_nested_call()
 
             assert_session_stack([(None, PARENT), (PARENT, CHILD)])
         assert_session_stack([(None, PARENT)])

--- a/tests/autologging/test_training_session.py
+++ b/tests/autologging/test_training_session.py
@@ -17,23 +17,28 @@ class Grandchild:
     pass
 
 
+parent = Parent()
+child = Child()
+grand_child = Grandchild()
+
+
 @pytest.fixture(autouse=True)
 def clear_session_stack():
     yield
     _TrainingSession._session_stack.clear()
 
 
-def assert_session_stack(classes):
-    assert len(_TrainingSession._session_stack) == len(classes)
+def assert_session_stack(estimators):
+    assert len(_TrainingSession._session_stack) == len(estimators)
 
-    for idx, (sess, (parent_clazz, clazz)) in enumerate(
-        zip(_TrainingSession._session_stack, classes)
+    for idx, (sess, (parent_estimator, estimator)) in enumerate(
+        zip(_TrainingSession._session_stack, estimators)
     ):
-        assert sess.clazz == clazz
+        assert sess.estimator is estimator
         if idx == 0:
             assert sess._parent is None
         else:
-            assert sess._parent.clazz == parent_clazz
+            assert sess._parent.estimator is parent_estimator
 
 
 @pytest.fixture(params=[True, False])
@@ -42,32 +47,32 @@ def allow_children(request):
 
 
 def test_should_log_always_returns_true_in_root_session(allow_children):
-    with _TrainingSession(Parent, allow_children=allow_children) as p:
-        assert_session_stack([(None, Parent)])
+    with _TrainingSession.init(parent, allow_children=allow_children) as p:
+        assert_session_stack([(None, parent)])
         assert p.should_log()
 
     assert_session_stack([])
 
 
 def test_nested_sessions(allow_children):
-    with _TrainingSession(Parent, allow_children=allow_children) as p:
-        assert_session_stack([(None, Parent)])
+    with _TrainingSession.init(parent, allow_children=allow_children) as p:
+        assert_session_stack([(None, parent)])
 
-        with _TrainingSession(Child, allow_children=True) as c:
-            assert_session_stack([(None, Parent), (Parent, Child)])
+        with _TrainingSession.init(child, allow_children=True) as c:
+            assert_session_stack([(None, parent), (parent, child)])
             assert p.should_log()
             assert c.should_log() == allow_children
 
-        assert_session_stack([(None, Parent)])
+        assert_session_stack([(None, parent)])
     assert_session_stack([])
 
 
 def test_session_is_active():
     assert not _TrainingSession.is_active()
-    with _TrainingSession(Parent, allow_children=True):
+    with _TrainingSession.init(parent, allow_children=True):
         assert _TrainingSession.is_active()
 
-        with _TrainingSession(Child, allow_children=False):
+        with _TrainingSession.init(child, allow_children=False):
             assert _TrainingSession.is_active()
 
         assert _TrainingSession.is_active()
@@ -77,40 +82,68 @@ def test_session_is_active():
 
 
 def test_parent_session_overrides_child_session():
-    with _TrainingSession(Parent, allow_children=False) as p:
-        assert_session_stack([(None, Parent)])
+    with _TrainingSession.init(parent, allow_children=False) as p:
+        assert_session_stack([(None, parent)])
 
-        with _TrainingSession(Child, allow_children=True) as c:
-            assert_session_stack([(None, Parent), (Parent, Child)])
+        with _TrainingSession.init(child, allow_children=True) as c:
+            assert_session_stack([(None, parent), (parent, child)])
 
-            with _TrainingSession(Grandchild, allow_children=True) as g:
-                assert_session_stack([(None, Parent), (Parent, Child), (Child, Grandchild)])
+            with _TrainingSession.init(grand_child, allow_children=True) as g:
+                assert_session_stack([(None, parent), (parent, child), (child, grand_child)])
 
                 assert p.should_log()
                 assert not c.should_log()
                 assert not g.should_log()
 
-            assert_session_stack([(None, Parent), (Parent, Child)])
-        assert_session_stack([(None, Parent)])
+            assert_session_stack([(None, parent), (parent, child)])
+        assert_session_stack([(None, parent)])
     assert_session_stack([])
 
 
 def test_should_log_returns_false_when_parrent_session_has_the_same_class():
     # This test case corresponds to when Pipeline.fit() calls Transformer.fit_transform()
     # which calls Transformer.fit()
-    with _TrainingSession(Parent, allow_children=True) as p:
-        assert_session_stack([(None, Parent)])
+    with _TrainingSession.init(parent, allow_children=True) as p:
+        assert_session_stack([(None, parent)])
+        assert p.should_log()
 
-        with _TrainingSession(Child, allow_children=True) as c1:
-            assert_session_stack([(None, Parent), (Parent, Child)])
+        with _TrainingSession.init(child, allow_children=True) as c1:
+            assert_session_stack([(None, parent), (parent, child)])
+            assert c1.should_log()
 
-            with _TrainingSession(Child, allow_children=True) as c2:
-                assert_session_stack([(None, Parent), (Parent, Child), (Child, Child)])
-
-                assert p.should_log()
-                assert c1.should_log()
+            with _TrainingSession.init(child, allow_children=True) as c2:
+                assert_session_stack([(None, parent), (parent, child)])
+                assert c1 is c2
                 assert not c2.should_log()
 
-            assert_session_stack([(None, Parent), (Parent, Child)])
-        assert_session_stack([(None, Parent)])
+            assert_session_stack([(None, parent), (parent, child)])
+        assert_session_stack([(None, parent)])
+    assert_session_stack([])
+
+
+def test_reenterring():
+    with _TrainingSession.init(parent, allow_children=True) as p:
+        assert_session_stack([(None, parent)])
+        assert p.should_log()
+
+        with _TrainingSession.init(parent) as p2:
+            assert_session_stack([(None, parent)])
+            assert p2 is p
+            assert not p2.should_log()
+            assert p2.should_log_without_reentrance()
+            assert p2.reentrant_count == 1
+
+            with _TrainingSession.init(parent) as p3:
+                assert_session_stack([(None, parent)])
+                assert p3 is p
+                assert not p3.should_log()
+                assert p3.should_log_without_reentrance()
+                assert p3.reentrant_count == 2
+
+            assert p3.reentrant_count == 1
+
+            assert_session_stack([(None, parent)])
+        assert_session_stack([(None, parent)])
+        assert p2.reentrant_count == 0
+
     assert_session_stack([])

--- a/tests/autologging/test_training_session.py
+++ b/tests/autologging/test_training_session.py
@@ -49,7 +49,7 @@ def allow_children(request):
 def test_should_log_always_returns_true_in_root_session(allow_children):
     with _TrainingSession(PARENT, allow_children=allow_children) as p:
         assert_session_stack([(None, PARENT)])
-        assert p.should_enable_patch()
+        assert p.should_log()
 
     assert_session_stack([])
 
@@ -60,8 +60,8 @@ def test_nested_sessions(allow_children):
 
         with _TrainingSession(CHILD, allow_children=True) as c:
             assert_session_stack([(None, PARENT), (PARENT, CHILD)])
-            assert p.should_enable_patch()
-            assert c.should_enable_patch() == allow_children
+            assert p.should_log()
+            assert c.should_log() == allow_children
 
         assert_session_stack([(None, PARENT)])
     assert_session_stack([])
@@ -91,9 +91,9 @@ def test_parent_session_overrides_child_session():
             with _TrainingSession(GRAND_CHILD, allow_children=True) as g:
                 assert_session_stack([(None, PARENT), (PARENT, CHILD), (CHILD, GRAND_CHILD)])
 
-                assert p.should_enable_patch()
-                assert not c.should_enable_patch()
-                assert not g.should_enable_patch()
+                assert p.should_log()
+                assert not c.should_log()
+                assert not g.should_log()
 
             assert_session_stack([(None, PARENT), (PARENT, CHILD)])
         assert_session_stack([(None, PARENT)])
@@ -112,12 +112,11 @@ def test_should_log_returns_false_when_parrent_session_has_the_same_estimator():
             with _TrainingSession(CHILD, allow_children=True) as c2:
                 assert_session_stack([(None, PARENT), (PARENT, CHILD), (CHILD, CHILD)])
 
-                assert p.should_enable_patch()
                 assert p.should_log()
-                assert c1.should_enable_patch()
                 assert c1.should_log()
-                assert not c2.should_enable_patch()
+                assert not c1.is_current_estimator_nested_call()
                 assert c2.should_log()
+                assert c2.is_current_estimator_nested_call()
 
             assert_session_stack([(None, PARENT), (PARENT, CHILD)])
         assert_session_stack([(None, PARENT)])

--- a/tests/autologging/test_training_session.py
+++ b/tests/autologging/test_training_session.py
@@ -47,21 +47,21 @@ def allow_children(request):
 
 
 def test_should_log_always_returns_true_in_root_session(allow_children):
-    with _TrainingSession.init(parent, allow_children=allow_children) as p:
+    with _TrainingSession(parent, allow_children=allow_children) as p:
         assert_session_stack([(None, parent)])
-        assert p.should_log()
+        assert p.should_enable_patch()
 
     assert_session_stack([])
 
 
 def test_nested_sessions(allow_children):
-    with _TrainingSession.init(parent, allow_children=allow_children) as p:
+    with _TrainingSession(parent, allow_children=allow_children) as p:
         assert_session_stack([(None, parent)])
 
-        with _TrainingSession.init(child, allow_children=True) as c:
+        with _TrainingSession(child, allow_children=True) as c:
             assert_session_stack([(None, parent), (parent, child)])
-            assert p.should_log()
-            assert c.should_log() == allow_children
+            assert p.should_enable_patch()
+            assert c.should_enable_patch() == allow_children
 
         assert_session_stack([(None, parent)])
     assert_session_stack([])
@@ -69,10 +69,10 @@ def test_nested_sessions(allow_children):
 
 def test_session_is_active():
     assert not _TrainingSession.is_active()
-    with _TrainingSession.init(parent, allow_children=True):
+    with _TrainingSession(parent, allow_children=True):
         assert _TrainingSession.is_active()
 
-        with _TrainingSession.init(child, allow_children=False):
+        with _TrainingSession(child, allow_children=False):
             assert _TrainingSession.is_active()
 
         assert _TrainingSession.is_active()
@@ -82,68 +82,43 @@ def test_session_is_active():
 
 
 def test_parent_session_overrides_child_session():
-    with _TrainingSession.init(parent, allow_children=False) as p:
+    with _TrainingSession(parent, allow_children=False) as p:
         assert_session_stack([(None, parent)])
 
-        with _TrainingSession.init(child, allow_children=True) as c:
+        with _TrainingSession(child, allow_children=True) as c:
             assert_session_stack([(None, parent), (parent, child)])
 
-            with _TrainingSession.init(grand_child, allow_children=True) as g:
+            with _TrainingSession(grand_child, allow_children=True) as g:
                 assert_session_stack([(None, parent), (parent, child), (child, grand_child)])
 
-                assert p.should_log()
-                assert not c.should_log()
-                assert not g.should_log()
+                assert p.should_enable_patch()
+                assert not c.should_enable_patch()
+                assert not g.should_enable_patch()
 
             assert_session_stack([(None, parent), (parent, child)])
         assert_session_stack([(None, parent)])
     assert_session_stack([])
 
 
-def test_should_log_returns_false_when_parrent_session_has_the_same_class():
+def test_should_log_returns_false_when_parrent_session_has_the_same_estimator():
     # This test case corresponds to when Pipeline.fit() calls Transformer.fit_transform()
     # which calls Transformer.fit()
-    with _TrainingSession.init(parent, allow_children=True) as p:
+    with _TrainingSession(parent, allow_children=True) as p:
         assert_session_stack([(None, parent)])
-        assert p.should_log()
 
-        with _TrainingSession.init(child, allow_children=True) as c1:
+        with _TrainingSession(child, allow_children=True) as c1:
             assert_session_stack([(None, parent), (parent, child)])
-            assert c1.should_log()
 
-            with _TrainingSession.init(child, allow_children=True) as c2:
-                assert_session_stack([(None, parent), (parent, child)])
-                assert c1 is c2
-                assert not c2.should_log()
+            with _TrainingSession(child, allow_children=True) as c2:
+                assert_session_stack([(None, parent), (parent, child), (child, child)])
+
+                assert p.should_enable_patch()
+                assert p.should_log()
+                assert c1.should_enable_patch()
+                assert c1.should_log()
+                assert not c2.should_enable_patch()
+                assert c2.should_log()
 
             assert_session_stack([(None, parent), (parent, child)])
         assert_session_stack([(None, parent)])
-    assert_session_stack([])
-
-
-def test_reenterring():
-    with _TrainingSession.init(parent, allow_children=True) as p:
-        assert_session_stack([(None, parent)])
-        assert p.should_log()
-
-        with _TrainingSession.init(parent) as p2:
-            assert_session_stack([(None, parent)])
-            assert p2 is p
-            assert not p2.should_log()
-            assert p2.should_log_without_reentrance()
-            assert p2.reentrant_count == 1
-
-            with _TrainingSession.init(parent) as p3:
-                assert_session_stack([(None, parent)])
-                assert p3 is p
-                assert not p3.should_log()
-                assert p3.should_log_without_reentrance()
-                assert p3.reentrant_count == 2
-
-            assert p3.reentrant_count == 1
-
-            assert_session_stack([(None, parent)])
-        assert_session_stack([(None, parent)])
-        assert p2.reentrant_count == 0
-
     assert_session_stack([])

--- a/tests/autologging/test_training_session.py
+++ b/tests/autologging/test_training_session.py
@@ -114,7 +114,7 @@ def test_should_log_returns_false_when_parrent_session_has_the_same_estimator():
 
                 assert p.should_log()
                 assert c1.should_log()
-                assert c2.should_log()
+                assert not c2.should_log()
 
             assert_session_stack([(None, PARENT), (PARENT, CHILD)])
         assert_session_stack([(None, PARENT)])

--- a/tests/autologging/test_training_session.py
+++ b/tests/autologging/test_training_session.py
@@ -17,9 +17,9 @@ class Grandchild:
     pass
 
 
-parent = Parent()
-child = Child()
-grand_child = Grandchild()
+PARENT = Parent()
+CHILD = Child()
+GRAND_CHILD = Grandchild()
 
 
 @pytest.fixture(autouse=True)
@@ -47,32 +47,32 @@ def allow_children(request):
 
 
 def test_should_log_always_returns_true_in_root_session(allow_children):
-    with _TrainingSession(parent, allow_children=allow_children) as p:
-        assert_session_stack([(None, parent)])
+    with _TrainingSession(PARENT, allow_children=allow_children) as p:
+        assert_session_stack([(None, PARENT)])
         assert p.should_enable_patch()
 
     assert_session_stack([])
 
 
 def test_nested_sessions(allow_children):
-    with _TrainingSession(parent, allow_children=allow_children) as p:
-        assert_session_stack([(None, parent)])
+    with _TrainingSession(PARENT, allow_children=allow_children) as p:
+        assert_session_stack([(None, PARENT)])
 
-        with _TrainingSession(child, allow_children=True) as c:
-            assert_session_stack([(None, parent), (parent, child)])
+        with _TrainingSession(CHILD, allow_children=True) as c:
+            assert_session_stack([(None, PARENT), (PARENT, CHILD)])
             assert p.should_enable_patch()
             assert c.should_enable_patch() == allow_children
 
-        assert_session_stack([(None, parent)])
+        assert_session_stack([(None, PARENT)])
     assert_session_stack([])
 
 
 def test_session_is_active():
     assert not _TrainingSession.is_active()
-    with _TrainingSession(parent, allow_children=True):
+    with _TrainingSession(PARENT, allow_children=True):
         assert _TrainingSession.is_active()
 
-        with _TrainingSession(child, allow_children=False):
+        with _TrainingSession(CHILD, allow_children=False):
             assert _TrainingSession.is_active()
 
         assert _TrainingSession.is_active()
@@ -82,35 +82,35 @@ def test_session_is_active():
 
 
 def test_parent_session_overrides_child_session():
-    with _TrainingSession(parent, allow_children=False) as p:
-        assert_session_stack([(None, parent)])
+    with _TrainingSession(PARENT, allow_children=False) as p:
+        assert_session_stack([(None, PARENT)])
 
-        with _TrainingSession(child, allow_children=True) as c:
-            assert_session_stack([(None, parent), (parent, child)])
+        with _TrainingSession(CHILD, allow_children=True) as c:
+            assert_session_stack([(None, PARENT), (PARENT, CHILD)])
 
-            with _TrainingSession(grand_child, allow_children=True) as g:
-                assert_session_stack([(None, parent), (parent, child), (child, grand_child)])
+            with _TrainingSession(GRAND_CHILD, allow_children=True) as g:
+                assert_session_stack([(None, PARENT), (PARENT, CHILD), (CHILD, GRAND_CHILD)])
 
                 assert p.should_enable_patch()
                 assert not c.should_enable_patch()
                 assert not g.should_enable_patch()
 
-            assert_session_stack([(None, parent), (parent, child)])
-        assert_session_stack([(None, parent)])
+            assert_session_stack([(None, PARENT), (PARENT, CHILD)])
+        assert_session_stack([(None, PARENT)])
     assert_session_stack([])
 
 
 def test_should_log_returns_false_when_parrent_session_has_the_same_estimator():
     # This test case corresponds to when Pipeline.fit() calls Transformer.fit_transform()
     # which calls Transformer.fit()
-    with _TrainingSession(parent, allow_children=True) as p:
-        assert_session_stack([(None, parent)])
+    with _TrainingSession(PARENT, allow_children=True) as p:
+        assert_session_stack([(None, PARENT)])
 
-        with _TrainingSession(child, allow_children=True) as c1:
-            assert_session_stack([(None, parent), (parent, child)])
+        with _TrainingSession(CHILD, allow_children=True) as c1:
+            assert_session_stack([(None, PARENT), (PARENT, CHILD)])
 
-            with _TrainingSession(child, allow_children=True) as c2:
-                assert_session_stack([(None, parent), (parent, child), (child, child)])
+            with _TrainingSession(CHILD, allow_children=True) as c2:
+                assert_session_stack([(None, PARENT), (PARENT, CHILD), (CHILD, CHILD)])
 
                 assert p.should_enable_patch()
                 assert p.should_log()
@@ -119,6 +119,6 @@ def test_should_log_returns_false_when_parrent_session_has_the_same_estimator():
                 assert not c2.should_enable_patch()
                 assert c2.should_log()
 
-            assert_session_stack([(None, parent), (parent, child)])
-        assert_session_stack([(None, parent)])
+            assert_session_stack([(None, PARENT), (PARENT, CHILD)])
+        assert_session_stack([(None, PARENT)])
     assert_session_stack([])

--- a/tests/lightgbm/test_lightgbm_autolog.py
+++ b/tests/lightgbm/test_lightgbm_autolog.py
@@ -184,7 +184,8 @@ def test_lgb_autolog_sklearn():
 def test_lgb_autolog_sklearn_nested_in_pipeline():
     from sklearn.pipeline import make_pipeline
 
-    mlflow.autolog()
+    mlflow.lightgbm.autolog()
+    mlflow.sklearn.autolog()
 
     X, y = datasets.load_iris(return_X_y=True)
     params = {"n_estimators": 10, "reg_lambda": 1}
@@ -198,9 +199,9 @@ def test_lgb_autolog_sklearn_nested_in_pipeline():
     client = MlflowClient()
     run = client.get_run(run.info.run_id)
     # assert pipeline logged
-    assert run.data.params['lgbmclassifier__reg_lambda'] == "1"
+    assert run.data.params["lgbmclassifier__reg_lambda"] == "1"
     # assert nested lgb classifier not logged
-    assert 'reg_lambda' not in run.data.params
+    assert "reg_lambda" not in run.data.params
 
 
 def test_lgb_autolog_with_sklearn_outputs_do_not_reflect_training_dataset_mutations():

--- a/tests/lightgbm/test_lightgbm_autolog.py
+++ b/tests/lightgbm/test_lightgbm_autolog.py
@@ -181,6 +181,28 @@ def test_lgb_autolog_sklearn():
     np.testing.assert_allclose(loaded_model.predict(X), model.predict(X))
 
 
+def test_lgb_autolog_sklearn_nested_in_pipeline():
+    from sklearn.pipeline import make_pipeline
+
+    mlflow.autolog()
+
+    X, y = datasets.load_iris(return_X_y=True)
+    params = {"n_estimators": 10, "reg_lambda": 1}
+    model = lgb.LGBMClassifier(**params)
+
+    model = make_pipeline(model)
+
+    with mlflow.start_run() as run:
+        model.fit(X, y)
+
+    client = MlflowClient()
+    run = client.get_run(run.info.run_id)
+    # assert pipeline logged
+    assert run.data.params['lgbmclassifier__reg_lambda'] == "1"
+    # assert nested lgb classifier not logged
+    assert 'reg_lambda' not in run.data.params
+
+
 def test_lgb_autolog_with_sklearn_outputs_do_not_reflect_training_dataset_mutations():
     original_lgb_classifier_fit = lgb.LGBMClassifier.fit
     original_lgb_classifier_predict = lgb.LGBMClassifier.predict


### PR DESCRIPTION
Signed-off-by: Weichen Xu <weichen.xu@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

Close https://github.com/mlflow/mlflow/issues/7402

## What changes are proposed in this pull request?

Prevent nested xgboost / lightgbm model being autologged

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->
- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
