### PR TITLE
Fix pydoc compatiblility with PYTHONOPTIMIZE=2

### DIFF
--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -1106,6 +1106,7 @@ def autolog(
 
     atexit.register(_flush_queue)
 
+
 if autolog.__doc__ is not None:
     autolog.__doc__ = autolog.__doc__.replace("MIN_REQ_VERSION", str(MIN_REQ_VERSION)).replace(
         "MAX_REQ_VERSION", str(MAX_REQ_VERSION)

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -1106,7 +1106,7 @@ def autolog(
 
     atexit.register(_flush_queue)
 
-
-autolog.__doc__ = autolog.__doc__.replace("MIN_REQ_VERSION", str(MIN_REQ_VERSION)).replace(
-    "MAX_REQ_VERSION", str(MAX_REQ_VERSION)
-)
+if autolog.__doc__ is not None:
+    autolog.__doc__ = autolog.__doc__.replace("MIN_REQ_VERSION", str(MIN_REQ_VERSION)).replace(
+        "MAX_REQ_VERSION", str(MAX_REQ_VERSION)
+    )

--- a/mlflow/statsmodels.py
+++ b/mlflow/statsmodels.py
@@ -580,6 +580,7 @@ def autolog(
     patch_class_tree(statsmodels.base.model.Model)
 
 
-autolog.__doc__ = autolog.__doc__.format(
-    autolog_metric_allowlist=", ".join(_autolog_metric_allowlist)
-)
+if autolog.__doc__ is not None:
+    autolog.__doc__ = autolog.__doc__.format(
+        autolog_metric_allowlist=", ".join(_autolog_metric_allowlist)
+    )

--- a/mlflow/utils/annotations.py
+++ b/mlflow/utils/annotations.py
@@ -31,9 +31,9 @@ def _experimental(api: Any, api_type: str):
         + "be removed in a future release without warning.\n\n"
     )
     if api_type == "property":
-        api.__doc__ = api.__doc__ + "\n\n" + notice
+        api.__doc__ = api.__doc__ + "\n\n" + notice if api.__doc__ else notice
     else:
-        api.__doc__ = notice + api.__doc__
+        api.__doc__ = notice + api.__doc__ if api.__doc__ else notice
     return api
 
 
@@ -114,5 +114,5 @@ def keyword_only(func):
         return func(**kwargs)
 
     notice = ".. Note:: This method requires all argument be specified by keyword.\n"
-    wrapper.__doc__ = notice + wrapper.__doc__
+    wrapper.__doc__ = notice + wrapper.__doc__ if wrapper.__doc__ else notice
     return wrapper

--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -420,7 +420,8 @@ def autologging_integration(name):
 
         if name in FLAVOR_TO_MODULE_NAME_AND_VERSION_INFO_KEY:
             wrapped_autolog.__doc__ = (
-                gen_autologging_package_version_requirements_doc(name) + wrapped_autolog.__doc__
+                gen_autologging_package_version_requirements_doc(name) +
+                (wrapped_autolog.__doc__ or "")
             )
         return wrapped_autolog
 

--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -419,9 +419,8 @@ def autologging_integration(name):
         wrapped_autolog.integration_name = name
 
         if name in FLAVOR_TO_MODULE_NAME_AND_VERSION_INFO_KEY:
-            wrapped_autolog.__doc__ = (
-                gen_autologging_package_version_requirements_doc(name) +
-                (wrapped_autolog.__doc__ or "")
+            wrapped_autolog.__doc__ = gen_autologging_package_version_requirements_doc(name) + (
+                wrapped_autolog.__doc__ or ""
             )
         return wrapped_autolog
 

--- a/mlflow/utils/docstring_utils.py
+++ b/mlflow/utils/docstring_utils.py
@@ -60,6 +60,9 @@ class ParamDocs(dict):
         :param p2:
             doc2
         """
+        if docstring is None:
+            return None
+
         min_indent = _get_minimum_indentation(docstring)
         for param_name, param_doc in self.items():
             param_doc = textwrap.indent(param_doc, min_indent + " " * 4)


### PR DESCRIPTION
Signed-off-by: dbczumar <corey.zumar@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

Closes #7789

<!-- Resolve -->

Fix pydoc compatiblility with PYTHONOPTIMIZE=2

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

Fix pydoc compatiblility with PYTHONOPTIMIZE=2

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [X] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
