### PR TITLE
Add `test-code-block` directive to test code examples in docstring

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
           name: Install Python dependencies
           command: |
             pip --version
-            pip install --progress-bar off -r requirements/doc-requirements.txt .
+            pip install --progress-bar off -r requirements/doc-requirements.txt . pytest
       - run:
           name: Build documentation
           working_directory: docs
@@ -42,6 +42,11 @@ jobs:
           command: |
             make rsthtml
             make javadocs
+      - run:
+          name: Test examples
+          working_directory: docs
+          command: |
+            make test-examples
       - store_artifacts:
           path: docs/build/html
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
           name: Install Python dependencies
           command: |
             pip --version
-            pip install --progress-bar off -r requirements/doc-requirements.txt . pytest pytest-cov
+            pip install --progress-bar off -r requirements/doc-requirements.txt pytest pytest-cov .
       - run:
           name: Build documentation
           working_directory: docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
           name: Install Python dependencies
           command: |
             pip --version
-            pip install --progress-bar off -r requirements/doc-requirements.txt . pytest
+            pip install --progress-bar off -r requirements/doc-requirements.txt . pytest pytest-cov
       - run:
           name: Build documentation
           working_directory: docs

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,1 @@
+.examples

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -64,6 +64,10 @@ javadocs:
 rdocs:
 	./build-rdoc.sh
 
+.PHONY: test-examples
+test-examples:
+	@pytest --no-cov .examples
+
 # Builds only the RST-based documentation (i.e., everything but Java & R docs)
 .PHONY: rsthtml
 rsthtml:

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+import mlflow
+
+
+@pytest.fixture(autouse=True)
+def tracking_uri_mock(tmp_path, monkeypatch):
+    tracking_uri = "sqlite:///{}".format(tmp_path / "mlruns.sqlite")
+    mlflow.set_tracking_uri(tracking_uri)
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", tracking_uri)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -40,6 +40,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.napoleon",
     "sphinx_click.ext",
+    "test_code_block",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/test_code_block.py
+++ b/docs/source/test_code_block.py
@@ -20,7 +20,6 @@ class TestCodeBlockDirective(CodeBlock):
             [
                 f"# source: {rel_from_root}",
                 f"# lineno_in_docstring: {lineno_in_docstring}",
-                f"# command to test this code block: python {filename}",
                 "",
                 "",
                 "def test_code_block():",

--- a/docs/source/test_code_block.py
+++ b/docs/source/test_code_block.py
@@ -1,0 +1,48 @@
+import hashlib
+import textwrap
+from pathlib import Path
+
+from sphinx.directives.code import CodeBlock
+
+
+class TestCodeBlockDirective(CodeBlock):
+    def _dump_code_block(self):
+        docs_dir = Path.cwd()
+        directory = docs_dir.joinpath(".examples")
+        directory.mkdir(exist_ok=True)
+        source, lineno_in_docstring = self.get_source_info()
+        rel_from_root = Path(source).relative_to(docs_dir.parent)
+        key = (rel_from_root, lineno_in_docstring)
+        suffix = hashlib.sha1(str(key).encode("utf-8")).hexdigest()[:32]
+        filename = "test_code_block_{}.py".format(suffix)
+        content = textwrap.indent("\n".join(self.content), " " * 4)
+        code = "\n".join(
+            [
+                f"# source: {rel_from_root}",
+                f"# lineno_in_docstring: {lineno_in_docstring}",
+                f"# command to test this code block: python {filename}",
+                "",
+                "",
+                "def test_code_block():",
+                content,
+                "",
+                "",
+                'if __name__ == "__main__":',
+                "    test_code_block()",
+                "",
+            ]
+        )
+        directory.joinpath(filename).write_text(code)
+
+    def run(self):
+        self._dump_code_block()
+        return super().run()
+
+
+def setup(app):
+    app.add_directive("test-code-block", TestCodeBlockDirective)
+    return {
+        "version": "builtin",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/mlflow/tracking/_tracking_service/utils.py
+++ b/mlflow/tracking/_tracking_service/utils.py
@@ -59,7 +59,7 @@ def set_tracking_uri(uri: Union[str, Path]) -> None:
                   "databricks://<profileName>".
                 - A :py:class:`pathlib.Path` instance
 
-    .. code-block:: python
+    .. test-code-block:: python
         :caption: Example
 
         import mlflow


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Add `test-code-block` directive to test code examples in docstring.

## Motivation

With `test-code-block`:

> Ok, this code works. Let's improve & simplify it! I might make mistakes but CI can save me.

With `code-block`:

> Not sure if this code works. I need to manually run it to make sure it really works.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
