### PR TITLE
Add an example of saving and loading Spark MLlib models using MLflow.

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -832,9 +832,13 @@ Spark MLlib (``spark``)
 
 The ``spark`` model flavor enables exporting Spark MLlib models as MLflow Models.
 
-The :py:mod:`mlflow.spark` module defines :py:func:`save_model() <mlflow.spark.save_model>` and
-:py:func:`log_model() <mlflow.spark.log_model>` methods that save Spark MLlib pipelines in MLflow
-model format. MLflow Models produced by these functions contain the ``python_function`` flavor,
+The :py:mod:`mlflow.spark` module defines
+
+* :py:func:`save_model() <mlflow.spark.save_model>` to save a Spark MLlib model to a DBFS path.
+* :py:func:`log_model() <mlflow.spark.log_model>` to upload a Spark MLlib model to the tracking server.
+* :py:func:`mlflow.spark.load_model()` to load MLflow Models with the ``spark`` flavor as Spark MLlib pipelines.
+
+MLflow Models produced by these functions contain the ``python_function`` flavor,
 allowing you to load them as generic Python functions via :py:func:`mlflow.pyfunc.load_model()`.
 This loaded PyFunc model can only be scored with DataFrame input.
 When a model with the ``spark`` flavor is loaded as a Python function via
@@ -846,6 +850,52 @@ is not ideal for high-performance use cases, it enables you to easily deploy any
 `MLlib PipelineModel <http://spark.apache.org/docs/latest/api/python/pyspark.ml.html?highlight=
 pipelinemodel#pyspark.ml.Pipeline>`_ to any production environment supported by MLflow
 (SageMaker, AzureML, etc).
+
+Spark MLlib pyfunc usage
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: py
+
+    from pyspark.ml.classification import LogisticRegression
+    from pyspark.ml.linalg import Vectors
+    from pyspark.sql import SparkSession
+    import mlflow
+
+    # Prepare training data from a list of (label, features) tuples.
+    spark = SparkSession.builder.appName("LogisticRegressionExample").getOrCreate()
+    training = spark.createDataFrame(
+        [
+            (1.0, Vectors.dense([0.0, 1.1, 0.1])),
+            (0.0, Vectors.dense([2.0, 1.0, -1.0])),
+            (0.0, Vectors.dense([2.0, 1.3, 1.0])),
+            (1.0, Vectors.dense([0.0, 1.2, -0.5]))
+        ],
+        ["label", "features"]
+    )
+
+    # Create and fit a LogisticRegression instance
+    lr = LogisticRegression(maxIter=10, regParam=0.01)
+    lr_model = lr.fit(training)
+
+    # Serialize the Model
+    with mlflow.start_run():
+        model_info = mlflow.spark.log_model(lr_model, "spark-model")
+
+    # Load saved model
+    lr_model_saved = mlflow.pyfunc.load_model(model_info.model_uri)
+
+    # Make predictions on test data.
+    # The DataFrame used in the predict method must be a Pandas DataFrame
+    test = spark.createDataFrame(
+        [
+            (1.0, Vectors.dense([-1.0, 1.5, 1.3])),
+            (0.0, Vectors.dense([3.0, 2.0, -0.1])),
+            (1.0, Vectors.dense([0.0, 2.2, -1.5]))
+        ],
+        ["label", "features"]
+    ).toPandas()
+
+    prediction = lr_model_saved.predict(test)
 
 .. note::
     Note that when the ``sample_input`` parameter is provided to ``log_model()`` or 
@@ -885,9 +935,6 @@ pipelinemodel#pyspark.ml.Pipeline>`_ to any production environment supported by 
         └── requirements.txt
 
     For more information, see :py:func:`mlflow.mleap<mlflow.mleap>`.
-
-Finally, the :py:func:`mlflow.spark.load_model()` method is used to load MLflow Models with
-the ``spark`` flavor as Spark MLlib pipelines.
 
 For more information, see :py:mod:`mlflow.spark`.
 


### PR DESCRIPTION
Signed-off-by: Dipanjan Kailthya <dipanjan.kailthya@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

#6099

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

## What changes are proposed in this pull request?

Added an example of saving and loading Spark MLlib models using MLflow. Link to preview doc here:
https://output.circle-artifacts.com/output/job/59360ef9-be92-441a-a79e-1fd80afce327/artifacts/0/docs/build/html/models.html#spark-mllib-pyfunc-usage

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [X] `area/docs`: MLflow documentation pages
- [X] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
