### PR TITLE
converted unittest to pytest for run_status

### DIFF
--- a/tests/entities/test_run_status.py
+++ b/tests/entities/test_run_status.py
@@ -1,51 +1,48 @@
-import unittest
 import pytest
 
 from mlflow.entities import RunStatus
 
+def test_all_status_covered():
+    # ensure that all known status are returned. Test will fail if new status are added to PB
+    all_statuses = {
+        RunStatus.RUNNING,
+        RunStatus.SCHEDULED,
+        RunStatus.FINISHED,
+        RunStatus.FAILED,
+        RunStatus.KILLED,
+    }
+    assert all_statuses == set(RunStatus.all_status())
 
-class TestRunStatus(unittest.TestCase):
-    def test_all_status_covered(self):
-        # ensure that all known status are returned. Test will fail if new status are added to PB
-        all_statuses = {
-            RunStatus.RUNNING,
-            RunStatus.SCHEDULED,
-            RunStatus.FINISHED,
-            RunStatus.FAILED,
-            RunStatus.KILLED,
-        }
-        assert all_statuses == set(RunStatus.all_status())
+def test_status_mappings():
+    # test enum to string mappings
+    assert RunStatus.to_string(RunStatus.RUNNING) == "RUNNING"
+    assert RunStatus.RUNNING == RunStatus.from_string("RUNNING")
 
-    def test_status_mappings(self):
-        # test enum to string mappings
-        assert RunStatus.to_string(RunStatus.RUNNING) == "RUNNING"
-        assert RunStatus.RUNNING == RunStatus.from_string("RUNNING")
+    assert RunStatus.to_string(RunStatus.SCHEDULED) == "SCHEDULED"
+    assert RunStatus.SCHEDULED == RunStatus.from_string("SCHEDULED")
 
-        assert RunStatus.to_string(RunStatus.SCHEDULED) == "SCHEDULED"
-        assert RunStatus.SCHEDULED == RunStatus.from_string("SCHEDULED")
+    assert RunStatus.to_string(RunStatus.FINISHED) == "FINISHED"
+    assert RunStatus.FINISHED == RunStatus.from_string("FINISHED")
 
-        assert RunStatus.to_string(RunStatus.FINISHED) == "FINISHED"
-        assert RunStatus.FINISHED == RunStatus.from_string("FINISHED")
+    assert RunStatus.to_string(RunStatus.FAILED) == "FAILED"
+    assert RunStatus.FAILED == RunStatus.from_string("FAILED")
 
-        assert RunStatus.to_string(RunStatus.FAILED) == "FAILED"
-        assert RunStatus.FAILED == RunStatus.from_string("FAILED")
+    assert RunStatus.to_string(RunStatus.KILLED) == "KILLED"
+    assert RunStatus.KILLED == RunStatus.from_string("KILLED")
 
-        assert RunStatus.to_string(RunStatus.KILLED) == "KILLED"
-        assert RunStatus.KILLED == RunStatus.from_string("KILLED")
+    with pytest.raises(
+        Exception, match=r"Could not get string corresponding to run status -120"
+    ):
+        RunStatus.to_string(-120)
 
-        with pytest.raises(
-            Exception, match=r"Could not get string corresponding to run status -120"
-        ):
-            RunStatus.to_string(-120)
+    with pytest.raises(
+        Exception, match=r"Could not get run status corresponding to string the IMPO"
+    ):
+        RunStatus.from_string("the IMPOSSIBLE status string")
 
-        with pytest.raises(
-            Exception, match=r"Could not get run status corresponding to string the IMPO"
-        ):
-            RunStatus.from_string("the IMPOSSIBLE status string")
-
-    def test_is_terminated(self):
-        assert RunStatus.is_terminated(RunStatus.FAILED)
-        assert RunStatus.is_terminated(RunStatus.FINISHED)
-        assert RunStatus.is_terminated(RunStatus.KILLED)
-        assert not RunStatus.is_terminated(RunStatus.SCHEDULED)
-        assert not RunStatus.is_terminated(RunStatus.RUNNING)
+def test_is_terminated():
+    assert RunStatus.is_terminated(RunStatus.FAILED)
+    assert RunStatus.is_terminated(RunStatus.FINISHED)
+    assert RunStatus.is_terminated(RunStatus.KILLED)
+    assert not RunStatus.is_terminated(RunStatus.SCHEDULED)
+    assert not RunStatus.is_terminated(RunStatus.RUNNING)

--- a/tests/entities/test_run_status.py
+++ b/tests/entities/test_run_status.py
@@ -2,6 +2,7 @@ import pytest
 
 from mlflow.entities import RunStatus
 
+
 def test_all_status_covered():
     # ensure that all known status are returned. Test will fail if new status are added to PB
     all_statuses = {
@@ -12,6 +13,7 @@ def test_all_status_covered():
         RunStatus.KILLED,
     }
     assert all_statuses == set(RunStatus.all_status())
+
 
 def test_status_mappings():
     # test enum to string mappings
@@ -30,15 +32,14 @@ def test_status_mappings():
     assert RunStatus.to_string(RunStatus.KILLED) == "KILLED"
     assert RunStatus.KILLED == RunStatus.from_string("KILLED")
 
-    with pytest.raises(
-        Exception, match=r"Could not get string corresponding to run status -120"
-    ):
+    with pytest.raises(Exception, match=r"Could not get string corresponding to run status -120"):
         RunStatus.to_string(-120)
 
     with pytest.raises(
         Exception, match=r"Could not get run status corresponding to string the IMPO"
     ):
         RunStatus.from_string("the IMPOSSIBLE status string")
+
 
 def test_is_terminated():
     assert RunStatus.is_terminated(RunStatus.FAILED)


### PR DESCRIPTION
Signed-off-by: nsenno-dbr <nick.senno@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

#7738 

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

This PR replaces the `unittest` class framework with `pytest` for the `test_run_status` series of tests 

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
