### PR TITLE
Optimizing the performance for custom split method

### DIFF
--- a/mlflow/recipes/steps/split.py
+++ b/mlflow/recipes/steps/split.py
@@ -349,15 +349,26 @@ class SplitStep(BaseStep):
 
         copy_df = input_df.copy()
         copy_df["split"] = custom_split_mapping_series
-        train_df = input_df[copy_df["split"] == SplitValues.TRAINING.value]
-        validation_df = input_df[copy_df["split"] == SplitValues.VALIDATION.value]
-        test_df = input_df[copy_df["split"] == SplitValues.TEST.value]
+        train_df = input_df[copy_df["split"] == SplitValues.TRAINING.value].reset_index(drop=True)
+        validation_df = input_df[copy_df["split"] == SplitValues.VALIDATION.value].reset_index(
+            drop=True
+        )
+        test_df = input_df[copy_df["split"] == SplitValues.TEST.value].reset_index(drop=True)
 
         if train_df.size + validation_df.size + test_df.size != input_df.size:
+            incorrect_args = custom_split_mapping_series[
+                ~custom_split_mapping_series.isin(
+                    [
+                        SplitValues.TRAINING.value,
+                        SplitValues.VALIDATION.value,
+                        SplitValues.TEST.value,
+                    ]
+                )
+            ].unique()
             raise MlflowException(
                 f"Returned pandas series from custom split step should only contain "
                 f"{SplitValues.TRAINING.value}, {SplitValues.VALIDATION.value} or "
-                f"{SplitValues.TEST.value} as values. Value returned back instead: {value}",
+                f"{SplitValues.TEST.value} as values. Value returned back: {incorrect_args}",
                 error_code=INVALID_PARAMETER_VALUE,
             )
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
Optimizing the performance for custom split method

Performance Measurements:
Dataset size: 130776 rows × 145 columns
Previous implementation: 1.02 hours
New Implementation: 0.84 seconds 

## How is this patch tested?
- [x] Test passes
- [x] Notebook test

Error usecase: 
<img width="1674" alt="image" src="https://user-images.githubusercontent.com/5621432/218214990-7a8fc942-f5af-4f67-b0f4-075e535e28fc.png">

Correct usecase:
![image](https://user-images.githubusercontent.com/5621432/218178995-6b5527b4-7291-4085-9ba6-be2381100bdb.png)


## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Optimizing the performance for custom split method

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
