### PR TITLE
Added getRegisteredModel method to Java MlflowClient (#6602)

### DIFF
--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -834,6 +834,22 @@ public class MlflowClient implements Serializable, Closeable {
   }
 
   /**
+   *  Returns a RegisteredModel from the model registry for the given model name.
+   *   <pre>
+   *       import org.mlflow.api.proto.ModelRegistry.RegisteredModel;
+   *       RegisteredModel registeredModel = getRegisteredModel("model");
+   *   </pre>
+   *
+   * @param modelName Name of the containing registered model. *
+   * @return a registered model {@link org.mlflow.api.proto.ModelRegistry.RegisteredModel}
+   */
+  public RegisteredModel getRegisteredModel(String modelName) {
+    String json = sendGet(mapper.makeGetRegisteredModel(modelName));
+    GetRegisteredModel.Response response = mapper.toGetRegisteredModelResponse(json);
+    return response.getRegisteredModel();
+  }
+
+  /**
    * Return the model URI containing for the given model version. The model URI can be used
    * to download the model version artifacts.
    *

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowProtobufMapper.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowProtobufMapper.java
@@ -160,6 +160,17 @@ class MlflowProtobufMapper {
     return print(builder);
   }
 
+  String makeGetRegisteredModel(String modelName) {
+    try {
+      return new URIBuilder("registered-models/get")
+          .addParameter("name", modelName)
+          .build()
+          .toString();
+    } catch (URISyntaxException e) {
+      throw new MlflowClientException("Failed to construct request URI for get model version.", e);
+    }
+  }
+
   String makeGetModelVersion(String modelName, String modelVersion) {
     try {
       return new URIBuilder("model-versions/get")
@@ -244,6 +255,12 @@ class MlflowProtobufMapper {
 
   GetModelVersion.Response toGetModelVersionResponse(String json) {
     GetModelVersion.Response.Builder builder = GetModelVersion.Response.newBuilder();
+    merge(json, builder);
+    return builder.build();
+  }
+
+  GetRegisteredModel.Response toGetRegisteredModelResponse(String json) {
+    GetRegisteredModel.Response.Builder builder = GetRegisteredModel.Response.newBuilder();
     merge(json, builder);
     return builder.build();
   }

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/ModelRegistryMlflowClientTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/ModelRegistryMlflowClientTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.UUID;
 import org.apache.commons.io.FileUtils;
 import org.mlflow.api.proto.ModelRegistry.ModelVersion;
+import org.mlflow.api.proto.ModelRegistry.RegisteredModel;
 import org.mlflow.api.proto.Service.RunInfo;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
@@ -106,6 +107,13 @@ public class ModelRegistryMlflowClientTest {
     @Test(expectedExceptions = MlflowHttpException.class, expectedExceptionsMessageRegExp = ".*RESOURCE_DOES_NOT_EXIST.*")
     public void testGetModelVersion_NotFound() {
         client.getModelVersion(modelName, "2");
+    }
+
+    @Test
+    public void testGetRegisteredModel() {
+	RegisteredModel model = client.getRegisteredModel(modelName);
+	Assert.assertEquals(model.getName(), modelName);
+	validateDetailedModelVersion(model.getLatestVersions(0), modelName, "Staging", "1" );
     }
 
     @Test


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

Close https://github.com/mlflow/mlflow/issues/6602

## What changes are proposed in this pull request?

Adds getRegisteredModel in Java MlflowClient to provide a way to get a registered model in Java API.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

Added new unit test for loading from test model registry: loads name, ModelVersions correctly.

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

Added getRegisteredModel method to Java MlflowClient (#6602)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [X] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [X] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
