### PR TITLE
Fix torch examples and tests that are broken by incompatible torchmetrics accuracy API change

### DIFF
--- a/examples/pytorch/AxHyperOptimizationPTL/iris.py
+++ b/examples/pytorch/AxHyperOptimizationPTL/iris.py
@@ -17,9 +17,9 @@ class IrisClassification(pl.LightningModule):
     def __init__(self, **kwargs):
         super().__init__()
 
-        self.train_acc = Accuracy()
-        self.val_acc = Accuracy()
-        self.test_acc = Accuracy()
+        self.train_acc = Accuracy(task="multiclass")
+        self.val_acc = Accuracy(task="multiclass")
+        self.test_acc = Accuracy(task="multiclass")
         self.args = kwargs
 
         self.fc1 = nn.Linear(4, 10)

--- a/examples/pytorch/AxHyperOptimizationPTL/iris.py
+++ b/examples/pytorch/AxHyperOptimizationPTL/iris.py
@@ -17,9 +17,9 @@ class IrisClassification(pl.LightningModule):
     def __init__(self, **kwargs):
         super().__init__()
 
-        self.train_acc = Accuracy(task="multiclass")
-        self.val_acc = Accuracy(task="multiclass")
-        self.test_acc = Accuracy(task="multiclass")
+        self.train_acc = Accuracy(task="multiclass", num_classes=10)
+        self.val_acc = Accuracy(task="multiclass", num_classes=10)
+        self.test_acc = Accuracy(task="multiclass", num_classes=10)
         self.args = kwargs
 
         self.fc1 = nn.Linear(4, 10)

--- a/examples/pytorch/AxHyperOptimizationPTL/iris.py
+++ b/examples/pytorch/AxHyperOptimizationPTL/iris.py
@@ -17,9 +17,9 @@ class IrisClassification(pl.LightningModule):
     def __init__(self, **kwargs):
         super().__init__()
 
-        self.train_acc = Accuracy(task="multiclass", num_classes=10)
-        self.val_acc = Accuracy(task="multiclass", num_classes=10)
-        self.test_acc = Accuracy(task="multiclass", num_classes=10)
+        self.train_acc = Accuracy(task="multiclass", num_classes=3)
+        self.val_acc = Accuracy(task="multiclass", num_classes=3)
+        self.test_acc = Accuracy(task="multiclass", num_classes=3)
         self.args = kwargs
 
         self.fc1 = nn.Linear(4, 10)

--- a/examples/pytorch/IterativePruning/mnist.py
+++ b/examples/pytorch/IterativePruning/mnist.py
@@ -214,7 +214,7 @@ class LightningMNISTClassifier(pl.LightningModule):
         x, y = test_batch
         output = self.forward(x)
         _, y_hat = torch.max(output, dim=1)
-        test_acc = accuracy(y_hat.cpu(), y.cpu(), task="multiclass")
+        test_acc = accuracy(y_hat.cpu(), y.cpu(), task="multiclass", num_classes=10)
         return {"test_acc": test_acc}
 
     def test_epoch_end(self, outputs):

--- a/examples/pytorch/IterativePruning/mnist.py
+++ b/examples/pytorch/IterativePruning/mnist.py
@@ -214,7 +214,7 @@ class LightningMNISTClassifier(pl.LightningModule):
         x, y = test_batch
         output = self.forward(x)
         _, y_hat = torch.max(output, dim=1)
-        test_acc = accuracy(y_hat.cpu(), y.cpu(), multiclass="multiclass")
+        test_acc = accuracy(y_hat.cpu(), y.cpu(), task="multiclass")
         return {"test_acc": test_acc}
 
     def test_epoch_end(self, outputs):

--- a/examples/pytorch/IterativePruning/mnist.py
+++ b/examples/pytorch/IterativePruning/mnist.py
@@ -214,7 +214,7 @@ class LightningMNISTClassifier(pl.LightningModule):
         x, y = test_batch
         output = self.forward(x)
         _, y_hat = torch.max(output, dim=1)
-        test_acc = accuracy(y_hat.cpu(), y.cpu())
+        test_acc = accuracy(y_hat.cpu(), y.cpu(), multiclass="multiclass")
         return {"test_acc": test_acc}
 
     def test_epoch_end(self, outputs):

--- a/examples/pytorch/MNIST/mnist_autolog_example.py
+++ b/examples/pytorch/MNIST/mnist_autolog_example.py
@@ -219,7 +219,7 @@ class LightningMNISTClassifier(pl.LightningModule):
         x, y = test_batch
         output = self.forward(x)
         _, y_hat = torch.max(output, dim=1)
-        test_acc = accuracy(y_hat.cpu(), y.cpu())
+        test_acc = accuracy(y_hat.cpu(), y.cpu(), multiclass="multiclass")
         return {"test_acc": test_acc}
 
     def test_epoch_end(self, outputs):

--- a/examples/pytorch/MNIST/mnist_autolog_example.py
+++ b/examples/pytorch/MNIST/mnist_autolog_example.py
@@ -219,7 +219,7 @@ class LightningMNISTClassifier(pl.LightningModule):
         x, y = test_batch
         output = self.forward(x)
         _, y_hat = torch.max(output, dim=1)
-        test_acc = accuracy(y_hat.cpu(), y.cpu(), task="multiclass")
+        test_acc = accuracy(y_hat.cpu(), y.cpu(), task="multiclass", num_classes=10)
         return {"test_acc": test_acc}
 
     def test_epoch_end(self, outputs):

--- a/examples/pytorch/MNIST/mnist_autolog_example.py
+++ b/examples/pytorch/MNIST/mnist_autolog_example.py
@@ -219,7 +219,7 @@ class LightningMNISTClassifier(pl.LightningModule):
         x, y = test_batch
         output = self.forward(x)
         _, y_hat = torch.max(output, dim=1)
-        test_acc = accuracy(y_hat.cpu(), y.cpu(), multiclass="multiclass")
+        test_acc = accuracy(y_hat.cpu(), y.cpu(), task="multiclass")
         return {"test_acc": test_acc}
 
     def test_epoch_end(self, outputs):

--- a/tests/pytorch/iris.py
+++ b/tests/pytorch/iris.py
@@ -18,9 +18,9 @@ def create_multiclass_accuracy():
         import torchmetrics
 
         if Version(torchmetrics.__version__) >= Version("0.11"):
-            return Accuracy(task="multiclass")
+            return Accuracy(task="multiclass", num_classes=3)
         else:
-            return Accuracy()
+            return Accuracy()  # pylint: disable=no-value-for-parameter
     except ImportError:
         from pytorch_lightning.metrics import Accuracy
 

--- a/tests/pytorch/iris.py
+++ b/tests/pytorch/iris.py
@@ -6,23 +6,32 @@ import pytorch_lightning as pl
 import torch
 from torch import nn
 import torch.nn.functional as F
+from packaging.version import Version
 
-# NB: Older versions of PyTorch Lightning define native APIs for metric computation,
-# (e.g., pytorch_lightning.metrics.Accuracy), while newer versions rely on the `torchmetrics`
-# package (e.g. `torchmetrics.Accuracy)
-try:
-    from torchmetrics import Accuracy
-except ImportError:
-    from pytorch_lightning.metrics import Accuracy
+
+def create_multitask_accuracy():
+    # NB: Older versions of PyTorch Lightning define native APIs for metric computation,
+    # (e.g., pytorch_lightning.metrics.Accuracy), while newer versions rely on the `torchmetrics`
+    # package (e.g. `torchmetrics.Accuracy)
+    try:
+        from torchmetrics import Accuracy
+        import torchmetrics
+        if Version(torchmetrics.__version__) >= Version("0.11"):
+            return Accuracy(task="multiclass")
+        else:
+            return Accuracy()
+    except ImportError:
+        from pytorch_lightning.metrics import Accuracy
+        return Accuracy()
 
 
 class IrisClassificationBase(pl.LightningModule):
     def __init__(self, **kwargs):
         super().__init__()
 
-        self.train_acc = Accuracy()
-        self.val_acc = Accuracy()
-        self.test_acc = Accuracy()
+        self.train_acc = create_multitask_accuracy()
+        self.val_acc = create_multitask_accuracy()
+        self.test_acc = create_multitask_accuracy()
         self.args = kwargs
 
         self.fc1 = nn.Linear(4, 10)

--- a/tests/pytorch/iris.py
+++ b/tests/pytorch/iris.py
@@ -9,7 +9,7 @@ import torch.nn.functional as F
 from packaging.version import Version
 
 
-def create_multitask_accuracy():
+def create_multiclass_accuracy():
     # NB: Older versions of PyTorch Lightning define native APIs for metric computation,
     # (e.g., pytorch_lightning.metrics.Accuracy), while newer versions rely on the `torchmetrics`
     # package (e.g. `torchmetrics.Accuracy)
@@ -29,9 +29,9 @@ class IrisClassificationBase(pl.LightningModule):
     def __init__(self, **kwargs):
         super().__init__()
 
-        self.train_acc = create_multitask_accuracy()
-        self.val_acc = create_multitask_accuracy()
-        self.test_acc = create_multitask_accuracy()
+        self.train_acc = create_multiclass_accuracy()
+        self.val_acc = create_multiclass_accuracy()
+        self.test_acc = create_multiclass_accuracy()
         self.args = kwargs
 
         self.fc1 = nn.Linear(4, 10)

--- a/tests/pytorch/iris.py
+++ b/tests/pytorch/iris.py
@@ -16,12 +16,14 @@ def create_multiclass_accuracy():
     try:
         from torchmetrics import Accuracy
         import torchmetrics
+
         if Version(torchmetrics.__version__) >= Version("0.11"):
             return Accuracy(task="multiclass")
         else:
             return Accuracy()
     except ImportError:
         from pytorch_lightning.metrics import Accuracy
+
         return Accuracy()
 
 


### PR DESCRIPTION
Signed-off-by: Weichen Xu <weichen.xu@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Fix torch examples / tests that are broken by imcompatible torchmetrics accuracy API change
See https://www.google.com/url?q=https://github.com/Lightning-AI/metrics/pull/1252&sa=D&source=docs&ust=1669951711678224&usg=AOvVaw04EDZusrH6-foBNTEa426S

## How is this patch tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [x] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
