### PR TITLE
Return an empty List on GetMetricHistory when a metric doesn't exist for a run

### DIFF
--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -773,11 +773,7 @@ class FileStore(AbstractStore):
 
         parent_path, metric_files = self._get_run_files(run_info, "metric")
         if metric_key not in metric_files:
-            run_id = run_info.run_id
-            raise MlflowException(
-                f"Metric '{metric_key}' not found under run '{run_id}'",
-                databricks_pb2.RESOURCE_DOES_NOT_EXIST,
-            )
+            return []
         return PagedList(
             [
                 FileStore._get_metric_from_line(metric_key, line)

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -1027,8 +1027,8 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         fs = FileStore(self.test_root)
         with pytest.raises(
             MlflowException,
-            match="The FileStore backend does not support pagination "
-            "for the `get_metric_history` API.",
+            match="The FileStore backend does not support pagination for the `get_metric_history` "
+            "API.",
         ):
             fs.get_metric_history("fake_run", "fake_metric", max_results=50, page_token="42")
 

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -1027,8 +1027,8 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         fs = FileStore(self.test_root)
         with pytest.raises(
             MlflowException,
-            match="The FileStore backend does not support pagination for the `get_metric_history` "
-            "API.",
+            match="The FileStore backend does not support pagination "
+            "for the `get_metric_history` API.",
         ):
             fs.get_metric_history("fake_run", "fake_metric", max_results=50, page_token="42")
 
@@ -1781,3 +1781,10 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         run = fs.get_run(run_id)
         assert run.info.run_name == "batch name"
         assert run.data.tags.get(MLFLOW_RUN_NAME) == "batch name"
+
+    def test_get_metric_history_on_non_existent_metric_key(self):
+        file_store = FileStore(self.test_root)
+        run = self._create_run(file_store)
+        run_id = run.info.run_id
+        test_metrics = file_store.get_metric_history(run_id, "test_metric")
+        assert test_metrics == []

--- a/tests/store/tracking/test_rest_store.py
+++ b/tests/store/tracking/test_rest_store.py
@@ -458,13 +458,9 @@ class TestRestStore:
         creds = MlflowHostCreds("https://hello")
         rest_store = RestStore(lambda: creds)
         empty_metric_response = self._mock_response_with_200_status_code()
-        metric_response = self._mock_response_with_200_status_code()
         empty_metric_response.text = json.dumps({})
-        metric_response.text = json.dumps(
-            {"key": "a_metric", "value": 10, "timestamp": 123456877, "step": 1}
-        )
         with mock.patch(
-            "requests.Session.request", side_effect=[empty_metric_response, metric_response]
+            "requests.Session.request", side_effect=[empty_metric_response]
         ) as mock_request:
             metrics = rest_store.get_metric_history(run_id="1", metric_key="test_metric")
             mock_request.assert_called_once()

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -2832,7 +2832,6 @@ def test_get_attribute_name():
 
 def test_get_orderby_clauses():
     store = SqlAlchemyStore("sqlite:///:memory:", ARTIFACT_URI)
-    store = SqlAlchemyStore("sqlite:///:memory:", ARTIFACT_URI)
     with store.ManagedSessionMaker() as session:
         # test that ['runs.start_time DESC', 'SqlRun.run_uuid'] is returned by default
         parsed = [str(x) for x in _get_orderby_clauses([], session)[1]]

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -2832,6 +2832,7 @@ def test_get_attribute_name():
 
 def test_get_orderby_clauses():
     store = SqlAlchemyStore("sqlite:///:memory:", ARTIFACT_URI)
+    store = SqlAlchemyStore("sqlite:///:memory:", ARTIFACT_URI)
     with store.ManagedSessionMaker() as session:
         # test that ['runs.start_time DESC', 'SqlRun.run_uuid'] is returned by default
         parsed = [str(x) for x in _get_orderby_clauses([], session)[1]]
@@ -2867,3 +2868,14 @@ def test_get_orderby_clauses():
         assert "value IS NULL" in select_clause[0]
         # test that clause name is in parsed
         assert "clause_1" in parsed[0]
+
+
+def test_get_metric_history_on_non_existent_metric_key():
+    store = SqlAlchemyStore("sqlite:///:memory:", ARTIFACT_URI)
+    experiment_id = store.create_experiment(name="exp1")
+    run = store.create_run(
+        experiment_id=experiment_id, user_id="user", start_time=0, tags=[], run_name="name"
+    )
+    run_id = run.info.run_id
+    metrics = store.get_metric_history(run_id, "test_metric")
+    assert metrics == []

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -2730,6 +2730,15 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
             assert tag.key == "k2"
             assert tag.value == "v2"
 
+    def test_get_metric_history_on_non_existent_metric_key(self):
+        experiment_id = self._experiment_factory("test_exp")[0]
+        run = self.store.create_run(
+            experiment_id=experiment_id, user_id="user", start_time=0, tags=[], run_name="name"
+        )
+        run_id = run.info.run_id
+        metrics = self.store.get_metric_history(run_id, "test_metric")
+        assert metrics == []
+
 
 def test_sqlalchemy_store_behaves_as_expected_with_inmemory_sqlite_db():
     store = SqlAlchemyStore("sqlite:///:memory:", ARTIFACT_URI)
@@ -2867,14 +2876,3 @@ def test_get_orderby_clauses():
         assert "value IS NULL" in select_clause[0]
         # test that clause name is in parsed
         assert "clause_1" in parsed[0]
-
-
-def test_get_metric_history_on_non_existent_metric_key():
-    store = SqlAlchemyStore("sqlite:///:memory:", ARTIFACT_URI)
-    experiment_id = store.create_experiment(name="exp1")
-    run = store.create_run(
-        experiment_id=experiment_id, user_id="user", start_time=0, tags=[], run_name="name"
-    )
-    run_id = run.info.run_id
-    metrics = store.get_metric_history(run_id, "test_metric")
-    assert metrics == []

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -245,9 +245,8 @@ def test_get_experiment_id_from_env():
         HelperEnv.assert_values(str(random_id), None)
         with pytest.raises(
             MlflowException,
-            match=f"The provided {_EXPERIMENT_ID_ENV_VAR} environment "
-            f"variable value `{random_id}` does not exist "
-            f"in the tracking server",
+            match=f"The provided {_EXPERIMENT_ID_ENV_VAR} environment variable value `{random_id}` "
+            "does not exist in the tracking server",
         ):
             _get_experiment_id_from_env()
 
@@ -261,8 +260,8 @@ def test_get_experiment_id_from_env():
         HelperEnv.assert_values(str(random_id), name)
         with pytest.raises(
             MlflowException,
-            match=f"The provided {_EXPERIMENT_ID_ENV_VAR} environment"
-            f" variable value `{random_id}` does not match the experiment id",
+            match=f"The provided {_EXPERIMENT_ID_ENV_VAR} environment variable value `{random_id}` "
+            "does not match the experiment id",
         ):
             _get_experiment_id_from_env()
 

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -245,8 +245,9 @@ def test_get_experiment_id_from_env():
         HelperEnv.assert_values(str(random_id), None)
         with pytest.raises(
             MlflowException,
-            match=f"The provided {_EXPERIMENT_ID_ENV_VAR} environment variable value `{random_id}` "
-            "does not exist in the tracking server",
+            match=f"The provided {_EXPERIMENT_ID_ENV_VAR} environment "
+            f"variable value `{random_id}` does not exist "
+            f"in the tracking server",
         ):
             _get_experiment_id_from_env()
 
@@ -260,8 +261,8 @@ def test_get_experiment_id_from_env():
         HelperEnv.assert_values(str(random_id), name)
         with pytest.raises(
             MlflowException,
-            match=f"The provided {_EXPERIMENT_ID_ENV_VAR} environment variable value `{random_id}` "
-            "does not match the experiment id",
+            match=f"The provided {_EXPERIMENT_ID_ENV_VAR} environment"
+            f" variable value `{random_id}` does not match the experiment id",
         ):
             _get_experiment_id_from_env()
 
@@ -1194,3 +1195,11 @@ def test_set_experiment_tags():
     assert len(finished_experiment.tags) == len(exact_expected_tags)
     for tag_key, tag_value in finished_experiment.tags.items():
         assert str(exact_expected_tags[tag_key]) == tag_value
+
+
+def test_get_metric_history_on_non_existent_metric_key():
+    with mlflow.start_run() as run:
+        run_id = run.info.run_id
+        client = mlflow.tracking.MlflowClient()
+        metric_history = client.get_metric_history(run_id, "test_accuracy")
+        assert metric_history == []

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -1194,11 +1194,3 @@ def test_set_experiment_tags():
     assert len(finished_experiment.tags) == len(exact_expected_tags)
     for tag_key, tag_value in finished_experiment.tags.items():
         assert str(exact_expected_tags[tag_key]) == tag_value
-
-
-def test_get_metric_history_on_non_existent_metric_key():
-    with mlflow.start_run() as run:
-        run_id = run.info.run_id
-        client = mlflow.tracking.MlflowClient()
-        metric_history = client.get_metric_history(run_id, "test_accuracy")
-        assert metric_history == []

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -295,6 +295,9 @@ def test_log_metrics_params_tags(mlflow_client):
     assert metric1.timestamp == 321
     assert metric1.step == 0
 
+    metric_history = mlflow_client.get_metric_history(run_id, "a_test_accuracy")
+    assert metric_history == []
+
 
 def test_log_metric_validation(mlflow_client):
     experiment_id = mlflow_client.create_experiment("metrics validation")


### PR DESCRIPTION
Signed-off-by: Jas Bali <bali0019@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs
#4973

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> 

## What changes are proposed in this pull request?

Return an empty List on GetMetricHistory when a metric doesn't exist for the FileStore backend (currently raises).

(Please fill in changes proposed in this fix)

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->
Added unit tests to verify the behavior in file, rest and sqlalchemy stores

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
