### PR TITLE
Support Model.load() from remote locations

### DIFF
--- a/mlflow/artifacts/__init__.py
+++ b/mlflow/artifacts/__init__.py
@@ -72,12 +72,12 @@ def load_text(artifact_uri: str) -> str:
     :return: str
 
     .. code-block:: python
-        :caption: Example
+        :caption: example
 
         import mlflow
         with mlflow.start_run() as run:
             artifact_uri = run.info.artifact_uri
-            mlflow.log_text("This is a sentence", "file.txt")
+            mlflow.log_text("this is a sentence", "file.txt")
             file_content = mlflow.artifacts.load_text(artifact_uri + "/file.txt")
             print(file_content)
 

--- a/mlflow/artifacts/__init__.py
+++ b/mlflow/artifacts/__init__.py
@@ -72,12 +72,12 @@ def load_text(artifact_uri: str) -> str:
     :return: str
 
     .. code-block:: python
-        :caption: example
+        :caption: Example
 
         import mlflow
         with mlflow.start_run() as run:
             artifact_uri = run.info.artifact_uri
-            mlflow.log_text("this is a sentence", "file.txt")
+            mlflow.log_text("This is a sentence", "file.txt")
             file_content = mlflow.artifacts.load_text(artifact_uri + "/file.txt")
             print(file_content)
 

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -10,6 +10,7 @@ import uuid
 from typing import Any, Dict, Optional, Union, Callable
 
 import mlflow
+from mlflow.artifacts import download_artifacts
 from mlflow.exceptions import MlflowException
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.utils.file_utils import TempDir
@@ -295,7 +296,27 @@ class Model:
 
     @classmethod
     def load(cls, path):
-        """Load a model from its YAML representation."""
+        """
+        Load a model from its YAML representation.
+
+        :param path: A local filesystem path or URI referring to the MLmodel YAML file
+                     representation of the :py:ref:`Model` object or to the directory containing
+                     the MLmodel YAML file representation.
+        :return: An instance of :py:ref:`Model`
+
+
+        .. code-block:: python
+            :caption: example
+
+            from mlflow.models import Model
+
+            # Load the Model object from a local MLmodel file
+            model1 = Model.load("~/path/to/my/MLmodel")
+
+            # Load the Model object from a remote model directory
+            model2 = Model.load("s3://mybucket/path/to/my/model")
+        """
+        path = download_artifacts(artifact_uri=path)
         if os.path.isdir(path):
             path = os.path.join(path, MLMODEL_FILE_NAME)
         with open(path) as f:

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -300,9 +300,9 @@ class Model:
         Load a model from its YAML representation.
 
         :param path: A local filesystem path or URI referring to the MLmodel YAML file
-                     representation of the :py:ref:`Model` object or to the directory containing
+                     representation of the :py:class:`Model` object or to the directory containing
                      the MLmodel YAML file representation.
-        :return: An instance of :py:ref:`Model`
+        :return: An instance of :py:class:`Model`.
 
 
         .. code-block:: python

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -97,8 +97,11 @@ def test_model_load_remote(tmp_path, mock_s3_bucket):
     artifact_repo = S3ArtifactRepository(artifact_root)
     artifact_repo.log_artifact(str(model_path))
 
-    model_reloaded = Model.load(f"{artifact_root}/MLmodel")
-    assert model_reloaded == model
+    model_reloaded_1 = Model.load(f"{artifact_root}/MLmodel")
+    assert model_reloaded_1 == model
+
+    model_reloaded_2 = Model.load(artifact_root)
+    assert model_reloaded_2 == model
 
 
 class TestFlavor:

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -10,6 +10,7 @@ from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.models import Model, infer_signature, validate_schema
 from mlflow.models.signature import ModelSignature
 from mlflow.models.utils import _save_example
+from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
 from mlflow.types.schema import Schema, ColSpec, TensorSpec
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils.model_utils import _validate_and_prepare_target_save_path
@@ -76,6 +77,28 @@ def test_model_save_load():
     assert m == o
     assert m.to_json() == o.to_json()
     assert m.to_yaml() == o.to_yaml()
+
+
+def test_model_load_remote(tmp_path, mock_s3_bucket):
+    model = Model(
+        artifact_path="some/path",
+        run_id="123",
+        flavors={"flavor1": {"a": 1, "b": 2}, "flavor2": {"x": 1, "y": 2}},
+        signature=ModelSignature(
+            inputs=Schema([ColSpec("integer", "x"), ColSpec("integer", "y")]),
+            outputs=Schema([ColSpec(name=None, type="double")]),
+        ),
+        saved_input_example_info={"x": 1, "y": 2},
+    )
+    model_path = tmp_path / "MLmodel"
+    model.save(model_path)
+
+    artifact_root = f"s3://{mock_s3_bucket}"
+    artifact_repo = S3ArtifactRepository(artifact_root)
+    artifact_repo.log_artifact(str(model_path))
+
+    model_reloaded = Model.load(f"{artifact_root}/MLmodel")
+    assert model_reloaded == model
 
 
 class TestFlavor:


### PR DESCRIPTION
Signed-off-by: dbczumar <corey.zumar@databricks.com>

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Support Model.load() from remote locations

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

Extended the `Model.load()` API to support loading model information from remote locations

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
