### PR TITLE
Add xgboost pyfunc example

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -1047,6 +1047,49 @@ Note that the ``xgboost`` model flavor only supports an instance of `xgboost.Boo
 not models that implement the `scikit-learn API
 <https://xgboost.readthedocs.io/en/latest/python/python_api.html#module-xgboost.sklearn>`__.
 
+``XGBoost`` pyfunc usage
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The example below
+
+* Loads the IRIS dataset from ``scikit-learn``
+* Trains an XGBoost Classifier
+* Logs the model and params using ``mlflow``
+* Loads the logged model and makes predictions
+
+.. code-block:: python
+
+    from sklearn.datasets import load_iris
+    from sklearn.model_selection import train_test_split
+    from xgboost import XGBClassifier
+    import mlflow
+
+    data = load_iris()
+    X_train, X_test, y_train, y_test = train_test_split(
+        data["data"], data["target"], test_size=0.2
+    )
+
+    xgb_classifier = XGBClassifier(
+        n_estimators=10,
+        max_depth=3,
+        learning_rate=1,
+        objective="binary:logistic",
+        random_state=123,
+    )
+
+    # log fitted model with anXGBClassifier parameters
+    with mlflow.start_run():
+        xgb_classifier.fit(X_train, y_train)
+        clf_params = xgb_classifier.get_xgb_params()
+        mlflow.log_params(clf_params)
+        model_info = mlflow.xgboost.log_model(xgb_classifier, "iris-classifier")
+
+    # Load saved model and make predictions
+    xgb_classifier_saved = mlflow.pyfunc.load_model(model_info.model_uri)
+    y_pred = xgb_classifier_saved.predict(X_test)
+    print(y_pred)
+
+
 For more information, see :py:mod:`mlflow.xgboost`.
 
 LightGBM (``lightgbm``)

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -1087,7 +1087,6 @@ The example below
     # Load saved model and make predictions
     xgb_classifier_saved = mlflow.pyfunc.load_model(model_info.model_uri)
     y_pred = xgb_classifier_saved.predict(X_test)
-    print(y_pred)
 
 
 For more information, see :py:mod:`mlflow.xgboost`.

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -1077,7 +1077,7 @@ The example below
         random_state=123,
     )
 
-    # log fitted model with anXGBClassifier parameters
+    # log fitted model and XGBClassifier parameters
     with mlflow.start_run():
         xgb_classifier.fit(X_train, y_train)
         clf_params = xgb_classifier.get_xgb_params()


### PR DESCRIPTION
Signed-off-by: Dipanjan Kailthya <dipanjan.kailthya@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #6099

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

Example of logging an xgboost model with mlflow and loading it to generate predictions.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

Generated docs link: https://output.circle-artifacts.com/output/job/aa921677-6e50-4653-a672-813bed4e9cc6/artifacts/0/docs/build/html/models.html#xgboost-pyfunc-usage

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [X] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
