### PR TITLE
Move fluent `search_registered_models` in `mlflow/tracking/_model_registry/fluent.py`

### DIFF
--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -144,7 +144,6 @@ from mlflow.tracking.fluent import (
     get_experiment,
     get_experiment_by_name,
     search_experiments,
-    search_registered_models,
     create_experiment,
     set_experiment,
     log_params,
@@ -157,7 +156,7 @@ from mlflow.tracking.fluent import (
     autolog,
     last_active_run,
 )
-from mlflow.tracking._model_registry.fluent import register_model
+from mlflow.tracking._model_registry.fluent import register_model, search_registered_models
 from mlflow.tracking import (
     get_tracking_uri,
     set_tracking_uri,

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -1,11 +1,14 @@
 from mlflow.tracking.client import MlflowClient
 from mlflow.exceptions import MlflowException
 from mlflow.entities.model_registry import ModelVersion
+from mlflow.entities.model_registry import RegisteredModel
 from mlflow.protos.databricks_pb2 import RESOURCE_ALREADY_EXISTS, ErrorCode
 from mlflow.store.artifact.runs_artifact_repo import RunsArtifactRepository
 from mlflow.utils.logging_utils import eprint
+from mlflow.utils import get_results_from_paginated_fn
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
-from typing import Any, Dict, Optional
+from mlflow.store.model_registry import SEARCH_REGISTERED_MODEL_MAX_RESULTS_DEFAULT
+from typing import Any, Dict, Optional, List
 
 
 def register_model(
@@ -93,3 +96,107 @@ def register_model(
         )
     )
     return create_version_response
+
+
+def search_registered_models(
+    max_results: Optional[int] = None,
+    filter_string: Optional[str] = None,
+    order_by: Optional[List[str]] = None,
+) -> List[RegisteredModel]:
+    """
+    Search for registered models that satisfy the filter criteria.
+
+    :param filter_string: Filter query string
+        (e.g., ``"name = 'a_model_name' and tag.key = 'value1'"``),
+        defaults to searching for all registered models. The following identifiers, comparators,
+        and logical operators are supported.
+
+        Identifiers
+          - ``name``: registered model name.
+          - ``tags.<tag_key>``: registered model tag. If ``tag_key`` contains spaces, it must be
+            wrapped with backticks (e.g., ``"tags.`extra key`"``).
+
+        Comparators
+          - ``=``: Equal to.
+          - ``!=``: Not equal to.
+          - ``LIKE``: Case-sensitive pattern match.
+          - ``ILIKE``: Case-insensitive pattern match.
+
+        Logical operators
+          - ``AND``: Combines two sub-queries and returns True if both of them are True.
+
+    :param max_results: If passed, specifies the maximum number of models desired. If not
+                        passed, all models will be returned.
+    :param order_by: List of column names with ASC|DESC annotation, to be used for ordering
+                     matching search results.
+    :return: A list of :py:class:`mlflow.entities.model_registry.RegisteredModel` objects
+             that satisfy the search expressions.
+
+    .. test-code-block:: python
+        :caption: Example
+
+        import mlflow
+        from sklearn.linear_model import LogisticRegression
+
+        with mlflow.start_run():
+            mlflow.sklearn.log_model(
+                LogisticRegression(),
+                "Cordoba",
+                registered_model_name="CordobaWeatherForecastModel",
+            )
+            mlflow.sklearn.log_model(
+                LogisticRegression(),
+                "Boston",
+                registered_model_name="BostonWeatherForecastModel",
+            )
+
+        # Get search results filtered by the registered model name
+        filter_string = "name = 'CordobaWeatherForecastModel'"
+        results = mlflow.search_registered_models(filter_string=filter_string)
+        print("-" * 80)
+        for res in results:
+            for mv in res.latest_versions:
+                print("name={}; run_id={}; version={}".format(mv.name, mv.run_id, mv.version))
+
+        # Get search results filtered by the registered model name that matches
+        # prefix pattern
+        filter_string = "name LIKE 'Boston%'"
+        results = mlflow.search_registered_models(filter_string=filter_string)
+        print("-" * 80)
+        for res in results:
+            for mv in res.latest_versions:
+                print("name={}; run_id={}; version={}".format(mv.name, mv.run_id, mv.version))
+
+        # Get all registered models and order them by ascending order of the names
+        results = mlflow.search_registered_models(order_by=["name ASC"])
+        print("-" * 80)
+        for res in results:
+            for mv in res.latest_versions:
+                print("name={}; run_id={}; version={}".format(mv.name, mv.run_id, mv.version))
+
+    .. code-block:: text
+        :caption: Output
+
+        --------------------------------------------------------------------------------
+        name=CordobaWeatherForecastModel; run_id=248c66a666744b4887bdeb2f9cf7f1c6; version=1
+        --------------------------------------------------------------------------------
+        name=BostonWeatherForecastModel; run_id=248c66a666744b4887bdeb2f9cf7f1c6; version=1
+        --------------------------------------------------------------------------------
+        name=BostonWeatherForecastModel; run_id=248c66a666744b4887bdeb2f9cf7f1c6; version=1
+        name=CordobaWeatherForecastModel; run_id=248c66a666744b4887bdeb2f9cf7f1c6; version=1
+
+    """
+
+    def pagination_wrapper_func(number_to_get, next_page_token):
+        return MlflowClient().search_registered_models(
+            max_results=number_to_get,
+            filter_string=filter_string,
+            order_by=order_by,
+            page_token=next_page_token,
+        )
+
+    return get_results_from_paginated_fn(
+        pagination_wrapper_func,
+        SEARCH_REGISTERED_MODEL_MAX_RESULTS_DEFAULT,
+        max_results,
+    )

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -12,13 +12,11 @@ from typing import Any, Dict, List, Optional, Union, TYPE_CHECKING
 
 from mlflow.entities import Experiment, Run, RunStatus, Param, RunTag, Metric, ViewType
 from mlflow.entities.lifecycle_stage import LifecycleStage
-from mlflow.entities.model_registry import RegisteredModel
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import (
     INVALID_PARAMETER_VALUE,
     RESOURCE_DOES_NOT_EXIST,
 )
-from mlflow.store.model_registry import SEARCH_REGISTERED_MODEL_MAX_RESULTS_DEFAULT
 from mlflow.tracking.client import MlflowClient
 from mlflow.tracking import artifact_utils, _get_store
 from mlflow.tracking.context import registry as context_registry
@@ -1166,110 +1164,6 @@ def search_experiments(
     return get_results_from_paginated_fn(
         pagination_wrapper_func,
         SEARCH_MAX_RESULTS_DEFAULT,
-        max_results,
-    )
-
-
-def search_registered_models(
-    max_results: Optional[int] = None,
-    filter_string: Optional[str] = None,
-    order_by: Optional[List[str]] = None,
-) -> List[RegisteredModel]:
-    """
-    Search for registered models that satisfy the filter criteria.
-
-    :param filter_string: Filter query string
-        (e.g., ``"name = 'a_model_name' and tag.key = 'value1'"``),
-        defaults to searching for all registered models. The following identifiers, comparators,
-        and logical operators are supported.
-
-        Identifiers
-          - ``name``: registered model name.
-          - ``tags.<tag_key>``: registered model tag. If ``tag_key`` contains spaces, it must be
-            wrapped with backticks (e.g., ``"tags.`extra key`"``).
-
-        Comparators
-          - ``=``: Equal to.
-          - ``!=``: Not equal to.
-          - ``LIKE``: Case-sensitive pattern match.
-          - ``ILIKE``: Case-insensitive pattern match.
-
-        Logical operators
-          - ``AND``: Combines two sub-queries and returns True if both of them are True.
-
-    :param max_results: If passed, specifies the maximum number of models desired. If not
-                        passed, all models will be returned.
-    :param order_by: List of column names with ASC|DESC annotation, to be used for ordering
-                     matching search results.
-    :return: A list of :py:class:`mlflow.entities.model_registry.RegisteredModel` objects
-             that satisfy the search expressions.
-
-    .. test-code-block:: python
-        :caption: Example
-
-        import mlflow
-        from sklearn.linear_model import LogisticRegression
-
-        with mlflow.start_run():
-            mlflow.sklearn.log_model(
-                LogisticRegression(),
-                "Cordoba",
-                registered_model_name="CordobaWeatherForecastModel",
-            )
-            mlflow.sklearn.log_model(
-                LogisticRegression(),
-                "Boston",
-                registered_model_name="BostonWeatherForecastModel",
-            )
-
-        # Get search results filtered by the registered model name
-        filter_string = "name = 'CordobaWeatherForecastModel'"
-        results = mlflow.search_registered_models(filter_string=filter_string)
-        print("-" * 80)
-        for res in results:
-            for mv in res.latest_versions:
-                print("name={}; run_id={}; version={}".format(mv.name, mv.run_id, mv.version))
-
-        # Get search results filtered by the registered model name that matches
-        # prefix pattern
-        filter_string = "name LIKE 'Boston%'"
-        results = mlflow.search_registered_models(filter_string=filter_string)
-        print("-" * 80)
-        for res in results:
-            for mv in res.latest_versions:
-                print("name={}; run_id={}; version={}".format(mv.name, mv.run_id, mv.version))
-
-        # Get all registered models and order them by ascending order of the names
-        results = mlflow.search_registered_models(order_by=["name ASC"])
-        print("-" * 80)
-        for res in results:
-            for mv in res.latest_versions:
-                print("name={}; run_id={}; version={}".format(mv.name, mv.run_id, mv.version))
-
-    .. code-block:: text
-        :caption: Output
-
-        --------------------------------------------------------------------------------
-        name=CordobaWeatherForecastModel; run_id=248c66a666744b4887bdeb2f9cf7f1c6; version=1
-        --------------------------------------------------------------------------------
-        name=BostonWeatherForecastModel; run_id=248c66a666744b4887bdeb2f9cf7f1c6; version=1
-        --------------------------------------------------------------------------------
-        name=BostonWeatherForecastModel; run_id=248c66a666744b4887bdeb2f9cf7f1c6; version=1
-        name=CordobaWeatherForecastModel; run_id=248c66a666744b4887bdeb2f9cf7f1c6; version=1
-
-    """
-
-    def pagination_wrapper_func(number_to_get, next_page_token):
-        return MlflowClient().search_registered_models(
-            max_results=number_to_get,
-            filter_string=filter_string,
-            order_by=order_by,
-            page_token=next_page_token,
-        )
-
-    return get_results_from_paginated_fn(
-        pagination_wrapper_func,
-        SEARCH_REGISTERED_MODEL_MAX_RESULTS_DEFAULT,
         max_results,
     )
 


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #7428 

## What changes are proposed in this pull request?

This PR just moves the fluent `search_registered_models` in `mlflow/tracking/_model_registry/fluent.py` as it's a function for model registry.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
