### PR TITLE
[Server][Feature] add plugin to allow custom configs for mlflow.server

### DIFF
--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -216,13 +216,13 @@ plugin:
        ``dataset`` (an instance of ``mlflow.models.evaluation.base._EvaluationDataset`` containing features and labels (optional) for model evaluation),
        ``run_id`` (the ID of the MLflow Run to which to log results), and ``evaluator_config`` (a dictionary of additional configurations for the evaluator).
      - `DummyEvaluator <https://github.com/mlflow/mlflow/blob/branch-1.23/tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_evaluator.py>`_.
-   * - Plugins for custom mlflow server flask app configuration `mlflow.server.app <https://github.com/mlflow/mlflow/blob/v2.1.1/mlflow/server/__init__.py#L30>`_.
+   * - Plugins for custom mlflow server flask app configuration `mlflow.server.app <https://github.com/mlflow/mlflow/blob/v2.2.0/mlflow/server/__init__.py#L30>`_.
      - mlflow.app 
      - The entry point name (e.g. ``mlflow_test_plugin:app``) specifies a customized flask application. This can be useful for implementing
        request hooks, custom logging and custom flask configurations. The plugin must import `mlflow.server.app` (e.g. ``from mlflow.server import app``) and may add custom configuration, middleware etc. to the app.
        The plugin should avoid altering the existing application routes, handlers and environment variables to avoid unexpected behavior. 
        Users who install the example plugin will have a customized flask application.
-     - `app <https://github.com/mlflow/mlflow/blob/v2.1.1/tests/resources/mlflow-test-plugin/mlflow_test_plugin/app.py>`_.
+     - `app <https://github.com/mlflow/mlflow/blob/v2.2.0/tests/resources/mlflow-test-plugin/mlflow_test_plugin/app.py>`_.
 
 
 Testing Your Plugin

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -216,6 +216,13 @@ plugin:
        ``dataset`` (an instance of ``mlflow.models.evaluation.base._EvaluationDataset`` containing features and labels (optional) for model evaluation),
        ``run_id`` (the ID of the MLflow Run to which to log results), and ``evaluator_config`` (a dictionary of additional configurations for the evaluator).
      - `DummyEvaluator <https://github.com/mlflow/mlflow/blob/branch-1.23/tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_evaluator.py>`_.
+   * - Plugins for custom mlflow server flask app configuration `mlflow.server.app <https://github.com/mlflow/mlflow/blob/v2.1.1/mlflow/server/__init__.py#L30>`_.
+     - mlflow.app 
+     - The entry point name (e.g. ``mlflow_test_plugin:app``) specifies a customized flask application. This can be useful for implementing
+       request hooks, custom logging and custom flask configurations. The plugin must import `mlflow.server.app` (e.g. ``from mlflow.server import app``) and may add custom configuration, middleware etc. to the app.
+       The plugin should avoid altering the existing application routes, handlers and environment variables to avoid unexpected behavior. 
+       Users who install the example plugin will have a customized flask application.
+     - `app <https://github.com/mlflow/mlflow/blob/v2.1.1/tests/resources/mlflow-test-plugin/mlflow_test_plugin/app.py>`_.
 
 
 Testing Your Plugin
@@ -231,6 +238,7 @@ reference implementations as an example:
 * `Example RunContextProvider tests <https://github.com/mlflow/mlflow/blob/branch-1.5/tests/tracking/context/test_git_context.py>`_
 * `Example Model Registry Store tests <https://github.com/mlflow/mlflow/blob/branch-1.5/tests/store/model_registry/test_sqlalchemy_store.py>`_
 * `Example Custom Mlflow Evaluator tests <https://github.com/mlflow/mlflow/blob/branch-1.23/tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_evaluator.py>`_
+* `Example Custom Mlflow server tests <https://github.com/mlflow/mlflow/blob/branch-2.2.0/tests/server/test_handlers.py>`_
 
 
 Distributing Your Plugin

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -112,15 +112,13 @@ def _get_app_name() -> str:
     apps = list(entrypoints.get_group_all("mlflow.app"))
     # Default, nothing installed
     if len(apps) == 0:
-        return "{}:app".format(__name__)
+        return f"{__name__}:app"
     # Cannot install more than one
     if len(apps) > 1:
         raise MlflowException(
             "Multiple server plugins detected. "
             "Only one server plugin may be installed. "
-            "Detected plugins: {}".format(
-                ", ".join([f"{a.module_name}.{a.object_name}" for a in apps])
-            )
+            f"Detected plugins: {', '.join([f'{a.module_name}.{a.object_name}' for a in apps])}"
         )
     # Has a plugin installed
     plugin_app = apps[0]

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -109,22 +109,22 @@ def serve():
 
 def _get_app_name() -> str:
     """Search for plugins for custom mlflow app, otherwise return default."""
-    apps = [app for app in entrypoints.get_group_all("mlflow.app")]
+    apps = list(entrypoints.get_group_all("mlflow.app"))
     # Default, nothing installed
-    if len(apps) < 1:
+    if len(apps) == 0:
         return "{}:app".format(__name__)
     # Cannot install more than one
     if len(apps) > 1:
         raise MlflowException(
-            "Multiple server plugins detected "
-            "Only one server plugin may be installed"
-            "Plugins: {}".format(
-                ", ".join(["{}.{}".format(a.module_name, a.object_name) for a in apps])
+            "Multiple server plugins detected. "
+            "Only one server plugin may be installed. "
+            "Detected plugins: {}".format(
+                ", ".join([f"{a.module_name}.{a.object_name}" for a in apps])
             )
         )
     # Has a plugin installed
     plugin_app = apps[0]
-    return "{}:{}".format(plugin_app.module_name, plugin_app.object_name)
+    return f"{plugin_app.module_name}:{plugin_app.object_name}"
 
 
 def _build_waitress_command(waitress_opts, host, port, app_name):

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -1,3 +1,4 @@
+import entrypoints
 import os
 import shlex
 import sys
@@ -5,6 +6,7 @@ import textwrap
 
 from flask import Flask, send_from_directory, Response
 
+from mlflow.exceptions import MlflowException
 from mlflow.server import handlers
 from mlflow.server.handlers import (
     get_artifact_handler,
@@ -105,19 +107,39 @@ def serve():
     return Response(text, mimetype="text/plain")
 
 
-def _build_waitress_command(waitress_opts, host, port):
+def _get_app_name() -> str:
+    """Search for plugins for custom mlflow app, otherwise return default."""
+    apps = [app for app in entrypoints.get_group_all("mlflow.app")]
+    # Default, nothing installed
+    if len(apps) < 1:
+        return "{}:app".format(__name__)
+    # Cannot install more than one
+    if len(apps) > 1:
+        raise MlflowException(
+            "Multiple server plugins detected "
+            "Only one server plugin may be installed"
+            "Plugins: {}".format(
+                ", ".join(["{}.{}".format(a.module_name, a.object_name) for a in apps])
+            )
+        )
+    # Has a plugin installed
+    plugin_app = apps[0]
+    return "{}:{}".format(plugin_app.module_name, plugin_app.object_name)
+
+
+def _build_waitress_command(waitress_opts, host, port, app_name):
     opts = shlex.split(waitress_opts) if waitress_opts else []
     return (
         ["waitress-serve"]
         + opts
-        + ["--host=%s" % host, "--port=%s" % port, "--ident=mlflow", "mlflow.server:app"]
+        + ["--host=%s" % host, "--port=%s" % port, "--ident=mlflow", app_name]
     )
 
 
-def _build_gunicorn_command(gunicorn_opts, host, port, workers):
+def _build_gunicorn_command(gunicorn_opts, host, port, workers, app_name):
     bind_address = f"{host}:{port}"
     opts = shlex.split(gunicorn_opts) if gunicorn_opts else []
-    return ["gunicorn"] + opts + ["-b", bind_address, "-w", "%s" % workers, "mlflow.server:app"]
+    return ["gunicorn"] + opts + ["-b", bind_address, "-w", "%s" % workers, app_name]
 
 
 def _run_server(
@@ -160,9 +182,10 @@ def _run_server(
     if expose_prometheus:
         env_map[PROMETHEUS_EXPORTER_ENV_VAR] = expose_prometheus
 
+    app_name = _get_app_name()
     # TODO: eventually may want waitress on non-win32
     if sys.platform == "win32":
-        full_command = _build_waitress_command(waitress_opts, host, port)
+        full_command = _build_waitress_command(waitress_opts, host, port, app_name)
     else:
-        full_command = _build_gunicorn_command(gunicorn_opts, host, port, workers or 4)
+        full_command = _build_gunicorn_command(gunicorn_opts, host, port, workers or 4, app_name)
     _exec_cmd(full_command, extra_env=env_map, capture_output=False)

--- a/tests/resources/mlflow-test-plugin/mlflow_test_plugin/app.py
+++ b/tests/resources/mlflow-test-plugin/mlflow_test_plugin/app.py
@@ -1,0 +1,28 @@
+import logging
+
+# This would be all that plugin author is required to import
+from mlflow.server import app as custom_app
+
+# Can do custom logging on either the app or logging itself
+# but you'll possibly have to clear the existing handlers or there will be duplicate output
+# See https://docs.python.org/3/howto/logging-cookbook.html
+
+app_logger = logging.getLogger(__name__)
+
+# Configure the app
+custom_app.config["MY_VAR"] = "config-var"
+
+
+def is_logged_in():
+    return False
+
+
+@custom_app.before_request
+def before_req_hook():
+    """A custom before request handler.
+
+    Can implement things such as authentication, special handling, etc.
+    """
+    app_logger.warning("Hello from before request!")
+    if not is_logged_in():
+        return "Unauthorized", 403

--- a/tests/resources/mlflow-test-plugin/mlflow_test_plugin/app.py
+++ b/tests/resources/mlflow-test-plugin/mlflow_test_plugin/app.py
@@ -14,7 +14,7 @@ custom_app.config["MY_VAR"] = "config-var"
 
 
 def is_logged_in():
-    return False
+    return True
 
 
 @custom_app.before_request

--- a/tests/resources/mlflow-test-plugin/setup.py
+++ b/tests/resources/mlflow-test-plugin/setup.py
@@ -31,5 +31,7 @@ setup(
         "mlflow.deployments": "faketarget=mlflow_test_plugin.fake_deployment_plugin",
         # Define a Mlflow model evaluator with name "dummy_evaluator"
         "mlflow.model_evaluator": "dummy_evaluator=mlflow_test_plugin.dummy_evaluator:DummyEvaluator",  # pylint: disable=line-too-long
+        # Define a Mlflow model evaluator with name "dummy_evaluator"
+        "mlflow.app": "app=mlflow_test_plugin.app:custom_app",
     },
 )

--- a/tests/resources/mlflow-test-plugin/setup.py
+++ b/tests/resources/mlflow-test-plugin/setup.py
@@ -31,7 +31,7 @@ setup(
         "mlflow.deployments": "faketarget=mlflow_test_plugin.fake_deployment_plugin",
         # Define a Mlflow model evaluator with name "dummy_evaluator"
         "mlflow.model_evaluator": "dummy_evaluator=mlflow_test_plugin.dummy_evaluator:DummyEvaluator",  # pylint: disable=line-too-long
-        # Define a Mlflow model evaluator with name "dummy_evaluator"
+        # Define a custom Mlflow application with name custom_app
         "mlflow.app": "app=mlflow_test_plugin.app:custom_app",
     },
 )

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -737,3 +737,14 @@ def test_guess_mime_type(file_path, expected_mime_type):
 )
 def test_guess_mime_type_on_windows(file_path, expected_mime_type):
     assert _guess_mime_type(file_path) == expected_mime_type
+
+
+def test_app_plugin(caplog):
+    """This test requires the package in tests/resources/mlflow-test-plugin to be installed"""
+    from mlflow_test_plugin.app import custom_app
+
+    with custom_app.test_client() as c:
+        response = c.get("/health")
+        assert response.status_code == 403
+        assert response.get_data().decode() == "Unauthorized"
+    assert "Hello from before request!" in caplog.text

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -737,14 +737,3 @@ def test_guess_mime_type(file_path, expected_mime_type):
 )
 def test_guess_mime_type_on_windows(file_path, expected_mime_type):
     assert _guess_mime_type(file_path) == expected_mime_type
-
-
-def test_app_plugin(caplog):
-    """This test requires the package in tests/resources/mlflow-test-plugin to be installed"""
-    from mlflow_test_plugin.app import custom_app
-
-    with custom_app.test_client() as c:
-        response = c.get("/health")
-        assert response.status_code == 403
-        assert response.get_data().decode() == "Unauthorized"
-    assert "Hello from before request!" in caplog.text

--- a/tests/server/test_init.py
+++ b/tests/server/test_init.py
@@ -15,7 +15,8 @@ def mock_exec_cmd():
 
 def test_get_app_name():
     # Hard to test if the test plugin is installed.
-    assert server._get_app_name() == f"{server.__name__}:app"
+    with mock.patch("mlflow.server.entrypoints.get_group_all", return_value=[]):
+        assert server._get_app_name() == f"{server.__name__}:app"
 
 
 def test_get_app_name_two_plugins():
@@ -54,13 +55,13 @@ def test_build_gunicorn_command():
 
 def test_run_server(mock_exec_cmd):
     """Make sure this runs."""
-    with mock.patch("sys.platform", "linux"):
+    with mock.patch("sys.platform", return_value="linux"):
         server._run_server("", "", "", "", "", "", "", "")
     mock_exec_cmd.assert_called_once()
 
 
 def test_run_server_win32(mock_exec_cmd):
     """Make sure this runs."""
-    with mock.patch("sys.platform", "win32"):
+    with mock.patch("sys.platform", return_value="win32"):
         server._run_server("", "", "", "", "", "", "", "")
     mock_exec_cmd.assert_called_once()

--- a/tests/server/test_init.py
+++ b/tests/server/test_init.py
@@ -32,9 +32,7 @@ def test_get_app_name_two_plugins():
 
 def test_get_app_name_custom_app_plugin():
     """This test requires the package in tests/resources/mlflow-test-plugin to be installed"""
-    from mlflow_test_plugin import app
-
-    assert server._get_app_name() == f"{app.__name__}:custom_app"
+    assert server._get_app_name() == "mlflow_test_plugin.app:custom_app"
 
 
 def test_build_waitress_command():

--- a/tests/server/test_init.py
+++ b/tests/server/test_init.py
@@ -8,35 +8,35 @@ from mlflow import server
 
 
 @pytest.fixture()
-def mock__exec_cmd():
+def mock_exec_cmd():
     with mock.patch("mlflow.server._exec_cmd") as m:
         yield m
 
 
-def test__get_app_name():
+def test_get_app_name():
     # Hard to test if the test plugin is installed.
     assert server._get_app_name() == f"{server.__name__}:app"
 
 
-def test__get_app_name_two_plugins():
+def test_get_app_name_two_plugins():
     """Two server apps cannot exist, which one would be served?"""
     plugins = [
         entrypoints.EntryPoint("one", "one.app", "app"),
         entrypoints.EntryPoint("two", "two.app", "two"),
     ]
     with mock.patch("mlflow.server.entrypoints.get_group_all", return_value=plugins):
-        with pytest.raises(MlflowException, match="one.*two"):
+        with pytest.raises(MlflowException, match=r"one.*two"):
             server._get_app_name()
 
 
-def test__get_app_name_custom_app_plugin():
+def test_get_app_name_custom_app_plugin():
     """This test requires the package in tests/resources/mlflow-test-plugin to be installed"""
     from mlflow_test_plugin import app
 
     assert server._get_app_name() == f"{app.__name__}:custom_app"
 
 
-def test__build_waitress_command():
+def test_build_waitress_command():
     assert server._build_waitress_command("", "localhost", "5000", f"{server.__name__}:app") == [
         "waitress-serve",
         "--host=localhost",
@@ -46,21 +46,21 @@ def test__build_waitress_command():
     ]
 
 
-def test__build_gunicorn_command():
+def test_build_gunicorn_command():
     assert server._build_gunicorn_command(
         "", "localhost", "5000", "4", f"{server.__name__}:app"
     ) == ["gunicorn", "-b", "localhost:5000", "-w", "4", "mlflow.server:app"]
 
 
-def test__run_server(mock__exec_cmd):
+def test_run_server(mock_exec_cmd):
     """Make sure this runs."""
     with mock.patch("sys.platform", "linux"):
         server._run_server("", "", "", "", "", "", "", "")
-    mock__exec_cmd.assert_called_once()
+    mock_exec_cmd.assert_called_once()
 
 
-def test__run_server_win32(mock__exec_cmd):
+def test_run_server_win32(mock_exec_cmd):
     """Make sure this runs."""
     with mock.patch("sys.platform", "win32"):
         server._run_server("", "", "", "", "", "", "", "")
-    mock__exec_cmd.assert_called_once()
+    mock_exec_cmd.assert_called_once()

--- a/tests/server/test_init.py
+++ b/tests/server/test_init.py
@@ -1,0 +1,66 @@
+from unittest import mock
+
+import entrypoints
+import pytest
+
+from mlflow.exceptions import MlflowException
+from mlflow import server
+
+
+@pytest.fixture()
+def mock__exec_cmd():
+    with mock.patch("mlflow.server._exec_cmd") as m:
+        yield m
+
+
+def test__get_app_name():
+    # Hard to test if the test plugin is installed.
+    assert server._get_app_name() == f"{server.__name__}:app"
+
+
+def test__get_app_name_two_plugins():
+    """Two server apps cannot exist, which one would be served?"""
+    plugins = [
+        entrypoints.EntryPoint("one", "one.app", "app"),
+        entrypoints.EntryPoint("two", "two.app", "two"),
+    ]
+    with mock.patch("mlflow.server.entrypoints.get_group_all", return_value=plugins):
+        with pytest.raises(MlflowException, match="one.*two"):
+            server._get_app_name()
+
+
+def test__get_app_name_custom_app_plugin():
+    """This test requires the package in tests/resources/mlflow-test-plugin to be installed"""
+    from mlflow_test_plugin import app
+
+    assert server._get_app_name() == f"{app.__name__}:custom_app"
+
+
+def test__build_waitress_command():
+    assert server._build_waitress_command("", "localhost", "5000", f"{server.__name__}:app") == [
+        "waitress-serve",
+        "--host=localhost",
+        "--port=5000",
+        "--ident=mlflow",
+        "mlflow.server:app",
+    ]
+
+
+def test__build_gunicorn_command():
+    assert server._build_gunicorn_command(
+        "", "localhost", "5000", "4", f"{server.__name__}:app"
+    ) == ["gunicorn", "-b", "localhost:5000", "-w", "4", "mlflow.server:app"]
+
+
+def test__run_server(mock__exec_cmd):
+    """Make sure this runs."""
+    with mock.patch("sys.platform", "linux"):
+        server._run_server("", "", "", "", "", "", "", "")
+    mock__exec_cmd.assert_called_once()
+
+
+def test__run_server_win32(mock__exec_cmd):
+    """Make sure this runs."""
+    with mock.patch("sys.platform", "win32"):
+        server._run_server("", "", "", "", "", "", "", "")
+    mock__exec_cmd.assert_called_once()


### PR DESCRIPTION
Signed-off-by: Justin Mahlik <38999128+jmahlik@users.noreply.github.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs


<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> Closes #7566 

## What changes are proposed in this pull request?

Add plugin interface for mlflow server app configuration.

## How is this patch tested?
Added tests for `server.__init__` and an example plugin.

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

Installed the example plugin and confirmed it is working as expected.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add plugin interface for `mlflow.server.app` to allow customizing the mlflow application.

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
