### PR TITLE
Fix `--artifact-destination` to `--artifacts-destination`

### DIFF
--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -222,7 +222,7 @@ need for an end-user to provide access credentials to interact with an underlyin
       # Artifact access is enabled through the proxy URI 'mlflow-artifacts:/',
       # giving users access to this location without having to manage credentials
       # or permissions.
-      --artifact-destination s3://bucket_name \
+      --artifacts-destination s3://bucket_name \
       --host remote_host
 
 Enabling the Tracking Server to perform proxied artifact access in order to route client artifact requests to an object store location:
@@ -278,7 +278,7 @@ MLflow's Tracking Server can be used in an exclusive artifact proxied artifact h
 .. code-block:: bash
     :caption: Command to run the tracking server in this configuration
 
-    mlflow server --artifact-destination s3://bucket_name --artifacts-only --host remote_host
+    mlflow server --artifacts-destination s3://bucket_name --artifacts-only --host remote_host
 
 Running an MLFlow server in ``--artifacts-only`` mode:
 

--- a/mlflow/utils/cli_args.py
+++ b/mlflow/utils/cli_args.py
@@ -195,7 +195,7 @@ SERVE_ARTIFACTS = click.option(
     default=True,
     help="Enables serving of artifact uploads, downloads, and list requests "
     "by routing these requests to the storage location that is specified by "
-    "'--artifact-destination' directly through a proxy. The default location that "
+    "'--artifacts-destination' directly through a proxy. The default location that "
     "these requests are served from is a local './mlartifacts' directory which can be "
     "overridden via the '--artifacts-destination' argument. To disable artifact serving, "
     "specify `--no-serve-artifacts`. Default: True",


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

`--artifact-destination` is not correct. `--artifacts-destination` is.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
