### PR TITLE
Move runs between experiments

### DIFF
--- a/mlflow/entities/run_info.py
+++ b/mlflow/entities/run_info.py
@@ -73,7 +73,9 @@ class RunInfo(_MLflowObject):
             return self.__dict__ == other.__dict__
         return False
 
-    def _copy_with_overrides(self, status=None, end_time=None, lifecycle_stage=None, run_name=None):
+    def copy_with_overrides(
+        self, status=None, end_time=None, lifecycle_stage=None, run_name=None, experiment_id=None
+    ):
         """A copy of the RunInfo with certain attributes modified."""
         proto = self.to_proto()
         if status:
@@ -84,6 +86,8 @@ class RunInfo(_MLflowObject):
             proto.lifecycle_stage = lifecycle_stage
         if run_name:
             proto.run_name = run_name
+        if experiment_id:
+            proto.experiment_id = experiment_id
         return RunInfo.from_proto(proto)
 
     @property

--- a/mlflow/java/client/src/main/java/org/mlflow/api/proto/Service.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/api/proto/Service.java
@@ -11697,6 +11697,1605 @@ public final class Service {
 
   }
 
+  public interface MoveRunsOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:mlflow.MoveRuns)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <pre>
+     * Run ids.
+     * </pre>
+     *
+     * <code>repeated string run_ids = 1 [(.mlflow.validate_required) = true];</code>
+     * @return A list containing the runIds.
+     */
+    java.util.List<java.lang.String>
+        getRunIdsList();
+    /**
+     * <pre>
+     * Run ids.
+     * </pre>
+     *
+     * <code>repeated string run_ids = 1 [(.mlflow.validate_required) = true];</code>
+     * @return The count of runIds.
+     */
+    int getRunIdsCount();
+    /**
+     * <pre>
+     * Run ids.
+     * </pre>
+     *
+     * <code>repeated string run_ids = 1 [(.mlflow.validate_required) = true];</code>
+     * @param index The index of the element to return.
+     * @return The runIds at the given index.
+     */
+    java.lang.String getRunIds(int index);
+    /**
+     * <pre>
+     * Run ids.
+     * </pre>
+     *
+     * <code>repeated string run_ids = 1 [(.mlflow.validate_required) = true];</code>
+     * @param index The index of the value to return.
+     * @return The bytes of the runIds at the given index.
+     */
+    com.google.protobuf.ByteString
+        getRunIdsBytes(int index);
+
+    /**
+     * <pre>
+     * Experiment id.
+     * </pre>
+     *
+     * <code>required string experiment_id = 2 [(.mlflow.validate_required) = true];</code>
+     * @return Whether the experimentId field is set.
+     */
+    boolean hasExperimentId();
+    /**
+     * <pre>
+     * Experiment id.
+     * </pre>
+     *
+     * <code>required string experiment_id = 2 [(.mlflow.validate_required) = true];</code>
+     * @return The experimentId.
+     */
+    java.lang.String getExperimentId();
+    /**
+     * <pre>
+     * Experiment id.
+     * </pre>
+     *
+     * <code>required string experiment_id = 2 [(.mlflow.validate_required) = true];</code>
+     * @return The bytes for experimentId.
+     */
+    com.google.protobuf.ByteString
+        getExperimentIdBytes();
+  }
+  /**
+   * Protobuf type {@code mlflow.MoveRuns}
+   */
+  public static final class MoveRuns extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:mlflow.MoveRuns)
+      MoveRunsOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use MoveRuns.newBuilder() to construct.
+    private MoveRuns(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private MoveRuns() {
+      runIds_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      experimentId_ = "";
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new MoveRuns();
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private MoveRuns(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
+                runIds_ = new com.google.protobuf.LazyStringArrayList();
+                mutable_bitField0_ |= 0x00000001;
+              }
+              runIds_.add(bs);
+              break;
+            }
+            case 18: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000001;
+              experimentId_ = bs;
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        if (((mutable_bitField0_ & 0x00000001) != 0)) {
+          runIds_ = runIds_.getUnmodifiableView();
+        }
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return org.mlflow.api.proto.Service.internal_static_mlflow_MoveRuns_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return org.mlflow.api.proto.Service.internal_static_mlflow_MoveRuns_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              org.mlflow.api.proto.Service.MoveRuns.class, org.mlflow.api.proto.Service.MoveRuns.Builder.class);
+    }
+
+    public interface ResponseOrBuilder extends
+        // @@protoc_insertion_point(interface_extends:mlflow.MoveRuns.Response)
+        com.google.protobuf.MessageOrBuilder {
+
+      /**
+       * <pre>
+       * Unique identifier for the experiment.
+       * </pre>
+       *
+       * <code>optional string experiment_id = 1;</code>
+       * @return Whether the experimentId field is set.
+       */
+      boolean hasExperimentId();
+      /**
+       * <pre>
+       * Unique identifier for the experiment.
+       * </pre>
+       *
+       * <code>optional string experiment_id = 1;</code>
+       * @return The experimentId.
+       */
+      java.lang.String getExperimentId();
+      /**
+       * <pre>
+       * Unique identifier for the experiment.
+       * </pre>
+       *
+       * <code>optional string experiment_id = 1;</code>
+       * @return The bytes for experimentId.
+       */
+      com.google.protobuf.ByteString
+          getExperimentIdBytes();
+    }
+    /**
+     * Protobuf type {@code mlflow.MoveRuns.Response}
+     */
+    public static final class Response extends
+        com.google.protobuf.GeneratedMessageV3 implements
+        // @@protoc_insertion_point(message_implements:mlflow.MoveRuns.Response)
+        ResponseOrBuilder {
+    private static final long serialVersionUID = 0L;
+      // Use Response.newBuilder() to construct.
+      private Response(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+        super(builder);
+      }
+      private Response() {
+        experimentId_ = "";
+      }
+
+      @java.lang.Override
+      @SuppressWarnings({"unused"})
+      protected java.lang.Object newInstance(
+          UnusedPrivateParameter unused) {
+        return new Response();
+      }
+
+      @java.lang.Override
+      public final com.google.protobuf.UnknownFieldSet
+      getUnknownFields() {
+        return this.unknownFields;
+      }
+      private Response(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        this();
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
+        int mutable_bitField0_ = 0;
+        com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+            com.google.protobuf.UnknownFieldSet.newBuilder();
+        try {
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 10: {
+                com.google.protobuf.ByteString bs = input.readBytes();
+                bitField0_ |= 0x00000001;
+                experimentId_ = bs;
+                break;
+              }
+              default: {
+                if (!parseUnknownField(
+                    input, unknownFields, extensionRegistry, tag)) {
+                  done = true;
+                }
+                break;
+              }
+            }
+          }
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(this);
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(
+              e).setUnfinishedMessage(this);
+        } finally {
+          this.unknownFields = unknownFields.build();
+          makeExtensionsImmutable();
+        }
+      }
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return org.mlflow.api.proto.Service.internal_static_mlflow_MoveRuns_Response_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return org.mlflow.api.proto.Service.internal_static_mlflow_MoveRuns_Response_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.mlflow.api.proto.Service.MoveRuns.Response.class, org.mlflow.api.proto.Service.MoveRuns.Response.Builder.class);
+      }
+
+      private int bitField0_;
+      public static final int EXPERIMENT_ID_FIELD_NUMBER = 1;
+      private volatile java.lang.Object experimentId_;
+      /**
+       * <pre>
+       * Unique identifier for the experiment.
+       * </pre>
+       *
+       * <code>optional string experiment_id = 1;</code>
+       * @return Whether the experimentId field is set.
+       */
+      @java.lang.Override
+      public boolean hasExperimentId() {
+        return ((bitField0_ & 0x00000001) != 0);
+      }
+      /**
+       * <pre>
+       * Unique identifier for the experiment.
+       * </pre>
+       *
+       * <code>optional string experiment_id = 1;</code>
+       * @return The experimentId.
+       */
+      @java.lang.Override
+      public java.lang.String getExperimentId() {
+        java.lang.Object ref = experimentId_;
+        if (ref instanceof java.lang.String) {
+          return (java.lang.String) ref;
+        } else {
+          com.google.protobuf.ByteString bs = 
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            experimentId_ = s;
+          }
+          return s;
+        }
+      }
+      /**
+       * <pre>
+       * Unique identifier for the experiment.
+       * </pre>
+       *
+       * <code>optional string experiment_id = 1;</code>
+       * @return The bytes for experimentId.
+       */
+      @java.lang.Override
+      public com.google.protobuf.ByteString
+          getExperimentIdBytes() {
+        java.lang.Object ref = experimentId_;
+        if (ref instanceof java.lang.String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          experimentId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+
+      private byte memoizedIsInitialized = -1;
+      @java.lang.Override
+      public final boolean isInitialized() {
+        byte isInitialized = memoizedIsInitialized;
+        if (isInitialized == 1) return true;
+        if (isInitialized == 0) return false;
+
+        memoizedIsInitialized = 1;
+        return true;
+      }
+
+      @java.lang.Override
+      public void writeTo(com.google.protobuf.CodedOutputStream output)
+                          throws java.io.IOException {
+        if (((bitField0_ & 0x00000001) != 0)) {
+          com.google.protobuf.GeneratedMessageV3.writeString(output, 1, experimentId_);
+        }
+        unknownFields.writeTo(output);
+      }
+
+      @java.lang.Override
+      public int getSerializedSize() {
+        int size = memoizedSize;
+        if (size != -1) return size;
+
+        size = 0;
+        if (((bitField0_ & 0x00000001) != 0)) {
+          size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, experimentId_);
+        }
+        size += unknownFields.getSerializedSize();
+        memoizedSize = size;
+        return size;
+      }
+
+      @java.lang.Override
+      public boolean equals(final java.lang.Object obj) {
+        if (obj == this) {
+         return true;
+        }
+        if (!(obj instanceof org.mlflow.api.proto.Service.MoveRuns.Response)) {
+          return super.equals(obj);
+        }
+        org.mlflow.api.proto.Service.MoveRuns.Response other = (org.mlflow.api.proto.Service.MoveRuns.Response) obj;
+
+        if (hasExperimentId() != other.hasExperimentId()) return false;
+        if (hasExperimentId()) {
+          if (!getExperimentId()
+              .equals(other.getExperimentId())) return false;
+        }
+        if (!unknownFields.equals(other.unknownFields)) return false;
+        return true;
+      }
+
+      @java.lang.Override
+      public int hashCode() {
+        if (memoizedHashCode != 0) {
+          return memoizedHashCode;
+        }
+        int hash = 41;
+        hash = (19 * hash) + getDescriptor().hashCode();
+        if (hasExperimentId()) {
+          hash = (37 * hash) + EXPERIMENT_ID_FIELD_NUMBER;
+          hash = (53 * hash) + getExperimentId().hashCode();
+        }
+        hash = (29 * hash) + unknownFields.hashCode();
+        memoizedHashCode = hash;
+        return hash;
+      }
+
+      public static org.mlflow.api.proto.Service.MoveRuns.Response parseFrom(
+          java.nio.ByteBuffer data)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+      public static org.mlflow.api.proto.Service.MoveRuns.Response parseFrom(
+          java.nio.ByteBuffer data,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+      public static org.mlflow.api.proto.Service.MoveRuns.Response parseFrom(
+          com.google.protobuf.ByteString data)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+      public static org.mlflow.api.proto.Service.MoveRuns.Response parseFrom(
+          com.google.protobuf.ByteString data,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+      public static org.mlflow.api.proto.Service.MoveRuns.Response parseFrom(byte[] data)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+      public static org.mlflow.api.proto.Service.MoveRuns.Response parseFrom(
+          byte[] data,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+      public static org.mlflow.api.proto.Service.MoveRuns.Response parseFrom(java.io.InputStream input)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input);
+      }
+      public static org.mlflow.api.proto.Service.MoveRuns.Response parseFrom(
+          java.io.InputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input, extensionRegistry);
+      }
+      public static org.mlflow.api.proto.Service.MoveRuns.Response parseDelimitedFrom(java.io.InputStream input)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseDelimitedWithIOException(PARSER, input);
+      }
+      public static org.mlflow.api.proto.Service.MoveRuns.Response parseDelimitedFrom(
+          java.io.InputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      }
+      public static org.mlflow.api.proto.Service.MoveRuns.Response parseFrom(
+          com.google.protobuf.CodedInputStream input)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input);
+      }
+      public static org.mlflow.api.proto.Service.MoveRuns.Response parseFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input, extensionRegistry);
+      }
+
+      @java.lang.Override
+      public Builder newBuilderForType() { return newBuilder(); }
+      public static Builder newBuilder() {
+        return DEFAULT_INSTANCE.toBuilder();
+      }
+      public static Builder newBuilder(org.mlflow.api.proto.Service.MoveRuns.Response prototype) {
+        return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+      }
+      @java.lang.Override
+      public Builder toBuilder() {
+        return this == DEFAULT_INSTANCE
+            ? new Builder() : new Builder().mergeFrom(this);
+      }
+
+      @java.lang.Override
+      protected Builder newBuilderForType(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        Builder builder = new Builder(parent);
+        return builder;
+      }
+      /**
+       * Protobuf type {@code mlflow.MoveRuns.Response}
+       */
+      public static final class Builder extends
+          com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+          // @@protoc_insertion_point(builder_implements:mlflow.MoveRuns.Response)
+          org.mlflow.api.proto.Service.MoveRuns.ResponseOrBuilder {
+        public static final com.google.protobuf.Descriptors.Descriptor
+            getDescriptor() {
+          return org.mlflow.api.proto.Service.internal_static_mlflow_MoveRuns_Response_descriptor;
+        }
+
+        @java.lang.Override
+        protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+            internalGetFieldAccessorTable() {
+          return org.mlflow.api.proto.Service.internal_static_mlflow_MoveRuns_Response_fieldAccessorTable
+              .ensureFieldAccessorsInitialized(
+                  org.mlflow.api.proto.Service.MoveRuns.Response.class, org.mlflow.api.proto.Service.MoveRuns.Response.Builder.class);
+        }
+
+        // Construct using org.mlflow.api.proto.Service.MoveRuns.Response.newBuilder()
+        private Builder() {
+          maybeForceBuilderInitialization();
+        }
+
+        private Builder(
+            com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+          super(parent);
+          maybeForceBuilderInitialization();
+        }
+        private void maybeForceBuilderInitialization() {
+          if (com.google.protobuf.GeneratedMessageV3
+                  .alwaysUseFieldBuilders) {
+          }
+        }
+        @java.lang.Override
+        public Builder clear() {
+          super.clear();
+          experimentId_ = "";
+          bitField0_ = (bitField0_ & ~0x00000001);
+          return this;
+        }
+
+        @java.lang.Override
+        public com.google.protobuf.Descriptors.Descriptor
+            getDescriptorForType() {
+          return org.mlflow.api.proto.Service.internal_static_mlflow_MoveRuns_Response_descriptor;
+        }
+
+        @java.lang.Override
+        public org.mlflow.api.proto.Service.MoveRuns.Response getDefaultInstanceForType() {
+          return org.mlflow.api.proto.Service.MoveRuns.Response.getDefaultInstance();
+        }
+
+        @java.lang.Override
+        public org.mlflow.api.proto.Service.MoveRuns.Response build() {
+          org.mlflow.api.proto.Service.MoveRuns.Response result = buildPartial();
+          if (!result.isInitialized()) {
+            throw newUninitializedMessageException(result);
+          }
+          return result;
+        }
+
+        @java.lang.Override
+        public org.mlflow.api.proto.Service.MoveRuns.Response buildPartial() {
+          org.mlflow.api.proto.Service.MoveRuns.Response result = new org.mlflow.api.proto.Service.MoveRuns.Response(this);
+          int from_bitField0_ = bitField0_;
+          int to_bitField0_ = 0;
+          if (((from_bitField0_ & 0x00000001) != 0)) {
+            to_bitField0_ |= 0x00000001;
+          }
+          result.experimentId_ = experimentId_;
+          result.bitField0_ = to_bitField0_;
+          onBuilt();
+          return result;
+        }
+
+        @java.lang.Override
+        public Builder clone() {
+          return super.clone();
+        }
+        @java.lang.Override
+        public Builder setField(
+            com.google.protobuf.Descriptors.FieldDescriptor field,
+            java.lang.Object value) {
+          return super.setField(field, value);
+        }
+        @java.lang.Override
+        public Builder clearField(
+            com.google.protobuf.Descriptors.FieldDescriptor field) {
+          return super.clearField(field);
+        }
+        @java.lang.Override
+        public Builder clearOneof(
+            com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+          return super.clearOneof(oneof);
+        }
+        @java.lang.Override
+        public Builder setRepeatedField(
+            com.google.protobuf.Descriptors.FieldDescriptor field,
+            int index, java.lang.Object value) {
+          return super.setRepeatedField(field, index, value);
+        }
+        @java.lang.Override
+        public Builder addRepeatedField(
+            com.google.protobuf.Descriptors.FieldDescriptor field,
+            java.lang.Object value) {
+          return super.addRepeatedField(field, value);
+        }
+        @java.lang.Override
+        public Builder mergeFrom(com.google.protobuf.Message other) {
+          if (other instanceof org.mlflow.api.proto.Service.MoveRuns.Response) {
+            return mergeFrom((org.mlflow.api.proto.Service.MoveRuns.Response)other);
+          } else {
+            super.mergeFrom(other);
+            return this;
+          }
+        }
+
+        public Builder mergeFrom(org.mlflow.api.proto.Service.MoveRuns.Response other) {
+          if (other == org.mlflow.api.proto.Service.MoveRuns.Response.getDefaultInstance()) return this;
+          if (other.hasExperimentId()) {
+            bitField0_ |= 0x00000001;
+            experimentId_ = other.experimentId_;
+            onChanged();
+          }
+          this.mergeUnknownFields(other.unknownFields);
+          onChanged();
+          return this;
+        }
+
+        @java.lang.Override
+        public final boolean isInitialized() {
+          return true;
+        }
+
+        @java.lang.Override
+        public Builder mergeFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+          org.mlflow.api.proto.Service.MoveRuns.Response parsedMessage = null;
+          try {
+            parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            parsedMessage = (org.mlflow.api.proto.Service.MoveRuns.Response) e.getUnfinishedMessage();
+            throw e.unwrapIOException();
+          } finally {
+            if (parsedMessage != null) {
+              mergeFrom(parsedMessage);
+            }
+          }
+          return this;
+        }
+        private int bitField0_;
+
+        private java.lang.Object experimentId_ = "";
+        /**
+         * <pre>
+         * Unique identifier for the experiment.
+         * </pre>
+         *
+         * <code>optional string experiment_id = 1;</code>
+         * @return Whether the experimentId field is set.
+         */
+        public boolean hasExperimentId() {
+          return ((bitField0_ & 0x00000001) != 0);
+        }
+        /**
+         * <pre>
+         * Unique identifier for the experiment.
+         * </pre>
+         *
+         * <code>optional string experiment_id = 1;</code>
+         * @return The experimentId.
+         */
+        public java.lang.String getExperimentId() {
+          java.lang.Object ref = experimentId_;
+          if (!(ref instanceof java.lang.String)) {
+            com.google.protobuf.ByteString bs =
+                (com.google.protobuf.ByteString) ref;
+            java.lang.String s = bs.toStringUtf8();
+            if (bs.isValidUtf8()) {
+              experimentId_ = s;
+            }
+            return s;
+          } else {
+            return (java.lang.String) ref;
+          }
+        }
+        /**
+         * <pre>
+         * Unique identifier for the experiment.
+         * </pre>
+         *
+         * <code>optional string experiment_id = 1;</code>
+         * @return The bytes for experimentId.
+         */
+        public com.google.protobuf.ByteString
+            getExperimentIdBytes() {
+          java.lang.Object ref = experimentId_;
+          if (ref instanceof String) {
+            com.google.protobuf.ByteString b = 
+                com.google.protobuf.ByteString.copyFromUtf8(
+                    (java.lang.String) ref);
+            experimentId_ = b;
+            return b;
+          } else {
+            return (com.google.protobuf.ByteString) ref;
+          }
+        }
+        /**
+         * <pre>
+         * Unique identifier for the experiment.
+         * </pre>
+         *
+         * <code>optional string experiment_id = 1;</code>
+         * @param value The experimentId to set.
+         * @return This builder for chaining.
+         */
+        public Builder setExperimentId(
+            java.lang.String value) {
+          if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+          experimentId_ = value;
+          onChanged();
+          return this;
+        }
+        /**
+         * <pre>
+         * Unique identifier for the experiment.
+         * </pre>
+         *
+         * <code>optional string experiment_id = 1;</code>
+         * @return This builder for chaining.
+         */
+        public Builder clearExperimentId() {
+          bitField0_ = (bitField0_ & ~0x00000001);
+          experimentId_ = getDefaultInstance().getExperimentId();
+          onChanged();
+          return this;
+        }
+        /**
+         * <pre>
+         * Unique identifier for the experiment.
+         * </pre>
+         *
+         * <code>optional string experiment_id = 1;</code>
+         * @param value The bytes for experimentId to set.
+         * @return This builder for chaining.
+         */
+        public Builder setExperimentIdBytes(
+            com.google.protobuf.ByteString value) {
+          if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+          experimentId_ = value;
+          onChanged();
+          return this;
+        }
+        @java.lang.Override
+        public final Builder setUnknownFields(
+            final com.google.protobuf.UnknownFieldSet unknownFields) {
+          return super.setUnknownFields(unknownFields);
+        }
+
+        @java.lang.Override
+        public final Builder mergeUnknownFields(
+            final com.google.protobuf.UnknownFieldSet unknownFields) {
+          return super.mergeUnknownFields(unknownFields);
+        }
+
+
+        // @@protoc_insertion_point(builder_scope:mlflow.MoveRuns.Response)
+      }
+
+      // @@protoc_insertion_point(class_scope:mlflow.MoveRuns.Response)
+      private static final org.mlflow.api.proto.Service.MoveRuns.Response DEFAULT_INSTANCE;
+      static {
+        DEFAULT_INSTANCE = new org.mlflow.api.proto.Service.MoveRuns.Response();
+      }
+
+      public static org.mlflow.api.proto.Service.MoveRuns.Response getDefaultInstance() {
+        return DEFAULT_INSTANCE;
+      }
+
+      @java.lang.Deprecated public static final com.google.protobuf.Parser<Response>
+          PARSER = new com.google.protobuf.AbstractParser<Response>() {
+        @java.lang.Override
+        public Response parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new Response(input, extensionRegistry);
+        }
+      };
+
+      public static com.google.protobuf.Parser<Response> parser() {
+        return PARSER;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Parser<Response> getParserForType() {
+        return PARSER;
+      }
+
+      @java.lang.Override
+      public org.mlflow.api.proto.Service.MoveRuns.Response getDefaultInstanceForType() {
+        return DEFAULT_INSTANCE;
+      }
+
+    }
+
+    private int bitField0_;
+    public static final int RUN_IDS_FIELD_NUMBER = 1;
+    private com.google.protobuf.LazyStringList runIds_;
+    /**
+     * <pre>
+     * Run ids.
+     * </pre>
+     *
+     * <code>repeated string run_ids = 1 [(.mlflow.validate_required) = true];</code>
+     * @return A list containing the runIds.
+     */
+    public com.google.protobuf.ProtocolStringList
+        getRunIdsList() {
+      return runIds_;
+    }
+    /**
+     * <pre>
+     * Run ids.
+     * </pre>
+     *
+     * <code>repeated string run_ids = 1 [(.mlflow.validate_required) = true];</code>
+     * @return The count of runIds.
+     */
+    public int getRunIdsCount() {
+      return runIds_.size();
+    }
+    /**
+     * <pre>
+     * Run ids.
+     * </pre>
+     *
+     * <code>repeated string run_ids = 1 [(.mlflow.validate_required) = true];</code>
+     * @param index The index of the element to return.
+     * @return The runIds at the given index.
+     */
+    public java.lang.String getRunIds(int index) {
+      return runIds_.get(index);
+    }
+    /**
+     * <pre>
+     * Run ids.
+     * </pre>
+     *
+     * <code>repeated string run_ids = 1 [(.mlflow.validate_required) = true];</code>
+     * @param index The index of the value to return.
+     * @return The bytes of the runIds at the given index.
+     */
+    public com.google.protobuf.ByteString
+        getRunIdsBytes(int index) {
+      return runIds_.getByteString(index);
+    }
+
+    public static final int EXPERIMENT_ID_FIELD_NUMBER = 2;
+    private volatile java.lang.Object experimentId_;
+    /**
+     * <pre>
+     * Experiment id.
+     * </pre>
+     *
+     * <code>required string experiment_id = 2 [(.mlflow.validate_required) = true];</code>
+     * @return Whether the experimentId field is set.
+     */
+    @java.lang.Override
+    public boolean hasExperimentId() {
+      return ((bitField0_ & 0x00000001) != 0);
+    }
+    /**
+     * <pre>
+     * Experiment id.
+     * </pre>
+     *
+     * <code>required string experiment_id = 2 [(.mlflow.validate_required) = true];</code>
+     * @return The experimentId.
+     */
+    @java.lang.Override
+    public java.lang.String getExperimentId() {
+      java.lang.Object ref = experimentId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          experimentId_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * Experiment id.
+     * </pre>
+     *
+     * <code>required string experiment_id = 2 [(.mlflow.validate_required) = true];</code>
+     * @return The bytes for experimentId.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getExperimentIdBytes() {
+      java.lang.Object ref = experimentId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        experimentId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      if (!hasExperimentId()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      for (int i = 0; i < runIds_.size(); i++) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, runIds_.getRaw(i));
+      }
+      if (((bitField0_ & 0x00000001) != 0)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 2, experimentId_);
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      {
+        int dataSize = 0;
+        for (int i = 0; i < runIds_.size(); i++) {
+          dataSize += computeStringSizeNoTag(runIds_.getRaw(i));
+        }
+        size += dataSize;
+        size += 1 * getRunIdsList().size();
+      }
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, experimentId_);
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof org.mlflow.api.proto.Service.MoveRuns)) {
+        return super.equals(obj);
+      }
+      org.mlflow.api.proto.Service.MoveRuns other = (org.mlflow.api.proto.Service.MoveRuns) obj;
+
+      if (!getRunIdsList()
+          .equals(other.getRunIdsList())) return false;
+      if (hasExperimentId() != other.hasExperimentId()) return false;
+      if (hasExperimentId()) {
+        if (!getExperimentId()
+            .equals(other.getExperimentId())) return false;
+      }
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (getRunIdsCount() > 0) {
+        hash = (37 * hash) + RUN_IDS_FIELD_NUMBER;
+        hash = (53 * hash) + getRunIdsList().hashCode();
+      }
+      if (hasExperimentId()) {
+        hash = (37 * hash) + EXPERIMENT_ID_FIELD_NUMBER;
+        hash = (53 * hash) + getExperimentId().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static org.mlflow.api.proto.Service.MoveRuns parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.mlflow.api.proto.Service.MoveRuns parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.mlflow.api.proto.Service.MoveRuns parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.mlflow.api.proto.Service.MoveRuns parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.mlflow.api.proto.Service.MoveRuns parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.mlflow.api.proto.Service.MoveRuns parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.mlflow.api.proto.Service.MoveRuns parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static org.mlflow.api.proto.Service.MoveRuns parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static org.mlflow.api.proto.Service.MoveRuns parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static org.mlflow.api.proto.Service.MoveRuns parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static org.mlflow.api.proto.Service.MoveRuns parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static org.mlflow.api.proto.Service.MoveRuns parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(org.mlflow.api.proto.Service.MoveRuns prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code mlflow.MoveRuns}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:mlflow.MoveRuns)
+        org.mlflow.api.proto.Service.MoveRunsOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return org.mlflow.api.proto.Service.internal_static_mlflow_MoveRuns_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return org.mlflow.api.proto.Service.internal_static_mlflow_MoveRuns_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.mlflow.api.proto.Service.MoveRuns.class, org.mlflow.api.proto.Service.MoveRuns.Builder.class);
+      }
+
+      // Construct using org.mlflow.api.proto.Service.MoveRuns.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        runIds_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        experimentId_ = "";
+        bitField0_ = (bitField0_ & ~0x00000002);
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return org.mlflow.api.proto.Service.internal_static_mlflow_MoveRuns_descriptor;
+      }
+
+      @java.lang.Override
+      public org.mlflow.api.proto.Service.MoveRuns getDefaultInstanceForType() {
+        return org.mlflow.api.proto.Service.MoveRuns.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public org.mlflow.api.proto.Service.MoveRuns build() {
+        org.mlflow.api.proto.Service.MoveRuns result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public org.mlflow.api.proto.Service.MoveRuns buildPartial() {
+        org.mlflow.api.proto.Service.MoveRuns result = new org.mlflow.api.proto.Service.MoveRuns(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((bitField0_ & 0x00000001) != 0)) {
+          runIds_ = runIds_.getUnmodifiableView();
+          bitField0_ = (bitField0_ & ~0x00000001);
+        }
+        result.runIds_ = runIds_;
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.experimentId_ = experimentId_;
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof org.mlflow.api.proto.Service.MoveRuns) {
+          return mergeFrom((org.mlflow.api.proto.Service.MoveRuns)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(org.mlflow.api.proto.Service.MoveRuns other) {
+        if (other == org.mlflow.api.proto.Service.MoveRuns.getDefaultInstance()) return this;
+        if (!other.runIds_.isEmpty()) {
+          if (runIds_.isEmpty()) {
+            runIds_ = other.runIds_;
+            bitField0_ = (bitField0_ & ~0x00000001);
+          } else {
+            ensureRunIdsIsMutable();
+            runIds_.addAll(other.runIds_);
+          }
+          onChanged();
+        }
+        if (other.hasExperimentId()) {
+          bitField0_ |= 0x00000002;
+          experimentId_ = other.experimentId_;
+          onChanged();
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        if (!hasExperimentId()) {
+          return false;
+        }
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        org.mlflow.api.proto.Service.MoveRuns parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (org.mlflow.api.proto.Service.MoveRuns) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private com.google.protobuf.LazyStringList runIds_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      private void ensureRunIdsIsMutable() {
+        if (!((bitField0_ & 0x00000001) != 0)) {
+          runIds_ = new com.google.protobuf.LazyStringArrayList(runIds_);
+          bitField0_ |= 0x00000001;
+         }
+      }
+      /**
+       * <pre>
+       * Run ids.
+       * </pre>
+       *
+       * <code>repeated string run_ids = 1 [(.mlflow.validate_required) = true];</code>
+       * @return A list containing the runIds.
+       */
+      public com.google.protobuf.ProtocolStringList
+          getRunIdsList() {
+        return runIds_.getUnmodifiableView();
+      }
+      /**
+       * <pre>
+       * Run ids.
+       * </pre>
+       *
+       * <code>repeated string run_ids = 1 [(.mlflow.validate_required) = true];</code>
+       * @return The count of runIds.
+       */
+      public int getRunIdsCount() {
+        return runIds_.size();
+      }
+      /**
+       * <pre>
+       * Run ids.
+       * </pre>
+       *
+       * <code>repeated string run_ids = 1 [(.mlflow.validate_required) = true];</code>
+       * @param index The index of the element to return.
+       * @return The runIds at the given index.
+       */
+      public java.lang.String getRunIds(int index) {
+        return runIds_.get(index);
+      }
+      /**
+       * <pre>
+       * Run ids.
+       * </pre>
+       *
+       * <code>repeated string run_ids = 1 [(.mlflow.validate_required) = true];</code>
+       * @param index The index of the value to return.
+       * @return The bytes of the runIds at the given index.
+       */
+      public com.google.protobuf.ByteString
+          getRunIdsBytes(int index) {
+        return runIds_.getByteString(index);
+      }
+      /**
+       * <pre>
+       * Run ids.
+       * </pre>
+       *
+       * <code>repeated string run_ids = 1 [(.mlflow.validate_required) = true];</code>
+       * @param index The index to set the value at.
+       * @param value The runIds to set.
+       * @return This builder for chaining.
+       */
+      public Builder setRunIds(
+          int index, java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureRunIdsIsMutable();
+        runIds_.set(index, value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Run ids.
+       * </pre>
+       *
+       * <code>repeated string run_ids = 1 [(.mlflow.validate_required) = true];</code>
+       * @param value The runIds to add.
+       * @return This builder for chaining.
+       */
+      public Builder addRunIds(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureRunIdsIsMutable();
+        runIds_.add(value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Run ids.
+       * </pre>
+       *
+       * <code>repeated string run_ids = 1 [(.mlflow.validate_required) = true];</code>
+       * @param values The runIds to add.
+       * @return This builder for chaining.
+       */
+      public Builder addAllRunIds(
+          java.lang.Iterable<java.lang.String> values) {
+        ensureRunIdsIsMutable();
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, runIds_);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Run ids.
+       * </pre>
+       *
+       * <code>repeated string run_ids = 1 [(.mlflow.validate_required) = true];</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearRunIds() {
+        runIds_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Run ids.
+       * </pre>
+       *
+       * <code>repeated string run_ids = 1 [(.mlflow.validate_required) = true];</code>
+       * @param value The bytes of the runIds to add.
+       * @return This builder for chaining.
+       */
+      public Builder addRunIdsBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureRunIdsIsMutable();
+        runIds_.add(value);
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object experimentId_ = "";
+      /**
+       * <pre>
+       * Experiment id.
+       * </pre>
+       *
+       * <code>required string experiment_id = 2 [(.mlflow.validate_required) = true];</code>
+       * @return Whether the experimentId field is set.
+       */
+      public boolean hasExperimentId() {
+        return ((bitField0_ & 0x00000002) != 0);
+      }
+      /**
+       * <pre>
+       * Experiment id.
+       * </pre>
+       *
+       * <code>required string experiment_id = 2 [(.mlflow.validate_required) = true];</code>
+       * @return The experimentId.
+       */
+      public java.lang.String getExperimentId() {
+        java.lang.Object ref = experimentId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            experimentId_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * Experiment id.
+       * </pre>
+       *
+       * <code>required string experiment_id = 2 [(.mlflow.validate_required) = true];</code>
+       * @return The bytes for experimentId.
+       */
+      public com.google.protobuf.ByteString
+          getExperimentIdBytes() {
+        java.lang.Object ref = experimentId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          experimentId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * Experiment id.
+       * </pre>
+       *
+       * <code>required string experiment_id = 2 [(.mlflow.validate_required) = true];</code>
+       * @param value The experimentId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setExperimentId(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        experimentId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Experiment id.
+       * </pre>
+       *
+       * <code>required string experiment_id = 2 [(.mlflow.validate_required) = true];</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearExperimentId() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        experimentId_ = getDefaultInstance().getExperimentId();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Experiment id.
+       * </pre>
+       *
+       * <code>required string experiment_id = 2 [(.mlflow.validate_required) = true];</code>
+       * @param value The bytes for experimentId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setExperimentIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        experimentId_ = value;
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:mlflow.MoveRuns)
+    }
+
+    // @@protoc_insertion_point(class_scope:mlflow.MoveRuns)
+    private static final org.mlflow.api.proto.Service.MoveRuns DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new org.mlflow.api.proto.Service.MoveRuns();
+    }
+
+    public static org.mlflow.api.proto.Service.MoveRuns getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated public static final com.google.protobuf.Parser<MoveRuns>
+        PARSER = new com.google.protobuf.AbstractParser<MoveRuns>() {
+      @java.lang.Override
+      public MoveRuns parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new MoveRuns(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<MoveRuns> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<MoveRuns> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public org.mlflow.api.proto.Service.MoveRuns getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
   public interface CreateExperimentOrBuilder extends
       // @@protoc_insertion_point(interface_extends:mlflow.CreateExperiment)
       com.google.protobuf.MessageOrBuilder {
@@ -51916,6 +53515,16 @@ public final class Service {
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_mlflow_Experiment_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_mlflow_MoveRuns_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_mlflow_MoveRuns_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_mlflow_MoveRuns_Response_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_mlflow_MoveRuns_Response_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_mlflow_CreateExperiment_descriptor;
   private static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
@@ -52170,175 +53779,182 @@ public final class Service {
       "_location\030\003 \001(\t\022\027\n\017lifecycle_stage\030\004 \001(\t" +
       "\022\030\n\020last_update_time\030\005 \001(\003\022\025\n\rcreation_t" +
       "ime\030\006 \001(\003\022#\n\004tags\030\007 \003(\0132\025.mlflow.Experim" +
-      "entTag\"\266\001\n\020CreateExperiment\022\022\n\004name\030\001 \001(" +
-      "\tB\004\370\206\031\001\022\031\n\021artifact_location\030\002 \001(\t\022#\n\004ta" +
-      "gs\030\003 \003(\0132\025.mlflow.ExperimentTag\032!\n\010Respo" +
+      "entTag\"\216\001\n\010MoveRuns\022\025\n\007run_ids\030\001 \003(\tB\004\370\206" +
+      "\031\001\022\033\n\rexperiment_id\030\002 \002(\tB\004\370\206\031\001\032!\n\010Respo" +
       "nse\022\025\n\rexperiment_id\030\001 \001(\t:+\342?(\n&com.dat" +
-      "abricks.rpc.RPC[$this.Response]\"\376\001\n\021Sear" +
-      "chExperiments\022\023\n\013max_results\030\001 \001(\003\022\022\n\npa" +
-      "ge_token\030\002 \001(\t\022\016\n\006filter\030\003 \001(\t\022\020\n\010order_" +
-      "by\030\004 \003(\t\022#\n\tview_type\030\005 \001(\0162\020.mlflow.Vie" +
-      "wType\032L\n\010Response\022\'\n\013experiments\030\001 \003(\0132\022" +
-      ".mlflow.Experiment\022\027\n\017next_page_token\030\002 " +
-      "\001(\t:+\342?(\n&com.databricks.rpc.RPC[$this.R" +
-      "esponse]\"\215\001\n\rGetExperiment\022\033\n\rexperiment" +
-      "_id\030\001 \001(\tB\004\370\206\031\001\0322\n\010Response\022&\n\nexperimen" +
-      "t\030\001 \001(\0132\022.mlflow.Experiment:+\342?(\n&com.da" +
-      "tabricks.rpc.RPC[$this.Response]\"h\n\020Dele" +
-      "teExperiment\022\033\n\rexperiment_id\030\001 \001(\tB\004\370\206\031" +
-      "\001\032\n\n\010Response:+\342?(\n&com.databricks.rpc.R" +
-      "PC[$this.Response]\"i\n\021RestoreExperiment\022" +
-      "\033\n\rexperiment_id\030\001 \001(\tB\004\370\206\031\001\032\n\n\010Response" +
-      ":+\342?(\n&com.databricks.rpc.RPC[$this.Resp" +
-      "onse]\"z\n\020UpdateExperiment\022\033\n\rexperiment_" +
-      "id\030\001 \001(\tB\004\370\206\031\001\022\020\n\010new_name\030\002 \001(\t\032\n\n\010Resp" +
-      "onse:+\342?(\n&com.databricks.rpc.RPC[$this." +
-      "Response]\"\312\001\n\tCreateRun\022\025\n\rexperiment_id" +
-      "\030\001 \001(\t\022\017\n\007user_id\030\002 \001(\t\022\020\n\010run_name\030\003 \001(" +
-      "\t\022\022\n\nstart_time\030\007 \001(\003\022\034\n\004tags\030\t \003(\0132\016.ml" +
-      "flow.RunTag\032$\n\010Response\022\030\n\003run\030\001 \001(\0132\013.m" +
-      "lflow.Run:+\342?(\n&com.databricks.rpc.RPC[$" +
-      "this.Response]\"\320\001\n\tUpdateRun\022\016\n\006run_id\030\004" +
-      " \001(\t\022\020\n\010run_uuid\030\001 \001(\t\022!\n\006status\030\002 \001(\0162\021" +
-      ".mlflow.RunStatus\022\020\n\010end_time\030\003 \001(\003\022\020\n\010r" +
-      "un_name\030\005 \001(\t\032-\n\010Response\022!\n\010run_info\030\001 " +
-      "\001(\0132\017.mlflow.RunInfo:+\342?(\n&com.databrick" +
-      "s.rpc.RPC[$this.Response]\"Z\n\tDeleteRun\022\024" +
-      "\n\006run_id\030\001 \001(\tB\004\370\206\031\001\032\n\n\010Response:+\342?(\n&c" +
-      "om.databricks.rpc.RPC[$this.Response]\"[\n" +
-      "\nRestoreRun\022\024\n\006run_id\030\001 \001(\tB\004\370\206\031\001\032\n\n\010Res" +
-      "ponse:+\342?(\n&com.databricks.rpc.RPC[$this" +
-      ".Response]\"\270\001\n\tLogMetric\022\016\n\006run_id\030\006 \001(\t" +
-      "\022\020\n\010run_uuid\030\001 \001(\t\022\021\n\003key\030\002 \001(\tB\004\370\206\031\001\022\023\n" +
-      "\005value\030\003 \001(\001B\004\370\206\031\001\022\027\n\ttimestamp\030\004 \001(\003B\004\370" +
-      "\206\031\001\022\017\n\004step\030\005 \001(\003:\0010\032\n\n\010Response:+\342?(\n&c" +
-      "om.databricks.rpc.RPC[$this.Response]\"\215\001" +
-      "\n\010LogParam\022\016\n\006run_id\030\004 \001(\t\022\020\n\010run_uuid\030\001" +
-      " \001(\t\022\021\n\003key\030\002 \001(\tB\004\370\206\031\001\022\023\n\005value\030\003 \001(\tB\004" +
-      "\370\206\031\001\032\n\n\010Response:+\342?(\n&com.databricks.rp" +
-      "c.RPC[$this.Response]\"\220\001\n\020SetExperimentT" +
-      "ag\022\033\n\rexperiment_id\030\001 \001(\tB\004\370\206\031\001\022\021\n\003key\030\002" +
-      " \001(\tB\004\370\206\031\001\022\023\n\005value\030\003 \001(\tB\004\370\206\031\001\032\n\n\010Respo" +
-      "nse:+\342?(\n&com.databricks.rpc.RPC[$this.R" +
-      "esponse]\"\213\001\n\006SetTag\022\016\n\006run_id\030\004 \001(\t\022\020\n\010r" +
-      "un_uuid\030\001 \001(\t\022\021\n\003key\030\002 \001(\tB\004\370\206\031\001\022\023\n\005valu" +
-      "e\030\003 \001(\tB\004\370\206\031\001\032\n\n\010Response:+\342?(\n&com.data" +
-      "bricks.rpc.RPC[$this.Response]\"m\n\tDelete" +
-      "Tag\022\024\n\006run_id\030\001 \001(\tB\004\370\206\031\001\022\021\n\003key\030\002 \001(\tB\004" +
-      "\370\206\031\001\032\n\n\010Response:+\342?(\n&com.databricks.rp" +
-      "c.RPC[$this.Response]\"}\n\006GetRun\022\016\n\006run_i" +
-      "d\030\002 \001(\t\022\020\n\010run_uuid\030\001 \001(\t\032$\n\010Response\022\030\n" +
-      "\003run\030\001 \001(\0132\013.mlflow.Run:+\342?(\n&com.databr" +
-      "icks.rpc.RPC[$this.Response]\"\230\002\n\nSearchR" +
-      "uns\022\026\n\016experiment_ids\030\001 \003(\t\022\016\n\006filter\030\004 " +
-      "\001(\t\0224\n\rrun_view_type\030\003 \001(\0162\020.mlflow.View" +
-      "Type:\013ACTIVE_ONLY\022\031\n\013max_results\030\005 \001(\005:\004" +
-      "1000\022\020\n\010order_by\030\006 \003(\t\022\022\n\npage_token\030\007 \001" +
-      "(\t\032>\n\010Response\022\031\n\004runs\030\001 \003(\0132\013.mlflow.Ru" +
-      "n\022\027\n\017next_page_token\030\002 \001(\t:+\342?(\n&com.dat" +
-      "abricks.rpc.RPC[$this.Response]\"\330\001\n\rList" +
-      "Artifacts\022\016\n\006run_id\030\003 \001(\t\022\020\n\010run_uuid\030\001 " +
-      "\001(\t\022\014\n\004path\030\002 \001(\t\022\022\n\npage_token\030\004 \001(\t\032V\n" +
-      "\010Response\022\020\n\010root_uri\030\001 \001(\t\022\037\n\005files\030\002 \003" +
-      "(\0132\020.mlflow.FileInfo\022\027\n\017next_page_token\030" +
-      "\003 \001(\t:+\342?(\n&com.databricks.rpc.RPC[$this" +
-      ".Response]\";\n\010FileInfo\022\014\n\004path\030\001 \001(\t\022\016\n\006" +
-      "is_dir\030\002 \001(\010\022\021\n\tfile_size\030\003 \001(\003\"\250\001\n\020GetM" +
-      "etricHistory\022\016\n\006run_id\030\003 \001(\t\022\020\n\010run_uuid" +
-      "\030\001 \001(\t\022\030\n\nmetric_key\030\002 \001(\tB\004\370\206\031\001\032+\n\010Resp" +
-      "onse\022\037\n\007metrics\030\001 \003(\0132\016.mlflow.Metric:+\342" +
-      "?(\n&com.databricks.rpc.RPC[$this.Respons" +
-      "e]\"\261\001\n\010LogBatch\022\016\n\006run_id\030\001 \001(\t\022\037\n\007metri" +
-      "cs\030\002 \003(\0132\016.mlflow.Metric\022\035\n\006params\030\003 \003(\013" +
-      "2\r.mlflow.Param\022\034\n\004tags\030\004 \003(\0132\016.mlflow.R" +
-      "unTag\032\n\n\010Response:+\342?(\n&com.databricks.r" +
-      "pc.RPC[$this.Response]\"g\n\010LogModel\022\016\n\006ru" +
-      "n_id\030\001 \001(\t\022\022\n\nmodel_json\030\002 \001(\t\032\n\n\010Respon" +
+      "abricks.rpc.RPC[$this.Response]\"\266\001\n\020Crea" +
+      "teExperiment\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022\031\n\021arti" +
+      "fact_location\030\002 \001(\t\022#\n\004tags\030\003 \003(\0132\025.mlfl" +
+      "ow.ExperimentTag\032!\n\010Response\022\025\n\rexperime" +
+      "nt_id\030\001 \001(\t:+\342?(\n&com.databricks.rpc.RPC" +
+      "[$this.Response]\"\376\001\n\021SearchExperiments\022\023" +
+      "\n\013max_results\030\001 \001(\003\022\022\n\npage_token\030\002 \001(\t\022" +
+      "\016\n\006filter\030\003 \001(\t\022\020\n\010order_by\030\004 \003(\t\022#\n\tvie" +
+      "w_type\030\005 \001(\0162\020.mlflow.ViewType\032L\n\010Respon" +
+      "se\022\'\n\013experiments\030\001 \003(\0132\022.mlflow.Experim" +
+      "ent\022\027\n\017next_page_token\030\002 \001(\t:+\342?(\n&com.d" +
+      "atabricks.rpc.RPC[$this.Response]\"\215\001\n\rGe" +
+      "tExperiment\022\033\n\rexperiment_id\030\001 \001(\tB\004\370\206\031\001" +
+      "\0322\n\010Response\022&\n\nexperiment\030\001 \001(\0132\022.mlflo" +
+      "w.Experiment:+\342?(\n&com.databricks.rpc.RP" +
+      "C[$this.Response]\"h\n\020DeleteExperiment\022\033\n" +
+      "\rexperiment_id\030\001 \001(\tB\004\370\206\031\001\032\n\n\010Response:+" +
+      "\342?(\n&com.databricks.rpc.RPC[$this.Respon" +
+      "se]\"i\n\021RestoreExperiment\022\033\n\rexperiment_i" +
+      "d\030\001 \001(\tB\004\370\206\031\001\032\n\n\010Response:+\342?(\n&com.data" +
+      "bricks.rpc.RPC[$this.Response]\"z\n\020Update" +
+      "Experiment\022\033\n\rexperiment_id\030\001 \001(\tB\004\370\206\031\001\022" +
+      "\020\n\010new_name\030\002 \001(\t\032\n\n\010Response:+\342?(\n&com." +
+      "databricks.rpc.RPC[$this.Response]\"\312\001\n\tC" +
+      "reateRun\022\025\n\rexperiment_id\030\001 \001(\t\022\017\n\007user_" +
+      "id\030\002 \001(\t\022\020\n\010run_name\030\003 \001(\t\022\022\n\nstart_time" +
+      "\030\007 \001(\003\022\034\n\004tags\030\t \003(\0132\016.mlflow.RunTag\032$\n\010" +
+      "Response\022\030\n\003run\030\001 \001(\0132\013.mlflow.Run:+\342?(\n" +
+      "&com.databricks.rpc.RPC[$this.Response]\"" +
+      "\320\001\n\tUpdateRun\022\016\n\006run_id\030\004 \001(\t\022\020\n\010run_uui" +
+      "d\030\001 \001(\t\022!\n\006status\030\002 \001(\0162\021.mlflow.RunStat" +
+      "us\022\020\n\010end_time\030\003 \001(\003\022\020\n\010run_name\030\005 \001(\t\032-" +
+      "\n\010Response\022!\n\010run_info\030\001 \001(\0132\017.mlflow.Ru" +
+      "nInfo:+\342?(\n&com.databricks.rpc.RPC[$this" +
+      ".Response]\"Z\n\tDeleteRun\022\024\n\006run_id\030\001 \001(\tB" +
+      "\004\370\206\031\001\032\n\n\010Response:+\342?(\n&com.databricks.r" +
+      "pc.RPC[$this.Response]\"[\n\nRestoreRun\022\024\n\006" +
+      "run_id\030\001 \001(\tB\004\370\206\031\001\032\n\n\010Response:+\342?(\n&com" +
+      ".databricks.rpc.RPC[$this.Response]\"\270\001\n\t" +
+      "LogMetric\022\016\n\006run_id\030\006 \001(\t\022\020\n\010run_uuid\030\001 " +
+      "\001(\t\022\021\n\003key\030\002 \001(\tB\004\370\206\031\001\022\023\n\005value\030\003 \001(\001B\004\370" +
+      "\206\031\001\022\027\n\ttimestamp\030\004 \001(\003B\004\370\206\031\001\022\017\n\004step\030\005 \001" +
+      "(\003:\0010\032\n\n\010Response:+\342?(\n&com.databricks.r" +
+      "pc.RPC[$this.Response]\"\215\001\n\010LogParam\022\016\n\006r" +
+      "un_id\030\004 \001(\t\022\020\n\010run_uuid\030\001 \001(\t\022\021\n\003key\030\002 \001" +
+      "(\tB\004\370\206\031\001\022\023\n\005value\030\003 \001(\tB\004\370\206\031\001\032\n\n\010Respons" +
+      "e:+\342?(\n&com.databricks.rpc.RPC[$this.Res" +
+      "ponse]\"\220\001\n\020SetExperimentTag\022\033\n\rexperimen" +
+      "t_id\030\001 \001(\tB\004\370\206\031\001\022\021\n\003key\030\002 \001(\tB\004\370\206\031\001\022\023\n\005v" +
+      "alue\030\003 \001(\tB\004\370\206\031\001\032\n\n\010Response:+\342?(\n&com.d" +
+      "atabricks.rpc.RPC[$this.Response]\"\213\001\n\006Se" +
+      "tTag\022\016\n\006run_id\030\004 \001(\t\022\020\n\010run_uuid\030\001 \001(\t\022\021" +
+      "\n\003key\030\002 \001(\tB\004\370\206\031\001\022\023\n\005value\030\003 \001(\tB\004\370\206\031\001\032\n" +
+      "\n\010Response:+\342?(\n&com.databricks.rpc.RPC[" +
+      "$this.Response]\"m\n\tDeleteTag\022\024\n\006run_id\030\001" +
+      " \001(\tB\004\370\206\031\001\022\021\n\003key\030\002 \001(\tB\004\370\206\031\001\032\n\n\010Respons" +
+      "e:+\342?(\n&com.databricks.rpc.RPC[$this.Res" +
+      "ponse]\"}\n\006GetRun\022\016\n\006run_id\030\002 \001(\t\022\020\n\010run_" +
+      "uuid\030\001 \001(\t\032$\n\010Response\022\030\n\003run\030\001 \001(\0132\013.ml" +
+      "flow.Run:+\342?(\n&com.databricks.rpc.RPC[$t" +
+      "his.Response]\"\230\002\n\nSearchRuns\022\026\n\016experime" +
+      "nt_ids\030\001 \003(\t\022\016\n\006filter\030\004 \001(\t\0224\n\rrun_view" +
+      "_type\030\003 \001(\0162\020.mlflow.ViewType:\013ACTIVE_ON" +
+      "LY\022\031\n\013max_results\030\005 \001(\005:\0041000\022\020\n\010order_b" +
+      "y\030\006 \003(\t\022\022\n\npage_token\030\007 \001(\t\032>\n\010Response\022" +
+      "\031\n\004runs\030\001 \003(\0132\013.mlflow.Run\022\027\n\017next_page_" +
+      "token\030\002 \001(\t:+\342?(\n&com.databricks.rpc.RPC" +
+      "[$this.Response]\"\330\001\n\rListArtifacts\022\016\n\006ru" +
+      "n_id\030\003 \001(\t\022\020\n\010run_uuid\030\001 \001(\t\022\014\n\004path\030\002 \001" +
+      "(\t\022\022\n\npage_token\030\004 \001(\t\032V\n\010Response\022\020\n\010ro" +
+      "ot_uri\030\001 \001(\t\022\037\n\005files\030\002 \003(\0132\020.mlflow.Fil" +
+      "eInfo\022\027\n\017next_page_token\030\003 \001(\t:+\342?(\n&com" +
+      ".databricks.rpc.RPC[$this.Response]\";\n\010F" +
+      "ileInfo\022\014\n\004path\030\001 \001(\t\022\016\n\006is_dir\030\002 \001(\010\022\021\n" +
+      "\tfile_size\030\003 \001(\003\"\250\001\n\020GetMetricHistory\022\016\n" +
+      "\006run_id\030\003 \001(\t\022\020\n\010run_uuid\030\001 \001(\t\022\030\n\nmetri" +
+      "c_key\030\002 \001(\tB\004\370\206\031\001\032+\n\010Response\022\037\n\007metrics" +
+      "\030\001 \003(\0132\016.mlflow.Metric:+\342?(\n&com.databri" +
+      "cks.rpc.RPC[$this.Response]\"\261\001\n\010LogBatch" +
+      "\022\016\n\006run_id\030\001 \001(\t\022\037\n\007metrics\030\002 \003(\0132\016.mlfl" +
+      "ow.Metric\022\035\n\006params\030\003 \003(\0132\r.mlflow.Param" +
+      "\022\034\n\004tags\030\004 \003(\0132\016.mlflow.RunTag\032\n\n\010Respon" +
       "se:+\342?(\n&com.databricks.rpc.RPC[$this.Re" +
-      "sponse]\"\225\001\n\023GetExperimentByName\022\035\n\017exper" +
-      "iment_name\030\001 \001(\tB\004\370\206\031\001\0322\n\010Response\022&\n\nex" +
-      "periment\030\001 \001(\0132\022.mlflow.Experiment:+\342?(\n" +
-      "&com.databricks.rpc.RPC[$this.Response]*" +
-      "6\n\010ViewType\022\017\n\013ACTIVE_ONLY\020\001\022\020\n\014DELETED_" +
-      "ONLY\020\002\022\007\n\003ALL\020\003*I\n\nSourceType\022\014\n\010NOTEBOO" +
-      "K\020\001\022\007\n\003JOB\020\002\022\013\n\007PROJECT\020\003\022\t\n\005LOCAL\020\004\022\014\n\007" +
-      "UNKNOWN\020\350\007*M\n\tRunStatus\022\013\n\007RUNNING\020\001\022\r\n\t" +
-      "SCHEDULED\020\002\022\014\n\010FINISHED\020\003\022\n\n\006FAILED\020\004\022\n\n" +
-      "\006KILLED\020\0052\201\027\n\rMlflowService\022\246\001\n\023getExper" +
-      "imentByName\022\033.mlflow.GetExperimentByName" +
-      "\032$.mlflow.GetExperimentByName.Response\"L" +
-      "\362\206\031H\n,\n\003GET\022\037/mlflow/experiments/get-by-" +
-      "name\032\004\010\002\020\000\020\001*\026Get Experiment By Name\022\224\001\n" +
-      "\020createExperiment\022\030.mlflow.CreateExperim" +
-      "ent\032!.mlflow.CreateExperiment.Response\"C" +
-      "\362\206\031?\n(\n\004POST\022\032/mlflow/experiments/create" +
-      "\032\004\010\002\020\000\020\001*\021Create Experiment\022\301\001\n\021searchEx" +
-      "periments\022\031.mlflow.SearchExperiments\032\".m" +
-      "lflow.SearchExperiments.Response\"m\362\206\031i\n(" +
-      "\n\004POST\022\032/mlflow/experiments/search\032\004\010\002\020\000" +
-      "\n\'\n\003GET\022\032/mlflow/experiments/search\032\004\010\002\020" +
-      "\000\020\001*\022Search Experiments\022\204\001\n\rgetExperimen" +
-      "t\022\025.mlflow.GetExperiment\032\036.mlflow.GetExp" +
-      "eriment.Response\"<\362\206\0318\n$\n\003GET\022\027/mlflow/e" +
-      "xperiments/get\032\004\010\002\020\000\020\001*\016Get Experiment\022\224" +
-      "\001\n\020deleteExperiment\022\030.mlflow.DeleteExper" +
-      "iment\032!.mlflow.DeleteExperiment.Response" +
-      "\"C\362\206\031?\n(\n\004POST\022\032/mlflow/experiments/dele" +
-      "te\032\004\010\002\020\000\020\001*\021Delete Experiment\022\231\001\n\021restor" +
-      "eExperiment\022\031.mlflow.RestoreExperiment\032\"" +
-      ".mlflow.RestoreExperiment.Response\"E\362\206\031A" +
-      "\n)\n\004POST\022\033/mlflow/experiments/restore\032\004\010" +
-      "\002\020\000\020\001*\022Restore Experiment\022\224\001\n\020updateExpe" +
-      "riment\022\030.mlflow.UpdateExperiment\032!.mlflo" +
-      "w.UpdateExperiment.Response\"C\362\206\031?\n(\n\004POS" +
-      "T\022\032/mlflow/experiments/update\032\004\010\002\020\000\020\001*\021U" +
-      "pdate Experiment\022q\n\tcreateRun\022\021.mlflow.C" +
-      "reateRun\032\032.mlflow.CreateRun.Response\"5\362\206" +
-      "\0311\n!\n\004POST\022\023/mlflow/runs/create\032\004\010\002\020\000\020\001*" +
-      "\nCreate Run\022q\n\tupdateRun\022\021.mlflow.Update" +
-      "Run\032\032.mlflow.UpdateRun.Response\"5\362\206\0311\n!\n" +
-      "\004POST\022\023/mlflow/runs/update\032\004\010\002\020\000\020\001*\nUpda" +
-      "te Run\022q\n\tdeleteRun\022\021.mlflow.DeleteRun\032\032" +
-      ".mlflow.DeleteRun.Response\"5\362\206\0311\n!\n\004POST" +
-      "\022\023/mlflow/runs/delete\032\004\010\002\020\000\020\001*\nDelete Ru" +
-      "n\022v\n\nrestoreRun\022\022.mlflow.RestoreRun\032\033.ml" +
-      "flow.RestoreRun.Response\"7\362\206\0313\n\"\n\004POST\022\024" +
-      "/mlflow/runs/restore\032\004\010\002\020\000\020\001*\013Restore Ru" +
-      "n\022u\n\tlogMetric\022\021.mlflow.LogMetric\032\032.mlfl" +
-      "ow.LogMetric.Response\"9\362\206\0315\n%\n\004POST\022\027/ml" +
-      "flow/runs/log-metric\032\004\010\002\020\000\020\001*\nLog Metric" +
-      "\022t\n\010logParam\022\020.mlflow.LogParam\032\031.mlflow." +
-      "LogParam.Response\";\362\206\0317\n(\n\004POST\022\032/mlflow" +
-      "/runs/log-parameter\032\004\010\002\020\000\020\001*\tLog Param\022\241" +
-      "\001\n\020setExperimentTag\022\030.mlflow.SetExperime" +
-      "ntTag\032!.mlflow.SetExperimentTag.Response" +
-      "\"P\362\206\031L\n4\n\004POST\022&/mlflow/experiments/set-" +
-      "experiment-tag\032\004\010\002\020\000\020\001*\022Set Experiment T" +
-      "ag\022f\n\006setTag\022\016.mlflow.SetTag\032\027.mlflow.Se" +
-      "tTag.Response\"3\362\206\031/\n\"\n\004POST\022\024/mlflow/run" +
-      "s/set-tag\032\004\010\002\020\000\020\001*\007Set Tag\022u\n\tdeleteTag\022" +
-      "\021.mlflow.DeleteTag\032\032.mlflow.DeleteTag.Re" +
-      "sponse\"9\362\206\0315\n%\n\004POST\022\027/mlflow/runs/delet" +
-      "e-tag\032\004\010\002\020\000\020\001*\nDelete Tag\022a\n\006getRun\022\016.ml" +
-      "flow.GetRun\032\027.mlflow.GetRun.Response\".\362\206" +
-      "\031*\n\035\n\003GET\022\020/mlflow/runs/get\032\004\010\002\020\000\020\001*\007Get" +
-      " Run\022u\n\nsearchRuns\022\022.mlflow.SearchRuns\032\033" +
-      ".mlflow.SearchRuns.Response\"6\362\206\0312\n!\n\004POS" +
-      "T\022\023/mlflow/runs/search\032\004\010\002\020\000\020\001*\013Search R" +
-      "uns\022\203\001\n\rlistArtifacts\022\025.mlflow.ListArtif" +
-      "acts\032\036.mlflow.ListArtifacts.Response\";\362\206" +
-      "\0317\n#\n\003GET\022\026/mlflow/artifacts/list\032\004\010\002\020\000\020" +
-      "\001*\016List Artifacts\022\225\001\n\020getMetricHistory\022\030" +
-      ".mlflow.GetMetricHistory\032!.mlflow.GetMet" +
-      "ricHistory.Response\"D\362\206\031@\n(\n\003GET\022\033/mlflo" +
-      "w/metrics/get-history\032\004\010\002\020\000\020\001*\022Get Metri" +
-      "c History\022p\n\010logBatch\022\020.mlflow.LogBatch\032" +
-      "\031.mlflow.LogBatch.Response\"7\362\206\0313\n$\n\004POST" +
-      "\022\026/mlflow/runs/log-batch\032\004\010\002\020\000\020\001*\tLog Ba" +
-      "tch\022p\n\010logModel\022\020.mlflow.LogModel\032\031.mlfl" +
-      "ow.LogModel.Response\"7\362\206\0313\n$\n\004POST\022\026/mlf" +
-      "low/runs/log-model\032\004\010\002\020\000\020\001*\tLog ModelB\036\n" +
-      "\024org.mlflow.api.proto\220\001\001\342?\002\020\001"
+      "sponse]\"g\n\010LogModel\022\016\n\006run_id\030\001 \001(\t\022\022\n\nm" +
+      "odel_json\030\002 \001(\t\032\n\n\010Response:+\342?(\n&com.da" +
+      "tabricks.rpc.RPC[$this.Response]\"\225\001\n\023Get" +
+      "ExperimentByName\022\035\n\017experiment_name\030\001 \001(" +
+      "\tB\004\370\206\031\001\0322\n\010Response\022&\n\nexperiment\030\001 \001(\0132" +
+      "\022.mlflow.Experiment:+\342?(\n&com.databricks" +
+      ".rpc.RPC[$this.Response]*6\n\010ViewType\022\017\n\013" +
+      "ACTIVE_ONLY\020\001\022\020\n\014DELETED_ONLY\020\002\022\007\n\003ALL\020\003" +
+      "*I\n\nSourceType\022\014\n\010NOTEBOOK\020\001\022\007\n\003JOB\020\002\022\013\n" +
+      "\007PROJECT\020\003\022\t\n\005LOCAL\020\004\022\014\n\007UNKNOWN\020\350\007*M\n\tR" +
+      "unStatus\022\013\n\007RUNNING\020\001\022\r\n\tSCHEDULED\020\002\022\014\n\010" +
+      "FINISHED\020\003\022\n\n\006FAILED\020\004\022\n\n\006KILLED\020\0052\372\027\n\rM" +
+      "lflowService\022\246\001\n\023getExperimentByName\022\033.m" +
+      "lflow.GetExperimentByName\032$.mlflow.GetEx" +
+      "perimentByName.Response\"L\362\206\031H\n,\n\003GET\022\037/m" +
+      "lflow/experiments/get-by-name\032\004\010\002\020\000\020\001*\026G" +
+      "et Experiment By Name\022w\n\010moveRuns\022\020.mlfl" +
+      "ow.MoveRuns\032\031.mlflow.MoveRuns.Response\">" +
+      "\362\206\031:\n+\n\004POST\022\035/mlflow/experiments/move-r" +
+      "uns\032\004\010\002\020\000\020\001*\tMove Runs\022\224\001\n\020createExperim" +
+      "ent\022\030.mlflow.CreateExperiment\032!.mlflow.C" +
+      "reateExperiment.Response\"C\362\206\031?\n(\n\004POST\022\032" +
+      "/mlflow/experiments/create\032\004\010\002\020\000\020\001*\021Crea" +
+      "te Experiment\022\301\001\n\021searchExperiments\022\031.ml" +
+      "flow.SearchExperiments\032\".mlflow.SearchEx" +
+      "periments.Response\"m\362\206\031i\n(\n\004POST\022\032/mlflo" +
+      "w/experiments/search\032\004\010\002\020\000\n\'\n\003GET\022\032/mlfl" +
+      "ow/experiments/search\032\004\010\002\020\000\020\001*\022Search Ex" +
+      "periments\022\204\001\n\rgetExperiment\022\025.mlflow.Get" +
+      "Experiment\032\036.mlflow.GetExperiment.Respon" +
+      "se\"<\362\206\0318\n$\n\003GET\022\027/mlflow/experiments/get" +
+      "\032\004\010\002\020\000\020\001*\016Get Experiment\022\224\001\n\020deleteExper" +
+      "iment\022\030.mlflow.DeleteExperiment\032!.mlflow" +
+      ".DeleteExperiment.Response\"C\362\206\031?\n(\n\004POST" +
+      "\022\032/mlflow/experiments/delete\032\004\010\002\020\000\020\001*\021De" +
+      "lete Experiment\022\231\001\n\021restoreExperiment\022\031." +
+      "mlflow.RestoreExperiment\032\".mlflow.Restor" +
+      "eExperiment.Response\"E\362\206\031A\n)\n\004POST\022\033/mlf" +
+      "low/experiments/restore\032\004\010\002\020\000\020\001*\022Restore" +
+      " Experiment\022\224\001\n\020updateExperiment\022\030.mlflo" +
+      "w.UpdateExperiment\032!.mlflow.UpdateExperi" +
+      "ment.Response\"C\362\206\031?\n(\n\004POST\022\032/mlflow/exp" +
+      "eriments/update\032\004\010\002\020\000\020\001*\021Update Experime" +
+      "nt\022q\n\tcreateRun\022\021.mlflow.CreateRun\032\032.mlf" +
+      "low.CreateRun.Response\"5\362\206\0311\n!\n\004POST\022\023/m" +
+      "lflow/runs/create\032\004\010\002\020\000\020\001*\nCreate Run\022q\n" +
+      "\tupdateRun\022\021.mlflow.UpdateRun\032\032.mlflow.U" +
+      "pdateRun.Response\"5\362\206\0311\n!\n\004POST\022\023/mlflow" +
+      "/runs/update\032\004\010\002\020\000\020\001*\nUpdate Run\022q\n\tdele" +
+      "teRun\022\021.mlflow.DeleteRun\032\032.mlflow.Delete" +
+      "Run.Response\"5\362\206\0311\n!\n\004POST\022\023/mlflow/runs" +
+      "/delete\032\004\010\002\020\000\020\001*\nDelete Run\022v\n\nrestoreRu" +
+      "n\022\022.mlflow.RestoreRun\032\033.mlflow.RestoreRu" +
+      "n.Response\"7\362\206\0313\n\"\n\004POST\022\024/mlflow/runs/r" +
+      "estore\032\004\010\002\020\000\020\001*\013Restore Run\022u\n\tlogMetric" +
+      "\022\021.mlflow.LogMetric\032\032.mlflow.LogMetric.R" +
+      "esponse\"9\362\206\0315\n%\n\004POST\022\027/mlflow/runs/log-" +
+      "metric\032\004\010\002\020\000\020\001*\nLog Metric\022t\n\010logParam\022\020" +
+      ".mlflow.LogParam\032\031.mlflow.LogParam.Respo" +
+      "nse\";\362\206\0317\n(\n\004POST\022\032/mlflow/runs/log-para" +
+      "meter\032\004\010\002\020\000\020\001*\tLog Param\022\241\001\n\020setExperime" +
+      "ntTag\022\030.mlflow.SetExperimentTag\032!.mlflow" +
+      ".SetExperimentTag.Response\"P\362\206\031L\n4\n\004POST" +
+      "\022&/mlflow/experiments/set-experiment-tag" +
+      "\032\004\010\002\020\000\020\001*\022Set Experiment Tag\022f\n\006setTag\022\016" +
+      ".mlflow.SetTag\032\027.mlflow.SetTag.Response\"" +
+      "3\362\206\031/\n\"\n\004POST\022\024/mlflow/runs/set-tag\032\004\010\002\020" +
+      "\000\020\001*\007Set Tag\022u\n\tdeleteTag\022\021.mlflow.Delet" +
+      "eTag\032\032.mlflow.DeleteTag.Response\"9\362\206\0315\n%" +
+      "\n\004POST\022\027/mlflow/runs/delete-tag\032\004\010\002\020\000\020\001*" +
+      "\nDelete Tag\022a\n\006getRun\022\016.mlflow.GetRun\032\027." +
+      "mlflow.GetRun.Response\".\362\206\031*\n\035\n\003GET\022\020/ml" +
+      "flow/runs/get\032\004\010\002\020\000\020\001*\007Get Run\022u\n\nsearch" +
+      "Runs\022\022.mlflow.SearchRuns\032\033.mlflow.Search" +
+      "Runs.Response\"6\362\206\0312\n!\n\004POST\022\023/mlflow/run" +
+      "s/search\032\004\010\002\020\000\020\001*\013Search Runs\022\203\001\n\rlistAr" +
+      "tifacts\022\025.mlflow.ListArtifacts\032\036.mlflow." +
+      "ListArtifacts.Response\";\362\206\0317\n#\n\003GET\022\026/ml" +
+      "flow/artifacts/list\032\004\010\002\020\000\020\001*\016List Artifa" +
+      "cts\022\225\001\n\020getMetricHistory\022\030.mlflow.GetMet" +
+      "ricHistory\032!.mlflow.GetMetricHistory.Res" +
+      "ponse\"D\362\206\031@\n(\n\003GET\022\033/mlflow/metrics/get-" +
+      "history\032\004\010\002\020\000\020\001*\022Get Metric History\022p\n\010l" +
+      "ogBatch\022\020.mlflow.LogBatch\032\031.mlflow.LogBa" +
+      "tch.Response\"7\362\206\0313\n$\n\004POST\022\026/mlflow/runs" +
+      "/log-batch\032\004\010\002\020\000\020\001*\tLog Batch\022p\n\010logMode" +
+      "l\022\020.mlflow.LogModel\032\031.mlflow.LogModel.Re" +
+      "sponse\"7\362\206\0313\n$\n\004POST\022\026/mlflow/runs/log-m" +
+      "odel\032\004\010\002\020\000\020\001*\tLog ModelB\036\n\024org.mlflow.ap" +
+      "i.proto\220\001\001\342?\002\020\001"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -52394,8 +54010,20 @@ public final class Service {
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_Experiment_descriptor,
         new java.lang.String[] { "ExperimentId", "Name", "ArtifactLocation", "LifecycleStage", "LastUpdateTime", "CreationTime", "Tags", });
-    internal_static_mlflow_CreateExperiment_descriptor =
+    internal_static_mlflow_MoveRuns_descriptor =
       getDescriptor().getMessageTypes().get(8);
+    internal_static_mlflow_MoveRuns_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_mlflow_MoveRuns_descriptor,
+        new java.lang.String[] { "RunIds", "ExperimentId", });
+    internal_static_mlflow_MoveRuns_Response_descriptor =
+      internal_static_mlflow_MoveRuns_descriptor.getNestedTypes().get(0);
+    internal_static_mlflow_MoveRuns_Response_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_mlflow_MoveRuns_Response_descriptor,
+        new java.lang.String[] { "ExperimentId", });
+    internal_static_mlflow_CreateExperiment_descriptor =
+      getDescriptor().getMessageTypes().get(9);
     internal_static_mlflow_CreateExperiment_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_CreateExperiment_descriptor,
@@ -52407,7 +54035,7 @@ public final class Service {
         internal_static_mlflow_CreateExperiment_Response_descriptor,
         new java.lang.String[] { "ExperimentId", });
     internal_static_mlflow_SearchExperiments_descriptor =
-      getDescriptor().getMessageTypes().get(9);
+      getDescriptor().getMessageTypes().get(10);
     internal_static_mlflow_SearchExperiments_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_SearchExperiments_descriptor,
@@ -52419,7 +54047,7 @@ public final class Service {
         internal_static_mlflow_SearchExperiments_Response_descriptor,
         new java.lang.String[] { "Experiments", "NextPageToken", });
     internal_static_mlflow_GetExperiment_descriptor =
-      getDescriptor().getMessageTypes().get(10);
+      getDescriptor().getMessageTypes().get(11);
     internal_static_mlflow_GetExperiment_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_GetExperiment_descriptor,
@@ -52431,7 +54059,7 @@ public final class Service {
         internal_static_mlflow_GetExperiment_Response_descriptor,
         new java.lang.String[] { "Experiment", });
     internal_static_mlflow_DeleteExperiment_descriptor =
-      getDescriptor().getMessageTypes().get(11);
+      getDescriptor().getMessageTypes().get(12);
     internal_static_mlflow_DeleteExperiment_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_DeleteExperiment_descriptor,
@@ -52443,7 +54071,7 @@ public final class Service {
         internal_static_mlflow_DeleteExperiment_Response_descriptor,
         new java.lang.String[] { });
     internal_static_mlflow_RestoreExperiment_descriptor =
-      getDescriptor().getMessageTypes().get(12);
+      getDescriptor().getMessageTypes().get(13);
     internal_static_mlflow_RestoreExperiment_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_RestoreExperiment_descriptor,
@@ -52455,7 +54083,7 @@ public final class Service {
         internal_static_mlflow_RestoreExperiment_Response_descriptor,
         new java.lang.String[] { });
     internal_static_mlflow_UpdateExperiment_descriptor =
-      getDescriptor().getMessageTypes().get(13);
+      getDescriptor().getMessageTypes().get(14);
     internal_static_mlflow_UpdateExperiment_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_UpdateExperiment_descriptor,
@@ -52467,7 +54095,7 @@ public final class Service {
         internal_static_mlflow_UpdateExperiment_Response_descriptor,
         new java.lang.String[] { });
     internal_static_mlflow_CreateRun_descriptor =
-      getDescriptor().getMessageTypes().get(14);
+      getDescriptor().getMessageTypes().get(15);
     internal_static_mlflow_CreateRun_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_CreateRun_descriptor,
@@ -52479,7 +54107,7 @@ public final class Service {
         internal_static_mlflow_CreateRun_Response_descriptor,
         new java.lang.String[] { "Run", });
     internal_static_mlflow_UpdateRun_descriptor =
-      getDescriptor().getMessageTypes().get(15);
+      getDescriptor().getMessageTypes().get(16);
     internal_static_mlflow_UpdateRun_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_UpdateRun_descriptor,
@@ -52491,7 +54119,7 @@ public final class Service {
         internal_static_mlflow_UpdateRun_Response_descriptor,
         new java.lang.String[] { "RunInfo", });
     internal_static_mlflow_DeleteRun_descriptor =
-      getDescriptor().getMessageTypes().get(16);
+      getDescriptor().getMessageTypes().get(17);
     internal_static_mlflow_DeleteRun_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_DeleteRun_descriptor,
@@ -52503,7 +54131,7 @@ public final class Service {
         internal_static_mlflow_DeleteRun_Response_descriptor,
         new java.lang.String[] { });
     internal_static_mlflow_RestoreRun_descriptor =
-      getDescriptor().getMessageTypes().get(17);
+      getDescriptor().getMessageTypes().get(18);
     internal_static_mlflow_RestoreRun_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_RestoreRun_descriptor,
@@ -52515,7 +54143,7 @@ public final class Service {
         internal_static_mlflow_RestoreRun_Response_descriptor,
         new java.lang.String[] { });
     internal_static_mlflow_LogMetric_descriptor =
-      getDescriptor().getMessageTypes().get(18);
+      getDescriptor().getMessageTypes().get(19);
     internal_static_mlflow_LogMetric_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_LogMetric_descriptor,
@@ -52527,7 +54155,7 @@ public final class Service {
         internal_static_mlflow_LogMetric_Response_descriptor,
         new java.lang.String[] { });
     internal_static_mlflow_LogParam_descriptor =
-      getDescriptor().getMessageTypes().get(19);
+      getDescriptor().getMessageTypes().get(20);
     internal_static_mlflow_LogParam_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_LogParam_descriptor,
@@ -52539,7 +54167,7 @@ public final class Service {
         internal_static_mlflow_LogParam_Response_descriptor,
         new java.lang.String[] { });
     internal_static_mlflow_SetExperimentTag_descriptor =
-      getDescriptor().getMessageTypes().get(20);
+      getDescriptor().getMessageTypes().get(21);
     internal_static_mlflow_SetExperimentTag_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_SetExperimentTag_descriptor,
@@ -52551,7 +54179,7 @@ public final class Service {
         internal_static_mlflow_SetExperimentTag_Response_descriptor,
         new java.lang.String[] { });
     internal_static_mlflow_SetTag_descriptor =
-      getDescriptor().getMessageTypes().get(21);
+      getDescriptor().getMessageTypes().get(22);
     internal_static_mlflow_SetTag_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_SetTag_descriptor,
@@ -52563,7 +54191,7 @@ public final class Service {
         internal_static_mlflow_SetTag_Response_descriptor,
         new java.lang.String[] { });
     internal_static_mlflow_DeleteTag_descriptor =
-      getDescriptor().getMessageTypes().get(22);
+      getDescriptor().getMessageTypes().get(23);
     internal_static_mlflow_DeleteTag_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_DeleteTag_descriptor,
@@ -52575,7 +54203,7 @@ public final class Service {
         internal_static_mlflow_DeleteTag_Response_descriptor,
         new java.lang.String[] { });
     internal_static_mlflow_GetRun_descriptor =
-      getDescriptor().getMessageTypes().get(23);
+      getDescriptor().getMessageTypes().get(24);
     internal_static_mlflow_GetRun_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_GetRun_descriptor,
@@ -52587,7 +54215,7 @@ public final class Service {
         internal_static_mlflow_GetRun_Response_descriptor,
         new java.lang.String[] { "Run", });
     internal_static_mlflow_SearchRuns_descriptor =
-      getDescriptor().getMessageTypes().get(24);
+      getDescriptor().getMessageTypes().get(25);
     internal_static_mlflow_SearchRuns_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_SearchRuns_descriptor,
@@ -52599,7 +54227,7 @@ public final class Service {
         internal_static_mlflow_SearchRuns_Response_descriptor,
         new java.lang.String[] { "Runs", "NextPageToken", });
     internal_static_mlflow_ListArtifacts_descriptor =
-      getDescriptor().getMessageTypes().get(25);
+      getDescriptor().getMessageTypes().get(26);
     internal_static_mlflow_ListArtifacts_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_ListArtifacts_descriptor,
@@ -52611,13 +54239,13 @@ public final class Service {
         internal_static_mlflow_ListArtifacts_Response_descriptor,
         new java.lang.String[] { "RootUri", "Files", "NextPageToken", });
     internal_static_mlflow_FileInfo_descriptor =
-      getDescriptor().getMessageTypes().get(26);
+      getDescriptor().getMessageTypes().get(27);
     internal_static_mlflow_FileInfo_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_FileInfo_descriptor,
         new java.lang.String[] { "Path", "IsDir", "FileSize", });
     internal_static_mlflow_GetMetricHistory_descriptor =
-      getDescriptor().getMessageTypes().get(27);
+      getDescriptor().getMessageTypes().get(28);
     internal_static_mlflow_GetMetricHistory_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_GetMetricHistory_descriptor,
@@ -52629,7 +54257,7 @@ public final class Service {
         internal_static_mlflow_GetMetricHistory_Response_descriptor,
         new java.lang.String[] { "Metrics", });
     internal_static_mlflow_LogBatch_descriptor =
-      getDescriptor().getMessageTypes().get(28);
+      getDescriptor().getMessageTypes().get(29);
     internal_static_mlflow_LogBatch_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_LogBatch_descriptor,
@@ -52641,7 +54269,7 @@ public final class Service {
         internal_static_mlflow_LogBatch_Response_descriptor,
         new java.lang.String[] { });
     internal_static_mlflow_LogModel_descriptor =
-      getDescriptor().getMessageTypes().get(29);
+      getDescriptor().getMessageTypes().get(30);
     internal_static_mlflow_LogModel_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_LogModel_descriptor,
@@ -52653,7 +54281,7 @@ public final class Service {
         internal_static_mlflow_LogModel_Response_descriptor,
         new java.lang.String[] { });
     internal_static_mlflow_GetExperimentByName_descriptor =
-      getDescriptor().getMessageTypes().get(30);
+      getDescriptor().getMessageTypes().get(31);
     internal_static_mlflow_GetExperimentByName_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_GetExperimentByName_descriptor,

--- a/mlflow/protos/service.proto
+++ b/mlflow/protos/service.proto
@@ -20,7 +20,7 @@ service MlflowService {
   // if an active and deleted experiment share the same name. If multiple deleted
   // experiments share the same name, the API will return one of them.
   //
-  // Throws ``RESOURCE_DOES_NOT_EXIST`` if no experiment with the specified name exists.
+  // Throws ``RESOURCE_DOES_NOT_EXIST`` if no experiment with the specified ID exists.
   //
   rpc getExperimentByName (GetExperimentByName) returns (GetExperimentByName.Response) {
     option (rpc) = {
@@ -31,6 +31,22 @@ service MlflowService {
       }],
       visibility: PUBLIC,
       rpc_doc_title: "Get Experiment By Name",
+    };
+  }
+
+  // Move runs to another experiment. Returns ID of the experiment.
+  //
+  // Throws ``RESOURCE_DOES_NOT_EXIST`` if no experiment with the specified name exists.
+  //
+  rpc moveRuns (MoveRuns) returns (MoveRuns.Response) {
+    option (rpc) = {
+      endpoints: [{
+        method: "POST",
+        path: "/mlflow/experiments/move-runs",
+        since { major: 2, minor: 0 },
+      }],
+      visibility: PUBLIC,
+      rpc_doc_title: "Move Runs",
     };
   }
 
@@ -574,6 +590,21 @@ message Experiment {
 
   // Tags: Additional metadata key-value pairs.
   repeated ExperimentTag tags = 7;
+}
+
+message MoveRuns {
+  option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
+
+  // Run ids.
+  repeated string run_ids = 1 [(validate_required) = true];
+
+  // Experiment id.
+  required string experiment_id = 2 [(validate_required) = true];
+
+  message Response {
+    // Unique identifier for the experiment.
+    optional string experiment_id = 1;
+  }
 }
 
 message CreateExperiment {

--- a/mlflow/protos/service.proto
+++ b/mlflow/protos/service.proto
@@ -20,7 +20,7 @@ service MlflowService {
   // if an active and deleted experiment share the same name. If multiple deleted
   // experiments share the same name, the API will return one of them.
   //
-  // Throws ``RESOURCE_DOES_NOT_EXIST`` if no experiment with the specified ID exists.
+  // Throws ``RESOURCE_DOES_NOT_EXIST`` if no experiment with the specified name exists.
   //
   rpc getExperimentByName (GetExperimentByName) returns (GetExperimentByName.Response) {
     option (rpc) = {
@@ -36,7 +36,7 @@ service MlflowService {
 
   // Move runs to another experiment. Returns ID of the experiment.
   //
-  // Throws ``RESOURCE_DOES_NOT_EXIST`` if no experiment with the specified name exists.
+  // Throws ``RESOURCE_DOES_NOT_EXIST`` if no experiment with the specified ID exists.
   //
   rpc moveRuns (MoveRuns) returns (MoveRuns.Response) {
     option (rpc) = {

--- a/mlflow/protos/service_pb2.py
+++ b/mlflow/protos/service_pb2.py
@@ -19,7 +19,7 @@ from .scalapb import scalapb_pb2 as scalapb_dot_scalapb__pb2
 from . import databricks_pb2 as databricks__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\rservice.proto\x12\x06mlflow\x1a\x15scalapb/scalapb.proto\x1a\x10\x64\x61tabricks.proto\"H\n\x06Metric\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x01\x12\x11\n\ttimestamp\x18\x03 \x01(\x03\x12\x0f\n\x04step\x18\x04 \x01(\x03:\x01\x30\"#\n\x05Param\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"C\n\x03Run\x12\x1d\n\x04info\x18\x01 \x01(\x0b\x32\x0f.mlflow.RunInfo\x12\x1d\n\x04\x64\x61ta\x18\x02 \x01(\x0b\x32\x0f.mlflow.RunData\"g\n\x07RunData\x12\x1f\n\x07metrics\x18\x01 \x03(\x0b\x32\x0e.mlflow.Metric\x12\x1d\n\x06params\x18\x02 \x03(\x0b\x32\r.mlflow.Param\x12\x1c\n\x04tags\x18\x03 \x03(\x0b\x32\x0e.mlflow.RunTag\"$\n\x06RunTag\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"+\n\rExperimentTag\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"\xdd\x01\n\x07RunInfo\x12\x0e\n\x06run_id\x18\x0f \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x10\n\x08run_name\x18\x03 \x01(\t\x12\x15\n\rexperiment_id\x18\x02 \x01(\t\x12\x0f\n\x07user_id\x18\x06 \x01(\t\x12!\n\x06status\x18\x07 \x01(\x0e\x32\x11.mlflow.RunStatus\x12\x12\n\nstart_time\x18\x08 \x01(\x03\x12\x10\n\x08\x65nd_time\x18\t \x01(\x03\x12\x14\n\x0c\x61rtifact_uri\x18\r \x01(\t\x12\x17\n\x0flifecycle_stage\x18\x0e \x01(\t\"\xbb\x01\n\nExperiment\x12\x15\n\rexperiment_id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x19\n\x11\x61rtifact_location\x18\x03 \x01(\t\x12\x17\n\x0flifecycle_stage\x18\x04 \x01(\t\x12\x18\n\x10last_update_time\x18\x05 \x01(\x03\x12\x15\n\rcreation_time\x18\x06 \x01(\x03\x12#\n\x04tags\x18\x07 \x03(\x0b\x32\x15.mlflow.ExperimentTag\"\xb6\x01\n\x10\x43reateExperiment\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x19\n\x11\x61rtifact_location\x18\x02 \x01(\t\x12#\n\x04tags\x18\x03 \x03(\x0b\x32\x15.mlflow.ExperimentTag\x1a!\n\x08Response\x12\x15\n\rexperiment_id\x18\x01 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xfe\x01\n\x11SearchExperiments\x12\x13\n\x0bmax_results\x18\x01 \x01(\x03\x12\x12\n\npage_token\x18\x02 \x01(\t\x12\x0e\n\x06\x66ilter\x18\x03 \x01(\t\x12\x10\n\x08order_by\x18\x04 \x03(\t\x12#\n\tview_type\x18\x05 \x01(\x0e\x32\x10.mlflow.ViewType\x1aL\n\x08Response\x12\'\n\x0b\x65xperiments\x18\x01 \x03(\x0b\x32\x12.mlflow.Experiment\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x8d\x01\n\rGetExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\x32\n\x08Response\x12&\n\nexperiment\x18\x01 \x01(\x0b\x32\x12.mlflow.Experiment:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"h\n\x10\x44\x65leteExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"i\n\x11RestoreExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"z\n\x10UpdateExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x10\n\x08new_name\x18\x02 \x01(\t\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xca\x01\n\tCreateRun\x12\x15\n\rexperiment_id\x18\x01 \x01(\t\x12\x0f\n\x07user_id\x18\x02 \x01(\t\x12\x10\n\x08run_name\x18\x03 \x01(\t\x12\x12\n\nstart_time\x18\x07 \x01(\x03\x12\x1c\n\x04tags\x18\t \x03(\x0b\x32\x0e.mlflow.RunTag\x1a$\n\x08Response\x12\x18\n\x03run\x18\x01 \x01(\x0b\x32\x0b.mlflow.Run:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xd0\x01\n\tUpdateRun\x12\x0e\n\x06run_id\x18\x04 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12!\n\x06status\x18\x02 \x01(\x0e\x32\x11.mlflow.RunStatus\x12\x10\n\x08\x65nd_time\x18\x03 \x01(\x03\x12\x10\n\x08run_name\x18\x05 \x01(\t\x1a-\n\x08Response\x12!\n\x08run_info\x18\x01 \x01(\x0b\x32\x0f.mlflow.RunInfo:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"Z\n\tDeleteRun\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"[\n\nRestoreRun\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb8\x01\n\tLogMetric\x12\x0e\n\x06run_id\x18\x06 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x03 \x01(\x01\x42\x04\xf8\x86\x19\x01\x12\x17\n\ttimestamp\x18\x04 \x01(\x03\x42\x04\xf8\x86\x19\x01\x12\x0f\n\x04step\x18\x05 \x01(\x03:\x01\x30\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x8d\x01\n\x08LogParam\x12\x0e\n\x06run_id\x18\x04 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x90\x01\n\x10SetExperimentTag\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x8b\x01\n\x06SetTag\x12\x0e\n\x06run_id\x18\x04 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"m\n\tDeleteTag\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"}\n\x06GetRun\x12\x0e\n\x06run_id\x18\x02 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x1a$\n\x08Response\x12\x18\n\x03run\x18\x01 \x01(\x0b\x32\x0b.mlflow.Run:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x98\x02\n\nSearchRuns\x12\x16\n\x0e\x65xperiment_ids\x18\x01 \x03(\t\x12\x0e\n\x06\x66ilter\x18\x04 \x01(\t\x12\x34\n\rrun_view_type\x18\x03 \x01(\x0e\x32\x10.mlflow.ViewType:\x0b\x41\x43TIVE_ONLY\x12\x19\n\x0bmax_results\x18\x05 \x01(\x05:\x04\x31\x30\x30\x30\x12\x10\n\x08order_by\x18\x06 \x03(\t\x12\x12\n\npage_token\x18\x07 \x01(\t\x1a>\n\x08Response\x12\x19\n\x04runs\x18\x01 \x03(\x0b\x32\x0b.mlflow.Run\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xd8\x01\n\rListArtifacts\x12\x0e\n\x06run_id\x18\x03 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x0c\n\x04path\x18\x02 \x01(\t\x12\x12\n\npage_token\x18\x04 \x01(\t\x1aV\n\x08Response\x12\x10\n\x08root_uri\x18\x01 \x01(\t\x12\x1f\n\x05\x66iles\x18\x02 \x03(\x0b\x32\x10.mlflow.FileInfo\x12\x17\n\x0fnext_page_token\x18\x03 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\";\n\x08\x46ileInfo\x12\x0c\n\x04path\x18\x01 \x01(\t\x12\x0e\n\x06is_dir\x18\x02 \x01(\x08\x12\x11\n\tfile_size\x18\x03 \x01(\x03\"\xa8\x01\n\x10GetMetricHistory\x12\x0e\n\x06run_id\x18\x03 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x18\n\nmetric_key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a+\n\x08Response\x12\x1f\n\x07metrics\x18\x01 \x03(\x0b\x32\x0e.mlflow.Metric:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb1\x01\n\x08LogBatch\x12\x0e\n\x06run_id\x18\x01 \x01(\t\x12\x1f\n\x07metrics\x18\x02 \x03(\x0b\x32\x0e.mlflow.Metric\x12\x1d\n\x06params\x18\x03 \x03(\x0b\x32\r.mlflow.Param\x12\x1c\n\x04tags\x18\x04 \x03(\x0b\x32\x0e.mlflow.RunTag\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"g\n\x08LogModel\x12\x0e\n\x06run_id\x18\x01 \x01(\t\x12\x12\n\nmodel_json\x18\x02 \x01(\t\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x95\x01\n\x13GetExperimentByName\x12\x1d\n\x0f\x65xperiment_name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\x32\n\x08Response\x12&\n\nexperiment\x18\x01 \x01(\x0b\x32\x12.mlflow.Experiment:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]*6\n\x08ViewType\x12\x0f\n\x0b\x41\x43TIVE_ONLY\x10\x01\x12\x10\n\x0c\x44\x45LETED_ONLY\x10\x02\x12\x07\n\x03\x41LL\x10\x03*I\n\nSourceType\x12\x0c\n\x08NOTEBOOK\x10\x01\x12\x07\n\x03JOB\x10\x02\x12\x0b\n\x07PROJECT\x10\x03\x12\t\n\x05LOCAL\x10\x04\x12\x0c\n\x07UNKNOWN\x10\xe8\x07*M\n\tRunStatus\x12\x0b\n\x07RUNNING\x10\x01\x12\r\n\tSCHEDULED\x10\x02\x12\x0c\n\x08\x46INISHED\x10\x03\x12\n\n\x06\x46\x41ILED\x10\x04\x12\n\n\x06KILLED\x10\x05\x32\x81\x17\n\rMlflowService\x12\xa6\x01\n\x13getExperimentByName\x12\x1b.mlflow.GetExperimentByName\x1a$.mlflow.GetExperimentByName.Response\"L\xf2\x86\x19H\n,\n\x03GET\x12\x1f/mlflow/experiments/get-by-name\x1a\x04\x08\x02\x10\x00\x10\x01*\x16Get Experiment By Name\x12\x94\x01\n\x10\x63reateExperiment\x12\x18.mlflow.CreateExperiment\x1a!.mlflow.CreateExperiment.Response\"C\xf2\x86\x19?\n(\n\x04POST\x12\x1a/mlflow/experiments/create\x1a\x04\x08\x02\x10\x00\x10\x01*\x11\x43reate Experiment\x12\xc1\x01\n\x11searchExperiments\x12\x19.mlflow.SearchExperiments\x1a\".mlflow.SearchExperiments.Response\"m\xf2\x86\x19i\n(\n\x04POST\x12\x1a/mlflow/experiments/search\x1a\x04\x08\x02\x10\x00\n\'\n\x03GET\x12\x1a/mlflow/experiments/search\x1a\x04\x08\x02\x10\x00\x10\x01*\x12Search Experiments\x12\x84\x01\n\rgetExperiment\x12\x15.mlflow.GetExperiment\x1a\x1e.mlflow.GetExperiment.Response\"<\xf2\x86\x19\x38\n$\n\x03GET\x12\x17/mlflow/experiments/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x0eGet Experiment\x12\x94\x01\n\x10\x64\x65leteExperiment\x12\x18.mlflow.DeleteExperiment\x1a!.mlflow.DeleteExperiment.Response\"C\xf2\x86\x19?\n(\n\x04POST\x12\x1a/mlflow/experiments/delete\x1a\x04\x08\x02\x10\x00\x10\x01*\x11\x44\x65lete Experiment\x12\x99\x01\n\x11restoreExperiment\x12\x19.mlflow.RestoreExperiment\x1a\".mlflow.RestoreExperiment.Response\"E\xf2\x86\x19\x41\n)\n\x04POST\x12\x1b/mlflow/experiments/restore\x1a\x04\x08\x02\x10\x00\x10\x01*\x12Restore Experiment\x12\x94\x01\n\x10updateExperiment\x12\x18.mlflow.UpdateExperiment\x1a!.mlflow.UpdateExperiment.Response\"C\xf2\x86\x19?\n(\n\x04POST\x12\x1a/mlflow/experiments/update\x1a\x04\x08\x02\x10\x00\x10\x01*\x11Update Experiment\x12q\n\tcreateRun\x12\x11.mlflow.CreateRun\x1a\x1a.mlflow.CreateRun.Response\"5\xf2\x86\x19\x31\n!\n\x04POST\x12\x13/mlflow/runs/create\x1a\x04\x08\x02\x10\x00\x10\x01*\nCreate Run\x12q\n\tupdateRun\x12\x11.mlflow.UpdateRun\x1a\x1a.mlflow.UpdateRun.Response\"5\xf2\x86\x19\x31\n!\n\x04POST\x12\x13/mlflow/runs/update\x1a\x04\x08\x02\x10\x00\x10\x01*\nUpdate Run\x12q\n\tdeleteRun\x12\x11.mlflow.DeleteRun\x1a\x1a.mlflow.DeleteRun.Response\"5\xf2\x86\x19\x31\n!\n\x04POST\x12\x13/mlflow/runs/delete\x1a\x04\x08\x02\x10\x00\x10\x01*\nDelete Run\x12v\n\nrestoreRun\x12\x12.mlflow.RestoreRun\x1a\x1b.mlflow.RestoreRun.Response\"7\xf2\x86\x19\x33\n\"\n\x04POST\x12\x14/mlflow/runs/restore\x1a\x04\x08\x02\x10\x00\x10\x01*\x0bRestore Run\x12u\n\tlogMetric\x12\x11.mlflow.LogMetric\x1a\x1a.mlflow.LogMetric.Response\"9\xf2\x86\x19\x35\n%\n\x04POST\x12\x17/mlflow/runs/log-metric\x1a\x04\x08\x02\x10\x00\x10\x01*\nLog Metric\x12t\n\x08logParam\x12\x10.mlflow.LogParam\x1a\x19.mlflow.LogParam.Response\";\xf2\x86\x19\x37\n(\n\x04POST\x12\x1a/mlflow/runs/log-parameter\x1a\x04\x08\x02\x10\x00\x10\x01*\tLog Param\x12\xa1\x01\n\x10setExperimentTag\x12\x18.mlflow.SetExperimentTag\x1a!.mlflow.SetExperimentTag.Response\"P\xf2\x86\x19L\n4\n\x04POST\x12&/mlflow/experiments/set-experiment-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x12Set Experiment Tag\x12\x66\n\x06setTag\x12\x0e.mlflow.SetTag\x1a\x17.mlflow.SetTag.Response\"3\xf2\x86\x19/\n\"\n\x04POST\x12\x14/mlflow/runs/set-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x07Set Tag\x12u\n\tdeleteTag\x12\x11.mlflow.DeleteTag\x1a\x1a.mlflow.DeleteTag.Response\"9\xf2\x86\x19\x35\n%\n\x04POST\x12\x17/mlflow/runs/delete-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\nDelete Tag\x12\x61\n\x06getRun\x12\x0e.mlflow.GetRun\x1a\x17.mlflow.GetRun.Response\".\xf2\x86\x19*\n\x1d\n\x03GET\x12\x10/mlflow/runs/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x07Get Run\x12u\n\nsearchRuns\x12\x12.mlflow.SearchRuns\x1a\x1b.mlflow.SearchRuns.Response\"6\xf2\x86\x19\x32\n!\n\x04POST\x12\x13/mlflow/runs/search\x1a\x04\x08\x02\x10\x00\x10\x01*\x0bSearch Runs\x12\x83\x01\n\rlistArtifacts\x12\x15.mlflow.ListArtifacts\x1a\x1e.mlflow.ListArtifacts.Response\";\xf2\x86\x19\x37\n#\n\x03GET\x12\x16/mlflow/artifacts/list\x1a\x04\x08\x02\x10\x00\x10\x01*\x0eList Artifacts\x12\x95\x01\n\x10getMetricHistory\x12\x18.mlflow.GetMetricHistory\x1a!.mlflow.GetMetricHistory.Response\"D\xf2\x86\x19@\n(\n\x03GET\x12\x1b/mlflow/metrics/get-history\x1a\x04\x08\x02\x10\x00\x10\x01*\x12Get Metric History\x12p\n\x08logBatch\x12\x10.mlflow.LogBatch\x1a\x19.mlflow.LogBatch.Response\"7\xf2\x86\x19\x33\n$\n\x04POST\x12\x16/mlflow/runs/log-batch\x1a\x04\x08\x02\x10\x00\x10\x01*\tLog Batch\x12p\n\x08logModel\x12\x10.mlflow.LogModel\x1a\x19.mlflow.LogModel.Response\"7\xf2\x86\x19\x33\n$\n\x04POST\x12\x16/mlflow/runs/log-model\x1a\x04\x08\x02\x10\x00\x10\x01*\tLog ModelB\x1e\n\x14org.mlflow.api.proto\x90\x01\x01\xe2?\x02\x10\x01')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\rservice.proto\x12\x06mlflow\x1a\x15scalapb/scalapb.proto\x1a\x10\x64\x61tabricks.proto\"H\n\x06Metric\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x01\x12\x11\n\ttimestamp\x18\x03 \x01(\x03\x12\x0f\n\x04step\x18\x04 \x01(\x03:\x01\x30\"#\n\x05Param\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"C\n\x03Run\x12\x1d\n\x04info\x18\x01 \x01(\x0b\x32\x0f.mlflow.RunInfo\x12\x1d\n\x04\x64\x61ta\x18\x02 \x01(\x0b\x32\x0f.mlflow.RunData\"g\n\x07RunData\x12\x1f\n\x07metrics\x18\x01 \x03(\x0b\x32\x0e.mlflow.Metric\x12\x1d\n\x06params\x18\x02 \x03(\x0b\x32\r.mlflow.Param\x12\x1c\n\x04tags\x18\x03 \x03(\x0b\x32\x0e.mlflow.RunTag\"$\n\x06RunTag\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"+\n\rExperimentTag\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"\xdd\x01\n\x07RunInfo\x12\x0e\n\x06run_id\x18\x0f \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x10\n\x08run_name\x18\x03 \x01(\t\x12\x15\n\rexperiment_id\x18\x02 \x01(\t\x12\x0f\n\x07user_id\x18\x06 \x01(\t\x12!\n\x06status\x18\x07 \x01(\x0e\x32\x11.mlflow.RunStatus\x12\x12\n\nstart_time\x18\x08 \x01(\x03\x12\x10\n\x08\x65nd_time\x18\t \x01(\x03\x12\x14\n\x0c\x61rtifact_uri\x18\r \x01(\t\x12\x17\n\x0flifecycle_stage\x18\x0e \x01(\t\"\xbb\x01\n\nExperiment\x12\x15\n\rexperiment_id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x19\n\x11\x61rtifact_location\x18\x03 \x01(\t\x12\x17\n\x0flifecycle_stage\x18\x04 \x01(\t\x12\x18\n\x10last_update_time\x18\x05 \x01(\x03\x12\x15\n\rcreation_time\x18\x06 \x01(\x03\x12#\n\x04tags\x18\x07 \x03(\x0b\x32\x15.mlflow.ExperimentTag\"\x8e\x01\n\x08MoveRuns\x12\x15\n\x07run_ids\x18\x01 \x03(\tB\x04\xf8\x86\x19\x01\x12\x1b\n\rexperiment_id\x18\x02 \x02(\tB\x04\xf8\x86\x19\x01\x1a!\n\x08Response\x12\x15\n\rexperiment_id\x18\x01 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb6\x01\n\x10\x43reateExperiment\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x19\n\x11\x61rtifact_location\x18\x02 \x01(\t\x12#\n\x04tags\x18\x03 \x03(\x0b\x32\x15.mlflow.ExperimentTag\x1a!\n\x08Response\x12\x15\n\rexperiment_id\x18\x01 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xfe\x01\n\x11SearchExperiments\x12\x13\n\x0bmax_results\x18\x01 \x01(\x03\x12\x12\n\npage_token\x18\x02 \x01(\t\x12\x0e\n\x06\x66ilter\x18\x03 \x01(\t\x12\x10\n\x08order_by\x18\x04 \x03(\t\x12#\n\tview_type\x18\x05 \x01(\x0e\x32\x10.mlflow.ViewType\x1aL\n\x08Response\x12\'\n\x0b\x65xperiments\x18\x01 \x03(\x0b\x32\x12.mlflow.Experiment\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x8d\x01\n\rGetExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\x32\n\x08Response\x12&\n\nexperiment\x18\x01 \x01(\x0b\x32\x12.mlflow.Experiment:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"h\n\x10\x44\x65leteExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"i\n\x11RestoreExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"z\n\x10UpdateExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x10\n\x08new_name\x18\x02 \x01(\t\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xca\x01\n\tCreateRun\x12\x15\n\rexperiment_id\x18\x01 \x01(\t\x12\x0f\n\x07user_id\x18\x02 \x01(\t\x12\x10\n\x08run_name\x18\x03 \x01(\t\x12\x12\n\nstart_time\x18\x07 \x01(\x03\x12\x1c\n\x04tags\x18\t \x03(\x0b\x32\x0e.mlflow.RunTag\x1a$\n\x08Response\x12\x18\n\x03run\x18\x01 \x01(\x0b\x32\x0b.mlflow.Run:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xd0\x01\n\tUpdateRun\x12\x0e\n\x06run_id\x18\x04 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12!\n\x06status\x18\x02 \x01(\x0e\x32\x11.mlflow.RunStatus\x12\x10\n\x08\x65nd_time\x18\x03 \x01(\x03\x12\x10\n\x08run_name\x18\x05 \x01(\t\x1a-\n\x08Response\x12!\n\x08run_info\x18\x01 \x01(\x0b\x32\x0f.mlflow.RunInfo:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"Z\n\tDeleteRun\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"[\n\nRestoreRun\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb8\x01\n\tLogMetric\x12\x0e\n\x06run_id\x18\x06 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x03 \x01(\x01\x42\x04\xf8\x86\x19\x01\x12\x17\n\ttimestamp\x18\x04 \x01(\x03\x42\x04\xf8\x86\x19\x01\x12\x0f\n\x04step\x18\x05 \x01(\x03:\x01\x30\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x8d\x01\n\x08LogParam\x12\x0e\n\x06run_id\x18\x04 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x90\x01\n\x10SetExperimentTag\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x8b\x01\n\x06SetTag\x12\x0e\n\x06run_id\x18\x04 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"m\n\tDeleteTag\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"}\n\x06GetRun\x12\x0e\n\x06run_id\x18\x02 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x1a$\n\x08Response\x12\x18\n\x03run\x18\x01 \x01(\x0b\x32\x0b.mlflow.Run:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x98\x02\n\nSearchRuns\x12\x16\n\x0e\x65xperiment_ids\x18\x01 \x03(\t\x12\x0e\n\x06\x66ilter\x18\x04 \x01(\t\x12\x34\n\rrun_view_type\x18\x03 \x01(\x0e\x32\x10.mlflow.ViewType:\x0b\x41\x43TIVE_ONLY\x12\x19\n\x0bmax_results\x18\x05 \x01(\x05:\x04\x31\x30\x30\x30\x12\x10\n\x08order_by\x18\x06 \x03(\t\x12\x12\n\npage_token\x18\x07 \x01(\t\x1a>\n\x08Response\x12\x19\n\x04runs\x18\x01 \x03(\x0b\x32\x0b.mlflow.Run\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xd8\x01\n\rListArtifacts\x12\x0e\n\x06run_id\x18\x03 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x0c\n\x04path\x18\x02 \x01(\t\x12\x12\n\npage_token\x18\x04 \x01(\t\x1aV\n\x08Response\x12\x10\n\x08root_uri\x18\x01 \x01(\t\x12\x1f\n\x05\x66iles\x18\x02 \x03(\x0b\x32\x10.mlflow.FileInfo\x12\x17\n\x0fnext_page_token\x18\x03 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\";\n\x08\x46ileInfo\x12\x0c\n\x04path\x18\x01 \x01(\t\x12\x0e\n\x06is_dir\x18\x02 \x01(\x08\x12\x11\n\tfile_size\x18\x03 \x01(\x03\"\xa8\x01\n\x10GetMetricHistory\x12\x0e\n\x06run_id\x18\x03 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x18\n\nmetric_key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a+\n\x08Response\x12\x1f\n\x07metrics\x18\x01 \x03(\x0b\x32\x0e.mlflow.Metric:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb1\x01\n\x08LogBatch\x12\x0e\n\x06run_id\x18\x01 \x01(\t\x12\x1f\n\x07metrics\x18\x02 \x03(\x0b\x32\x0e.mlflow.Metric\x12\x1d\n\x06params\x18\x03 \x03(\x0b\x32\r.mlflow.Param\x12\x1c\n\x04tags\x18\x04 \x03(\x0b\x32\x0e.mlflow.RunTag\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"g\n\x08LogModel\x12\x0e\n\x06run_id\x18\x01 \x01(\t\x12\x12\n\nmodel_json\x18\x02 \x01(\t\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x95\x01\n\x13GetExperimentByName\x12\x1d\n\x0f\x65xperiment_name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\x32\n\x08Response\x12&\n\nexperiment\x18\x01 \x01(\x0b\x32\x12.mlflow.Experiment:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]*6\n\x08ViewType\x12\x0f\n\x0b\x41\x43TIVE_ONLY\x10\x01\x12\x10\n\x0c\x44\x45LETED_ONLY\x10\x02\x12\x07\n\x03\x41LL\x10\x03*I\n\nSourceType\x12\x0c\n\x08NOTEBOOK\x10\x01\x12\x07\n\x03JOB\x10\x02\x12\x0b\n\x07PROJECT\x10\x03\x12\t\n\x05LOCAL\x10\x04\x12\x0c\n\x07UNKNOWN\x10\xe8\x07*M\n\tRunStatus\x12\x0b\n\x07RUNNING\x10\x01\x12\r\n\tSCHEDULED\x10\x02\x12\x0c\n\x08\x46INISHED\x10\x03\x12\n\n\x06\x46\x41ILED\x10\x04\x12\n\n\x06KILLED\x10\x05\x32\xfa\x17\n\rMlflowService\x12\xa6\x01\n\x13getExperimentByName\x12\x1b.mlflow.GetExperimentByName\x1a$.mlflow.GetExperimentByName.Response\"L\xf2\x86\x19H\n,\n\x03GET\x12\x1f/mlflow/experiments/get-by-name\x1a\x04\x08\x02\x10\x00\x10\x01*\x16Get Experiment By Name\x12w\n\x08moveRuns\x12\x10.mlflow.MoveRuns\x1a\x19.mlflow.MoveRuns.Response\">\xf2\x86\x19:\n+\n\x04POST\x12\x1d/mlflow/experiments/move-runs\x1a\x04\x08\x02\x10\x00\x10\x01*\tMove Runs\x12\x94\x01\n\x10\x63reateExperiment\x12\x18.mlflow.CreateExperiment\x1a!.mlflow.CreateExperiment.Response\"C\xf2\x86\x19?\n(\n\x04POST\x12\x1a/mlflow/experiments/create\x1a\x04\x08\x02\x10\x00\x10\x01*\x11\x43reate Experiment\x12\xc1\x01\n\x11searchExperiments\x12\x19.mlflow.SearchExperiments\x1a\".mlflow.SearchExperiments.Response\"m\xf2\x86\x19i\n(\n\x04POST\x12\x1a/mlflow/experiments/search\x1a\x04\x08\x02\x10\x00\n\'\n\x03GET\x12\x1a/mlflow/experiments/search\x1a\x04\x08\x02\x10\x00\x10\x01*\x12Search Experiments\x12\x84\x01\n\rgetExperiment\x12\x15.mlflow.GetExperiment\x1a\x1e.mlflow.GetExperiment.Response\"<\xf2\x86\x19\x38\n$\n\x03GET\x12\x17/mlflow/experiments/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x0eGet Experiment\x12\x94\x01\n\x10\x64\x65leteExperiment\x12\x18.mlflow.DeleteExperiment\x1a!.mlflow.DeleteExperiment.Response\"C\xf2\x86\x19?\n(\n\x04POST\x12\x1a/mlflow/experiments/delete\x1a\x04\x08\x02\x10\x00\x10\x01*\x11\x44\x65lete Experiment\x12\x99\x01\n\x11restoreExperiment\x12\x19.mlflow.RestoreExperiment\x1a\".mlflow.RestoreExperiment.Response\"E\xf2\x86\x19\x41\n)\n\x04POST\x12\x1b/mlflow/experiments/restore\x1a\x04\x08\x02\x10\x00\x10\x01*\x12Restore Experiment\x12\x94\x01\n\x10updateExperiment\x12\x18.mlflow.UpdateExperiment\x1a!.mlflow.UpdateExperiment.Response\"C\xf2\x86\x19?\n(\n\x04POST\x12\x1a/mlflow/experiments/update\x1a\x04\x08\x02\x10\x00\x10\x01*\x11Update Experiment\x12q\n\tcreateRun\x12\x11.mlflow.CreateRun\x1a\x1a.mlflow.CreateRun.Response\"5\xf2\x86\x19\x31\n!\n\x04POST\x12\x13/mlflow/runs/create\x1a\x04\x08\x02\x10\x00\x10\x01*\nCreate Run\x12q\n\tupdateRun\x12\x11.mlflow.UpdateRun\x1a\x1a.mlflow.UpdateRun.Response\"5\xf2\x86\x19\x31\n!\n\x04POST\x12\x13/mlflow/runs/update\x1a\x04\x08\x02\x10\x00\x10\x01*\nUpdate Run\x12q\n\tdeleteRun\x12\x11.mlflow.DeleteRun\x1a\x1a.mlflow.DeleteRun.Response\"5\xf2\x86\x19\x31\n!\n\x04POST\x12\x13/mlflow/runs/delete\x1a\x04\x08\x02\x10\x00\x10\x01*\nDelete Run\x12v\n\nrestoreRun\x12\x12.mlflow.RestoreRun\x1a\x1b.mlflow.RestoreRun.Response\"7\xf2\x86\x19\x33\n\"\n\x04POST\x12\x14/mlflow/runs/restore\x1a\x04\x08\x02\x10\x00\x10\x01*\x0bRestore Run\x12u\n\tlogMetric\x12\x11.mlflow.LogMetric\x1a\x1a.mlflow.LogMetric.Response\"9\xf2\x86\x19\x35\n%\n\x04POST\x12\x17/mlflow/runs/log-metric\x1a\x04\x08\x02\x10\x00\x10\x01*\nLog Metric\x12t\n\x08logParam\x12\x10.mlflow.LogParam\x1a\x19.mlflow.LogParam.Response\";\xf2\x86\x19\x37\n(\n\x04POST\x12\x1a/mlflow/runs/log-parameter\x1a\x04\x08\x02\x10\x00\x10\x01*\tLog Param\x12\xa1\x01\n\x10setExperimentTag\x12\x18.mlflow.SetExperimentTag\x1a!.mlflow.SetExperimentTag.Response\"P\xf2\x86\x19L\n4\n\x04POST\x12&/mlflow/experiments/set-experiment-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x12Set Experiment Tag\x12\x66\n\x06setTag\x12\x0e.mlflow.SetTag\x1a\x17.mlflow.SetTag.Response\"3\xf2\x86\x19/\n\"\n\x04POST\x12\x14/mlflow/runs/set-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x07Set Tag\x12u\n\tdeleteTag\x12\x11.mlflow.DeleteTag\x1a\x1a.mlflow.DeleteTag.Response\"9\xf2\x86\x19\x35\n%\n\x04POST\x12\x17/mlflow/runs/delete-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\nDelete Tag\x12\x61\n\x06getRun\x12\x0e.mlflow.GetRun\x1a\x17.mlflow.GetRun.Response\".\xf2\x86\x19*\n\x1d\n\x03GET\x12\x10/mlflow/runs/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x07Get Run\x12u\n\nsearchRuns\x12\x12.mlflow.SearchRuns\x1a\x1b.mlflow.SearchRuns.Response\"6\xf2\x86\x19\x32\n!\n\x04POST\x12\x13/mlflow/runs/search\x1a\x04\x08\x02\x10\x00\x10\x01*\x0bSearch Runs\x12\x83\x01\n\rlistArtifacts\x12\x15.mlflow.ListArtifacts\x1a\x1e.mlflow.ListArtifacts.Response\";\xf2\x86\x19\x37\n#\n\x03GET\x12\x16/mlflow/artifacts/list\x1a\x04\x08\x02\x10\x00\x10\x01*\x0eList Artifacts\x12\x95\x01\n\x10getMetricHistory\x12\x18.mlflow.GetMetricHistory\x1a!.mlflow.GetMetricHistory.Response\"D\xf2\x86\x19@\n(\n\x03GET\x12\x1b/mlflow/metrics/get-history\x1a\x04\x08\x02\x10\x00\x10\x01*\x12Get Metric History\x12p\n\x08logBatch\x12\x10.mlflow.LogBatch\x1a\x19.mlflow.LogBatch.Response\"7\xf2\x86\x19\x33\n$\n\x04POST\x12\x16/mlflow/runs/log-batch\x1a\x04\x08\x02\x10\x00\x10\x01*\tLog Batch\x12p\n\x08logModel\x12\x10.mlflow.LogModel\x1a\x19.mlflow.LogModel.Response\"7\xf2\x86\x19\x33\n$\n\x04POST\x12\x16/mlflow/runs/log-model\x1a\x04\x08\x02\x10\x00\x10\x01*\tLog ModelB\x1e\n\x14org.mlflow.api.proto\x90\x01\x01\xe2?\x02\x10\x01')
 
 _VIEWTYPE = DESCRIPTOR.enum_types_by_name['ViewType']
 ViewType = enum_type_wrapper.EnumTypeWrapper(_VIEWTYPE)
@@ -50,6 +50,8 @@ _RUNTAG = DESCRIPTOR.message_types_by_name['RunTag']
 _EXPERIMENTTAG = DESCRIPTOR.message_types_by_name['ExperimentTag']
 _RUNINFO = DESCRIPTOR.message_types_by_name['RunInfo']
 _EXPERIMENT = DESCRIPTOR.message_types_by_name['Experiment']
+_MOVERUNS = DESCRIPTOR.message_types_by_name['MoveRuns']
+_MOVERUNS_RESPONSE = _MOVERUNS.nested_types_by_name['Response']
 _CREATEEXPERIMENT = DESCRIPTOR.message_types_by_name['CreateExperiment']
 _CREATEEXPERIMENT_RESPONSE = _CREATEEXPERIMENT.nested_types_by_name['Response']
 _SEARCHEXPERIMENTS = DESCRIPTOR.message_types_by_name['SearchExperiments']
@@ -150,6 +152,21 @@ Experiment = _reflection.GeneratedProtocolMessageType('Experiment', (_message.Me
   # @@protoc_insertion_point(class_scope:mlflow.Experiment)
   })
 _sym_db.RegisterMessage(Experiment)
+
+MoveRuns = _reflection.GeneratedProtocolMessageType('MoveRuns', (_message.Message,), {
+
+  'Response' : _reflection.GeneratedProtocolMessageType('Response', (_message.Message,), {
+    'DESCRIPTOR' : _MOVERUNS_RESPONSE,
+    '__module__' : 'service_pb2'
+    # @@protoc_insertion_point(class_scope:mlflow.MoveRuns.Response)
+    })
+  ,
+  'DESCRIPTOR' : _MOVERUNS,
+  '__module__' : 'service_pb2'
+  # @@protoc_insertion_point(class_scope:mlflow.MoveRuns)
+  })
+_sym_db.RegisterMessage(MoveRuns)
+_sym_db.RegisterMessage(MoveRuns.Response)
 
 CreateExperiment = _reflection.GeneratedProtocolMessageType('CreateExperiment', (_message.Message,), {
 
@@ -493,6 +510,12 @@ if _descriptor._USE_C_DESCRIPTORS == False:
 
   DESCRIPTOR._options = None
   DESCRIPTOR._serialized_options = b'\n\024org.mlflow.api.proto\220\001\001\342?\002\020\001'
+  _MOVERUNS.fields_by_name['run_ids']._options = None
+  _MOVERUNS.fields_by_name['run_ids']._serialized_options = b'\370\206\031\001'
+  _MOVERUNS.fields_by_name['experiment_id']._options = None
+  _MOVERUNS.fields_by_name['experiment_id']._serialized_options = b'\370\206\031\001'
+  _MOVERUNS._options = None
+  _MOVERUNS._serialized_options = b'\342?(\n&com.databricks.rpc.RPC[$this.Response]'
   _CREATEEXPERIMENT.fields_by_name['name']._options = None
   _CREATEEXPERIMENT.fields_by_name['name']._serialized_options = b'\370\206\031\001'
   _CREATEEXPERIMENT._options = None
@@ -581,6 +604,8 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _GETEXPERIMENTBYNAME._serialized_options = b'\342?(\n&com.databricks.rpc.RPC[$this.Response]'
   _MLFLOWSERVICE.methods_by_name['getExperimentByName']._options = None
   _MLFLOWSERVICE.methods_by_name['getExperimentByName']._serialized_options = b'\362\206\031H\n,\n\003GET\022\037/mlflow/experiments/get-by-name\032\004\010\002\020\000\020\001*\026Get Experiment By Name'
+  _MLFLOWSERVICE.methods_by_name['moveRuns']._options = None
+  _MLFLOWSERVICE.methods_by_name['moveRuns']._serialized_options = b'\362\206\031:\n+\n\004POST\022\035/mlflow/experiments/move-runs\032\004\010\002\020\000\020\001*\tMove Runs'
   _MLFLOWSERVICE.methods_by_name['createExperiment']._options = None
   _MLFLOWSERVICE.methods_by_name['createExperiment']._serialized_options = b'\362\206\031?\n(\n\004POST\022\032/mlflow/experiments/create\032\004\010\002\020\000\020\001*\021Create Experiment'
   _MLFLOWSERVICE.methods_by_name['searchExperiments']._options = None
@@ -623,12 +648,12 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _MLFLOWSERVICE.methods_by_name['logBatch']._serialized_options = b'\362\206\0313\n$\n\004POST\022\026/mlflow/runs/log-batch\032\004\010\002\020\000\020\001*\tLog Batch'
   _MLFLOWSERVICE.methods_by_name['logModel']._options = None
   _MLFLOWSERVICE.methods_by_name['logModel']._serialized_options = b'\362\206\0313\n$\n\004POST\022\026/mlflow/runs/log-model\032\004\010\002\020\000\020\001*\tLog Model'
-  _VIEWTYPE._serialized_start=4401
-  _VIEWTYPE._serialized_end=4455
-  _SOURCETYPE._serialized_start=4457
-  _SOURCETYPE._serialized_end=4530
-  _RUNSTATUS._serialized_start=4532
-  _RUNSTATUS._serialized_end=4609
+  _VIEWTYPE._serialized_start=4546
+  _VIEWTYPE._serialized_end=4600
+  _SOURCETYPE._serialized_start=4602
+  _SOURCETYPE._serialized_end=4675
+  _RUNSTATUS._serialized_start=4677
+  _RUNSTATUS._serialized_end=4754
   _METRIC._serialized_start=66
   _METRIC._serialized_end=138
   _PARAM._serialized_start=140
@@ -645,98 +670,102 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _RUNINFO._serialized_end=656
   _EXPERIMENT._serialized_start=659
   _EXPERIMENT._serialized_end=846
-  _CREATEEXPERIMENT._serialized_start=849
-  _CREATEEXPERIMENT._serialized_end=1031
-  _CREATEEXPERIMENT_RESPONSE._serialized_start=953
-  _CREATEEXPERIMENT_RESPONSE._serialized_end=986
-  _SEARCHEXPERIMENTS._serialized_start=1034
-  _SEARCHEXPERIMENTS._serialized_end=1288
-  _SEARCHEXPERIMENTS_RESPONSE._serialized_start=1167
-  _SEARCHEXPERIMENTS_RESPONSE._serialized_end=1243
-  _GETEXPERIMENT._serialized_start=1291
-  _GETEXPERIMENT._serialized_end=1432
-  _GETEXPERIMENT_RESPONSE._serialized_start=1337
-  _GETEXPERIMENT_RESPONSE._serialized_end=1387
-  _DELETEEXPERIMENT._serialized_start=1434
-  _DELETEEXPERIMENT._serialized_end=1538
-  _DELETEEXPERIMENT_RESPONSE._serialized_start=953
-  _DELETEEXPERIMENT_RESPONSE._serialized_end=963
-  _RESTOREEXPERIMENT._serialized_start=1540
-  _RESTOREEXPERIMENT._serialized_end=1645
-  _RESTOREEXPERIMENT_RESPONSE._serialized_start=953
-  _RESTOREEXPERIMENT_RESPONSE._serialized_end=963
-  _UPDATEEXPERIMENT._serialized_start=1647
-  _UPDATEEXPERIMENT._serialized_end=1769
-  _UPDATEEXPERIMENT_RESPONSE._serialized_start=953
-  _UPDATEEXPERIMENT_RESPONSE._serialized_end=963
-  _CREATERUN._serialized_start=1772
-  _CREATERUN._serialized_end=1974
-  _CREATERUN_RESPONSE._serialized_start=1893
-  _CREATERUN_RESPONSE._serialized_end=1929
-  _UPDATERUN._serialized_start=1977
-  _UPDATERUN._serialized_end=2185
-  _UPDATERUN_RESPONSE._serialized_start=2095
-  _UPDATERUN_RESPONSE._serialized_end=2140
-  _DELETERUN._serialized_start=2187
-  _DELETERUN._serialized_end=2277
-  _DELETERUN_RESPONSE._serialized_start=953
-  _DELETERUN_RESPONSE._serialized_end=963
-  _RESTORERUN._serialized_start=2279
-  _RESTORERUN._serialized_end=2370
-  _RESTORERUN_RESPONSE._serialized_start=953
-  _RESTORERUN_RESPONSE._serialized_end=963
-  _LOGMETRIC._serialized_start=2373
-  _LOGMETRIC._serialized_end=2557
-  _LOGMETRIC_RESPONSE._serialized_start=953
-  _LOGMETRIC_RESPONSE._serialized_end=963
-  _LOGPARAM._serialized_start=2560
-  _LOGPARAM._serialized_end=2701
-  _LOGPARAM_RESPONSE._serialized_start=953
-  _LOGPARAM_RESPONSE._serialized_end=963
-  _SETEXPERIMENTTAG._serialized_start=2704
-  _SETEXPERIMENTTAG._serialized_end=2848
-  _SETEXPERIMENTTAG_RESPONSE._serialized_start=953
-  _SETEXPERIMENTTAG_RESPONSE._serialized_end=963
-  _SETTAG._serialized_start=2851
-  _SETTAG._serialized_end=2990
-  _SETTAG_RESPONSE._serialized_start=953
-  _SETTAG_RESPONSE._serialized_end=963
-  _DELETETAG._serialized_start=2992
-  _DELETETAG._serialized_end=3101
-  _DELETETAG_RESPONSE._serialized_start=953
-  _DELETETAG_RESPONSE._serialized_end=963
-  _GETRUN._serialized_start=3103
-  _GETRUN._serialized_end=3228
-  _GETRUN_RESPONSE._serialized_start=1893
-  _GETRUN_RESPONSE._serialized_end=1929
-  _SEARCHRUNS._serialized_start=3231
-  _SEARCHRUNS._serialized_end=3511
-  _SEARCHRUNS_RESPONSE._serialized_start=3404
-  _SEARCHRUNS_RESPONSE._serialized_end=3466
-  _LISTARTIFACTS._serialized_start=3514
-  _LISTARTIFACTS._serialized_end=3730
-  _LISTARTIFACTS_RESPONSE._serialized_start=3599
-  _LISTARTIFACTS_RESPONSE._serialized_end=3685
-  _FILEINFO._serialized_start=3732
-  _FILEINFO._serialized_end=3791
-  _GETMETRICHISTORY._serialized_start=3794
-  _GETMETRICHISTORY._serialized_end=3962
-  _GETMETRICHISTORY_RESPONSE._serialized_start=3874
-  _GETMETRICHISTORY_RESPONSE._serialized_end=3917
-  _LOGBATCH._serialized_start=3965
-  _LOGBATCH._serialized_end=4142
-  _LOGBATCH_RESPONSE._serialized_start=953
-  _LOGBATCH_RESPONSE._serialized_end=963
-  _LOGMODEL._serialized_start=4144
-  _LOGMODEL._serialized_end=4247
-  _LOGMODEL_RESPONSE._serialized_start=953
-  _LOGMODEL_RESPONSE._serialized_end=963
-  _GETEXPERIMENTBYNAME._serialized_start=4250
-  _GETEXPERIMENTBYNAME._serialized_end=4399
-  _GETEXPERIMENTBYNAME_RESPONSE._serialized_start=1337
-  _GETEXPERIMENTBYNAME_RESPONSE._serialized_end=1387
-  _MLFLOWSERVICE._serialized_start=4612
-  _MLFLOWSERVICE._serialized_end=7557
+  _MOVERUNS._serialized_start=849
+  _MOVERUNS._serialized_end=991
+  _MOVERUNS_RESPONSE._serialized_start=913
+  _MOVERUNS_RESPONSE._serialized_end=946
+  _CREATEEXPERIMENT._serialized_start=994
+  _CREATEEXPERIMENT._serialized_end=1176
+  _CREATEEXPERIMENT_RESPONSE._serialized_start=913
+  _CREATEEXPERIMENT_RESPONSE._serialized_end=946
+  _SEARCHEXPERIMENTS._serialized_start=1179
+  _SEARCHEXPERIMENTS._serialized_end=1433
+  _SEARCHEXPERIMENTS_RESPONSE._serialized_start=1312
+  _SEARCHEXPERIMENTS_RESPONSE._serialized_end=1388
+  _GETEXPERIMENT._serialized_start=1436
+  _GETEXPERIMENT._serialized_end=1577
+  _GETEXPERIMENT_RESPONSE._serialized_start=1482
+  _GETEXPERIMENT_RESPONSE._serialized_end=1532
+  _DELETEEXPERIMENT._serialized_start=1579
+  _DELETEEXPERIMENT._serialized_end=1683
+  _DELETEEXPERIMENT_RESPONSE._serialized_start=913
+  _DELETEEXPERIMENT_RESPONSE._serialized_end=923
+  _RESTOREEXPERIMENT._serialized_start=1685
+  _RESTOREEXPERIMENT._serialized_end=1790
+  _RESTOREEXPERIMENT_RESPONSE._serialized_start=913
+  _RESTOREEXPERIMENT_RESPONSE._serialized_end=923
+  _UPDATEEXPERIMENT._serialized_start=1792
+  _UPDATEEXPERIMENT._serialized_end=1914
+  _UPDATEEXPERIMENT_RESPONSE._serialized_start=913
+  _UPDATEEXPERIMENT_RESPONSE._serialized_end=923
+  _CREATERUN._serialized_start=1917
+  _CREATERUN._serialized_end=2119
+  _CREATERUN_RESPONSE._serialized_start=2038
+  _CREATERUN_RESPONSE._serialized_end=2074
+  _UPDATERUN._serialized_start=2122
+  _UPDATERUN._serialized_end=2330
+  _UPDATERUN_RESPONSE._serialized_start=2240
+  _UPDATERUN_RESPONSE._serialized_end=2285
+  _DELETERUN._serialized_start=2332
+  _DELETERUN._serialized_end=2422
+  _DELETERUN_RESPONSE._serialized_start=913
+  _DELETERUN_RESPONSE._serialized_end=923
+  _RESTORERUN._serialized_start=2424
+  _RESTORERUN._serialized_end=2515
+  _RESTORERUN_RESPONSE._serialized_start=913
+  _RESTORERUN_RESPONSE._serialized_end=923
+  _LOGMETRIC._serialized_start=2518
+  _LOGMETRIC._serialized_end=2702
+  _LOGMETRIC_RESPONSE._serialized_start=913
+  _LOGMETRIC_RESPONSE._serialized_end=923
+  _LOGPARAM._serialized_start=2705
+  _LOGPARAM._serialized_end=2846
+  _LOGPARAM_RESPONSE._serialized_start=913
+  _LOGPARAM_RESPONSE._serialized_end=923
+  _SETEXPERIMENTTAG._serialized_start=2849
+  _SETEXPERIMENTTAG._serialized_end=2993
+  _SETEXPERIMENTTAG_RESPONSE._serialized_start=913
+  _SETEXPERIMENTTAG_RESPONSE._serialized_end=923
+  _SETTAG._serialized_start=2996
+  _SETTAG._serialized_end=3135
+  _SETTAG_RESPONSE._serialized_start=913
+  _SETTAG_RESPONSE._serialized_end=923
+  _DELETETAG._serialized_start=3137
+  _DELETETAG._serialized_end=3246
+  _DELETETAG_RESPONSE._serialized_start=913
+  _DELETETAG_RESPONSE._serialized_end=923
+  _GETRUN._serialized_start=3248
+  _GETRUN._serialized_end=3373
+  _GETRUN_RESPONSE._serialized_start=2038
+  _GETRUN_RESPONSE._serialized_end=2074
+  _SEARCHRUNS._serialized_start=3376
+  _SEARCHRUNS._serialized_end=3656
+  _SEARCHRUNS_RESPONSE._serialized_start=3549
+  _SEARCHRUNS_RESPONSE._serialized_end=3611
+  _LISTARTIFACTS._serialized_start=3659
+  _LISTARTIFACTS._serialized_end=3875
+  _LISTARTIFACTS_RESPONSE._serialized_start=3744
+  _LISTARTIFACTS_RESPONSE._serialized_end=3830
+  _FILEINFO._serialized_start=3877
+  _FILEINFO._serialized_end=3936
+  _GETMETRICHISTORY._serialized_start=3939
+  _GETMETRICHISTORY._serialized_end=4107
+  _GETMETRICHISTORY_RESPONSE._serialized_start=4019
+  _GETMETRICHISTORY_RESPONSE._serialized_end=4062
+  _LOGBATCH._serialized_start=4110
+  _LOGBATCH._serialized_end=4287
+  _LOGBATCH_RESPONSE._serialized_start=913
+  _LOGBATCH_RESPONSE._serialized_end=923
+  _LOGMODEL._serialized_start=4289
+  _LOGMODEL._serialized_end=4392
+  _LOGMODEL_RESPONSE._serialized_start=913
+  _LOGMODEL_RESPONSE._serialized_end=923
+  _GETEXPERIMENTBYNAME._serialized_start=4395
+  _GETEXPERIMENTBYNAME._serialized_end=4544
+  _GETEXPERIMENTBYNAME_RESPONSE._serialized_start=1482
+  _GETEXPERIMENTBYNAME_RESPONSE._serialized_end=1532
+  _MLFLOWSERVICE._serialized_start=4757
+  _MLFLOWSERVICE._serialized_end=7823
 MlflowService = service_reflection.GeneratedServiceType('MlflowService', (_service.Service,), dict(
   DESCRIPTOR = _MLFLOWSERVICE,
   __module__ = 'service_pb2'

--- a/mlflow/server/js/src/experiment-tracking/actions.js
+++ b/mlflow/server/js/src/experiment-tracking/actions.js
@@ -6,6 +6,18 @@ import { ViewType } from './sdk/MlflowEnums';
 
 export const RUNS_SEARCH_MAX_RESULTS = 100;
 
+export const MOVE_RUNS_API = 'MOVE_RUNS_API';
+export const moveRunsApi = (runIds, experimentId, id = getUUID()) => {
+  return {
+    type: MOVE_RUNS_API,
+    payload: MlflowService.moveRuns({
+      run_ids: runIds,
+      experiment_id: experimentId,
+    }),
+    meta: { id },
+  };
+};
+
 export const SEARCH_EXPERIMENTS_API = 'SEARCH_EXPERIMENTS_API';
 export const searchExperimentsApi = (id = getUUID()) => {
   return {

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunModals.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunModals.tsx
@@ -4,7 +4,7 @@ import { RenameRunModal } from '../../../modals/RenameRunModal';
 import RestoreRunModal from '../../../modals/RestoreRunModal';
 import { useFetchExperimentRuns } from '../../hooks/useFetchExperimentRuns';
 import { MoveRunsModal } from '../../../modals/MoveRunsModal';
-import {ExperimentEntity} from "../../../../types";
+import { ExperimentEntity } from '../../../../types';
 
 export interface ExperimentViewModalsProps {
   showDeleteRunModal: boolean;

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunModals.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunModals.tsx
@@ -3,16 +3,21 @@ import DeleteRunModal from '../../../modals/DeleteRunModal';
 import { RenameRunModal } from '../../../modals/RenameRunModal';
 import RestoreRunModal from '../../../modals/RestoreRunModal';
 import { useFetchExperimentRuns } from '../../hooks/useFetchExperimentRuns';
+import { MoveRunsModal } from '../../../modals/MoveRunsModal';
+import {ExperimentEntity} from "../../../../types";
 
 export interface ExperimentViewModalsProps {
   showDeleteRunModal: boolean;
   showRestoreRunModal: boolean;
   showRenameRunModal: boolean;
+  showMoveRunsModal: boolean;
   runsSelected: Record<string, boolean>;
   onCloseDeleteRunModal: () => void;
   onCloseRestoreRunModal: () => void;
   onCloseRenameRunModal: () => void;
+  onCloseMoveRunsModal: () => void;
   renamedRunName: string;
+  experimentList: Record<string, ExperimentEntity>;
 }
 
 /**
@@ -23,11 +28,14 @@ export const ExperimentViewRunModals = ({
   showDeleteRunModal,
   showRestoreRunModal,
   showRenameRunModal,
+  showMoveRunsModal,
   runsSelected,
   onCloseDeleteRunModal,
   onCloseRestoreRunModal,
   onCloseRenameRunModal,
+  onCloseMoveRunsModal,
   renamedRunName,
+  experimentList,
 }: ExperimentViewModalsProps) => {
   const { updateSearchFacets } = useFetchExperimentRuns();
 
@@ -67,6 +75,13 @@ export const ExperimentViewRunModals = ({
         onClose={onCloseRenameRunModal}
         runName={renamedRunName}
         isOpen={showRenameRunModal}
+        onSuccess={() => refreshRuns()}
+      />
+      <MoveRunsModal
+        isOpen={showMoveRunsModal}
+        onClose={onCloseMoveRunsModal}
+        selectedRunIds={selectedRunIds}
+        experimentList={experimentList}
         onSuccess={() => refreshRuns()}
       />
     </>

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsControlsActions.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsControlsActions.tsx
@@ -21,7 +21,7 @@ export type ExperimentViewRunsControlsActionsProps = {
 export const ExperimentViewRunsControlsActions = React.memo(
   ({ viewState, runsData, searchFacetsState }: ExperimentViewRunsControlsActionsProps) => {
     const { runsSelected } = viewState;
-    const { runInfos } = runsData;
+    const { runInfos, experimentList } = runsData;
     const { lifecycleFilter } = searchFacetsState;
 
     const history = useHistory();
@@ -29,6 +29,7 @@ export const ExperimentViewRunsControlsActions = React.memo(
     const [showDeleteRunModal, setShowDeleteRunModal] = useState(false);
     const [showRestoreRunModal, setShowRestoreRunModal] = useState(false);
     const [showRenameRunModal, setShowRenameRunModal] = useState(false);
+    const [showMoveRunsModal, setShowMoveRunsModal] = useState(false);
     const [renamedRunName, setRenamedRunName] = useState('');
 
     const renameButtonClicked = useCallback(() => {
@@ -39,6 +40,8 @@ export const ExperimentViewRunsControlsActions = React.memo(
         setShowRenameRunModal(true);
       }
     }, [runInfos, runsSelected]);
+
+    const moveButtonClicked = useCallback(() => setShowMoveRunsModal(true), []);
 
     const compareButtonClicked = useCallback(() => {
       const runsSelectedList = Object.keys(runsSelected);
@@ -55,6 +58,7 @@ export const ExperimentViewRunsControlsActions = React.memo(
     const onCloseDeleteRunModal = useCallback(() => setShowDeleteRunModal(false), []);
     const onCloseRestoreRunModal = useCallback(() => setShowRestoreRunModal(false), []);
     const onCloseRenameRunModal = useCallback(() => setShowRenameRunModal(false), []);
+    const onCloseMoveRunsModal = useCallback(() => setShowMoveRunsModal(false), []);
 
     const selectedRunsCount = Object.values(viewState.runsSelected).filter(Boolean).length;
     const canRestoreRuns = selectedRunsCount > 0;
@@ -65,12 +69,15 @@ export const ExperimentViewRunsControlsActions = React.memo(
       <div css={styles.controlBar}>
         <ExperimentViewRunModals
           runsSelected={runsSelected}
+          experimentList={experimentList}
           onCloseRenameRunModal={onCloseRenameRunModal}
           onCloseDeleteRunModal={onCloseDeleteRunModal}
           onCloseRestoreRunModal={onCloseRestoreRunModal}
+          onCloseMoveRunsModal={onCloseMoveRunsModal}
           showDeleteRunModal={showDeleteRunModal}
           showRestoreRunModal={showRestoreRunModal}
           showRenameRunModal={showRenameRunModal}
+          showMoveRunsModal={showMoveRunsModal}
           renamedRunName={renamedRunName}
         />
         <Button
@@ -82,6 +89,13 @@ export const ExperimentViewRunsControlsActions = React.memo(
             defaultMessage='Compare'
             // eslint-disable-next-line max-len
             description='String for the compare button to compare experiment runs to find an ideal model'
+          />
+        </Button>
+        <Button data-testid='runs-move-button' onClick={moveButtonClicked}>
+          <FormattedMessage
+            defaultMessage='Move'
+            // eslint-disable-next-line max-len
+            description='String for the move button to move experiment runs into another experiment'
           />
         </Button>
         <Button

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentRuns.selector.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentRuns.selector.ts
@@ -29,6 +29,11 @@ export type ExperimentRunsSelectorResult = {
   metricKeyList: string[];
 
   /**
+   * List of experiments
+   */
+  experimentList: Record<string, ExperimentEntity>;
+
+  /**
    * List of unique param keys
    */
   paramKeyList: string[];
@@ -188,6 +193,8 @@ export const experimentRunsSelector = (
     comparingExperiments ? {} : getExperimentTags(firstExperimentId, state)
   ) as Record<string, KeyValueEntity>;
 
+  const experimentList = state.entities.experimentsById;
+
   return {
     modelVersionsByRunUuid,
     experimentTags,
@@ -195,6 +202,7 @@ export const experimentRunsSelector = (
     paramsList,
     tagsList,
     metricsList,
+    experimentList,
     runUuidsMatchingFilter,
     metricKeyList: Array.from(metricKeysSet.values()).sort(),
     paramKeyList: Array.from(paramKeysSet.values()).sort(),

--- a/mlflow/server/js/src/experiment-tracking/components/modals/MoveRunsForm.js
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/MoveRunsForm.js
@@ -23,21 +23,6 @@ class MoveRunsFormComponent extends Component {
     this.setState({ selectedExperiment });
   };
 
-  autoFocusInputRef = (inputToAutoFocus) => {
-    this.inputToAutoFocus = inputToAutoFocus;
-    inputToAutoFocus && inputToAutoFocus.focus();
-    inputToAutoFocus && inputToAutoFocus.select();
-  };
-
-  autoFocus = (prevProps) => {
-    if (prevProps.visible === false && this.props.visible === true) {
-      // focus on input field
-      this.inputToAutoFocus && this.inputToAutoFocus.focus();
-      // select text
-      this.inputToAutoFocus && this.inputToAutoFocus.select();
-    }
-  };
-
   render() {
     return (
       <Form ref={this.props.innerRef} layout='vertical'>

--- a/mlflow/server/js/src/experiment-tracking/components/modals/MoveRunsForm.js
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/MoveRunsForm.js
@@ -1,0 +1,68 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Form, Select } from '@databricks/design-system';
+
+const { Option } = Select;
+export const EXPERIMENT_FIELD = 'experimentId';
+
+/**
+ * Component that renders a form for updating a run's or experiment's name.
+ */
+class MoveRunsFormComponent extends Component {
+  static propTypes = {
+    visible: PropTypes.bool.isRequired,
+    experimentList: PropTypes.array.isRequired,
+    innerRef: PropTypes.any.isRequired,
+  };
+
+  state = {
+    selectedExperiment: null,
+  };
+
+  handleExperimentSelectChange = (selectedExperiment) => {
+    this.setState({ selectedExperiment });
+  };
+
+  autoFocusInputRef = (inputToAutoFocus) => {
+    this.inputToAutoFocus = inputToAutoFocus;
+    inputToAutoFocus && inputToAutoFocus.focus();
+    inputToAutoFocus && inputToAutoFocus.select();
+  };
+
+  autoFocus = (prevProps) => {
+    if (prevProps.visible === false && this.props.visible === true) {
+      // focus on input field
+      this.inputToAutoFocus && this.inputToAutoFocus.focus();
+      // select text
+      this.inputToAutoFocus && this.inputToAutoFocus.select();
+    }
+  };
+
+  render() {
+    return (
+      <Form ref={this.props.innerRef} layout='vertical'>
+        <Form.Item
+          name={EXPERIMENT_FIELD}
+          rules={[{ required: true, message: `Please select an experiment.` }]}
+          label={`Experiment name`}
+        >
+          <Select
+            dropdownClassName='experiment-select-dropdown'
+            onChange={this.handleExperimentSelectChange}
+            placeholder='Move runs'
+            filterOption={this.handleFilterOption}
+            showSearch
+          >
+            {Object.values(this.props.experimentList).map((experiment) => (
+              <Option value={experiment.experiment_id} key={experiment.experiment_id}>
+                {experiment.name}
+              </Option>
+            ))}
+          </Select>
+        </Form.Item>
+      </Form>
+    );
+  }
+}
+
+export const MoveRunsForm = MoveRunsFormComponent;

--- a/mlflow/server/js/src/experiment-tracking/components/modals/MoveRunsForm.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/MoveRunsForm.test.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { MoveRunsForm } from './MoveRunsForm';
+
+describe('Render test', () => {
+  const minimalProps = {
+    visible: true,
+    experimentList: [{ experiment_id: '1' }, { experiment_id: '2' }],
+    // eslint-disable-next-line no-unused-vars
+    form: { getFieldDecorator: jest.fn((opts) => (c) => c) },
+  };
+
+  it('should render with minimal props without exploding', () => {
+    const wrapper = shallow(<MoveRunsForm {...minimalProps} />);
+    expect(wrapper.length).toBe(1);
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/components/modals/MoveRunsModal.js
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/MoveRunsModal.js
@@ -48,7 +48,6 @@ export class MoveRunsModalImpl extends Component {
         <MoveRunsForm
           visible={isOpen}
           experimentList={this.props.experimentList}
-          innerRef={this.form}
         />
       </GenericInputModal>
     );

--- a/mlflow/server/js/src/experiment-tracking/components/modals/MoveRunsModal.js
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/MoveRunsModal.js
@@ -1,0 +1,63 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { injectIntl } from 'react-intl';
+
+import { GenericInputModal } from './GenericInputModal';
+import { MoveRunsForm } from './MoveRunsForm';
+
+import { moveRunsApi } from '../../actions';
+
+export class MoveRunsModalImpl extends Component {
+  static propTypes = {
+    isOpen: PropTypes.bool,
+    onClose: PropTypes.func.isRequired,
+    moveRunsApi: PropTypes.func.isRequired,
+    experimentList: PropTypes.array.isRequired,
+    selectedRunIds: PropTypes.array.isRequired,
+    intl: PropTypes.shape({ formatMessage: PropTypes.func.isRequired }).isRequired,
+    onSuccess: PropTypes.func,
+  };
+  constructor() {
+    super();
+    this.form = React.createRef();
+  }
+
+  handleMoveRuns = (values) => {
+    return this.props
+      .moveRunsApi(this.props.selectedRunIds, values.experimentId)
+      .then(() => this.props.onSuccess?.());
+  };
+
+  render() {
+    const { isOpen } = this.props;
+    return (
+      <GenericInputModal
+        title={this.props.intl.formatMessage({
+          defaultMessage: 'Move Runs',
+          description: 'Modal title to move runs to another experiment',
+        })}
+        okText={this.props.intl.formatMessage({
+          defaultMessage: 'Move',
+          description: 'Modal button text to move runs to another experiment',
+        })}
+        isOpen={isOpen}
+        handleSubmit={this.handleMoveRuns}
+        onClose={this.props.onClose}
+      >
+        <MoveRunsForm
+          visible={isOpen}
+          experimentList={this.props.experimentList}
+          innerRef={this.form}
+        />
+      </GenericInputModal>
+    );
+  }
+}
+
+const mapDispatchToProps = {
+  moveRunsApi,
+};
+
+export const MoveRunsModalWithIntl = injectIntl(MoveRunsModalImpl);
+export const MoveRunsModal = connect(undefined, mapDispatchToProps)(MoveRunsModalWithIntl);

--- a/mlflow/server/js/src/experiment-tracking/components/modals/MoveRunsModal.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/MoveRunsModal.test.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import { shallowWithInjectIntl } from '../../../common/utils/TestUtils';
+import { MoveRunsModalWithIntl } from './MoveRunsModal';
+import { GenericInputModal } from './GenericInputModal';
+
+describe('MoveRunsModal', () => {
+  let wrapper;
+  let minimalProps;
+  let mockMoveRunsApi;
+
+  beforeEach(() => {
+    mockMoveRunsApi = jest.fn(() => Promise.resolve({}));
+    minimalProps = {
+      isOpen: false,
+      experimentList: [{ experiment_id: '1' }, { experiment_id: '2' }],
+      selectedRunIds: [1, 2],
+      onClose: jest.fn(() => Promise.resolve({})),
+      moveRunsApi: mockMoveRunsApi,
+    };
+
+    wrapper = shallowWithInjectIntl(<MoveRunsModalWithIntl {...minimalProps} />);
+  });
+
+  test('should render with minimal props without exploding', () => {
+    expect(wrapper.length).toBe(1);
+    expect(wrapper.find(GenericInputModal).length).toBe(1);
+  });
+
+  test('test handleMoveRuns closes modal in both success & failure cases', (done) => {
+    const values = { runIds: [1, 2], experimentId: '1' };
+    const promise = wrapper.find(GenericInputModal).prop('handleSubmit')(values);
+    promise.finally(() => {
+      expect(mockMoveRunsApi).toHaveBeenCalledTimes(1);
+      expect(mockMoveRunsApi).toHaveBeenCalledWith([1, 2], '1');
+      done();
+    });
+
+    const mockFailMoveRunsApi = jest.fn(
+      () =>
+        new Promise((resolve, reject) => {
+          window.setTimeout(() => {
+            reject();
+          }, 100);
+        }),
+    );
+    const failProps = { ...minimalProps, moveRunsApi: mockFailMoveRunsApi };
+    const failWrapper = shallowWithInjectIntl(<MoveRunsModalWithIntl {...failProps} />);
+    const failPromise = failWrapper.find(GenericInputModal).prop('handleSubmit')(values);
+    failPromise.finally(() => {
+      expect(mockFailMoveRunsApi).toHaveBeenCalledTimes(1);
+      expect(mockFailMoveRunsApi).toHaveBeenCalledWith([1, 2], '1', expect.any(String));
+      done();
+    });
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/sdk/MlflowService.js
+++ b/mlflow/server/js/src/experiment-tracking/sdk/MlflowService.js
@@ -16,6 +16,12 @@ export class MlflowService {
     postJson({ relativeUrl: 'ajax-api/2.0/mlflow/experiments/create', data });
 
   /**
+   * Create a mlflow experiment
+   */
+  static moveRuns = (data) =>
+    postJson({ relativeUrl: 'ajax-api/2.0/mlflow/experiments/move-runs', data });
+
+  /**
    * Delete a mlflow experiment
    */
   static deleteExperiment = (data) =>

--- a/mlflow/server/js/src/setupProxy.js
+++ b/mlflow/server/js/src/setupProxy.js
@@ -6,7 +6,7 @@ module.exports = function(app) {
   // (eg /ajax-api) to that port.
   // Exception: If the caller has specified an MLFLOW_PROXY, we instead forward server requests
   // there.
-  const proxyTarget = process.env.MLFLOW_PROXY || 'http://127.0.0.1:5000/';
+  const proxyTarget = process.env.MLFLOW_PROXY || 'http://localhost:5000/';
   const proxyStaticTarget = process.env.MLFLOW_STATIC_PROXY || proxyTarget;
   app.use(
     createProxyMiddleware('/ajax-api', {

--- a/mlflow/server/js/src/setupProxy.js
+++ b/mlflow/server/js/src/setupProxy.js
@@ -6,7 +6,7 @@ module.exports = function(app) {
   // (eg /ajax-api) to that port.
   // Exception: If the caller has specified an MLFLOW_PROXY, we instead forward server requests
   // there.
-  const proxyTarget = process.env.MLFLOW_PROXY || 'http://localhost:5000/';
+  const proxyTarget = process.env.MLFLOW_PROXY || 'http://127.0.0.1:5000/';
   const proxyStaticTarget = process.env.MLFLOW_STATIC_PROXY || proxyTarget;
   app.use(
     createProxyMiddleware('/ajax-api', {

--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -99,6 +99,17 @@ class AbstractStore:
         pass
 
     @abstractmethod
+    def move_runs(self, run_ids, experiment_id):
+        """
+        Move runs to another experiment.
+
+        :param run_ids: IDs of the runs to be moved.
+        :param experiment_id: IDs of the experiment the runs are moved to.
+        :return: String ID of the experiment.
+        """
+        pass
+
+    @abstractmethod
     def get_experiment(self, experiment_id):
         """
         Fetch the experiment by ID from the backend store.

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -24,6 +24,7 @@ from mlflow.protos.service_pb2 import (
     DeleteTag,
     SetExperimentTag,
     GetExperimentByName,
+    MoveRuns,
 )
 from mlflow.store.tracking.abstract_store import AbstractStore
 from mlflow.store.entities.paged_list import PagedList
@@ -78,6 +79,18 @@ class RestStore(AbstractStore):
             response_proto.next_page_token if response_proto.HasField("next_page_token") else None
         )
         return PagedList(experiments, token)
+
+    def move_runs(self, run_ids, experiment_id):
+        """
+        Move runs to another experiment.
+
+        :param run_ids: IDs of the runs to be moved.
+        :param experiment_id: IDs of the experiment the runs are moved to.
+        :return: String ID of the experiment.
+        """
+        req_body = message_to_json(MoveRuns(run_ids=run_ids, experiment_id=experiment_id))
+        response_proto = self._call_endpoint(MoveRuns, req_body)
+        return response_proto.experiment_id
 
     def create_experiment(self, name, artifact_location=None, tags=None):
         """

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -242,6 +242,18 @@ class SqlAlchemyStore(AbstractStore):
     def _get_artifact_location(self, experiment_id):
         return append_to_uri_path(self.artifact_root_uri, str(experiment_id))
 
+    def move_runs(self, run_ids, experiment_id):
+
+        # @todo assert experiment exists
+
+        with self.ManagedSessionMaker() as session:
+            for run_id in run_ids:
+                run = self._get_run(run_uuid=run_id, session=session)
+                run.experiment_id = int(experiment_id)
+                self._save_to_db(objs=run, session=session)
+
+        return experiment_id
+
     def create_experiment(self, name, artifact_location=None, tags=None):
         _validate_experiment_name(name)
 

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -214,6 +214,16 @@ class TrackingServiceClient:
             tags=[ExperimentTag(key, value) for (key, value) in tags.items()] if tags else [],
         )
 
+    def move_runs(self, run_ids, experiment_id):
+        """
+        Move runs to another experiment.
+
+        :param run_ids: IDs of the runs to be moved.
+        :param experiment_id: IDs of the experiment the runs are moved to.
+        :return: String ID of the experiment.
+        """
+        return self.store.move_runs(run_ids=run_ids, experiment_id=experiment_id)
+
     def delete_experiment(self, experiment_id):
         """
         Delete an experiment from the backend store.

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -500,6 +500,16 @@ class MlflowClient:
         """
         return self._tracking_client.create_experiment(name, artifact_location, tags)
 
+    def move_runs(self, run_ids, experiment_id):
+        """
+        Move runs to another experiment.
+
+        :param run_ids: IDs of the runs to be moved.
+        :param experiment_id: IDs of the experiment the runs are moved to.
+        :return: String ID of the experiment.
+        """
+        return self._tracking_client.move_runs(run_ids=run_ids, experiment_id=experiment_id)
+
     def delete_experiment(self, experiment_id: str) -> None:
         """
         Delete an experiment from the backend store.

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1215,6 +1215,20 @@ def create_experiment(
     return MlflowClient().create_experiment(name, artifact_location, tags)
 
 
+def move_runs(
+    run_ids: List[str],
+    experiment_id: str,
+) -> str:
+    """
+    Move runs to another experiment.
+
+    :param run_ids: IDs of the runs to be moved.
+    :param experiment_id: IDs of the experiment the runs are moved to.
+    :return: String ID of the experiment.
+    """
+    return MlflowClient().move_runs(run_ids, experiment_id)
+
+
 def delete_experiment(experiment_id: str) -> None:
     """
     Delete an experiment from the backend store.

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -824,3 +824,16 @@ def test_search_runs_multiple_experiments():
     assert len(MlflowClient().search_runs(experiment_ids, "metrics.m_1 > 0", ViewType.ALL)) == 1
     assert len(MlflowClient().search_runs(experiment_ids, "metrics.m_2 = 2", ViewType.ALL)) == 1
     assert len(MlflowClient().search_runs(experiment_ids, "metrics.m_3 < 4", ViewType.ALL)) == 1
+
+
+@pytest.mark.usefixtures("reset_active_experiment")
+def test_move_runs():
+    exp1_id = mlflow.create_experiment("exp__1")
+    exp2_id = mlflow.create_experiment("exp__2")
+    run1 = mlflow.start_run(experiment_id=exp1_id)
+    mlflow.end_run()
+    run2 = mlflow.start_run(experiment_id=exp1_id)
+    mlflow.end_run()
+    assert (
+        tracking.MlflowClient().move_runs([run1.info.run_id, run2.info.run_id], exp2_id) == exp2_id
+    )


### PR DESCRIPTION
## Related Issues/PRs

Resolve #7444 and #1028.

## What changes are proposed in this pull request?

Add functionality to move runs between experiments.

## How is this patch tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add Python `fluent` API for `move_runs`.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
