### PR TITLE
Fix: Update run-test-container.sh to run on arm64

### DIFF
--- a/dev/Dockerfile.test
+++ b/dev/Dockerfile.test
@@ -1,5 +1,6 @@
 FROM python:3.8
 
+ARG MINIFORG_FILENAME=Miniforge3-Linux-x86_64.sh
 ENV DEBIAN_FRONTEND=noninteractive \
     PATH=/opt/conda/bin:$PATH
 
@@ -12,9 +13,9 @@ RUN apt-get update && \
     # cmake and protobuf-compiler required for onnx install
     cmake protobuf-compiler && \
     # Install miniforge
-    wget -q https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh && \
-    bash Miniforge3-Linux-x86_64.sh -b -p /opt/conda && \
-    rm Miniforge3-Linux-x86_64.sh && \
+    wget -q https://github.com/conda-forge/miniforge/releases/latest/download/$MINIFORG_FILENAME && \
+    bash $MINIFORG_FILENAME -b -p /opt/conda && \
+    rm $MINIFORG_FILENAME && \
     # install required python packages
     pip install --no-cache-dir -r requirements/test-requirements.txt --no-cache-dir -r requirements/lint-requirements.txt && \
     # install mlflow in editable form

--- a/dev/run-test-container.sh
+++ b/dev/run-test-container.sh
@@ -1,6 +1,17 @@
+#!/usr/bin/env bash
+
 ROOT_DIR=$(git rev-parse --show-toplevel)
-DOCKER_BUILDKIT=1 docker build -f "${ROOT_DIR}/dev/Dockerfile.test" -t mlflow-test-env "$ROOT_DIR"
-docker container rm -f mlflow-test 2> /dev/null
+ARCH=$(uname -m)
+echo "Running tests in a Docker container on $ARCH"
+
+if [ "$ARCH" == "aarch64" ] || [ "$ARCH" == "arm64" ]; then
+  MINIFORG_FILENAME="Miniforge3-Linux-aarch64.sh"
+else
+  MINIFORG_FILENAME="Miniforge3-Linux-x86_64.sh"
+fi
+
+DOCKER_BUILDKIT=1 docker build -f "${ROOT_DIR}/dev/Dockerfile.test" -t mlflow-test-env "$ROOT_DIR" --build-arg MINIFORG_FILENAME="$MINIFORG_FILENAME"
+docker container rm -f mlflow-test 2>/dev/null
 docker run \
   -v "${ROOT_DIR}"/tests:/app/tests \
   -v "${ROOT_DIR}"/mlflow:/app/mlflow \


### PR DESCRIPTION
- fix failing install on arm64
- made miniforge to be dynamically updated based on arch

Signed-off-by: Joel Hanson <joelhanson025@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

None created so far, but I can create one if needed.

## What changes are proposed in this pull request?

Update dev/run-test-container.sh to dynamically install miniforge based on the architecture of the host machine.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
