### PR TITLE
[Recipes] Matching the metric names of recipes and mlflow.evaluate

### DIFF
--- a/mlflow/recipes/steps/automl/flaml.py
+++ b/mlflow/recipes/steps/automl/flaml.py
@@ -138,6 +138,8 @@ def _create_model_automl(
     try:
         if primary_metric in _MLFLOW_TO_FLAML_METRICS and primary_metric in evaluation_metrics:
             metric = _MLFLOW_TO_FLAML_METRICS[primary_metric]
+            if primary_metric == "roc_auc" and extended_task == "classification/multiclass":
+                metric = "roc_auc_ovr"
         elif primary_metric in _SKLEARN_METRICS and primary_metric in evaluation_metrics:
             metric = _create_sklearn_metric_flaml(
                 primary_metric,

--- a/mlflow/recipes/utils/metrics.py
+++ b/mlflow/recipes/utils/metrics.py
@@ -47,6 +47,7 @@ BUILTIN_BINARY_CLASSIFICATION_RECIPE_METRICS = [
     RecipeMetric(name="f1_score", greater_is_better=True),
     RecipeMetric(name="accuracy_score", greater_is_better=True),
     RecipeMetric(name="roc_auc", greater_is_better=True),
+    RecipeMetric(name="log_loss", greater_is_better=False),
 ]
 
 BUILTIN_MULTICLASS_CLASSIFICATION_RECIPE_METRICS = [
@@ -55,7 +56,7 @@ BUILTIN_MULTICLASS_CLASSIFICATION_RECIPE_METRICS = [
     RecipeMetric(name="f1_score_macro", greater_is_better=True),
     RecipeMetric(name="f1_score_micro", greater_is_better=True),
     RecipeMetric(name="accuracy_score", greater_is_better=True),
-    RecipeMetric(name="roc_auc_ovr", greater_is_better=True),
+    RecipeMetric(name="roc_auc", greater_is_better=True),
     RecipeMetric(name="log_loss", greater_is_better=False),
 ]
 

--- a/tests/recipes/test_train_step.py
+++ b/tests/recipes/test_train_step.py
@@ -282,7 +282,7 @@ def test_train_step_classifier_automl(
         """
         recipe: "classification/v1"
         target_col: "y"
-        primary_metric: {metric}
+        primary_metric: "roc_auc"
         profile: "test_profile"
         {positive_class}
         run_args:
@@ -300,7 +300,6 @@ def test_train_step_classifier_automl(
                     - lgbm
         """.format(
             tracking_uri=mlflow.get_tracking_uri(),
-            metric="roc_auc" if recipe == "classification/binary" else "roc_auc_ovr",
             positive_class='positive_class: "a"' if recipe == "classification/binary" else "",
         )
     )


### PR DESCRIPTION
## What changes are proposed in this pull request?
[Recipes] Matching the metric names of recipes and mlflow.evaluate

## How is this patch tested?
- [x] Test passes

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
