### PR TITLE
[Tracking] [Artifacts] Extended log_text feature to log multiple files at a time

### DIFF
--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1066,7 +1066,9 @@ class MlflowClient:
             yield tmp_path
             self.log_artifact(run_id, tmp_path, artifact_dir)
 
-    def log_text(self, run_id: str, text: str, artifact_file: str) -> None:
+    def log_text(
+        self, run_id: str, text: Union[List[str], str], artifact_file: Union[List[str], str]
+        ) -> None:
         """
         Log text as an artifact.
 
@@ -1091,10 +1093,22 @@ class MlflowClient:
 
             # Log HTML text
             client.log_text(run.info.run_id, "<h1>header</h1>", "index.html")
+
+            # Log multiple files
+            client.log_text(run.info.run_id,
+                            ["text1", "text2", "<h1>header</h1>"],
+                            ["file1.txt", "dir/file2.txt", "index.html"]
+                            )
+
         """
-        with self._log_artifact_helper(run_id, artifact_file) as tmp_path:
-            with open(tmp_path, "w", encoding="utf-8") as f:
-                f.write(text)
+        if isinstance(text, str) and isinstance(artifact_file, str):
+            text = [text]
+            artifact_file = [artifact_file]
+        for text, artifact_file in zip(text, artifact_file):
+            with self._log_artifact_helper(run_id, artifact_file) as tmp_path:
+                with open(tmp_path, "w", encoding="utf-8") as f:
+                    f.write(text)
+                    _logger.debug(f"File saved to {artifact_file}")
 
     def log_dict(self, run_id: str, dictionary: Any, artifact_file: str) -> None:
         """

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -811,7 +811,9 @@ def log_artifacts(local_dir: str, artifact_path: Optional[str] = None) -> None:
     MlflowClient().log_artifacts(run_id, local_dir, artifact_path)
 
 
-def log_text(text: str, artifact_file: str) -> None:
+def log_text(
+    text: Union[List[str], str], artifact_file: Union[List[str], str]
+    ) -> None:
     """
     Log text as an artifact.
 
@@ -833,6 +835,12 @@ def log_text(text: str, artifact_file: str) -> None:
 
             # Log HTML text
             mlflow.log_text("<h1>header</h1>", "index.html")
+
+            # Log multiple files
+            mlflow.log_text(run.info.run_id,
+                            ["text1", "text2", "<h1>header</h1>"],
+                            ["file1.txt", "dir/file2.txt", "index.html"]
+                            )
     """
     run_id = _get_or_start_run().info.run_id
     MlflowClient().log_text(run_id, text, artifact_file)

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -811,7 +811,9 @@ def log_artifacts(local_dir: str, artifact_path: Optional[str] = None) -> None:
     MlflowClient().log_artifacts(run_id, local_dir, artifact_path)
 
 
-def log_text(text: str, artifact_file: str) -> None:
+def log_text(
+    text: Union[List[str], str], artifact_file: Union[List[str], str]
+    ) -> None:
     """
     Log text as an artifact.
 
@@ -833,6 +835,12 @@ def log_text(text: str, artifact_file: str) -> None:
 
             # Log HTML text
             mlflow.log_text("<h1>header</h1>", "index.html")
+
+            # Log multiple files
+            client.log_text(run.info.run_id,
+                            ["text1", "text2", "<h1>header</h1>"],
+                            ["file1.txt", "dir/file2.txt", "index.html"]
+                            )
     """
     run_id = _get_or_start_run().info.run_id
     MlflowClient().log_text(run_id, text, artifact_file)

--- a/tests/artifacts/test_artifacts.py
+++ b/tests/artifacts/test_artifacts.py
@@ -84,6 +84,21 @@ def run_with_text_artifact():
 
 
 @pytest.fixture()
+def run_with_multiple_text_artifacts():
+    artifact_paths = ["test/file1.txt", "test/file2.txt"]
+    artifact_contents = [
+        "This is content of file1", "This is content of file2"
+        ]
+    artifacts = []
+    with mlflow.start_run() as run:
+        mlflow.log_text(text=artifact_contents, artifact_file=artifact_paths)
+    for artifact_path, artifact_content in zip(artifact_paths, artifact_contents):
+        artifact_uri = str(pathlib.PurePosixPath(run.info.artifact_uri) / artifact_path)
+        artifacts.append(Artifact(artifact_uri, artifact_content))
+    return artifacts
+
+
+@pytest.fixture()
 def run_with_json_artifact():
     artifact_path = "test/config.json"
     artifact_content = {"mlflow-version": "0.28", "n_cores": "10"}
@@ -110,6 +125,12 @@ def run_with_image_artifact():
 def test_load_text(run_with_text_artifact):
     artifact = run_with_text_artifact
     assert mlflow.artifacts.load_text(artifact.uri) == artifact.content
+
+
+def test_run_with_multiple_text_artifacts(run_with_multiple_text_artifacts):
+    artifacts = run_with_multiple_text_artifacts
+    for artifact in artifacts:
+        assert mlflow.artifacts.load_text(artifact.uri) == artifact.content
 
 
 def test_load_dict(run_with_json_artifact):


### PR DESCRIPTION
This commit allows us to log multiple files with its appropriate content using log_text

Signed-off-by: sarveshwar-s <59520591+sarveshwar-s@users.noreply.github.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

This PR allows us to log multiple files at a time using log_text. 
Eg: 
`mlflow.log_text(text=["content of file_1","<header>Hello</header>"], artifact_path=["dir/file_1", "index.html"])`

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->
I checked this feature by creating new unit tests

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

log_text support multiple files to be logged at the same time.
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
