### PR TITLE
Add runs search aliases for run name and start time to correspond to UI column names

### DIFF
--- a/docs/source/search-runs.rst
+++ b/docs/source/search-runs.rst
@@ -41,13 +41,13 @@ Example Expressions
 
     attributes.status = "FAILED"
 
-- Search for runs created after UNIX timestamp ``1640502832``.
+- Search for runs created after UNIX timestamp ``1670628787527``.
 
   .. code-block:: sql
 
-    attributes.created > 1640502832
-    attributes.Created > 1640502832
-    attributes.start_time > 1640502832
+    attributes.created > 1670628787527
+    attributes.Created > 1670628787527
+    attributes.start_time > 1670628787527
 
 - Search for the subset of runs with F1 score greater than 0.5.
 

--- a/docs/source/search-runs.rst
+++ b/docs/source/search-runs.rst
@@ -88,6 +88,8 @@ Run Attributes
 
 You can search using the following run attributes contained in :py:class:`mlflow.entities.RunInfo`: ``run_id``, ``run_name``, ``status``, ``artifact_uri``, ``user_id``, ``start_time`` and ``end_time``. The ``run_id``, ``run_name``, ``status``, ``user_id`` and ``artifact_uri`` attributes have string values, while ``start_time`` and ``end_time`` are numeric. Other fields in ``mlflow.entities.RunInfo`` are not searchable.
 
+``Run name``, ``Run Name`` and ``run name`` are aliases for ``run_name``. ``created`` and ``Created`` are aliases for ``start_time``.
+
 .. note::
 
   - The experiment ID is implicitly selected by the search API.

--- a/docs/source/search-runs.rst
+++ b/docs/source/search-runs.rst
@@ -35,12 +35,19 @@ Example Expressions
 
     attributes.status = "FINISHED"
 
-
 - Search for all failed runs.
 
   .. code-block:: sql
 
     attributes.status = "FAILED"
+
+- Search for runs created after UNIX timestamp ``1640502832``.
+
+  .. code-block:: sql
+
+    attributes.created > 1640502832
+    attributes.Created > 1640502832
+    attributes.start_time > 1640502832
 
 - Search for the subset of runs with F1 score greater than 0.5.
 
@@ -71,6 +78,9 @@ Example Expressions
   .. code-block:: sql
 
     attributes.`run_name` IN ('alpha', 'beta', 'gamma')
+    attributes.`run name` IN ('alpha', 'beta', 'gamma')
+    attributes.`Run name` IN ('alpha', 'beta', 'gamma')
+    attributes.`Run Name` IN ('alpha', 'beta', 'gamma')
 
 - Search for runs created using a Logistic Regression model, a learning rate (lambda) of 0.001, and recorded error metric under 0.05.
 

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -1257,11 +1257,10 @@ def _get_orderby_clauses(order_by_list, session):
         for order_by_clause in order_by_list:
             clause_id += 1
             (key_type, key, ascending) = SearchUtils.parse_order_by_for_search_runs(order_by_clause)
+            key = SearchUtils.translate_key_alias(key)
             if SearchUtils.is_string_attribute(
                 key_type, key, "="
             ) or SearchUtils.is_numeric_attribute(key_type, key, "="):
-                if key in ["created", "Created"]:
-                    key = "start_time"
                 order_value = getattr(SqlRun, SqlRun.get_attribute_name(key))
             else:
                 if SearchUtils.is_metric(key_type, "="):  # any valid comparator

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -1260,6 +1260,8 @@ def _get_orderby_clauses(order_by_list, session):
             if SearchUtils.is_string_attribute(
                 key_type, key, "="
             ) or SearchUtils.is_numeric_attribute(key_type, key, "="):
+                if key in ["created", "Created"]:
+                    key = "start_time"
                 order_value = getattr(SqlRun, SqlRun.get_attribute_name(key))
             else:
                 if SearchUtils.is_metric(key_type, "="):  # any valid comparator

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -1195,7 +1195,7 @@ def _get_sqlalchemy_filter_clauses(parsed, session, dialect):
         if SearchUtils.is_string_attribute(
             key_type, key_name, comparator
         ) or SearchUtils.is_numeric_attribute(key_type, key_name, comparator):
-            if key_name == "run_name":
+            if key_name in ["run_name", "run name", "Run name", "Run Name"]:
                 # Treat "attributes.run_name == <value>" as "tags.`mlflow.runName` == <value>".
                 # The name column in the runs table is empty for runs logged in MLflow <= 1.29.0.
                 key_filter = SearchUtils.get_sql_comparison_func("=", dialect)(
@@ -1208,6 +1208,9 @@ def _get_sqlalchemy_filter_clauses(parsed, session, dialect):
                     session.query(SqlTag).filter(key_filter, val_filter).subquery()
                 )
             else:
+                if key_name in ["start_time", "created", "Created"]:
+                    # Treat created and Created as aliases for start time
+                    key_name = "start_time"
                 attribute = getattr(SqlRun, SqlRun.get_attribute_name(key_name))
                 attr_filter = SearchUtils.get_sql_comparison_func(comparator, dialect)(
                     attribute, value

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -52,7 +52,7 @@ class SearchUtils:
     VALID_TAG_COMPARATORS = {"!=", "=", LIKE_OPERATOR, ILIKE_OPERATOR}
     VALID_STRING_ATTRIBUTE_COMPARATORS = {"!=", "=", LIKE_OPERATOR, ILIKE_OPERATOR, "IN", "NOT IN"}
     VALID_NUMERIC_ATTRIBUTE_COMPARATORS = VALID_METRIC_COMPARATORS
-    NUMERIC_ATTRIBUTES = {"start_time", "end_time"}
+    NUMERIC_ATTRIBUTES = {"start_time", "created", "Created", "end_time"}
     VALID_SEARCH_ATTRIBUTE_KEYS = set(RunInfo.get_searchable_attributes())
     VALID_ORDER_BY_ATTRIBUTE_KEYS = set(RunInfo.get_orderable_attributes())
     _METRIC_IDENTIFIER = "metric"

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -167,7 +167,7 @@ class SearchUtils:
     def translate_key_alias(key):
         if key in ["created", "Created"]:
             return "start_time"
-        elif key in ["run name", "Run name", "Run Name"]:
+        if key in ["run name", "Run name", "Run Name"]:
             return "run_name"
         return key
 

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -55,10 +55,9 @@ class SearchUtils:
     _BUILTIN_NUMERIC_ATTRIBUTES = {"start_time", "end_time"}
     _ALTERNATE_NUMERIC_ATTRIBUTES = {"created", "Created"}
     _ALTERNATE_STRING_ATTRIBUTES = {"run name", "Run name", "Run Name"}
-    NUMERIC_IDENTIFIERS = set(
+    NUMERIC_ATTRIBUTES = set(
         list(_BUILTIN_NUMERIC_ATTRIBUTES) + list(_ALTERNATE_NUMERIC_ATTRIBUTES)
     )
-    NUMERIC_ATTRIBUTES = {"start_time", "created", "Created", "end_time"}
     VALID_SEARCH_ATTRIBUTE_KEYS = set(
         RunInfo.get_searchable_attributes()
         + list(_ALTERNATE_NUMERIC_ATTRIBUTES)

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -55,10 +55,18 @@ class SearchUtils:
     _BUILTIN_NUMERIC_ATTRIBUTES = {"start_time", "end_time"}
     _ALTERNATE_NUMERIC_ATTRIBUTES = {"created", "Created"}
     _ALTERNATE_STRING_ATTRIBUTES = {"run name", "Run name", "Run Name"}
-    NUMERIC_IDENTIFIERS = set(list(_BUILTIN_NUMERIC_ATTRIBUTES) + list(_ALTERNATE_NUMERIC_ATTRIBUTES))
+    NUMERIC_IDENTIFIERS = set(
+        list(_BUILTIN_NUMERIC_ATTRIBUTES) + list(_ALTERNATE_NUMERIC_ATTRIBUTES)
+    )
     NUMERIC_ATTRIBUTES = {"start_time", "created", "Created", "end_time"}
-    VALID_SEARCH_ATTRIBUTE_KEYS = set(RunInfo.get_searchable_attributes() + list(_ALTERNATE_NUMERIC_ATTRIBUTES) + list(_ALTERNATE_STRING_ATTRIBUTES))
-    VALID_ORDER_BY_ATTRIBUTE_KEYS = set(RunInfo.get_orderable_attributes() + list(_ALTERNATE_NUMERIC_ATTRIBUTES))
+    VALID_SEARCH_ATTRIBUTE_KEYS = set(
+        RunInfo.get_searchable_attributes()
+        + list(_ALTERNATE_NUMERIC_ATTRIBUTES)
+        + list(_ALTERNATE_STRING_ATTRIBUTES)
+    )
+    VALID_ORDER_BY_ATTRIBUTE_KEYS = set(
+        RunInfo.get_orderable_attributes() + list(_ALTERNATE_NUMERIC_ATTRIBUTES)
+    )
     _METRIC_IDENTIFIER = "metric"
     _ALTERNATE_METRIC_IDENTIFIERS = {"metrics"}
     _PARAM_IDENTIFIER = "parameter"
@@ -155,6 +163,14 @@ class SearchUtils:
             MSSQL: mssql_comparison_func,
             MYSQL: mysql_comparison_func,
         }[dialect]
+
+    @staticmethod
+    def translate_key_alias(key):
+        if key in ["created", "Created"]:
+            return "start_time"
+        elif key in ["run name", "Run name", "Run Name"]:
+            return "run_name"
+        return key
 
     @classmethod
     def _trim_ends(cls, string_value):
@@ -433,6 +449,8 @@ class SearchUtils:
         value = sed.get("value")
         comparator = sed.get("comparator").upper()
 
+        key = SearchUtils.translate_key_alias(key)
+
         if cls.is_metric(key_type, comparator):
             lhs = run.data.metrics.get(key, None)
             value = float(value)
@@ -551,6 +569,7 @@ class SearchUtils:
     def _get_value_for_sort(cls, run, key_type, key, ascending):
         """Returns a tuple suitable to be used as a sort key for runs."""
         sort_value = None
+        key = SearchUtils.translate_key_alias(key)
         if key_type == cls._METRIC_IDENTIFIER:
             sort_value = run.data.metrics.get(key)
         elif key_type == cls._PARAM_IDENTIFIER:

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -52,9 +52,13 @@ class SearchUtils:
     VALID_TAG_COMPARATORS = {"!=", "=", LIKE_OPERATOR, ILIKE_OPERATOR}
     VALID_STRING_ATTRIBUTE_COMPARATORS = {"!=", "=", LIKE_OPERATOR, ILIKE_OPERATOR, "IN", "NOT IN"}
     VALID_NUMERIC_ATTRIBUTE_COMPARATORS = VALID_METRIC_COMPARATORS
+    _BUILTIN_NUMERIC_ATTRIBUTES = {"start_time", "end_time"}
+    _ALTERNATE_NUMERIC_ATTRIBUTES = {"created", "Created"}
+    _ALTERNATE_STRING_ATTRIBUTES = {"run name", "Run name", "Run Name"}
+    NUMERIC_IDENTIFIERS = set(list(_BUILTIN_NUMERIC_ATTRIBUTES) + list(_ALTERNATE_NUMERIC_ATTRIBUTES))
     NUMERIC_ATTRIBUTES = {"start_time", "created", "Created", "end_time"}
-    VALID_SEARCH_ATTRIBUTE_KEYS = set(RunInfo.get_searchable_attributes())
-    VALID_ORDER_BY_ATTRIBUTE_KEYS = set(RunInfo.get_orderable_attributes())
+    VALID_SEARCH_ATTRIBUTE_KEYS = set(RunInfo.get_searchable_attributes() + list(_ALTERNATE_NUMERIC_ATTRIBUTES) + list(_ALTERNATE_STRING_ATTRIBUTES))
+    VALID_ORDER_BY_ATTRIBUTE_KEYS = set(RunInfo.get_orderable_attributes() + list(_ALTERNATE_NUMERIC_ATTRIBUTES))
     _METRIC_IDENTIFIER = "metric"
     _ALTERNATE_METRIC_IDENTIFIERS = {"metrics"}
     _PARAM_IDENTIFIER = "parameter"

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -1300,7 +1300,7 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
             filter_string="attributes.Created > 2",
             run_view_type=ViewType.ACTIVE_ONLY,
         )
-        assert set([r.info.run_id for r in result]) == set([])
+assert result == []
 
     def test_weird_param_names(self):
         WEIRD_PARAM_NAME = "this is/a weird/but valid param"

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -1281,6 +1281,27 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         )
         assert [r.info.run_id for r in result] == [run_id2, run_id1]
 
+        result = fs.search_runs(
+            [exp_id],
+            filter_string="attributes.start_time > 0",
+            run_view_type=ViewType.ACTIVE_ONLY,
+        )
+        assert set([r.info.run_id for r in result]) == {run_id1, run_id2}
+
+        result = fs.search_runs(
+            [exp_id],
+            filter_string="attributes.created > 1",
+            run_view_type=ViewType.ACTIVE_ONLY,
+        )
+        assert set([r.info.run_id for r in result]) == {run_id2}
+
+        result = fs.search_runs(
+            [exp_id],
+            filter_string="attributes.Created > 2",
+            run_view_type=ViewType.ACTIVE_ONLY,
+        )
+        assert set([r.info.run_id for r in result]) == set([])
+
     def test_weird_param_names(self):
         WEIRD_PARAM_NAME = "this is/a weird/but valid param"
         fs = FileStore(self.test_root)

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -1286,7 +1286,7 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
             filter_string="attributes.start_time > 0",
             run_view_type=ViewType.ACTIVE_ONLY,
         )
-        assert set([r.info.run_id for r in result]) == {run_id1, run_id2}
+        assert {r.info.run_id for r in result]} == {run_id1, run_id2}
 
         result = fs.search_runs(
             [exp_id],

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -1286,21 +1286,21 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
             filter_string="attributes.start_time > 0",
             run_view_type=ViewType.ACTIVE_ONLY,
         )
-        assert {r.info.run_id for r in result]} == {run_id1, run_id2}
+        assert {r.info.run_id for r in result} == {run_id1, run_id2}
 
         result = fs.search_runs(
             [exp_id],
             filter_string="attributes.created > 1",
             run_view_type=ViewType.ACTIVE_ONLY,
         )
-        assert set([r.info.run_id for r in result]) == {run_id2}
+        assert [r.info.run_id for r in result] == [run_id2]
 
         result = fs.search_runs(
             [exp_id],
             filter_string="attributes.Created > 2",
             run_view_type=ViewType.ACTIVE_ONLY,
         )
-assert result == []
+        assert result == []
 
     def test_weird_param_names(self):
         WEIRD_PARAM_NAME = "this is/a weird/but valid param"

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -2221,14 +2221,14 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
             filter_string="attributes.start_time > 0",
             run_view_type=ViewType.ACTIVE_ONLY,
         )
-        assert set([r.info.run_id for r in result]) == {run_id1, run_id2}
+        assert {r.info.run_id for r in result} == {run_id1, run_id2}
 
         result = self.store.search_runs(
             [exp_id],
             filter_string="attributes.created > 1",
             run_view_type=ViewType.ACTIVE_ONLY,
         )
-        assert set([r.info.run_id for r in result]) == {run_id2}
+        assert [r.info.run_id for r in result] == [run_id2]
 
         result = self.store.search_runs(
             [exp_id],

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -2235,7 +2235,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
             filter_string="attributes.Created > 2",
             run_view_type=ViewType.ACTIVE_ONLY,
         )
-        assert set([r.info.run_id for r in result]) == set([])
+        assert result == []
 
     def test_log_batch(self):
         experiment_id = self._experiment_factory("log_batch")

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -2196,7 +2196,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
             [exp_id],
             filter_string="attributes.run_name = 'name'",
             run_view_type=ViewType.ACTIVE_ONLY,
-            order_by=["attributes.start_time DESC"]
+            order_by=["attributes.start_time DESC"],
         )
         assert [r.info.run_id for r in result] == [run_id2, run_id1]
 
@@ -2204,7 +2204,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
             [exp_id],
             filter_string="attributes.run_name = 'name'",
             run_view_type=ViewType.ACTIVE_ONLY,
-            order_by=["attributes.created ASC"]
+            order_by=["attributes.created ASC"],
         )
         assert [r.info.run_id for r in result] == [run_id1, run_id2]
 
@@ -2212,10 +2212,9 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
             [exp_id],
             filter_string="attributes.run_name = 'name'",
             run_view_type=ViewType.ACTIVE_ONLY,
-            order_by=["attributes.Created DESC"]
+            order_by=["attributes.Created DESC"],
         )
         assert [r.info.run_id for r in result] == [run_id2, run_id1]
-
 
     def test_log_batch(self):
         experiment_id = self._experiment_factory("log_batch")

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -2194,7 +2194,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
 
         result = self.store.search_runs(
             [exp_id],
-            filter_string=f"attributes.run_name = 'name'",
+            filter_string="attributes.run_name = 'name'",
             run_view_type=ViewType.ACTIVE_ONLY,
             order_by=["attributes.start_time DESC"]
         )
@@ -2202,7 +2202,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
 
         result = self.store.search_runs(
             [exp_id],
-            filter_string=f"attributes.run_name = 'name'",
+            filter_string="attributes.run_name = 'name'",
             run_view_type=ViewType.ACTIVE_ONLY,
             order_by=["attributes.created ASC"]
         )
@@ -2210,7 +2210,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
 
         result = self.store.search_runs(
             [exp_id],
-            filter_string=f"attributes.run_name = 'name'",
+            filter_string="attributes.run_name = 'name'",
             run_view_type=ViewType.ACTIVE_ONLY,
             order_by=["attributes.Created DESC"]
         )

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -2216,6 +2216,27 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         )
         assert [r.info.run_id for r in result] == [run_id2, run_id1]
 
+        result = self.store.search_runs(
+            [exp_id],
+            filter_string="attributes.start_time > 0",
+            run_view_type=ViewType.ACTIVE_ONLY,
+        )
+        assert set([r.info.run_id for r in result]) == {run_id1, run_id2}
+
+        result = self.store.search_runs(
+            [exp_id],
+            filter_string="attributes.created > 1",
+            run_view_type=ViewType.ACTIVE_ONLY,
+        )
+        assert set([r.info.run_id for r in result]) == {run_id2}
+
+        result = self.store.search_runs(
+            [exp_id],
+            filter_string="attributes.Created > 2",
+            run_view_type=ViewType.ACTIVE_ONLY,
+        )
+        assert set([r.info.run_id for r in result]) == set([])
+
     def test_log_batch(self):
         experiment_id = self._experiment_factory("log_batch")
         run_id = self._run_factory(self._get_run_configs(experiment_id)).info.run_id


### PR DESCRIPTION
Signed-off-by: Apurva Koti <apurva.koti@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Add `run_name` search aliases `run name, Run name, Run Name` and `start_time` aliases `created` and `Created`.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Searching runs by run names now work with the aliases `run name`, `Run name` and `Run Name`. Searching runs by start time now works with the aliases `created` and `Created`.

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
