### PR TITLE
Fix test failures for deprecations in scikit-learn 1.20.0

### DIFF
--- a/examples/pytorch/BertNewsClassification/conda.yaml
+++ b/examples/pytorch/BertNewsClassification/conda.yaml
@@ -5,7 +5,7 @@ dependencies:
   - pip
   - pip:
       - mlflow
-      - sklearn
+      - scikit-learn
       - cloudpickle==1.6.0
       - boto3
       - transformers>=4.0.0

--- a/examples/pytorch/BertNewsClassification/python_env.yaml
+++ b/examples/pytorch/BertNewsClassification/python_env.yaml
@@ -3,7 +3,7 @@ build_dependencies:
   - pip
 dependencies:
   - mlflow
-  - sklearn
+  - scikit-learn
   - cloudpickle==1.6.0
   - boto3
   - transformers>=4.0.0

--- a/tests/shap/test_log.py
+++ b/tests/shap/test_log.py
@@ -40,22 +40,20 @@ def test_sklearn_log_explainer():
 
         run_id = run.info.run_id
 
-        housing = fetch_california_housing(as_frame=True)
-        training_df = housing.data
-        target = housing.target
+        X, y = fetch_california_housing(as_frame=True, return_X_y=True)
 
         model = sklearn.ensemble.RandomForestRegressor(n_estimators=100)
-        model.fit(training_df, target)
+        model.fit(X, y)
 
-        explainer_original = shap.Explainer(model.predict, training_df, algorithm="permutation")
-        shap_values_original = explainer_original(training_df[:5])
+        explainer_original = shap.Explainer(model.predict, X, algorithm="permutation")
+        shap_values_original = explainer_original(X[:5])
 
         mlflow.shap.log_explainer(explainer_original, "test_explainer")
 
         explainer_uri = "runs:/" + run_id + "/test_explainer"
 
         explainer_loaded = mlflow.shap.load_explainer(explainer_uri)
-        shap_values_new = explainer_loaded(training_df[:5])
+        shap_values_new = explainer_loaded(X[:5])
 
         explainer_path = _download_artifact_from_uri(artifact_uri=explainer_uri)
         flavor_conf = _get_flavor_configuration(
@@ -79,15 +77,13 @@ def test_sklearn_log_explainer_self_serialization():
 
         run_id = run.info.run_id
 
-        housing = fetch_california_housing(as_frame=True)
-        training_df = housing.data
-        target = housing.target
+        X, y = fetch_california_housing(as_frame=True, return_X_y=True)
 
         model = sklearn.ensemble.RandomForestRegressor(n_estimators=100)
-        model.fit(training_df, target)
+        model.fit(X, y)
 
-        explainer_original = shap.Explainer(model.predict, training_df, algorithm="permutation")
-        shap_values_original = explainer_original(training_df[:5])
+        explainer_original = shap.Explainer(model.predict, X, algorithm="permutation")
+        shap_values_original = explainer_original(X[:5])
 
         mlflow.shap.log_explainer(
             explainer_original, "test_explainer", serialize_model_using_mlflow=False
@@ -96,7 +92,7 @@ def test_sklearn_log_explainer_self_serialization():
         explainer_uri = "runs:/" + run_id + "/test_explainer"
 
         explainer_loaded = mlflow.shap.load_explainer("runs:/" + run_id + "/test_explainer")
-        shap_values_new = explainer_loaded(training_df[:5])
+        shap_values_new = explainer_loaded(X[:5])
 
         explainer_path = _download_artifact_from_uri(artifact_uri=explainer_uri)
         flavor_conf = _get_flavor_configuration(
@@ -121,20 +117,18 @@ def test_sklearn_log_explainer_pyfunc():
 
         run_id = run.info.run_id
 
-        housing = fetch_california_housing(as_frame=True)
-        training_df = housing.data
-        target = housing.target
+        X, y = fetch_california_housing(as_frame=True, return_X_y=True)
 
         model = sklearn.ensemble.RandomForestRegressor(n_estimators=100)
-        model.fit(training_df, target)
+        model.fit(X, y)
 
-        explainer_original = shap.Explainer(model.predict, training_df, algorithm="permutation")
-        shap_values_original = explainer_original(training_df[:2])
+        explainer_original = shap.Explainer(model.predict, X, algorithm="permutation")
+        shap_values_original = explainer_original(X[:2])
 
         mlflow.shap.log_explainer(explainer_original, "test_explainer")
 
         explainer_pyfunc = mlflow.pyfunc.load_model("runs:/" + run_id + "/test_explainer")
-        shap_values_new = explainer_pyfunc.predict(training_df[:2])
+        shap_values_new = explainer_pyfunc.predict(X[:2])
 
         np.testing.assert_allclose(shap_values_original.values, shap_values_new, rtol=100, atol=100)
 
@@ -163,20 +157,18 @@ def test_log_explanation_doesnt_create_autologged_run():
 
 def test_load_pyfunc(tmpdir):
 
-    housing = fetch_california_housing(as_frame=True)
-    training_df = housing.data
-    target = housing.target
+    X, y = fetch_california_housing(as_frame=True, return_X_y=True)
 
     model = sklearn.ensemble.RandomForestRegressor(n_estimators=100)
-    model.fit(training_df, target)
+    model.fit(X, y)
 
-    explainer_original = shap.Explainer(model.predict, training_df, algorithm="permutation")
-    shap_values_original = explainer_original(training_df[:2])
+    explainer_original = shap.Explainer(model.predict, X, algorithm="permutation")
+    shap_values_original = explainer_original(X[:2])
     path = tmpdir.join("pyfunc_test").strpath
     mlflow.shap.save_explainer(explainer_original, path)
 
     explainer_pyfunc = mlflow.shap._load_pyfunc(path)
-    shap_values_new = explainer_pyfunc.predict(training_df[:2])
+    shap_values_new = explainer_pyfunc.predict(X[:2])
 
     np.testing.assert_allclose(shap_values_original.values, shap_values_new, rtol=100, atol=100)
 
@@ -323,14 +315,12 @@ def create_identity_function():
 
 
 def test_pyfunc_serve_and_score():
-    housing = fetch_california_housing(as_frame=True)
-    training_df = housing.data
-    target = housing.target
+    X, y = fetch_california_housing(as_frame=True, return_X_y=True)
 
-    reg = sklearn.ensemble.RandomForestRegressor(n_estimators=10).fit(training_df, target)
+    reg = sklearn.ensemble.RandomForestRegressor(n_estimators=10).fit(X, y)
     model = shap.Explainer(
         reg.predict,
-        masker=training_df,
+        masker=X,
         algorithm="permutation",
         # `link` defaults to `shap.links.identity` which is decorated by `numba.jit` and causes
         # the following error when loading the explainer for serving:
@@ -348,12 +338,12 @@ def test_pyfunc_serve_and_score():
 
     resp = pyfunc_serve_and_score_model(
         model_uri,
-        data=pd.DataFrame(training_df[:3]),
+        data=pd.DataFrame(X[:3]),
         content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
     )
     decoded_json = json.loads(resp.content.decode("utf-8"))
     scores = pd.DataFrame(data=decoded_json["predictions"]).values
-    np.testing.assert_allclose(scores, model(training_df[:3]).values, rtol=100, atol=100)
+    np.testing.assert_allclose(scores, model(X[:3]).values, rtol=100, atol=100)
 
 
 def test_log_model_with_code_paths(shap_model):


### PR DESCRIPTION
Signed-off-by: Ben Wilson <benjamin.wilson@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Remove references to `sklearn` from pip install targets.
Remove usage of `boston housing dataset` as it is removed from scikit-learn.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [X] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
