### PR TITLE
Fix redirected links to appropriate resolved URL references in Docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -427,7 +427,7 @@ yarn lint:fix
 
 If contributing to MLflow's R APIs, install
 [R](https://cloud.r-project.org/) and make sure that you have satisfied
-all the [Common prerequisites and dependencies](#environment-setup-and-python-configuration).
+all the [Environment Setup and Python configuration](#environment-setup-and-python-configuration).
 
 For changes to R documentation, also install
 [pandoc](https://pandoc.org/installing.html) 2.2.1 or above, verifying
@@ -503,7 +503,7 @@ and the Model Scoring Server for Java-based models like MLeap
 
 Other Java functionality (like artifact storage) depends on the Python
 package, so first install the Python package in a conda environment as
-described in [Common prerequisites and dependencies](#environment-setup-and-python-configuration).
+described in [Environment Setup and Python configuration](#environment-setup-and-python-configuration).
 [Install](https://www.oracle.com/technetwork/java/javase/downloads/index.html)
 the Java 8 JDK (or above), and
 [download](https://maven.apache.org/download.cgi) and
@@ -522,7 +522,7 @@ the updated docs to your PR branch.
 ### Python
 
 If you are contributing in Python, make sure that you have satisfied all
-the [Common prerequisites and dependencies](#environment-setup-and-python-configuration), including installing
+the [Environment Setup and Python configuration](#environment-setup-and-python-configuration), including installing
 `pytest`, as you will need it for the sections described below.
 
 #### Writing Python Tests
@@ -785,8 +785,7 @@ python setup.py bdist_wheel
 
 ### Writing Docs
 
-First, install dependencies for building docs as described in [Common
-prerequisites and dependencies](#environment-setup-and-python-configuration).
+First, install dependencies for building docs as described in [Environment Setup and Python configuration](#environment-setup-and-python-configuration).
 
 To generate a live preview of Python & other rst documentation, run the
 following snippet. Note that R & Java API docs must be regenerated

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -427,7 +427,7 @@ yarn lint:fix
 
 If contributing to MLflow's R APIs, install
 [R](https://cloud.r-project.org/) and make sure that you have satisfied
-all the [Common prerequisites and dependencies]().
+all the [Common prerequisites and dependencies](#environment-setup-and-python-configuration).
 
 For changes to R documentation, also install
 [pandoc](https://pandoc.org/installing.html) 2.2.1 or above, verifying
@@ -503,7 +503,7 @@ and the Model Scoring Server for Java-based models like MLeap
 
 Other Java functionality (like artifact storage) depends on the Python
 package, so first install the Python package in a conda environment as
-described in [Common prerequisites and dependencies]().
+described in [Common prerequisites and dependencies](#environment-setup-and-python-configuration).
 [Install](https://www.oracle.com/technetwork/java/javase/downloads/index.html)
 the Java 8 JDK (or above), and
 [download](https://maven.apache.org/download.cgi) and
@@ -522,7 +522,7 @@ the updated docs to your PR branch.
 ### Python
 
 If you are contributing in Python, make sure that you have satisfied all
-the [Common prerequisites and dependencies](), including installing
+the [Common prerequisites and dependencies](#environment-setup-and-python-configuration), including installing
 `pytest`, as you will need it for the sections described below.
 
 #### Writing Python Tests
@@ -786,7 +786,7 @@ python setup.py bdist_wheel
 ### Writing Docs
 
 First, install dependencies for building docs as described in [Common
-prerequisites and dependencies]().
+prerequisites and dependencies](#environment-setup-and-python-configuration).
 
 To generate a live preview of Python & other rst documentation, run the
 following snippet. Note that R & Java API docs must be regenerated

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -697,7 +697,7 @@ MLeap (``mleap``)
 ^^^^^^^^^^^^^^^^^
 
 The ``mleap`` model flavor supports saving Spark models in MLflow format using the
-`MLeap <http://mleap-docs.combust.ml/>`_ persistence mechanism. MLeap is an inference-optimized
+`MLeap <https://combust.github.io/mleap-docs/>`_ persistence mechanism. MLeap is an inference-optimized
 format and execution engine for Spark models that does not depend on
 `SparkContext <https://spark.apache.org/docs/latest/api/python/pyspark.html#pyspark.SparkContext>`_
 to evaluate inputs.
@@ -718,7 +718,7 @@ A companion module for loading MLflow Models with the MLeap flavor is available 
 ``mlflow/java`` package.
 
 For more information, see :py:mod:`mlflow.spark`, :py:mod:`mlflow.mleap`, and the
-`MLeap documentation <http://mleap-docs.combust.ml/>`_.
+`MLeap documentation <https://combust.github.io/mleap-docs/>`_.
 
 PyTorch (``pytorch``)
 ^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Signed-off-by: nsenno-dbr <nick.senno@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

Updated links in CONTRIBUTION.md that had been renamed/removed 
Updated link to MLeap documentation that had been moved

(Please fill in changes proposed in this fix)

update to docs were tested by building the documents locally and ensuring links point to correct MLeap documentation

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests (describe details, including test results, below)

Validate docs rendering is correct and links function properly

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [X] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
