### PR TITLE
[Recipes][Bug Fix] Fixing transform step step_config for positive_class

### DIFF
--- a/mlflow/recipes/steps/transform.py
+++ b/mlflow/recipes/steps/transform.py
@@ -228,6 +228,8 @@ class TransformStep(BaseStep):
             step_config.update(recipe_config.get("steps", {}).get("transform", {}))
         step_config["target_col"] = recipe_config.get("target_col")
         step_config["recipe"] = recipe_config.get("recipe", "regression/v1")
+        if "positive_class" in recipe_config:
+            step_config["positive_class"] = recipe_config.get("positive_class")
         step_config.update(
             get_recipe_tracking_config(
                 recipe_root_path=recipe_root,

--- a/tests/recipes/test_transform_step.py
+++ b/tests/recipes/test_transform_step.py
@@ -84,15 +84,17 @@ def test_transform_step_writes_onehot_encoded_dataframe_and_transformer_pkl(tmp_
     assert os.path.exists(transform_step_output_dir / "transformer.pkl")
 
 
-def test_transform_steps_work_without_step_config(tmp_recipe_root_path):
+@pytest.mark.parametrize("recipe", ["regression/v1", "classification/v1"])
+def test_transform_steps_work_without_step_config(tmp_recipe_root_path, recipe):
     recipe_yaml = tmp_recipe_root_path.joinpath(_RECIPE_CONFIG_FILE_NAME)
     experiment_name = "demo"
     MlflowClient().create_experiment(experiment_name)
 
     recipe_yaml.write_text(
         """
-        recipe: "regression/v1"
+        recipe: {recipe}
         target_col: "y"
+        {positive_class}
         experiment:
           name: {experiment_name}
           tracking_uri: {tracking_uri}
@@ -102,10 +104,13 @@ def test_transform_steps_work_without_step_config(tmp_recipe_root_path):
         """.format(
             tracking_uri=mlflow.get_tracking_uri(),
             experiment_name=experiment_name,
+            recipe=recipe,
+            positive_class='positive_class: "a"' if recipe == "regression/v1" else "",
         )
     )
     recipe_config = read_yaml(tmp_recipe_root_path, _RECIPE_CONFIG_FILE_NAME)
-    TransformStep.from_recipe_config(recipe_config, str(tmp_recipe_root_path))
+    transform_step = TransformStep.from_recipe_config(recipe_config, str(tmp_recipe_root_path))
+    transform_step._validate_and_apply_step_config()
 
 
 def test_transform_empty_step(tmp_recipe_root_path):


### PR DESCRIPTION
## What changes are proposed in this pull request?
[Recipes][Bug Fix] Fixing transform step step_config for positive_class

## How is this patch tested?
- [x] Verified that the notebook works with transform step with classification

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
