### PR TITLE
Add doc for PyFuncModel and spark_udf supporting multi-dimensional array input

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -2335,6 +2335,8 @@ column 'b' containing arrays of length 20, then invoke the UDF like following ex
     # Assuming the model requires input 'a' of shape (-1, 2, 3) and input 'b' of shape (-1, 4, 5)
     model_path = <path-to-model-requiring-multidimensional-inputs>
     pyfunc_udf = mlflow.pyfunc.spark_udf(spark, model_path)
+    # The `spark_df` has column 'a' containing arrays of length 6 and
+    # column 'b' containing arrays of length 20
     df = spark_df.withColumn("prediction", pyfunc_udf(struct('a', 'b')))
 
 The resulting UDF is based on Spark's Pandas UDF and is currently limited to producing either a single

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -2317,8 +2317,9 @@ dataframe's column names must match the model signature's column names.
     pyfunc_udf = mlflow.pyfunc.spark_udf(spark, <path-to-model-with-signature>)
     df = spark_df.withColumn("prediction", pyfunc_udf())
 
-If a model requires multi-dimensional data input, you need to pass a column of array type
-as a corresponding UDF argument, the column values must be one dimension arrays and the
+If a model contains a signature with tensor spec inputs,
+you need to pass a column of array type as a corresponding UDF argument,
+the column values must be one dimension arrays and the
 UDF will reshape the column values to the required shape with C_CONTIGUOUS (row-major)
 order and cast the values as the required tensor spec type. For example, assuming a model
 requires input 'a' of shape (-1, 2, 3) and input 'b' of shape (-1, 4, 5), then we need to

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -2317,6 +2317,26 @@ dataframe's column names must match the model signature's column names.
     pyfunc_udf = mlflow.pyfunc.spark_udf(spark, <path-to-model-with-signature>)
     df = spark_df.withColumn("prediction", pyfunc_udf())
 
+If a model requires multi-dimensional data input, you need to pass a column of array type
+as a corresponding UDF argument, the column values must be one dimension arrays and the
+UDF will reshape the column values to the required shape with C_CONTIGUOUS (row-major)
+order and cast the values as the required tensor spec type. For example, assuming a model
+requires input 'a' of shape (-1, 2, 3) and input 'b' of shape (-1, 4, 5), then we need to
+prepare an inference spark dataframe with column 'a' containing arrays of length 6 and
+column 'b' containing arrays of length 20, then invoke the UDF like following example code.
+
+.. rubric:: Example
+
+.. code-block:: py
+
+    from pyspark.sql import SparkSession
+
+    spark = SparkSession.builder.getOrCreate()
+    # Assuming the model requires input 'a' of shape (-1, 2, 3) and input 'b' of shape (-1, 4, 5)
+    model_path = <path-to-model-requiring-multidimensional-inputs>
+    pyfunc_udf = mlflow.pyfunc.spark_udf(spark, model_path)
+    df = spark_df.withColumn("prediction", pyfunc_udf(struct('a', 'b')))
+
 The resulting UDF is based on Spark's Pandas UDF and is currently limited to producing either a single
 value, an array of values, or a struct containing multiple field values
 of the same type per observation. By default, we return the first

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -2318,13 +2318,15 @@ dataframe's column names must match the model signature's column names.
     df = spark_df.withColumn("prediction", pyfunc_udf())
 
 If a model contains a signature with tensor spec inputs,
-you need to pass a column of array type as a corresponding UDF argument,
-the column values must be one dimension arrays and the
-UDF will reshape the column values to the required shape with C_CONTIGUOUS (row-major)
-order and cast the values as the required tensor spec type. For example, assuming a model
-requires input 'a' of shape (-1, 2, 3) and input 'b' of shape (-1, 4, 5), then we need to
-prepare an inference spark dataframe with column 'a' containing arrays of length 6 and
-column 'b' containing arrays of length 20, then invoke the UDF like following example code.
+you will need to pass a column of array type as a corresponding UDF argument.
+The values in this column must be comprised of one-dimensional arrays. The
+UDF will reshape the array values to the required shape with 'C' order
+(i.e. read / write the elements using C-like index order) and cast the values
+as the required tensor spec type. For example, assuming a model
+requires input 'a' of shape (-1, 2, 3) and input 'b' of shape (-1, 4, 5). In order to
+perform inference on this data, we need to prepare a Spark DataFrame with column 'a'
+containing arrays of length 6 and column 'b' containing arrays of length 20. We can then
+invoke the UDF like following example code:
 
 .. rubric:: Example
 

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -401,9 +401,9 @@ class PyFuncModel:
                      `numpy.ndarray`, `List[numpy.ndarray]`, `Dict[str, numpy.ndarray]` or
                      `pandas.DataFrame`. If data is of `pandas.DataFrame` type and an input field
                      requires multidimensional array input, the corresponding column values in
-                     the pandas DataFrame will be reshaped to the required shape with C_CONTIGUOUS
-                     (row-major) order, and DataFrame column values will be cast as the required
-                     tensor spec type.
+                     the pandas DataFrame will be reshaped to the required shape with 'C' order
+                     (i.e. read / write the elements using C-like index order), and DataFrame
+                     column values will be cast as the required tensor spec type.
 
         :return: Model predictions as one of pandas.DataFrame, pandas.Series, numpy.ndarray or list.
         """
@@ -812,10 +812,11 @@ def spark_udf(spark, model_uri, result_type="double", env_manager=_EnvManager.LO
     names given by the struct definition (e.g. when invoked as my_udf(struct('x', 'y')), the model
     will get the data as a pandas DataFrame with 2 columns 'x' and 'y').
 
-    If a model contains a signature with tensor spec inputs, you need to pass a column of array
-    type as a corresponding UDF argument, the column values must be one dimension arrays and the
-    UDF will reshape the column values to the required shape with C_CONTIGUOUS (row-major) order
-    and cast the values as the required tensor spec type.
+    If a model contains a signature with tensor spec inputs, you will need to pass a column of
+    array type as a corresponding UDF argument. The column values of which must be one dimensional
+    arrays. The UDF will reshape the column values to the required shape with 'C' order
+    (i.e. read / write the elements using C-like index order) and cast the values as the required
+    tensor spec type.
 
     If a model contains a signature, the UDF can be called without specifying column name
     arguments. In this case, the UDF will be called with column names from signature, so the

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -401,8 +401,9 @@ class PyFuncModel:
                      `numpy.ndarray`, `List[numpy.ndarray]`, `Dict[str, numpy.ndarray]` or
                      `pandas.DataFrame`. If data is of `pandas.DataFrame` type and an input field
                      requires multidimensional array input, the corresponding column values in
-                     the pandas DataFrame will be reshaped to the required shape and DataFrame
-                     column values will be cast as the required tensor spec type.
+                     the pandas DataFrame will be reshaped to the required shape with C_CONTIGUOUS
+                     (row-major) order, and DataFrame column values will be cast as the required
+                     tensor spec type.
 
         :return: Model predictions as one of pandas.DataFrame, pandas.Series, numpy.ndarray or list.
         """
@@ -809,7 +810,11 @@ def spark_udf(spark, model_uri, result_type="double", env_manager=_EnvManager.LO
     are ordinals (0, 1, ...). On some versions of Spark (3.0 and above), it is also possible to
     wrap the input in a struct. In that case, the data will be passed as a DataFrame with column
     names given by the struct definition (e.g. when invoked as my_udf(struct('x', 'y')), the model
-    will get the data as a pandas DataFrame with 2 columns 'x' and 'y').
+    will get the data as a pandas DataFrame with 2 columns 'x' and 'y'). If a model requires
+    multi-dimensional data input, you need to pass a column of array type as a corresponding UDF
+    argument, the column values must be one dimension arrays and the UDF will reshape the column
+    values to the required shape with C_CONTIGUOUS (row-major) order and cast the values as the
+    required tensor spec type.
 
     If a model contains a signature, the UDF can be called without specifying column name
     arguments. In this case, the UDF will be called with column names from signature, so the

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -810,11 +810,12 @@ def spark_udf(spark, model_uri, result_type="double", env_manager=_EnvManager.LO
     are ordinals (0, 1, ...). On some versions of Spark (3.0 and above), it is also possible to
     wrap the input in a struct. In that case, the data will be passed as a DataFrame with column
     names given by the struct definition (e.g. when invoked as my_udf(struct('x', 'y')), the model
-    will get the data as a pandas DataFrame with 2 columns 'x' and 'y'). If a model requires
-    multi-dimensional data input, you need to pass a column of array type as a corresponding UDF
-    argument, the column values must be one dimension arrays and the UDF will reshape the column
-    values to the required shape with C_CONTIGUOUS (row-major) order and cast the values as the
-    required tensor spec type.
+    will get the data as a pandas DataFrame with 2 columns 'x' and 'y').
+
+    If a model contains a signature with tensor spec inputs, you need to pass a column of array
+    type as a corresponding UDF argument, the column values must be one dimension arrays and the
+    UDF will reshape the column values to the required shape with C_CONTIGUOUS (row-major) order
+    and cast the values as the required tensor spec type.
 
     If a model contains a signature, the UDF can be called without specifying column name
     arguments. In this case, the UDF will be called with column names from signature, so the


### PR DESCRIPTION
Signed-off-by: Weichen Xu <weichen.xu@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Add doc for PyFuncModel and spark_udf supporting multi-dimensional array input

## How is this patch tested?

N/A

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [X] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
