### PR TITLE
Add env variable to let users set Azure artifact upload timeout

### DIFF
--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -941,7 +941,7 @@ See `Set up AWS Credentials and Region for Development <https://docs.aws.amazon.
 
 You may set an MLflow environment variable to configure the timeout for artifact uploads and downloads:
 
-- ``MLFLOW_UPLOAD_DOWNLOAD_TIMEOUT`` - Sets the timeout for artifact upload/download in seconds (Default set by individual artifact stores).
+- ``MLFLOW_ARTIFACT_UPLOAD_DOWNLOAD_TIMEOUT`` - (Experimental, may be changed or removed) Sets the timeout for artifact upload/download in seconds (Default set by individual artifact stores).
 
 Amazon S3 and S3-compatible storage
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1020,7 +1020,7 @@ MLflow does not declare a dependency on these packages by default.
 
 You may set an MLflow environment variable to configure the timeout for artifact uploads and downloads:
 
-- ``MLFLOW_UPLOAD_DOWNLOAD_TIMEOUT`` - Sets the timeout for artifact upload/download in seconds (Default: 600).
+- ``MLFLOW_ARTIFACT_UPLOAD_DOWNLOAD_TIMEOUT`` - (Experimental, may be changed or removed) Sets the timeout for artifact upload/download in seconds (Default: 600).
 
 Google Cloud Storage
 ^^^^^^^^^^^^^^^^^^^^
@@ -1035,7 +1035,8 @@ to access Google Cloud Storage; MLflow does not declare a dependency on this pac
 
 You may set some MLflow environment variables to troubleshoot GCS read-timeouts (eg. due to slow transfer speeds) using the following variables:
 
-- ``MLFLOW_UPLOAD_DOWNLOAD_TIMEOUT`` - Sets the standard timeout for transfer operations in seconds (Default: 60). Use -1 for indefinite timeout.
+- ``MLFLOW_ARTIFACT_UPLOAD_DOWNLOAD_TIMEOUT`` - (Experimental, may be changed or removed) Sets the standard timeout for transfer operations in seconds (Default: 60). Use -1 for indefinite timeout.
+- ``MLFLOW_GCS_DEFAULT_TIMEOUT`` - (Deprecated, please use ``MLFLOW_ARTIFACT_UPLOAD_DOWNLOAD_TIMEOUT``) Sets the standard timeout for transfer operations in seconds (Default: 60). Use -1 for indefinite timeout.
 - ``MLFLOW_GCS_UPLOAD_CHUNK_SIZE`` - Sets the standard upload chunk size for bigger files in bytes (Default: 104857600 ≙ 100MiB), must be multiple of 256 KB.
 - ``MLFLOW_GCS_DOWNLOAD_CHUNK_SIZE`` - Sets the standard download chunk size for bigger files in bytes (Default: 104857600 ≙ 100MiB), must be multiple of 256 KB
 

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -939,6 +939,9 @@ See `Set up AWS Credentials and Region for Development <https://docs.aws.amazon.
   is a path inside the file store. Typically this is not an appropriate location, as the client and
   server probably refer to different physical locations (that is, the same path on different disks).
 
+You may set an MLflow environment variable to configure the timeout for artifact uploads and downloads:
+
+- ``MLFLOW_UPLOAD_DOWNLOAD_TIMEOUT`` - Sets the timeout for artifact upload/download in seconds (Default set by individual artifact stores).
 
 Amazon S3 and S3-compatible storage
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1015,9 +1018,9 @@ Also, you must run ``pip install azure-storage-blob`` separately (on both your c
 Finally, if you want to use DefaultAzureCredential, you must ``pip install azure-identity``;
 MLflow does not declare a dependency on these packages by default.
 
-You may set an MLflow environment variable to configure the timeout for artifact uploads:
+You may set an MLflow environment variable to configure the timeout for artifact uploads and downloads:
 
-- ``MLFLOW_AZURE_ARTIFACT_UPLOAD_TIMEOUT`` - Sets the timeout for artifact upload in seconds (Default: 600).
+- ``MLFLOW_UPLOAD_DOWNLOAD_TIMEOUT`` - Sets the timeout for artifact upload/download in seconds (Default: 600).
 
 Google Cloud Storage
 ^^^^^^^^^^^^^^^^^^^^
@@ -1032,7 +1035,7 @@ to access Google Cloud Storage; MLflow does not declare a dependency on this pac
 
 You may set some MLflow environment variables to troubleshoot GCS read-timeouts (eg. due to slow transfer speeds) using the following variables:
 
-- ``MLFLOW_GCS_DEFAULT_TIMEOUT`` - Sets the standard timeout for transfer operations in seconds (Default: 60). Use -1 for indefinite timeout.
+- ``MLFLOW_UPLOAD_DOWNLOAD_TIMEOUT`` - Sets the standard timeout for transfer operations in seconds (Default: 60). Use -1 for indefinite timeout.
 - ``MLFLOW_GCS_UPLOAD_CHUNK_SIZE`` - Sets the standard upload chunk size for bigger files in bytes (Default: 104857600 ≙ 100MiB), must be multiple of 256 KB.
 - ``MLFLOW_GCS_DOWNLOAD_CHUNK_SIZE`` - Sets the standard download chunk size for bigger files in bytes (Default: 104857600 ≙ 100MiB), must be multiple of 256 KB
 

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -1020,7 +1020,7 @@ MLflow does not declare a dependency on these packages by default.
 
 You may set an MLflow environment variable to configure the timeout for artifact uploads and downloads:
 
-- ``MLFLOW_ARTIFACT_UPLOAD_DOWNLOAD_TIMEOUT`` - (Experimental, may be changed or removed) Sets the timeout for artifact upload/download in seconds (Default: 600).
+- ``MLFLOW_ARTIFACT_UPLOAD_DOWNLOAD_TIMEOUT`` - (Experimental, may be changed or removed) Sets the timeout for artifact upload/download in seconds (Default: 600 for Azure blob).
 
 Google Cloud Storage
 ^^^^^^^^^^^^^^^^^^^^
@@ -1035,7 +1035,7 @@ to access Google Cloud Storage; MLflow does not declare a dependency on this pac
 
 You may set some MLflow environment variables to troubleshoot GCS read-timeouts (eg. due to slow transfer speeds) using the following variables:
 
-- ``MLFLOW_ARTIFACT_UPLOAD_DOWNLOAD_TIMEOUT`` - (Experimental, may be changed or removed) Sets the standard timeout for transfer operations in seconds (Default: 60). Use -1 for indefinite timeout.
+- ``MLFLOW_ARTIFACT_UPLOAD_DOWNLOAD_TIMEOUT`` - (Experimental, may be changed or removed) Sets the standard timeout for transfer operations in seconds (Default: 60 for GCS). Use -1 for indefinite timeout.
 - ``MLFLOW_GCS_DEFAULT_TIMEOUT`` - (Deprecated, please use ``MLFLOW_ARTIFACT_UPLOAD_DOWNLOAD_TIMEOUT``) Sets the standard timeout for transfer operations in seconds (Default: 60). Use -1 for indefinite timeout.
 - ``MLFLOW_GCS_UPLOAD_CHUNK_SIZE`` - Sets the standard upload chunk size for bigger files in bytes (Default: 104857600 ≙ 100MiB), must be multiple of 256 KB.
 - ``MLFLOW_GCS_DOWNLOAD_CHUNK_SIZE`` - Sets the standard download chunk size for bigger files in bytes (Default: 104857600 ≙ 100MiB), must be multiple of 256 KB

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -1015,6 +1015,10 @@ Also, you must run ``pip install azure-storage-blob`` separately (on both your c
 Finally, if you want to use DefaultAzureCredential, you must ``pip install azure-identity``;
 MLflow does not declare a dependency on these packages by default.
 
+You may set an MLflow environment variable to configure the timeout for artifact uploads:
+
+- ``MLFLOW_AZURE_ARTIFACT_UPLOAD_TIMEOUT`` - Sets the timeout for artifact upload in seconds (Default: 600).
+
 Google Cloud Storage
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -188,7 +188,8 @@ MLFLOW_SCORING_SERVER_REQUEST_TIMEOUT = _EnvironmentVariable(
     "MLFLOW_SCORING_SERVER_REQUEST_TIMEOUT", int, 60
 )
 
-#: (Experimental, may be changed or removed) Specifies the timeout to use when uploading or downloading a file
+#: (Experimental, may be changed or removed)
+#: Specifies the timeout to use when uploading or downloading a file
 #: (default: ``None``). If None, individual artifact stores will choose defaults.
 MLFLOW_ARTIFACT_UPLOAD_DOWNLOAD_TIMEOUT = _EnvironmentVariable(
     "MLFLOW_ARTIFACT_UPLOAD_DOWNLOAD_TIMEOUT", int, None

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -100,6 +100,11 @@ MLFLOW_GCS_DOWNLOAD_CHUNK_SIZE = _EnvironmentVariable("MLFLOW_GCS_DOWNLOAD_CHUNK
 #: ``google-cloud-storage`` package.
 MLFLOW_GCS_UPLOAD_CHUNK_SIZE = _EnvironmentVariable("MLFLOW_GCS_UPLOAD_CHUNK_SIZE", int, None)
 
+#: (Deprecated, please use ``MLFLOW_ARTIFACT_UPLOAD_DOWNLOAD_TIMEOUT``) 
+#: Specifies the default timeout to use when downloading/uploading a file from/to GCS
+#: (default: ``None``). If None, ``google.cloud.storage.constants._DEFAULT_TIMEOUT`` is used.
+MLFLOW_GCS_DEFAULT_TIMEOUT = _EnvironmentVariable("MLFLOW_GCS_DEFAULT_TIMEOUT", int, None)
+
 #: Specifies whether to disable model logging and loading via mlflowdbfs.
 #: (default: ``None``)
 _DISABLE_MLFLOWDBFS = _EnvironmentVariable("DISABLE_MLFLOWDBFS", str, None)
@@ -183,8 +188,8 @@ MLFLOW_SCORING_SERVER_REQUEST_TIMEOUT = _EnvironmentVariable(
     "MLFLOW_SCORING_SERVER_REQUEST_TIMEOUT", int, 60
 )
 
-#: Specifies the timeout to use when uploading or downloading a file
+#: (Experimental, may be changed or removed) Specifies the timeout to use when uploading or downloading a file
 #: (default: ``None``). If None, individual artifact stores will choose defaults.
-MLFLOW_UPLOAD_DOWNLOAD_TIMEOUT = _EnvironmentVariable(
-    "MLFLOW_AZURE_ARTIFACT_UPLOAD_TIMEOUT", int, None
+MLFLOW_ARTIFACT_UPLOAD_DOWNLOAD_TIMEOUT = _EnvironmentVariable(
+    "MLFLOW_ARTIFACT_UPLOAD_DOWNLOAD_TIMEOUT", int, None
 )

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -100,7 +100,7 @@ MLFLOW_GCS_DOWNLOAD_CHUNK_SIZE = _EnvironmentVariable("MLFLOW_GCS_DOWNLOAD_CHUNK
 #: ``google-cloud-storage`` package.
 MLFLOW_GCS_UPLOAD_CHUNK_SIZE = _EnvironmentVariable("MLFLOW_GCS_UPLOAD_CHUNK_SIZE", int, None)
 
-#: (Deprecated, please use ``MLFLOW_ARTIFACT_UPLOAD_DOWNLOAD_TIMEOUT``) 
+#: (Deprecated, please use ``MLFLOW_ARTIFACT_UPLOAD_DOWNLOAD_TIMEOUT``)
 #: Specifies the default timeout to use when downloading/uploading a file from/to GCS
 #: (default: ``None``). If None, ``google.cloud.storage.constants._DEFAULT_TIMEOUT`` is used.
 MLFLOW_GCS_DEFAULT_TIMEOUT = _EnvironmentVariable("MLFLOW_GCS_DEFAULT_TIMEOUT", int, None)

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -100,10 +100,6 @@ MLFLOW_GCS_DOWNLOAD_CHUNK_SIZE = _EnvironmentVariable("MLFLOW_GCS_DOWNLOAD_CHUNK
 #: ``google-cloud-storage`` package.
 MLFLOW_GCS_UPLOAD_CHUNK_SIZE = _EnvironmentVariable("MLFLOW_GCS_UPLOAD_CHUNK_SIZE", int, None)
 
-#: Specifies the default timeout to use when downloading/uploading a file from/to GCS
-#: (default: ``None``). If None, ``google.cloud.storage.constants._DEFAULT_TIMEOUT`` is used.
-MLFLOW_GCS_DEFAULT_TIMEOUT = _EnvironmentVariable("MLFLOW_GCS_DEFAULT_TIMEOUT", int, None)
-
 #: Specifies whether to disable model logging and loading via mlflowdbfs.
 #: (default: ``None``)
 _DISABLE_MLFLOWDBFS = _EnvironmentVariable("DISABLE_MLFLOWDBFS", str, None)
@@ -187,8 +183,8 @@ MLFLOW_SCORING_SERVER_REQUEST_TIMEOUT = _EnvironmentVariable(
     "MLFLOW_SCORING_SERVER_REQUEST_TIMEOUT", int, 60
 )
 
-#: Specifies the timeout to use when uploading a file to Azure blob
-#: (default: ``600``)
-MLFLOW_AZURE_ARTIFACT_UPLOAD_TIMEOUT = _EnvironmentVariable(
-    "MLFLOW_AZURE_ARTIFACT_UPLOAD_TIMEOUT", int, 600
+#: Specifies the timeout to use when uploading or downloading a file
+#: (default: ``None``). If None, individual artifact stores will choose defaults.
+MLFLOW_UPLOAD_DOWNLOAD_TIMEOUT = _EnvironmentVariable(
+    "MLFLOW_AZURE_ARTIFACT_UPLOAD_TIMEOUT", int, None
 )

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -186,3 +186,9 @@ MLFLOW_REQUIREMENTS_INFERENCE_TIMEOUT = _EnvironmentVariable(
 MLFLOW_SCORING_SERVER_REQUEST_TIMEOUT = _EnvironmentVariable(
     "MLFLOW_SCORING_SERVER_REQUEST_TIMEOUT", int, 60
 )
+
+#: Specifies the timeout to use when uploading a file to Azure blob
+#: (default: ``600``)
+MLFLOW_AZURE_ARTIFACT_UPLOAD_TIMEOUT = _EnvironmentVariable(
+    "MLFLOW_AZURE_ARTIFACT_UPLOAD_TIMEOUT", int, 600
+)

--- a/mlflow/store/artifact/azure_blob_artifact_repo.py
+++ b/mlflow/store/artifact/azure_blob_artifact_repo.py
@@ -25,15 +25,15 @@ class AzureBlobArtifactRepository(ArtifactRepository):
     def __init__(self, artifact_uri, client=None):
         super().__init__(artifact_uri)
 
+        _DEFAULT_TIMEOUT = 600  # 10 minutes
+        self.write_timeout = MLFLOW_ARTIFACT_UPLOAD_DOWNLOAD_TIMEOUT.get() or _DEFAULT_TIMEOUT
+
         # Allow override for testing
         if client:
             self.client = client
             return
 
         from azure.storage.blob import BlobServiceClient
-
-        _DEFAULT_TIMEOUT = 600  # 10 minutes
-        self.write_timeout = MLFLOW_ARTIFACT_UPLOAD_DOWNLOAD_TIMEOUT.get() or _DEFAULT_TIMEOUT
 
         (_, account, _, api_uri_suffix) = AzureBlobArtifactRepository.parse_wasbs_uri(artifact_uri)
         if "AZURE_STORAGE_CONNECTION_STRING" in os.environ:

--- a/mlflow/store/artifact/azure_blob_artifact_repo.py
+++ b/mlflow/store/artifact/azure_blob_artifact_repo.py
@@ -7,7 +7,7 @@ from mlflow.entities import FileInfo
 from mlflow.exceptions import MlflowException
 from mlflow.store.artifact.artifact_repo import ArtifactRepository
 
-from mlflow.environment_variables import MLFLOW_AZURE_ARTIFACT_UPLOAD_TIMEOUT
+from mlflow.environment_variables import MLFLOW_UPLOAD_DOWNLOAD_TIMEOUT
 
 class AzureBlobArtifactRepository(ArtifactRepository):
     """
@@ -31,7 +31,8 @@ class AzureBlobArtifactRepository(ArtifactRepository):
 
         from azure.storage.blob import BlobServiceClient
 
-        self.write_timeout = MLFLOW_AZURE_ARTIFACT_UPLOAD_TIMEOUT.get()
+        _DEFAULT_TIMEOUT = 600 # 10 minutes
+        self.write_timeout = MLFLOW_UPLOAD_DOWNLOAD_TIMEOUT.get() or _DEFAULT_TIMEOUT
 
         (_, account, _, api_uri_suffix) = AzureBlobArtifactRepository.parse_wasbs_uri(artifact_uri)
         if "AZURE_STORAGE_CONNECTION_STRING" in os.environ:

--- a/mlflow/store/artifact/azure_blob_artifact_repo.py
+++ b/mlflow/store/artifact/azure_blob_artifact_repo.py
@@ -7,7 +7,8 @@ from mlflow.entities import FileInfo
 from mlflow.exceptions import MlflowException
 from mlflow.store.artifact.artifact_repo import ArtifactRepository
 
-from mlflow.environment_variables import MLFLOW_UPLOAD_DOWNLOAD_TIMEOUT
+from mlflow.environment_variables import MLFLOW_ARTIFACT_UPLOAD_DOWNLOAD_TIMEOUT
+
 
 class AzureBlobArtifactRepository(ArtifactRepository):
     """
@@ -31,8 +32,8 @@ class AzureBlobArtifactRepository(ArtifactRepository):
 
         from azure.storage.blob import BlobServiceClient
 
-        _DEFAULT_TIMEOUT = 600 # 10 minutes
-        self.write_timeout = MLFLOW_UPLOAD_DOWNLOAD_TIMEOUT.get() or _DEFAULT_TIMEOUT
+        _DEFAULT_TIMEOUT = 600  # 10 minutes
+        self.write_timeout = MLFLOW_ARTIFACT_UPLOAD_DOWNLOAD_TIMEOUT.get() or _DEFAULT_TIMEOUT
 
         (_, account, _, api_uri_suffix) = AzureBlobArtifactRepository.parse_wasbs_uri(artifact_uri)
         if "AZURE_STORAGE_CONNECTION_STRING" in os.environ:
@@ -90,7 +91,9 @@ class AzureBlobArtifactRepository(ArtifactRepository):
             dest_path = posixpath.join(dest_path, artifact_path)
         dest_path = posixpath.join(dest_path, os.path.basename(local_file))
         with open(local_file, "rb") as file:
-            container_client.upload_blob(dest_path, file, overwrite=True, timeout=self.write_timeout)
+            container_client.upload_blob(
+                dest_path, file, overwrite=True, timeout=self.write_timeout
+            )
 
     def log_artifacts(self, local_dir, artifact_path=None):
         (container, _, dest_path, _) = self.parse_wasbs_uri(self.artifact_uri)
@@ -107,7 +110,9 @@ class AzureBlobArtifactRepository(ArtifactRepository):
                 remote_file_path = posixpath.join(upload_path, f)
                 local_file_path = os.path.join(root, f)
                 with open(local_file_path, "rb") as file:
-                    container_client.upload_blob(remote_file_path, file, overwrite=True, timeout=self.write_timeout)
+                    container_client.upload_blob(
+                        remote_file_path, file, overwrite=True, timeout=self.write_timeout
+                    )
 
     def list_artifacts(self, path=None):
         # Newer versions of `azure-storage-blob` (>= 12.4.0) provide a public

--- a/mlflow/store/artifact/gcs_artifact_repo.py
+++ b/mlflow/store/artifact/gcs_artifact_repo.py
@@ -7,7 +7,8 @@ from mlflow.entities import FileInfo
 from mlflow.store.artifact.artifact_repo import ArtifactRepository
 from mlflow.utils.file_utils import relative_path_to_artifact_path
 from mlflow.environment_variables import (
-    MLFLOW_UPLOAD_DOWNLOAD_TIMEOUT,
+    MLFLOW_ARTIFACT_UPLOAD_DOWNLOAD_TIMEOUT,
+    MLFLOW_GCS_DEFAULT_TIMEOUT,
     MLFLOW_GCS_DOWNLOAD_CHUNK_SIZE,
     MLFLOW_GCS_UPLOAD_CHUNK_SIZE,
 )
@@ -33,7 +34,11 @@ class GCSArtifactRepository(ArtifactRepository):
 
         self._GCS_DOWNLOAD_CHUNK_SIZE = MLFLOW_GCS_DOWNLOAD_CHUNK_SIZE.get()
         self._GCS_UPLOAD_CHUNK_SIZE = MLFLOW_GCS_UPLOAD_CHUNK_SIZE.get()
-        self._GCS_DEFAULT_TIMEOUT = MLFLOW_UPLOAD_DOWNLOAD_TIMEOUT.get() or _DEFAULT_TIMEOUT
+        self._GCS_DEFAULT_TIMEOUT = (
+            MLFLOW_ARTIFACT_UPLOAD_DOWNLOAD_TIMEOUT.get()
+            or MLFLOW_GCS_DEFAULT_TIMEOUT.get()
+            or _DEFAULT_TIMEOUT
+        )
 
         # If the user-supplied timeout environment variable value is -1,
         # use `None` for `self._GCS_DEFAULT_TIMEOUT`

--- a/mlflow/store/artifact/gcs_artifact_repo.py
+++ b/mlflow/store/artifact/gcs_artifact_repo.py
@@ -7,7 +7,7 @@ from mlflow.entities import FileInfo
 from mlflow.store.artifact.artifact_repo import ArtifactRepository
 from mlflow.utils.file_utils import relative_path_to_artifact_path
 from mlflow.environment_variables import (
-    MLFLOW_GCS_DEFAULT_TIMEOUT,
+    MLFLOW_UPLOAD_DOWNLOAD_TIMEOUT,
     MLFLOW_GCS_DOWNLOAD_CHUNK_SIZE,
     MLFLOW_GCS_UPLOAD_CHUNK_SIZE,
 )
@@ -33,7 +33,7 @@ class GCSArtifactRepository(ArtifactRepository):
 
         self._GCS_DOWNLOAD_CHUNK_SIZE = MLFLOW_GCS_DOWNLOAD_CHUNK_SIZE.get()
         self._GCS_UPLOAD_CHUNK_SIZE = MLFLOW_GCS_UPLOAD_CHUNK_SIZE.get()
-        self._GCS_DEFAULT_TIMEOUT = MLFLOW_GCS_DEFAULT_TIMEOUT.get() or _DEFAULT_TIMEOUT
+        self._GCS_DEFAULT_TIMEOUT = MLFLOW_UPLOAD_DOWNLOAD_TIMEOUT.get() or _DEFAULT_TIMEOUT
 
         # If the user-supplied timeout environment variable value is -1,
         # use `None` for `self._GCS_DEFAULT_TIMEOUT`


### PR DESCRIPTION
Signed-off-by: Walter Martin <wamartin@microsoft.com>


## Related Issues/PRs

Resolve #3746

## What changes are proposed in this pull request?

Add an Azure blob-specific artifact upload timeout environment variable.

## How is this patch tested?
Existing tests make sure nothing is broken, manual testing for the timeout itself.

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Adds an environment variable to allow configuration of artifact upload timeout for the Azure blob store.

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [x] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
