### PR TITLE
[Branch-2.1] Make ScoringServerClient support input dataframe with elements of Numpy array

### DIFF
--- a/mlflow/pyfunc/scoring_server/client.py
+++ b/mlflow/pyfunc/scoring_server/client.py
@@ -7,7 +7,7 @@ import pandas as pd
 from mlflow.pyfunc import scoring_server
 
 from mlflow.exceptions import MlflowException
-from mlflow.utils.proto_json_utils import _DateTimeEncoder
+from mlflow.utils.proto_json_utils import _MLflowJsonEncoder
 from mlflow.deployments import PredictionsResponse
 
 
@@ -66,7 +66,7 @@ class ScoringServerClient:
         else:
             post_data = data
         if not isinstance(post_data, str):
-            post_data = json.dumps(post_data, cls=_DateTimeEncoder)
+            post_data = json.dumps(post_data, cls=_MLflowJsonEncoder)
         response = requests.post(
             url=self.url_prefix + "/invocations",
             data=post_data,

--- a/mlflow/pyfunc/scoring_server/client.py
+++ b/mlflow/pyfunc/scoring_server/client.py
@@ -7,7 +7,7 @@ import pandas as pd
 from mlflow.pyfunc import scoring_server
 
 from mlflow.exceptions import MlflowException
-from mlflow.utils.proto_json_utils import _MLflowJsonEncoder
+from mlflow.utils.proto_json_utils import _CustomJsonEncoder
 from mlflow.deployments import PredictionsResponse
 
 
@@ -66,7 +66,7 @@ class ScoringServerClient:
         else:
             post_data = data
         if not isinstance(post_data, str):
-            post_data = json.dumps(post_data, cls=_MLflowJsonEncoder)
+            post_data = json.dumps(post_data, cls=_CustomJsonEncoder)
         response = requests.post(
             url=self.url_prefix + "/invocations",
             data=post_data,

--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -452,7 +452,7 @@ def parse_tf_serving_input(inp_dict, schema=None):
 
 
 # Reference: https://stackoverflow.com/a/12126976
-class _MLflowJsonEncoder(json.JSONEncoder):
+class _CustomJsonEncoder(json.JSONEncoder):
     def default(self, o):
         import pandas as pd
         import numpy as np

--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -452,11 +452,15 @@ def parse_tf_serving_input(inp_dict, schema=None):
 
 
 # Reference: https://stackoverflow.com/a/12126976
-class _DateTimeEncoder(json.JSONEncoder):
+class _MLflowJsonEncoder(json.JSONEncoder):
     def default(self, o):
         import pandas as pd
+        import numpy as np
 
         if isinstance(o, (datetime.datetime, datetime.date, datetime.time, pd.Timestamp)):
             return o.isoformat()
+
+        if isinstance(o, np.ndarray):
+            return o.tolist()
 
         return super().default(o)

--- a/tests/tensorflow/test_keras_pyfunc_model_works_with_all_input_types.py
+++ b/tests/tensorflow/test_keras_pyfunc_model_works_with_all_input_types.py
@@ -287,8 +287,9 @@ def test_model_multi_multidim_tensor_input(
         np.testing.assert_allclose(actual, expected, rtol=1e-5)
 
 
+@pytest.mark.parametrize("env_manager", ["local", "virtualenv"])
 def test_single_multidim_input_model_spark_udf(
-    single_multidim_tensor_input_model, spark_session, data
+    env_manager, single_multidim_tensor_input_model, spark_session, data
 ):
     model, signature = single_multidim_tensor_input_model
     x, _ = data
@@ -300,7 +301,7 @@ def test_single_multidim_input_model_spark_udf(
     with mlflow.start_run():
         model_uri = mlflow.tensorflow.log_model(model, "model", signature=signature).model_uri
 
-    infer_udf = spark_udf(spark_session, model_uri, env_manager="local")
+    infer_udf = spark_udf(spark_session, model_uri, env_manager=env_manager)
     actual = (
         test_input_spark_df.select(infer_udf("x").alias("prediction"))
         .toPandas()
@@ -309,8 +310,9 @@ def test_single_multidim_input_model_spark_udf(
     np.testing.assert_allclose(actual, np.squeeze(expected), rtol=1e-5)
 
 
+@pytest.mark.parametrize("env_manager", ["local", "virtualenv"])
 def test_multi_multidim_input_model_spark_udf(
-    multi_multidim_tensor_input_model, spark_session, data
+    env_manager, multi_multidim_tensor_input_model, spark_session, data
 ):
     model, signature = multi_multidim_tensor_input_model
     x, _ = data
@@ -333,7 +335,7 @@ def test_multi_multidim_input_model_spark_udf(
     with mlflow.start_run():
         model_uri = mlflow.tensorflow.log_model(model, "model", signature=signature).model_uri
 
-    infer_udf = spark_udf(spark_session, model_uri, env_manager="local")
+    infer_udf = spark_udf(spark_session, model_uri, env_manager=env_manager)
     actual = (
         test_input_spark_df.select(infer_udf("a", "b").alias("prediction"))
         .toPandas()

--- a/tests/utils/test_proto_json_utils.py
+++ b/tests/utils/test_proto_json_utils.py
@@ -21,7 +21,7 @@ from mlflow.utils.proto_json_utils import (
     _stringify_all_experiment_ids,
     parse_tf_serving_input,
     dataframe_from_raw_json,
-    _MLflowJsonEncoder,
+    _CustomJsonEncoder,
 )
 from tests.protos.test_message_pb2 import TestMessage
 
@@ -568,4 +568,4 @@ def test_dataframe_from_json():
     ],
 )
 def test_datetime_encoder(dt, expected):
-    assert json.dumps(dt, cls=_MLflowJsonEncoder) == expected
+    assert json.dumps(dt, cls=_CustomJsonEncoder) == expected

--- a/tests/utils/test_proto_json_utils.py
+++ b/tests/utils/test_proto_json_utils.py
@@ -21,7 +21,7 @@ from mlflow.utils.proto_json_utils import (
     _stringify_all_experiment_ids,
     parse_tf_serving_input,
     dataframe_from_raw_json,
-    _DateTimeEncoder,
+    _MLflowJsonEncoder,
 )
 from tests.protos.test_message_pb2 import TestMessage
 
@@ -568,4 +568,4 @@ def test_dataframe_from_json():
     ],
 )
 def test_datetime_encoder(dt, expected):
-    assert json.dumps(dt, cls=_DateTimeEncoder) == expected
+    assert json.dumps(dt, cls=_MLflowJsonEncoder) == expected


### PR DESCRIPTION
Signed-off-by: Weichen Xu <weichen.xu@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Make ScoringServerClient support input dataframe with elements of Numpy array.
This is for fixing the case:
 spark_udf + tensor_spec input schema model + env_manger=conda/virtualenv

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [X] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
