### PR TITLE
Enable `mlserver` inference engine for SageMaker serving applications

### DIFF
--- a/mlflow/sagemaker/cli.py
+++ b/mlflow/sagemaker/cli.py
@@ -8,6 +8,7 @@ import mlflow.sagemaker
 from mlflow.sagemaker import DEFAULT_IMAGE_NAME as IMAGE
 from mlflow.utils import cli_args
 import mlflow.models.docker_utils
+from mlflow.models.docker_utils import DISABLE_ENV_CREATION
 from mlflow.utils import env_manager as em
 
 
@@ -344,7 +345,8 @@ def push_model_to_sagemaker(
 @click.option("--container", "-c", default=IMAGE, help="image name")
 @cli_args.ENV_MANAGER
 @cli_args.MLFLOW_HOME
-def build_and_push_container(build, push, container, env_manager, mlflow_home):
+@cli_args.ENABLE_MLSERVER
+def build_and_push_container(build, push, container, env_manager, mlflow_home, enable_mlserver):
     """
     Build new MLflow Sagemaker image, assign it a name, and push to ECR.
 
@@ -366,9 +368,10 @@ def build_and_push_container(build, push, container, env_manager, mlflow_home):
         def setup_container(_):
             return "\n".join(
                 [
-                    'ENV {disable_env}="false"',
+                    f'ENV {DISABLE_ENV_CREATION}="false"',
+                    f'ENV {ENABLE_MLSERVER}={enable_mlserver}',
                     'RUN python -c "from mlflow.models.container import _install_pyfunc_deps;'
-                    '_install_pyfunc_deps(None, False)"',
+                    f'_install_pyfunc_deps(None, False, enable_mlserver={enable_mlserver})"',
                 ]
             )
 


### PR DESCRIPTION
## Related Issues/PRs

N/A

## What changes are proposed in this pull request?

Enable the `mlserver` inference engine backend for use when serving on AWS SageMaker. This is done by adding the standard `--enable-mlserver` command when building and pushing the base SageMaker inference image i.e.

```bash
$ mlflow sagemaker build-and-push-container --enable-mlserver -n <container-name>
```

## How is this patch tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Enable the MLserver backend for use on SageMaker endpoints serving. This makes it easy to skip the NGINX requirements and to get around Gunicorn limitations.

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [x] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
