### PR TITLE
Adding links to searching runs with user_id and life cycle stage

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/RunView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/RunView.js
@@ -339,8 +339,7 @@ export class RunViewImpl extends Component {
               defaultMessage: 'User',
               description: 'Label for displaying the user who created the experiment run',
             })}
-          >
-            {Utils.getUser(run, tags)}
+          > {<Link data-test-id='user-id-search' to={Routes.getExperimentByUser(this.props.experimentId, Utils.getUser(run, tags))}>{Utils.getUser(run, tags)}</Link>}
           </Descriptions.Item>
           {duration ? (
             <Descriptions.Item
@@ -371,7 +370,7 @@ export class RunViewImpl extends Component {
                   'Label for displaying lifecycle stage of the experiment run to see if its active or deleted',
               })}
             >
-              {lifecycleStage}
+              {<Link data-test-id='life-cycle-search' to={Routes.getExperimentByLifeCycle(this.props.experimentId, lifecycleStage)}>{lifecycleStage}</Link>}
             </Descriptions.Item>
           ) : null}
           {tags['mlflow.parentRunId'] !== undefined ? (

--- a/mlflow/server/js/src/experiment-tracking/components/RunView.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/RunView.test.js
@@ -179,6 +179,53 @@ describe('RunView', () => {
     expect(wrapper.html()).toContain('Job Output');
   });
 
+  test('With user_id, when clicked, link to searchRuns with user_id filter', () => {
+    const store = mockStore({
+      ...minimalStoreRaw,
+      entities: {
+        ...minimalStoreRaw.entities,
+        runInfosByUuid: {
+          ...minimalStoreRaw.entities.runInfosByUuid,
+          'uuid-1234-5678-9012': RunInfo.fromJs({
+            run_uuid: 'uuid-1234-5678-9012',
+            experiment_id: '12345',
+            user_id: 'me@me.com',
+            status: 'RUNNING',
+            start_time: 12345678990,
+            end_time: 12345678999,
+            artifact_uri: 'dbfs:/databricks/abc/uuid-1234-5678-9012',
+            lifecycle_stage: 'active',
+          }),
+        },
+        tagsByRunUuid: {
+          'uuid-1234-5678-9012': {
+            'mlflow.source.type': RunTag.fromJs({ key: 'mlflow.source.type', value: 'PROJECT' }),
+            'mlflow.source.name': RunTag.fromJs({ key: 'mlflow.source.name', value: 'notebook' }),
+            'mlflow.source.git.commit': RunTag.fromJs({
+              key: 'mlflow.source.git.commit',
+              value: 'abc',
+            })
+          },
+        },
+        paramsByRunUuid: {
+          'uuid-1234-5678-9012': {
+            p1: Param.fromJs({ key: 'p1', value: 'v1' }),
+          },
+        },
+      },
+    });
+    wrapper = mountWithIntl(
+      <Provider store={store}>
+        <BrowserRouter>
+          <RunView {...minimalProps} />
+        </BrowserRouter>
+      </Provider>,
+    ).find(RunView);
+
+    expect(wrapper.find("a[data-test-id='user-id-search']").text()).toBe("me@me.com");
+    expect(wrapper.find("a[data-test-id='life-cycle-search']").text()).toBe("active");
+  });
+
   test('state: showNoteEditor false/true -> edit button shown/hidden', () => {
     wrapper = mountWithIntl(
       <Provider store={minimalStore}>

--- a/mlflow/server/js/src/experiment-tracking/routes.js
+++ b/mlflow/server/js/src/experiment-tracking/routes.js
@@ -7,6 +7,16 @@ class Routes {
     return `/experiments/${experimentId}`;
   }
 
+  static getExperimentByUser(experimentId, user_id) {
+    const searchString = `searchFilter=user_id:${user_id}`
+    return `/experiments/${experimentId}/${searchString}`;
+  }
+
+  static getExperimentByLifeCycle(experimentId, lifeCycleStage) {
+    const searchString = `searchFilter=lifeCycleStage:${lifeCycleStage}`
+    return `/experiments/${experimentId}/${searchString}`;
+  }
+
   static experimentPageRoute = '/experiments/:experimentId';
 
   static experimentPageSearchRoute = '/experiments/:experimentId/:searchString';


### PR DESCRIPTION
Signed-off-by: Jaehyun Shim <jaeday@umich.edu>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #6749 

## What changes are proposed in this pull request?

- FR for adding links to searching runs based on user_id and life_cycle_stage, on RunView.js

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)
Manually added multiple runs with different user_id and life_cycle_stage, and made sure that we were able to search for runs with user_id and life_cycle_stage upon clicking a hyperlink for user_id and life_cycle_stage in RunView.js.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
Users are now able to search for runs with user_id and life_cycle_stage upon clicking a hyperlink for user_id and life_cycle_stage in RunView.js.


### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
