### PR TITLE
Adding links to searching runs with user_id and life cycle stage

### DIFF
--- a/mlflow/server/js/src/common/utils/StringUtils.js
+++ b/mlflow/server/js/src/common/utils/StringUtils.js
@@ -25,3 +25,7 @@ export const middleTruncateStr = (str, maxLen) => {
     return str;
   }
 };
+
+export const capitalizeFirstLetter = (string) => {
+  return string.charAt(0).toUpperCase() + string.slice(1);
+};

--- a/mlflow/server/js/src/experiment-tracking/components/RunView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/RunView.js
@@ -340,14 +340,12 @@ export class RunViewImpl extends Component {
               description: 'Label for displaying the user who created the experiment run',
             })}
           >
-            {
               <Link
                 data-test-id='user-id-search'
                 to={Routes.getExperimentByUser(this.props.experimentId, Utils.getUser(run, tags))}
               >
                 {Utils.getUser(run, tags)}
               </Link>
-            }
           </Descriptions.Item>
           {duration ? (
             <Descriptions.Item
@@ -378,14 +376,12 @@ export class RunViewImpl extends Component {
                   'Label for displaying lifecycle stage of the experiment run to see if its active or deleted',
               })}
             >
-              {
                 <Link
                   data-test-id='life-cycle-search'
                   to={Routes.getExperimentByLifeCycle(this.props.experimentId, lifecycleStage)}
                 >
                   {lifecycleStage}
                 </Link>
-              }
             </Descriptions.Item>
           ) : null}
           {tags['mlflow.parentRunId'] !== undefined ? (

--- a/mlflow/server/js/src/experiment-tracking/components/RunView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/RunView.js
@@ -340,7 +340,7 @@ export class RunViewImpl extends Component {
               description: 'Label for displaying the user who created the experiment run',
             })}
           >
-            {Utils.getUser(run, tags)}
+            {<Link data-test-id='user-id-search' to={Routes.getExperimentByUser(this.props.experimentId, Utils.getUser(run, tags))}>{Utils.getUser(run, tags)}</Link>}
           </Descriptions.Item>
           {duration ? (
             <Descriptions.Item
@@ -371,7 +371,7 @@ export class RunViewImpl extends Component {
                   'Label for displaying lifecycle stage of the experiment run to see if its active or deleted',
               })}
             >
-              {lifecycleStage}
+              {<Link data-test-id='life-cycle-search' to={Routes.getExperimentByLifeCycle(this.props.experimentId, lifecycleStage)}>{lifecycleStage}</Link>}
             </Descriptions.Item>
           ) : null}
           {tags['mlflow.parentRunId'] !== undefined ? (

--- a/mlflow/server/js/src/experiment-tracking/components/RunView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/RunView.js
@@ -229,8 +229,8 @@ export class RunViewImpl extends Component {
 
   renderUserIdLink = () => {
     const { run, tags, experimentId } = this.props;
-    // TODO: On Databricks, just return `user` instead of a link because MLflow backend on Databricks
-    // does not support searching runs by user.
+    // TODO: On Databricks, just return `user` instead of a link because MLflow backend on
+    // Databricks does not support searching runs by user.
     const user = Utils.getUser(run, tags);
     return <Link to={Routes.searchRunsByUser(experimentId, user)}>{user}</Link>;
   };

--- a/mlflow/server/js/src/experiment-tracking/components/RunView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/RunView.js
@@ -11,6 +11,7 @@ import ArtifactPage from './ArtifactPage';
 import { getLatestMetrics } from '../reducers/MetricReducer';
 import { Experiment } from '../sdk/MlflowMessages';
 import Utils from '../../common/utils/Utils';
+import { capitalizeFirstLetter } from '../../common/utils/StringUtils';
 import { NOTE_CONTENT_TAG, NoteInfo } from '../utils/NoteUtils';
 import { RenameRunModal } from './modals/RenameRunModal';
 import { EditableTagsTableView } from '../../common/components/EditableTagsTableView';
@@ -226,6 +227,28 @@ export class RunViewImpl extends Component {
     );
   }
 
+  renderUserIdLink = () => {
+    const { run, tags, experimentId } = this.props;
+    // TODO: On Databricks, just return `user` instead of a link because MLflow backend on Databricks
+    // does not support searching runs by user.
+    const user = Utils.getUser(run, tags);
+    return <Link to={Routes.searchRunsByUser(experimentId, user)}>{user}</Link>;
+  };
+
+  renderLifecycleLink = () => {
+    const lifecycleStage = this.props.run.getLifecycleStage();
+    return (
+      <Link
+        to={Routes.searchRunsByLifecycleStage(
+          this.props.experimentId,
+          capitalizeFirstLetter(lifecycleStage),
+        )}
+      >
+        {lifecycleStage}
+      </Link>
+    );
+  };
+
   render() {
     const {
       runUuid,
@@ -340,12 +363,7 @@ export class RunViewImpl extends Component {
               description: 'Label for displaying the user who created the experiment run',
             })}
           >
-            <Link
-              data-test-id='user-id-search'
-              to={Routes.getExperimentByUser(this.props.experimentId, Utils.getUser(run, tags))}
-            >
-              {Utils.getUser(run, tags)}
-            </Link>
+            {this.renderUserIdLink()}
           </Descriptions.Item>
           {duration ? (
             <Descriptions.Item
@@ -376,12 +394,7 @@ export class RunViewImpl extends Component {
                   'Label for displaying lifecycle stage of the experiment run to see if its active or deleted',
               })}
             >
-              <Link
-                data-test-id='life-cycle-search'
-                to={Routes.getExperimentByLifeCycle(this.props.experimentId, lifecycleStage)}
-              >
-                {lifecycleStage}
-              </Link>
+              {this.renderLifecycleLink()}
             </Descriptions.Item>
           ) : null}
           {tags['mlflow.parentRunId'] !== undefined ? (

--- a/mlflow/server/js/src/experiment-tracking/components/RunView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/RunView.js
@@ -340,12 +340,12 @@ export class RunViewImpl extends Component {
               description: 'Label for displaying the user who created the experiment run',
             })}
           >
-              <Link
-                data-test-id='user-id-search'
-                to={Routes.getExperimentByUser(this.props.experimentId, Utils.getUser(run, tags))}
-              >
-                {Utils.getUser(run, tags)}
-              </Link>
+            <Link
+              data-test-id='user-id-search'
+              to={Routes.getExperimentByUser(this.props.experimentId, Utils.getUser(run, tags))}
+            >
+              {Utils.getUser(run, tags)}
+            </Link>
           </Descriptions.Item>
           {duration ? (
             <Descriptions.Item
@@ -376,12 +376,12 @@ export class RunViewImpl extends Component {
                   'Label for displaying lifecycle stage of the experiment run to see if its active or deleted',
               })}
             >
-                <Link
-                  data-test-id='life-cycle-search'
-                  to={Routes.getExperimentByLifeCycle(this.props.experimentId, lifecycleStage)}
-                >
-                  {lifecycleStage}
-                </Link>
+              <Link
+                data-test-id='life-cycle-search'
+                to={Routes.getExperimentByLifeCycle(this.props.experimentId, lifecycleStage)}
+              >
+                {lifecycleStage}
+              </Link>
             </Descriptions.Item>
           ) : null}
           {tags['mlflow.parentRunId'] !== undefined ? (

--- a/mlflow/server/js/src/experiment-tracking/components/RunView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/RunView.js
@@ -340,7 +340,14 @@ export class RunViewImpl extends Component {
               description: 'Label for displaying the user who created the experiment run',
             })}
           >
-            {<Link data-test-id='user-id-search' to={Routes.getExperimentByUser(this.props.experimentId, Utils.getUser(run, tags))}>{Utils.getUser(run, tags)}</Link>}
+            {
+              <Link
+                data-test-id='user-id-search'
+                to={Routes.getExperimentByUser(this.props.experimentId, Utils.getUser(run, tags))}
+              >
+                {Utils.getUser(run, tags)}
+              </Link>
+            }
           </Descriptions.Item>
           {duration ? (
             <Descriptions.Item
@@ -371,7 +378,14 @@ export class RunViewImpl extends Component {
                   'Label for displaying lifecycle stage of the experiment run to see if its active or deleted',
               })}
             >
-              {<Link data-test-id='life-cycle-search' to={Routes.getExperimentByLifeCycle(this.props.experimentId, lifecycleStage)}>{lifecycleStage}</Link>}
+              {
+                <Link
+                  data-test-id='life-cycle-search'
+                  to={Routes.getExperimentByLifeCycle(this.props.experimentId, lifecycleStage)}
+                >
+                  {lifecycleStage}
+                </Link>
+              }
             </Descriptions.Item>
           ) : null}
           {tags['mlflow.parentRunId'] !== undefined ? (

--- a/mlflow/server/js/src/experiment-tracking/components/RunView.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/RunView.test.js
@@ -179,53 +179,6 @@ describe('RunView', () => {
     expect(wrapper.html()).toContain('Job Output');
   });
 
-  test('With user_id, when clicked, link to searchRuns with user_id filter', () => {
-    const store = mockStore({
-      ...minimalStoreRaw,
-      entities: {
-        ...minimalStoreRaw.entities,
-        runInfosByUuid: {
-          ...minimalStoreRaw.entities.runInfosByUuid,
-          'uuid-1234-5678-9012': RunInfo.fromJs({
-            run_uuid: 'uuid-1234-5678-9012',
-            experiment_id: '12345',
-            user_id: 'me@me.com',
-            status: 'RUNNING',
-            start_time: 12345678990,
-            end_time: 12345678999,
-            artifact_uri: 'dbfs:/databricks/abc/uuid-1234-5678-9012',
-            lifecycle_stage: 'active',
-          }),
-        },
-        tagsByRunUuid: {
-          'uuid-1234-5678-9012': {
-            'mlflow.source.type': RunTag.fromJs({ key: 'mlflow.source.type', value: 'PROJECT' }),
-            'mlflow.source.name': RunTag.fromJs({ key: 'mlflow.source.name', value: 'notebook' }),
-            'mlflow.source.git.commit': RunTag.fromJs({
-              key: 'mlflow.source.git.commit',
-              value: 'abc',
-            }),
-          },
-        },
-        paramsByRunUuid: {
-          'uuid-1234-5678-9012': {
-            p1: Param.fromJs({ key: 'p1', value: 'v1' }),
-          },
-        },
-      },
-    });
-    wrapper = mountWithIntl(
-      <Provider store={store}>
-        <BrowserRouter>
-          <RunView {...minimalProps} />
-        </BrowserRouter>
-      </Provider>,
-    ).find(RunView);
-
-    expect(wrapper.find("a[data-test-id='user-id-search']").text()).toBe('me@me.com');
-    expect(wrapper.find("a[data-test-id='life-cycle-search']").text()).toBe('active');
-  });
-
   test('state: showNoteEditor false/true -> edit button shown/hidden', () => {
     wrapper = mountWithIntl(
       <Provider store={minimalStore}>

--- a/mlflow/server/js/src/experiment-tracking/components/RunView.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/RunView.test.js
@@ -179,6 +179,53 @@ describe('RunView', () => {
     expect(wrapper.html()).toContain('Job Output');
   });
 
+  test('With user_id, when clicked, link to searchRuns with user_id filter', () => {
+    const store = mockStore({
+      ...minimalStoreRaw,
+      entities: {
+        ...minimalStoreRaw.entities,
+        runInfosByUuid: {
+          ...minimalStoreRaw.entities.runInfosByUuid,
+          'uuid-1234-5678-9012': RunInfo.fromJs({
+            run_uuid: 'uuid-1234-5678-9012',
+            experiment_id: '12345',
+            user_id: 'me@me.com',
+            status: 'RUNNING',
+            start_time: 12345678990,
+            end_time: 12345678999,
+            artifact_uri: 'dbfs:/databricks/abc/uuid-1234-5678-9012',
+            lifecycle_stage: 'active',
+          }),
+        },
+        tagsByRunUuid: {
+          'uuid-1234-5678-9012': {
+            'mlflow.source.type': RunTag.fromJs({ key: 'mlflow.source.type', value: 'PROJECT' }),
+            'mlflow.source.name': RunTag.fromJs({ key: 'mlflow.source.name', value: 'notebook' }),
+            'mlflow.source.git.commit': RunTag.fromJs({
+              key: 'mlflow.source.git.commit',
+              value: 'abc',
+            })
+          },
+        },
+        paramsByRunUuid: {
+          'uuid-1234-5678-9012': {
+            p1: Param.fromJs({ key: 'p1', value: 'v1' }),
+          },
+        },
+      },
+    });
+    wrapper = mountWithIntl(
+      <Provider store={store}>
+        <BrowserRouter>
+          <RunView {...minimalProps} />
+        </BrowserRouter>
+      </Provider>,
+    ).find(RunView);
+
+    expect(wrapper.find("a[data-test-id='user-id-search']").text()).toBe("me@me.com");
+    expect(wrapper.find("a[data-test-id='life-cycle-search']").text()).toBe("active");
+  });
+
   test('state: showNoteEditor false/true -> edit button shown/hidden', () => {
     wrapper = mountWithIntl(
       <Provider store={minimalStore}>

--- a/mlflow/server/js/src/experiment-tracking/components/RunView.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/RunView.test.js
@@ -203,7 +203,7 @@ describe('RunView', () => {
             'mlflow.source.name': RunTag.fromJs({ key: 'mlflow.source.name', value: 'notebook' }),
             'mlflow.source.git.commit': RunTag.fromJs({
               key: 'mlflow.source.git.commit',
-              value: 'abc'
+              value: 'abc',
             }),
           },
         },

--- a/mlflow/server/js/src/experiment-tracking/components/RunView.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/RunView.test.js
@@ -203,8 +203,8 @@ describe('RunView', () => {
             'mlflow.source.name': RunTag.fromJs({ key: 'mlflow.source.name', value: 'notebook' }),
             'mlflow.source.git.commit': RunTag.fromJs({
               key: 'mlflow.source.git.commit',
-              value: 'abc',
-            })
+              value: 'abc'
+            }),
           },
         },
         paramsByRunUuid: {
@@ -222,8 +222,8 @@ describe('RunView', () => {
       </Provider>,
     ).find(RunView);
 
-    expect(wrapper.find("a[data-test-id='user-id-search']").text()).toBe("me@me.com");
-    expect(wrapper.find("a[data-test-id='life-cycle-search']").text()).toBe("active");
+    expect(wrapper.find("a[data-test-id='user-id-search']").text()).toBe('me@me.com');
+    expect(wrapper.find("a[data-test-id='life-cycle-search']").text()).toBe('active');
   });
 
   test('state: showNoteEditor false/true -> edit button shown/hidden', () => {

--- a/mlflow/server/js/src/experiment-tracking/routes.js
+++ b/mlflow/server/js/src/experiment-tracking/routes.js
@@ -8,13 +8,12 @@ class Routes {
   }
 
   static getExperimentByUser(experimentId, user_id) {
-    const searchString = `searchFilter=user_id:${user_id}`
-    return `/experiments/${experimentId}/${searchString}`;
+    const filter_string = `user_id = ${user_id}`;
+    return `/experiments/${experimentId}?searchFilter=${escape(filter_string)}`;
   }
 
   static getExperimentByLifeCycle(experimentId, lifeCycleStage) {
-    const searchString = `searchFilter=lifeCycleStage:${lifeCycleStage}`
-    return `/experiments/${experimentId}/${searchString}`;
+    return `/experiments/${experimentId}?lifecycleFilter=${lifeCycleStage}`;
   }
 
   static experimentPageRoute = '/experiments/:experimentId';

--- a/mlflow/server/js/src/experiment-tracking/routes.js
+++ b/mlflow/server/js/src/experiment-tracking/routes.js
@@ -8,8 +8,8 @@ class Routes {
   }
 
   static searchRunsByUser(experimentId, user_id) {
-    const filter_string = `user_id = '${user_id}'`;
-    return `/experiments/${experimentId}?searchFilter=${encodeURIComponent(filter_string)}`;
+    const filterString = `user_id = '${user_id}'`;
+    return `/experiments/${experimentId}?searchFilter=${encodeURIComponent(filterString)}`;
   }
 
   static searchRunsByLifecycleStage(experimentId, lifecycleStage) {

--- a/mlflow/server/js/src/experiment-tracking/routes.js
+++ b/mlflow/server/js/src/experiment-tracking/routes.js
@@ -7,6 +7,16 @@ class Routes {
     return `/experiments/${experimentId}`;
   }
 
+  static getExperimentByUser(experimentId, user_id) {
+    const searchString = `searchFilter=user_id:${user_id}`
+    return `/experiments/${experimentId}/${searchString}`;
+  }
+
+  static getExperimentByLifeCycle(experimentId, lifeCycleStage) {
+    const searchString = `searchFilter=lifeCycleStage:${lifeCycleStage}`
+    return `/experiments/${experimentId}/${searchString}`;
+  }
+
   static experimentPageRoute = '/experiments/:experimentId';
 
   static experimentPageSearchRoute = '/experiments/:experimentId/:searchString';

--- a/mlflow/server/js/src/experiment-tracking/routes.js
+++ b/mlflow/server/js/src/experiment-tracking/routes.js
@@ -7,13 +7,13 @@ class Routes {
     return `/experiments/${experimentId}`;
   }
 
-  static getExperimentByUser(experimentId, user_id) {
-    const filter_string = `user_id = ${user_id}`;
-    return `/experiments/${experimentId}?searchFilter=${escape(filter_string)}`;
+  static searchRunsByUser(experimentId, user_id) {
+    const filter_string = `user_id = '${user_id}'`;
+    return `/experiments/${experimentId}?searchFilter=${encodeURIComponent(filter_string)}`;
   }
 
-  static getExperimentByLifeCycle(experimentId, lifeCycleStage) {
-    return `/experiments/${experimentId}?lifecycleFilter=${lifeCycleStage}`;
+  static searchRunsByLifecycleStage(experimentId, lifecycleStage) {
+    return `/experiments/${experimentId}?lifecycleFilter=${lifecycleStage}`;
   }
 
   static experimentPageRoute = '/experiments/:experimentId';


### PR DESCRIPTION
Signed-off-by: Jaehyun Shim <jaeday@umich.edu>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

Resolve #6749

## What changes are proposed in this pull request?
FR for adding links to searching runs based on user_id lifecycle_stage, on RunView.js

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

https://drive.google.com/file/d/1-lLfzWq-AAA2OVeony91_JhOiPxc7rat/view?usp=sharing - a short demo of the features added.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Users are now able to search for runs with user_id and lifecycle_stage upon clicking a hyperlink for user_id and lifecycle_stage in RunView.js

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
