### PR TITLE
Distribute model to spark executor by NFS directory instead of calling `sparkContext.addFile`

### DIFF
--- a/mlflow/utils/_spark_utils.py
+++ b/mlflow/utils/_spark_utils.py
@@ -83,11 +83,10 @@ _NFS_PATH_PREFIX = "nfs:"
 
 
 def _get_spark_distributor_nfs_cache_dir():
-    from mlflow.utils.nfs_on_spark import get_nfs_cache_root_dir  # avoid recursive importing
+    from mlflow.utils.nfs_on_spark import get_nfs_cache_root_dir  # avoid circular import
 
-    _nfs_root_dir = get_nfs_cache_root_dir()
-    if _nfs_root_dir is not None:
-        cache_dir = os.path.join(_nfs_root_dir, "mlflow_distributor_cache_dir")
+    if (nfs_root_dir := get_nfs_cache_root_dir()) is not None:
+        cache_dir = os.path.join(nfs_root_dir, "mlflow_distributor_cache_dir")
         os.makedirs(cache_dir, exist_ok=True)
         return cache_dir
     return None
@@ -112,12 +111,11 @@ class _SparkDirectoryDistributor:
         # directories when recursive=True.
         archive_path = shutil.make_archive(archive_basepath, "zip", dir_path)
 
-        nfs_cache_dir = _get_spark_distributor_nfs_cache_dir()
-        if nfs_cache_dir is not None:
+        if (nfs_cache_dir := _get_spark_distributor_nfs_cache_dir()) is not None:
             # If NFS directory (shared by all spark nodes) is available, use NFS directory
             # instead of `SparkContext.addFile` to distribute files.
-            # Because on databricks runtime, `SparkContext.addFile` has security issue and
-            # is not allowed to be called on shared cluster.
+            # Because `SparkContext.addFile` is not secure, so it is not allowed to be called
+            # on a shared cluster.
             dest_path = os.path.join(nfs_cache_dir, os.path.basename(archive_path))
             shutil.copy(archive_path, dest_path)
             return _NFS_PATH_PREFIX + dest_path
@@ -141,7 +139,7 @@ class _SparkDirectoryDistributor:
         # and Python, it turns out that we actually need to use the basename as the input to
         # SparkFiles.get(), as opposed to the (absolute) path.
         if archive_path.startswith(_NFS_PATH_PREFIX):
-            local_path = archive_path[len(_NFS_PATH_PREFIX):]
+            local_path = archive_path[len(_NFS_PATH_PREFIX) :]
         else:
             archive_path_basename = os.path.basename(archive_path)
             local_path = SparkFiles.get(archive_path_basename)


### PR DESCRIPTION
Signed-off-by: Weichen Xu <weichen.xu@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

If NFS directory (shared by all spark nodes) is available, use NFS directory instead of `SparkContext.addFile` to broadcast files.
Because on databricks runtime, `SparkContext.addFile` has security issue and is not allowed to be called on shared cluster, see databricks/runtime `JavaSparkContext.addFile` comment:
>  // WARNING(greg) 2018-09-11: We must NEVER whitelist this in production, since it allows users to 
>  // run arbitrary code as the (root) JVM user. 

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests (describe details, including test results, below)
Manually test on databricks runtime:
https://e2-dogfood.staging.cloud.databricks.com/?o=6051921418418893#notebook/795822750063471/command/795822750063490

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
