### PR TITLE
Add parallelization support to hdfs log_artifacts

### DIFF
--- a/mlflow/store/artifact/hdfs_artifact_repo.py
+++ b/mlflow/store/artifact/hdfs_artifact_repo.py
@@ -14,6 +14,11 @@ from mlflow.environment_variables import (
     MLFLOW_KERBEROS_USER,
     MLFLOW_PYARROW_EXTRA_CONF,
 )
+from concurrent.futures import ThreadPoolExecutor
+
+_NUM_MAX_THREADS = 8
+_NUM_MAX_THREADS_PER_CPU = 2
+_NUM_DEFAULT_CPUS = _NUM_MAX_THREADS // _NUM_MAX_THREADS_PER_CPU
 
 
 class HdfsArtifactRepository(ArtifactRepository):
@@ -69,11 +74,22 @@ class HdfsArtifactRepository(ArtifactRepository):
                 if not hdfs.exists(hdfs_subdir_path):
                     hdfs.mkdir(hdfs_subdir_path)
 
-                for each_file in files:
-                    source = os.path.join(subdir_path, each_file)
-                    destination = posixpath.join(hdfs_subdir_path, each_file)
-                    with open(source, "rb") as f:
-                        hdfs.upload(destination, f)
+                num_of_cpus = os.cpu_count() or _NUM_DEFAULT_CPUS
+                with ThreadPoolExecutor(max_workers=num_of_cpus) as executor:
+                    for each_file in files:
+                        executor.submit(
+                            HdfsArtifactRepository._upload_dir_files_to_hdfs,
+                            hdfs=hdfs, 
+                            subdir_path=subdir_path, 
+                            hdfs_subdir_path=hdfs_subdir_path,
+                            each_file=each_file
+                        )
+
+    def _upload_dir_files_to_hdfs(self, hdfs, subdir_path, hdfs_subdir_path, each_file):
+        source = os.path.join(subdir_path, each_file)
+        destination = posixpath.join(hdfs_subdir_path, each_file)
+        with open(source, "rb") as f:
+            hdfs.upload(destination, f)
 
     def list_artifacts(self, path=None):
         """

--- a/mlflow/store/artifact/hdfs_artifact_repo.py
+++ b/mlflow/store/artifact/hdfs_artifact_repo.py
@@ -14,6 +14,11 @@ from mlflow.environment_variables import (
     MLFLOW_KERBEROS_USER,
     MLFLOW_PYARROW_EXTRA_CONF,
 )
+from concurrent.futures import ThreadPoolExecutor
+
+_NUM_MAX_THREADS = 8
+_NUM_MAX_THREADS_PER_CPU = 2
+_NUM_DEFAULT_CPUS = _NUM_MAX_THREADS // _NUM_MAX_THREADS_PER_CPU
 
 
 class HdfsArtifactRepository(ArtifactRepository):
@@ -69,11 +74,18 @@ class HdfsArtifactRepository(ArtifactRepository):
                 if not hdfs.exists(hdfs_subdir_path):
                     hdfs.mkdir(hdfs_subdir_path)
 
-                for each_file in files:
-                    source = os.path.join(subdir_path, each_file)
-                    destination = posixpath.join(hdfs_subdir_path, each_file)
-                    with open(source, "rb") as f:
-                        hdfs.upload(destination, f)
+                num_of_cpus = os.cpu_count() or _NUM_DEFAULT_CPUS
+                with ThreadPoolExecutor(max_workers=num_of_cpus) as executor:
+                    for each_file in files:
+                        executor.submit(
+                            self._upload_dir_files_to_hdfs(hdfs, subdir_path, hdfs_subdir_path, each_file), each_file
+                        )
+
+    def _upload_dir_files_to_hdfs(self, hdfs, subdir_path, hdfs_subdir_path, each_file):
+        source = os.path.join(subdir_path, each_file)
+        destination = posixpath.join(hdfs_subdir_path, each_file)
+        with open(source, "rb") as f:
+            hdfs.upload(destination, f)
 
     def list_artifacts(self, path=None):
         """


### PR DESCRIPTION
This commit parallelizes the upload of files to hdfs in log_artifacts function

Signed-off-by: sarveshwar-s <59520591+sarveshwar-s@users.noreply.github.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

This commit parallelizes the upload of files to hdfs in log_artifacts function

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
