### PR TITLE
convert recipies/cards to pytest

### DIFF
--- a/tests/recipes/cards/test_histogram_generator.py
+++ b/tests/recipes/cards/test_histogram_generator.py
@@ -9,412 +9,406 @@ from mlflow.recipes.cards import histogram_generator
 from google.protobuf import text_format
 
 
-class HistogramGeneratorTestCase(unittest.TestCase):
-    """Base class to test histogram_generator.py."""
-
-    def assert_histogram(
-        self,
-        expected: facet_feature_statistics_pb2.Histogram,
-        actual: facet_feature_statistics_pb2.Histogram,
-    ):
-        """
-        Helper function to assert the actual histogram is almost equal to the expected histogram.
-        """
-        assert expected.type == actual.type
-        assert len(expected.buckets) == len(actual.buckets)
-        for act_bucket, exp_bucket in zip(actual.buckets, expected.buckets):
-            assert act_bucket.low_value == pytest.approx(exp_bucket.low_value, rel=1e-2)
-            assert act_bucket.high_value == pytest.approx(exp_bucket.high_value, rel=1e-2)
-            assert act_bucket.sample_count == pytest.approx(exp_bucket.sample_count, rel=1e-2)
-
-
-class EqualHeightHistogramGeneratorTestCase(HistogramGeneratorTestCase):
+def assert_histogram(
+    expected: facet_feature_statistics_pb2.Histogram,
+    actual: facet_feature_statistics_pb2.Histogram,
+):
     """
-    Test case for histogram_generator.generate_equal_height_histogram.
+    Helper function to assert the actual histogram is almost equal to the expected histogram.
     """
-
-    def test_invalid_quantiles(self):
-        """
-        Tests generate_equal_height_histogram returns None when quantiles is invalid.
-        """
-        # Empty quantiles is invalid.
-        assert (
-            histogram_generator.generate_equal_height_histogram(quantiles=[], num_buckets=5) is None
-        )
-        # Quantiles which has less than 3 elements is invalid.
-        assert (
-            histogram_generator.generate_equal_height_histogram(quantiles=[1, 2], num_buckets=1)
-            is None
-        )
-        # When (len(quantiles) - 1) % num_buckets != 0, quantiles is considered as invalid.
-        assert (
-            histogram_generator.generate_equal_height_histogram(
-                quantiles=[1, 2, 3, 4, 5], num_buckets=3
-            )
-            is None
-        )
-
-    def test_valid_quantiles(self):
-        """
-        Tests generate_equal_height_histogram returns correct histogram.
-        """
-        quantiles = list(range(11))
-        actual_histogram = histogram_generator.generate_equal_height_histogram(
-            quantiles=quantiles, num_buckets=5
-        )
-        expected_histogram = text_format.Parse(
-            """
-            buckets {
-                low_value: 0.0
-                high_value: 2.0
-            }
-            buckets {
-                low_value: 2.0
-                high_value: 4.0
-            }
-            buckets {
-                low_value: 4.0
-                high_value: 6.0
-            }
-            buckets {
-                low_value: 6.0
-                high_value: 8.0
-            }
-            buckets {
-                low_value: 8.0
-                high_value: 10.0
-            }
-            type: QUANTILES
-            """,
-            facet_feature_statistics_pb2.Histogram(),
-        )
-        self.assert_histogram(expected_histogram, actual_histogram)
+    assert expected.type == actual.type
+    assert len(expected.buckets) == len(actual.buckets)
+    for act_bucket, exp_bucket in zip(actual.buckets, expected.buckets):
+        assert act_bucket.low_value == pytest.approx(exp_bucket.low_value, rel=1e-2)
+        assert act_bucket.high_value == pytest.approx(exp_bucket.high_value, rel=1e-2)
+        assert act_bucket.sample_count == pytest.approx(exp_bucket.sample_count, rel=1e-2)
 
 
-class EqualWidthHistogramGeneratorTestCase(HistogramGeneratorTestCase):
+def test_invalid_quantiles():
     """
-    Test case for histogram_generator.generate_equal_width_histogram.
+    Tests generate_equal_height_histogram returns None when quantiles is invalid.
     """
+    # Empty quantiles is invalid.
+    assert (
+        histogram_generator.generate_equal_height_histogram(quantiles=[], num_buckets=5) is None
+    )
+    # Quantiles which has less than 3 elements is invalid.
+    assert (
+        histogram_generator.generate_equal_height_histogram(quantiles=[1, 2], num_buckets=1)
+        is None
+    )
+    # When (len(quantiles) - 1) % num_buckets != 0, quantiles is considered as invalid.
+    assert (
+        histogram_generator.generate_equal_height_histogram(
+            quantiles=[1, 2, 3, 4, 5], num_buckets=3
+        )
+        is None
+    )
 
-    def test_uniform(self):
-        """
-        Tests the scenario where the single quantile bucket contains all histogram buckets.
 
-        Setup:
-          - the value range is [1.0, 2.0] and we request 5 buckets, so the bucket boundaries are
-          [1.0, 1.2), [1.2, 1.4), [1.4, 1.6), [1.6, 1.8), [1.8, 2.0].
-          - A single quantile bucket contains all histogram buckets. Hence, each histogram bucket
-          gets assigned 1/5 of the total quantile bucket.
+def test_valid_quantiles():
+    """
+    Tests generate_equal_height_histogram returns correct histogram.
+    """
+    quantiles = list(range(11))
+    actual_histogram = histogram_generator.generate_equal_height_histogram(
+        quantiles=quantiles, num_buckets=5
+    )
+    expected_histogram = text_format.Parse(
         """
-        quantiles = [1.0, 2.0]
-        total_freq = 100
-        num_buckets = 5
-        expected_histogram = text_format.Parse(
-            """
-            buckets {
-                low_value: 1.0
-                high_value: 1.2
-                sample_count: 20.0
-            }
-            buckets {
-                low_value: 1.2
-                high_value: 1.4
-                sample_count: 20.0
-            }
-            buckets {
-                low_value: 1.4
-                high_value: 1.6
-                sample_count: 20.0
-            }
-            buckets {
-                low_value: 1.6
-                high_value: 1.8
-                sample_count: 20.0
-            }
-            buckets {
-                low_value: 1.8
-                high_value: 2.0
-                sample_count: 20.0
-            }
-            type: STANDARD
-            """,
-            facet_feature_statistics_pb2.Histogram(),
-        )
-        actual_histogram = histogram_generator.generate_equal_width_histogram(
-            quantiles=quantiles, num_buckets=num_buckets, total_freq=total_freq
-        )
-        self.assert_histogram(expected_histogram, actual_histogram)
+        buckets {
+            low_value: 0.0
+            high_value: 2.0
+        }
+        buckets {
+            low_value: 2.0
+            high_value: 4.0
+        }
+        buckets {
+            low_value: 4.0
+            high_value: 6.0
+        }
+        buckets {
+            low_value: 6.0
+            high_value: 8.0
+        }
+        buckets {
+            low_value: 8.0
+            high_value: 10.0
+        }
+        type: QUANTILES
+        """,
+        facet_feature_statistics_pb2.Histogram(),
+    )
+    assert_histogram(expected_histogram, actual_histogram)
 
-    def test_slightly_non_uniform(self):
-        """
-        Tests multiple quantile buckets with non-uniform distribution.
 
-        Setup:
-          - Histogram buckets: [1.0, 1.2), [1.2, 1.4), [1.4, 1.6), [1.6, 1.8), [1.8, 2.0).
-          - There are two quantile buckets. The first contains the first two histogram buckets and
-          the second contains the last three histogram buckets respectively.
-        """
-        quantiles = [1.0, 1.4, 2.0]
-        total_freq = 100
-        num_buckets = 5
-        expected_histogram = text_format.Parse(
-            """
-            buckets {
-                low_value: 1.0
-                high_value: 1.2
-                sample_count: 25.0
-            }
-            buckets {
-                low_value: 1.2
-                high_value: 1.4
-                sample_count: 25.0
-            }
-            buckets {
-                low_value: 1.4
-                high_value: 1.6
-                sample_count: 16.667
-            }
-            buckets {
-                low_value: 1.6
-                high_value: 1.8
-                sample_count: 16.667
-            }
-            buckets {
-                low_value: 1.8
-                high_value: 2.0
-                sample_count: 16.667
-            }
-            type: STANDARD
-            """,
-            facet_feature_statistics_pb2.Histogram(),
-        )
-        actual_histogram = histogram_generator.generate_equal_width_histogram(
-            quantiles=quantiles, num_buckets=num_buckets, total_freq=total_freq
-        )
-        self.assert_histogram(expected_histogram, actual_histogram)
+def test_uniform():
+    """
+    Tests the scenario where the single quantile bucket contains all histogram buckets.
 
-    def test_extremely_skewed_left(self):
+    Setup:
+      - the value range is [1.0, 2.0] and we request 5 buckets, so the bucket boundaries are
+      [1.0, 1.2), [1.2, 1.4), [1.4, 1.6), [1.6, 1.8), [1.8, 2.0].
+      - A single quantile bucket contains all histogram buckets. Hence, each histogram bucket
+      gets assigned 1/5 of the total quantile bucket.
+    """
+    quantiles = [1.0, 2.0]
+    total_freq = 100
+    num_buckets = 5
+    expected_histogram = text_format.Parse(
         """
-        Tests multiple quantile buckets with distribution heavily skewed to the left side.
+        buckets {
+            low_value: 1.0
+            high_value: 1.2
+            sample_count: 20.0
+        }
+        buckets {
+            low_value: 1.2
+            high_value: 1.4
+            sample_count: 20.0
+        }
+        buckets {
+            low_value: 1.4
+            high_value: 1.6
+            sample_count: 20.0
+        }
+        buckets {
+            low_value: 1.6
+            high_value: 1.8
+            sample_count: 20.0
+        }
+        buckets {
+            low_value: 1.8
+            high_value: 2.0
+            sample_count: 20.0
+        }
+        type: STANDARD
+        """,
+        facet_feature_statistics_pb2.Histogram(),
+    )
+    actual_histogram = histogram_generator.generate_equal_width_histogram(
+        quantiles=quantiles, num_buckets=num_buckets, total_freq=total_freq
+    )
+    assert_histogram(expected_histogram, actual_histogram)
 
-        Setup:
-          - Histogram buckets: [1.0, 1.2), [1.2, 1.4), [1.4, 1.6), [1.6, 1.8), [1.8, 2.0).
-          - The distribution is "left-skewed" so that the first histogram bucket fully contains the
-          first four quantile buckets and 1/9 of the last quantile bucket. The remaining 8/9 of the
-          last quantile bucket overlap uniformly with the last four histogram buckets.
-        """
-        quantiles = [1.0, 1.01, 1.02, 1.03, 1.1, 2.0]
-        total_freq = 100
-        num_buckets = 5
-        expected_histogram = text_format.Parse(
-            """
-            buckets {
-                low_value: 1.0
-                high_value: 1.2
-                sample_count: 82.22
-            }
-            buckets {
-                low_value: 1.2
-                high_value: 1.4
-                sample_count: 4.44
-            }
-            buckets {
-                low_value: 1.4
-                high_value: 1.6
-                sample_count: 4.44
-            }
-            buckets {
-                low_value: 1.6
-                high_value: 1.8
-                sample_count: 4.44
-            }
-            buckets {
-                low_value: 1.8
-                high_value: 2.0
-                sample_count: 4.44
-            }
-            type: STANDARD
-            """,
-            facet_feature_statistics_pb2.Histogram(),
-        )
-        actual_histogram = histogram_generator.generate_equal_width_histogram(
-            quantiles=quantiles, num_buckets=num_buckets, total_freq=total_freq
-        )
-        self.assert_histogram(expected_histogram, actual_histogram)
 
-    def test_extremely_skewed_right(self):
-        """
-        Tests multiple quantile buckets with distribution heavily skewed to the right side.
+def test_slightly_non_uniform():
+    """
+    Tests multiple quantile buckets with non-uniform distribution.
 
-        Setup:
-          - Histogram buckets: [1.0, 1.2), [1.2, 1.4), [1.4, 1.6), [1.6, 1.8), [1.8, 2.0).
-          - The distribution is "right-skewed" so that the last histogram bucket fully contains the
-          last four quantile buckets and 1/9 of the first quantile bucket. The remaining 8/9 of the
-          first quantile bucket overlap uniformly with the first four histogram buckets.
+    Setup:
+      - Histogram buckets: [1.0, 1.2), [1.2, 1.4), [1.4, 1.6), [1.6, 1.8), [1.8, 2.0).
+      - There are two quantile buckets. The first contains the first two histogram buckets and
+      the second contains the last three histogram buckets respectively.
+    """
+    quantiles = [1.0, 1.4, 2.0]
+    total_freq = 100
+    num_buckets = 5
+    expected_histogram = text_format.Parse(
         """
-        quantiles = [1.0, 1.9, 1.97, 1.98, 1.99, 2.0]
-        total_freq = 100
-        num_buckets = 5
-        expected_histogram = text_format.Parse(
-            """
-            buckets {
-                low_value: 1.0
-                high_value: 1.2
-                sample_count: 4.44
-            }
-            buckets {
-                low_value: 1.2
-                high_value: 1.4
-                sample_count: 4.44
-            }
-            buckets {
-                low_value: 1.4
-                high_value: 1.6
-                sample_count: 4.44
-            }
-            buckets {
-                low_value: 1.6
-                high_value: 1.8
-                sample_count: 4.44
-            }
-            buckets {
-                low_value: 1.8
-                high_value: 2.0
-                sample_count: 82.22
-            }
-            type: STANDARD
-            """,
-            facet_feature_statistics_pb2.Histogram(),
-        )
-        actual_histogram = histogram_generator.generate_equal_width_histogram(
-            quantiles=quantiles, num_buckets=num_buckets, total_freq=total_freq
-        )
-        self.assert_histogram(expected_histogram, actual_histogram)
+        buckets {
+            low_value: 1.0
+            high_value: 1.2
+            sample_count: 25.0
+        }
+        buckets {
+            low_value: 1.2
+            high_value: 1.4
+            sample_count: 25.0
+        }
+        buckets {
+            low_value: 1.4
+            high_value: 1.6
+            sample_count: 16.667
+        }
+        buckets {
+            low_value: 1.6
+            high_value: 1.8
+            sample_count: 16.667
+        }
+        buckets {
+            low_value: 1.8
+            high_value: 2.0
+            sample_count: 16.667
+        }
+        type: STANDARD
+        """,
+        facet_feature_statistics_pb2.Histogram(),
+    )
+    actual_histogram = histogram_generator.generate_equal_width_histogram(
+        quantiles=quantiles, num_buckets=num_buckets, total_freq=total_freq
+    )
+    assert_histogram(expected_histogram, actual_histogram)
 
-    def test_single_histogram_bucket(self):
-        """
-        Tests the single histogram bucket.
-        """
-        quantiles = [1.0, 1.9, 1.97, 1.98, 1.99, 2.0]
-        total_freq = 100
-        num_buckets = 1
-        expected_histogram = text_format.Parse(
-            """
-            buckets {
-                low_value: 1.0
-                high_value: 2.0
-                sample_count: 100
-            }
-            type: STANDARD
-            """,
-            facet_feature_statistics_pb2.Histogram(),
-        )
-        actual_histogram = histogram_generator.generate_equal_width_histogram(
-            quantiles=quantiles, num_buckets=num_buckets, total_freq=total_freq
-        )
-        self.assert_histogram(expected_histogram, actual_histogram)
 
-    def test_repeated_quantiles(self):
-        """
-        Tests the repeated quantiles.
+def test_extremely_skewed_left():
+    """
+    Tests multiple quantile buckets with distribution heavily skewed to the left side.
 
-        Setup:
-          - Histogram buckets boundaries are [1.0, 2.0) and [2.0, 3.0]
-          - The first histogram bucket contains the first three quantile buckets, and 1/2 of the
-          last quantile bucket: 25 * 3 + 25 / 2 = 87.5
-          - The second histogram bucket contains 1/2 of the last quantile bucket: 25 / 2 = 12.5
+    Setup:
+      - Histogram buckets: [1.0, 1.2), [1.2, 1.4), [1.4, 1.6), [1.6, 1.8), [1.8, 2.0).
+      - The distribution is "left-skewed" so that the first histogram bucket fully contains the
+      first four quantile buckets and 1/9 of the last quantile bucket. The remaining 8/9 of the
+      last quantile bucket overlap uniformly with the last four histogram buckets.
+    """
+    quantiles = [1.0, 1.01, 1.02, 1.03, 1.1, 2.0]
+    total_freq = 100
+    num_buckets = 5
+    expected_histogram = text_format.Parse(
         """
-        quantiles = [1.0, 1.0, 1.0, 1.0, 3.0]
-        total_freq = 100
-        num_buckets = 2
-        expected_histogram = text_format.Parse(
-            """
-            buckets {
-                low_value: 1.0
-                high_value: 2.0
-                sample_count: 87.5
-            }
-            buckets {
-                low_value: 2.0
-                high_value: 3.0
-                sample_count: 12.5
-            }
-            type: STANDARD
-            """,
-            facet_feature_statistics_pb2.Histogram(),
-        )
-        actual_histogram = histogram_generator.generate_equal_width_histogram(
-            quantiles=quantiles, num_buckets=num_buckets, total_freq=total_freq
-        )
-        self.assert_histogram(expected_histogram, actual_histogram)
+        buckets {
+            low_value: 1.0
+            high_value: 1.2
+            sample_count: 82.22
+        }
+        buckets {
+            low_value: 1.2
+            high_value: 1.4
+            sample_count: 4.44
+        }
+        buckets {
+            low_value: 1.4
+            high_value: 1.6
+            sample_count: 4.44
+        }
+        buckets {
+            low_value: 1.6
+            high_value: 1.8
+            sample_count: 4.44
+        }
+        buckets {
+            low_value: 1.8
+            high_value: 2.0
+            sample_count: 4.44
+        }
+        type: STANDARD
+        """,
+        facet_feature_statistics_pb2.Histogram(),
+    )
+    actual_histogram = histogram_generator.generate_equal_width_histogram(
+        quantiles=quantiles, num_buckets=num_buckets, total_freq=total_freq
+    )
+    assert_histogram(expected_histogram, actual_histogram)
 
-    def test_edge_overlapping_ranges(self):
-        """
-        Tests the case where histogram buckets are the same as the quantile buckets.
-        """
-        quantiles = [1.0, 2.0, 3.0]
-        total_freq = 200
-        num_buckets = 2
-        expected_histogram = text_format.Parse(
-            """
-            buckets {
-                low_value: 1.0
-                high_value: 2.0
-                sample_count: 100
-            }
-            buckets {
-                low_value: 2.0
-                high_value: 3.0
-                sample_count: 100
-            }
-            type: STANDARD
-            """,
-            facet_feature_statistics_pb2.Histogram(),
-        )
-        actual_histogram = histogram_generator.generate_equal_width_histogram(
-            quantiles=quantiles, num_buckets=num_buckets, total_freq=total_freq
-        )
-        self.assert_histogram(expected_histogram, actual_histogram)
 
-    def test_same_value(self):
+def test_extremely_skewed_right():
+    """
+    Tests multiple quantile buckets with distribution heavily skewed to the right side.
+
+    Setup:
+      - Histogram buckets: [1.0, 1.2), [1.2, 1.4), [1.4, 1.6), [1.6, 1.8), [1.8, 2.0).
+      - The distribution is "right-skewed" so that the last histogram bucket fully contains the
+      last four quantile buckets and 1/9 of the first quantile bucket. The remaining 8/9 of the
+      first quantile bucket overlap uniformly with the first four histogram buckets.
+    """
+    quantiles = [1.0, 1.9, 1.97, 1.98, 1.99, 2.0]
+    total_freq = 100
+    num_buckets = 5
+    expected_histogram = text_format.Parse(
         """
-        Tests the case where all quantiles are the same.
+        buckets {
+            low_value: 1.0
+            high_value: 1.2
+            sample_count: 4.44
+        }
+        buckets {
+            low_value: 1.2
+            high_value: 1.4
+            sample_count: 4.44
+        }
+        buckets {
+            low_value: 1.4
+            high_value: 1.6
+            sample_count: 4.44
+        }
+        buckets {
+            low_value: 1.6
+            high_value: 1.8
+            sample_count: 4.44
+        }
+        buckets {
+            low_value: 1.8
+            high_value: 2.0
+            sample_count: 82.22
+        }
+        type: STANDARD
+        """,
+        facet_feature_statistics_pb2.Histogram(),
+    )
+    actual_histogram = histogram_generator.generate_equal_width_histogram(
+        quantiles=quantiles, num_buckets=num_buckets, total_freq=total_freq
+    )
+    assert_histogram(expected_histogram, actual_histogram)
+
+
+def test_single_histogram_bucket():
+    """
+    Tests the single histogram bucket.
+    """
+    quantiles = [1.0, 1.9, 1.97, 1.98, 1.99, 2.0]
+    total_freq = 100
+    num_buckets = 1
+    expected_histogram = text_format.Parse(
         """
-        quantiles = [1.0, 1.0, 1.0, 1.0, 1.0]
-        total_freq = 100
-        num_buckets = 5
-        expected_histogram = text_format.Parse(
-            """
-            buckets {
-                low_value: -1.0
-                high_value: 0
-                sample_count: 0
-            }
-            buckets {
-                low_value: 0
-                high_value: 1.0
-                sample_count: 0
-            }
-            buckets {
-                low_value: 1.0
-                high_value: 1.0
-                sample_count: 100
-            }
-            buckets {
-                low_value: 1.0
-                high_value: 2.0
-                sample_count: 0
-            }
-            buckets {
-                low_value: 2.0
-                high_value: 3.0
-                sample_count: 0
-            }
-            type: STANDARD
-            """,
-            facet_feature_statistics_pb2.Histogram(),
-        )
-        actual_histogram = histogram_generator.generate_equal_width_histogram(
-            quantiles=quantiles, num_buckets=num_buckets, total_freq=total_freq
-        )
-        self.assert_histogram(expected_histogram, actual_histogram)
+        buckets {
+            low_value: 1.0
+            high_value: 2.0
+            sample_count: 100
+        }
+        type: STANDARD
+        """,
+        facet_feature_statistics_pb2.Histogram(),
+    )
+    actual_histogram = histogram_generator.generate_equal_width_histogram(
+        quantiles=quantiles, num_buckets=num_buckets, total_freq=total_freq
+    )
+    assert_histogram(expected_histogram, actual_histogram)
+
+
+def test_repeated_quantiles():
+    """
+    Tests the repeated quantiles.
+
+    Setup:
+      - Histogram buckets boundaries are [1.0, 2.0) and [2.0, 3.0]
+      - The first histogram bucket contains the first three quantile buckets, and 1/2 of the
+      last quantile bucket: 25 * 3 + 25 / 2 = 87.5
+      - The second histogram bucket contains 1/2 of the last quantile bucket: 25 / 2 = 12.5
+    """
+    quantiles = [1.0, 1.0, 1.0, 1.0, 3.0]
+    total_freq = 100
+    num_buckets = 2
+    expected_histogram = text_format.Parse(
+        """
+        buckets {
+            low_value: 1.0
+            high_value: 2.0
+            sample_count: 87.5
+        }
+        buckets {
+            low_value: 2.0
+            high_value: 3.0
+            sample_count: 12.5
+        }
+        type: STANDARD
+        """,
+        facet_feature_statistics_pb2.Histogram(),
+    )
+    actual_histogram = histogram_generator.generate_equal_width_histogram(
+        quantiles=quantiles, num_buckets=num_buckets, total_freq=total_freq
+    )
+    assert_histogram(expected_histogram, actual_histogram)
+
+
+def test_edge_overlapping_ranges():
+    """
+    Tests the case where histogram buckets are the same as the quantile buckets.
+    """
+    quantiles = [1.0, 2.0, 3.0]
+    total_freq = 200
+    num_buckets = 2
+    expected_histogram = text_format.Parse(
+        """
+        buckets {
+            low_value: 1.0
+            high_value: 2.0
+            sample_count: 100
+        }
+        buckets {
+            low_value: 2.0
+            high_value: 3.0
+            sample_count: 100
+        }
+        type: STANDARD
+        """,
+        facet_feature_statistics_pb2.Histogram(),
+    )
+    actual_histogram = histogram_generator.generate_equal_width_histogram(
+        quantiles=quantiles, num_buckets=num_buckets, total_freq=total_freq
+    )
+    assert_histogram(expected_histogram, actual_histogram)
+
+
+def test_same_value():
+    """
+    Tests the case where all quantiles are the same.
+    """
+    quantiles = [1.0, 1.0, 1.0, 1.0, 1.0]
+    total_freq = 100
+    num_buckets = 5
+    expected_histogram = text_format.Parse(
+        """
+        buckets {
+            low_value: -1.0
+            high_value: 0
+            sample_count: 0
+        }
+        buckets {
+            low_value: 0
+            high_value: 1.0
+            sample_count: 0
+        }
+        buckets {
+            low_value: 1.0
+            high_value: 1.0
+            sample_count: 100
+        }
+        buckets {
+            low_value: 1.0
+            high_value: 2.0
+            sample_count: 0
+        }
+        buckets {
+            low_value: 2.0
+            high_value: 3.0
+            sample_count: 0
+        }
+        type: STANDARD
+        """,
+        facet_feature_statistics_pb2.Histogram(),
+    )
+    actual_histogram = histogram_generator.generate_equal_width_histogram(
+        quantiles=quantiles, num_buckets=num_buckets, total_freq=total_freq
+    )
+    assert_histogram(expected_histogram, actual_histogram)


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs
[#7201 ](https://github.com/mlflow/mlflow/issues/7201)

## What changes are proposed in this pull request?

convert recipies/cards to pytest

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
