### PR TITLE
Use `pytest.mark.parameterize` for simple validation tests

### DIFF
--- a/tests/utils/test_validation.py
+++ b/tests/utils/test_validation.py
@@ -62,59 +62,99 @@ def test_path_not_unique(path, expected):
     assert path_not_unique(path) is expected
 
 
-def test_is_numeric():
-    assert _is_numeric(0)
-    assert _is_numeric(0.0)
-    assert not _is_numeric(True)
-    assert not _is_numeric(False)
-    assert not _is_numeric("0")
-    assert not _is_numeric(None)
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (0, True),
+        (0.0, True),
+        # error cases
+        (True, False),
+        (False, False),
+        ("0", False),
+        (None, False),
+    ],
+)
+def test_is_numeric(value, expected):
+    assert _is_numeric(value) is expected
 
 
-def test_validate_metric_name():
-    for good_name in GOOD_METRIC_OR_PARAM_NAMES:
-        _validate_metric_name(good_name)
-    for bad_name in BAD_METRIC_OR_PARAM_NAMES:
+@pytest.mark.parametrize(
+    ("name", "is_good_name"),
+    [
+        *[(name, True) for name in GOOD_METRIC_OR_PARAM_NAMES],
+        # error cases
+        *[(name, False) for name in BAD_METRIC_OR_PARAM_NAMES],
+    ],
+)
+def test_validate_metric_name(name, is_good_name):
+    if is_good_name:
+        _validate_metric_name(name)
+    else:
         with pytest.raises(MlflowException, match="Invalid metric name") as e:
-            _validate_metric_name(bad_name)
+            _validate_metric_name(name)
         assert e.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
 
-def test_validate_param_name():
-    for good_name in GOOD_METRIC_OR_PARAM_NAMES:
-        _validate_param_name(good_name)
-    for bad_name in BAD_METRIC_OR_PARAM_NAMES:
+@pytest.mark.parametrize(
+    ("name", "is_good_name"),
+    [
+        *[(name, True) for name in GOOD_METRIC_OR_PARAM_NAMES],
+        # error cases
+        *[(name, False) for name in BAD_METRIC_OR_PARAM_NAMES],
+    ],
+)
+def test_validate_param_name(name, is_good_name):
+    if is_good_name:
+        _validate_param_name(name)
+    else:
         with pytest.raises(MlflowException, match="Invalid parameter name") as e:
-            _validate_param_name(bad_name)
+            _validate_param_name(name)
         assert e.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
 
-def test_validate_tag_name():
-    for good_name in GOOD_METRIC_OR_PARAM_NAMES:
-        _validate_tag_name(good_name)
-    for bad_name in BAD_METRIC_OR_PARAM_NAMES:
+@pytest.mark.parametrize(
+    ("name", "is_good_name"),
+    [
+        *[(name, True) for name in GOOD_METRIC_OR_PARAM_NAMES],
+        # error cases
+        *[(name, False) for name in BAD_METRIC_OR_PARAM_NAMES],
+    ],
+)
+def test_validate_tag_name(name, is_good_name):
+    if is_good_name:
+        _validate_tag_name(name)
+    else:
         with pytest.raises(MlflowException, match="Invalid tag name") as e:
-            _validate_tag_name(bad_name)
+            _validate_tag_name(name)
         assert e.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
 
-def test_validate_run_id():
-    for good_id in [
-        "a" * 32,
-        "f0" * 16,
-        "abcdef0123456789" * 2,
-        "a" * 33,
-        "a" * 31,
-        "a" * 256,
-        "A" * 32,
-        "g" * 32,
-        "a_" * 32,
-        "abcdefghijklmnopqrstuvqxyz",
-    ]:
-        _validate_run_id(good_id)
-    for bad_id in ["a/bc" * 8, "", "a" * 400, "*" * 5]:
+@pytest.mark.parametrize(
+    ("run_id", "is_good_id"),
+    [
+        ("a" * 32, True),
+        ("f0" * 16, True),
+        ("abcdef0123456789" * 2, True),
+        ("a" * 33, True),
+        ("a" * 31, True),
+        ("a" * 256, True),
+        ("A" * 32, True),
+        ("g" * 32, True),
+        ("a_" * 32, True),
+        ("abcdefghijklmnopqrstuvqxyz", True),
+        # error cases
+        ("a/bc" * 8, False),
+        ("", False),
+        ("a" * 400, False),
+        ("*" * 5, False),
+    ],
+)
+def test_validate_run_id(run_id, is_good_id):
+    if is_good_id:
+        _validate_run_id(run_id)
+    else:
         with pytest.raises(MlflowException, match="Invalid run ID") as e:
-            _validate_run_id(bad_id)
+            _validate_run_id(run_id)
         assert e.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
 
@@ -198,29 +238,64 @@ def test_validate_batch_log_data():
     )
 
 
-def test_validate_experiment_artifact_location():
-    _validate_experiment_artifact_location("abcde")
-    _validate_experiment_artifact_location(None)
-    with pytest.raises(MlflowException, match="Artifact location cannot be a runs:/ URI"):
-        _validate_experiment_artifact_location("runs:/blah/bleh/blergh")
+@pytest.mark.parametrize(
+    ("location", "is_good_location"),
+    [
+        ("abcde", True),
+        (None, True),
+        # error cases
+        ("runs:/blah/bleh/blergh", False),
+    ],
+)
+def test_validate_experiment_artifact_location(location, is_good_location):
+    if is_good_location:
+        _validate_experiment_artifact_location(location)
+    else:
+        with pytest.raises(MlflowException, match="Artifact location cannot be a runs:/ URI"):
+            _validate_experiment_artifact_location(location)
 
 
-def test_validate_experiment_name():
-    _validate_experiment_name("validstring")
-    bytestring = b"test byte string"
-    _validate_experiment_name(bytestring.decode("utf-8"))
-    for invalid_name in ["", 12, 12.7, None, {}, []]:
+@pytest.mark.parametrize(
+    ("experiment_name", "is_good_name"),
+    [
+        ("validstring", True),
+        (b"test byte string".decode("utf-8"), True),
+        # error cases
+        ("", False),
+        (12, False),
+        (12.7, False),
+        (None, False),
+        ({}, False),
+        ([], False),
+    ],
+)
+def test_validate_experiment_name(experiment_name, is_good_name):
+    if is_good_name:
+        _validate_experiment_name(experiment_name)
+    else:
         with pytest.raises(MlflowException, match="Invalid experiment name"):
-            _validate_experiment_name(invalid_name)
+            _validate_experiment_name(experiment_name)
 
 
-def test_db_type():
-    for db_type in ["mysql", "mssql", "postgresql", "sqlite"]:
-        # should not raise an exception
+@pytest.mark.parametrize(
+    ("db_type", "is_good_type"),
+    [
+        ("mysql", True),
+        ("mssql", True),
+        ("postgresql", True),
+        ("sqlite", True),
+        # error cases
+        ("MySQL", False),
+        ("mongo", False),
+        ("cassandra", False),
+        ("sql", False),
+        ("", False),
+    ],
+)
+def test_db_type(db_type, is_good_type):
+    if is_good_type:
         _validate_db_type_string(db_type)
-
-    # error cases
-    for db_type in ["MySQL", "mongo", "cassandra", "sql", ""]:
+    else:
         with pytest.raises(MlflowException, match="Invalid database engine") as e:
             _validate_db_type_string(db_type)
         assert "Invalid database engine" in e.value.message

--- a/tests/utils/test_validation.py
+++ b/tests/utils/test_validation.py
@@ -78,84 +78,66 @@ def test_is_numeric(value, expected):
     assert _is_numeric(value) is expected
 
 
-@pytest.mark.parametrize(
-    ("name", "is_good_name"),
-    [
-        *[(name, True) for name in GOOD_METRIC_OR_PARAM_NAMES],
-        # error cases
-        *[(name, False) for name in BAD_METRIC_OR_PARAM_NAMES],
-    ],
-)
-def test_validate_metric_name(name, is_good_name):
-    if is_good_name:
-        _validate_metric_name(name)
-    else:
-        with pytest.raises(MlflowException, match="Invalid metric name") as e:
-            _validate_metric_name(name)
-        assert e.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+@pytest.mark.parametrize("metric_name", GOOD_METRIC_OR_PARAM_NAMES)
+def test_validate_metric_name_good(metric_name):
+    _validate_metric_name(metric_name)
+
+
+@pytest.mark.parametrize("metric_name", BAD_METRIC_OR_PARAM_NAMES)
+def test_validate_metric_name_bad(metric_name):
+    with pytest.raises(MlflowException, match="Invalid metric name") as e:
+        _validate_metric_name(metric_name)
+    assert e.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+
+
+@pytest.mark.parametrize("param_name", GOOD_METRIC_OR_PARAM_NAMES)
+def test_validate_param_name_good(param_name):
+    _validate_param_name(param_name)
+
+
+@pytest.mark.parametrize("param_name", BAD_METRIC_OR_PARAM_NAMES)
+def test_validate_param_name_bad(param_name):
+    with pytest.raises(MlflowException, match="Invalid parameter name") as e:
+        _validate_param_name(param_name)
+    assert e.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+
+
+@pytest.mark.parametrize("tag_name", GOOD_METRIC_OR_PARAM_NAMES)
+def test_validate_tag_name_good(tag_name):
+    _validate_tag_name(tag_name)
+
+
+@pytest.mark.parametrize("tag_name", BAD_METRIC_OR_PARAM_NAMES)
+def test_validate_tag_name_bad(tag_name):
+    with pytest.raises(MlflowException, match="Invalid tag name") as e:
+        _validate_tag_name(tag_name)
+    assert e.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
 
 @pytest.mark.parametrize(
-    ("name", "is_good_name"),
+    "run_id",
     [
-        *[(name, True) for name in GOOD_METRIC_OR_PARAM_NAMES],
-        # error cases
-        *[(name, False) for name in BAD_METRIC_OR_PARAM_NAMES],
+        "a" * 32,
+        "f0" * 16,
+        "abcdef0123456789" * 2,
+        "a" * 33,
+        "a" * 31,
+        "a" * 256,
+        "A" * 32,
+        "g" * 32,
+        "a_" * 32,
+        "abcdefghijklmnopqrstuvqxyz",
     ],
 )
-def test_validate_param_name(name, is_good_name):
-    if is_good_name:
-        _validate_param_name(name)
-    else:
-        with pytest.raises(MlflowException, match="Invalid parameter name") as e:
-            _validate_param_name(name)
-        assert e.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+def test_validate_run_id_good(run_id):
+    _validate_run_id(run_id)
 
 
-@pytest.mark.parametrize(
-    ("name", "is_good_name"),
-    [
-        *[(name, True) for name in GOOD_METRIC_OR_PARAM_NAMES],
-        # error cases
-        *[(name, False) for name in BAD_METRIC_OR_PARAM_NAMES],
-    ],
-)
-def test_validate_tag_name(name, is_good_name):
-    if is_good_name:
-        _validate_tag_name(name)
-    else:
-        with pytest.raises(MlflowException, match="Invalid tag name") as e:
-            _validate_tag_name(name)
-        assert e.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
-
-
-@pytest.mark.parametrize(
-    ("run_id", "is_good_id"),
-    [
-        ("a" * 32, True),
-        ("f0" * 16, True),
-        ("abcdef0123456789" * 2, True),
-        ("a" * 33, True),
-        ("a" * 31, True),
-        ("a" * 256, True),
-        ("A" * 32, True),
-        ("g" * 32, True),
-        ("a_" * 32, True),
-        ("abcdefghijklmnopqrstuvqxyz", True),
-        # error cases
-        ("a/bc" * 8, False),
-        ("", False),
-        ("a" * 400, False),
-        ("*" * 5, False),
-    ],
-)
-def test_validate_run_id(run_id, is_good_id):
-    if is_good_id:
+@pytest.mark.parametrize("run_id", ["a/bc" * 8, "", "a" * 400, "*" * 5])
+def test_validate_run_id_bad(run_id):
+    with pytest.raises(MlflowException, match="Invalid run ID") as e:
         _validate_run_id(run_id)
-    else:
-        with pytest.raises(MlflowException, match="Invalid run ID") as e:
-            _validate_run_id(run_id)
-        assert e.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+    assert e.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
 
 def test_validate_batch_log_limits():
@@ -238,64 +220,35 @@ def test_validate_batch_log_data():
     )
 
 
-@pytest.mark.parametrize(
-    ("location", "is_good_location"),
-    [
-        ("abcde", True),
-        (None, True),
-        # error cases
-        ("runs:/blah/bleh/blergh", False),
-    ],
-)
-def test_validate_experiment_artifact_location(location, is_good_location):
-    if is_good_location:
+@pytest.mark.parametrize("location", ["abcde", None])
+def test_validate_experiment_artifact_location_good(location):
+    _validate_experiment_artifact_location(location)
+
+
+@pytest.mark.parametrize("location", ["runs:/blah/bleh/blergh"])
+def test_validate_experiment_artifact_location_bad(location):
+    with pytest.raises(MlflowException, match="Artifact location cannot be a runs:/ URI"):
         _validate_experiment_artifact_location(location)
-    else:
-        with pytest.raises(MlflowException, match="Artifact location cannot be a runs:/ URI"):
-            _validate_experiment_artifact_location(location)
 
 
-@pytest.mark.parametrize(
-    ("experiment_name", "is_good_name"),
-    [
-        ("validstring", True),
-        (b"test byte string".decode("utf-8"), True),
-        # error cases
-        ("", False),
-        (12, False),
-        (12.7, False),
-        (None, False),
-        ({}, False),
-        ([], False),
-    ],
-)
-def test_validate_experiment_name(experiment_name, is_good_name):
-    if is_good_name:
+@pytest.mark.parametrize("experiment_name", ["validstring", b"test byte string".decode("utf-8")])
+def test_validate_experiment_name_good(experiment_name):
+    _validate_experiment_name(experiment_name)
+
+
+@pytest.mark.parametrize("experiment_name", ["", 12, 12.7, None, {}, []])
+def test_validate_experiment_name_bad(experiment_name):
+    with pytest.raises(MlflowException, match="Invalid experiment name"):
         _validate_experiment_name(experiment_name)
-    else:
-        with pytest.raises(MlflowException, match="Invalid experiment name"):
-            _validate_experiment_name(experiment_name)
 
 
-@pytest.mark.parametrize(
-    ("db_type", "is_good_type"),
-    [
-        ("mysql", True),
-        ("mssql", True),
-        ("postgresql", True),
-        ("sqlite", True),
-        # error cases
-        ("MySQL", False),
-        ("mongo", False),
-        ("cassandra", False),
-        ("sql", False),
-        ("", False),
-    ],
-)
-def test_db_type(db_type, is_good_type):
-    if is_good_type:
+@pytest.mark.parametrize("db_type", ["mysql", "mssql", "postgresql", "sqlite"])
+def test_validate_db_type_string_good(db_type):
+    _validate_db_type_string(db_type)
+
+
+@pytest.mark.parametrize("db_type", ["MySQL", "mongo", "cassandra", "sql", ""])
+def test_validate_db_type_string_bad(db_type):
+    with pytest.raises(MlflowException, match="Invalid database engine") as e:
         _validate_db_type_string(db_type)
-    else:
-        with pytest.raises(MlflowException, match="Invalid database engine") as e:
-            _validate_db_type_string(db_type)
-        assert "Invalid database engine" in e.value.message
+    assert "Invalid database engine" in e.value.message

--- a/tests/utils/test_validation.py
+++ b/tests/utils/test_validation.py
@@ -51,6 +51,7 @@ BAD_METRIC_OR_PARAM_NAMES = [
         ("a/b/c", False),
         ("a.b/c", False),
         (".a", False),
+        # Not unique paths
         ("./a", True),
         ("a/b/../c", True),
         (".", True),
@@ -67,7 +68,7 @@ def test_path_not_unique(path, expected):
     [
         (0, True),
         (0.0, True),
-        # error cases
+        # Non-numeric cases
         (True, False),
         (False, False),
         ("0", False),


### PR DESCRIPTION
Signed-off-by: tsugumi-sys <tidemark0105@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

Resolve #7448 

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

- Use `pytest.mark.parameterize` for simple validation unit tests.
- NOT use in `test_validate_batch_log_limits` and `test_validate_batch_log_data` because readability gets rather worse.

### NOTE

If you use `pytest.mark.parameterize`, the pytest log generated for each cases like below.

![image](https://user-images.githubusercontent.com/61897166/205819301-951a8caa-9109-4d6d-bca7-eb49da1f9012.png)


## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

@harupy 