### PR TITLE
Convert `test-code` to `test-code-block` and fix some failed tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
           name: Install Python dependencies
           command: |
             pip --version
-            pip install --progress-bar off -r requirements/doc-requirements.txt pytest pytest-cov .
+            pip install --progress-bar off -r requirements/doc-requirements.txt pytest pytest-cov plotly .
       - run:
           name: Build documentation
           working_directory: docs

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -7,3 +7,11 @@ def tracking_uri_mock(tmp_path, monkeypatch):
     tracking_uri = "sqlite:///{}".format(tmp_path / "mlruns.sqlite")
     mlflow.set_tracking_uri(tracking_uri)
     monkeypatch.setenv("MLFLOW_TRACKING_URI", tracking_uri)
+    yield
+    mlflow.set_tracking_uri(None)
+
+
+@pytest.fixture(autouse=True)
+def reset_active_experiment_id():
+    yield
+    mlflow.tracking.fluent._active_experiment_id = None

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -79,7 +79,7 @@ def set_experiment(experiment_name: str = None, experiment_id: str = None) -> Ex
     :return: An instance of :py:class:`mlflow.entities.Experiment` representing the new active
              experiment.
 
-    .. code-block:: python
+    .. test-code-block:: python
         :caption: Example
 
         import mlflow
@@ -215,7 +215,7 @@ def start_run(
     :return: :py:class:`mlflow.ActiveRun` object that acts as a context manager wrapping
              the run's state.
 
-    .. code-block:: python
+    .. test-code-block:: python
         :caption: Example
 
         import mlflow
@@ -361,7 +361,7 @@ def start_run(
 def end_run(status: str = RunStatus.to_string(RunStatus.FINISHED)) -> None:
     """End an active MLflow run (if there is one).
 
-    .. code-block:: python
+    .. test-code-block:: python
         :caption: Example
 
         import mlflow
@@ -407,7 +407,7 @@ def active_run() -> Optional[ActiveRun]:
     (parameters, metrics, etc.) through the run returned by ``mlflow.active_run``. In order
     to access such attributes, use the :py:class:`mlflow.client.MlflowClient` as follows:
 
-    .. code-block:: python
+    .. test-code-block:: python
         :caption: Example
 
         import mlflow
@@ -431,7 +431,7 @@ def last_active_run() -> Optional[Run]:
 
     Examples:
 
-    .. code-block:: python
+    .. test-code-block:: python
         :caption: To retrieve the most recent autologged run:
 
         import mlflow
@@ -453,7 +453,7 @@ def last_active_run() -> Optional[Run]:
         predictions = rf.predict(X_test)
         autolog_run = mlflow.last_active_run()
 
-    .. code-block:: python
+    .. test-code-block:: python
         :caption: To get the most recently active run that ended:
 
         import mlflow
@@ -462,7 +462,7 @@ def last_active_run() -> Optional[Run]:
         mlflow.end_run()
         run = mlflow.last_active_run()
 
-    .. code-block:: python
+    .. test-code-block:: python
         :caption: To retrieve the currently active run:
 
         import mlflow
@@ -497,7 +497,7 @@ def get_run(run_id: str) -> Run:
     :return: A single :py:class:`mlflow.entities.Run` object, if the run exists. Otherwise,
                 raises an exception.
 
-    .. code-block:: python
+    .. test-code-block:: python
         :caption: Example
 
         import mlflow
@@ -532,7 +532,7 @@ def log_param(key: str, value: Any) -> Any:
 
     :return: the parameter value that is logged.
 
-    .. code-block:: python
+    .. test-code-block:: python
         :caption: Example
 
         import mlflow
@@ -557,7 +557,7 @@ def set_experiment_tag(key: str, value: Any) -> None:
                   All backend stores will support values up to length 5000, but some
                   may support larger values.
 
-    .. code-block:: python
+    .. test-code-block:: python
         :caption: Example
 
         import mlflow
@@ -582,7 +582,7 @@ def set_tag(key: str, value: Any) -> None:
                   All backend stores will support values up to length 5000, but some
                   may support larger values.
 
-    .. code-block:: python
+    .. test-code-block:: python
         :caption: Example
 
         import mlflow
@@ -601,7 +601,7 @@ def delete_tag(key: str) -> None:
 
     :param key: Name of the tag
 
-    .. code-block:: python
+    .. test-code-block:: python
         :caption: Example
 
         import mlflow
@@ -635,7 +635,7 @@ def log_metric(key: str, value: float, step: Optional[int] = None) -> None:
                   may support larger values.
     :param step: Metric step (int). Defaults to zero if unspecified.
 
-    .. code-block:: python
+    .. test-code-block:: python
         :caption: Example
 
         import mlflow
@@ -661,7 +661,7 @@ def log_metrics(metrics: Dict[str, float], step: Optional[int] = None) -> None:
 
     :returns: None
 
-    .. code-block:: python
+    .. test-code-block:: python
         :caption: Example
 
         import mlflow
@@ -687,7 +687,7 @@ def log_params(params: Dict[str, Any]) -> None:
                    not)
     :returns: None
 
-    .. code-block:: python
+    .. test-code-block:: python
         :caption: Example
 
         import mlflow
@@ -709,7 +709,7 @@ def set_experiment_tags(tags: Dict[str, Any]) -> None:
 
     :param tags: Dictionary containing tag names and corresponding values.
 
-    .. code-block:: python
+    .. test-code-block:: python
         :caption: Example
 
         import mlflow
@@ -735,7 +735,7 @@ def set_tags(tags: Dict[str, Any]) -> None:
                  not)
     :returns: None
 
-    .. code-block:: python
+    .. test-code-block:: python
         :caption: Example
 
         import mlflow
@@ -761,7 +761,7 @@ def log_artifact(local_path: str, artifact_path: Optional[str] = None) -> None:
     :param local_path: Path to the file to write.
     :param artifact_path: If provided, the directory in ``artifact_uri`` to write to.
 
-    .. code-block:: python
+    .. test-code-block:: python
         :caption: Example
 
         import mlflow
@@ -788,9 +788,10 @@ def log_artifacts(local_dir: str, artifact_path: Optional[str] = None) -> None:
     :param local_dir: Path to the directory of files to write.
     :param artifact_path: If provided, the directory in ``artifact_uri`` to write to.
 
-    .. code-block:: python
+    .. test-code-block:: python
         :caption: Example
 
+        import json
         import os
         import mlflow
 
@@ -821,7 +822,7 @@ def log_text(text: str, artifact_file: str) -> None:
     :param artifact_file: The run-relative artifact file path in posixpath format to which
                           the text is saved (e.g. "dir/file.txt").
 
-    .. code-block:: python
+    .. test-code-block:: python
         :caption: Example
 
         import mlflow
@@ -851,7 +852,7 @@ def log_dict(dictionary: Any, artifact_file: str) -> None:
     :param artifact_file: The run-relative artifact file path in posixpath format to which
                           the dictionary is saved (e.g. "dir/data.json").
 
-    .. code-block:: python
+    .. test-code-block:: python
         :caption: Example
 
         import mlflow
@@ -893,7 +894,7 @@ def log_figure(
     :param artifact_file: The run-relative artifact file path in posixpath format to which
                           the figure is saved (e.g. "dir/file.png").
 
-    .. code-block:: python
+    .. test-code-block:: python
         :caption: Matplotlib Example
 
         import mlflow
@@ -905,7 +906,7 @@ def log_figure(
         with mlflow.start_run():
             mlflow.log_figure(fig, "figure.png")
 
-    .. code-block:: python
+    .. test-code-block:: python
         :caption: Plotly Example
 
         import mlflow
@@ -957,7 +958,7 @@ def log_image(image: Union["numpy.ndarray", "PIL.Image.Image"], artifact_file: s
     :param artifact_file: The run-relative artifact file path in posixpath format to which
                           the image is saved (e.g. "dir/image.png").
 
-    .. code-block:: python
+    .. test-code-block:: python
         :caption: Numpy Example
 
         import mlflow
@@ -968,7 +969,7 @@ def log_image(image: Union["numpy.ndarray", "PIL.Image.Image"], artifact_file: s
         with mlflow.start_run():
             mlflow.log_image(image, "image.png")
 
-    .. code-block:: python
+    .. test-code-block:: python
         :caption: Pillow Example
 
         import mlflow
@@ -995,7 +996,7 @@ def get_experiment(experiment_id: str) -> Experiment:
     :param experiment_id: The string-ified experiment ID returned from ``create_experiment``.
     :return: :py:class:`mlflow.entities.Experiment`
 
-    .. code-block:: python
+    .. test-code-block:: python
         :caption: Example
 
         import mlflow
@@ -1027,7 +1028,7 @@ def get_experiment_by_name(name: str) -> Optional[Experiment]:
     :return: An instance of :py:class:`mlflow.entities.Experiment`
              if an experiment with the specified name exists, otherwise None.
 
-    .. code-block:: python
+    .. test-code-block:: python
         :caption: Example
 
         import mlflow
@@ -1106,7 +1107,7 @@ def search_experiments(
 
     :return: A list of :py:class:`Experiment <mlflow.entities.Experiment>` objects.
 
-    .. code-block:: python
+    .. test-code-block:: python
         :caption: Example
 
         import mlflow
@@ -1203,7 +1204,7 @@ def search_registered_models(
     :return: A list of :py:class:`mlflow.entities.model_registry.RegisteredModel` objects
              that satisfy the search expressions.
 
-    .. code-block:: python
+    .. test-code-block:: python
         :caption: Example
 
         import mlflow
@@ -1288,7 +1289,7 @@ def create_experiment(
                             tags on the experiment.
     :return: String ID of the created experiment.
 
-    .. code-block:: python
+    .. test-code-block:: python
         :caption: Example
 
         import mlflow
@@ -1327,7 +1328,7 @@ def delete_experiment(experiment_id: str) -> None:
 
     :param experiment_id: The The string-ified experiment ID returned from ``create_experiment``.
 
-    .. code-block:: python
+    .. test-code-block:: python
         :caption: Example
 
         import mlflow
@@ -1358,7 +1359,7 @@ def delete_run(run_id: str) -> None:
 
     :param run_id: Unique identifier for the run to delete.
 
-    .. code-block:: python
+    .. test-code-block:: python
         :caption: Example
 
         import mlflow
@@ -1399,7 +1400,7 @@ def get_artifact_uri(artifact_path: Optional[str] = None) -> str:
              is not provided and the currently active run uses an S3-backed store, this may be a
              URI of the form ``s3://<bucket_name>/path/to/artifact/root``.
 
-    .. code-block:: python
+    .. test-code-block:: python
         :caption: Example
 
         import mlflow
@@ -1474,7 +1475,7 @@ def search_runs(
              the value for the corresponding column is (NumPy) ``Nan``, ``None``, or ``None``
              respectively.
 
-    .. code-block:: python
+    .. test-code-block:: python
         :caption: Example
 
         import mlflow
@@ -1699,17 +1700,20 @@ def autolog(
     Note that framework-specific configurations set at any point will take precedence over
     any configurations set by this function. For example:
 
-    .. code-block:: python
+    .. test-code-block:: python
 
+        import mlflow
         mlflow.autolog(log_models=False, exclusive=True)
         import sklearn
 
     would enable autologging for `sklearn` with `log_models=False` and `exclusive=True`,
     but
 
-    .. code-block:: python
+    .. test-code-block:: python
 
+        import mlflow
         mlflow.autolog(log_models=False, exclusive=True)
+
         import sklearn
         mlflow.sklearn.autolog(log_models=True)
 
@@ -1746,7 +1750,7 @@ def autolog(
                    setup and training execution. If ``False``, show all events and warnings during
                    autologging setup and training execution.
 
-    .. code-block:: python
+    .. test-code-block:: python
         :caption: Example
 
         import numpy as np


### PR DESCRIPTION
Signed-off-by: tsugumi-sys <tidemark0105@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #7457 

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

- Convert `test-code` to `test-code-block` in `mlflow.tracking.fluent.py`
- Fix some failed tests.
![image](https://user-images.githubusercontent.com/61897166/205898431-7368c62e-624b-4104-ab73-8069ae031efa.png)

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

```bash
cd docs
make rsthtml  # should dump code blocks in `docs/.examples` as python scripts.
make test-examples
```

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

@harupy 