### PR TITLE
[Recipes][Bug Fix] add run_id and artifact path to logged model

### DIFF
--- a/mlflow/recipes/steps/train.py
+++ b/mlflow/recipes/steps/train.py
@@ -391,9 +391,20 @@ class TrainStep(BaseStep):
                 model = mlflow.pyfunc.load_model(model_uri)
                 # Adding a sklearn flavor to the pyfunc model so models could be loaded easily
                 # using mlflow.sklearn.load_model
-                model_info = Model.load(model_uri)
+                tmp_model_info = Model.load(model_uri)
                 model_data_subpath = os.path.join(
                     "artifacts", TrainStep.SKLEARN_MODEL_ARTIFACT_RELATIVE_PATH, "model.pkl"
+                )
+                model_info = Model(
+                    artifact_path="train/model",
+                    run_id=run.info.run_id,
+                    utc_time_created=tmp_model_info.utc_time_created,
+                    flavors=tmp_model_info.flavors,
+                    signature=tmp_model_info.signature,  # ModelSignature
+                    saved_input_example_info=tmp_model_info.saved_input_example_info,
+                    model_uuid=tmp_model_info.model_uuid,
+                    mlflow_version=tmp_model_info.mlflow_version,
+                    metadata=tmp_model_info.metadata,
                 )
                 model_info.add_flavor(
                     mlflow.sklearn.FLAVOR_NAME,


### PR DESCRIPTION
## What changes are proposed in this pull request?
[Recipes][Bug Fix] add run_id and artifact path to logged model

## How is this patch tested?
```
artifact_path: train/model
databricks_runtime: 12.x-snapshot-cpu-ml-scala2.12
flavors:
  python_function:
    artifacts:
      model_path:
        path: artifacts/sk_model
        uri: /root/.mlflow/recipes/d496cd7d2671bd98b673352829898ca07804aa3e592e27147e729327bbacb0e9/steps/train/outputs/sk_model
    cloudpickle_version: 2.0.0
    code: code
    env:
      conda: conda.yaml
      virtualenv: python_env.yaml
    loader_module: mlflow.pyfunc.model
    python_model: python_model.pkl
    python_version: 3.9.5
  sklearn:
    code: code
    pickled_model: artifacts/sk_model/model.pkl
    serialization_format: cloudpickle
    sklearn_version: 1.2.0
mlflow_version: 2.1.1.dev0
model_uuid: 8fbc01442321406a9a2ed026d8cd8bd8
run_id: aef7117f33b044419df06863f8c95322
signature:
  inputs: '[{"name": "fixed acidity", "type": "double"}, {"name": "volatile acidity",
    "type": "double"}, {"name": "citric acid", "type": "double"}, {"name": "residual
    sugar", "type": "double"}, {"name": "chlorides", "type": "double"}, {"name": "free
    sulfur dioxide", "type": "double"}, {"name": "total sulfur dioxide", "type": "double"},
    {"name": "density", "type": "double"}, {"name": "pH", "type": "double"}, {"name":
    "sulphates", "type": "double"}, {"name": "alcohol", "type": "double"}, {"name":
    "quality", "type": "long"}]'
  outputs: '[{"type": "tensor", "tensor-spec": {"dtype": "int64", "shape": [-1]}}]'
utc_time_created: '2023-01-05 05:29:29.600991'
```

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
