### PR TITLE
venv/Dockerfile.protos: Grouping RUNs, cleaning cache and packets, replacing ENV

### DIFF
--- a/dev/Dockerfile.protos
+++ b/dev/Dockerfile.protos
@@ -8,6 +8,6 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends curl unzip ca-certificates \
     && curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v3.19.4/protoc-3.19.4-linux-x86_64.zip \
     && unzip protoc-3.19.4-linux-x86_64.zip -d /root/protoc \
-    && apt-get remove -y curl unzip \
+    && apt-get remove -y curl unzip ca-certificates \
     && apt-get autoremove -yqq --purge && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && protoc --version

--- a/dev/Dockerfile.protos
+++ b/dev/Dockerfile.protos
@@ -3,10 +3,11 @@
 # $ docker run --rm -w /app -v $(pwd):/app gen-protos ./dev/generate-protos.sh
 
 FROM ubuntu:20.04
-
-RUN apt-get update --yes
-RUN apt-get install curl unzip --yes
-RUN curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v3.19.4/protoc-3.19.4-linux-x86_64.zip
-RUN unzip protoc-3.19.4-linux-x86_64.zip -d /root/protoc
 ENV PATH="/root/protoc/bin:${PATH}"
-RUN protoc --version
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl unzip ca-certificates \
+    && curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v3.19.4/protoc-3.19.4-linux-x86_64.zip \
+    && unzip protoc-3.19.4-linux-x86_64.zip -d /root/protoc \
+    && apt-get remove -y curl unzip \
+    && apt-get autoremove -yqq --purge && apt-get clean && rm -rf /var/lib/apt/lists/* \
+    && protoc --version

--- a/dev/Dockerfile.protos
+++ b/dev/Dockerfile.protos
@@ -4,10 +4,10 @@
 
 FROM ubuntu:20.04
 ENV PATH="/root/protoc/bin:${PATH}"
-RUN apt-get update \
+RUN apt-get update --yes \
     && apt-get install -y --no-install-recommends curl unzip ca-certificates \
     && curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v3.19.4/protoc-3.19.4-linux-x86_64.zip \
     && unzip protoc-3.19.4-linux-x86_64.zip -d /root/protoc \
     && apt-get remove -y curl unzip ca-certificates \
-    && apt-get autoremove -yqq --purge && apt-get clean && rm -rf /var/lib/apt/lists/* \
+    && apt-get autoremove -yqq --purge && apt-get clean && rm -rf /var/lib/apt/lists/* && rm -f protoc-3.19.4-linux-x86_64.zip \
     && protoc --version

--- a/dev/Dockerfile.protos
+++ b/dev/Dockerfile.protos
@@ -4,7 +4,7 @@
 
 FROM ubuntu:20.04
 ENV PATH="/root/protoc/bin:${PATH}"
-RUN apt-get update --yes \
+RUN apt-get update \
     && apt-get install -y --no-install-recommends curl unzip ca-certificates \
     && curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v3.19.4/protoc-3.19.4-linux-x86_64.zip \
     && unzip protoc-3.19.4-linux-x86_64.zip -d /root/protoc \


### PR DESCRIPTION
Using dockerfiles best practices for this file. Grouping multiple commands of RUN together will reduce the number of layers. ENV command was written first, because won't change and it is easier to cache.

Signed-off-by: Eldar <52000884+Eseeldur@users.noreply.github.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> none

## What changes are proposed in this pull request?

Changing dev/Dockerfile.protos to be more optimized:

- Grouping multiple commands of RUN together;
- Cache cleaning and packets removing commands was added;
- ENV command was replaced.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
