### PR TITLE
Do not log to sys.stderr if it is None.

### DIFF
--- a/mlflow/utils/logging_utils.py
+++ b/mlflow/utils/logging_utils.py
@@ -21,11 +21,11 @@ class MlflowLoggingStream:
         self._enabled = True
 
     def write(self, text):
-        if self._enabled:
+        if self._enabled and sys.stderr:
             sys.stderr.write(text)
 
     def flush(self):
-        if self._enabled:
+        if self._enabled and sys.stderr:
             sys.stderr.flush()
 
     @property

--- a/tests/utils/test_logging_utils.py
+++ b/tests/utils/test_logging_utils.py
@@ -98,9 +98,9 @@ def test_event_logging_stream_flushes_properly():
     assert stream.flush_count > 0
 
 
-def test_ignore_logging_if_stderr_is_none():
-    sys.stderr = None
-
+def test_ignore_logging_if_stderr_is_none(monkeypatch):
+    monkeypatch.setattr(sys, 'stderr', None)
+    # Make sure this does not fail.
     eprint("foo", flush=True)
 
 

--- a/tests/utils/test_logging_utils.py
+++ b/tests/utils/test_logging_utils.py
@@ -98,6 +98,12 @@ def test_event_logging_stream_flushes_properly():
     assert stream.flush_count > 0
 
 
+def test_ignore_logging_if_stderr_is_none():
+    sys.stderr = None
+
+    eprint("foo", flush=True)
+
+
 def test_debug_logs_emitted_correctly_when_configured():
     stream = TestStream()
     sys.stderr = stream


### PR DESCRIPTION
## Related Issues/PRs
## What changes are proposed in this pull request?
Ignore write and flush to sys.stderr if sys.stderr being None. This happens with Python 3.10 compiled Windows applications without a Console.

## How is this patch tested?
- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
