### PR TITLE
[Recipes][Bug Fix] Fixing custom ingest step format check

### DIFF
--- a/mlflow/recipes/steps/ingest/datasets.py
+++ b/mlflow/recipes/steps/ingest/datasets.py
@@ -247,9 +247,12 @@ class _DownloadThenConvertDataset(_LocationBasedDataset):
             if os.path.isdir(local_dataset_path):
                 # NB: Sort the file names alphanumerically to ensure a consistent
                 # ordering across invocations
-                dataset_file_paths = sorted(
-                    pathlib.Path(local_dataset_path).glob(f"*.{self.dataset_format}")
-                )
+                if self.dataset_format == "custom":
+                    dataset_file_paths = sorted(pathlib.Path(local_dataset_path).glob("*"))
+                else:
+                    dataset_file_paths = sorted(
+                        pathlib.Path(local_dataset_path).glob(f"*.{self.dataset_format}")
+                    )
                 if len(dataset_file_paths) == 0:
                     raise MlflowException(
                         message=(
@@ -261,7 +264,9 @@ class _DownloadThenConvertDataset(_LocationBasedDataset):
                         error_code=INVALID_PARAMETER_VALUE,
                     )
             else:
-                if not local_dataset_path.endswith(f".{self.dataset_format}"):
+                if self.dataset_format != "custom" and not local_dataset_path.endswith(
+                    f".{self.dataset_format}"
+                ):
                     raise MlflowException(
                         message=(
                             f"Resolved data file with path '{local_dataset_path}' does not have the"


### PR DESCRIPTION
## What changes are proposed in this pull request?
[Recipes][Bug Fix] Fixing custom ingest step format check

## How is this patch tested?
- [x] added tests

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
