### PR TITLE
Avoid using GitHub API

### DIFF
--- a/tests/projects/test_utils.py
+++ b/tests/projects/test_utils.py
@@ -2,7 +2,6 @@ import git
 import os
 import tempfile
 
-import requests
 import pytest
 from unittest import mock
 
@@ -108,8 +107,7 @@ def test__fetch_git_repo(local_git_repo, local_git_repo_uri, version, expected_v
 
 @pytest.mark.parametrize(
     "commit",
-    # Fetch the most recent two commits
-    requests.get("https://api.github.com/repos/mlflow/mlflow-example/commits").json()[:2],
+    ["0651d1c962aa35e4dd02608c51a7b0efc2412407", "3c0711f8868232f17a9adbb69fb1186ec8a3c0c7"],
 )
 def test_fetch_git_repo_commit(tmp_path, commit):
     _fetch_git_repo(

--- a/tests/projects/test_utils.py
+++ b/tests/projects/test_utils.py
@@ -110,13 +110,9 @@ def test__fetch_git_repo(local_git_repo, local_git_repo_uri, version, expected_v
     ["0651d1c962aa35e4dd02608c51a7b0efc2412407", "3c0711f8868232f17a9adbb69fb1186ec8a3c0c7"],
 )
 def test_fetch_git_repo_commit(tmp_path, commit):
-    _fetch_git_repo(
-        "https://github.com/mlflow/mlflow-example.git",
-        commit["sha"],
-        tmp_path,
-    )
+    _fetch_git_repo("https://github.com/mlflow/mlflow-example.git", commit, tmp_path)
     repo = git.Repo(tmp_path)
-    assert repo.commit().hexsha == commit["sha"]
+    assert repo.commit().hexsha == commit
 
 
 def test_fetching_non_existing_version_fails(local_git_repo, local_git_repo_uri):


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

GitHub API sometimes fails with the rate-limit error:

https://github.com/mlflow/mlflow/actions/runs/3736861149/jobs/6341567794

```
tests/projects/test_utils.py:112: in <module>
    requests.get("https://api.github.com/repos/mlflow/mlflow-example/commits").json()[:2],
E   TypeError: unhashable type: 'slice'
```
(Please fill in changes proposed in this fix)

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
