### PR TITLE
Parse artifact path correctly in windows UNC format with servername

### DIFF
--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -2,7 +2,6 @@ import codecs
 import errno
 import gzip
 import os
-import platform
 import posixpath
 import shutil
 import sys
@@ -31,6 +30,7 @@ from mlflow.utils.rest_utils import cloud_storage_http_request, augmented_raise_
 from mlflow.utils.process import cache_return_value_per_process
 from mlflow.utils import merge_dicts
 from mlflow.utils.databricks_utils import _get_dbutils
+from mlflow.utils.helper_functions import is_local_os_windows
 
 ENCODING = "utf-8"
 
@@ -540,7 +540,7 @@ def local_file_uri_to_path(uri):
         parsed_path = urllib.parse.urlparse(uri)
         path = parsed_path.path
         # Fix for retaining server name in UNC path.
-        if platform.system().lower() == "windows" and parsed_path.hostname:
+        if is_local_os_windows() and parsed_path.hostname:
             return urllib.request.url2pathname(rf"\\{parsed_path.netloc}{path}")
     return urllib.request.url2pathname(path)
 

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -535,12 +535,14 @@ def local_file_uri_to_path(uri):
     Convert URI to local filesystem path.
     No-op if the uri does not have the expected scheme.
     """
+    path = uri
     if uri.startswith("file:"):
         parsed_path = urllib.parse.urlparse(uri)
+        path = parsed_path.path
         # Fix for retaining server name in UNC path.
         if platform.system().lower() == "windows" and parsed_path.hostname:
-            return urllib.request.url2pathname(rf"\\{parsed_path.netloc}{parsed_path.path}")
-    return urllib.request.url2pathname(uri)
+            return urllib.request.url2pathname(f"\\{parsed_path.netloc}{path}")
+    return urllib.request.url2pathname(path)
 
 
 def get_local_path_or_none(path_or_uri):

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -30,7 +30,7 @@ from mlflow.utils.rest_utils import cloud_storage_http_request, augmented_raise_
 from mlflow.utils.process import cache_return_value_per_process
 from mlflow.utils import merge_dicts
 from mlflow.utils.databricks_utils import _get_dbutils
-from mlflow.utils.helper_functions import is_local_os_windows
+from mlflow.utils.os import is_windows
 
 ENCODING = "utf-8"
 
@@ -540,7 +540,7 @@ def local_file_uri_to_path(uri):
         parsed_path = urllib.parse.urlparse(uri)
         path = parsed_path.path
         # Fix for retaining server name in UNC path.
-        if is_local_os_windows() and parsed_path.hostname:
+        if is_windows() and parsed_path.hostname:
             return urllib.request.url2pathname(rf"\\{parsed_path.netloc}{path}")
     return urllib.request.url2pathname(path)
 

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -541,7 +541,7 @@ def local_file_uri_to_path(uri):
         path = parsed_path.path
         # Fix for retaining server name in UNC path.
         if platform.system().lower() == "windows" and parsed_path.hostname:
-            return urllib.request.url2pathname(f"\\{parsed_path.netloc}{path}")
+            return urllib.request.url2pathname(rf"\\{parsed_path.netloc}{path}")
     return urllib.request.url2pathname(path)
 
 

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -2,6 +2,7 @@ import codecs
 import errno
 import gzip
 import os
+import platform
 import posixpath
 import shutil
 import sys
@@ -534,8 +535,12 @@ def local_file_uri_to_path(uri):
     Convert URI to local filesystem path.
     No-op if the uri does not have the expected scheme.
     """
-    path = urllib.parse.urlparse(uri).path if uri.startswith("file:") else uri
-    return urllib.request.url2pathname(path)
+    if uri.startswith("file:"):
+        parsed_path = urllib.parse.urlparse(uri)
+        # Fix for retaining server name in UNC path with server name.
+        if platform.system().lower() == "windows" and parsed_path.hostname:
+            return urllib.request.url2pathname(rf"\\{parsed_path.netloc}{parsed_path.path}")
+    return urllib.request.url2pathname(uri)
 
 
 def get_local_path_or_none(path_or_uri):

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -537,7 +537,7 @@ def local_file_uri_to_path(uri):
     """
     if uri.startswith("file:"):
         parsed_path = urllib.parse.urlparse(uri)
-        # Fix for retaining server name in UNC path with server name.
+        # Fix for retaining server name in UNC path.
         if platform.system().lower() == "windows" and parsed_path.hostname:
             return urllib.request.url2pathname(rf"\\{parsed_path.netloc}{parsed_path.path}")
     return urllib.request.url2pathname(uri)

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -540,7 +540,7 @@ def local_file_uri_to_path(uri):
         parsed_path = urllib.parse.urlparse(uri)
         path = parsed_path.path
         # Fix for retaining server name in UNC path.
-        if is_windows() and parsed_path.hostname:
+        if is_windows() and parsed_path.netloc:
             return urllib.request.url2pathname(rf"\\{parsed_path.netloc}{path}")
     return urllib.request.url2pathname(path)
 

--- a/mlflow/utils/helper_functions.py
+++ b/mlflow/utils/helper_functions.py
@@ -1,0 +1,8 @@
+import platform
+
+
+def is_local_os_windows():
+    """
+    :return: Returns true if the local system/OS name is Windows.
+    """
+    return platform.system().lower() == "windows"

--- a/mlflow/utils/os.py
+++ b/mlflow/utils/os.py
@@ -1,8 +1,8 @@
-import platform
+import os
 
 
 def is_windows():
     """
     :return: Returns true if the local system/OS name is Windows.
     """
-    return platform.system().lower() == "windows"
+    return os.name == "nt"

--- a/mlflow/utils/os.py
+++ b/mlflow/utils/os.py
@@ -1,7 +1,7 @@
 import platform
 
 
-def is_local_os_windows():
+def is_windows():
     """
     :return: Returns true if the local system/OS name is Windows.
     """

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -1,12 +1,12 @@
 import pathlib
 import posixpath
 import urllib.parse
-import platform
 
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.store.db.db_types import DATABASE_ENGINES
 from mlflow.utils.validation import _validate_db_type_string
+from mlflow.utils.helper_functions import is_local_os_windows
 
 _INVALID_DB_URI_MSG = (
     "Please refer to https://mlflow.org/docs/latest/tracking.html#storage for "
@@ -306,7 +306,7 @@ def resolve_uri_if_local(local_uri):
         local_path = local_file_uri_to_path(local_uri)
         if not pathlib.Path(local_path).is_absolute():
             if scheme == "":
-                if platform.system().lower() == "windows":
+                if is_local_os_windows():
                     return urllib.parse.urlunsplit(
                         (
                             "file",

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -293,7 +293,9 @@ def resolve_uri_if_local(local_uri):
     """
     if `local_uri` is passed in as a relative local path, this function
     resolves it to absolute path relative to current working directory.
+
     :param local_uri: Relative or absolute path or local file uri
+
     :return: a fully-formed absolute uri path or an absolute filesystem path
     """
     from mlflow.utils.file_utils import local_file_uri_to_path

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -289,48 +289,41 @@ def dbfs_hdfs_uri_to_fuse_path(dbfs_uri):
     return _DBFS_FUSE_PREFIX + dbfs_uri[len(_DBFS_HDFS_URI_PREFIX) :]
 
 
-def _build_uri_from_components(scheme, netloc, path, query, fragment):
-    return urllib.parse.urlunsplit(
-        (
-            scheme,
-            netloc,
-            path,
-            query,
-            fragment,
-        )
-    )
-
-
 def resolve_uri_if_local(local_uri):
     """
     if `local_uri` is passed in as a relative local path, this function
     resolves it to absolute path relative to current working directory.
-
     :param local_uri: Relative or absolute path or local file uri
-
     :return: a fully-formed absolute uri path or an absolute filesystem path
     """
     from mlflow.utils.file_utils import local_file_uri_to_path
 
     if local_uri is not None and is_local_uri(local_uri):
-        cwd = pathlib.Path.cwd()
         scheme = get_uri_scheme(local_uri)
-        local_uri_split = urllib.parse.urlsplit(local_uri)
-        final_uri_schema = local_uri_split.scheme or "file"
-        uri_path = pathlib.Path(local_file_uri_to_path(local_uri)).as_posix()
-        # local_path =
-        if not pathlib.Path(uri_path).is_absolute():
-            uri_path = cwd.joinpath(local_uri_split.path).as_posix()
-            if scheme == "" and platform.system().lower() != "windows":
-                return cwd.joinpath(uri_path).as_posix()
-        elif pathlib.Path(uri_path).is_absolute() and platform.system().lower() != "windows":
-            return local_uri
-        resolved_absolute_uri = _build_uri_from_components(
-            final_uri_schema,
-            None,
-            uri_path,
-            local_uri_split.query,
-            local_uri_split.fragment,
-        )
-        return resolved_absolute_uri
+        cwd = pathlib.Path.cwd()
+        local_path = local_file_uri_to_path(local_uri)
+        if not pathlib.Path(local_path).is_absolute():
+            if scheme == "":
+                if platform.system().lower() == "windows":
+                    return urllib.parse.urlunsplit(
+                        (
+                            "file",
+                            None,
+                            cwd.joinpath(local_path).as_posix(),
+                            None,
+                            None,
+                        )
+                    )
+                return cwd.joinpath(local_path).as_posix()
+            local_uri_split = urllib.parse.urlsplit(local_uri)
+            resolved_absolute_uri = urllib.parse.urlunsplit(
+                (
+                    local_uri_split.scheme,
+                    None,
+                    cwd.joinpath(local_path).as_posix(),
+                    local_uri_split.query,
+                    local_uri_split.fragment,
+                )
+            )
+            return resolved_absolute_uri
     return local_uri

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -317,17 +317,18 @@ def resolve_uri_if_local(local_uri):
         scheme = get_uri_scheme(local_uri)
         local_uri_split = urllib.parse.urlsplit(local_uri)
         final_uri_schema = local_uri_split.scheme or "file"
-        uri_path = pathlib.Path(local_uri_split.path)
+        uri_path = pathlib.Path(local_file_uri_to_path(local_uri)).as_posix()
+        # local_path =
         if not pathlib.Path(uri_path).is_absolute():
-            uri_path = cwd.joinpath(local_uri_split.path)
+            uri_path = cwd.joinpath(local_uri_split.path).as_posix()
             if scheme == "" and platform.system().lower() != "windows":
-                return cwd.joinpath(local_file_uri_to_path(local_uri)).as_posix()
+                return cwd.joinpath(uri_path).as_posix()
         elif pathlib.Path(uri_path).is_absolute() and platform.system().lower() != "windows":
             return local_uri
         resolved_absolute_uri = _build_uri_from_components(
             final_uri_schema,
             None,
-            uri_path.as_posix(),
+            uri_path,
             local_uri_split.query,
             local_uri_split.fragment,
         )

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -6,7 +6,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.store.db.db_types import DATABASE_ENGINES
 from mlflow.utils.validation import _validate_db_type_string
-from mlflow.utils.helper_functions import is_local_os_windows
+from mlflow.utils.os import is_windows
 
 _INVALID_DB_URI_MSG = (
     "Please refer to https://mlflow.org/docs/latest/tracking.html#storage for "
@@ -306,7 +306,7 @@ def resolve_uri_if_local(local_uri):
         local_path = local_file_uri_to_path(local_uri)
         if not pathlib.Path(local_path).is_absolute():
             if scheme == "":
-                if is_local_os_windows():
+                if is_windows():
                     return urllib.parse.urlunsplit(
                         (
                             "file",

--- a/tests/artifacts/test_artifacts.py
+++ b/tests/artifacts/test_artifacts.py
@@ -238,9 +238,9 @@ def test_log_artifact_windows_path_with_hostname(text_artifact):
         with mock.patch("shutil.copyfile") as copyfile_mock, mock.patch(
             "os.path.exists", return_value=True
         ) as exists_mock:
+            mlflow.log_artifact(text_artifact.artifact_path)
             copyfile_mock.assert_called_once()
             exists_mock.assert_called_once()
-            mlflow.log_artifact(text_artifact.artifact_path)
             local_path = mlflow.artifacts.download_artifacts(
                 run_id=run.info.run_id, artifact_path=text_artifact.artifact_name
             )
@@ -257,9 +257,9 @@ def test_log_artifact_windows_path_with_hostname(text_artifact):
         with mock.patch("shutil.copyfile") as copyfile_mock, mock.patch(
             "os.path.exists", return_value=True
         ) as exists_mock:
+            mlflow.log_artifact(text_artifact.artifact_path)
             copyfile_mock.assert_called_once()
             exists_mock.assert_called_once()
-            mlflow.log_artifact(text_artifact.artifact_path)
             local_path = mlflow.artifacts.download_artifacts(
                 run_id=run.info.run_id, artifact_path=text_artifact.artifact_name
             )

--- a/tests/artifacts/test_artifacts.py
+++ b/tests/artifacts/test_artifacts.py
@@ -1,13 +1,15 @@
 import pathlib
 import uuid
 import os
+from unittest import mock
 
 import pytest
 
 import mlflow
 from mlflow.exceptions import MlflowException
-from mlflow.utils.file_utils import path_to_local_file_uri, mkdir
+from mlflow.utils.file_utils import path_to_local_file_uri, mkdir, local_file_uri_to_path
 from collections import namedtuple
+from tests.helper_functions import is_local_os_windows
 
 
 Artifact = namedtuple("Artifact", ["uri", "content"])
@@ -224,3 +226,38 @@ def test_artifact_logging_resolution_works_with_non_root_working_directory(text_
             run.info.run_id,
         )
     os.chdir(original_cwd)
+
+
+@pytest.mark.skipif(not is_local_os_windows(), reason="This test only passes on Windows")
+def test_log_artifact_windows_path_with_hostname(text_artifact):
+    experiment_test_1_artifact_location = r"\\my_server\my_path\my_sub_path\1"
+    experiment_test_1_id = mlflow.create_experiment(
+        "test_exp_d", experiment_test_1_artifact_location
+    )
+    with mlflow.start_run(experiment_id=experiment_test_1_id) as run:
+        with mock.patch("shutil.copyfile"), mock.patch("os.path.exists") as mock_unc_path:
+            mock_unc_path.return_value = True
+            mlflow.log_artifact(text_artifact.artifact_path)
+            artifact_uri = mlflow.artifacts.download_artifacts(
+                run_id=run.info.run_id, artifact_path=text_artifact.artifact_name
+            )
+            assert (
+                rf"{experiment_test_1_artifact_location}\{run.info.run_id}"
+                rf"\artifacts\{text_artifact.artifact_name}" == artifact_uri
+            )
+
+    experiment_test_2_artifact_location = "file://my_server/my_path/my_sub_path"
+    experiment_test_2_id = mlflow.create_experiment(
+        "test_exp_e", experiment_test_2_artifact_location
+    )
+    with mlflow.start_run(experiment_id=experiment_test_2_id) as run:
+        with mock.patch("shutil.copyfile"), mock.patch("os.path.exists") as mock_unc_path:
+            mock_unc_path.return_value = True
+            mlflow.log_artifact(text_artifact.artifact_path)
+            artifact_uri = mlflow.artifacts.download_artifacts(
+                run_id=run.info.run_id, artifact_path=text_artifact.artifact_name
+            )
+            assert (
+                rf"{local_file_uri_to_path(experiment_test_2_artifact_location)}"
+                rf"\{run.info.run_id}\artifacts\{text_artifact.artifact_name}" == artifact_uri
+            )

--- a/tests/artifacts/test_artifacts.py
+++ b/tests/artifacts/test_artifacts.py
@@ -235,7 +235,11 @@ def test_log_artifact_windows_path_with_hostname(text_artifact):
         "test_exp_d", experiment_test_1_artifact_location
     )
     with mlflow.start_run(experiment_id=experiment_test_1_id) as run:
-        with mock.patch("shutil.copyfile"), mock.patch("os.path.exists", return_value=True):
+        with mock.patch("shutil.copyfile") as copyfile_mock, mock.patch(
+            "os.path.exists", return_value=True
+        ) as exists_mock:
+            copyfile_mock.assert_called_once()
+            exists_mock.assert_called_once()
             mlflow.log_artifact(text_artifact.artifact_path)
             local_path = mlflow.artifacts.download_artifacts(
                 run_id=run.info.run_id, artifact_path=text_artifact.artifact_name
@@ -250,7 +254,11 @@ def test_log_artifact_windows_path_with_hostname(text_artifact):
         "test_exp_e", experiment_test_2_artifact_location
     )
     with mlflow.start_run(experiment_id=experiment_test_2_id) as run:
-        with mock.patch("shutil.copyfile"), mock.patch("os.path.exists", return_value=True):
+        with mock.patch("shutil.copyfile") as copyfile_mock, mock.patch(
+            "os.path.exists", return_value=True
+        ) as exists_mock:
+            copyfile_mock.assert_called_once()
+            exists_mock.assert_called_once()
             mlflow.log_artifact(text_artifact.artifact_path)
             local_path = mlflow.artifacts.download_artifacts(
                 run_id=run.info.run_id, artifact_path=text_artifact.artifact_name

--- a/tests/artifacts/test_artifacts.py
+++ b/tests/artifacts/test_artifacts.py
@@ -9,7 +9,7 @@ import mlflow
 from mlflow.exceptions import MlflowException
 from mlflow.utils.file_utils import path_to_local_file_uri, mkdir, local_file_uri_to_path
 from collections import namedtuple
-from tests.helper_functions import is_local_os_windows
+from mlflow.utils.helper_functions import is_local_os_windows
 
 
 Artifact = namedtuple("Artifact", ["uri", "content"])

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -16,7 +16,6 @@ import sys
 import yaml
 import json
 import numbers
-import platform
 
 import pytest
 
@@ -547,7 +546,3 @@ def _mlflow_major_version_string():
     major = ver.major
     minor = ver.minor
     return f"mlflow<{major + 1},>={major}.{minor}"
-
-
-def is_local_os_windows():
-    return platform.system().lower() == "windows"

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -28,6 +28,7 @@ from mlflow.exceptions import MlflowException, MissingConfigException
 from mlflow.store.tracking import SEARCH_MAX_RESULTS_DEFAULT
 from mlflow.store.tracking.file_store import FileStore
 from mlflow.utils.file_utils import write_yaml, read_yaml, path_to_local_file_uri, TempDir
+from mlflow.utils.helper_functions import is_local_os_windows
 from mlflow.utils.uri import append_to_uri_path
 from mlflow.utils.name_utils import _GENERATOR_PREDICATES, _EXPERIMENT_ID_FIXED_WIDTH
 from mlflow.utils.mlflow_tags import MLFLOW_RUN_NAME
@@ -39,7 +40,7 @@ from mlflow.protos.databricks_pb2 import (
     INVALID_PARAMETER_VALUE,
 )
 
-from tests.helper_functions import random_int, random_str, safe_edit_yaml, is_local_os_windows
+from tests.helper_functions import random_int, random_str, safe_edit_yaml
 from tests.store.tracking import AbstractStoreTest
 
 FILESTORE_PACKAGE = "mlflow.store.tracking.file_store"

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -1752,6 +1752,10 @@ def _assert_create_run_appends_to_artifact_uri_path_correctly(
 @pytest.mark.parametrize(
     ("input_uri", "expected_uri"),
     [
+        (
+            "file://my_server/my_path/my_sub_path",
+            "file://my_server/my_path/my_sub_path/{e}/{r}/artifacts",
+        ),
         ("path/to/local/folder", "file://{cwd}/path/to/local/folder/{e}/{r}/artifacts"),
         ("/path/to/local/folder", "file:///{drive}path/to/local/folder/{e}/{r}/artifacts"),
         ("#path/to/local/folder?", "file://{cwd}/{e}/{r}/artifacts#path/to/local/folder?"),
@@ -1852,6 +1856,7 @@ def _assert_create_experiment_appends_to_artifact_uri_path_correctly(
 @pytest.mark.parametrize(
     ("input_uri", "expected_uri"),
     [
+        ("file://my_server/my_path/my_sub_path", "file://my_server/my_path/my_sub_path/{e}"),
         ("path/to/local/folder", "file://{cwd}/path/to/local/folder/{e}"),
         ("/path/to/local/folder", "file:///{drive}path/to/local/folder/{e}"),
         ("#path/to/local/folder?", "file://{cwd}/{e}#path/to/local/folder?"),

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -28,7 +28,7 @@ from mlflow.exceptions import MlflowException, MissingConfigException
 from mlflow.store.tracking import SEARCH_MAX_RESULTS_DEFAULT
 from mlflow.store.tracking.file_store import FileStore
 from mlflow.utils.file_utils import write_yaml, read_yaml, path_to_local_file_uri, TempDir
-from mlflow.utils.helper_functions import is_local_os_windows
+from mlflow.utils.os import is_windows
 from mlflow.utils.uri import append_to_uri_path
 from mlflow.utils.name_utils import _GENERATOR_PREDICATES, _EXPERIMENT_ID_FIXED_WIDTH
 from mlflow.utils.mlflow_tags import MLFLOW_RUN_NAME
@@ -1713,7 +1713,7 @@ def test_experiment_with_default_root_artifact_uri(tmp_path):
     file_store = FileStore(file_store_root_uri)
     experiment_id = file_store.create_experiment(name="test", artifact_location="test")
     experiment_info = file_store.get_experiment(experiment_id)
-    if is_local_os_windows():
+    if is_windows():
         assert experiment_info.artifact_location == Path.cwd().joinpath("test").as_uri()
     else:
         assert experiment_info.artifact_location == str(Path.cwd().joinpath("test"))
@@ -1741,7 +1741,7 @@ def _assert_create_run_appends_to_artifact_uri_path_correctly(
         )
         cwd = Path.cwd().as_posix()
         drive = Path.cwd().drive
-        if is_local_os_windows() and expected_artifact_uri_format.startswith("file:"):
+        if is_windows() and expected_artifact_uri_format.startswith("file:"):
             cwd = f"/{cwd}"
             drive = f"{drive}/"
         assert run.info.artifact_uri == expected_artifact_uri_format.format(
@@ -1749,7 +1749,7 @@ def _assert_create_run_appends_to_artifact_uri_path_correctly(
         )
 
 
-@pytest.mark.skipif(not is_local_os_windows(), reason="This test only passes on Windows")
+@pytest.mark.skipif(not is_windows(), reason="This test only passes on Windows")
 @pytest.mark.parametrize(
     ("input_uri", "expected_uri"),
     [
@@ -1781,7 +1781,7 @@ def test_create_run_appends_to_artifact_local_path_file_uri_correctly_on_windows
     _assert_create_run_appends_to_artifact_uri_path_correctly(input_uri, expected_uri)
 
 
-@pytest.mark.skipif(is_local_os_windows(), reason="This test fails on Windows")
+@pytest.mark.skipif(is_windows(), reason="This test fails on Windows")
 @pytest.mark.parametrize(
     ("input_uri", "expected_uri"),
     [
@@ -1844,7 +1844,7 @@ def _assert_create_experiment_appends_to_artifact_uri_path_correctly(
         exp = fs.get_experiment(exp_id)
         cwd = Path.cwd().as_posix()
         drive = Path.cwd().drive
-        if is_local_os_windows() and expected_artifact_uri_format.startswith("file:"):
+        if is_windows() and expected_artifact_uri_format.startswith("file:"):
             cwd = f"/{cwd}"
             drive = f"{drive}/"
 
@@ -1853,7 +1853,7 @@ def _assert_create_experiment_appends_to_artifact_uri_path_correctly(
         )
 
 
-@pytest.mark.skipif(not is_local_os_windows(), reason="This test only passes on Windows")
+@pytest.mark.skipif(not is_windows(), reason="This test only passes on Windows")
 @pytest.mark.parametrize(
     ("input_uri", "expected_uri"),
     [
@@ -1880,7 +1880,7 @@ def test_create_experiment_appends_to_artifact_local_path_file_uri_correctly_on_
     _assert_create_experiment_appends_to_artifact_uri_path_correctly(input_uri, expected_uri)
 
 
-@pytest.mark.skipif(is_local_os_windows(), reason="This test fails on Windows")
+@pytest.mark.skipif(is_windows(), reason="This test fails on Windows")
 @pytest.mark.parametrize(
     ("input_uri", "expected_uri"),
     [

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -2818,6 +2818,7 @@ def _assert_create_experiment_appends_to_artifact_uri_path_correctly(
 @pytest.mark.parametrize(
     ("input_uri", "expected_uri"),
     [
+        ("file://my_server/my_path/my_sub_path", "file://my_server/my_path/my_sub_path/{e}"),
         ("path/to/local/folder", "file://{cwd}/path/to/local/folder/{e}"),
         ("/path/to/local/folder", "file:///{drive}path/to/local/folder/{e}"),
         ("#path/to/local/folder?", "file://{cwd}/{e}#path/to/local/folder?"),
@@ -2921,6 +2922,10 @@ def _assert_create_run_appends_to_artifact_uri_path_correctly(
 @pytest.mark.parametrize(
     ("input_uri", "expected_uri"),
     [
+        (
+            "file://my_server/my_path/my_sub_path",
+            "file://my_server/my_path/my_sub_path/{e}/{r}/artifacts",
+        ),
         ("path/to/local/folder", "file://{cwd}/path/to/local/folder/{e}/{r}/artifacts"),
         ("/path/to/local/folder", "file:///{drive}path/to/local/folder/{e}/{r}/artifacts"),
         ("#path/to/local/folder?", "file://{cwd}/{e}/{r}/artifacts#path/to/local/folder?"),

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -51,7 +51,7 @@ from mlflow.utils.mlflow_tags import MLFLOW_RUN_NAME
 from mlflow.utils.name_utils import _GENERATOR_PREDICATES
 from mlflow.utils.uri import extract_db_type_from_uri
 from mlflow.utils.time_utils import get_current_time_millis
-from mlflow.utils.helper_functions import is_local_os_windows
+from mlflow.utils.os import is_windows
 from mlflow.store.tracking.dbmodels.initial_models import Base as InitialBase
 from mlflow.tracking._tracking_service.utils import _TRACKING_URI_ENV_VAR
 from mlflow.store.tracking.dbmodels.models import (
@@ -1805,7 +1805,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         filter_string = "attribute.status = 'KILLED'"
         assert self._search([e1, e2], filter_string) == []
 
-        if is_local_os_windows():
+        if is_windows():
             expected_artifact_uri = (
                 pathlib.Path.cwd().joinpath(ARTIFACT_URI, e1, r1, "artifacts").as_uri()
             )
@@ -2806,7 +2806,7 @@ def _assert_create_experiment_appends_to_artifact_uri_path_correctly(
             exp = store.get_experiment(exp_id)
             cwd = Path.cwd().as_posix()
             drive = Path.cwd().drive
-            if is_local_os_windows() and expected_artifact_uri_format.startswith("file:"):
+            if is_windows() and expected_artifact_uri_format.startswith("file:"):
                 cwd = f"/{cwd}"
                 drive = f"{drive}/"
             assert exp.artifact_location == expected_artifact_uri_format.format(
@@ -2814,7 +2814,7 @@ def _assert_create_experiment_appends_to_artifact_uri_path_correctly(
             )
 
 
-@pytest.mark.skipif(not is_local_os_windows(), reason="This test only passes on Windows")
+@pytest.mark.skipif(not is_windows(), reason="This test only passes on Windows")
 @pytest.mark.parametrize(
     ("input_uri", "expected_uri"),
     [
@@ -2841,7 +2841,7 @@ def test_create_experiment_appends_to_artifact_local_path_file_uri_correctly_on_
     _assert_create_experiment_appends_to_artifact_uri_path_correctly(input_uri, expected_uri)
 
 
-@pytest.mark.skipif(is_local_os_windows(), reason="This test fails on Windows")
+@pytest.mark.skipif(is_windows(), reason="This test fails on Windows")
 @pytest.mark.parametrize(
     ("input_uri", "expected_uri"),
     [
@@ -2910,7 +2910,7 @@ def _assert_create_run_appends_to_artifact_uri_path_correctly(
             )
             cwd = Path.cwd().as_posix()
             drive = Path.cwd().drive
-            if is_local_os_windows() and expected_artifact_uri_format.startswith("file:"):
+            if is_windows() and expected_artifact_uri_format.startswith("file:"):
                 cwd = f"/{cwd}"
                 drive = f"{drive}/"
             assert run.info.artifact_uri == expected_artifact_uri_format.format(
@@ -2918,7 +2918,7 @@ def _assert_create_run_appends_to_artifact_uri_path_correctly(
             )
 
 
-@pytest.mark.skipif(not is_local_os_windows(), reason="This test only passes on Windows")
+@pytest.mark.skipif(not is_windows(), reason="This test only passes on Windows")
 @pytest.mark.parametrize(
     ("input_uri", "expected_uri"),
     [
@@ -2954,7 +2954,7 @@ def test_create_run_appends_to_artifact_local_path_file_uri_correctly_on_windows
     _assert_create_run_appends_to_artifact_uri_path_correctly(input_uri, expected_uri)
 
 
-@pytest.mark.skipif(is_local_os_windows(), reason="This test fails on Windows")
+@pytest.mark.skipif(is_windows(), reason="This test fails on Windows")
 @pytest.mark.parametrize(
     ("input_uri", "expected_uri"),
     [

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -51,6 +51,7 @@ from mlflow.utils.mlflow_tags import MLFLOW_RUN_NAME
 from mlflow.utils.name_utils import _GENERATOR_PREDICATES
 from mlflow.utils.uri import extract_db_type_from_uri
 from mlflow.utils.time_utils import get_current_time_millis
+from mlflow.utils.helper_functions import is_local_os_windows
 from mlflow.store.tracking.dbmodels.initial_models import Base as InitialBase
 from mlflow.tracking._tracking_service.utils import _TRACKING_URI_ENV_VAR
 from mlflow.store.tracking.dbmodels.models import (
@@ -64,7 +65,6 @@ from mlflow.store.tracking.dbmodels.models import (
 )
 from tests.integration.utils import invoke_cli_runner
 from tests.store.tracking import AbstractStoreTest
-from tests.helper_functions import is_local_os_windows
 
 DB_URI = "sqlite:///"
 ARTIFACT_URI = "artifact_folder"

--- a/tests/tracking/_tracking_service/test_utils.py
+++ b/tests/tracking/_tracking_service/test_utils.py
@@ -27,7 +27,7 @@ from mlflow.tracking._tracking_service.utils import (
     _TRACKING_USERNAME_ENV_VAR,
 )
 from mlflow.utils.file_utils import path_to_local_file_uri
-from mlflow.utils.helper_functions import is_local_os_windows
+from mlflow.utils.os import is_windows
 
 # pylint: disable=unused-argument
 
@@ -147,7 +147,7 @@ def test_get_store_sqlalchemy_store(tmp_wkdir, db_type):
         store = _get_store()
         assert isinstance(store, SqlAlchemyStore)
         assert store.db_uri == uri
-        if is_local_os_windows():
+        if is_windows():
             assert store.artifact_root_uri == Path.cwd().joinpath("mlruns").as_uri()
         else:
             assert store.artifact_root_uri == Path.cwd().joinpath("mlruns").as_posix()
@@ -174,7 +174,7 @@ def test_get_store_sqlalchemy_store_with_artifact_uri(tmp_wkdir, db_type):
         store = _get_store(artifact_uri=artifact_uri)
         assert isinstance(store, SqlAlchemyStore)
         assert store.db_uri == uri
-        if is_local_os_windows():
+        if is_windows():
             assert store.artifact_root_uri == Path.cwd().joinpath("artifact", "path").as_uri()
         else:
             assert store.artifact_root_uri == path_to_local_file_uri(

--- a/tests/tracking/_tracking_service/test_utils.py
+++ b/tests/tracking/_tracking_service/test_utils.py
@@ -27,7 +27,7 @@ from mlflow.tracking._tracking_service.utils import (
     _TRACKING_USERNAME_ENV_VAR,
 )
 from mlflow.utils.file_utils import path_to_local_file_uri
-from tests.helper_functions import is_local_os_windows
+from mlflow.utils.helper_functions import is_local_os_windows
 
 # pylint: disable=unused-argument
 

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -39,7 +39,7 @@ from mlflow.utils.mlflow_tags import (
 )
 from mlflow.utils.file_utils import path_to_local_file_uri
 from mlflow.utils.time_utils import get_current_time_millis
-from mlflow.utils.helper_functions import is_local_os_windows
+from mlflow.utils.os import is_windows
 
 from tests.integration.utils import invoke_cli_runner
 from tests.tracking.integration_test_utils import (
@@ -94,7 +94,7 @@ def test_create_get_search_experiment(mlflow_client):
     )
     exp = mlflow_client.get_experiment(experiment_id)
     assert exp.name == "My Experiment"
-    if is_local_os_windows():
+    if is_windows():
         assert exp.artifact_location == pathlib.Path.cwd().joinpath("my_location").as_uri()
     else:
         assert exp.artifact_location == str(pathlib.Path.cwd().joinpath("my_location"))

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -39,6 +39,7 @@ from mlflow.utils.mlflow_tags import (
 )
 from mlflow.utils.file_utils import path_to_local_file_uri
 from mlflow.utils.time_utils import get_current_time_millis
+from mlflow.utils.helper_functions import is_local_os_windows
 
 from tests.integration.utils import invoke_cli_runner
 from tests.tracking.integration_test_utils import (
@@ -46,7 +47,6 @@ from tests.tracking.integration_test_utils import (
     _init_server,
     _send_rest_tracking_post_request,
 )
-from tests.helper_functions import is_local_os_windows
 
 
 _logger = logging.getLogger(__name__)

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -33,7 +33,7 @@ from mlflow.utils.validation import (
 )
 from mlflow.utils.time_utils import get_current_time_millis
 from mlflow.tracking.fluent import _RUN_ID_ENV_VAR
-from mlflow.utils.helper_functions import is_local_os_windows
+from mlflow.utils.os import is_windows
 
 MockExperiment = namedtuple("MockExperiment", ["experiment_id", "lifecycle_stage"])
 
@@ -750,14 +750,14 @@ def test_get_artifact_uri_appends_to_uri_path_component_correctly(
     )
 
 
-@pytest.mark.skipif(not is_local_os_windows(), reason="This test only passes on Windows")
+@pytest.mark.skipif(not is_windows(), reason="This test only passes on Windows")
 def test_get_artifact_uri_appends_to_local_path_component_correctly_on_windows():
     _assert_get_artifact_uri_appends_to_uri_path_component_correctly(
         "/dirname/rootpa#th?", "file:///{drive}/dirname/rootpa/{run_id}/artifacts/{path}#th?"
     )
 
 
-@pytest.mark.skipif(is_local_os_windows(), reason="This test fails on Windows")
+@pytest.mark.skipif(is_windows(), reason="This test fails on Windows")
 def test_get_artifact_uri_appends_to_local_path_component_correctly():
     _assert_get_artifact_uri_appends_to_uri_path_component_correctly(
         "/dirname/rootpa#th?", "{drive}/dirname/rootpa#th?/{run_id}/artifacts/{path}"

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -33,7 +33,7 @@ from mlflow.utils.validation import (
 )
 from mlflow.utils.time_utils import get_current_time_millis
 from mlflow.tracking.fluent import _RUN_ID_ENV_VAR
-from tests.helper_functions import is_local_os_windows
+from mlflow.utils.helper_functions import is_local_os_windows
 
 MockExperiment = namedtuple("MockExperiment", ["experiment_id", "lifecycle_stage"])
 

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -337,8 +337,8 @@ def test_handle_readonly_on_windows(tmpdir):
 @pytest.mark.parametrize(
     ("input_uri", "expected_path"),
     [
-        ("file://a/b/c", "\\\\a\\b\\c"),
-        (r"\\a\b\c", "\\\\a\\b\\c"),
+        ("file://my_server/my_path/my_sub_path", r"\\my_server\my_path\my_sub_path"),
+        (r"\\my_server\my_path\my_sub_path", r"\\my_server\my_path\my_sub_path"),
     ],
 )
 def test_local_file_uri_to_path_on_windows(input_uri, expected_path):

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -24,9 +24,10 @@ from mlflow.utils.file_utils import (
     _handle_readonly_on_windows,
     local_file_uri_to_path,
 )
+from mlflow.utils.helper_functions import is_local_os_windows
 from tests.projects.utils import TEST_PROJECT_DIR
 
-from tests.helper_functions import random_int, random_file, safe_edit_yaml, is_local_os_windows
+from tests.helper_functions import random_int, random_file, safe_edit_yaml
 
 
 @pytest.fixture(scope="module")

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -24,7 +24,7 @@ from mlflow.utils.file_utils import (
     _handle_readonly_on_windows,
     local_file_uri_to_path,
 )
-from mlflow.utils.helper_functions import is_local_os_windows
+from mlflow.utils.os import is_windows
 from tests.projects.utils import TEST_PROJECT_DIR
 
 from tests.helper_functions import random_int, random_file, safe_edit_yaml
@@ -314,7 +314,7 @@ def test_write_spark_df_to_parquet(spark_session, tmp_path):
     pd.testing.assert_frame_equal(sdf.toPandas(), pd.read_parquet(output_path))
 
 
-@pytest.mark.skipif(not is_local_os_windows(), reason="requires Windows")
+@pytest.mark.skipif(not is_windows(), reason="requires Windows")
 def test_handle_readonly_on_windows(tmpdir):
     tmp_path = tmpdir.join("file").strpath
     with open(tmp_path, "w"):
@@ -334,7 +334,7 @@ def test_handle_readonly_on_windows(tmpdir):
     assert not os.path.exists(tmp_path)
 
 
-@pytest.mark.skipif(not is_local_os_windows(), reason="This test only passes on Windows")
+@pytest.mark.skipif(not is_windows(), reason="This test only passes on Windows")
 @pytest.mark.parametrize(
     ("input_uri", "expected_path"),
     [

--- a/tests/utils/test_uri.py
+++ b/tests/utils/test_uri.py
@@ -21,7 +21,7 @@ from mlflow.utils.uri import (
     dbfs_hdfs_uri_to_fuse_path,
     resolve_uri_if_local,
 )
-from tests.helper_functions import is_local_os_windows
+from mlflow.utils.helper_functions import is_local_os_windows
 
 
 def test_extract_db_type_from_uri():

--- a/tests/utils/test_uri.py
+++ b/tests/utils/test_uri.py
@@ -546,7 +546,7 @@ def _assert_resolve_uri_if_local(input_uri, expected_uri):
         ("file://myhostname/my/path", "file://myhostname/my/path"),
         ("file:///my/path", "file:///{drive}my/path"),
         ("file:my/path", "file://{cwd}/my/path"),
-        ("/home/my/path", "{drive}/home/my/path"),
+        ("/home/my/path", "/home/my/path"),
         ("dbfs://databricks/a/b", "dbfs://databricks/a/b"),
         ("s3://host/my/path", "s3://host/my/path"),
     ],
@@ -560,7 +560,7 @@ def test_resolve_uri_if_local(input_uri, expected_uri):
     ("input_uri", "expected_uri"),
     [
         ("my/path", "file://{cwd}/my/path"),
-        ("#my/path?a=b", "file://{cwd}/#my/path?a=b"),
+        ("#my/path?a=b", "file://{cwd}#my/path?a=b"),
         ("file://myhostname/my/path", "file://myhostname/my/path"),
         ("file:///my/path", "file:///{drive}my/path"),
         ("file:my/path", "file://{cwd}/my/path"),

--- a/tests/utils/test_uri.py
+++ b/tests/utils/test_uri.py
@@ -560,7 +560,7 @@ def test_resolve_uri_if_local(input_uri, expected_uri):
     ("input_uri", "expected_uri"),
     [
         ("my/path", "file://{cwd}/my/path"),
-        ("#my/path?a=b", "file://{cwd}#my/path?a=b"),
+        ("#my/path?a=b", "file://{cwd}/#my/path?a=b"),
         ("file://myhostname/my/path", "file://myhostname/my/path"),
         ("file:///my/path", "file:///{drive}my/path"),
         ("file:my/path", "file://{cwd}/my/path"),

--- a/tests/utils/test_uri.py
+++ b/tests/utils/test_uri.py
@@ -21,7 +21,7 @@ from mlflow.utils.uri import (
     dbfs_hdfs_uri_to_fuse_path,
     resolve_uri_if_local,
 )
-from mlflow.utils.helper_functions import is_local_os_windows
+from mlflow.utils.os import is_windows
 
 
 def test_extract_db_type_from_uri():
@@ -531,13 +531,13 @@ def test_dbfs_hdfs_uri_to_fuse_path_raises(path):
 def _assert_resolve_uri_if_local(input_uri, expected_uri):
     cwd = pathlib.Path.cwd().as_posix()
     drive = pathlib.Path.cwd().drive
-    if is_local_os_windows():
+    if is_windows():
         cwd = f"/{cwd}"
         drive = f"{drive}/"
     assert resolve_uri_if_local(input_uri) == expected_uri.format(cwd=cwd, drive=drive)
 
 
-@pytest.mark.skipif(is_local_os_windows(), reason="This test fails on Windows")
+@pytest.mark.skipif(is_windows(), reason="This test fails on Windows")
 @pytest.mark.parametrize(
     ("input_uri", "expected_uri"),
     [
@@ -555,7 +555,7 @@ def test_resolve_uri_if_local(input_uri, expected_uri):
     _assert_resolve_uri_if_local(input_uri, expected_uri)
 
 
-@pytest.mark.skipif(not is_local_os_windows(), reason="This test only passes on Windows")
+@pytest.mark.skipif(not is_windows(), reason="This test only passes on Windows")
 @pytest.mark.parametrize(
     ("input_uri", "expected_uri"),
     [


### PR DESCRIPTION
Signed-off-by: Jas Bali <bali0019@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #7645

## What changes are proposed in this pull request?

In order to parse the artifact path correctly on windows when it contains a server name/UNC format, this PR explicitly parses out the `netloc` and rebuilds the path component containing that `netloc` in UNC format so that `pathlib` can correctly resolve it.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
