### PR TITLE
[Recipes] Adding support for custom split step

### DIFF
--- a/mlflow/recipes/steps/split.py
+++ b/mlflow/recipes/steps/split.py
@@ -6,6 +6,7 @@ import sys
 from functools import partial
 import numpy as np
 import pandas as pd
+from enum import Enum
 from multiprocessing.pool import ThreadPool, Pool
 
 from mlflow.recipes.artifacts import DataframeArtifact
@@ -28,6 +29,19 @@ _OUTPUT_VALIDATION_FILE_NAME = "validation.parquet"
 _OUTPUT_TEST_FILE_NAME = "test.parquet"
 _USER_DEFINED_SPLIT_STEP_MODULE = "steps.split"
 _MAX_CLASSES_TO_PROFILE = 5
+
+
+class SplitValues(Enum):
+    """
+    Represents the custom split return values.
+    """
+
+    # Indicates that the row is part of test split
+    TEST = "TEST"
+    # Indicates that the row is part of train split
+    TRAIN = "TRAIN"
+    # Indicates that the row is part of validation split
+    VALIDATION = "VALIDATION"
 
 
 def _make_elem_hashable(elem):
@@ -199,14 +213,32 @@ class SplitStep(BaseStep):
             )
         self.skip_data_profiling = self.step_config.get("skip_data_profiling", False)
 
-        self.split_ratios = self.step_config.get("split_ratios", [0.75, 0.125, 0.125])
-        if not (
-            isinstance(self.split_ratios, list)
-            and len(self.split_ratios) == 3
-            and all(isinstance(x, (int, float)) and x > 0 for x in self.split_ratios)
-        ):
+        if "using" in self.step_config:
+            if self.step_config["using"] not in ["custom", "split_ratio"]:
+                raise MlflowException(
+                    f"Invalid split step configuration value {self.step_config['using']} for "
+                    f"key 'using'. Supported values are: ['custom', 'split_ratio']",
+                    error_code=INVALID_PARAMETER_VALUE,
+                )
+        else:
+            self.step_config["using"] = "split_ratio"
+
+        if self.step_config["using"] == "split_ratio":
+            self.split_ratios = self.step_config.get("split_ratios", [0.75, 0.125, 0.125])
+            if not (
+                isinstance(self.split_ratios, list)
+                and len(self.split_ratios) == 3
+                and all(isinstance(x, (int, float)) and x > 0 for x in self.split_ratios)
+            ):
+                raise MlflowException(
+                    "Config split_ratios must be a list containing 3 positive numbers."
+                )
+
+        if "split_method" not in self.step_config and self.step_config["using"] == "custom":
             raise MlflowException(
-                "Config split_ratios must be a list containing 3 positive numbers."
+                "Missing 'split_method' configuration in the split step, "
+                "which is using 'custom'.",
+                error_code=INVALID_PARAMETER_VALUE,
             )
 
     def _build_profiles_and_card(self, train_df, validation_df, test_df) -> BaseCard:
@@ -307,6 +339,40 @@ class SplitStep(BaseStep):
 
         return card
 
+    def _validate_and_execute_custom_split(self, split_fn, input_df):
+        custom_split_mapping_series = split_fn(input_df)
+        if not isinstance(custom_split_mapping_series, pd.Series):
+            raise MlflowException(
+                "Return type of the custom split function should be a pandas series",
+                error_code=INVALID_PARAMETER_VALUE,
+            )
+        train_df = validation_df = test_df = pd.DataFrame()
+        for index, value in custom_split_mapping_series.items():
+            if value == SplitValues.TRAIN.value:
+                train_df = pd.concat([train_df, input_df.iloc[[index]]], ignore_index=True)
+            elif value == SplitValues.VALIDATION.value:
+                validation_df = pd.concat(
+                    [validation_df, input_df.iloc[[index]]], ignore_index=True
+                )
+            elif value == SplitValues.TEST.value:
+                test_df = pd.concat([test_df, input_df.iloc[[index]]], ignore_index=True)
+            else:
+                raise MlflowException(
+                    f"Returned pandas series from custom split step should only contain "
+                    f"{SplitValues.TRAIN.value}, {SplitValues.VALIDATION.value} or "
+                    f"{SplitValues.TEST.value} as values. Value returned back instead: {value}",
+                    error_code=INVALID_PARAMETER_VALUE,
+                )
+
+        return test_df, train_df, validation_df
+
+    def _run_custom_split(self, input_df):
+        split_fn = getattr(
+            importlib.import_module(_USER_DEFINED_SPLIT_STEP_MODULE),
+            self.step_config["split_method"],
+        )
+        return self._validate_and_execute_custom_split(split_fn, input_df)
+
     def _run(self, output_directory):
         run_start_time = time.time()
 
@@ -331,9 +397,12 @@ class SplitStep(BaseStep):
         self.num_dropped_rows = raw_input_num_rows - len(input_df)
 
         # split dataset
-        test_df, train_df, validation_df = _run_split(
-            self.task, input_df, self.split_ratios, self.target_col
-        )
+        if self.step_config["using"] == "custom":
+            test_df, train_df, validation_df = self._run_custom_split(input_df)
+        else:
+            test_df, train_df, validation_df = _run_split(
+                self.task, input_df, self.split_ratios, self.target_col
+            )
         # Import from user function module to process dataframes
         post_split_config = self.step_config.get("post_split_method", None)
         post_split_filter_config = self.step_config.get("post_split_filter_method", None)

--- a/tests/recipes/test_split_step.py
+++ b/tests/recipes/test_split_step.py
@@ -13,6 +13,7 @@ from mlflow.recipes.steps.split import (
     _OUTPUT_TRAIN_FILE_NAME,
     _OUTPUT_VALIDATION_FILE_NAME,
     _OUTPUT_TEST_FILE_NAME,
+    SplitValues,
 )
 from mlflow.recipes.steps.split import (
     _get_split_df,
@@ -250,14 +251,9 @@ def test_validation_split_step_validates_split_correctly():
 def custom_split(df):
     from pandas import Series
 
-    splits = Series()
-    for index, row in df.iterrows():
-        if row["a"] >= 800:
-            splits.at[index] = "TEST"
-        elif row["a"] >= 500:
-            splits.at[index] = "VALIDATION"
-        else:
-            splits.at[index] = "TRAIN"
+    splits = Series(SplitValues.TRAINING.value, index=range(len(df)))
+    splits[df["a"] >= 500] = SplitValues.VALIDATION.value
+    splits[df["a"] >= 800] = SplitValues.TEST.value
 
     return splits
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
[Recipes] Adding support for custom split step

## How is this patch tested?
- [x] Test added
- [x] Verified by running a notebook locally

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
Adding support for custom split step in MLflow Recipes

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
