### PR TITLE
Allow environment variable and tag specification for models deployed via MLflow SageMaker integration

### DIFF
--- a/mlflow/deployments/cli.py
+++ b/mlflow/deployments/cli.py
@@ -12,7 +12,8 @@ def _user_args_to_dict(user_list):
     user_dict = {}
     for s in user_list:
         try:
-            name, value = s.split("=")
+            # Some configs may contain '=' in the value
+            name, value = s.split("=", 1)
         except ValueError as exc:
             # not enough values to unpack
             raise click.BadOptionUsage(

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -312,8 +312,8 @@ def _deploy(
                                     mfs.deploy(..., data_capture_config=data_capture_config)
 
     :param variant_name: The name to assign to the new production variant.
-    :param env: A optional dictionary of environment variables to set for the model.
-    :param tags: A optional dictionary of tags to apply to the endpoint.
+    :param env: An optional dictionary of environment variables to set for the model.
+    :param tags: An optional dictionary of tags to apply to the endpoint.
     """
     import boto3
 

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -850,7 +850,7 @@ def terminate_transform_job(
         if transform_job_info["TransformJobStatus"] == "Stopping":
             return _SageMakerOperationStatus.in_progress(
                 "Termination is still in progress. Current batch transform job status: "
-                "       {transform_job_status}".format(
+                "{transform_job_status}".format(
                     transform_job_status=transform_job_info["TransformJobStatus"]
                 )
             )

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -2439,7 +2439,7 @@ class SageMakerDeploymentClient(BaseDeploymentClient):
         if final_config["mode"] not in [DEPLOYMENT_MODE_ADD, DEPLOYMENT_MODE_REPLACE]:
             raise MlflowException(
                 message=(
-                    f"Invalid mode `{final_config['mode']}` for deployment                        "
+                    f"Invalid mode `{final_config['mode']}` for deployment"
                     " to a pre-existing application"
                 ),
                 error_code=INVALID_PARAMETER_VALUE,

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -175,6 +175,8 @@ def _deploy(
     timeout_seconds=1200,
     data_capture_config=None,
     variant_name=None,
+    env=None,
+    tags=None,
 ):
     """
     Deploy an MLflow model on AWS SageMaker.
@@ -310,6 +312,8 @@ def _deploy(
                                     mfs.deploy(..., data_capture_config=data_capture_config)
 
     :param variant_name: The name to assign to the new production variant.
+    :param env: A optional dictionary of environment variables to set for the model.
+    :param tags: A optional dictionary of tags to apply to the endpoint.
     """
     import boto3
 
@@ -404,6 +408,8 @@ def _deploy(
             s3_client=s3_client,
             variant_name=variant_name,
             data_capture_config=data_capture_config,
+            env=env,
+            tags=tags,
         )
     else:
         deployment_operation = _create_sagemaker_endpoint(
@@ -420,6 +426,8 @@ def _deploy(
             role=execution_role_arn,
             sage_client=sage_client,
             variant_name=variant_name,
+            env=env,
+            tags=tags,
         )
 
     if synchronous:
@@ -841,8 +849,8 @@ def terminate_transform_job(
 
         if transform_job_info["TransformJobStatus"] == "Stopping":
             return _SageMakerOperationStatus.in_progress(
-                "Termination is still in progress. Current batch transform job status:\
-                    {transform_job_status}".format(
+                "Termination is still in progress. Current batch transform job status: "
+                "       {transform_job_status}".format(
                     transform_job_status=transform_job_info["TransformJobStatus"]
                 )
             )
@@ -1013,6 +1021,8 @@ def push_model_to_sagemaker(
         image_url=image_url,
         execution_role=execution_role_arn,
         sage_client=sage_client,
+        env={},
+        tags={},
     )
 
     _logger.info("Created Sagemaker model with arn: %s", model_response["ModelArn"])
@@ -1278,7 +1288,7 @@ def _upload_s3(local_model_path, bucket, prefix, region_name, s3_client, **assum
             return "s3://{}/{}".format(bucket, key)
 
 
-def _get_deployment_config(flavor_name):
+def _get_deployment_config(flavor_name, env_override=None):
     """
     :return: The deployment configuration as a dictionary
     """
@@ -1286,6 +1296,8 @@ def _get_deployment_config(flavor_name):
         DEPLOYMENT_CONFIG_KEY_FLAVOR_NAME: flavor_name,
         SERVING_ENVIRONMENT: SAGEMAKER_SERVING_ENVIRONMENT,
     }
+    if env_override:
+        deployment_config.update(env_override)
 
     if os.getenv("http_proxy") is not None:
         deployment_config.update({"http_proxy": os.environ["http_proxy"]})
@@ -1378,6 +1390,8 @@ def _create_sagemaker_transform_job(
         image_url=image_url,
         execution_role=role,
         sage_client=sage_client,
+        env={},
+        tags={},
     )
     _logger.info("Created model with arn: %s", model_response["ModelArn"])
 
@@ -1426,9 +1440,10 @@ def _create_sagemaker_transform_job(
         transform_job_status = transform_job_info["TransformJobStatus"]
         if transform_job_status == "InProgress":
             return _SageMakerOperationStatus.in_progress(
-                'Waiting for batch transform job to reach the "Completed" state. \
-                    Current batch transform job status:'
-                ' "{transform_job_status}"'.format(transform_job_status=transform_job_status)
+                'Waiting for batch transform job to reach the "Completed" state.                   '
+                '  Current batch transform job status: "{transform_job_status}"'.format(
+                    transform_job_status=transform_job_status
+                )
             )
         elif transform_job_status == "Completed":
             return _SageMakerOperationStatus.succeeded(
@@ -1437,10 +1452,8 @@ def _create_sagemaker_transform_job(
         else:
             failure_reason = transform_job_info.get(
                 "FailureReason",
-                (
-                    "An unknown SageMaker failure occurred. Please see the SageMaker console logs"
-                    " for more information."
-                ),
+                "An unknown SageMaker failure occurred. Please see the SageMaker console logs"
+                " for more information.",
             )
             return _SageMakerOperationStatus.failed(failure_reason)
 
@@ -1468,6 +1481,8 @@ def _create_sagemaker_endpoint(
     role,
     sage_client,
     variant_name=None,
+    env=None,
+    tags=None,
 ):
     """
     :param endpoint_name: The name of the SageMaker endpoint to create.
@@ -1486,6 +1501,8 @@ def _create_sagemaker_endpoint(
     :param role: SageMaker execution ARN role.
     :param sage_client: A boto3 client for SageMaker.
     :param variant_name: The name to assign to the new production variant.
+    :param env: A dictionary of environment variables to set for the model.
+    :param tags: A dictionary of tags to apply to the endpoint.
     """
     _logger.info("Creating new endpoint with name: %s ...", endpoint_name)
 
@@ -1498,6 +1515,8 @@ def _create_sagemaker_endpoint(
         image_url=image_url,
         execution_role=role,
         sage_client=sage_client,
+        env=env or {},
+        tags=tags or {},
     )
     _logger.info("Created model with arn: %s", model_response["ModelArn"])
 
@@ -1551,10 +1570,8 @@ def _create_sagemaker_endpoint(
         else:
             failure_reason = endpoint_info.get(
                 "FailureReason",
-                (
-                    "An unknown SageMaker failure occurred. Please see the SageMaker console logs"
-                    " for more information."
-                ),
+                "An unknown SageMaker failure occurred. Please see the SageMaker console logs"
+                " for more information.",
             )
             return _SageMakerOperationStatus.failed(failure_reason)
 
@@ -1580,6 +1597,8 @@ def _update_sagemaker_endpoint(
     s3_client,
     variant_name=None,
     data_capture_config=None,
+    env=None,
+    tags=None,
 ):
     """
     :param endpoint_name: The name of the SageMaker endpoint to update.
@@ -1602,6 +1621,8 @@ def _update_sagemaker_endpoint(
     :param: data_capture_config: A dictionary specifying the data capture configuration to use.
                                  For more information, see https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_DataCaptureConfig.html.
                                  Defaults to ``None``.
+    :param env: A dictionary of environment variables to set for the model.
+    :param tags: A dictionary of tags to apply to the endpoint.
     """
     if mode not in [DEPLOYMENT_MODE_ADD, DEPLOYMENT_MODE_REPLACE]:
         msg = "Invalid mode `{md}` for deployment to a pre-existing application".format(md=mode)
@@ -1627,6 +1648,8 @@ def _update_sagemaker_endpoint(
         image_url=image_url,
         execution_role=role,
         sage_client=sage_client,
+        env=env or {},
+        tags=tags or {},
     )
     _logger.info("Created new model with arn: %s", new_model_response["ModelArn"])
 
@@ -1685,11 +1708,9 @@ def _update_sagemaker_endpoint(
         if endpoint_update_was_rolled_back or endpoint_info["EndpointStatus"] == "Failed":
             failure_reason = endpoint_info.get(
                 "FailureReason",
-                (
-                    "An unknown SageMaker failure occurred."
-                    " Please see the SageMaker console logs for"
-                    " more information."
-                ),
+                "An unknown SageMaker failure occurred."
+                " Please see the SageMaker console logs for"
+                " more information.",
             )
             return _SageMakerOperationStatus.failed(failure_reason)
         elif endpoint_info["EndpointStatus"] == "InService":
@@ -1718,7 +1739,16 @@ def _update_sagemaker_endpoint(
 
 
 def _create_sagemaker_model(
-    model_name, model_s3_path, model_uri, flavor, vpc_config, image_url, execution_role, sage_client
+    model_name,
+    model_s3_path,
+    model_uri,
+    flavor,
+    vpc_config,
+    image_url,
+    execution_role,
+    sage_client,
+    env,
+    tags,
 ):
     """
     :param model_name: The name to assign the new SageMaker model that is created.
@@ -1731,17 +1761,20 @@ def _create_sagemaker_model(
                       model's container,
     :param execution_role: The ARN of the role that SageMaker will assume when creating the model.
     :param sage_client: A boto3 client for SageMaker.
+    :param env: A dictionary of environment variables to set for the model.
+    :param tags: A dictionary of tags to apply to the SageMaker model.
     :return: AWS response containing metadata associated with the new model.
     """
+    tags["model_uri"] = str(model_uri)
     create_model_args = {
         "ModelName": model_name,
         "PrimaryContainer": {
             "Image": image_url,
             "ModelDataUrl": model_s3_path,
-            "Environment": _get_deployment_config(flavor_name=flavor),
+            "Environment": _get_deployment_config(flavor_name=flavor, env_override=env),
         },
         "ExecutionRoleArn": execution_role,
-        "Tags": [{"Key": "model_uri", "Value": str(model_uri)}],
+        "Tags": [{"Key": key, "Value": str(value)} for key, value in tags.items()],
     }
     if vpc_config is not None:
         create_model_args["VpcConfig"] = vpc_config
@@ -1937,6 +1970,8 @@ class SageMakerDeploymentClient(BaseDeploymentClient):
             "synchronous": True,
             "timeout_seconds": 1200,
             "variant_name": None,
+            "env": None,
+            "tags": None,
         }
 
         if create_mode:
@@ -1951,7 +1986,7 @@ class SageMakerDeploymentClient(BaseDeploymentClient):
 
         int_fields = {"instance_count", "timeout_seconds"}
         bool_fields = {"synchronous", "archive"}
-        dict_fields = {"vpc_config", "data_capture_config"}
+        dict_fields = {"vpc_config", "data_capture_config", "tags", "env"}
         for key, value in custom_config.items():
             if key not in config:
                 continue
@@ -2077,6 +2112,12 @@ class SageMakerDeploymentClient(BaseDeploymentClient):
                        - ``variant_name``: A string specifying the desired name when creating a
                                            production variant.  Defaults to ``None``.
 
+                       - ``env``: A dictionary specifying environment variables as key-value
+                         pairs to be set for the deployed model. Defaults to ``None``.
+
+                       - ``tags``: A dictionary of key-value pairs representing additional
+                         tags to be set for the deployed model. Defaults to ``None``.
+
         :param endpoint: (optional) Endpoint to create the deployment under. Currently unsupported
 
         .. code-block:: python
@@ -2105,6 +2146,8 @@ class SageMakerDeploymentClient(BaseDeploymentClient):
                 timeout_seconds=300,
                 vpc_config=vpc_config,
                 variant_name="prod-variant-1",
+                env={"DISABLE_NGINX": "1", "GUNICORN_CMD_ARGS": "\"--timeout 60\""},
+                tags={"training_timestamp": "2022-11-01T05:12:26"}
             )
             client = get_deploy_client("sagemaker")
             client.create_deployment(
@@ -2135,6 +2178,8 @@ class SageMakerDeploymentClient(BaseDeploymentClient):
                     -C data_capture_config='{"EnableCapture": True, \\
                     'InitalSamplingPercentage': 100, 'DestinationS3Uri": 's3://my-bucket/path', \\
                     'CaptureOptions': [{'CaptureMode': 'Output'}]}'
+                    -C env='{"DISABLE_NGINX": "1", "GUNICORN_CMD_ARGS": "\"--timeout 60\""}' \\
+                    -C tags='{"training_timestamp": "2022-11-01T05:12:26"}' \\
         """
         final_config = self._default_deployment_config()
         if config:
@@ -2158,6 +2203,8 @@ class SageMakerDeploymentClient(BaseDeploymentClient):
             synchronous=final_config["synchronous"],
             timeout_seconds=final_config["timeout_seconds"],
             variant_name=final_config["variant_name"],
+            env=final_config["env"],
+            tags=final_config["tags"],
         )
 
         return {"name": app_name, "flavor": flavor}
@@ -2298,6 +2345,12 @@ class SageMakerDeploymentClient(BaseDeploymentClient):
                        - ``variant_name``: A string specifying the desired name when creating a
                                            production variant.  Defaults to ``None``.
 
+                       - ``env``: A dictionary specifying environment variables as key-value pairs
+                         to be set for the deployed model. Defaults to ``None``.
+
+                       - ``tags``: A dictionary of key-value pairs representing additional tags
+                         to be set for the deployed model. Defaults to ``None``.
+
         :param endpoint: (optional) Endpoint containing the deployment to update. Currently
                          unsupported
 
@@ -2337,6 +2390,8 @@ class SageMakerDeploymentClient(BaseDeploymentClient):
                 variant_name="prod-variant-1",
                 vpc_config=vpc_config
                 data_capture_config=data_capture_config
+                env={"DISABLE_NGINX": "1", "GUNICORN_CMD_ARGS": "\"--timeout 60\""},
+                tags={"training_timestamp": "2022-11-01T05:12:26"}
             )
             client = get_deploy_client("sagemaker")
             client.update_deployment(
@@ -2366,8 +2421,10 @@ class SageMakerDeploymentClient(BaseDeploymentClient):
                     -C vpc_config='{"SecurityGroupIds": ["sg-123456abc"], \\
                     "Subnets": ["subnet-123456abc"]}' \\
                     -C data_capture_config='{"EnableCapture": True, \\
-                    'InitalSamplingPercentage': 100, 'DestinationS3Uri": 's3://my-bucket/path', \\
-                    'CaptureOptions': [{'CaptureMode': 'Output'}]}'
+                    "InitalSamplingPercentage": 100, "DestinationS3Uri": "s3://my-bucket/path", \\
+                    "CaptureOptions": [{"CaptureMode": "Output"}]}'
+                    -C env='{"DISABLE_NGINX": "1", "GUNICORN_CMD_ARGS": "\"--timeout 60\""}' \\
+                    -C tags='{"training_timestamp": "2022-11-01T05:12:26"}' \\
         """
         final_config = self._default_deployment_config(create_mode=False)
         if config:
@@ -2375,14 +2432,16 @@ class SageMakerDeploymentClient(BaseDeploymentClient):
 
         if model_uri is None:
             raise MlflowException(
-                message=("A model_uri must be provided when updating a SageMaker deployment"),
+                message="A model_uri must be provided when updating a SageMaker deployment",
                 error_code=INVALID_PARAMETER_VALUE,
             )
 
         if final_config["mode"] not in [DEPLOYMENT_MODE_ADD, DEPLOYMENT_MODE_REPLACE]:
             raise MlflowException(
-                message=f"Invalid mode `{final_config['mode']}` for deployment \
-                        to a pre-existing application",
+                message=(
+                    f"Invalid mode `{final_config['mode']}` for deployment                        "
+                    " to a pre-existing application"
+                ),
                 error_code=INVALID_PARAMETER_VALUE,
             )
 
@@ -2404,6 +2463,8 @@ class SageMakerDeploymentClient(BaseDeploymentClient):
             synchronous=final_config["synchronous"],
             timeout_seconds=final_config["timeout_seconds"],
             variant_name=final_config["variant_name"],
+            env=final_config["env"],
+            tags=final_config["tags"],
         )
 
         return {"name": app_name, "flavor": flavor}
@@ -2575,7 +2636,7 @@ class SageMakerDeploymentClient(BaseDeploymentClient):
             return sage_client.describe_endpoint(EndpointName=name)
         except Exception as exc:
             raise MlflowException(
-                message=(f"There was an error while retrieving the deployment: {exc}\n")
+                message=f"There was an error while retrieving the deployment: {exc}\n"
             )
 
     def predict(self, deployment_name=None, inputs=None, endpoint=None):
@@ -2648,7 +2709,7 @@ class SageMakerDeploymentClient(BaseDeploymentClient):
             return PredictionsResponse.from_json(response_body)
         except Exception as exc:
             raise MlflowException(
-                message=(f"There was an error while getting model prediction: {exc}\n")
+                message=f"There was an error while getting model prediction: {exc}\n"
             )
 
     def explain(self, deployment_name=None, df=None, endpoint=None):

--- a/tests/sagemaker/mock/__init__.py
+++ b/tests/sagemaker/mock/__init__.py
@@ -516,7 +516,7 @@ class SageMakerBackend(BaseBackend):
         Modifies backend state during calls to the SageMaker "ListTags" API
         https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_ListTags.html
         """
-        model = [model for model in self.models.values() if model.arn == resource_arn][0]
+        model = next(model for model in self.models.values() if model.arn == resource_arn)
         return model.resource.tags
 
     def create_model(

--- a/tests/sagemaker/mock/__init__.py
+++ b/tests/sagemaker/mock/__init__.py
@@ -182,6 +182,20 @@ class SageMakerResponse(BaseResponse):
         self.sagemaker_backend.delete_model(model_name)
         return ""
 
+    def list_tags(self):
+        """
+        Handler for the SageMaker "ListTags" API call documented here:
+        https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_ListTags.html
+        """
+        model_arn = self.request_params["ResourceArn"]
+
+        results = self.sagemaker_backend.list_tags(
+            resource_arn=model_arn,
+            region_name=self.region,
+        )
+
+        return json.dumps({"Tags": results, "NextToken": None})
+
     def create_transform_job(self):
         """
         Handler for the SageMaker "CreateTransformJob" API call documented here:
@@ -496,6 +510,14 @@ class SageMakerBackend(BaseBackend):
             summary = ModelSummary(model=model.resource, arn=model.arn)
             summaries.append(summary)
         return summaries
+
+    def list_tags(self, resource_arn, region_name):
+        """
+        Modifies backend state during calls to the SageMaker "ListTags" API
+        https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_ListTags.html
+        """
+        model = [model for model in self.models.values() if model.arn == resource_arn][0]
+        return model.resource.tags
 
     def create_model(
         self, model_name, primary_container, execution_role_arn, tags, region_name, vpc_config=None

--- a/tests/sagemaker/test_sagemaker_deployment_client.py
+++ b/tests/sagemaker/test_sagemaker_deployment_client.py
@@ -62,9 +62,17 @@ def sagemaker_deployment_client():
     )
 
 
-def create_sagemaker_deployment_through_cli(app_name, model_uri, region_name, env=None):
+def create_sagemaker_deployment_through_cli(
+    app_name, model_uri, region_name, env=None, config=None
+):
     if env is None:
         env = {"LC_ALL": "en_US.UTF-8", "LANG": "en_US.UTF-8"}
+    if config is not None:
+        _config = []
+        for c in config:
+            _config += ["-C", c]
+    else:
+        _config = []
     result = CliRunner(env=env).invoke(
         cli_commands,
         [
@@ -75,7 +83,8 @@ def create_sagemaker_deployment_through_cli(app_name, model_uri, region_name, en
             app_name,
             "--model-uri",
             model_uri,
-        ],
+        ]
+        + _config,
     )
     assert result.exit_code == 0
 
@@ -199,12 +208,24 @@ def test__apply_custom_config_converts_from_string_to_dict_for_dict_fields(
             "subnet-123456abc",
         ],
     }
-    config = {"vpc_config": None}
-    custom_config = {"vpc_config": json.dumps(vpc_config)}
+    env_config = {
+        "GUNICORN_CMD_ARGS": "--timeout=60",
+    }
+    tags_config = {
+        "tag1": "value1",
+    }
+    config = {"vpc_config": None, "env": None, "tags": None}
+    custom_config = {
+        "vpc_config": json.dumps(vpc_config),
+        "env": json.dumps(env_config),
+        "tags": json.dumps(tags_config),
+    }
 
     sagemaker_deployment_client._apply_custom_config(config, custom_config)
 
     assert config["vpc_config"] == vpc_config
+    assert config["env"] == env_config
+    assert config["tags"] == tags_config
 
 
 def test__apply_custom_config_does_not_change_type_of_string_fields(sagemaker_deployment_client):
@@ -305,6 +326,34 @@ def test_attempting_to_deploy_in_asynchronous_mode_without_archiving_throws_exce
     assert exc.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
 
+@mock_sagemaker_aws_services
+def test_create_deployment_create_sagemaker_and_s3_resources_with_expected_tags_from_local(
+    pretrained_model, sagemaker_client, sagemaker_deployment_client
+):
+    expected_tags = [{"Key": "key1", "Value": "value1"}, {"Key": "key2", "Value": "value2"}]
+
+    name = "test-app"
+    with mock.patch.dict(os.environ, {}, clear=True):
+        sagemaker_deployment_client.create_deployment(
+            name=name,
+            model_uri=pretrained_model.model_uri,
+            config=dict(
+                tags={"key1": "value1", "key2": "value2"},
+            ),
+        )
+
+    endpoint_description = sagemaker_client.describe_endpoint(EndpointName=name)
+    endpoint_production_variants = endpoint_description["ProductionVariants"]
+    assert len(endpoint_production_variants) == 1
+    model_name = endpoint_production_variants[0]["VariantName"]
+    description = sagemaker_client.describe_model(ModelName=model_name)
+
+    tags = sagemaker_client.list_tags(ResourceArn=description["ModelArn"])
+
+    # Extra tags exist besides the ones we set, so avoid strict equality
+    assert all(tag in tags["Tags"] for tag in expected_tags)
+
+
 @pytest.mark.parametrize("proxies_enabled", [True, False])
 @mock_sagemaker_aws_services
 def test_create_deployment_create_sagemaker_and_s3_resources_with_expected_names_and_env_from_local(
@@ -313,6 +362,8 @@ def test_create_deployment_create_sagemaker_and_s3_resources_with_expected_names
     expected_model_environment = {
         "MLFLOW_DEPLOYMENT_FLAVOR_NAME": "python_function",
         "SERVING_ENVIRONMENT": "SageMaker",
+        "GUNCORN_CMD_ARGS": '"--timeout 60"',
+        "DISABLE_NGINX": "1",
     }
 
     if proxies_enabled:
@@ -327,6 +378,9 @@ def test_create_deployment_create_sagemaker_and_s3_resources_with_expected_names
             sagemaker_deployment_client.create_deployment(
                 name=name,
                 model_uri=pretrained_model.model_uri,
+                config=dict(
+                    env={"DISABLE_NGINX": "1", "GUNCORN_CMD_ARGS": '"--timeout 60"'},
+                ),
             )
     else:
         name = "test-app"
@@ -334,6 +388,9 @@ def test_create_deployment_create_sagemaker_and_s3_resources_with_expected_names
             sagemaker_deployment_client.create_deployment(
                 name=name,
                 model_uri=pretrained_model.model_uri,
+                config=dict(
+                    env={"DISABLE_NGINX": "1", "GUNCORN_CMD_ARGS": '"--timeout 60"'},
+                ),
             )
 
     region_name = sagemaker_client.meta.region_name
@@ -369,9 +426,12 @@ def test_deploy_cli_creates_sagemaker_and_s3_resources_with_expected_names_and_e
 ):
     region_name = sagemaker_client.meta.region_name
     environment_variables = {"LC_ALL": "en_US.UTF-8", "LANG": "en_US.UTF-8"}
+    override_environment_variables = {"DISABLE_NGINX": "1", "GUNCORN_CMD_ARGS": '"--timeout 60"'}
     expected_model_environment = {
         "MLFLOW_DEPLOYMENT_FLAVOR_NAME": "python_function",
         "SERVING_ENVIRONMENT": "SageMaker",
+        "GUNCORN_CMD_ARGS": '"--timeout 60"',
+        "DISABLE_NGINX": "1",
     }
 
     if proxies_enabled:
@@ -387,6 +447,7 @@ def test_deploy_cli_creates_sagemaker_and_s3_resources_with_expected_names_and_e
             pretrained_model.model_uri,
             region_name,
             {**environment_variables, **proxy_variables},
+            config=["env={}".format(json.dumps(override_environment_variables))],
         )
     else:
         proxy_variables = {
@@ -400,6 +461,7 @@ def test_deploy_cli_creates_sagemaker_and_s3_resources_with_expected_names_and_e
             pretrained_model.model_uri,
             region_name,
             {**environment_variables, **proxy_variables},
+            config=["env={}".format(json.dumps(override_environment_variables))],
         )
 
     s3_client = boto3.client("s3", region_name=region_name)
@@ -425,6 +487,34 @@ def test_deploy_cli_creates_sagemaker_and_s3_resources_with_expected_names_and_e
     ]
 
     assert model_environment == expected_model_environment
+
+
+@mock_sagemaker_aws_services
+def test_deploy_cli_creates_sagemaker_and_s3_resources_with_expected_tags_from_local(
+    pretrained_model, sagemaker_client
+):
+    expected_tags = [{"Key": "key1", "Value": "value1"}, {"Key": "key2", "Value": "value2"}]
+    region_name = sagemaker_client.meta.region_name
+
+    app_name = "test-app"
+    create_sagemaker_deployment_through_cli(
+        app_name,
+        pretrained_model.model_uri,
+        region_name,
+        env=None,
+        config=["tags={}".format(json.dumps({"key1": "value1", "key2": "value2"}))],
+    )
+
+    endpoint_description = sagemaker_client.describe_endpoint(EndpointName=app_name)
+    endpoint_production_variants = endpoint_description["ProductionVariants"]
+    assert len(endpoint_production_variants) == 1
+    model_name = endpoint_production_variants[0]["VariantName"]
+    description = sagemaker_client.describe_model(ModelName=model_name)
+
+    tags = sagemaker_client.list_tags(ResourceArn=description["ModelArn"])
+
+    # Extra tags exist besides the ones we set, so avoid strict equality
+    assert all(tag in tags["Tags"] for tag in expected_tags)
 
 
 @pytest.mark.parametrize("proxies_enabled", [True, False])


### PR DESCRIPTION
## Related Issues/PRs

N/A 

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

This change serves to allow users of the MLflow SageMaker deployment a way of setting environment variables and tags for the models they deploy. 

This is accomplished by adding two new options to the deployment config dictionary, available to set during deployment creation or update

1. `env`: dictionary of key/value pairs representing environment variables to set for the created model
2. `tags`: dictionary of key/value pairs representing tags to set for the created model

For `mlflow deployments {create|update}` CLI, these are set via the `-C {<json>}` interface, similar to `vpc_config`. For the Python SDK interface, these are passed in as simple dictionaries.

The primary motivation here was that one of our models was configured via envvars and we had no simple way of setting these when deploying via the `mlflow deployments create -t sagemaker` command without going into the AWS console and performing a manual override there. We also keep track of resources via tags, and there was no simple way of setting those either.

## How is this patch tested?


- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

Updated existing unit tests for both the SDK and CLI interfaces to ensure that environment variables are threaded through correctly. I also updated the `moto` SageMaker backend to have a `list_tags` method to help test the tag-setting capabilities.

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Users of the SageMaker deployment functionality can now configure environment variables and tags for the deployed models from both the CLI and Python SDK.

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [x] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations


<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
