### PR TITLE
Fix test failures in SQLAlchemy 2.0

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -315,6 +315,12 @@ jobs:
         run: |
           git clone https://github.com/cdarlint/winutils
       - name: Run python tests
+        env:
+          # Starting from SQLAlchemy version 2.0, `QueuePool` is the default connection pool
+          # when creating an `Engine`. `QueuePool` prevents the removal of temporary database
+          # files created during tests on Windows as it keeps the DB connection open until
+          # it's explicitly disposed.
+          MLFLOW_SQLALCHEMYSTORE_POOLCLASS: "NullPool"
         run: |
           # Set Hadoop environment variables required for testing Spark integrations on Windows
           export HADOOP_HOME=`realpath winutils/hadoop-3.2.2`

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -387,6 +387,7 @@ class SqlAlchemyStore(AbstractStore):
                 select(SqlRegisteredModelTag.name)
                 .filter(sqlalchemy.or_(*sql_tag_filters))
                 .group_by(SqlRegisteredModelTag.name)
+                # pylint: disable-next=not-callable
                 .having(sqlalchemy.func.count(sqlalchemy.literal(1)) == len(tag_filters))
                 .subquery()
             )
@@ -457,6 +458,7 @@ class SqlAlchemyStore(AbstractStore):
                 select(SqlModelVersionTag.name, SqlModelVersionTag.version)
                 .filter(sqlalchemy.or_(*sql_tag_filters))
                 .group_by(SqlModelVersionTag.name, SqlModelVersionTag.version)
+                # pylint: disable-next=not-callable
                 .having(sqlalchemy.func.count(sqlalchemy.literal(1)) == len(tag_filters))
                 .subquery()
             )

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -103,6 +103,9 @@ class SqlAlchemyStore(AbstractStore):
     def _get_dialect(self):
         return self.engine.dialect.name
 
+    def _dispose_engine(self):
+        self.engine.dispose()
+
     @staticmethod
     def _verify_registry_tables_exist(engine):
         # Verify that all tables have been created.

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -149,6 +149,9 @@ class SqlAlchemyStore(AbstractStore):
     def _get_dialect(self):
         return self.engine.dialect.name
 
+    def _dispose_engine(self):
+        self.engine.dispose()
+
     def _set_zero_value_insertion_for_autoincrement_column(self, session):
         if self.db_type == MYSQL:
             # config letting MySQL override default
@@ -1440,7 +1443,7 @@ def _get_search_experiments_filter_clauses(parsed_filters, dialect):
 
 def _get_search_experiments_order_by_clauses(order_by):
     order_by_clauses = []
-    for (type_, key, ascending) in map(
+    for type_, key, ascending in map(
         SearchExperimentsUtils.parse_order_by_for_search_experiments,
         order_by or ["creation_time DESC", "experiment_id ASC"],
     ):

--- a/requirements/core-requirements.txt
+++ b/requirements/core-requirements.txt
@@ -9,7 +9,7 @@ numpy<2
 scipy<2
 pandas<2
 querystring_parser<2
-sqlalchemy<2,>=1.4.0
+sqlalchemy<3,>=1.4.0
 gunicorn<21; platform_system != 'Windows'
 waitress<3; platform_system == 'Windows'
 scikit-learn<2

--- a/requirements/core-requirements.yaml
+++ b/requirements/core-requirements.yaml
@@ -35,7 +35,7 @@ querystring_parser:
 sqlalchemy:
   pip_release: sqlalchemy
   minimum: "1.4.0"
-  max_major_version: 1
+  max_major_version: 2
 
 gunicorn:
   pip_release: gunicorn

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -166,6 +166,6 @@ def monkeypatch():
 
 
 @pytest.fixture
-def tmp_file_uri(tmp_path):
+def tmp_sqlite_uri(tmp_path):
     path = tmp_path.joinpath("mlflow.db").as_uri()
     return ("sqlite://" if is_windows() else "sqlite:////") + path[len("file://") :]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ import pytest
 
 import mlflow
 from mlflow.utils.file_utils import path_to_local_sqlite_uri
+from mlflow.utils.os import is_windows
 
 from tests.autologging.fixtures import enable_test_mode
 
@@ -162,3 +163,9 @@ def monkeypatch():
     """
     with ExtendedMonkeyPatch().context() as mp:
         yield mp
+
+
+@pytest.fixture
+def tmp_file_uri(tmp_path):
+    path = tmp_path.joinpath("mlflow.db").as_uri()
+    return ("sqlite://" if is_windows() else "sqlite:////") + path[len("file://") :]

--- a/tests/store/db/test_utils.py
+++ b/tests/store/db/test_utils.py
@@ -49,11 +49,11 @@ def test_create_sqlalchemy_engine_invalid_pool(monkeypatch):
             utils.create_sqlalchemy_engine("mydb://host:port/")
 
 
-def test_create_sqlalchemy_engine_no_pool_options():
-    with mock.patch.dict(os.environ, {}):
-        with mock.patch("sqlalchemy.create_engine") as mock_create_engine:
-            utils.create_sqlalchemy_engine("mydb://host:port/")
-            mock_create_engine.assert_called_once_with("mydb://host:port/", pool_pre_ping=True)
+def test_create_sqlalchemy_engine_no_pool_options(monkeypatch):
+    monkeypatch.delenv("MLFLOW_SQLALCHEMYSTORE_POOLCLASS", raising=False)
+    with mock.patch("sqlalchemy.create_engine") as mock_create_engine:
+        utils.create_sqlalchemy_engine("mydb://host:port/")
+        mock_create_engine.assert_called_once_with("mydb://host:port/", pool_pre_ping=True)
 
 
 def test_alembic_escape_logic():

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -2436,6 +2436,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         for _ in range(3):
             invoke_cli_runner(mlflow.db.commands, ["upgrade", self.db_url])
             assert _get_schema_version(engine) == _get_latest_schema_revision()
+        engine.dispose()
 
     def test_metrics_materialization_upgrade_succeeds_and_produces_expected_latest_metric_values(
         self,
@@ -2688,6 +2689,7 @@ class TestSqlAlchemyStoreMigratedDB(TestSqlAlchemyStore):
         super()._setup_db_uri()
         engine = sqlalchemy.create_engine(self.db_url)
         InitialBase.metadata.create_all(engine)
+        engine.dispose()
         invoke_cli_runner(mlflow.db.commands, ["upgrade", self.db_url])
         self.store = SqlAlchemyStore(self.db_url, ARTIFACT_URI)
 

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -2654,7 +2654,8 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         assert metrics == []
 
 
-def test_sqlalchemy_store_behaves_as_expected_with_inmemory_sqlite_db():
+def test_sqlalchemy_store_behaves_as_expected_with_inmemory_sqlite_db(monkeypatch):
+    monkeypatch.setenv("MLFLOW_SQLALCHEMYSTORE_POOLCLASS", "SingletonThreadPool")
     store = SqlAlchemyStore("sqlite:///:memory:", ARTIFACT_URI)
     experiment_id = store.create_experiment(name="exp1")
     run = store.create_run(
@@ -2671,12 +2672,13 @@ def test_sqlalchemy_store_behaves_as_expected_with_inmemory_sqlite_db():
     assert param.key in fetched_run.data.params
 
 
-def test_sqlalchemy_store_can_be_initialized_when_default_experiment_has_been_deleted(tmpdir):
-    db_uri = "sqlite:///{}/mlflow.db".format(tmpdir.strpath)
-    store = SqlAlchemyStore(db_uri, ARTIFACT_URI)
+def test_sqlalchemy_store_can_be_initialized_when_default_experiment_has_been_deleted(
+    tmp_sqlite_uri,
+):
+    store = SqlAlchemyStore(tmp_sqlite_uri, ARTIFACT_URI)
     store.delete_experiment("0")
     assert store.get_experiment("0").lifecycle_stage == entities.LifecycleStage.DELETED
-    SqlAlchemyStore(db_uri, ARTIFACT_URI)
+    SqlAlchemyStore(tmp_sqlite_uri, ARTIFACT_URI)
 
 
 class TestSqlAlchemyStoreMigratedDB(TestSqlAlchemyStore):
@@ -2754,8 +2756,8 @@ def test_get_attribute_name():
     assert len(entities.RunInfo.get_orderable_attributes()) == 7
 
 
-def test_get_orderby_clauses():
-    store = SqlAlchemyStore("sqlite:///:memory:", ARTIFACT_URI)
+def test_get_orderby_clauses(tmp_sqlite_uri):
+    store = SqlAlchemyStore(tmp_sqlite_uri, ARTIFACT_URI)
     with store.ManagedSessionMaker() as session:
         # test that ['runs.start_time DESC', 'SqlRun.run_uuid'] is returned by default
         parsed = [str(x) for x in _get_orderby_clauses([], session)[1]]

--- a/tests/tracking/_model_registry/test_utils.py
+++ b/tests/tracking/_model_registry/test_utils.py
@@ -78,7 +78,8 @@ def test_fallback_to_tracking_store():
 
 
 @pytest.mark.parametrize("db_type", DATABASE_ENGINES)
-def test_get_store_sqlalchemy_store(db_type):
+def test_get_store_sqlalchemy_store(db_type, monkeypatch):
+    monkeypatch.delenv("MLFLOW_SQLALCHEMYSTORE_POOLCLASS", raising=False)
     patch_create_engine = mock.patch("sqlalchemy.create_engine")
     uri = f"{db_type}://hostname/database"
     env = {_TRACKING_URI_ENV_VAR: uri}

--- a/tests/tracking/_tracking_service/test_utils.py
+++ b/tests/tracking/_tracking_service/test_utils.py
@@ -130,7 +130,8 @@ def test_get_store_rest_store_with_no_insecure():
 
 
 @pytest.mark.parametrize("db_type", DATABASE_ENGINES)
-def test_get_store_sqlalchemy_store(tmp_wkdir, db_type):
+def test_get_store_sqlalchemy_store(tmp_wkdir, db_type, monkeypatch):
+    monkeypatch.delenv("MLFLOW_SQLALCHEMYSTORE_POOLCLASS", raising=False)
     patch_create_engine = mock.patch("sqlalchemy.create_engine")
 
     uri = f"{db_type}://hostname/database"
@@ -299,7 +300,6 @@ def test_plugin_registration_via_entrypoints():
     with mock.patch(
         "entrypoints.get_group_all", return_value=[mock_entrypoint]
     ) as mock_get_group_all:
-
         tracking_store = TrackingStoreRegistry()
         tracking_store.register_entrypoints()
 
@@ -319,7 +319,6 @@ def test_handle_plugin_registration_failure_via_entrypoints(exception):
     with mock.patch(
         "entrypoints.get_group_all", return_value=[mock_entrypoint]
     ) as mock_get_group_all:
-
         tracking_store = TrackingStoreRegistry()
 
         # Check that the raised warning contains the message from the original exception
@@ -331,7 +330,6 @@ def test_handle_plugin_registration_failure_via_entrypoints(exception):
 
 
 def test_get_store_for_unregistered_scheme():
-
     tracking_store = TrackingStoreRegistry()
 
     with pytest.raises(

--- a/tests/tracking/test_model_registry.py
+++ b/tests/tracking/test_model_registry.py
@@ -2,13 +2,13 @@
 Integration test which starts a local Tracking Server on an ephemeral port,
 and ensures we can use the tracking API to communicate with it.
 """
-import sys
 import pytest
 
 from mlflow.entities.model_registry import RegisteredModel
 from mlflow.exceptions import MlflowException
 from mlflow import MlflowClient
 from mlflow.utils.time_utils import get_current_time_millis
+from mlflow.utils.os import is_windows
 from tests.tracking.integration_test_utils import _terminate_server, _init_server
 
 
@@ -18,9 +18,7 @@ def client(request, tmp_path):
         backend_uri = tmp_path.joinpath("file").as_uri()
     else:
         path = tmp_path.joinpath("sqlalchemy.db").as_uri()
-        backend_uri = ("sqlite://" if sys.platform == "win32" else "sqlite:////") + path[
-            len("file://") :
-        ]
+        backend_uri = ("sqlite://" if is_windows() else "sqlite:////") + path[len("file://") :]
 
     url, process = _init_server(
         backend_uri=backend_uri, root_artifact_uri=tmp_path.joinpath("artifacts").as_uri()

--- a/tests/tracking/test_model_registry.py
+++ b/tests/tracking/test_model_registry.py
@@ -4,63 +4,29 @@ and ensures we can use the tracking API to communicate with it.
 """
 import sys
 import pytest
-import logging
-import shutil
-import tempfile
-from pathlib import Path
 
-from mlflow.store.model_registry.file_store import FileStore
-from mlflow.store.model_registry.sqlalchemy_store import SqlAlchemyStore
 from mlflow.entities.model_registry import RegisteredModel
 from mlflow.exceptions import MlflowException
 from mlflow import MlflowClient
-from mlflow.utils.file_utils import path_to_local_file_uri
 from mlflow.utils.time_utils import get_current_time_millis
-from tests.tracking.integration_test_utils import _await_server_down_or_die, _init_server
+from tests.tracking.integration_test_utils import _terminate_server, _init_server
 
 
-_logger = logging.getLogger(__name__)
-
-
-@pytest.fixture(scope="module")
-def module_scoped_tmp_dir():
-    with tempfile.TemporaryDirectory() as tmpdir:
-        yield Path(tmpdir)
-
-
-@pytest.fixture(scope="module", params=["file", "sqlalchemy"])
-def backend_uri(request, module_scoped_tmp_dir):
+@pytest.fixture(params=["file", "sqlalchemy"])
+def client(request, tmp_path):
     if request.param == "file":
-        return path_to_local_file_uri(str(module_scoped_tmp_dir.joinpath("file")))
+        backend_uri = tmp_path.joinpath("file").as_uri()
     else:
-        path = path_to_local_file_uri(str(module_scoped_tmp_dir.joinpath("sqlalchemy.db")))
-        return ("sqlite://" if sys.platform == "win32" else "sqlite:////") + path[len("file://") :]
+        path = tmp_path.joinpath("sqlalchemy.db").as_uri()
+        backend_uri = ("sqlite://" if sys.platform == "win32" else "sqlite:////") + path[
+            len("file://") :
+        ]
 
-
-@pytest.fixture(autouse=True)
-def reset_backend(backend_uri, module_scoped_tmp_dir):
-    for child in module_scoped_tmp_dir.iterdir():
-        if child.is_dir():
-            shutil.rmtree(child)
-        else:
-            child.unlink()
-
-    if backend_uri.startswith("file"):
-        FileStore(backend_uri)
-    else:
-        SqlAlchemyStore(backend_uri)
-
-
-@pytest.fixture(scope="module")
-def client(backend_uri, module_scoped_tmp_dir):
-    _logger.info("Launching server...")
     url, process = _init_server(
-        backend_uri=backend_uri, root_artifact_uri=module_scoped_tmp_dir.as_uri()
+        backend_uri=backend_uri, root_artifact_uri=tmp_path.joinpath("artifacts").as_uri()
     )
     yield MlflowClient(url)
-    _logger.info(f"Terminating server at {url}...")
-    process.terminate()
-    _await_server_down_or_die(process)
+    _terminate_server(process)
 
 
 def assert_is_between(start_time, end_time, expected_time):

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -842,6 +842,7 @@ def test_search_experiments(mlflow_client):
     assert [e.name for e in experiments] == ["a", "Default"]
 
     # view_type
+    time.sleep(0.001)
     mlflow_client.delete_experiment(experiment_ids[1])
     experiments = mlflow_client.search_experiments(view_type=ViewType.ACTIVE_ONLY)
     assert [e.name for e in experiments] == ["Abc", "a", "Default"]

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -26,7 +26,6 @@ from mlflow.entities import Metric, Param, RunTag, ViewType
 from mlflow.models import Model
 import mlflow.pyfunc
 from mlflow.server.handlers import validate_path_is_safe
-from mlflow.store.tracking.file_store import FileStore
 from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils.mlflow_tags import (
@@ -43,7 +42,7 @@ from mlflow.utils.os import is_windows
 
 from tests.integration.utils import invoke_cli_runner
 from tests.tracking.integration_test_utils import (
-    _await_server_down_or_die,
+    _terminate_server,
     _init_server,
     _send_rest_tracking_post_request,
 )
@@ -55,22 +54,18 @@ _logger = logging.getLogger(__name__)
 @pytest.fixture(params=["file", "sqlalchemy"])
 def mlflow_client(request, tmp_path):
     """Provides an MLflow Tracking API client pointed at the local tracking server."""
-    root_artifact_uri = str(tmp_path)
     if request.param == "file":
-        uri = path_to_local_file_uri(str(tmp_path.joinpath("file")))
-        FileStore(uri)
+        backend_uri = tmp_path.joinpath("file").as_uri()
     elif request.param == "sqlalchemy":
-        path = path_to_local_file_uri(str(tmp_path.joinpath("sqlalchemy.db")))
-        uri = ("sqlite://" if sys.platform == "win32" else "sqlite:////") + path[len("file://") :]
-        SqlAlchemyStore(uri, root_artifact_uri)
+        path = tmp_path.joinpath("sqlalchemy.db").as_uri()
+        backend_uri = ("sqlite://" if sys.platform == "win32" else "sqlite:////") + path[
+            len("file://") :
+        ]
 
-    url, process = _init_server(backend_uri=uri, root_artifact_uri=root_artifact_uri)
-
+    url, process = _init_server(backend_uri, root_artifact_uri=tmp_path.as_uri())
     yield MlflowClient(url)
 
-    _logger.info(f"Terminating server at {url}...")
-    process.terminate()
-    _await_server_down_or_die(process)
+    _terminate_server(process)
 
 
 @pytest.fixture()


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Fix test failures in SQLAlchemy 2.0. See https://github.com/sqlalchemy/sqlalchemy/discussions/9188 for what caused tests to fail.

https://github.com/mlflow/mlflow/actions/runs/4044156811/jobs/6953961682

```python
Traceback (most recent call last):
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1942, in _exec_single_context
    self.dialect.do_execute(
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/sqlalchemy/engine/default.py", line 744, in do_execute
    cursor.execute(statement, parameters)
sqlite3.OperationalError: attempt to write a readonly database

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/haru/Desktop/repositories/mlflow/mlflow/store/db/utils.py", line 130, in make_managed_session
    yield session
  File "/home/haru/Desktop/repositories/mlflow/mlflow/store/model_registry/sqlalchemy_store.py", line 186, in create_registered_model
    session.flush()
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/sqlalchemy/orm/session.py", line 3939, in flush
    self._flush(objects)
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/sqlalchemy/orm/session.py", line 4076, in _flush
    transaction.rollback(_capture_exception=True)
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/sqlalchemy/util/langhelpers.py", line 148, in __exit__
    raise exc_value.with_traceback(exc_tb)
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/sqlalchemy/orm/session.py", line 4036, in _flush
    flush_context.execute()
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/sqlalchemy/orm/unitofwork.py", line 467, in execute
    rec.execute(self)
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/sqlalchemy/orm/unitofwork.py", line 644, in execute
    util.preloaded.orm_persistence.save_obj(
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/sqlalchemy/orm/persistence.py", line 93, in save_obj
    _emit_insert_statements(
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/sqlalchemy/orm/persistence.py", line 1011, in _emit_insert_statements
    result = connection.execute(
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1392, in execute
    return meth(
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/sqlalchemy/sql/elements.py", line 487, in _execute_on_connection
    return connection._execute_clauseelement(
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1616, in _execute_clauseelement
    ret = self._execute_context(
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1820, in _execute_context
    return self._exec_single_context(
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1961, in _exec_single_context
    self._handle_dbapi_exception(
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 2303, in _handle_dbapi_exception
    raise sqlalchemy_exception.with_traceback(exc_info[2]) from e
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1942, in _exec_single_context
    self.dialect.do_execute(
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/sqlalchemy/engine/default.py", line 744, in do_execute
    cursor.execute(statement, parameters)
sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) attempt to write a readonly database
[SQL: INSERT INTO registered_models (name, creation_time, last_updated_time, description) VALUES (?, ?, ?, ?)]
[parameters: ('CreateRMsearch000', 1675088981152, 1675088981152, '')]
(Background on this error at: https://sqlalche.me/e/20/e3q8)
127.0.0.1 - - [30/Jan/2023 23:29:41] "POST /api/2.0/mlflow/registered-models/create HTTP/1.1" 503 -
INFO  [werkzeug] 127.0.0.1 - - [30/Jan/2023 23:29:41] "POST /api/2.0/mlflow/registered-models/create HTTP/1.1" 503 -
```

```
sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) attempt to write a readonly database
```

indicates the DB file is still open so we can read, but we can't write because it's deleted.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
