### PR TITLE
[Tracking][Artifacts] Added feature to log code to mlflow artifacts/code

### DIFF
--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -491,17 +491,17 @@ class TrackingServiceClient:
         )
 
     @staticmethod
-    def _filter_based_on_file_extension(path: str, file_extension: str) -> bool:
+    def _filter_based_on_file_extension(path: str, file_extension: Tuple[str]) -> bool:
         return path.endswith(file_extension)
 
-    def _get_code_files(self, local_dir: str, file_extension: str) -> Iterator[Tuple[str, str]]:
+    def _get_code_files(self, local_dir: str, file_extension: Tuple[str]) -> Iterator[Tuple[str, str]]:
         for directory_path, _, file_names in os.walk(local_dir):
             for file_name in file_names:
                 file_path = os.path.join(directory_path, file_name)
                 if self._filter_based_on_file_extension(path=file_path, file_extension=file_extension):
                     yield file_path, directory_path
 
-    def log_code_to_artifact(self, run_id, local_dir=os.path.abspath("."), file_extension=".py", artifact_path="code"):
+    def log_code_to_artifact(self, run_id, local_dir=os.path.abspath("."), file_extension=(".py"), artifact_path="code"):
         """
         Write directory containing code to artifacts
         """

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1047,6 +1047,45 @@ class MlflowClient:
         """
         self._tracking_client.log_artifacts(run_id, local_dir, artifact_path)
 
+    def log_code_to_artifact(
+        self, run_id, local_dir=os.path.abspath("."), file_extension=".py", artifact_path="code"
+    ) -> None:
+        """
+        Write a directory of code to the remote ``artifact_uri``.
+
+        :param local_dir: Path to the directory of code.
+        :param artifact_path: If provided, the directory in ``artifact_uri`` to write to.
+
+        .. code-block:: python
+            :caption: Example
+
+            import os
+            import json
+            from mlflow import MlflowClient
+
+            features = ["rooms, zipcode, median_price, school_rating, transport"]
+            with open("features.py", 'w') as f:
+                f.write(features)
+
+            # Create a run under the default experiment (whose id is '0').
+            client = MlflowClient()
+            experiment_id = "0"
+            run = client.create_run(experiment_id)
+
+            # log and fetch the artifact
+            client.log_code_to_artifact(run.info.run_id, os.path.abspath("features.py"))
+            artifacts = client.list_artifacts(run.info.run_id)
+            for artifact in artifacts:
+                print("artifact: {}".format(artifact.path))
+            client.set_terminated(run.info.run_id)
+
+        .. code-block:: text
+            :caption: Output
+
+            artifact: code/features.py
+        """
+        self._tracking_client.log_code_to_artifact(run_id, local_dir, file_extension, artifact_path)
+
     @contextlib.contextmanager
     def _log_artifact_helper(self, run_id, artifact_file):
         """


### PR DESCRIPTION
Signed-off-by: sarveshwar-s <59520591+sarveshwar-s@users.noreply.github.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?
This PR allows us to log code to mlflow artifacts under the directory "artifacts/code"
(Please fill in changes proposed in this fix)

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

MlflowClient.log_code_to_artifact() allows to log the code in the specified directory to artifacts/code directory.
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
