### PR TITLE
Add support for Diviner models fit in Spark

### DIFF
--- a/mlflow/diviner.py
+++ b/mlflow/diviner.py
@@ -288,7 +288,7 @@ def load_model(model_uri, dst_path=None):
 
     local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
 
-    if os.path.exists(os.path.join(local_model_path, "_fit_in_spark")):
+    if os.path.exists(os.path.join(local_model_path, _MODEL_BINARY_FILE_NAME, "_fit_in_spark")):
         return _load_model_fit_in_spark(local_model_path)
 
     return _load_model(local_model_path)

--- a/mlflow/diviner.py
+++ b/mlflow/diviner.py
@@ -225,6 +225,8 @@ def _save_diviner_model(diviner_model, path, **kwargs) -> bool:
     """
     fit_with_spark = False
 
+    save_path = str(path.joinpath(_MODEL_BINARY_FILE_NAME))
+
     if hasattr(diviner_model, "_fit_with_spark") and diviner_model._fit_with_spark:
         # Validate that the path is a relative path early in order to fail fast prior to attempting
         # to write the (large) DataFrame to a tmp DFS path first and raise a path validation
@@ -242,7 +244,7 @@ def _save_diviner_model(diviner_model, path, **kwargs) -> bool:
         # Save the model Spark DataFrame to the temporary DFS location
         diviner_model._save_model_df_to_path(tmp_path, **kwargs)
 
-        diviner_data_path = os.path.abspath(path)
+        diviner_data_path = os.path.abspath(save_path)
 
         tmp_fuse_path = dbfs_hdfs_uri_to_fuse_path(tmp_path)
         shutil.move(src=tmp_fuse_path, dst=diviner_data_path)
@@ -251,7 +253,7 @@ def _save_diviner_model(diviner_model, path, **kwargs) -> bool:
         diviner_model._save_model_metadata_components_to_path(path=diviner_data_path)
         fit_with_spark = True
     else:
-        diviner_model.save(str(path.joinpath(_MODEL_BINARY_FILE_NAME)))
+        diviner_model.save(save_path)
     return fit_with_spark
 
 

--- a/mlflow/diviner.py
+++ b/mlflow/diviner.py
@@ -166,7 +166,7 @@ def save_model(
         FLAVOR_NAME, diviner_version=diviner.__version__, code=code_dir_subpath, **flavor_conf
     )
 
-    if diviner_model._fit_with_spark:
+    if hasattr(diviner_model, "_fit_with_spark") and diviner_model._fit_with_spark:
         _save_model_fit_in_spark(
             diviner_model=diviner_model, path=str(path.joinpath(MLMODEL_FILE_NAME))
         )

--- a/mlflow/diviner.py
+++ b/mlflow/diviner.py
@@ -251,7 +251,7 @@ def _load_model_fit_in_spark(local_model_path: str):
     os.makedirs(dfs_fuse_directory)
     _shutil_copytree_without_file_permissions(src_dir=local_model_path, dst_dir=dfs_fuse_directory)
 
-    return _load_model(dfs_fuse_directory)
+    return _load_model(dfs_temp_directory)
 
 
 def load_model(model_uri, dst_path=None):
@@ -288,8 +288,8 @@ def load_model(model_uri, dst_path=None):
 
     local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
 
-    if os.path.isfile(os.path.join(local_model_path, "_fit_in_spark")):
-        return _load_model_fit_in_spark(model_uri, local_model_path)
+    if os.path.exists(os.path.join(local_model_path, "_fit_in_spark")):
+        return _load_model_fit_in_spark(local_model_path)
 
     return _load_model(local_model_path)
 

--- a/mlflow/diviner.py
+++ b/mlflow/diviner.py
@@ -222,14 +222,8 @@ def _save_model_fit_in_spark(diviner_model, path: str):
 
     diviner_pata_path = os.path.abspath(os.path.join(path, _DIVINER_MODEL_SUB))
 
-    if is_valid_dbfs_uri(tmp_path) and is_dbfs_fuse_available():
-        tmp_fuse_path = dbfs_hdfs_uri_to_fuse_path(tmp_path)
-        shutil.move(src=tmp_fuse_path, dst=diviner_pata_path)
-    else:
-        raise MlflowException(
-            f"The path specified `{path}` is unsupported. To save Diviner "
-            "models fit in Spark, a '/dbfs/' fuse mount path must be used."
-        )
+    tmp_fuse_path = dbfs_hdfs_uri_to_fuse_path(tmp_path)
+    shutil.move(src=tmp_fuse_path, dst=diviner_pata_path)
 
     # Save the model metadata to the path location
     diviner_model._save_model_metadata_components_to_path(path=path)

--- a/mlflow/diviner.py
+++ b/mlflow/diviner.py
@@ -30,8 +30,6 @@ from mlflow.models import Model, ModelInputExample
 from mlflow.models.model import MLMODEL_FILE_NAME
 from mlflow.models.signature import ModelSignature
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
-from mlflow.store.artifact.runs_artifact_repo import RunsArtifactRepository
-from mlflow.store.artifact.models_artifact_repo import ModelsArtifactRepository
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.utils.docstring_utils import format_docstring, LOG_MODEL_PARAM_DOCS
@@ -140,13 +138,15 @@ def save_model(
 
     :param kwargs: Optional configurations for Spark DataFrame storage iff the model has
                    been fit in Spark.
+
                    Current supported options:
-                   - `partition_by` for setting a (or several) partition columns as a list of
+
+                   - `partition_by`  for setting a (or several) partition columns as a list of \
                    column names. Must be a list of strings of grouping key column(s).
-                   - `partition_count` for setting the number of part files to write from a
+                   - `partition_count`  for setting the number of part files to write from a \
                    repartition per `partition_by` group. The default part file count is 200.
-                   - `dfs_tmpdir` for specifying the DFS temporary location where the model will be
-                   stored while copying from a local file system to a Spark-supported "dbfs:/"
+                   - `dfs_tmpdir`  for specifying the DFS temporary location where the model will \
+                   be stored while copying from a local file system to a Spark-supported "dbfs:/" \
                    scheme.
     """
     import diviner
@@ -416,14 +416,15 @@ def log_model(
                                              release without warning.
     :param kwargs: Additional arguments for :py:class:`mlflow.models.model.Model`
                    Additionally, for models that have been fit in Spark, the following supported
-                   configuration options are available to set:
+                   configuration options are available to set.
                    Current supported options:
-                   - `partition_by` for setting a (or several) partition columns as a list of
+
+                   - `partition_by`  for setting a (or several) partition columns as a list of \
                    column names. Must be a list of strings of grouping key column(s).
-                   - `partition_count` for setting the number of part files to write from a
+                   - `partition_count`  for setting the number of part files to write from a \
                    repartition per `partition_by` group. The default part file count is 200.
-                   - `dfs_tmpdir` for specifying the DFS temporary location where the model will be
-                   stored while copying from a local file system to a Spark-supported "dbfs:/"
+                   - `dfs_tmpdir`  for specifying the DFS temporary location where the model will \
+                   be stored while copying from a local file system to a Spark-supported "dbfs:/" \
                    scheme.
     :return: A :py:class:`ModelInfo <mlflow.models.model.ModelInfo>` instance that contains the
              metadata of the logged model.

--- a/mlflow/diviner.py
+++ b/mlflow/diviner.py
@@ -270,7 +270,7 @@ def _load_model_fit_in_spark(local_model_path: str, flavor_conf, **kwargs):
     dfs_temp_directory = generate_tmp_dfs_path(kwargs.get("dfs_tmpdir", MLFLOW_DFS_TMP.get()))
     dfs_fuse_directory = dbfs_hdfs_uri_to_fuse_path(dfs_temp_directory)
     os.makedirs(dfs_fuse_directory)
-    shutil.copytree(src=local_model_path, dst=dfs_fuse_directory)
+    shutil_copytree_without_file_permissions(src_dir=local_model_path, dst_dir=dfs_fuse_directory)
 
     diviner_instance = getattr(diviner, flavor_conf[_MODEL_TYPE_KEY])
     load_directory = os.path.join(dfs_fuse_directory, flavor_conf[_MODEL_BINARY_KEY])

--- a/mlflow/diviner.py
+++ b/mlflow/diviner.py
@@ -302,7 +302,6 @@ def load_model(model_uri, dst_path=None):
     _add_code_from_conf_to_system_path(local_model_path, flavor_conf)
 
     if flavor_conf.get(_SPARK_MODEL_INDICATOR, False):
-
         return _load_model_fit_in_spark(local_model_path, flavor_conf)
 
     return _load_model(local_model_path)

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -23,7 +23,6 @@ import logging
 import posixpath
 import re
 import shutil
-import uuid
 import yaml
 
 import mlflow
@@ -55,7 +54,7 @@ from mlflow.utils.docstring_utils import format_docstring, LOG_MODEL_PARAM_DOCS
 from mlflow.store.artifact.databricks_artifact_repo import DatabricksArtifactRepository
 from mlflow.store.artifact.runs_artifact_repo import RunsArtifactRepository
 from mlflow.store.artifact.models_artifact_repo import ModelsArtifactRepository
-from mlflow.utils.file_utils import TempDir, write_to
+from mlflow.utils.file_utils import TempDir, write_to, _shutil_copytree_without_file_permissions
 from mlflow.utils.uri import (
     is_local_uri,
     append_to_uri_path,
@@ -63,6 +62,7 @@ from mlflow.utils.uri import (
     is_valid_dbfs_uri,
     is_databricks_acled_artifacts_uri,
     get_databricks_profile_uri_from_artifact_uri,
+    generate_tmp_dfs_path,
 )
 from mlflow.utils import databricks_utils
 from mlflow.utils.model_utils import (
@@ -290,10 +290,6 @@ def log_model(
                 await_registration_for,
             )
         return mlflow_model.get_model_info()
-
-
-def _tmp_path(dfs_tmp):
-    return posixpath.join(dfs_tmp, str(uuid.uuid4()))
 
 
 def _mlflowdbfs_path(run_id, artifact_path):
@@ -692,7 +688,7 @@ def save_model(
     # Save it to a DFS temp dir first and copy it to local path
     if dfs_tmpdir is None:
         dfs_tmpdir = MLFLOW_DFS_TMP.get()
-    tmp_path = _tmp_path(dfs_tmpdir)
+    tmp_path = generate_tmp_dfs_path(dfs_tmpdir)
     spark_model.save(tmp_path)
     sparkml_data_path = os.path.abspath(os.path.join(path, _SPARK_MODEL_PATH_SUB))
     # We're copying the Spark model from DBFS to the local filesystem if (a) the temporary DFS URI
@@ -721,26 +717,6 @@ def save_model(
     )
 
 
-def _shutil_copytree_without_file_permissions(src_dir, dst_dir):
-    """
-    Copies the directory src_dir into dst_dir, without preserving filesystem permissions
-    """
-    for dirpath, dirnames, filenames in os.walk(src_dir):
-        for dirname in dirnames:
-            relative_dir_path = os.path.relpath(os.path.join(dirpath, dirname), src_dir)
-            # For each directory <dirname> immediately under <dirpath>, create an equivalently-named
-            # directory under the destination directory
-            abs_dir_path = os.path.join(dst_dir, relative_dir_path)
-            os.mkdir(abs_dir_path)
-        for filename in filenames:
-            # For each file with name <filename> immediately under <dirpath>, copy that file to
-            # the appropriate location in the destination directory
-            file_path = os.path.join(dirpath, filename)
-            relative_file_path = os.path.relpath(file_path, src_dir)
-            abs_file_path = os.path.join(dst_dir, relative_file_path)
-            shutil.copyfile(file_path, abs_file_path)
-
-
 def _load_model_databricks(dfs_tmpdir, local_model_path):
     from pyspark.ml.pipeline import PipelineModel
 
@@ -758,7 +734,7 @@ def _load_model_databricks(dfs_tmpdir, local_model_path):
 def _load_model(model_uri, dfs_tmpdir_base=None, local_model_path=None):
     from pyspark.ml.pipeline import PipelineModel
 
-    dfs_tmpdir = _tmp_path(dfs_tmpdir_base or MLFLOW_DFS_TMP.get())
+    dfs_tmpdir = generate_tmp_dfs_path(dfs_tmpdir_base or MLFLOW_DFS_TMP.get())
     if databricks_utils.is_in_cluster() and databricks_utils.is_dbfs_fuse_available():
         return _load_model_databricks(
             dfs_tmpdir, local_model_path or _download_artifact_from_uri(model_uri)

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -691,3 +691,23 @@ def write_spark_dataframe_to_parquet_on_local_disk(spark_df, output_path):
         shutil.rmtree("/dbfs/" + dbfs_path)
     else:
         spark_df.coalesce(1).write.format("parquet").save(output_path)
+
+
+def _shutil_copytree_without_file_permissions(src_dir, dst_dir):
+    """
+    Copies the directory src_dir into dst_dir, without preserving filesystem permissions
+    """
+    for dirpath, dirnames, filenames in os.walk(src_dir):
+        for dirname in dirnames:
+            relative_dir_path = os.path.relpath(os.path.join(dirpath, dirname), src_dir)
+            # For each directory <dirname> immediately under <dirpath>, create an equivalently-named
+            # directory under the destination directory
+            abs_dir_path = os.path.join(dst_dir, relative_dir_path)
+            os.mkdir(abs_dir_path)
+        for filename in filenames:
+            # For each file with name <filename> immediately under <dirpath>, copy that file to
+            # the appropriate location in the destination directory
+            file_path = os.path.join(dirpath, filename)
+            relative_file_path = os.path.relpath(file_path, src_dir)
+            abs_file_path = os.path.join(dst_dir, relative_file_path)
+            shutil.copyfile(file_path, abs_file_path)

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -693,7 +693,7 @@ def write_spark_dataframe_to_parquet_on_local_disk(spark_df, output_path):
         spark_df.coalesce(1).write.format("parquet").save(output_path)
 
 
-def _shutil_copytree_without_file_permissions(src_dir, dst_dir):
+def shutil_copytree_without_file_permissions(src_dir, dst_dir):
     """
     Copies the directory src_dir into dst_dir, without preserving filesystem permissions
     """

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -56,17 +56,16 @@ def _get_flavor_configuration_from_uri(model_uri, flavor_name, logger):
     :return: The flavor configuration as a dictionary.
     """
     try:
+        resolved_uri = model_uri
         if RunsArtifactRepository.is_runs_uri(model_uri):
-            runs_uri = model_uri
-            model_uri = RunsArtifactRepository.get_underlying_uri(model_uri)
-            logger.info("'%s' resolved as '%s'", runs_uri, model_uri)
+            resolved_uri = RunsArtifactRepository.get_underlying_uri(model_uri)
+            logger.info("'%s' resolved as '%s'", model_uri, resolved_uri)
         elif ModelsArtifactRepository.is_models_uri(model_uri):
-            runs_uri = model_uri
-            model_uri = ModelsArtifactRepository.get_underlying_uri(model_uri)
-            logger.info("'%s' resolved as '%s'", runs_uri, model_uri)
+            resolved_uri = ModelsArtifactRepository.get_underlying_uri(model_uri)
+            logger.info("'%s' resolved as '%s'", model_uri, resolved_uri)
 
         ml_model_file = _download_artifact_from_uri(
-            artifact_uri=append_to_uri_path(model_uri, MLMODEL_FILE_NAME)
+            artifact_uri=append_to_uri_path(resolved_uri, MLMODEL_FILE_NAME)
         )
     except Exception as ex:
         raise MlflowException(

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -6,6 +6,8 @@ from mlflow.exceptions import MlflowException
 from mlflow.models import Model
 from mlflow.models.model import MLMODEL_FILE_NAME
 from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST, RESOURCE_ALREADY_EXISTS
+from mlflow.store.artifact.runs_artifact_repo import RunsArtifactRepository
+from mlflow.store.artifact.models_artifact_repo import ModelsArtifactRepository
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.uri import append_to_uri_path
 from mlflow.utils.file_utils import _copy_file_or_tree
@@ -41,7 +43,7 @@ def _get_flavor_configuration(model_path, flavor_name):
     return conf
 
 
-def _get_flavor_configuration_from_uri(model_uri, flavor_name):
+def _get_flavor_configuration_from_uri(model_uri, flavor_name, logger):
     """
     Obtains the configuration for the specified flavor from the specified
     MLflow model uri. If the model does not contain the specified flavor,
@@ -50,17 +52,27 @@ def _get_flavor_configuration_from_uri(model_uri, flavor_name):
     :param model_uri: The path to the root directory of the MLflow model for which to load
                        the specified flavor configuration.
     :param flavor_name: The name of the flavor configuration to load.
+    :param logger: The local flavor's logger to report the resolved path of the model uri.
     :return: The flavor configuration as a dictionary.
     """
     try:
+        if RunsArtifactRepository.is_runs_uri(model_uri):
+            runs_uri = model_uri
+            model_uri = RunsArtifactRepository.get_underlying_uri(model_uri)
+            logger.info("'%s' resolved as '%s'", runs_uri, model_uri)
+        elif ModelsArtifactRepository.is_models_uri(model_uri):
+            runs_uri = model_uri
+            model_uri = ModelsArtifactRepository.get_underlying_uri(model_uri)
+            logger.info("'%s' resolved as '%s'", runs_uri, model_uri)
+
         ml_model_file = _download_artifact_from_uri(
             artifact_uri=append_to_uri_path(model_uri, MLMODEL_FILE_NAME)
         )
     except Exception as ex:
         raise MlflowException(
-            f'Failed to download an "{MLMODEL_FILE_NAME}" model file from "{model_uri}": {ex}',
+            f'Failed to download an "{MLMODEL_FILE_NAME}" model file from "{model_uri}"',
             RESOURCE_DOES_NOT_EXIST,
-        )
+        ) from ex
     return _get_flavor_configuration_from_ml_model_file(ml_model_file, flavor_name)
 
 

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -2,7 +2,6 @@ import pathlib
 import posixpath
 import urllib.parse
 import uuid
-from os import path
 
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -1,6 +1,8 @@
 import pathlib
 import posixpath
 import urllib.parse
+import uuid
+from os import path
 
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
@@ -329,3 +331,7 @@ def resolve_uri_if_local(local_uri):
             )
             return resolved_absolute_uri
     return local_uri
+
+
+def generate_tmp_dfs_path(dfs_tmp):
+    return posixpath.join(dfs_tmp, str(uuid.uuid4()))

--- a/tests/diviner/test_diviner_model_export.py
+++ b/tests/diviner/test_diviner_model_export.py
@@ -499,14 +499,14 @@ def test_model_log_with_metadata(grouped_pmdarima):
     assert reloaded_model.metadata.metadata["metadata_key"] == "metadata_value"
 
 
-def test_diviner_model_fit_in_spark_cannot_be_loaded_as_pyfunc(grouped_prophet, model_path):
+def test_diviner_model_fit_with_spark_cannot_be_loaded_as_pyfunc(grouped_prophet, model_path):
     mlflow.diviner.save_model(grouped_prophet, model_path)
 
     diviner_model_info_path = model_path.joinpath(MLMODEL_FILE_NAME)
     diviner_model_info = yaml.safe_load(diviner_model_info_path.read_text())
 
     # We can't actually test this by saving in Spark due to method unavailability in OSS Diviner.
-    diviner_model_info["flavors"]["diviner"]["fit_in_spark"] = True
+    diviner_model_info["flavors"]["diviner"]["fit_with_spark"] = True
 
     diviner_model_info_path.write_text(yaml.safe_dump(diviner_model_info))
 
@@ -515,6 +515,6 @@ def test_diviner_model_fit_in_spark_cannot_be_loaded_as_pyfunc(grouped_prophet, 
 
 
 @pytest.mark.parametrize("path", ["dbfs:/model", "file/storage", "Users/model/save"])
-def test_diviner_model_fit_in_spark_raises_with_invalid_paths(grouped_prophet, path):
+def test_diviner_model_fit_with_spark_raises_with_invalid_paths(grouped_prophet, path):
     with pytest.raises(MlflowException, match="The save path provided must be a run-relative"):
         mlflow.diviner._save_model_fit_in_spark(grouped_prophet, path)

--- a/tests/diviner/test_diviner_model_export.py
+++ b/tests/diviner/test_diviner_model_export.py
@@ -20,7 +20,7 @@ from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.utils.environment import _mlflow_conda_env
-from mlflow.utils.model_utils import _get_flavor_configuration, _get_flavor_configuration_from_uri
+from mlflow.utils.model_utils import _get_flavor_configuration
 
 import mlflow.diviner
 from mlflow import pyfunc

--- a/tests/diviner/test_diviner_model_export.py
+++ b/tests/diviner/test_diviner_model_export.py
@@ -2,6 +2,8 @@ import os
 from pathlib import Path
 import pytest
 from unittest import mock
+from copy import deepcopy
+from pathlib import Path
 
 import json
 import yaml
@@ -516,5 +518,7 @@ def test_diviner_model_fit_with_spark_cannot_be_loaded_as_pyfunc(grouped_prophet
 
 @pytest.mark.parametrize("path", ["dbfs:/model", "file/storage", "Users/model/save"])
 def test_diviner_model_fit_with_spark_raises_with_invalid_paths(grouped_prophet, path):
+    mod_model = deepcopy(grouped_prophet)
+    setattr(mod_model, "_fit_with_spark", True)
     with pytest.raises(MlflowException, match="The save path provided must be a run-relative"):
-        mlflow.diviner._save_model_fit_in_spark(grouped_prophet, path)
+        mlflow.diviner._save_diviner_model(mod_model, Path(path))

--- a/tests/diviner/test_diviner_model_export.py
+++ b/tests/diviner/test_diviner_model_export.py
@@ -13,13 +13,14 @@ from diviner.utils.example_utils import example_data_generator
 
 from mlflow.exceptions import MlflowException
 from mlflow.models import infer_signature, Model
+from mlflow.models.model import MLMODEL_FILE_NAME
 from mlflow.models.utils import _read_example
 import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.utils.environment import _mlflow_conda_env
-from mlflow.utils.model_utils import _get_flavor_configuration
+from mlflow.utils.model_utils import _get_flavor_configuration, _get_flavor_configuration_from_uri
 
 import mlflow.diviner
 from mlflow import pyfunc
@@ -93,7 +94,7 @@ def test_diviner_native_save_and_load(grouped_prophet, model_path):
 
 def test_diviner_pyfunc_save_load(grouped_pmdarima, model_path):
     mlflow.diviner.save_model(diviner_model=grouped_pmdarima, path=model_path)
-    loaded_pyfunc = pyfunc.load_pyfunc(model_uri=model_path)
+    loaded_pyfunc = pyfunc.load_model(model_uri=model_path)
 
     model_predict = grouped_pmdarima.predict(n_periods=10, return_conf_int=True, alpha=0.075)
 
@@ -496,3 +497,24 @@ def test_model_log_with_metadata(grouped_pmdarima):
 
     reloaded_model = mlflow.pyfunc.load_model(model_uri=model_uri)
     assert reloaded_model.metadata.metadata["metadata_key"] == "metadata_value"
+
+
+def test_diviner_model_fit_in_spark_cannot_be_loaded_as_pyfunc(grouped_prophet, model_path):
+    mlflow.diviner.save_model(grouped_prophet, model_path)
+
+    diviner_model_info_path = model_path.joinpath(MLMODEL_FILE_NAME)
+    diviner_model_info = yaml.safe_load(diviner_model_info_path.read_text())
+
+    # We can't actually test this by saving in Spark due to method unavailability in OSS Diviner.
+    diviner_model_info["flavors"]["diviner"]["fit_in_spark"] = True
+
+    diviner_model_info_path.write_text(yaml.safe_dump(diviner_model_info))
+
+    with pytest.raises(MlflowException, match="The model being loaded was fit in Spark. Diviner"):
+        pyfunc.load_model(model_uri=model_path)
+
+
+@pytest.mark.parametrize("path", ["dbfs:/model", "file/storage", "Users/model/save"])
+def test_diviner_model_fit_in_spark_raises_with_invalid_paths(grouped_prophet, path):
+    with pytest.raises(MlflowException, match="The save path provided must be a run-relative"):
+        mlflow.diviner._save_model_fit_in_spark(grouped_prophet, path)

--- a/tests/diviner/test_diviner_model_export.py
+++ b/tests/diviner/test_diviner_model_export.py
@@ -1,5 +1,4 @@
 import os
-from pathlib import Path
 import pytest
 from unittest import mock
 from copy import deepcopy

--- a/tests/diviner/test_diviner_model_export.py
+++ b/tests/diviner/test_diviner_model_export.py
@@ -520,5 +520,5 @@ def test_diviner_model_fit_with_spark_cannot_be_loaded_as_pyfunc(grouped_prophet
 def test_diviner_model_fit_with_spark_raises_with_invalid_paths(grouped_prophet, path):
     mod_model = deepcopy(grouped_prophet)
     setattr(mod_model, "_fit_with_spark", True)
-    with pytest.raises(MlflowException, match="The save path provided must be a run-relative"):
+    with pytest.raises(MlflowException, match="The save path provided must be a relative"):
         mlflow.diviner._save_diviner_model(mod_model, Path(path))

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -94,7 +94,6 @@ def get_spark_session(conf):
     # If running in local mode on certain OS configurations (M1 Mac ARM CPUs)
     # adding `.config("spark.driver.bindAddress", "127.0.0.1")` to the SparkSession
     # builder configuration will enable a SparkSession to start.
-
     # For local testing, uncomment the following line:
     # spark_master = os.environ.get("SPARK_MASTER", "local[1]")
     # If doing local testing, comment-out the following line.

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -95,14 +95,14 @@ def get_spark_session(conf):
     # adding `.config("spark.driver.bindAddress", "127.0.0.1")` to the SparkSession
     # builder configuration will enable a SparkSession to start.
     # For local testing, uncomment the following line:
-    spark_master = os.environ.get("SPARK_MASTER", "local[1]")
+    # spark_master = os.environ.get("SPARK_MASTER", "local[1]")
     # If doing local testing, comment-out the following line.
-    # spark_master = os.environ.get("SPARK_MASTER", "local-cluster[2, 1, 1024]")
+    spark_master = os.environ.get("SPARK_MASTER", "local-cluster[2, 1, 1024]")
     # Don't forget to revert these changes prior to pushing a branch!
     return (
         pyspark.sql.SparkSession.builder.config(conf=conf)
         .master(spark_master)
-        .config("spark.driver.bindAddress", "127.0.0.1")  # Uncomment for testing on M1 locally
+        # .config("spark.driver.bindAddress", "127.0.0.1")  # Uncomment for testing on M1 locally
         .config("spark.task.maxFailures", "1")  # avoid retry failed spark tasks
         .getOrCreate()
     )

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -102,7 +102,8 @@ def get_spark_session(conf):
     return (
         pyspark.sql.SparkSession.builder.config(conf=conf)
         .master(spark_master)
-        # .config("spark.driver.bindAddress", "127.0.0.1")  # Uncomment for testing on M1 locally
+        # Uncomment the following line for testing on Apple silicon locally
+        # .config("spark.driver.bindAddress", "127.0.0.1")
         .config("spark.task.maxFailures", "1")  # avoid retry failed spark tasks
         .getOrCreate()
     )

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -95,14 +95,14 @@ def get_spark_session(conf):
     # adding `.config("spark.driver.bindAddress", "127.0.0.1")` to the SparkSession
     # builder configuration will enable a SparkSession to start.
     # For local testing, uncomment the following line:
-    # spark_master = os.environ.get("SPARK_MASTER", "local[1]")
+    spark_master = os.environ.get("SPARK_MASTER", "local[1]")
     # If doing local testing, comment-out the following line.
-    spark_master = os.environ.get("SPARK_MASTER", "local-cluster[2, 1, 1024]")
+    # spark_master = os.environ.get("SPARK_MASTER", "local-cluster[2, 1, 1024]")
     # Don't forget to revert these changes prior to pushing a branch!
     return (
         pyspark.sql.SparkSession.builder.config(conf=conf)
         .master(spark_master)
-        # .config("spark.driver.bindAddress", "127.0.0.1") # Uncomment for testing on M1 locally
+        .config("spark.driver.bindAddress", "127.0.0.1")  # Uncomment for testing on M1 locally
         .config("spark.task.maxFailures", "1")  # avoid retry failed spark tasks
         .getOrCreate()
     )

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -19,6 +19,7 @@ from packaging.version import Version
 import mlflow
 import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 import mlflow.tracking
+import mlflow.utils.file_utils
 from mlflow import pyfunc
 from mlflow import spark as sparkm
 from mlflow.environment_variables import MLFLOW_DFS_TMP
@@ -839,12 +840,12 @@ def test_shutil_copytree_without_file_permissions(tmpdir):
     src_dir = tmpdir.mkdir("src-dir")
     dst_dir = tmpdir.mkdir("dst-dir")
     # Test copying empty directory
-    mlflow.spark._shutil_copytree_without_file_permissions(src_dir.strpath, dst_dir.strpath)
+    mlflow.utils.file_utils._shutil_copytree_without_file_permissions(src_dir.strpath, dst_dir.strpath)
     assert len(os.listdir(dst_dir.strpath)) == 0
     # Test copying directory with contents
     src_dir.mkdir("subdir").join("subdir-file.txt").write("testing 123")
     src_dir.join("top-level-file.txt").write("hi")
-    mlflow.spark._shutil_copytree_without_file_permissions(src_dir.strpath, dst_dir.strpath)
+    mlflow.utils.file_utils._shutil_copytree_without_file_permissions(src_dir.strpath, dst_dir.strpath)
     assert set(os.listdir(dst_dir.strpath)) == {"top-level-file.txt", "subdir"}
     assert set(os.listdir(dst_dir.join("subdir").strpath)) == {"subdir-file.txt"}
     assert dst_dir.join("subdir").join("subdir-file.txt").read() == "testing 123"

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -836,22 +836,6 @@ def test_model_logging_uses_mlflowdbfs_if_appropriate_when_hdfs_check_fails(
             )
 
 
-def test_shutil_copytree_without_file_permissions(tmpdir):
-    src_dir = tmpdir.mkdir("src-dir")
-    dst_dir = tmpdir.mkdir("dst-dir")
-    # Test copying empty directory
-    mlflow.utils.file_utils._shutil_copytree_without_file_permissions(src_dir.strpath, dst_dir.strpath)
-    assert len(os.listdir(dst_dir.strpath)) == 0
-    # Test copying directory with contents
-    src_dir.mkdir("subdir").join("subdir-file.txt").write("testing 123")
-    src_dir.join("top-level-file.txt").write("hi")
-    mlflow.utils.file_utils._shutil_copytree_without_file_permissions(src_dir.strpath, dst_dir.strpath)
-    assert set(os.listdir(dst_dir.strpath)) == {"top-level-file.txt", "subdir"}
-    assert set(os.listdir(dst_dir.join("subdir").strpath)) == {"subdir-file.txt"}
-    assert dst_dir.join("subdir").join("subdir-file.txt").read() == "testing 123"
-    assert dst_dir.join("top-level-file.txt").read() == "hi"
-
-
 def test_log_model_with_code_paths(spark_model_iris):
     artifact_path = "model"
     with mlflow.start_run(), mock.patch(

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -351,14 +351,14 @@ def test_shutil_copytree_without_file_permissions(tmpdir):
     src_dir = tmpdir.mkdir("src-dir")
     dst_dir = tmpdir.mkdir("dst-dir")
     # Test copying empty directory
-    mlflow.utils.file_utils._shutil_copytree_without_file_permissions(
+    mlflow.utils.file_utils.shutil_copytree_without_file_permissions(
         src_dir.strpath, dst_dir.strpath
     )
     assert len(os.listdir(dst_dir.strpath)) == 0
     # Test copying directory with contents
     src_dir.mkdir("subdir").join("subdir-file.txt").write("testing 123")
     src_dir.join("top-level-file.txt").write("hi")
-    mlflow.utils.file_utils._shutil_copytree_without_file_permissions(
+    mlflow.utils.file_utils.shutil_copytree_without_file_permissions(
         src_dir.strpath, dst_dir.strpath
     )
     assert set(os.listdir(dst_dir.strpath)) == {"top-level-file.txt", "subdir"}

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -347,21 +347,20 @@ def test_local_file_uri_to_path_on_windows(input_uri, expected_path):
     assert local_file_uri_to_path(input_uri) == expected_path
 
 
-def test_shutil_copytree_without_file_permissions(tmpdir):
-    src_dir = tmpdir.mkdir("src-dir")
-    dst_dir = tmpdir.mkdir("dst-dir")
+def test_shutil_copytree_without_file_permissions(tmp_path):
+    src_dir = tmp_path.joinpath("src-dir")
+    src_dir.mkdir()
+    dst_dir = tmp_path.joinpath("dst-dir")
+    dst_dir.mkdir()
     # Test copying empty directory
-    mlflow.utils.file_utils.shutil_copytree_without_file_permissions(
-        src_dir.strpath, dst_dir.strpath
-    )
-    assert len(os.listdir(dst_dir.strpath)) == 0
+    mlflow.utils.file_utils.shutil_copytree_without_file_permissions(src_dir, dst_dir)
+    assert len(os.listdir(dst_dir)) == 0
     # Test copying directory with contents
-    src_dir.mkdir("subdir").join("subdir-file.txt").write("testing 123")
-    src_dir.join("top-level-file.txt").write("hi")
-    mlflow.utils.file_utils.shutil_copytree_without_file_permissions(
-        src_dir.strpath, dst_dir.strpath
-    )
-    assert set(os.listdir(dst_dir.strpath)) == {"top-level-file.txt", "subdir"}
-    assert set(os.listdir(dst_dir.join("subdir").strpath)) == {"subdir-file.txt"}
-    assert dst_dir.join("subdir").join("subdir-file.txt").read() == "testing 123"
-    assert dst_dir.join("top-level-file.txt").read() == "hi"
+    src_dir.joinpath("subdir").mkdir()
+    src_dir.joinpath("subdir/subdir-file.txt").write_text("testing 123")
+    src_dir.joinpath("top-level-file.txt").write_text("hi")
+    mlflow.utils.file_utils.shutil_copytree_without_file_permissions(src_dir, dst_dir)
+    assert set(os.listdir(dst_dir)) == {"top-level-file.txt", "subdir"}
+    assert set(os.listdir(dst_dir.joinpath("subdir"))) == {"subdir-file.txt"}
+    assert dst_dir.joinpath("subdir/subdir-file.txt").read_text() == "testing 123"
+    assert dst_dir.joinpath("top-level-file.txt").read_text() == "hi"


### PR DESCRIPTION
Signed-off-by: Ben Wilson <benjamin.wilson@databricks.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Add support for Diviner models fit in Spark

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests (describe details, including test results, below)

Manual validation via workspace testing


## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [X] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
