### PR TITLE
Change `mlflow.autolog` metrics name to the same as `mlflow.evaluate`

### DIFF
--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -1142,10 +1142,10 @@ def autolog(
 
         pprint(metrics)
         # {'training_score': 1.0,
-           'training_mae': 2.220446049250313e-16,
-           'training_mse': 1.9721522630525295e-31,
+           'training_mean_absolute_error': 2.220446049250313e-16,
+           'training_mean_squared_error': 1.9721522630525295e-31,
            'training_r2_score': 1.0,
-           'training_rmse': 4.440892098500626e-16}
+           'training_root_mean_squared_error': 4.440892098500626e-16}
 
         pprint(tags)
         # {'estimator_class': 'sklearn.linear_model._base.LinearRegression',

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -264,7 +264,7 @@ def _get_classifier_metrics(fitted_estimator, prefix, X, y_true, sample_weight, 
             classifier_metrics.extend(
                 [
                     _SklearnMetric(
-                        name=prefix + "roc_auc_score",
+                        name=prefix + "roc_auc",
                         function=sklearn.metrics.roc_auc_score,
                         arguments={
                             "y_true": y_true,
@@ -427,7 +427,7 @@ def _get_regressor_metrics(fitted_estimator, prefix, X, y_true, sample_weight):
 
     regressor_metrics = [
         _SklearnMetric(
-            name=prefix + "mse",
+            name=prefix + "mean_squared_error",
             function=sklearn.metrics.mean_squared_error,
             arguments={
                 "y_true": y_true,
@@ -437,7 +437,7 @@ def _get_regressor_metrics(fitted_estimator, prefix, X, y_true, sample_weight):
             },
         ),
         _SklearnMetric(
-            name=prefix + "mae",
+            name=prefix + "mean_absolute_error",
             function=sklearn.metrics.mean_absolute_error,
             arguments={
                 "y_true": y_true,
@@ -462,7 +462,7 @@ def _get_regressor_metrics(fitted_estimator, prefix, X, y_true, sample_weight):
     # `sklearn.metrics.mean_squared_error` does not have "squared" parameter to calculate `rmse`,
     # we compute it through np.sqrt(<value of mse>)
     metrics_value_dict = _get_metrics_value_dict(regressor_metrics)
-    metrics_value_dict[prefix + "rmse"] = np.sqrt(metrics_value_dict[prefix + "mse"])
+    metrics_value_dict[prefix + "root_mean_squared_error"] = np.sqrt(metrics_value_dict[prefix + "mse"])
 
     return metrics_value_dict
 

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -462,7 +462,9 @@ def _get_regressor_metrics(fitted_estimator, prefix, X, y_true, sample_weight):
     # `sklearn.metrics.mean_squared_error` does not have "squared" parameter to calculate `rmse`,
     # we compute it through np.sqrt(<value of mse>)
     metrics_value_dict = _get_metrics_value_dict(regressor_metrics)
-    metrics_value_dict[prefix + "root_mean_squared_error"] = np.sqrt(metrics_value_dict[prefix + "mse"])
+    metrics_value_dict[prefix + "root_mean_squared_error"] = np.sqrt(
+        metrics_value_dict[prefix + "mse"]
+    )
 
     return metrics_value_dict
 

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -463,7 +463,7 @@ def _get_regressor_metrics(fitted_estimator, prefix, X, y_true, sample_weight):
     # we compute it through np.sqrt(<value of mse>)
     metrics_value_dict = _get_metrics_value_dict(regressor_metrics)
     metrics_value_dict[prefix + "root_mean_squared_error"] = np.sqrt(
-        metrics_value_dict[prefix + "mse"]
+        metrics_value_dict[prefix + "mean_squared_error"]
     )
 
     return metrics_value_dict

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1680,10 +1680,10 @@ def autolog(
                  'fit_intercept': 'True',
                  'n_jobs': 'None'}
         metrics: {'training_score': 1.0,
-                  'training_rmse': 4.440892098500626e-16,
+                  'training_root_mean_squared_error': 4.440892098500626e-16,
                   'training_r2_score': 1.0,
-                  'training_mae': 2.220446049250313e-16,
-                  'training_mse': 1.9721522630525295e-31}
+                  'training_mean_absolute_error': 2.220446049250313e-16,
+                  'training_mean_squared_error': 1.9721522630525295e-31}
         tags: {'estimator_class': 'sklearn.linear_model._base.LinearRegression',
                'estimator_name': 'LinearRegression'}
     """

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -340,7 +340,9 @@ def test_regressor():
     assert metrics == {
         TRAINING_SCORE: model.score(X, y_true),
         "training_mean_squared_error": sklearn.metrics.mean_squared_error(y_true, y_pred),
-        "training_root_mean_squared_error": np.sqrt(sklearn.metrics.mean_squared_error(y_true, y_pred)),
+        "training_root_mean_squared_error": np.sqrt(
+            sklearn.metrics.mean_squared_error(y_true, y_pred)
+        ),
         "training_mean_absolute_error": sklearn.metrics.mean_absolute_error(y_true, y_pred),
         "training_r2_score": sklearn.metrics.r2_score(y_true, y_pred),
     }

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -235,7 +235,7 @@ def test_classifier_binary():
         "training_log_loss": sklearn.metrics.log_loss(y_true, y_pred_prob),
     }
     if _is_metric_supported("roc_auc_score"):
-        expected_metrics["training_roc_auc_score"] = sklearn.metrics.roc_auc_score(
+        expected_metrics["training_roc_auc"] = sklearn.metrics.roc_auc_score(
             y_true,
             y_score=y_pred_prob_roc,
             average="weighted",
@@ -298,7 +298,7 @@ def test_classifier_multi_class():
         "training_log_loss": sklearn.metrics.log_loss(y_true, y_pred_prob),
     }
     if _is_metric_supported("roc_auc_score"):
-        expected_metrics["training_roc_auc_score"] = sklearn.metrics.roc_auc_score(
+        expected_metrics["training_roc_auc"] = sklearn.metrics.roc_auc_score(
             y_true,
             y_score=y_pred_prob,
             average="weighted",
@@ -339,9 +339,9 @@ def test_regressor():
 
     assert metrics == {
         TRAINING_SCORE: model.score(X, y_true),
-        "training_mse": sklearn.metrics.mean_squared_error(y_true, y_pred),
-        "training_rmse": np.sqrt(sklearn.metrics.mean_squared_error(y_true, y_pred)),
-        "training_mae": sklearn.metrics.mean_absolute_error(y_true, y_pred),
+        "training_mean_squared_error": sklearn.metrics.mean_squared_error(y_true, y_pred),
+        "training_root_mean_squared_error": np.sqrt(sklearn.metrics.mean_squared_error(y_true, y_pred)),
+        "training_mean_absolute_error": sklearn.metrics.mean_absolute_error(y_true, y_pred),
         "training_r2_score": sklearn.metrics.r2_score(y_true, y_pred),
     }
     assert tags == get_expected_class_tags(model)
@@ -977,7 +977,7 @@ def test_autolog_metrics_input_example_and_signature_do_not_reflect_training_mut
 
     metrics = get_run_data(mlflow.last_active_run().info.run_id)[1]
     assert "training_r2_score" in metrics
-    assert "training_rmse" in metrics
+    assert "training_root_mean_squared_error" in metrics
 
 
 def test_autolog_does_not_throw_when_failing_to_sample_X():


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->


## What changes are proposed in this pull request?

Currently the metric names from `autolog` (mse) and `evaluate` (mean_squared_error) are different. This PR change the metric names in `autolog` to the same as ones in `evaluate`

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->
- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The metric names logged by `mlflow.autolog` are now the same as `mlflow.evaluate`.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
