### PR TITLE
Unshallow the repository in `update_changelog.py`

### DIFF
--- a/dev/update_changelog.py
+++ b/dev/update_changelog.py
@@ -102,8 +102,15 @@ def is_shallow():
 )
 def main(prev_branch, curr_branch, release_version, remote):
     if is_shallow():
-        # To ensure that `git log` works correctly, unshallow the repository if it's shallow.
+        print("Unshallowing repository to ensure `git log` works correctly")
         subprocess.check_call(["git", "fetch", "--unshallow"])
+        print("Modifying .git/config to fetch remote branches")
+        subprocess.check_call(
+            ["git", "config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*"]
+        )
+    subprocess.check_call(["git", "fetch", remote, prev_branch])
+    subprocess.check_call(["git", "fetch", remote, curr_branch])
+    subprocess.check_call(["git", "branch", "-r"])
     git_log_output = subprocess.check_output(
         [
             "git",

--- a/dev/update_changelog.py
+++ b/dev/update_changelog.py
@@ -71,6 +71,20 @@ class Section(NamedTuple):
         )
 
 
+def is_shallow():
+    return (
+        subprocess.check_output(
+            [
+                "git",
+                "rev-parse",
+                "--is-shallow-repository",
+            ],
+            text=True,
+        ).strip()
+        == "true"
+    )
+
+
 @click.command(help="Update CHANGELOG.md")
 @click.option(
     "--prev-branch",
@@ -87,8 +101,9 @@ class Section(NamedTuple):
     "--remote", required=False, default="origin", help="Git remote to use (default: origin). "
 )
 def main(prev_branch, curr_branch, release_version, remote):
-    subprocess.check_call(["git", "fetch", remote, curr_branch])
-    subprocess.check_call(["git", "fetch", remote, prev_branch])
+    if is_shallow():
+        # To ensure that `git log` works correctly, unshallow the repository if it's shallow.
+        subprocess.check_call(["git", "fetch", "--unshallow"])
     git_log_output = subprocess.check_output(
         [
             "git",


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

It took me a while to figure out why `git log` doesn't work in our internal CI job. `git log <revison1>...<revision2>` doesn't work in a shallow-cloned repository. To fix this issue, unshallow the repository.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
