### PR TITLE
Fix permission issue in `get_nfs_cache_root_dir`

### DIFF
--- a/mlflow/utils/nfs_on_spark.py
+++ b/mlflow/utils/nfs_on_spark.py
@@ -29,8 +29,7 @@ def get_nfs_cache_root_dir():
         )
         if nfs_enabled:
             try:
-                # If databricks runtime has dbutils entrypoint function `getReplNFSTempDir`,
-                # the directory it returns is ensured to have read / write permission granted.
+                # The directory `getReplNFSTempDir` returns has read/write permissions.
                 return _get_dbutils().entry_point.getReplNFSTempDir()
             except Exception:
                 nfs_root_dir = "/local_disk0/.ephemeral_nfs"
@@ -41,7 +40,7 @@ def get_nfs_cache_root_dir():
                     return nfs_root_dir
                 except Exception:
                     # For databricks cluster enabled Table ACL, we have no permission to access NFS
-                    # directory, in this case, return None representing NFS is not available.
+                    # directory, in this case, return None, meaning NFS is not available.
                     return None
                 finally:
                     shutil.rmtree(test_path, ignore_errors=True)

--- a/mlflow/utils/nfs_on_spark.py
+++ b/mlflow/utils/nfs_on_spark.py
@@ -4,6 +4,7 @@ import shutil
 
 from mlflow.utils.databricks_utils import is_in_databricks_runtime
 from mlflow.utils._spark_utils import _get_active_spark_session
+from mlflow.utils.databricks_utils import _get_dbutils
 
 # Set spark config "spark.mlflow.nfs.rootDir" to specify a NFS (network file system) directory
 # which is shared with all spark cluster nodes.
@@ -27,18 +28,23 @@ def get_nfs_cache_root_dir():
             spark_sess.conf.get("spark.databricks.mlflow.nfs.enabled", "true").lower() == "true"
         )
         if nfs_enabled:
-            nfs_root_dir = "/local_disk0/.ephemeral_nfs"
-            # Test whether the NFS directory is writable.
-            test_path = os.path.join(nfs_root_dir, uuid.uuid4().hex)
             try:
-                os.makedirs(test_path)
-                return nfs_root_dir
+                # If databricks runtime has dbutils entrypoint function `getReplNFSTempDir`,
+                # the directory it returns always has available permission.
+                return _get_dbutils().entry_point.getReplNFSTempDir()
             except Exception:
-                # For databricks cluster enabled Table ACL, we have no permission to access NFS
-                # directory, in this case, return None representing NFS is not available.
-                return None
-            finally:
-                shutil.rmtree(test_path, ignore_errors=True)
+                nfs_root_dir = "/local_disk0/.ephemeral_nfs"
+                # Test whether the NFS directory is writable.
+                test_path = os.path.join(nfs_root_dir, uuid.uuid4().hex)
+                try:
+                    os.makedirs(test_path)
+                    return nfs_root_dir
+                except Exception:
+                    # For databricks cluster enabled Table ACL, we have no permission to access NFS
+                    # directory, in this case, return None representing NFS is not available.
+                    return None
+                finally:
+                    shutil.rmtree(test_path, ignore_errors=True)
         else:
             return None
     else:

--- a/mlflow/utils/nfs_on_spark.py
+++ b/mlflow/utils/nfs_on_spark.py
@@ -30,7 +30,7 @@ def get_nfs_cache_root_dir():
         if nfs_enabled:
             try:
                 # If databricks runtime has dbutils entrypoint function `getReplNFSTempDir`,
-                # the directory it returns always has available permission.
+                # the directory it returns is ensured to have read / write permission granted.
                 return _get_dbutils().entry_point.getReplNFSTempDir()
             except Exception:
                 nfs_root_dir = "/local_disk0/.ephemeral_nfs"


### PR DESCRIPTION
Signed-off-by: Weichen Xu <weichen.xu@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Fix permission issue in `get_nfs_cache_root_dir`

On databricks, if running on cluster with user isolation,
non-root user cannot access `/local_disk0/.ephemeral_nfs` directory, that will cause `get_nfs_cache_root_dir` return False and cause NFS related optimization disabled.
We can try to call `getReplNFSTempDir` first, the directory `getReplNFSTempDir` returned is always readable and writable.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->
- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
