### PR TITLE
Move from pkg_resources to importlib

### DIFF
--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -89,12 +89,12 @@ def _read_log_model_allowlist():
         from importlib.resources import as_file, files
 
         with as_file(files(__name__).joinpath("log_model_allowlist.txt")) as file:
-            builtin_allowlist_file = file
+            builtin_allowlist_file = file.as_posix()
     else:
         from importlib.resources import path
 
         with path(__name__, "log_model_allowlist.txt") as file:
-            builtin_allowlist_file = file
+            builtin_allowlist_file = file.as_posix()
     spark_session = _get_active_spark_session()
     if not spark_session:
         _logger.info(

--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -2,10 +2,9 @@ from collections import defaultdict, namedtuple, OrderedDict
 import logging
 import numpy as np
 import os
-from pkg_resources import resource_filename
 from urllib.parse import urlparse
 import weakref
-
+import sys
 import mlflow
 from mlflow.tracking.client import MlflowClient
 from mlflow.entities import Metric, Param
@@ -85,7 +84,17 @@ def _read_log_model_allowlist():
     """
     from mlflow.utils._spark_utils import _get_active_spark_session
 
-    builtin_allowlist_file = resource_filename(__name__, "log_model_allowlist.txt")
+    # New in 3.9: https://docs.python.org/3/library/importlib.resources.html#importlib.resources.files
+    if sys.version_info.major > 2 and sys.version_info.minor > 8:
+        from importlib.resources import as_file, files
+
+        with as_file(files(__name__).joinpath("log_model_allowlist.txt")) as file:
+            builtin_allowlist_file = file
+    else:
+        from importlib.resources import path
+
+        with path(__name__, "log_model_allowlist.txt") as file:
+            builtin_allowlist_file = file
     spark_session = _get_active_spark_session()
     if not spark_session:
         _logger.info(

--- a/mlflow/utils/autologging_utils/versioning.py
+++ b/mlflow/utils/autologging_utils/versioning.py
@@ -1,9 +1,8 @@
 import importlib
 import re
 import yaml
-
+import sys
 from packaging.version import Version, InvalidVersion
-from pkg_resources import resource_filename
 
 import mlflow
 from mlflow.utils.databricks_utils import is_in_databricks_runtime
@@ -59,7 +58,17 @@ def _strip_dev_version_suffix(version):
 
 
 def _load_version_file_as_dict():
-    version_file_path = resource_filename(mlflow.__name__, "ml-package-versions.yml")
+    # New in 3.9: https://docs.python.org/3/library/importlib.resources.html#importlib.resources.files
+    if sys.version_info.major > 2 and sys.version_info.minor > 8:
+        from importlib.resources import as_file, files
+
+        with as_file(files(mlflow).joinpath("ml-package-versions.yml")) as file:
+            version_file_path = file
+    else:
+        from importlib.resources import path
+
+        with path(mlflow, "ml-package-versions.yml") as file:
+            version_file_path = file
     with open(version_file_path) as f:
         return yaml.load(f, Loader=yaml.SafeLoader)
 

--- a/mlflow/utils/autologging_utils/versioning.py
+++ b/mlflow/utils/autologging_utils/versioning.py
@@ -63,12 +63,12 @@ def _load_version_file_as_dict():
         from importlib.resources import as_file, files
 
         with as_file(files(mlflow).joinpath("ml-package-versions.yml")) as file:
-            version_file_path = file
+            version_file_path = file.as_posix()
     else:
         from importlib.resources import path
 
         with path(mlflow, "ml-package-versions.yml") as file:
-            version_file_path = file
+            version_file_path = file.as_posix()
     with open(version_file_path) as f:
         return yaml.load(f, Loader=yaml.SafeLoader)
 


### PR DESCRIPTION

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Moving from pkg_resources to importlib; see https://setuptools.pypa.io/en/latest/pkg_resources.html for recommendation to use importlib instead

## How is this patch tested?


- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)


## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
