### PR TITLE
Create models directory when intializing model registry FileStore

### DIFF
--- a/mlflow/store/model_registry/file_store.py
+++ b/mlflow/store/model_registry/file_store.py
@@ -82,9 +82,13 @@ class FileStore(AbstractStore):
 
         super().__init__()
         self.root_directory = local_file_uri_to_path(root_directory or _default_root_dir())
-        # Create root directory if needed
-        if not exists(self.root_directory):
-            mkdir(self.root_directory)
+        # Create models directory if needed
+        if not exists(self.models_directory):
+            mkdir(self.models_directory)
+
+    @property
+    def models_directory(self):
+        return os.path.join(self.root_directory, FileStore.MODELS_FOLDER_NAME)
 
     def _check_root_dir(self):
         """


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

I found running `mlflow ui` throws the following exception because the `./mlruns/models` directory is missing. This PR fixes it.

```
% mlflow ui
[2022-11-30 13:23:42 +0900] [32759] [INFO] Starting gunicorn 20.1.0
[2022-11-30 13:23:42 +0900] [32759] [INFO] Listening at: http://127.0.0.1:5000 (32759)
[2022-11-30 13:23:42 +0900] [32759] [INFO] Using worker: sync
[2022-11-30 13:23:42 +0900] [32761] [INFO] Booting worker with pid: 32761
[2022-11-30 13:23:42 +0900] [32762] [INFO] Booting worker with pid: 32762
[2022-11-30 13:23:42 +0900] [32763] [INFO] Booting worker with pid: 32763
[2022-11-30 13:23:42 +0900] [32764] [INFO] Booting worker with pid: 32764
2022/11/30 13:23:44 ERROR mlflow.server: Exception on /ajax-api/2.0/mlflow/model-versions/search [GET]
Traceback (most recent call last):
  File "/Users/harutakakawamura/.pyenv/versions/miniconda3-4.7.12/envs/mlflow-dev-env/lib/python3.8/site-packages/flask/app.py", line 2525, in wsgi_app
    response = self.full_dispatch_request()
  File "/Users/harutakakawamura/.pyenv/versions/miniconda3-4.7.12/envs/mlflow-dev-env/lib/python3.8/site-packages/flask/app.py", line 1822, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/Users/harutakakawamura/.pyenv/versions/miniconda3-4.7.12/envs/mlflow-dev-env/lib/python3.8/site-packages/flask/app.py", line 1820, in full_dispatch_request
    rv = self.dispatch_request()
  File "/Users/harutakakawamura/.pyenv/versions/miniconda3-4.7.12/envs/mlflow-dev-env/lib/python3.8/site-packages/flask/app.py", line 1796, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
  File "/Users/harutakakawamura/Desktop/repositories/mlflow/mlflow/server/handlers.py", line 459, in wrapper
    return func(*args, **kwargs)
  File "/Users/harutakakawamura/Desktop/repositories/mlflow/mlflow/server/handlers.py", line 529, in wrapper
    return func(*args, **kwargs)
  File "/Users/harutakakawamura/Desktop/repositories/mlflow/mlflow/server/handlers.py", line 1414, in _search_model_versions
    model_versions = _get_model_registry_store().search_model_versions(request_message.filter)
  File "/Users/harutakakawamura/Desktop/repositories/mlflow/mlflow/store/model_registry/file_store.py", line 697, in search_model_versions
    registered_model_paths = self._get_all_registered_model_paths()
  File "/Users/harutakakawamura/Desktop/repositories/mlflow/mlflow/store/model_registry/file_store.py", line 668, in _get_all_registered_model_paths
    model_dirs = list_subdirs(
  File "/Users/harutakakawamura/Desktop/repositories/mlflow/mlflow/utils/file_utils.py", line 75, in list_subdirs
    return list_all(dir_name, os.path.isdir, full_path)
  File "/Users/harutakakawamura/Desktop/repositories/mlflow/mlflow/utils/file_utils.py", line 60, in list_all
    raise Exception("Invalid parent directory '%s'" % root)
Exception: Invalid parent directory './mlruns/models'
2022/11/30 13:23:45 ERROR mlflow.server: Exception on /ajax-api/2.0/mlflow/model-versions/search [GET]
Traceback (most recent call last):
  File "/Users/harutakakawamura/.pyenv/versions/miniconda3-4.7.12/envs/mlflow-dev-env/lib/python3.8/site-packages/flask/app.py", line 2525, in wsgi_app
    response = self.full_dispatch_request()
  File "/Users/harutakakawamura/.pyenv/versions/miniconda3-4.7.12/envs/mlflow-dev-env/lib/python3.8/site-packages/flask/app.py", line 1822, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/Users/harutakakawamura/.pyenv/versions/miniconda3-4.7.12/envs/mlflow-dev-env/lib/python3.8/site-packages/flask/app.py", line 1820, in full_dispatch_request
    rv = self.dispatch_request()
  File "/Users/harutakakawamura/.pyenv/versions/miniconda3-4.7.12/envs/mlflow-dev-env/lib/python3.8/site-packages/flask/app.py", line 1796, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
  File "/Users/harutakakawamura/Desktop/repositories/mlflow/mlflow/server/handlers.py", line 459, in wrapper
    return func(*args, **kwargs)
  File "/Users/harutakakawamura/Desktop/repositories/mlflow/mlflow/server/handlers.py", line 529, in wrapper
    return func(*args, **kwargs)
  File "/Users/harutakakawamura/Desktop/repositories/mlflow/mlflow/server/handlers.py", line 1414, in _search_model_versions
    model_versions = _get_model_registry_store().search_model_versions(request_message.filter)
  File "/Users/harutakakawamura/Desktop/repositories/mlflow/mlflow/store/model_registry/file_store.py", line 697, in search_model_versions
    registered_model_paths = self._get_all_registered_model_paths()
  File "/Users/harutakakawamura/Desktop/repositories/mlflow/mlflow/store/model_registry/file_store.py", line 668, in _get_all_registered_model_paths
    model_dirs = list_subdirs(
  File "/Users/harutakakawamura/Desktop/repositories/mlflow/mlflow/utils/file_utils.py", line 75, in list_subdirs
    return list_all(dir_name, os.path.isdir, full_path)
  File "/Users/harutakakawamura/Desktop/repositories/mlflow/mlflow/utils/file_utils.py", line 60, in list_all
    raise Exception("Invalid parent directory '%s'" % root)
Exception: Invalid parent directory './mlruns/models'
2022/11/30 13:23:50 ERROR mlflow.server: Exception on /ajax-api/2.0/mlflow/model-versions/search [GET]
Traceback (most recent call last):
  File "/Users/harutakakawamura/.pyenv/versions/miniconda3-4.7.12/envs/mlflow-dev-env/lib/python3.8/site-packages/flask/app.py", line 2525, in wsgi_app
    response = self.full_dispatch_request()
  File "/Users/harutakakawamura/.pyenv/versions/miniconda3-4.7.12/envs/mlflow-dev-env/lib/python3.8/site-packages/flask/app.py", line 1822, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/Users/harutakakawamura/.pyenv/versions/miniconda3-4.7.12/envs/mlflow-dev-env/lib/python3.8/site-packages/flask/app.py", line 1820, in full_dispatch_request
    rv = self.dispatch_request()
  File "/Users/harutakakawamura/.pyenv/versions/miniconda3-4.7.12/envs/mlflow-dev-env/lib/python3.8/site-packages/flask/app.py", line 1796, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
  File "/Users/harutakakawamura/Desktop/repositories/mlflow/mlflow/server/handlers.py", line 459, in wrapper
    return func(*args, **kwargs)
  File "/Users/harutakakawamura/Desktop/repositories/mlflow/mlflow/server/handlers.py", line 529, in wrapper
    return func(*args, **kwargs)
  File "/Users/harutakakawamura/Desktop/repositories/mlflow/mlflow/server/handlers.py", line 1414, in _search_model_versions
    model_versions = _get_model_registry_store().search_model_versions(request_message.filter)
  File "/Users/harutakakawamura/Desktop/repositories/mlflow/mlflow/store/model_registry/file_store.py", line 697, in search_model_versions
    registered_model_paths = self._get_all_registered_model_paths()
  File "/Users/harutakakawamura/Desktop/repositories/mlflow/mlflow/store/model_registry/file_store.py", line 668, in _get_all_registered_model_paths
    model_dirs = list_subdirs(
  File "/Users/harutakakawamura/Desktop/repositories/mlflow/mlflow/utils/file_utils.py", line 75, in list_subdirs
    return list_all(dir_name, os.path.isdir, full_path)
  File "/Users/harutakakawamura/Desktop/repositories/mlflow/mlflow/utils/file_utils.py", line 60, in list_all
    raise Exception("Invalid parent directory '%s'" % root)
Exception: Invalid parent directory './mlruns/models'
2022/11/30 13:23:51 ERROR mlflow.server: Exception on /ajax-api/2.0/mlflow/registered-models/search [GET]
Traceback (most recent call last):
  File "/Users/harutakakawamura/.pyenv/versions/miniconda3-4.7.12/envs/mlflow-dev-env/lib/python3.8/site-packages/flask/app.py", line 2525, in wsgi_app
    response = self.full_dispatch_request()
  File "/Users/harutakakawamura/.pyenv/versions/miniconda3-4.7.12/envs/mlflow-dev-env/lib/python3.8/site-packages/flask/app.py", line 1822, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/Users/harutakakawamura/.pyenv/versions/miniconda3-4.7.12/envs/mlflow-dev-env/lib/python3.8/site-packages/flask/app.py", line 1820, in full_dispatch_request
    rv = self.dispatch_request()
  File "/Users/harutakakawamura/.pyenv/versions/miniconda3-4.7.12/envs/mlflow-dev-env/lib/python3.8/site-packages/flask/app.py", line 1796, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
  File "/Users/harutakakawamura/Desktop/repositories/mlflow/mlflow/server/handlers.py", line 459, in wrapper
    return func(*args, **kwargs)
  File "/Users/harutakakawamura/Desktop/repositories/mlflow/mlflow/server/handlers.py", line 529, in wrapper
    return func(*args, **kwargs)
  File "/Users/harutakakawamura/Desktop/repositories/mlflow/mlflow/server/handlers.py", line 1208, in _search_registered_models
    registered_models = store.search_registered_models(
  File "/Users/harutakakawamura/Desktop/repositories/mlflow/mlflow/store/model_registry/file_store.py", line 306, in search_registered_models
    registered_models = self._list_all_registered_models()
  File "/Users/harutakakawamura/Desktop/repositories/mlflow/mlflow/store/model_registry/file_store.py", line 268, in _list_all_registered_models
    registered_model_paths = self._get_all_registered_model_paths()
  File "/Users/harutakakawamura/Desktop/repositories/mlflow/mlflow/store/model_registry/file_store.py", line 668, in _get_all_registered_model_paths
    model_dirs = list_subdirs(
  File "/Users/harutakakawamura/Desktop/repositories/mlflow/mlflow/utils/file_utils.py", line 75, in list_subdirs
    return list_all(dir_name, os.path.isdir, full_path)
  File "/Users/harutakakawamura/Desktop/repositories/mlflow/mlflow/utils/file_utils.py", line 60, in list_all
    raise Exception("Invalid parent directory '%s'" % root)
Exception: Invalid parent directory './mlruns/models'
```

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->
- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
