### PR TITLE
Add support for client pagination in GetMetricHistory to the Java API

### DIFF
--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -72,10 +72,9 @@ public class MlflowClient implements Serializable, Closeable {
       .setParameter("metric_key", key)
       .setParameter("max_results", "25000");
 
-    List<Metric> metrics = new ArrayList();
     GetMetricHistory.Response response = mapper
             .toGetMetricHistoryResponse(httpCaller.get(builder.toString()));
-    metrics.addAll(response.getMetricsList());
+    List<Metric> metrics = response.getMetricsList();
     String token = response.getNextPageToken();
     while (!token.isEmpty()) {
       URIBuilder bld = builder.setParameter("page_token", token);

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -69,8 +69,22 @@ public class MlflowClient implements Serializable, Closeable {
     URIBuilder builder = newURIBuilder("metrics/get-history")
       .setParameter("run_uuid", runId)
       .setParameter("run_id", runId)
-      .setParameter("metric_key", key);
-    return mapper.toGetMetricHistoryResponse(httpCaller.get(builder.toString())).getMetricsList();
+      .setParameter("metric_key", key)
+      .setParameter("max_results", "25000");
+
+    List<Metric> metrics = new ArrayList();
+    GetMetricHistory.Response response = mapper
+            .toGetMetricHistoryResponse(httpCaller.get(builder.toString()));
+    metrics.addAll(response.getMetricsList());
+    String token = response.getNextPageToken();
+    while (!token.isEmpty()) {
+      URIBuilder bld = builder.setParameter("page_token", token);
+      GetMetricHistory.Response resp = mapper
+              .toGetMetricHistoryResponse(httpCaller.get(bld.toString()));
+      metrics.addAll(resp.getMetricsList());
+      token = resp.getNextPageToken();
+    }
+    return metrics;
   }
 
   /**

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
@@ -15,6 +15,7 @@ import java.util.Set;
 import java.util.Stack;
 import java.util.Vector;
 import java.util.stream.Collectors;
+import java.util.stream.LongStream;
 
 import com.google.common.collect.Lists;
 import org.apache.commons.io.FileUtils;
@@ -525,6 +526,20 @@ public class MlflowClientTest {
     List<RunTag> tags = run.getData().getTagsList();
     Assert.assertEquals(tags.size(), 2);
     assertTag(tags, "user_email", USER_EMAIL);
+  }
+
+  @Test
+  public void getMetricHistoryPagination() {
+    String expId = client.createExperiment("getMetricHistoryPagination");
+    RunInfo run = client.createRun(expId);
+    String runId = run.getRunUuid();
+    List<Long> steps = LongStream.range(0, 26000).boxed().collect(Collectors.toList());
+    for (Long step: steps) {
+      client.logMetric(runId, "random_metric", step, step, step);
+    }
+    List<Metric> metrics = client.getMetricHistory(runId, "random_metric");
+    List<Double> values = steps.stream().mapToDouble(x -> x).boxed().collect(Collectors.toList());
+    assertMetricHistory(metrics, "random_metric", values, steps);
   }
 
   @Test


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Add support for client pagination in GetMetricHistory to the Java API.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

1. Build a JAR on this PR.
2. Install that JAR in a cluster.
3. Run the following code.

```java
import org.mlflow.tracking.MlflowClient

val client = new MlflowClient()

client.getMetricHistory("eb0669c4a60249898b40847ee78290e0", "metric1").size()
```

<img width="889" alt="image" src="https://user-images.githubusercontent.com/17039389/208002325-26aedd93-97c6-493e-a8ed-772c7001aa17.png">

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
