### PR TITLE
Sktime custom flavor

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -16,7 +16,7 @@ that can be understood by different downstream tools.
 .. _model-storage-format:
 
 Storage Format
---------------
+--------------l
 
 Each MLflow Model is a directory containing arbitrary files, together with an ``MLmodel``
 file in the root of the directory that can define multiple *flavors* that the model can be viewed
@@ -2551,3 +2551,56 @@ Example:
         style="vegalite",
         input_example=df_iris.head(5),
     )
+
+MLflow Sktime
+^^^^^^^^^^^^^
+
+The ``sktime`` custom model flavor enables logging of `sktime models <https://github.com/sktime/sktime>`_ in MLflow
+format via the `mlflow_sktime.save_model()  <https://www.sktime.org/en/latest/api_reference/auto_generated/sktime.utils.mlflow_sktime.save_model.html>`_ and
+`mlflow_sktime.log_model()  <https://www.sktime.org/en/latest/api_reference/auto_generated/sktime.utils.mlflow_sktime.log_model.html>`_ methods.
+These methods also add the ``python_function`` flavor to the MLflow Models that they produce, allowing the
+model to be interpreted as generic Python functions for inference via :py:func:`mlflow.pyfunc.load_model()`.
+This loaded PyFunc model can only be scored with a DataFrame input.
+You can also use the `mlflow_sktime.load_model()  <https://www.sktime.org/en/latest/api_reference/auto_generated/sktime.utils.mlflow_sktime.load_model.html>`_ method to load MLflow Models with the ``sktime``
+model flavor in native sktime formats.
+
+Refer to the `sktime mlflow documentation <https://www.sktime.org/en/latest/api_reference/deployment.html>`_ for details on the interface for utilizing a sktime model loaded as a pyfunc type and an `example notebook <https://github.com/sktime/sktime/blob/main/examples/mlflow.ipynb>`_ for extended code usage examples.
+
+Installation:
+
+.. code-block:: bash
+
+    pip install sktime[mlflow]
+
+Example:
+
+.. code-block:: python
+
+    import pandas as pd
+
+    from sktime.datasets import load_airline
+    from sktime.forecasting.arima import AutoARIMA
+    from sktime.utils import mlflow_sktime
+
+    airline = load_airline()
+    model_path = "model"
+
+
+    auto_arima_model = AutoARIMA(sp=12, d=0, max_p=2, max_q=2, suppress_warnings=True).fit(
+        airline, fh=[1, 2, 3]
+    )
+
+    mlflow_sktime.save_model(
+        sktime_model=auto_arima_model,
+        path=model_path,
+    )
+
+    loaded_model = mlflow_sktime.load_model(
+        model_uri=model_path,
+    )
+    loaded_pyfunc = mlflow_sktime.pyfunc.load_model(
+        model_uri=model_path,
+    )
+
+    print(loaded_model.predict())
+    print(loaded_pyfunc.predict(pd.DataFrame()))

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -2572,7 +2572,7 @@ Install sktime with mlflow dependency:
     pip install sktime[mlflow]
 
 Usage example
-~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~
 
 Refer to the `sktime mlflow documentation <https://www.sktime.org/en/latest/api_reference/deployment.html>`_ for details on the interface for utilizing sktime models loaded as a pyfunc type and an `example notebook <https://github.com/sktime/sktime/blob/main/examples/mlflow.ipynb>`_ for extended code usage examples.
 

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -2553,7 +2553,7 @@ Example:
     )
 
 Sktime
-^^^^^^^^^^^^^
+^^^^^^
 
 The ``sktime`` custom model flavor enables logging of `sktime <https://github.com/sktime/sktime>`_ models in MLflow
 format via the ``save_model()`` and ``log_model()`` methods. These methods also add the ``python_function`` flavor to the MLflow Models that they produce, allowing the

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -2552,27 +2552,29 @@ Example:
         input_example=df_iris.head(5),
     )
 
-MLflow Sktime
+Sktime
 ^^^^^^^^^^^^^
 
-The ``sktime`` custom model flavor enables logging of `sktime models <https://github.com/sktime/sktime>`_ in MLflow
-format via the `mlflow_sktime.save_model()  <https://www.sktime.org/en/latest/api_reference/auto_generated/sktime.utils.mlflow_sktime.save_model.html>`_ and
-`mlflow_sktime.log_model()  <https://www.sktime.org/en/latest/api_reference/auto_generated/sktime.utils.mlflow_sktime.log_model.html>`_ methods.
-These methods also add the ``python_function`` flavor to the MLflow Models that they produce, allowing the
+The ``sktime`` custom model flavor enables logging of `sktime <https://github.com/sktime/sktime>`_ models in MLflow
+format via the ``save_model()`` and ``log_model()`` methods. These methods also add the ``python_function`` flavor to the MLflow Models that they produce, allowing the
 model to be interpreted as generic Python functions for inference via :py:func:`mlflow.pyfunc.load_model()`.
 This loaded PyFunc model can only be scored with a DataFrame input.
-You can also use the `mlflow_sktime.load_model()  <https://www.sktime.org/en/latest/api_reference/auto_generated/sktime.utils.mlflow_sktime.load_model.html>`_ method to load MLflow Models with the ``sktime``
+You can also use the ``load_model()`` method to load MLflow Models with the ``sktime``
 model flavor in native sktime formats.
 
-Refer to the `sktime mlflow documentation <https://www.sktime.org/en/latest/api_reference/deployment.html>`_ for details on the interface for utilizing a sktime model loaded as a pyfunc type and an `example notebook <https://github.com/sktime/sktime/blob/main/examples/mlflow.ipynb>`_ for extended code usage examples.
+Installing Sktime
+~~~~~~~~~~~~~~~~~~~~
 
-Installation:
+Install sktime with mlflow dependency:
 
 .. code-block:: bash
 
     pip install sktime[mlflow]
 
-Example:
+Usage example
+~~~~~~~~~~~~~~~~~~~~
+
+Refer to the `sktime mlflow documentation <https://www.sktime.org/en/latest/api_reference/deployment.html>`_ for details on the interface for utilizing sktime models loaded as a pyfunc type and an `example notebook <https://github.com/sktime/sktime/blob/main/examples/mlflow.ipynb>`_ for extended code usage examples.
 
 .. code-block:: python
 

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -16,7 +16,7 @@ that can be understood by different downstream tools.
 .. _model-storage-format:
 
 Storage Format
---------------l
+--------------
 
 Each MLflow Model is a directory containing arbitrary files, together with an ``MLmodel``
 file in the root of the directory that can define multiple *flavors* that the model can be viewed

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -2563,7 +2563,7 @@ You can also use the ``load_model()`` method to load MLflow Models with the ``sk
 model flavor in native sktime formats.
 
 Installing Sktime
-~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~
 
 Install sktime with mlflow dependency:
 


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs
Resolve #7617
<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

## What changes are proposed in this pull request?

Adds sktime to the MLflow docs in the community model flavor section

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add documentation for custom model flavor of sktime library

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
