### PR TITLE
Migrate model-registry `RestStore` to pytest

### DIFF
--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -546,3 +546,24 @@ def _mlflow_major_version_string():
     major = ver.major
     minor = ver.minor
     return f"mlflow<{major + 1},>={major}.{minor}"
+
+
+@contextmanager
+def mock_http_request_200():
+    with mock.patch(
+        "mlflow.utils.rest_utils.http_request",
+        return_value=mock.MagicMock(status_code=200, text="{}"),
+    ) as m:
+        yield m
+
+
+@contextmanager
+def mock_http_request_403_200():
+    with mock.patch(
+        "mlflow.utils.rest_utils.http_request",
+        side_effect=[
+            mock.MagicMock(status_code=403, text='{"error_code": "ENDPOINT_NOT_FOUND"}'),
+            mock.MagicMock(status_code=200, text="{}"),
+        ],
+    ) as m:
+        yield m

--- a/tests/store/model_registry/test_rest_store.py
+++ b/tests/store/model_registry/test_rest_store.py
@@ -1,5 +1,3 @@
-from itertools import combinations
-
 import json
 import pytest
 import uuid
@@ -125,22 +123,19 @@ def test_search_registered_models(store, creds):
     _verify_requests(mock_http, creds, "registered-models/search", "GET", SearchRegisteredModels())
 
 
-def _search_registered_models_params():
-    params_list = [
-        {"filter_string": "model = 'yo'"},
-        {"max_results": 400},
-        {"page_token": "blah"},
-        {"order_by": ["x", "Y"]},
-    ]
-    # Generate all combinations of the above params
-    for sz in [0, 1, 2, 3, 4]:
-        for combination in combinations(params_list, sz):
-            params = {k: v for d in combination for k, v in d.items()}
-            yield params
-
-
-@pytest.mark.parametrize("params", _search_registered_models_params())
-def test_search_registered_models_params(store, creds, params):
+@pytest.mark.parametrize("filter_string", [None, "model = 'yo'"])
+@pytest.mark.parametrize("max_results", [None, 400])
+@pytest.mark.parametrize("page_token", [None, "blah"])
+@pytest.mark.parametrize("order_by", [None, ["x", "Y"]])
+def test_search_registered_models_params(
+    store, creds, filter_string, max_results, page_token, order_by
+):
+    params = {
+        **({"filter_string": filter_string} if filter_string else {}),
+        **({"max_results": max_results} if max_results else {}),
+        **({"page_token": page_token} if page_token else {}),
+        **({"order_by": order_by} if order_by else {}),
+    }
     with mock_http_request_200() as mock_http:
         store.search_registered_models(**params)
     if "filter_string" in params:

--- a/tests/store/model_registry/test_rest_store.py
+++ b/tests/store/model_registry/test_rest_store.py
@@ -153,7 +153,7 @@ def _search_registered_models_params():
         {"page_token": "blah"},
         {"order_by": ["x", "Y"]},
     ]
-    # test all combination of params
+    # Generate all combinations of the above params
     for sz in [0, 1, 2, 3, 4]:
         for combination in combinations(params_list, sz):
             params = {k: v for d in combination for k, v in d.items()}

--- a/tests/store/model_registry/test_rest_store.py
+++ b/tests/store/model_registry/test_rest_store.py
@@ -63,7 +63,7 @@ def store(creds):
     return RestStore(lambda: creds)
 
 
-def args(host_creds, endpoint, method, json_body):
+def _args(host_creds, endpoint, method, json_body):
     res = {"host_creds": host_creds, "endpoint": "/api/2.0/mlflow/%s" % endpoint, "method": method}
     if method == "GET":
         res["params"] = json.loads(json_body)
@@ -74,13 +74,13 @@ def args(host_creds, endpoint, method, json_body):
 
 def _verify_requests(http_request, creds, endpoint, method, proto_message):
     json_body = message_to_json(proto_message)
-    http_request.assert_any_call(**(args(creds, endpoint, method, json_body)))
+    http_request.assert_any_call(**(_args(creds, endpoint, method, json_body)))
 
 
 def _verify_all_requests(http_request, creds, endpoints, proto_message):
     json_body = message_to_json(proto_message)
     http_request.assert_has_calls(
-        [mock.call(**(args(creds, endpoint, method, json_body))) for endpoint, method in endpoints]
+        [mock.call(**(_args(creds, endpoint, method, json_body))) for endpoint, method in endpoints]
     )
 
 

--- a/tests/store/model_registry/test_rest_store.py
+++ b/tests/store/model_registry/test_rest_store.py
@@ -1,11 +1,10 @@
-import unittest
 from itertools import combinations
+from contextlib import contextmanager
 
 import json
 import pytest
 import uuid
 from unittest import mock
-import functools
 
 from mlflow.entities.model_registry import RegisteredModelTag, ModelVersionTag
 from mlflow.protos.model_registry_pb2 import (
@@ -33,218 +32,225 @@ from mlflow.utils.proto_json_utils import message_to_json
 from mlflow.utils.rest_utils import MlflowHostCreds
 
 
-@pytest.fixture(scope="class")
-def request_fixture():
-    with mock.patch("requests.request") as request_mock:
-        response = mock.MagicMock()
-        response.status_code = 200
-        response.text = "{}"
-        request_mock.return_value = response
-        yield request_mock
-
-
-def mock_http_request(f):
-    @functools.wraps(f)
-    @mock.patch(
+@contextmanager
+def mock_http_request_200():
+    with mock.patch(
         "mlflow.utils.rest_utils.http_request",
         return_value=mock.MagicMock(status_code=200, text="{}"),
-    )
-    def wrapper(*args, **kwargs):
-        return f(*args, **kwargs)
-
-    return wrapper
+    ) as m:
+        yield m
 
 
-def mock_multiple_http_requests(f):
-    @functools.wraps(f)
-    @mock.patch(
+@contextmanager
+def mock_http_request_403_200():
+    with mock.patch(
         "mlflow.utils.rest_utils.http_request",
         side_effect=[
             mock.MagicMock(status_code=403, text='{"error_code": "ENDPOINT_NOT_FOUND"}'),
             mock.MagicMock(status_code=200, text="{}"),
         ],
+    ) as m:
+        yield m
+
+
+@pytest.fixture
+def creds():
+    return MlflowHostCreds("https://hello")
+
+
+@pytest.fixture
+def store(creds):
+    return RestStore(lambda: creds)
+
+
+def args(host_creds, endpoint, method, json_body):
+    res = {"host_creds": host_creds, "endpoint": "/api/2.0/mlflow/%s" % endpoint, "method": method}
+    if method == "GET":
+        res["params"] = json.loads(json_body)
+    else:
+        res["json"] = json.loads(json_body)
+    return res
+
+
+def _verify_requests(http_request, creds, endpoint, method, proto_message):
+    json_body = message_to_json(proto_message)
+    http_request.assert_any_call(**(args(creds, endpoint, method, json_body)))
+
+
+def _verify_all_requests(http_request, creds, endpoints, proto_message):
+    json_body = message_to_json(proto_message)
+    http_request.assert_has_calls(
+        [mock.call(**(args(creds, endpoint, method, json_body))) for endpoint, method in endpoints]
     )
-    def wrapper(*args, **kwargs):
-        return f(*args, **kwargs)
-
-    return wrapper
 
 
-@pytest.mark.usefixtures("request_fixture")
-class TestRestStore(unittest.TestCase):
-    def setUp(self):
-        self.creds = MlflowHostCreds("https://hello")
-        self.store = RestStore(lambda: self.creds)
+def test_create_registered_model(store, creds):
+    tags = [
+        RegisteredModelTag(key="key", value="value"),
+        RegisteredModelTag(key="anotherKey", value="some other value"),
+    ]
+    description = "best model ever"
+    with mock_http_request_200() as mock_http:
+        store.create_registered_model("model_1", tags, description)
+    _verify_requests(
+        mock_http,
+        creds,
+        "registered-models/create",
+        "POST",
+        CreateRegisteredModel(
+            name="model_1", tags=[tag.to_proto() for tag in tags], description=description
+        ),
+    )
 
-    def tearDown(self):
-        pass
 
-    def _args(self, host_creds, endpoint, method, json_body):
-        res = {
-            "host_creds": host_creds,
-            "endpoint": "/api/2.0/mlflow/%s" % endpoint,
-            "method": method,
-        }
-        if method == "GET":
-            res["params"] = json.loads(json_body)
-        else:
-            res["json"] = json.loads(json_body)
-        return res
+def test_update_registered_model_name(store, creds):
+    name = "model_1"
+    new_name = "model_2"
+    with mock_http_request_200() as mock_http:
+        store.rename_registered_model(name=name, new_name=new_name)
+    _verify_requests(
+        mock_http,
+        creds,
+        "registered-models/rename",
+        "POST",
+        RenameRegisteredModel(name=name, new_name=new_name),
+    )
 
-    def _verify_requests(self, http_request, endpoint, method, proto_message):
-        json_body = message_to_json(proto_message)
-        http_request.assert_any_call(**(self._args(self.creds, endpoint, method, json_body)))
 
-    def _verify_all_requests(self, http_request, endpoints, proto_message):
-        json_body = message_to_json(proto_message)
-        http_request.assert_has_calls(
-            [
-                mock.call(**(self._args(self.creds, endpoint, method, json_body)))
-                for endpoint, method in endpoints
-            ]
-        )
+def test_update_registered_model_description(store, creds):
+    name = "model_1"
+    description = "test model"
+    with mock_http_request_200() as mock_http:
+        store.update_registered_model(name=name, description=description)
+    _verify_requests(
+        mock_http,
+        creds,
+        "registered-models/update",
+        "PATCH",
+        UpdateRegisteredModel(name=name, description=description),
+    )
 
-    @mock_http_request
-    def test_create_registered_model(self, mock_http):
-        tags = [
-            RegisteredModelTag(key="key", value="value"),
-            RegisteredModelTag(key="anotherKey", value="some other value"),
-        ]
-        description = "best model ever"
-        self.store.create_registered_model("model_1", tags, description)
-        self._verify_requests(
-            mock_http,
-            "registered-models/create",
-            "POST",
-            CreateRegisteredModel(
-                name="model_1", tags=[tag.to_proto() for tag in tags], description=description
-            ),
-        )
 
-    @mock_http_request
-    def test_update_registered_model_name(self, mock_http):
-        name = "model_1"
-        new_name = "model_2"
-        self.store.rename_registered_model(name=name, new_name=new_name)
-        self._verify_requests(
-            mock_http,
-            "registered-models/rename",
-            "POST",
-            RenameRegisteredModel(name=name, new_name=new_name),
-        )
+def test_delete_registered_model(store, creds):
+    name = "model_1"
+    with mock_http_request_200() as mock_http:
+        store.delete_registered_model(name=name)
+    _verify_requests(
+        mock_http, creds, "registered-models/delete", "DELETE", DeleteRegisteredModel(name=name)
+    )
 
-    @mock_http_request
-    def test_update_registered_model_description(self, mock_http):
-        name = "model_1"
-        description = "test model"
-        self.store.update_registered_model(name=name, description=description)
-        self._verify_requests(
-            mock_http,
-            "registered-models/update",
-            "PATCH",
-            UpdateRegisteredModel(name=name, description=description),
-        )
 
-    @mock_http_request
-    def test_delete_registered_model(self, mock_http):
-        name = "model_1"
-        self.store.delete_registered_model(name=name)
-        self._verify_requests(
-            mock_http, "registered-models/delete", "DELETE", DeleteRegisteredModel(name=name)
-        )
+def test_search_registered_models(store, creds):
+    with mock_http_request_200() as mock_http:
+        store.search_registered_models()
+    _verify_requests(mock_http, creds, "registered-models/search", "GET", SearchRegisteredModels())
 
-    @mock_http_request
-    def test_search_registered_model(self, mock_http):
-        self.store.search_registered_models()
-        self._verify_requests(
-            mock_http, "registered-models/search", "GET", SearchRegisteredModels()
-        )
-        params_list = [
-            {"filter_string": "model = 'yo'"},
-            {"max_results": 400},
-            {"page_token": "blah"},
-            {"order_by": ["x", "Y"]},
-        ]
-        # test all combination of params
-        for sz in [0, 1, 2, 3, 4]:
-            for combination in combinations(params_list, sz):
-                params = {k: v for d in combination for k, v in d.items()}
-                self.store.search_registered_models(**params)
-                if "filter_string" in params:
-                    params["filter"] = params.pop("filter_string")
-                self._verify_requests(
-                    mock_http, "registered-models/search", "GET", SearchRegisteredModels(**params)
-                )
 
-    @mock_http_request
-    def test_get_registered_model(self, mock_http):
-        name = "model_1"
-        self.store.get_registered_model(name=name)
-        self._verify_requests(
-            mock_http, "registered-models/get", "GET", GetRegisteredModel(name=name)
-        )
+def _search_registered_models_params():
+    params_list = [
+        {"filter_string": "model = 'yo'"},
+        {"max_results": 400},
+        {"page_token": "blah"},
+        {"order_by": ["x", "Y"]},
+    ]
+    # test all combination of params
+    for sz in [0, 1, 2, 3, 4]:
+        for combination in combinations(params_list, sz):
+            params = {k: v for d in combination for k, v in d.items()}
+            yield params
 
-    @mock_multiple_http_requests
-    def test_get_latest_versions(self, mock_multiple_http_requests):
-        name = "model_1"
-        self.store.get_latest_versions(name=name)
-        endpoint = "registered-models/get-latest-versions"
-        endpoints = [(endpoint, "POST"), (endpoint, "GET")]
-        self._verify_all_requests(
-            mock_multiple_http_requests, endpoints, GetLatestVersions(name=name)
-        )
 
-    @mock_multiple_http_requests
-    def test_get_latest_versions_with_stages(self, mock_multiple_http_requests):
-        name = "model_1"
-        self.store.get_latest_versions(name=name, stages=["blaah"])
-        endpoint = "registered-models/get-latest-versions"
-        endpoints = [(endpoint, "POST"), (endpoint, "GET")]
-        self._verify_all_requests(
-            mock_multiple_http_requests, endpoints, GetLatestVersions(name=name, stages=["blaah"])
-        )
+@pytest.mark.parametrize("params", _search_registered_models_params())
+def test_search_registered_models_params(store, creds, params):
+    with mock_http_request_200() as mock_http:
+        store.search_registered_models(**params)
+    if "filter_string" in params:
+        params["filter"] = params.pop("filter_string")
+    _verify_requests(
+        mock_http,
+        creds,
+        "registered-models/search",
+        "GET",
+        SearchRegisteredModels(**params),
+    )
 
-    @mock_http_request
-    def test_set_registered_model_tag(self, mock_http):
-        name = "model_1"
-        tag = RegisteredModelTag(key="key", value="value")
-        self.store.set_registered_model_tag(name=name, tag=tag)
-        self._verify_requests(
-            mock_http,
-            "registered-models/set-tag",
-            "POST",
-            SetRegisteredModelTag(name=name, key=tag.key, value=tag.value),
-        )
 
-    @mock_http_request
-    def test_delete_registered_model_tag(self, mock_http):
-        name = "model_1"
-        self.store.delete_registered_model_tag(name=name, key="key")
-        self._verify_requests(
-            mock_http,
-            "registered-models/delete-tag",
-            "DELETE",
-            DeleteRegisteredModelTag(name=name, key="key"),
-        )
+def test_get_registered_model(store, creds):
+    name = "model_1"
+    with mock_http_request_200() as mock_http:
+        store.get_registered_model(name=name)
+    _verify_requests(
+        mock_http, creds, "registered-models/get", "GET", GetRegisteredModel(name=name)
+    )
 
-    @mock_http_request
-    def test_create_model_version(self, mock_http):
-        self.store.create_model_version("model_1", "path/to/source")
-        self._verify_requests(
-            mock_http,
-            "model-versions/create",
-            "POST",
-            CreateModelVersion(name="model_1", source="path/to/source"),
-        )
-        # test optional fields
-        run_id = uuid.uuid4().hex
-        tags = [
-            ModelVersionTag(key="key", value="value"),
-            ModelVersionTag(key="anotherKey", value="some other value"),
-        ]
-        run_link = "localhost:5000/path/to/run"
-        description = "version description"
-        self.store.create_model_version(
+
+def test_get_latest_versions(store, creds):
+    name = "model_1"
+    with mock_http_request_403_200() as mock_http:
+        store.get_latest_versions(name=name)
+    endpoint = "registered-models/get-latest-versions"
+    endpoints = [(endpoint, "POST"), (endpoint, "GET")]
+    _verify_all_requests(mock_http, creds, endpoints, GetLatestVersions(name=name))
+
+
+def test_get_latest_versions_with_stages(store, creds):
+    name = "model_1"
+    with mock_http_request_403_200() as mock_http:
+        store.get_latest_versions(name=name, stages=["blaah"])
+    endpoint = "registered-models/get-latest-versions"
+    endpoints = [(endpoint, "POST"), (endpoint, "GET")]
+    _verify_all_requests(
+        mock_http, creds, endpoints, GetLatestVersions(name=name, stages=["blaah"])
+    )
+
+
+def test_set_registered_model_tag(store, creds):
+    name = "model_1"
+    tag = RegisteredModelTag(key="key", value="value")
+    with mock_http_request_200() as mock_http:
+        store.set_registered_model_tag(name=name, tag=tag)
+    _verify_requests(
+        mock_http,
+        creds,
+        "registered-models/set-tag",
+        "POST",
+        SetRegisteredModelTag(name=name, key=tag.key, value=tag.value),
+    )
+
+
+def test_delete_registered_model_tag(store, creds):
+    name = "model_1"
+    with mock_http_request_200() as mock_http:
+        store.delete_registered_model_tag(name=name, key="key")
+    _verify_requests(
+        mock_http,
+        creds,
+        "registered-models/delete-tag",
+        "DELETE",
+        DeleteRegisteredModelTag(name=name, key="key"),
+    )
+
+
+def test_create_model_version(store, creds):
+    with mock_http_request_200() as mock_http:
+        store.create_model_version("model_1", "path/to/source")
+    _verify_requests(
+        mock_http,
+        creds,
+        "model-versions/create",
+        "POST",
+        CreateModelVersion(name="model_1", source="path/to/source"),
+    )
+    # test optional fields
+    run_id = uuid.uuid4().hex
+    tags = [
+        ModelVersionTag(key="key", value="value"),
+        ModelVersionTag(key="anotherKey", value="some other value"),
+    ]
+    run_link = "localhost:5000/path/to/run"
+    description = "version description"
+    with mock_http_request_200() as mock_http:
+        store.create_model_version(
             "model_1",
             "path/to/source",
             run_id,
@@ -252,108 +258,127 @@ class TestRestStore(unittest.TestCase):
             run_link=run_link,
             description=description,
         )
-        self._verify_requests(
-            mock_http,
-            "model-versions/create",
-            "POST",
-            CreateModelVersion(
-                name="model_1",
-                source="path/to/source",
-                run_id=run_id,
-                run_link=run_link,
-                tags=[tag.to_proto() for tag in tags],
-                description=description,
-            ),
-        )
+    _verify_requests(
+        mock_http,
+        creds,
+        "model-versions/create",
+        "POST",
+        CreateModelVersion(
+            name="model_1",
+            source="path/to/source",
+            run_id=run_id,
+            run_link=run_link,
+            tags=[tag.to_proto() for tag in tags],
+            description=description,
+        ),
+    )
 
-    @mock_http_request
-    def test_transition_model_version_stage(self, mock_http):
-        name = "model_1"
-        version = "5"
-        self.store.transition_model_version_stage(
+
+def test_transition_model_version_stage(store, creds):
+    name = "model_1"
+    version = "5"
+    with mock_http_request_200() as mock_http:
+        store.transition_model_version_stage(
             name=name, version=version, stage="prod", archive_existing_versions=True
         )
-        self._verify_requests(
-            mock_http,
-            "model-versions/transition-stage",
-            "POST",
-            TransitionModelVersionStage(
-                name=name, version=version, stage="prod", archive_existing_versions=True
-            ),
-        )
+    _verify_requests(
+        mock_http,
+        creds,
+        "model-versions/transition-stage",
+        "POST",
+        TransitionModelVersionStage(
+            name=name, version=version, stage="prod", archive_existing_versions=True
+        ),
+    )
 
-    @mock_http_request
-    def test_update_model_version_description(self, mock_http):
-        name = "model_1"
-        version = "5"
-        description = "test model version"
-        self.store.update_model_version(name=name, version=version, description=description)
-        self._verify_requests(
-            mock_http,
-            "model-versions/update",
-            "PATCH",
-            UpdateModelVersion(name=name, version=version, description="test model version"),
-        )
 
-    @mock_http_request
-    def test_delete_model_version(self, mock_http):
-        name = "model_1"
-        version = "12"
-        self.store.delete_model_version(name=name, version=version)
-        self._verify_requests(
-            mock_http,
-            "model-versions/delete",
-            "DELETE",
-            DeleteModelVersion(name=name, version=version),
-        )
+def test_update_model_version_description(store, creds):
+    name = "model_1"
+    version = "5"
+    description = "test model version"
+    with mock_http_request_200() as mock_http:
+        store.update_model_version(name=name, version=version, description=description)
+    _verify_requests(
+        mock_http,
+        creds,
+        "model-versions/update",
+        "PATCH",
+        UpdateModelVersion(name=name, version=version, description="test model version"),
+    )
 
-    @mock_http_request
-    def test_get_model_version_details(self, mock_http):
-        name = "model_11"
-        version = "8"
-        self.store.get_model_version(name=name, version=version)
-        self._verify_requests(
-            mock_http, "model-versions/get", "GET", GetModelVersion(name=name, version=version)
-        )
 
-    @mock_http_request
-    def test_get_model_version_download_uri(self, mock_http):
-        name = "model_11"
-        version = "8"
-        self.store.get_model_version_download_uri(name=name, version=version)
-        self._verify_requests(
-            mock_http,
-            "model-versions/get-download-uri",
-            "GET",
-            GetModelVersionDownloadUri(name=name, version=version),
-        )
+def test_delete_model_version(store, creds):
+    name = "model_1"
+    version = "12"
+    with mock_http_request_200() as mock_http:
+        store.delete_model_version(name=name, version=version)
+    _verify_requests(
+        mock_http,
+        creds,
+        "model-versions/delete",
+        "DELETE",
+        DeleteModelVersion(name=name, version=version),
+    )
 
-    @mock_http_request
-    def test_search_model_versions(self, mock_http):
-        self.store.search_model_versions(filter_string="name='model_12'")
-        self._verify_requests(
-            mock_http, "model-versions/search", "GET", SearchModelVersions(filter="name='model_12'")
-        )
 
-    @mock_http_request
-    def test_set_model_version_tag(self, mock_http):
-        name = "model_1"
-        tag = ModelVersionTag(key="key", value="value")
-        self.store.set_model_version_tag(name=name, version="1", tag=tag)
-        self._verify_requests(
-            mock_http,
-            "model-versions/set-tag",
-            "POST",
-            SetModelVersionTag(name=name, version="1", key=tag.key, value=tag.value),
-        )
+def test_get_model_version_details(store, creds):
+    name = "model_11"
+    version = "8"
+    with mock_http_request_200() as mock_http:
+        store.get_model_version(name=name, version=version)
+    _verify_requests(
+        mock_http, creds, "model-versions/get", "GET", GetModelVersion(name=name, version=version)
+    )
 
-    @mock_http_request
-    def test_delete_model_version_tag(self, mock_http):
-        name = "model_1"
-        self.store.delete_model_version_tag(name=name, version="1", key="key")
-        self._verify_requests(
-            mock_http,
-            "model-versions/delete-tag",
-            "DELETE",
-            DeleteModelVersionTag(name=name, version="1", key="key"),
-        )
+
+def test_get_model_version_download_uri(store, creds):
+    name = "model_11"
+    version = "8"
+    with mock_http_request_200() as mock_http:
+        store.get_model_version_download_uri(name=name, version=version)
+    _verify_requests(
+        mock_http,
+        creds,
+        "model-versions/get-download-uri",
+        "GET",
+        GetModelVersionDownloadUri(name=name, version=version),
+    )
+
+
+def test_search_model_versions(store, creds):
+    with mock_http_request_200() as mock_http:
+        store.search_model_versions(filter_string="name='model_12'")
+    _verify_requests(
+        mock_http,
+        creds,
+        "model-versions/search",
+        "GET",
+        SearchModelVersions(filter="name='model_12'"),
+    )
+
+
+def test_set_model_version_tag(store, creds):
+    name = "model_1"
+    tag = ModelVersionTag(key="key", value="value")
+    with mock_http_request_200() as mock_http:
+        store.set_model_version_tag(name=name, version="1", tag=tag)
+    _verify_requests(
+        mock_http,
+        creds,
+        "model-versions/set-tag",
+        "POST",
+        SetModelVersionTag(name=name, version="1", key=tag.key, value=tag.value),
+    )
+
+
+def test_delete_model_version_tag(store, creds):
+    name = "model_1"
+    with mock_http_request_200() as mock_http:
+        store.delete_model_version_tag(name=name, version="1", key="key")
+    _verify_requests(
+        mock_http,
+        creds,
+        "model-versions/delete-tag",
+        "DELETE",
+        DeleteModelVersionTag(name=name, version="1", key="key"),
+    )

--- a/tests/store/model_registry/test_rest_store.py
+++ b/tests/store/model_registry/test_rest_store.py
@@ -131,11 +131,12 @@ def test_search_registered_models_params(
     store, creds, filter_string, max_results, page_token, order_by
 ):
     params = {
-        **({"filter_string": filter_string} if filter_string else {}),
-        **({"max_results": max_results} if max_results else {}),
-        **({"page_token": page_token} if page_token else {}),
-        **({"order_by": order_by} if order_by else {}),
+        "filter_string": filter_string,
+        "max_results": max_results,
+        "page_token": page_token,
+        "order_by": order_by,
     }
+    params = {k: v for k, v in params.items() if v is not None}
     with mock_http_request_200() as mock_http:
         store.search_registered_models(**params)
     if "filter_string" in params:

--- a/tests/store/model_registry/test_rest_store.py
+++ b/tests/store/model_registry/test_rest_store.py
@@ -1,5 +1,4 @@
 from itertools import combinations
-from contextlib import contextmanager
 
 import json
 import pytest
@@ -30,27 +29,7 @@ from mlflow.protos.model_registry_pb2 import (
 from mlflow.store.model_registry.rest_store import RestStore
 from mlflow.utils.proto_json_utils import message_to_json
 from mlflow.utils.rest_utils import MlflowHostCreds
-
-
-@contextmanager
-def mock_http_request_200():
-    with mock.patch(
-        "mlflow.utils.rest_utils.http_request",
-        return_value=mock.MagicMock(status_code=200, text="{}"),
-    ) as m:
-        yield m
-
-
-@contextmanager
-def mock_http_request_403_200():
-    with mock.patch(
-        "mlflow.utils.rest_utils.http_request",
-        side_effect=[
-            mock.MagicMock(status_code=403, text='{"error_code": "ENDPOINT_NOT_FOUND"}'),
-            mock.MagicMock(status_code=200, text="{}"),
-        ],
-    ) as m:
-        yield m
+from tests.helper_functions import mock_http_request_200, mock_http_request_403_200
 
 
 @pytest.fixture


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #7201 

## What changes are proposed in this pull request?

Migrates model-registry `RestStore` to pytest.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
