### PR TITLE
Resolve relative artifact uri when creating experiments (For FileStore)

### DIFF
--- a/mlflow/R/mlflow/tests/testthat/test-tracking-experiments.R
+++ b/mlflow/R/mlflow/tests/testthat/test-tracking-experiments.R
@@ -252,7 +252,7 @@ test_that("mlflow_set_experiment() creates experiments", {
   experiment_root_dir <- "artifact/location"
   mlflow_set_experiment(experiment_name = "foo", artifact_location = experiment_root_dir)
   experiment <- mlflow_get_experiment()
-  expect_identical(experiment$artifact_location, sprintf("%s/%s", getwd(), experiment_root_dir))
+  expect_identical(experiment$artifact_location, sprintf("%s/mlruns/%s", getwd(), experiment_root_dir))
   expect_identical(experiment$name, "foo")
 })
 

--- a/mlflow/R/mlflow/tests/testthat/test-tracking-experiments.R
+++ b/mlflow/R/mlflow/tests/testthat/test-tracking-experiments.R
@@ -249,9 +249,10 @@ test_that("experiment setting works", {
 
 test_that("mlflow_set_experiment() creates experiments", {
   mlflow_clear_test_dir("mlruns")
-  mlflow_set_experiment(experiment_name = "foo", artifact_location = "artifact/location")
+  experiment_root_dir <- "artifact/location"
+  mlflow_set_experiment(experiment_name = "foo", artifact_location = experiment_root_dir)
   experiment <- mlflow_get_experiment()
-  expect_identical(experiment$artifact_location, "artifact/location")
+  expect_identical(experiment$artifact_location, sprintf("%s/%s", getwd(), experiment_root_dir))
   expect_identical(experiment$name, "foo")
 })
 

--- a/mlflow/R/mlflow/tests/testthat/test-tracking-experiments.R
+++ b/mlflow/R/mlflow/tests/testthat/test-tracking-experiments.R
@@ -249,10 +249,11 @@ test_that("experiment setting works", {
 
 test_that("mlflow_set_experiment() creates experiments", {
   mlflow_clear_test_dir("mlruns")
-  experiment_root_dir <- "artifact/location"
-  mlflow_set_experiment(experiment_name = "foo", artifact_location = experiment_root_dir)
+  artifact_relative_path <- "artifact/location"
+  mlflow_set_experiment(experiment_name = "foo", artifact_location = artifact_relative_path)
   experiment <- mlflow_get_experiment()
-  expect_identical(experiment$artifact_location, sprintf("%s/mlruns/%s", getwd(), experiment_root_dir))
+  expected_artifact_location <- sprintf("%s/mlruns/%s", getwd(), artifact_relative_path)
+  expect_identical(experiment$artifact_location, expected_artifact_location)
   expect_identical(experiment$name, "foo")
 })
 

--- a/mlflow/R/mlflow/tests/testthat/test-tracking-experiments.R
+++ b/mlflow/R/mlflow/tests/testthat/test-tracking-experiments.R
@@ -6,13 +6,14 @@ teardown({
 
 test_that("mlflow_create/get_experiment() basic functionality (fluent)", {
   mlflow_clear_test_dir("mlruns")
-
-  experiment_1_id <- mlflow_create_experiment("exp_name", "art_loc")
+  artifact_relative_path <- "art_loc"
+  experiment_1_id <- mlflow_create_experiment("exp_name", artifact_relative_path)
   experiment_1a <- mlflow_get_experiment(experiment_id = experiment_1_id)
   experiment_1b <- mlflow_get_experiment(name = "exp_name")
 
   expect_identical(experiment_1a, experiment_1b)
-  expect_identical(experiment_1a$artifact_location, "art_loc")
+  expected_artifact_location <- sprintf("%s/mlruns/%s", getwd(), artifact_relative_path)
+  expect_identical(experiment_1a$artifact_location, expected_artifact_location)
   expect_identical(experiment_1a$name, "exp_name")
 })
 
@@ -20,18 +21,19 @@ test_that("mlflow_create/get_experiment() basic functionality (client)", {
   mlflow_clear_test_dir("mlruns")
 
   client <- mlflow_client()
-
+  artifact_relative_path <- "art_loc"
   experiment_1_id <- mlflow_create_experiment(
     client = client,
     name = "exp_name",
-    artifact_location = "art_loc",
+    artifact_location = artifact_relative_path,
     tags = list(foo = "bar", foz = "baz", fiz = "biz")
   )
   experiment_1a <- mlflow_get_experiment(client = client, experiment_id = experiment_1_id)
   experiment_1b <- mlflow_get_experiment(client = client, name = "exp_name")
 
   expect_identical(experiment_1a, experiment_1b)
-  expect_identical(experiment_1a$artifact_location, "art_loc")
+  expected_artifact_location <- sprintf("%s/mlruns/%s", getwd(), artifact_relative_path)
+  expect_identical(experiment_1a$artifact_location, expected_artifact_location)
   expect_identical(experiment_1a$name, "exp_name")
 
   expect_true(
@@ -70,9 +72,9 @@ test_that("mlflow_search_experiments() works properly", {
   expect_setequal(allexperiments$name, c("Default", "foo1", "foo2", "foo3"))
   default_artifact_loc <- file.path(getwd(), "mlruns", "0", fsep = "/")
   expect_setequal(allexperiments$artifact_location, c(default_artifact_loc,
-                                                      "art_loc1",
-                                                      "art_loc2",
-                                                      "art_loc3"))
+                                                      sprintf("%s/mlruns/%s", getwd(), "art_loc1"),
+                                                      sprintf("%s/mlruns/%s", getwd(), "art_loc2"),
+                                                      sprintf("%s/mlruns/%s", getwd(), "art_loc3")))
   expect_null(allexperiments_result$next_page_token)
 
   ex1_result = mlflow_search_experiments(filter = "attribute.name = 'foo1'")
@@ -126,9 +128,9 @@ test_that("mlflow_search_experiments() works properly", {
   expect_setequal(allexperiments$name, c("Default", "foo1", "foo2", "foo3"))
   default_artifact_loc <- file.path(getwd(), "mlruns", "0", fsep = "/")
   expect_setequal(allexperiments$artifact_location, c(default_artifact_loc,
-                                                      "art_loc1",
-                                                      "art_loc2",
-                                                      "art_loc3"))
+                                                      sprintf("%s/mlruns/%s", getwd(), "art_loc1"),
+                                                      sprintf("%s/mlruns/%s", getwd(), "art_loc2"),
+                                                      sprintf("%s/mlruns/%s", getwd(), "art_loc3")))
   expect_null(allexperiments_result$next_page_token)
 
   ex1_result = mlflow_search_experiments(filter = "attribute.name = 'foo1'")
@@ -215,11 +217,12 @@ test_that("mlflow_get_experiment_by_name() works properly", {
     mlflow_get_experiment(client = client, name = "exp"),
     "Could not find experiment with name 'exp'"
   )
-  experiment_id <- mlflow_create_experiment(client = client, "exp", "art")
+  artifact_relative_path <- "art"
+  experiment_id <- mlflow_create_experiment(client = client, "exp", artifact_relative_path)
   experiment <- mlflow_get_experiment(client = client, name = "exp")
   expect_identical(experiment_id, experiment$experiment_id)
   expect_identical(experiment$name, "exp")
-  expect_identical(experiment$artifact_location, "art")
+  expect_identical(experiment$artifact_location, sprintf("%s/mlruns/%s", getwd(), artifact_relative_path))
 })
 
 test_that("infer experiment id works properly", {

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -4,6 +4,7 @@ import time
 import os
 import sys
 import shutil
+import pathlib
 
 import uuid
 
@@ -314,8 +315,26 @@ class FileStore(AbstractStore):
         )
         return experiments[0] if len(experiments) > 0 else None
 
+    def _resolve_relative_artifact_uri(self, artifact_uri):
+        """
+        if `artifact_uri` is passed in as a relative path, this method
+        resolves it to absolute path against the `artifact_root_uri`.
+        if `artifact_uri` is already an absolute path or file uri,
+        this method returns it back.
+
+        :param artifact_uri: Relative or absolute path or local file uri
+
+        :return: Absolute path or file uri
+        """
+        if (
+            artifact_uri is not None
+            and not pathlib.Path(local_file_uri_to_path(artifact_uri)).is_absolute()
+        ):
+            return append_to_uri_path(self.artifact_root_uri, artifact_uri)
+        return artifact_uri
+
     def _create_experiment_with_id(self, name, experiment_id, artifact_uri, tags):
-        artifact_uri = artifact_uri or append_to_uri_path(
+        artifact_uri = self._resolve_relative_artifact_uri(artifact_uri) or append_to_uri_path(
             self.artifact_root_uri, str(experiment_id)
         )
         self._check_root_dir()

--- a/tests/artifacts/test_artifacts.py
+++ b/tests/artifacts/test_artifacts.py
@@ -163,7 +163,7 @@ def _assert_artifact_uri(tracking_uri, expected_artifact_uri, test_artifact, run
     assert pathlib.Path(artifact_uri) == expected_artifact_uri
 
 
-def test_relative_artifact_uri_resolves(test_artifact):
+def test_default_relative_artifact_uri_resolves(test_artifact):
     tracking_uri = path_to_local_file_uri(test_artifact.tmp_path.joinpath("mlruns"))
     mlflow.set_tracking_uri(tracking_uri)
     experiment_id = mlflow.create_experiment("test_exp_a", "test_artifacts_root")

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -27,6 +27,7 @@ from mlflow.exceptions import MlflowException, MissingConfigException
 from mlflow.store.tracking import SEARCH_MAX_RESULTS_DEFAULT
 from mlflow.store.tracking.file_store import FileStore
 from mlflow.utils.file_utils import write_yaml, read_yaml, path_to_local_file_uri, TempDir
+from mlflow.utils.uri import append_to_uri_path
 from mlflow.utils.name_utils import _GENERATOR_PREDICATES, _EXPERIMENT_ID_FIXED_WIDTH
 from mlflow.utils.mlflow_tags import MLFLOW_RUN_NAME
 from mlflow.utils.time_utils import get_current_time_millis
@@ -1791,17 +1792,17 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
 
 
 def test_experiment_with_default_root_artifact_uri(tmp_path):
-    file_store_root_uri = f"file://{tmp_path}"
+    file_store_root_uri = path_to_local_file_uri(tmp_path)
     file_store = FileStore(file_store_root_uri)
     experiment_id = file_store.create_experiment(name="test", artifact_location="test")
     experiment_info = file_store.get_experiment(experiment_id)
-    assert experiment_info.artifact_location == f"{file_store_root_uri}/test"
+    assert experiment_info.artifact_location == append_to_uri_path(file_store_root_uri, "test")
 
 
-def test_experiment_with_root_artifact_uri(tmp_path):
-    file_store_root_uri = f"file://{tmp_path}/experiments"
-    artifacts_root_uri = f"file://{tmp_path}/artifacts"
+def test_experiment_with_relative_artifact_uri(tmp_path):
+    file_store_root_uri = append_to_uri_path(path_to_local_file_uri(tmp_path), "experiments")
+    artifacts_root_uri = append_to_uri_path(path_to_local_file_uri(tmp_path), "artifacts")
     file_store = FileStore(file_store_root_uri, artifacts_root_uri)
     experiment_id = file_store.create_experiment(name="test", artifact_location="test")
     experiment_info = file_store.get_experiment(experiment_id)
-    assert experiment_info.artifact_location == f"{artifacts_root_uri}/test"
+    assert experiment_info.artifact_location == append_to_uri_path(artifacts_root_uri, "test")

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -1788,3 +1788,20 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         run_id = run.info.run_id
         test_metrics = file_store.get_metric_history(run_id, "test_metric")
         assert test_metrics == []
+
+
+def test_experiment_with_default_root_artifact_uri(tmp_path):
+    file_store_root_uri = f"file://{tmp_path}"
+    file_store = FileStore(file_store_root_uri)
+    experiment_id = file_store.create_experiment(name="test", artifact_location="test")
+    experiment_info = file_store.get_experiment(experiment_id)
+    assert experiment_info.artifact_location == f"{file_store_root_uri}/test"
+
+
+def test_experiment_with_root_artifact_uri(tmp_path):
+    file_store_root_uri = f"file://{tmp_path}/experiments"
+    artifacts_root_uri = f"file://{tmp_path}/artifacts"
+    file_store = FileStore(file_store_root_uri, artifacts_root_uri)
+    experiment_id = file_store.create_experiment(name="test", artifact_location="test")
+    experiment_info = file_store.get_experiment(experiment_id)
+    assert experiment_info.artifact_location == f"{artifacts_root_uri}/test"


### PR DESCRIPTION
Signed-off-by: Jas Bali <bali0019@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #2816

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
