### PR TITLE
Add option to return data in python pickle format

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -2104,6 +2104,14 @@ the type and encoding of the input data
 
 Example requests:
 
+The REST API server, by default, returns the output of the model in JSON format. However, you can specify a
+different format by setting the ``Accept`` HTTP header. Currently, the following formats are supported:
+
+* ``application/json``: Returns the output of the model in JSON format.
+* ``application/octet-stream``: Returns the output of the model in the Python pickle format.
+
+Examples with bash:
+
 .. code-block:: bash
 
     # split-oriented DataFrame input
@@ -2136,6 +2144,43 @@ Example requests:
         "inputs": {"a": ["s1", "s2", "s3"], "b": [1, 2, 3], "c": [[1, 2, 3], [4, 5, 6], [7, 8, 9]]}
     }'
 
+Examples with python:
+
+.. code-block:: python
+
+    # With json response
+    import pandas as pd
+    import requests
+
+    data = {'col1': [1, 2], 'col2': [3, 4]}
+    df = pd.DataFrame(data=data)
+
+    response = requests.post(
+        "http://localhost:5000/invocations",
+        data=df.to_json(orient='split'),
+        headers={
+            'Content-Type': 'application/json',
+        }
+    )
+    predictions = response.json()
+
+    # With python pickle response
+    import pandas as pd
+    import pickle
+    import requests
+
+    data = {'col1': [1, 2], 'col2': [3, 4]}
+    df = pd.DataFrame(data=data)
+
+    response = requests.post(
+        "http://localhost:5000/invocations",
+        data=df.to_json(orient='split'),
+        headers={
+            'Content-Type': 'application/json',
+            'Accept': 'application/octet-stream',
+        }
+    )
+    predictions = pickle.loads(response.content)
 
 For more information about serializing pandas DataFrames, see
 `pandas.DataFrame.to_json <https://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.to_json.html>`_.


### PR DESCRIPTION

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

None

## What changes are proposed in this pull request?

With this PR, I add the option to define the HTTP response format of the scoring server. The current implementation converts all model outputs to json. This process is not reversible, since the original type of the object (=the class) is lost. This gives some problems for us because we want to be able to transparently call the models either in the same python process or - if the dependencies (library versions) don't match - start the http server in a different python environment and call the model encapsulated. Because the return type of the model should always be the same, I implemented the option to return the model output as python pickle dump. The return format can be specified by sending a HTTP `Accept` Header with either `application/json`(default) or `application/octet-stream` (python pickle). If your prefer another MIME Type, just let me know. Other options not implemented here were for instance CSV.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

Add option to specify the response type of the scoring server.

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
