### PR TITLE
Ensure the version is a dev version when running `dev/update_mlflow_versions.py --post-release`

### DIFF
--- a/dev/update_mlflow_versions.py
+++ b/dev/update_mlflow_versions.py
@@ -113,7 +113,9 @@ python dev/update_mlflow_versions.py post-release --new-version 1.29.0
 )
 def post_release(new_version: str):
     current_version = Version(get_current_py_version())
-    assert current_version.is_devrelease, f"{current_version} is not a dev version"
+    assert (
+        current_version.is_devrelease
+    ), f"{current_version} is not a dev version. This script must be run on master branch."
     new_version = Version(new_version)
     next_new_version = f"{new_version.major}.{new_version.minor}.{new_version.micro + 1}"
     update_versions(next_new_version, add_dev_suffix=True)

--- a/dev/update_mlflow_versions.py
+++ b/dev/update_mlflow_versions.py
@@ -6,7 +6,7 @@ import click
 from packaging.version import Version
 
 
-def get_current_version() -> str:
+def get_current_py_version() -> str:
     text = Path("mlflow", "version.py").read_text()
     ver = Version(re.search(r'VERSION = "(.+)"', text).group(1))
     return f"{ver.major}.{ver.minor}.{ver.micro}"
@@ -23,7 +23,7 @@ def replace_occurrences(files: List[Path], pattern: str, repl: str) -> None:
 
 
 def update_versions(new_version: str, add_dev_suffix: bool) -> None:
-    current_version = re.escape(get_current_version())
+    current_version = re.escape(get_current_py_version())
     # Java
     suffix = "-SNAPSHOT" if add_dev_suffix else ""
     for java_extension in ["xml", "java"]:
@@ -67,7 +67,7 @@ def validate_new_version(
     ctx: click.Context, param: click.Parameter, value: str  # pylint: disable=unused-argument
 ) -> str:
     new = Version(value)
-    current = Version(get_current_version())
+    current = Version(get_current_py_version())
     if new < current:
         raise click.BadParameter(
             f"New version {new} is not greater than or equal to current version {current}"
@@ -112,6 +112,8 @@ python dev/update_mlflow_versions.py post-release --new-version 1.29.0
     help="New version that was released",
 )
 def post_release(new_version: str):
+    current_version = Version(get_current_py_version())
+    assert current_version.is_devrelease, f"{current_version} is not a dev version"
     new_version = Version(new_version)
     next_new_version = f"{new_version.major}.{new_version.minor}.{new_version.micro + 1}"
     update_versions(next_new_version, add_dev_suffix=True)


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Ensure the version is a dev version when running `dev/update_mlflow_versions.py --post-release`.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
