### PR TITLE
[Feat] MLflow Recipes: Add option for score calibration for classification recipe

### DIFF
--- a/tests/recipes/test_train_step.py
+++ b/tests/recipes/test_train_step.py
@@ -760,7 +760,7 @@ def test_train_step_with_predict_probability(
         (str(transform_step_output_dir / "transformed_validation_data.parquet"))
     )
 
-    output = model.predict(validation_dataset)
+    output = model.predict(validation_dataset.drop("y", axis=1))
 
     assert list(output.columns) == [
         "predicted_score_a",
@@ -829,7 +829,7 @@ def test_train_step_with_predict_probability_with_custom_prefix(
         (str(transform_step_output_dir / "transformed_validation_data.parquet"))
     )
 
-    output = model.predict(validation_dataset)
+    output = model.predict(validation_dataset.drop("y", axis=1))
 
     assert list(output.columns) == [
         "custom_prefix_score_a",
@@ -886,9 +886,69 @@ def test_train_step_with_label_encoding(tmp_recipe_root_path: Path, tmp_recipe_e
         (str(transform_step_output_dir / "transformed_validation_data.parquet"))
     )
 
-    predicted_output = model.predict(validation_dataset)
+    predicted_output = model.predict(validation_dataset.drop("y", axis=1))
     predicted_label = predicted_output["predicted_label"]
 
     import numpy as np
 
     assert np.array_equal(np.unique(predicted_label), np.array(["a1", "a2", "a3", "b"]))
+
+
+def test_train_step_with_probability_calibration(
+    tmp_recipe_root_path: Path, tmp_recipe_exec_path: Path
+):
+    train_step_output_dir = setup_train_dataset(
+        tmp_recipe_exec_path, recipe="classification/binary"
+    )
+    recipe_steps_dir = tmp_recipe_root_path.joinpath("steps")
+    recipe_steps_dir.mkdir(parents=True)
+    recipe_yaml = tmp_recipe_root_path.joinpath(_RECIPE_CONFIG_FILE_NAME)
+    recipe_yaml.write_text(
+        """
+        recipe: "classification/v1"
+        target_col: "y"
+        primary_metric: "f1_score"
+        profile: "test_profile"
+        positive_class: "a"
+        run_args:
+            step: "train"
+        experiment:
+            name: "demo"
+            tracking_uri: {tracking_uri}
+        steps:
+            train:
+                using: custom
+                estimator_method: estimator_fn
+                calibrate_proba: isotonic
+                tuning:
+                    enabled: false
+        """.format(
+            tracking_uri=mlflow.get_tracking_uri()
+        )
+    )
+    with mock.patch(
+        "steps.train.estimator_fn",
+        classifier_with_predict_proba_estimator_fn,
+    ):
+        recipe_config = read_yaml(tmp_recipe_root_path, _RECIPE_CONFIG_FILE_NAME)
+        train_step = TrainStep.from_recipe_config(recipe_config, str(tmp_recipe_root_path))
+        train_step.run(str(train_step_output_dir))
+
+    model_uri = get_step_output_path(
+        recipe_root_path=tmp_recipe_root_path,
+        step_name="train",
+        relative_path=TrainStep.MODEL_ARTIFACT_RELATIVE_PATH,
+    )
+    model = mlflow.pyfunc.load_model(model_uri)
+    transform_step_output_dir = tmp_recipe_exec_path.joinpath("steps", "transform", "outputs")
+
+    validation_dataset = pd.read_parquet(
+        (str(transform_step_output_dir / "transformed_validation_data.parquet"))
+    )
+
+    predicted_output = model.predict(validation_dataset.drop("y", axis=1))
+    predicted_label = predicted_output["predicted_label"]
+
+    import numpy as np
+
+    assert np.array_equal(np.unique(predicted_label), np.array(["a", "b"]))


### PR DESCRIPTION
## What changes are proposed in this pull request?
[Feat] MLflow Recipes: Add score calibration for classification recipe

## How is this patch tested?
- [x] test added
- [x] pipeline
![image](https://user-images.githubusercontent.com/5621432/215609258-d8665b22-38fa-4af5-8f22-f6f10fc7f32b.png) 
- [x] Calibration plot 
![image](https://user-images.githubusercontent.com/5621432/215609353-4381a14d-eecc-4368-b1cc-d9f01df9d803.png)


## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

MLflow Recipes: Add option for score calibration for classification recipe

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
