### PR TITLE
Fix `post-relesae` command in `update_mlflow_versions.py`

### DIFF
--- a/dev/update_mlflow_versions.py
+++ b/dev/update_mlflow_versions.py
@@ -26,8 +26,10 @@ def replace_occurrences(files: List[Path], pattern: str, repl: str) -> None:
 
 
 def update_versions(new_py_version: str) -> None:
-    # `new_py_version` is either a release version (e.g. "2.1.0") or a dev version
-    # (e.g. "2.1.0.dev0")
+    """
+    `new_py_version` is either a release version (e.g. "2.1.0") or a dev version
+    (e.g. "2.1.0.dev0").
+    """
     current_py_version = get_current_py_version()
     current_py_version_without_suffix = replace_dev_suffix_with(current_py_version, "")
 

--- a/dev/update_mlflow_versions.py
+++ b/dev/update_mlflow_versions.py
@@ -8,8 +8,11 @@ from packaging.version import Version
 
 def get_current_py_version() -> str:
     text = Path("mlflow", "version.py").read_text()
-    ver = Version(re.search(r'VERSION = "(.+)"', text).group(1))
-    return f"{ver.major}.{ver.minor}.{ver.micro}"
+    return re.search(r'VERSION = "(.+)"', text).group(1)
+
+
+def replace_dev_suffix_with(version, repl):
+    return re.sub(r"\.dev0$", repl, version)
 
 
 def replace_occurrences(files: List[Path], pattern: str, repl: str) -> None:
@@ -22,25 +25,19 @@ def replace_occurrences(files: List[Path], pattern: str, repl: str) -> None:
         f.write_text(new_text)
 
 
-def update_versions(new_version: str, add_dev_suffix: bool) -> None:
-    current_version = re.escape(get_current_py_version())
-    # Java
-    suffix = "-SNAPSHOT" if add_dev_suffix else ""
-    for java_extension in ["xml", "java"]:
-        replace_occurrences(
-            files=Path("mlflow", "java").rglob(f"*.{java_extension}"),
-            pattern=rf"{current_version}(-SNAPSHOT)?",
-            repl=new_version + suffix,
-        )
+def update_versions(new_py_version: str) -> None:
+    # `new_py_version` is either a release version (e.g. "2.1.0") or a dev version
+    # (e.g. "2.1.0.dev0")
+    current_py_version = get_current_py_version()
+    current_py_version_without_suffix = replace_dev_suffix_with(current_py_version, "")
+
     # Python
-    suffix = ".dev0" if add_dev_suffix else ""
     replace_occurrences(
         files=[Path("mlflow", "version.py")],
-        pattern=rf"{current_version}(\.dev0)?",
-        repl=new_version + suffix,
+        pattern=re.escape(current_py_version),
+        repl=new_py_version,
     )
     # JS
-    suffix = ".dev0" if add_dev_suffix else ""
     replace_occurrences(
         files=[
             Path(
@@ -52,14 +49,23 @@ def update_versions(new_version: str, add_dev_suffix: bool) -> None:
                 "constants.js",
             )
         ],
-        pattern=rf"{current_version}(\.dev0)?",
-        repl=new_version + suffix,
+        pattern=re.escape(current_py_version),
+        repl=new_py_version,
     )
+
+    # Java
+    for java_extension in ["xml", "java"]:
+        replace_occurrences(
+            files=Path("mlflow", "java").rglob(f"*.{java_extension}"),
+            pattern=rf"{re.escape(current_py_version_without_suffix)}(-SNAPSHOT)?",
+            repl=replace_dev_suffix_with(new_py_version, "-SNAPSHOT"),
+        )
+
     # R
     replace_occurrences(
         files=[Path("mlflow", "R", "mlflow", "DESCRIPTION")],
-        pattern=f"Version: {current_version}",
-        repl=f"Version: {new_version}",
+        pattern=f"Version: {re.escape(current_py_version_without_suffix)}",
+        repl=f"Version: {current_py_version_without_suffix}",
     )
 
 
@@ -93,7 +99,7 @@ python dev/update_mlflow_versions.py pre-release --new-version 1.29.0
     "--new-version", callback=validate_new_version, required=True, help="New version to release"
 )
 def pre_release(new_version: str):
-    update_versions(new_version, add_dev_suffix=False)
+    update_versions(new_py_version=new_version)
 
 
 @update_mlflow_versions.command(
@@ -113,12 +119,16 @@ python dev/update_mlflow_versions.py post-release --new-version 1.29.0
 )
 def post_release(new_version: str):
     current_version = Version(get_current_py_version())
-    assert (
-        current_version.is_devrelease
-    ), f"{current_version} is not a dev version. This script must be run on master branch."
+    msg = (
+        "It appears you ran this command on a release branch because the current version "
+        f"({current_version}) is not a dev version. Please re-run this command on the master "
+        "branch."
+    )
+    assert current_version.is_devrelease, msg
     new_version = Version(new_version)
-    next_new_version = f"{new_version.major}.{new_version.minor}.{new_version.micro + 1}"
-    update_versions(next_new_version, add_dev_suffix=True)
+    # Increment the patch version and append ".dev0"
+    new_py_version = f"{new_version.major}.{new_version.minor}.{new_version.micro + 1}.dev0"
+    update_versions(new_py_version=new_py_version)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Fix `update mlflow versions.py` (again).

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
