### PR TITLE
[Bug-fix][Recipes] Updating the run_name API to be run_name_prefix

### DIFF
--- a/mlflow/recipes/utils/tracking.py
+++ b/mlflow/recipes/utils/tracking.py
@@ -3,6 +3,7 @@ import logging
 import pathlib
 import tempfile
 import shutil
+import random
 from typing import Dict, Any, TypeVar
 
 import mlflow
@@ -28,6 +29,15 @@ from mlflow.utils.mlflow_tags import (
 _logger = logging.getLogger(__name__)
 
 TrackingConfigType = TypeVar("TrackingConfig")
+
+
+def _get_run_name(run_name_prefix):
+    if run_name_prefix is None:
+        return None
+
+    sep = "-"
+    num = random.randint(0, 10**3)
+    return f"{run_name_prefix}{sep}{num}"
 
 
 class TrackingConfig:
@@ -152,7 +162,7 @@ def get_recipe_tracking_config(
     tracking_config = recipe_config.get("experiment", {})
 
     config_obj_kwargs = {
-        "run_name": tracking_config.get("run_name", None),
+        "run_name": _get_run_name(tracking_config.get("run_name_prefix")),
         "tracking_uri": tracking_config.get("tracking_uri", default_tracking_uri),
         "artifact_location": tracking_config.get("artifact_location", default_artifact_location),
     }

--- a/mlflow/recipes/utils/tracking.py
+++ b/mlflow/recipes/utils/tracking.py
@@ -3,7 +3,7 @@ import logging
 import pathlib
 import tempfile
 import shutil
-import random
+import uuid
 from typing import Dict, Any, TypeVar
 
 import mlflow
@@ -36,7 +36,7 @@ def _get_run_name(run_name_prefix):
         return None
 
     sep = "-"
-    num = random.randint(0, 10**3)
+    num = uuid.uuid4().hex[:8]
     return f"{run_name_prefix}{sep}{num}"
 
 

--- a/tests/recipes/test_tracking_utils.py
+++ b/tests/recipes/test_tracking_utils.py
@@ -77,10 +77,10 @@ def test_get_recipe_tracking_config_returns_expected_config(
     assert recipe_tracking_config.artifact_location == (
         artifact_location or default_artifact_location
     )
-    if run_name_prefix is not None:
-        assert run_name_prefix in recipe_tracking_config.run_name
-    else:
+    if run_name_prefix is None:
         assert recipe_tracking_config.run_name is None
+    else:
+        assert run_name_prefix in recipe_tracking_config.run_name
     if experiment_name is not None:
         assert recipe_tracking_config.experiment_name == experiment_name
     elif experiment_id is not None:
@@ -142,11 +142,10 @@ def test_get_recipe_tracking_config_returns_expected_config_on_databricks(
         )
         assert recipe_tracking_config.tracking_uri == (tracking_uri or default_tracking_uri)
         assert recipe_tracking_config.artifact_location == artifact_location
-        if run_name_prefix is not None:
-            assert run_name_prefix in recipe_tracking_config.run_name
-        else:
+        if run_name_prefix is None:
             assert recipe_tracking_config.run_name is None
-        # assert recipe_tracking_config.run_name == (run_name_prefix or None)
+        else:
+            assert run_name_prefix in recipe_tracking_config.run_name
         if experiment_name is not None:
             assert recipe_tracking_config.experiment_name == experiment_name
         elif experiment_id is not None:

--- a/tests/recipes/test_tracking_utils.py
+++ b/tests/recipes/test_tracking_utils.py
@@ -20,7 +20,7 @@ from tests.recipes.helper_functions import (
 
 @pytest.mark.usefixtures("enter_test_recipe_directory")
 @pytest.mark.parametrize(
-    ("tracking_uri", "artifact_location", "experiment_name", "experiment_id", "run_name"),
+    ("tracking_uri", "artifact_location", "experiment_name", "experiment_id", "run_name_prefix"),
     [
         (
             "mysql://myhost:8000/test_uri",
@@ -38,7 +38,7 @@ from tests.recipes.helper_functions import (
     ],
 )
 def test_get_recipe_tracking_config_returns_expected_config(
-    tracking_uri, artifact_location, experiment_name, experiment_id, run_name
+    tracking_uri, artifact_location, experiment_name, experiment_id, run_name_prefix
 ):
     default_tracking_uri = path_to_local_sqlite_uri(
         path=str((pathlib.Path.cwd() / "metadata" / "mlflow" / "mlruns.db").resolve())
@@ -62,8 +62,8 @@ def test_get_recipe_tracking_config_returns_expected_config(
         profile_contents["experiment"]["name"] = experiment_name
     if experiment_id is not None:
         profile_contents["experiment"]["id"] = experiment_id
-    if run_name is not None:
-        profile_contents["experiment"]["run_name"] = run_name
+    if run_name_prefix is not None:
+        profile_contents["experiment"]["run_name_prefix"] = run_name_prefix
 
     profile_path = pathlib.Path.cwd() / "profiles" / "testprofile.yaml"
     with open(profile_path, "w") as f:
@@ -77,7 +77,10 @@ def test_get_recipe_tracking_config_returns_expected_config(
     assert recipe_tracking_config.artifact_location == (
         artifact_location or default_artifact_location
     )
-    assert recipe_tracking_config.run_name == (run_name or None)
+    if run_name_prefix is not None:
+        assert run_name_prefix in recipe_tracking_config.run_name
+    else:
+        assert recipe_tracking_config.run_name is None
     if experiment_name is not None:
         assert recipe_tracking_config.experiment_name == experiment_name
     elif experiment_id is not None:
@@ -88,7 +91,7 @@ def test_get_recipe_tracking_config_returns_expected_config(
 
 @pytest.mark.usefixtures("enter_test_recipe_directory")
 @pytest.mark.parametrize(
-    ("tracking_uri", "artifact_location", "experiment_name", "experiment_id", "run_name"),
+    ("tracking_uri", "artifact_location", "experiment_name", "experiment_id", "run_name_prefix"),
     [
         (
             "mysql://myhost:8000/test_uri",
@@ -106,7 +109,7 @@ def test_get_recipe_tracking_config_returns_expected_config(
     ],
 )
 def test_get_recipe_tracking_config_returns_expected_config_on_databricks(
-    tracking_uri, artifact_location, experiment_name, experiment_id, run_name
+    tracking_uri, artifact_location, experiment_name, experiment_id, run_name_prefix
 ):
     with mock.patch("mlflow.recipes.utils.tracking.is_in_databricks_runtime", return_value=True):
         default_tracking_uri = "databricks"
@@ -126,8 +129,8 @@ def test_get_recipe_tracking_config_returns_expected_config_on_databricks(
             profile_contents["experiment"]["name"] = experiment_name
         if experiment_id is not None:
             profile_contents["experiment"]["id"] = experiment_id
-        if run_name is not None:
-            profile_contents["experiment"]["run_name"] = run_name
+        if run_name_prefix is not None:
+            profile_contents["experiment"]["run_name_prefix"] = run_name_prefix
 
         profile_path = pathlib.Path.cwd() / "profiles" / "testprofile.yaml"
         with open(profile_path, "w") as f:
@@ -139,7 +142,11 @@ def test_get_recipe_tracking_config_returns_expected_config_on_databricks(
         )
         assert recipe_tracking_config.tracking_uri == (tracking_uri or default_tracking_uri)
         assert recipe_tracking_config.artifact_location == artifact_location
-        assert recipe_tracking_config.run_name == (run_name or None)
+        if run_name_prefix is not None:
+            assert run_name_prefix in recipe_tracking_config.run_name
+        else:
+            assert recipe_tracking_config.run_name is None
+        # assert recipe_tracking_config.run_name == (run_name_prefix or None)
         if experiment_name is not None:
             assert recipe_tracking_config.experiment_name == experiment_name
         elif experiment_id is not None:


### PR DESCRIPTION
## What changes are proposed in this pull request?
[Bug-fix][Recipes] Updating the run_name API to be run_name_prefix

## How is this patch tested?
- [x] Test added
- [x] Experiment Page:
<img width="1734" alt="image" src="https://user-images.githubusercontent.com/5621432/215904179-75b84f11-bbad-470f-a937-ba7b2034039c.png">
 

## Does this PR change the documentation?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
