### PR TITLE
Change volume of test validation data for shap logging suite

### DIFF
--- a/tests/shap/test_log.py
+++ b/tests/shap/test_log.py
@@ -31,6 +31,13 @@ def shap_model():
     return shap.Explainer(model.predict, X, algorithm="permutation")
 
 
+def get_housing_data():
+
+    X, y = fetch_california_housing(as_frame=True, return_X_y=True)
+
+    return X[:1000], y[:1000]
+
+
 def test_sklearn_log_explainer():
     """
     Tests mlflow.shap log_explainer with mlflow serialization of the underlying model
@@ -40,7 +47,7 @@ def test_sklearn_log_explainer():
 
         run_id = run.info.run_id
 
-        X, y = fetch_california_housing(as_frame=True, return_X_y=True)
+        X, y = get_housing_data()
 
         model = sklearn.ensemble.RandomForestRegressor(n_estimators=100)
         model.fit(X, y)
@@ -77,7 +84,7 @@ def test_sklearn_log_explainer_self_serialization():
 
         run_id = run.info.run_id
 
-        X, y = fetch_california_housing(as_frame=True, return_X_y=True)
+        X, y = get_housing_data()
 
         model = sklearn.ensemble.RandomForestRegressor(n_estimators=100)
         model.fit(X, y)
@@ -117,7 +124,7 @@ def test_sklearn_log_explainer_pyfunc():
 
         run_id = run.info.run_id
 
-        X, y = fetch_california_housing(as_frame=True, return_X_y=True)
+        X, y = get_housing_data()
 
         model = sklearn.ensemble.RandomForestRegressor(n_estimators=100)
         model.fit(X, y)
@@ -157,7 +164,7 @@ def test_log_explanation_doesnt_create_autologged_run():
 
 def test_load_pyfunc(tmpdir):
 
-    X, y = fetch_california_housing(as_frame=True, return_X_y=True)
+    X, y = get_housing_data()
 
     model = sklearn.ensemble.RandomForestRegressor(n_estimators=100)
     model.fit(X, y)
@@ -315,7 +322,7 @@ def create_identity_function():
 
 
 def test_pyfunc_serve_and_score():
-    X, y = fetch_california_housing(as_frame=True, return_X_y=True)
+    X, y = get_housing_data()
 
     reg = sklearn.ensemble.RandomForestRegressor(n_estimators=10).fit(X, y)
     model = shap.Explainer(


### PR DESCRIPTION
Signed-off-by: Ben Wilson <benjamin.wilson@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Reduce test data volume to speed up unit tests

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [X] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
