### PR TITLE
Adding positive and negative splits profiling

### DIFF
--- a/mlflow/recipes/steps/evaluate.py
+++ b/mlflow/recipes/steps/evaluate.py
@@ -330,7 +330,7 @@ class EvaluateStep(BaseStep):
         # Tab 2: Classifier plots.
         if self.recipe == "classification/v1":
             classifiers_plot_tab = card.add_tab(
-                "Classifier Plots on the Validation Dataset",
+                "Model Performance Plots",
                 "{{ CONFUSION_MATRIX }} {{CONFUSION_MATRIX_PLOT}}"
                 + "{{ LIFT_CURVE }} {{LIFT_CURVE_PLOT}}"
                 + "{{ PR_CURVE }} {{PR_CURVE_PLOT}}"

--- a/tests/recipes/test_evaluate_step.py
+++ b/tests/recipes/test_evaluate_step.py
@@ -146,7 +146,7 @@ steps:
         step_card_content = f.read()
 
     assert "Model Validation" in step_card_content
-    assert "Classifier Plots on the Validation Dataset" in step_card_content
+    assert "Model Performance Plots" in step_card_content
     assert "Warning Logs" in step_card_content
     assert "Run Summary" in step_card_content
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
Adding positive and negative splits profiling

## How is this patch tested?
![image](https://user-images.githubusercontent.com/5621432/204403308-54179bfd-9449-4241-b4c7-f1e964f3b573.png)


## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

For binary classification template, adding feature to visualize positive and negative split profiling

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
