### PR TITLE
Do not drop mlflow's dependencies in dependency inference

### DIFF
--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -197,7 +197,7 @@ def _prune_packages(packages):
     """
     packages = set(packages)
     requires = set(_flatten(map(_get_requires_recursive, packages)))
-    return packages - requires
+    return packages - (requires - {"scikit-learn"})
 
 
 def _run_command(cmd, timeout_seconds, env=None):

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -156,15 +156,7 @@ def _normalize_package_name(pkg_name):
     return _NORMALIZE_REGEX.sub("-", pkg_name).lower()
 
 
-def _get_requires_recursive(pkg_name, top_pkg_name=None) -> set:
-    """
-    Recursively yields both direct and transitive dependencies of the specified
-    package.
-    The `top_pkg_name` argument will track what's the top-level dependency for
-    which we want to list all sub-dependencies.
-    This ensures that we don't fall into recursive loops for packages with are
-    dependant on each other.
-    """
+def _get_requires(pkg_name, top_pkg_name=None):
     if top_pkg_name is None:
         # Assume the top package
         top_pkg_name = pkg_name
@@ -187,7 +179,20 @@ def _get_requires_recursive(pkg_name, top_pkg_name=None) -> set:
             continue
 
         yield req_name
-        yield from _get_requires_recursive(req.name, top_pkg_name)
+
+
+def _get_requires_recursive(pkg_name, top_pkg_name=None) -> set:
+    """
+    Recursively yields both direct and transitive dependencies of the specified
+    package.
+    The `top_pkg_name` argument will track what's the top-level dependency for
+    which we want to list all sub-dependencies.
+    This ensures that we don't fall into recursive loops for packages with are
+    dependant on each other.
+    """
+    for req in _get_requires(pkg_name, top_pkg_name):
+        yield req
+        yield from _get_requires_recursive(req, top_pkg_name)
 
 
 def _prune_packages(packages):
@@ -197,7 +202,8 @@ def _prune_packages(packages):
     """
     packages = set(packages)
     requires = set(_flatten(map(_get_requires_recursive, packages)))
-    return packages - (requires - {"scikit-learn"})
+    # Do not exclude mlflow's dependencies
+    return packages - (requires - set(_get_requires("mlflow")))
 
 
 def _run_command(cmd, timeout_seconds, env=None):

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -1163,7 +1163,7 @@ class SklearnModel(mlflow.pyfunc.PythonModel):
         return self.model.predict(model_input)
 
 
-def test_dependency_inference_does_not_drop_sklearn(tmp_path):
+def test_dependency_inference_does_not_exclude_mlflow_dependencies(tmp_path):
     mlflow.pyfunc.save_model(
         path=tmp_path,
         python_model=SklearnModel(),

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -9,6 +9,7 @@ import numpy as np
 import pandas as pd
 import pandas.testing
 import pytest
+import sklearn
 import sklearn.datasets
 import sklearn.linear_model
 import sklearn.neighbors
@@ -1150,3 +1151,22 @@ def test_model_log_with_metadata():
 
     reloaded_model = mlflow.pyfunc.load_model(model_uri=pyfunc_model_uri)
     assert reloaded_model.metadata.metadata["metadata_key"] == "metadata_value"
+
+
+class SklearnModel(mlflow.pyfunc.PythonModel):
+    def __init__(self) -> None:
+        from sklearn.linear_model import LinearRegression
+
+        self.model = LinearRegression()
+
+    def predict(self, context, model_input):
+        return self.model.predict(model_input)
+
+
+def test_dependency_inference_does_not_drop_sklearn(tmp_path):
+    mlflow.pyfunc.save_model(
+        path=tmp_path,
+        python_model=SklearnModel(),
+    )
+    requiments = tmp_path.joinpath("requirements.txt").read_text()
+    assert f"scikit-learn=={sklearn.__version__}" in requiments

--- a/tests/utils/test_requirements_utils.py
+++ b/tests/utils/test_requirements_utils.py
@@ -199,7 +199,6 @@ def test_normalize_package_name():
 
 def test_prune_packages():
     assert _prune_packages(["mlflow"]) == {"mlflow"}
-    assert _prune_packages(["mlflow", "packaging"]) == {"mlflow"}
     assert _prune_packages(["mlflow", "scikit-learn"]) == {"mlflow"}
 
 

--- a/tests/utils/test_requirements_utils.py
+++ b/tests/utils/test_requirements_utils.py
@@ -199,7 +199,7 @@ def test_normalize_package_name():
 
 def test_prune_packages():
     assert _prune_packages(["mlflow"]) == {"mlflow"}
-    assert _prune_packages(["mlflow", "scikit-learn"]) == {"mlflow"}
+    assert _prune_packages(["mlflow", "scikit-learn"]) == {"mlflow", "scikit-learn"}
 
 
 def test_capture_imported_modules():


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

MLflow includes scikit-learn as a dependency. This results in `_infer_requirements` dropping `scikit-learn`. This PR fixes it.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
