### PR TITLE
[Branch-2.1] For spark dataframe with array type column input, remove to_list conversion in spark_udf and make PyFuncModel.predict support dataframe contains numpy array field

### DIFF
--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -500,6 +500,9 @@ def _reshape_and_cast_pandas_column_values(name, pd_series, tensor_spec):
             "array elements are of uniform length and can be reshaped to above expected shape."
         )
         try:
+            # Because numpy array includes precise type information, so we don't convert type
+            # here, so that in following schema validation we can have strict type check on
+            # numpy array column.
             reshaped_numpy_arr = np.vstack(pd_series.tolist()).reshape(tensor_spec.shape)
         except ValueError:
             raise MlflowException(reshape_err_msg, error_code=INVALID_PARAMETER_VALUE)

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -399,8 +399,8 @@ class PyFuncModel:
                      For model signatures with tensor spec inputs
                      (e.g. the Tensorflow core / Keras model), the input data type must be one of
                      `numpy.ndarray`, `List[numpy.ndarray]`, `Dict[str, numpy.ndarray]` or
-                     `pandas.DataFrame`. If data is of `pandas.DataFrame` type and an input field
-                     requires multidimensional array input, the corresponding column values in
+                     `pandas.DataFrame`. If data is of `pandas.DataFrame` type and a model contains
+                     a signature with tensor spec inputs, the corresponding column values in
                      the pandas DataFrame will be reshaped to the required shape with 'C' order
                      (i.e. read / write the elements using C-like index order), and DataFrame
                      column values will be cast as the required tensor spec type.
@@ -1054,18 +1054,6 @@ def spark_udf(spark, model_uri, result_type="double", env_manager=_EnvManager.LO
                     )
             pdf = pandas.DataFrame(data={names[i]: x for i, x in enumerate(args)}, columns=names)
 
-        # If the spark dataframe input column is array type,
-        # then in spark pandas_udf, the passed in arguments
-        # (`pd.dataframe` instance or `pd.Series`) contains numpy array values.
-        # Converting the numpy array values into list
-        # Because `PyFuncModel.predict` only accepts pandas dataframe
-        # containing column values of scalar type or list type.
-        pdf = pandas.DataFrame(
-            {
-                col: pdf[col].map(lambda x: x.tolist() if isinstance(x, np.ndarray) else x)
-                for col in pdf.columns
-            }
-        )
         result = predict_fn(pdf)
 
         if isinstance(result, dict):

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -399,9 +399,9 @@ class PyFuncModel:
                      For model signatures with tensor spec inputs
                      (e.g. the Tensorflow core / Keras model), the input data type must be one of
                      `numpy.ndarray`, `List[numpy.ndarray]`, `Dict[str, numpy.ndarray]` or
-                     `pandas.DataFrame`. If data is of `pandas.DataFrame` type and a model contains
-                     a signature with tensor spec inputs, the corresponding column values in
-                     the pandas DataFrame will be reshaped to the required shape with 'C' order
+                     `pandas.DataFrame`. If data is of `pandas.DataFrame` type and the model
+                     contains a signature with tensor spec inputs, the corresponding column values
+                     in the pandas DataFrame will be reshaped to the required shape with 'C' order
                      (i.e. read / write the elements using C-like index order), and DataFrame
                      column values will be cast as the required tensor spec type.
 

--- a/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
+++ b/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
@@ -602,6 +602,14 @@ def test_schema_enforcement_named_tensor_schema_multidimensional():
     # test dataframe input works for 1d tensor specs and input is converted to dict
     res = pyfunc_model.predict(pdf)
     assert _compare_exact_tensor_dict_input(res, d_inp)
+
+    # test dataframe input works for 1d tensor specs and input is converted to dict
+    pdf_contains_numpy_array = pd.DataFrame(
+        {"a": list(data_a.reshape(-1, 2 * 3)), "b": list(data_b.reshape(-1, 3 * 4))}
+    )
+    res = pyfunc_model.predict(pdf_contains_numpy_array)
+    assert _compare_exact_tensor_dict_input(res, d_inp)
+
     expected_types = dict(zip(input_schema.input_names(), input_schema.input_types()))
     actual_types = {k: v.dtype for k, v in res.items()}
     assert expected_types == actual_types
@@ -617,16 +625,6 @@ def test_schema_enforcement_named_tensor_schema_multidimensional():
         pyfunc_model.predict(
             pdf.assign(a=np.array(range(16), dtype=np.uint64).reshape(-1, 8).tolist())
         )
-
-    with pytest.raises(
-        expected_exception=MlflowException,
-        match=re.escape(
-            "Because the model signature requires tensor spec input, the input pandas dataframe "
-            "values should be either scalar value or python list containing scalar values, "
-            "other types are not supported."
-        ),
-    ):
-        pyfunc_model.predict(pdf.assign(a=[np.array([1]), np.array([2])]))
 
     # test that dictionary works too
     res = pyfunc_model.predict(d_inp)

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -639,28 +639,57 @@ def test_spark_udf_string_datetime_with_model_schema(spark):
     np.testing.assert_almost_equal(result.to_numpy().squeeze(), model.predict(inference_sample))
 
 
-def test_spark_udf_with_col_spec_int32_and_float32_type_input(spark):
+def test_spark_udf_with_col_spec_type_input(spark):
+    input_pdf = pd.DataFrame(
+        {
+            "c_bool": [True],
+            "c_int": [10],
+            "c_long": [20],
+            "c_float": [1.5],
+            "c_double": [2.5],
+            "c_str": ["abc"],
+            "c_binary": [b"xyz"],
+            "c_datetime": [pd.to_datetime("2018-01-01")],
+        }
+    )
+
     class TestModel(PythonModel):
         def predict(self, context, model_input):
-            return model_input + 100
+            assert model_input.to_dict() == input_pdf.to_dict()
+            return model_input[["c_int", "c_float"]]
 
     signature = ModelSignature(
-        inputs=Schema([ColSpec("integer", "a"), ColSpec("float", "b")]),
+        inputs=Schema(
+            [
+                ColSpec("boolean", "c_bool"),
+                ColSpec("integer", "c_int"),
+                ColSpec("long", "c_long"),
+                ColSpec("float", "c_float"),
+                ColSpec("double", "c_double"),
+                ColSpec("string", "c_str"),
+                ColSpec("binary", "c_binary"),
+                ColSpec("datetime", "c_datetime"),
+            ]
+        ),
     )
 
-    data = spark.createDataFrame(
-        pd.DataFrame({"a": [1], "b": [1.5]}),
-        schema="a int, b float"
+    spark_schema = (
+        "c_bool boolean, c_int int, c_long long, c_float float, c_double double, "
+        "c_str string, c_binary binary, c_datetime timestamp"
     )
+    data = spark.createDataFrame(
+        data=input_pdf,
+        schema=spark_schema,
+    ).repartition(1)
 
     with mlflow.start_run() as run:
         mlflow.pyfunc.log_model("model", python_model=TestModel(), signature=signature)
         udf = mlflow.pyfunc.spark_udf(
             spark,
             "runs:/{}/model".format(run.info.run_id),
-            result_type="a int, b float",
+            result_type="c_int int, c_float float",
             env_manager="local",
         )
-        res = data.withColumn("res", udf("a", "b")).select("res.a", "res.b").toPandas()
-        assert res.a.tolist() == [101]
-        np.testing.assert_almost_equal(res.b.tolist(), [101.5])
+        res = data.withColumn("res", udf()).select("res.c_int", "res.c_float").toPandas()
+        assert res.c_int.tolist() == [10]
+        np.testing.assert_almost_equal(res.c_float.tolist(), [1.5])

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -639,7 +639,7 @@ def test_spark_udf_string_datetime_with_model_schema(spark):
     np.testing.assert_almost_equal(result.to_numpy().squeeze(), model.predict(inference_sample))
 
 
-def test_spark_udf_with_and_col_spec_int_type_input(spark):
+def test_spark_udf_with_col_spec_int_type_input(spark):
     class TestModel(PythonModel):
         def predict(self, context, model_input):
             return model_input + 100


### PR DESCRIPTION
Signed-off-by: Weichen Xu <weichen.xu@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

For spark dataframe with array type column input, remove to_list conversion in spark_udf and make PyFuncModel.predict support dataframe contains numpy array field

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
