### PR TITLE
Add custom `use-f-string` rule

### DIFF
--- a/pylint_plugins/__init__.py
+++ b/pylint_plugins/__init__.py
@@ -1,6 +1,7 @@
 from .pytest_raises_checker import PytestRaisesChecker
 from .print_function import PrintFunction
 from .unittest_assert_raises import UnittestAssertRaises
+from .string_checker import StringChecker
 from .set_checker import SetChecker
 
 
@@ -9,3 +10,4 @@ def register(linter):
     linter.register_checker(PrintFunction(linter))
     linter.register_checker(UnittestAssertRaises(linter))
     linter.register_checker(SetChecker(linter))
+    linter.register_checker(StringChecker(linter))

--- a/pylint_plugins/__init__.py
+++ b/pylint_plugins/__init__.py
@@ -1,7 +1,7 @@
 from .pytest_raises_checker import PytestRaisesChecker
 from .print_function import PrintFunction
 from .unittest_assert_raises import UnittestAssertRaises
-from .string_checker import StringChecker
+from .string_checker import StringChecker  # pylint: disable=unused-import
 from .set_checker import SetChecker
 
 
@@ -10,4 +10,4 @@ def register(linter):
     linter.register_checker(PrintFunction(linter))
     linter.register_checker(UnittestAssertRaises(linter))
     linter.register_checker(SetChecker(linter))
-    linter.register_checker(StringChecker(linter))
+    # linter.register_checker(StringChecker(linter))

--- a/pylint_plugins/errors.py
+++ b/pylint_plugins/errors.py
@@ -64,5 +64,5 @@ USE_F_STRING = Message(
     id="W0006",
     name="use-f-string",
     message="Use f-string instead of format",
-    reason='`f"{foo} bar"` is simpler than `"{} bar".format(foo)`',
+    reason='`f"{foo} bar"` is simpler and faster than `"{} bar".format(foo)`',
 )

--- a/pylint_plugins/errors.py
+++ b/pylint_plugins/errors.py
@@ -59,3 +59,10 @@ USE_SET_LITERAL = Message(
     ),
     reason="`{1, 2}` is more efficient than `set([1, 2])`.",
 )
+
+USE_F_STRING = Message(
+    id="W0006",
+    name="use-f-string",
+    message="Use f-string instead of format",
+    reason='`f"{foo} bar"` is simpler than `"{} bar".format(foo)`',
+)

--- a/pylint_plugins/string_checker.py
+++ b/pylint_plugins/string_checker.py
@@ -8,7 +8,7 @@ from .errors import USE_F_STRING, to_msgs
 class StringChecker(BaseChecker):
     __implements__ = IAstroidChecker
 
-    name = "set-checker"
+    name = "string-checker"
     msgs = to_msgs(USE_F_STRING)
     priority = -1
 
@@ -21,6 +21,7 @@ class StringChecker(BaseChecker):
         ):
             if node.kwargs or node.starargs:
                 return
+
             if all(isinstance(a, astroid.Name) for a in node.args) and all(
                 isinstance(kw.value, astroid.Name) for kw in node.keywords
             ):

--- a/pylint_plugins/string_checker.py
+++ b/pylint_plugins/string_checker.py
@@ -1,0 +1,27 @@
+import astroid
+from pylint.interfaces import IAstroidChecker
+from pylint.checkers import BaseChecker
+
+from .errors import USE_F_STRING, to_msgs
+
+
+class StringChecker(BaseChecker):
+    __implements__ = IAstroidChecker
+
+    name = "set-checker"
+    msgs = to_msgs(USE_F_STRING)
+    priority = -1
+
+    def visit_call(self, node: astroid.Call):
+        if (
+            isinstance(node.func, astroid.Attribute)
+            and node.func.attrname == "format"
+            and isinstance(node.func.expr, astroid.Const)
+            and isinstance(node.func.expr.value, str)
+        ):
+            if node.kwargs or node.starargs:
+                return
+            if all(isinstance(a, astroid.Name) for a in node.args) and all(
+                isinstance(kw.value, astroid.Name) for kw in node.keywords
+            ):
+                self.add_message(USE_F_STRING.name, node=node)

--- a/pylint_plugins/tests/test_string_checker.py
+++ b/pylint_plugins/tests/test_string_checker.py
@@ -14,7 +14,7 @@ def test_case():
     return test_case
 
 
-def test_unittest_assert_raises(test_case):
+def test_use_f_string(test_case):
     node = astroid.extract_node('"{} {}".format(a, b)')
     with test_case.assertAddsMessages(
         MessageTest(errors.USE_F_STRING.name, node=node, line=1, col_offset=0)
@@ -25,6 +25,14 @@ def test_unittest_assert_raises(test_case):
     with test_case.assertAddsMessages(
         MessageTest(errors.USE_F_STRING.name, node=node, line=1, col_offset=0)
     ):
+        test_case.walk(node)
+
+    node = astroid.extract_node('"{} {} {}".format(*a)')
+    with test_case.assertNoMessages():
+        test_case.walk(node)
+
+    node = astroid.extract_node('"{a} {b}".format(**a)')
+    with test_case.assertNoMessages():
         test_case.walk(node)
 
     node = astroid.extract_node('"{}".format(func())')

--- a/pylint_plugins/tests/test_string_checker.py
+++ b/pylint_plugins/tests/test_string_checker.py
@@ -1,0 +1,36 @@
+import pytest
+import astroid
+from pylint.testutils import MessageTest, CheckerTestCase
+from pylint_plugins import StringChecker, errors
+
+
+@pytest.fixture(scope="module")
+def test_case():
+    class TestUnittestAssertRaises(CheckerTestCase):
+        CHECKER_CLASS = StringChecker
+
+    test_case = TestUnittestAssertRaises()
+    test_case.setup_method()
+    return test_case
+
+
+def test_unittest_assert_raises(test_case):
+    node = astroid.extract_node('"{} {}".format(a, b)')
+    with test_case.assertAddsMessages(
+        MessageTest(errors.USE_F_STRING.name, node=node, line=1, col_offset=0)
+    ):
+        test_case.walk(node)
+
+    node = astroid.extract_node('"{a} {b}".format(a=a, b=b)')
+    with test_case.assertAddsMessages(
+        MessageTest(errors.USE_F_STRING.name, node=node, line=1, col_offset=0)
+    ):
+        test_case.walk(node)
+
+    node = astroid.extract_node('"{}".format(func())')
+    with test_case.assertNoMessages():
+        test_case.walk(node)
+
+    node = astroid.extract_node('"{}".format(a.b)')
+    with test_case.assertNoMessages():
+        test_case.walk(node)


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

https://github.com/mlflow/mlflow/issues/7205#issuecomment-1340271489

## What changes are proposed in this pull request?

Add a custom pylint rule that enforces the following style 

```python
# bad
"{}_{}".format(a, b)  # should be f"{a}_{b}"

# bad
"{a}_{b}".format(a=a, b=b)  # should be f"{a}_{b}"

# good: f-string might decrease readability
"{}_{}".format(a.b, c.d)

# good: f-string might decrease readability
"{}_{}".format(a(), c())
```

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
