### PR TITLE
fix stfp delete_artifacts incorrect path

### DIFF
--- a/mlflow/store/artifact/sftp_artifact_repo.py
+++ b/mlflow/store/artifact/sftp_artifact_repo.py
@@ -128,8 +128,9 @@ class SFTPArtifactRepository(ArtifactRepository):
             sftp.get(remote_full_path, local_path)
 
     def delete_artifacts(self, artifact_path=None):
+        artifact_dir = posixpath.join(self.path, artifact_path) if artifact_path else self.path
         with self.pool.get_sfp_connection() as sftp:
-            self._delete_inner(artifact_path, sftp)
+            self._delete_inner(artifact_dir, sftp)
 
     def _delete_inner(self, artifact_path, sftp):
         if sftp.isdir(artifact_path):


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

When using sftp artifacts store and running `mlflow gc` to permanently delete artifacts, the below exception could throw.

```
Traceback (most recent call last):
  File "/home/user/.local/bin/mlflow", line 8, in <module>
    sys.exit(cli())
  File "/home/user/.local/lib/python3.8/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/home/user/.local/lib/python3.8/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/home/user/.local/lib/python3.8/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/user/.local/lib/python3.8/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/user/.local/lib/python3.8/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/home/user/.local/lib/python3.8/site-packages/mlflow/cli.py", line 493, in gc
    artifact_repo.delete_artifacts()
  File "/home/user/.local/lib/python3.8/site-packages/mlflow/store/artifact/sftp_artifact_repo.py", line 133, in delete_artifacts
    self._delete_inner(artifact_path, sftp)
  File "/home/user/.local/lib/python3.8/site-packages/mlflow/store/artifact/sftp_artifact_repo.py", line 142, in _delete_inner
    if sftp.isdir(artifact_path):
  File "/home/user/.local/lib/python3.8/site-packages/pysftp/__init__.py", line 652, in isdir
    result = S_ISDIR(self._sftp.stat(remotepath).st_mode)
  File "/home/user/.local/lib/python3.8/site-packages/paramiko/sftp_client.py", line 491, in stat
    path = self._adjust_cwd(path)
  File "/home/user/.local/lib/python3.8/site-packages/paramiko/sftp_client.py", line 914, in _adjust_cwd
    path = b(path)
  File "/home/user/.local/lib/python3.8/site-packages/paramiko/py3compat.py", line 156, in b
    raise TypeError("Expected unicode or bytes, got {!r}".format(s))
TypeError: Expected unicode or bytes, got None
```
## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

The path passed into `self._delete_inner(artifact_path, sftp)` seems to be incorrect. When `artifact_path=None`, the above error would be thrown.
```python
def delete_artifacts(self, artifact_path=None):
    with self.pool.get_sfp_connection() as sftp:
        self._delete_inner(artifact_path, sftp)

def _delete_inner(self, artifact_path, sftp):
    if sftp.isdir(artifact_path):
        with sftp.cd(artifact_path):
            for element in sftp.listdir():
                self._delete_inner(element, sftp)
        sftp.rmdir(artifact_path)
    elif sftp.isfile(artifact_path):
        sftp.remove(artifact_path)
```
Corrected path (code referencing `log_artifacts` and `list_artifacts` method in the same script):
```python
def delete_artifacts(self, artifact_path=None):
    artifact_dir = posixpath.join(self.path, artifact_path) if artifact_path else self.path
    with self.pool.get_sfp_connection() as sftp:
        self._delete_inner(artifact_dir, sftp)
```

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->
- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

With above changes, I was able to run `mlflow gc` without error.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
Fix error of permanently deleting runs using `mlflow gc` when using `SFTP` artifacts store. 

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
