### PR TITLE
Add feature to specify run name for recipes

### DIFF
--- a/mlflow/recipes/utils/tracking.py
+++ b/mlflow/recipes/utils/tracking.py
@@ -39,6 +39,7 @@ class TrackingConfig:
     _KEY_TRACKING_URI = "mlflow_tracking_uri"
     _KEY_EXPERIMENT_NAME = "mlflow_experiment_name"
     _KEY_EXPERIMENT_ID = "mlflow_experiment_id"
+    _KEY_RUN_NAME = "mlflow_run_name"
     _KEY_ARTIFACT_LOCATION = "mlflow_experiment_artifact_location"
 
     def __init__(
@@ -46,6 +47,7 @@ class TrackingConfig:
         tracking_uri: str,
         experiment_name: str = None,
         experiment_id: str = None,
+        run_name: str = None,
         artifact_location: str = None,
     ):
         """
@@ -58,6 +60,8 @@ class TrackingConfig:
                               ``experiment_id`` must be specified. If both are specified, they
                               must be consistent with Tracking server state. Note that this
                               Experiment may not exist prior to recipe execution.
+        :param run_name: The MLFlow Run Name. If the run name is not specified, then a random
+                                name is set for the run.
         :param artifact_location: The artifact location to use for the Experiment, if the Experiment
                                   does not already exist. If the Experiment already exists, this
                                   location is ignored.
@@ -76,6 +80,7 @@ class TrackingConfig:
         self.tracking_uri = tracking_uri
         self.experiment_name = experiment_name
         self.experiment_id = experiment_id
+        self.run_name = run_name
         self.artifact_location = artifact_location
 
     def to_dict(self) -> Dict[str, str]:
@@ -97,6 +102,9 @@ class TrackingConfig:
         if self.artifact_location:
             config_dict[TrackingConfig._KEY_ARTIFACT_LOCATION] = self.artifact_location
 
+        if self.run_name:
+            config_dict[TrackingConfig._KEY_RUN_NAME] = self.run_name
+
         return config_dict
 
     @classmethod
@@ -111,6 +119,7 @@ class TrackingConfig:
             tracking_uri=config_dict.get(TrackingConfig._KEY_TRACKING_URI),
             experiment_name=config_dict.get(TrackingConfig._KEY_EXPERIMENT_NAME),
             experiment_id=config_dict.get(TrackingConfig._KEY_EXPERIMENT_ID),
+            run_name=config_dict.get(TrackingConfig._KEY_RUN_NAME),
             artifact_location=config_dict.get(TrackingConfig._KEY_ARTIFACT_LOCATION),
         )
 
@@ -143,6 +152,7 @@ def get_recipe_tracking_config(
     tracking_config = recipe_config.get("experiment", {})
 
     config_obj_kwargs = {
+        "run_name": tracking_config.get("run_name", None),
         "tracking_uri": tracking_config.get("tracking_uri", default_tracking_uri),
         "artifact_location": tracking_config.get("artifact_location", default_artifact_location),
     }

--- a/tests/recipes/test_tracking_utils.py
+++ b/tests/recipes/test_tracking_utils.py
@@ -20,18 +20,25 @@ from tests.recipes.helper_functions import (
 
 @pytest.mark.usefixtures("enter_test_recipe_directory")
 @pytest.mark.parametrize(
-    ("tracking_uri", "artifact_location", "experiment_name", "experiment_id"),
+    ("tracking_uri", "artifact_location", "experiment_name", "experiment_id", "run_name"),
     [
-        ("mysql://myhost:8000/test_uri", "test/artifact/location", "myexpname", "myexpid"),
-        ("mysql://myhost:8000/test_uri", "test/artifact/location", None, "myexpid"),
-        ("mysql://myhost:8000/test_uri", "test/artifact/location", "myexpname", None),
-        (None, "test/artifact/location", "myexpname", "myexpid"),
-        ("mysql://myhost:8000/test_uri", None, "myexpname", "myexpid"),
-        (None, None, None, "myexpid"),
+        (
+            "mysql://myhost:8000/test_uri",
+            "test/artifact/location",
+            "myexpname",
+            "myexpid",
+            "testrun",
+        ),
+        ("mysql://myhost:8000/test_uri", "test/artifact/location", None, "myexpid", "testrun"),
+        ("mysql://myhost:8000/test_uri", "test/artifact/location", "myexpname", None, "testrun"),
+        (None, "test/artifact/location", "myexpname", "myexpid", "testrun"),
+        ("mysql://myhost:8000/test_uri", None, "myexpname", "myexpid", "testrun"),
+        ("mysql://myhost:8000/test_uri", "test/artifact/location", "myexpname", "myexpid", None),
+        (None, None, None, "myexpid", None),
     ],
 )
 def test_get_recipe_tracking_config_returns_expected_config(
-    tracking_uri, artifact_location, experiment_name, experiment_id
+    tracking_uri, artifact_location, experiment_name, experiment_id, run_name
 ):
     default_tracking_uri = path_to_local_sqlite_uri(
         path=str((pathlib.Path.cwd() / "metadata" / "mlflow" / "mlruns.db").resolve())
@@ -55,6 +62,8 @@ def test_get_recipe_tracking_config_returns_expected_config(
         profile_contents["experiment"]["name"] = experiment_name
     if experiment_id is not None:
         profile_contents["experiment"]["id"] = experiment_id
+    if run_name is not None:
+        profile_contents["experiment"]["run_name"] = run_name
 
     profile_path = pathlib.Path.cwd() / "profiles" / "testprofile.yaml"
     with open(profile_path, "w") as f:
@@ -68,6 +77,7 @@ def test_get_recipe_tracking_config_returns_expected_config(
     assert recipe_tracking_config.artifact_location == (
         artifact_location or default_artifact_location
     )
+    assert recipe_tracking_config.run_name == (run_name or None)
     if experiment_name is not None:
         assert recipe_tracking_config.experiment_name == experiment_name
     elif experiment_id is not None:
@@ -78,18 +88,25 @@ def test_get_recipe_tracking_config_returns_expected_config(
 
 @pytest.mark.usefixtures("enter_test_recipe_directory")
 @pytest.mark.parametrize(
-    ("tracking_uri", "artifact_location", "experiment_name", "experiment_id"),
+    ("tracking_uri", "artifact_location", "experiment_name", "experiment_id", "run_name"),
     [
-        ("mysql://myhost:8000/test_uri", "test/artifact/location", "myexpname", "myexpid"),
-        ("mysql://myhost:8000/test_uri", "test/artifact/location", None, "myexpid"),
-        ("mysql://myhost:8000/test_uri", "test/artifact/location", "myexpname", None),
-        (None, "test/artifact/location", "myexpname", "myexpid"),
-        ("mysql://myhost:8000/test_uri", None, "myexpname", "myexpid"),
-        (None, None, None, "myexpid"),
+        (
+            "mysql://myhost:8000/test_uri",
+            "test/artifact/location",
+            "myexpname",
+            "myexpid",
+            "testrun",
+        ),
+        ("mysql://myhost:8000/test_uri", "test/artifact/location", None, "myexpid", "testrun"),
+        ("mysql://myhost:8000/test_uri", "test/artifact/location", "myexpname", None, "testrun"),
+        (None, "test/artifact/location", "myexpname", "myexpid", "testrun"),
+        ("mysql://myhost:8000/test_uri", None, "myexpname", "myexpid", "testrun"),
+        ("mysql://myhost:8000/test_uri", "test/artifact/location", "myexpname", "myexpid", None),
+        (None, None, None, "myexpid", None),
     ],
 )
 def test_get_recipe_tracking_config_returns_expected_config_on_databricks(
-    tracking_uri, artifact_location, experiment_name, experiment_id
+    tracking_uri, artifact_location, experiment_name, experiment_id, run_name
 ):
     with mock.patch("mlflow.recipes.utils.tracking.is_in_databricks_runtime", return_value=True):
         default_tracking_uri = "databricks"
@@ -109,6 +126,8 @@ def test_get_recipe_tracking_config_returns_expected_config_on_databricks(
             profile_contents["experiment"]["name"] = experiment_name
         if experiment_id is not None:
             profile_contents["experiment"]["id"] = experiment_id
+        if run_name is not None:
+            profile_contents["experiment"]["run_name"] = run_name
 
         profile_path = pathlib.Path.cwd() / "profiles" / "testprofile.yaml"
         with open(profile_path, "w") as f:
@@ -120,6 +139,7 @@ def test_get_recipe_tracking_config_returns_expected_config_on_databricks(
         )
         assert recipe_tracking_config.tracking_uri == (tracking_uri or default_tracking_uri)
         assert recipe_tracking_config.artifact_location == artifact_location
+        assert recipe_tracking_config.run_name == (run_name or None)
         if experiment_name is not None:
             assert recipe_tracking_config.experiment_name == experiment_name
         elif experiment_id is not None:


### PR DESCRIPTION
Signed-off-by: Kamalesh Palanisamy <kamalesh800@gmail.com>

## Related Issues/PRs

Resolve #7647 

## What changes are proposed in this pull request?

This PR adds the feature to set a custom run name for a recipe. To specify the run name, we need to set the following value in the yaml file:

```
experiment:
       name: ......
       run_name: "test_run_name"
```

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [X] Manual tests (describe details, including test results, below)

I have tested the changes by mentioning a run name and removing the run name as well.

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [X] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
