### PR TITLE
Dockerfile optimization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,22 +5,23 @@ WORKDIR /app
 ADD . /app
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && \
-    # install prequired modules to support install of mlflow and related components
-    apt-get install -y default-libmysqlclient-dev build-essential curl openjdk-11-jre-headless \
-    # cmake and protobuf-compiler required for onnx install
-    cmake protobuf-compiler &&  \
-    # install required python packages
-    pip install -r requirements/dev-requirements.txt --no-cache-dir && \
-    # install mlflow in editable form
-    pip install --no-cache-dir -e .
-
-# Build MLflow UI
 RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
-    apt-get update && apt-get install -y nodejs && \
+    # install prequired modules to support install of mlflow and related components
+    apt-get install -y nodejs build-essential openjdk-11-jre-headless \
+    # cmake and protobuf-compiler required for onnx install
+    cmake protobuf-compiler && \
+    # install required python packages
+    pip install --no-cache-dir -r requirements/dev-requirements.txt && \
+    # install mlflow in editable form
+    pip install --no-cache-dir -e . && \
+    # Build MLflow UI
     npm install --global yarn && \
     cd mlflow/server/js && \
     yarn install && \
-    yarn build
+    yarn build && \
+    # clear cache
+    apt-get autoremove -yqq --purge && apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    npm cache clean --force && \
+    yarn cache clean --all
 
 CMD ["bash"]


### PR DESCRIPTION
The command to pull the setup_16.x script was added due to the fact that there is already apt update command inside the script, executing this command a second time had no effect, it only increased the image build time, the curl and installation was also removed due to the fact that the image is python3.8 already has curl and default-libmysqlclient-dev, apt jarn and npm cache removal has also been added. There was also no need to separate the installation into two layers, so they were combined into one layer.

Signed-off-by: alekseyolg <86011874+alekseyolg@users.noreply.github.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
