### PR TITLE
Remove the TensorFlow links - the examples don't exist

### DIFF
--- a/docs/source/tutorials-and-examples/index.rst
+++ b/docs/source/tutorials-and-examples/index.rst
@@ -57,12 +57,6 @@ Below, you can find a number of tutorials and examples for various MLflow use ca
 
     + `Logistic Regression example <https://github.com/mlflow/mlflow/tree/master/examples/sklearn_logistic_regression>`_
 
-  - TensorFlow
-
-    + `TensorFlow 1.X <https://github.com/mlflow/mlflow/tree/master/examples/tensorflow/tf1>`_
-
-    + `TensorFlow 2.X <https://github.com/mlflow/mlflow/tree/master/examples/tensorflow/tf2>`_
-
   - RAPIDS
 
     + `Random Forest Classifier <https://github.com/mlflow/mlflow/tree/master/examples/rapids>`_


### PR DESCRIPTION
Remove   - TensorFlow, TensorFlow 1.X, TensorFlow 2.X as these links don't exist anymore so just go to a 404 Page Not Found.

Signed-off-by: mutron3k <asloan7@gmail.com>

- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
