### PR TITLE
Add example documentation to show MLeap functionality for SparkML flavor

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -843,7 +843,7 @@ pipelinemodel#pyspark.ml.Pipeline>`_ to any production environment supported by 
 
 .. note::
     Note that when the ``sample_input`` parameter is provided to ``log_model()`` or 
-    ``save_model()``, the Spark model is automatically saved with using the ``mleap`` flavor
+    ``save_model()``, the Spark model is automatically saved as an ``mleap`` flavor
     by invoking :py:func:`mlflow.mleap.add_to_model()<mlflow.mleap.add_to_model>`.
     
     For example, the follow code block:

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -702,9 +702,13 @@ format and execution engine for Spark models that does not depend on
 `SparkContext <https://spark.apache.org/docs/latest/api/python/pyspark.html#pyspark.SparkContext>`_
 to evaluate inputs.
 
-You can save Spark models in MLflow format with the ``mleap`` flavor by specifying the
-``sample_input`` argument of the :py:func:`mlflow.spark.save_model()` or
-:py:func:`mlflow.spark.log_model()` method (recommended). The :py:mod:`mlflow.mleap` module also
+.. note::
+
+    You can save Spark models in MLflow format with the ``mleap`` flavor by specifying the
+    ``sample_input`` argument of the :py:func:`mlflow.spark.save_model()` or
+    :py:func:`mlflow.spark.log_model()` method (recommended). For more details see :ref:`Spark MLlib <model-spark>`.
+
+The :py:mod:`mlflow.mleap` module also
 defines :py:func:`save_model() <mlflow.mleap.save_model>` and
 :py:func:`log_model() <mlflow.mleap.log_model>` methods for saving MLeap models in MLflow format,
 but these methods do not include the ``python_function`` flavor in the models they produce.
@@ -820,6 +824,8 @@ For a Scikit-learn LogisticRegression model, an example configuration for the py
     predictions = sklearn_pyfunc.predict(data)
 
 For more information, see :py:mod:`mlflow.sklearn`.
+
+.. _model-spark:
 
 Spark MLlib (``spark``)
 ^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Signed-off-by: nsenno-dbr <nick.senno@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Resolve --> #6098

## What changes are proposed in this pull request?
Added documentation that describes how the `sample_input` parameter of the `mlflow.spark.log_model` and `mlflow.spark.save_model` functionality invoke `mlflow.mleap.add_to_model`. This includes the MLeap flavor to the logged model. 


## How is this patch tested?

Manually using livehtml 

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
