### PR TITLE
Don't load ml-package-version.yml on `import mlflow`

### DIFF
--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -28,6 +28,7 @@ from mlflow.utils.autologging_utils.versioning import (
     FLAVOR_TO_MODULE_NAME_AND_VERSION_INFO_KEY,
     get_min_max_version_and_pip_release,
     is_flavor_supported_for_associated_package_versions,
+    load_version_file_as_dict
 )
 
 # Wildcard import other autologging utilities (e.g. safety utilities, event logging utilities) used
@@ -301,8 +302,9 @@ def gen_autologging_package_version_requirements_doc(integration_name):
     :return: A document note string saying the compatibility for the specified autologging
              integration's associated package versions.
     """
+    module_version_info_dict=load_version_file_as_dict()
     _, module_key = FLAVOR_TO_MODULE_NAME_AND_VERSION_INFO_KEY[integration_name]
-    min_ver, max_ver, pip_release = get_min_max_version_and_pip_release(module_key)
+    min_ver, max_ver, pip_release = get_min_max_version_and_pip_release(module_key, module_version_info_dict)
     required_pkg_versions = f"``{min_ver}`` <= ``{pip_release}`` <= ``{max_ver}``"
 
     return (

--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -28,7 +28,7 @@ from mlflow.utils.autologging_utils.versioning import (
     FLAVOR_TO_MODULE_NAME_AND_VERSION_INFO_KEY,
     get_min_max_version_and_pip_release,
     is_flavor_supported_for_associated_package_versions,
-    load_version_file_as_dict
+    load_version_file_as_dict,
 )
 
 # Wildcard import other autologging utilities (e.g. safety utilities, event logging utilities) used
@@ -302,9 +302,11 @@ def gen_autologging_package_version_requirements_doc(integration_name):
     :return: A document note string saying the compatibility for the specified autologging
              integration's associated package versions.
     """
-    module_version_info_dict=load_version_file_as_dict()
+    module_version_info_dict = load_version_file_as_dict()
     _, module_key = FLAVOR_TO_MODULE_NAME_AND_VERSION_INFO_KEY[integration_name]
-    min_ver, max_ver, pip_release = get_min_max_version_and_pip_release(module_key, module_version_info_dict)
+    min_ver, max_ver, pip_release = get_min_max_version_and_pip_release(
+        module_key, module_version_info_dict
+    )
     required_pkg_versions = f"``{min_ver}`` <= ``{pip_release}`` <= ``{max_ver}``"
 
     return (

--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -26,9 +26,7 @@ from mlflow.utils.autologging_utils.safety import (
 )
 from mlflow.utils.autologging_utils.versioning import (
     FLAVOR_TO_MODULE_NAME_AND_VERSION_INFO_KEY,
-    get_min_max_version_and_pip_release,
     is_flavor_supported_for_associated_package_versions,
-    load_version_file_as_dict,
 )
 
 # Wildcard import other autologging utilities (e.g. safety utilities, event logging utilities) used
@@ -297,26 +295,6 @@ def batch_metrics_logger(run_id):
     batch_metrics_logger.flush()
 
 
-def gen_autologging_package_version_requirements_doc(integration_name):
-    """
-    :return: A document note string saying the compatibility for the specified autologging
-             integration's associated package versions.
-    """
-    module_version_info_dict = load_version_file_as_dict()
-    _, module_key = FLAVOR_TO_MODULE_NAME_AND_VERSION_INFO_KEY[integration_name]
-    min_ver, max_ver, pip_release = get_min_max_version_and_pip_release(
-        module_key, module_version_info_dict
-    )
-    required_pkg_versions = f"``{min_ver}`` <= ``{pip_release}`` <= ``{max_ver}``"
-
-    return (
-        "    .. Note:: Autologging is known to be compatible with the following package versions: "
-        + required_pkg_versions
-        + ". Autologging may not succeed when used with package versions outside of this range."
-        + "\n\n"
-    )
-
-
 def _check_and_log_warning_for_unsupported_package_versions(integration_name):
     """
     When autologging is enabled and `disable_for_unsupported_versions=False` for the specified
@@ -423,10 +401,6 @@ def autologging_integration(name):
         # during the execution of import hooks for `mlflow.autolog()`.
         wrapped_autolog.integration_name = name
 
-        if name in FLAVOR_TO_MODULE_NAME_AND_VERSION_INFO_KEY:
-            wrapped_autolog.__doc__ = (
-                gen_autologging_package_version_requirements_doc(name) + wrapped_autolog.__doc__
-            )
         return wrapped_autolog
 
     return wrapper

--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -26,7 +26,9 @@ from mlflow.utils.autologging_utils.safety import (
 )
 from mlflow.utils.autologging_utils.versioning import (
     FLAVOR_TO_MODULE_NAME_AND_VERSION_INFO_KEY,
+    get_min_max_version_and_pip_release,
     is_flavor_supported_for_associated_package_versions,
+    load_version_file_as_dict,
 )
 
 # Wildcard import other autologging utilities (e.g. safety utilities, event logging utilities) used
@@ -295,6 +297,26 @@ def batch_metrics_logger(run_id):
     batch_metrics_logger.flush()
 
 
+def gen_autologging_package_version_requirements_doc(integration_name):
+    """
+    :return: A document note string saying the compatibility for the specified autologging
+             integration's associated package versions.
+    """
+    _, module_key = FLAVOR_TO_MODULE_NAME_AND_VERSION_INFO_KEY[integration_name]
+    module_version_info_dict = load_version_file_as_dict()
+    min_ver, max_ver, pip_release = get_min_max_version_and_pip_release(
+        module_key, module_version_info_dict
+    )
+    required_pkg_versions = f"``{min_ver}`` <= ``{pip_release}`` <= ``{max_ver}``"
+
+    return (
+        "    .. Note:: Autologging is known to be compatible with the following package versions: "
+        + required_pkg_versions
+        + ". Autologging may not succeed when used with package versions outside of this range."
+        + "\n\n"
+    )
+
+
 def _check_and_log_warning_for_unsupported_package_versions(integration_name):
     """
     When autologging is enabled and `disable_for_unsupported_versions=False` for the specified
@@ -401,6 +423,16 @@ def autologging_integration(name):
         # during the execution of import hooks for `mlflow.autolog()`.
         wrapped_autolog.integration_name = name
 
+        try:
+            if name in FLAVOR_TO_MODULE_NAME_AND_VERSION_INFO_KEY:
+                wrapped_autolog.__doc__ = (
+                    gen_autologging_package_version_requirements_doc(name) + wrapped_autolog.__doc__
+                )
+        except Exception as e:
+            _logger.warning(
+                "Unable to load configuration for autologging; autologging may fail. %s",
+                "Exception: " + str(e),
+            )
         return wrapped_autolog
 
     return wrapper

--- a/mlflow/utils/autologging_utils/versioning.py
+++ b/mlflow/utils/autologging_utils/versioning.py
@@ -57,7 +57,7 @@ def _strip_dev_version_suffix(version):
     return re.sub(r"(\.?)dev.*", "", version)
 
 
-def _load_version_file_as_dict():
+def load_version_file_as_dict():
     # New in 3.9: https://docs.python.org/3/library/importlib.resources.html#importlib.resources.files
     if sys.version_info.major > 2 and sys.version_info.minor > 8:
         from importlib.resources import as_file, files
@@ -85,7 +85,7 @@ def is_flavor_supported_for_associated_package_versions(flavor_name):
     :return: True if the specified flavor is supported for the currently-installed versions of its
              associated packages
     """
-    module_version_info_dict = _load_version_file_as_dict()
+    module_version_info_dict = load_version_file_as_dict()
     module_name, module_key = FLAVOR_TO_MODULE_NAME_AND_VERSION_INFO_KEY[flavor_name]
     actual_version = importlib.import_module(module_name).__version__
 

--- a/mlflow/utils/autologging_utils/versioning.py
+++ b/mlflow/utils/autologging_utils/versioning.py
@@ -85,7 +85,7 @@ def is_flavor_supported_for_associated_package_versions(flavor_name):
     :return: True if the specified flavor is supported for the currently-installed versions of its
              associated packages
     """
-    module_version_info_dict=load_version_file_as_dict()
+    module_version_info_dict = load_version_file_as_dict()
     module_name, module_key = FLAVOR_TO_MODULE_NAME_AND_VERSION_INFO_KEY[flavor_name]
     actual_version = importlib.import_module(module_name).__version__
 
@@ -95,7 +95,9 @@ def is_flavor_supported_for_associated_package_versions(flavor_name):
 
     if _violates_pep_440(actual_version) or _is_pre_or_dev_release(actual_version):
         return False
-    min_version, max_version, _ = get_min_max_version_and_pip_release(module_key, module_version_info_dict)
+    min_version, max_version, _ = get_min_max_version_and_pip_release(
+        module_key, module_version_info_dict
+    )
 
     if module_name == "pyspark" and is_in_databricks_runtime():
         # MLflow 1.25.0 is known to be compatible with PySpark 3.3.0 on Databricks, despite the

--- a/mlflow/utils/autologging_utils/versioning.py
+++ b/mlflow/utils/autologging_utils/versioning.py
@@ -57,7 +57,7 @@ def _strip_dev_version_suffix(version):
     return re.sub(r"(\.?)dev.*", "", version)
 
 
-def load_version_file_as_dict():
+def _load_version_file_as_dict():
     # New in 3.9: https://docs.python.org/3/library/importlib.resources.html#importlib.resources.files
     if sys.version_info.major > 2 and sys.version_info.minor > 8:
         from importlib.resources import as_file, files
@@ -85,7 +85,7 @@ def is_flavor_supported_for_associated_package_versions(flavor_name):
     :return: True if the specified flavor is supported for the currently-installed versions of its
              associated packages
     """
-    module_version_info_dict = load_version_file_as_dict()
+    module_version_info_dict = _load_version_file_as_dict()
     module_name, module_key = FLAVOR_TO_MODULE_NAME_AND_VERSION_INFO_KEY[flavor_name]
     actual_version = importlib.import_module(module_name).__version__
 

--- a/tests/autologging/test_autologging_utils.py
+++ b/tests/autologging/test_autologging_utils.py
@@ -779,8 +779,8 @@ _module_version_info_dict_patch = {
     ],
 )
 @mock.patch(
-    "mlflow.utils.autologging_utils.versioning._module_version_info_dict",
-    _module_version_info_dict_patch,
+    "mlflow.utils.autologging_utils.versioning.load_version_file_as_dict",
+    lambda: _module_version_info_dict_patch,
 )
 def test_is_autologging_integration_supported(flavor, module_version, expected_result):
     module_name, _ = FLAVOR_TO_MODULE_NAME_AND_VERSION_INFO_KEY[flavor]
@@ -800,8 +800,8 @@ def test_is_autologging_integration_supported(flavor, module_version, expected_r
     ],
 )
 @mock.patch(
-    "mlflow.utils.autologging_utils.versioning._module_version_info_dict",
-    _module_version_info_dict_patch,
+    "mlflow.utils.autologging_utils.versioning.load_version_file_as_dict",
+    lambda: _module_version_info_dict_patch,
 )
 def test_dev_version_pyspark_is_supported_in_databricks(flavor, module_version, expected_result):
     module_name, _ = FLAVOR_TO_MODULE_NAME_AND_VERSION_INFO_KEY[flavor]
@@ -819,8 +819,8 @@ def test_dev_version_pyspark_is_supported_in_databricks(flavor, module_version, 
 
 
 @mock.patch(
-    "mlflow.utils.autologging_utils.versioning._module_version_info_dict",
-    _module_version_info_dict_patch,
+    "mlflow.utils.autologging_utils.versioning.load_version_file_as_dict",
+    lambda: _module_version_info_dict_patch,
 )
 def test_disable_for_unsupported_versions_warning_sklearn_integration():
     log_warn_fn_name = "mlflow.utils.autologging_utils._logger.warning"


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## What changes are proposed in this pull request?

Currently, https://github.com/mlflow/mlflow/blob/master/mlflow/ml-package-versions.yml is loaded on the initial `import mlflow`.  This slows down importing MLFlow, and more importantly makes MLFlow dependent on the filesystem on the system in which MLFlow is installed.  

This file is loaded here: https://github.com/mlflow/mlflow/blob/6953c364d35259937dc9587bf4dd55cc8c3d5196/mlflow/utils/autologging_utils/versioning.py#L76.  

My first change is putting this loading inside a function: https://github.com/danielhstahl/mlflow/blob/188f9672e10b007699165899176a387338b9fdf0/mlflow/utils/autologging_utils/versioning.py#L88

My second change is removing the "appending" of the version information to the autoloader docs. 
 The current MLFlow loads the ml-package-version.yml and applies the information to the docs for each supported ML framework: https://github.com/mlflow/mlflow/blob/6953c364d35259937dc9587bf4dd55cc8c3d5196/mlflow/utils/autologging_utils/__init__.py#L424.  I'm removing this completely since it has limited utility and causes slower imports and the aforementioned filesystem dependency.  

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

I imported my version of MLFlow in an environment that does not allow for importing resources and it imported correctly.

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
