### PR TITLE
Save ONNX model external data True to overcome 2GB limit.

### DIFF
--- a/mlflow/onnx.py
+++ b/mlflow/onnx.py
@@ -217,9 +217,9 @@ def save_model(
 def _load_model(model_file):
     import onnx
 
+    onnx.checker.check_model(model_file)
     onnx_model = onnx.load(model_file)
     # Check Formation
-    onnx.checker.check_model(onnx_model)
     return onnx_model
 
 

--- a/mlflow/onnx.py
+++ b/mlflow/onnx.py
@@ -11,6 +11,7 @@ import os
 import yaml
 import numpy as np
 from pathlib import Path
+from packaging.version import Version
 
 import pandas as pd
 
@@ -157,7 +158,10 @@ def save_model(
     model_data_path = os.path.join(path, model_data_subpath)
 
     # Save onnx-model
-    onnx.save_model(onnx_model, model_data_path, save_as_external_data=True)
+    if Version(onnx.__version__) >= Version("1.9.0"):
+        onnx.save_model(onnx_model, model_data_path, save_as_external_data=True)
+    else:
+        onnx.save_model(onnx_model, model_data_path)
 
     pyfunc.add_to_model(
         mlflow_model,

--- a/mlflow/onnx.py
+++ b/mlflow/onnx.py
@@ -157,7 +157,7 @@ def save_model(
     model_data_path = os.path.join(path, model_data_subpath)
 
     # Save onnx-model
-    onnx.save_model(onnx_model, model_data_path)
+    onnx.save_model(onnx_model, model_data_path, save_as_external_data=True)
 
     pyfunc.add_to_model(
         mlflow_model,

--- a/tests/onnx/test_onnx_model_export.py
+++ b/tests/onnx/test_onnx_model_export.py
@@ -10,6 +10,7 @@ from torch import nn
 import torch.onnx
 from torch.utils.data import DataLoader
 from sklearn import datasets
+from packaging.version import Version
 import pandas as pd
 import numpy as np
 import yaml
@@ -117,9 +118,20 @@ def onnx_model_2gb(tmpdir):
     )
 
     sample_input = torch.ones(1, 2**14)
-    torch.onnx.export(
-        big_model, sample_input, model_path, dynamic_axes=dynamic_axes, input_names=["input"]
-    )
+    if Version(torch.__version__) >= Version("1.11.0"):
+        torch.onnx.export(
+            big_model, sample_input, model_path, dynamic_axes=dynamic_axes, input_names=["input"]
+        )
+    # Exporting with pytorch use_external_data_format required for large models for <1.11
+    else:
+        torch.onnx.export(
+            big_model,
+            sample_input,
+            model_path,
+            dynamic_axes=dynamic_axes,
+            input_names=["input"],
+            use_external_data_format=True,
+        )
     return onnx.load(model_path)
 
 


### PR DESCRIPTION
Signed-off-by: Albert Chung <albertswchung@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #7799 

## What changes are proposed in this pull request?

To overcome the 2GB protobuf limit we enable the save_as_external_data flag. A test for this scenario is created by exporting a 2GB pytorch model to ONNX and then reloading it with ONNX. Let me know if this is unnecessary or if there is better way of testing this as it does take a little bit of time to export.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.


### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
