### PR TITLE
bugfix-7801 Fixing validation bugs in experiments, models modals

### DIFF
--- a/mlflow/server/js/src/common/components/EditableTagsTableView.js
+++ b/mlflow/server/js/src/common/components/EditableTagsTableView.js
@@ -95,7 +95,7 @@ export class EditableTagsTableViewImpl extends Component {
                 },
                 {
                   validator: this.tagNameValidator,
-                }
+                },
               ]}
             >
               <Input

--- a/mlflow/server/js/src/common/components/EditableTagsTableView.js
+++ b/mlflow/server/js/src/common/components/EditableTagsTableView.js
@@ -92,8 +92,10 @@ export class EditableTagsTableViewImpl extends Component {
                     description:
                       'Error message for name requirement in editable tags table view in MLflow',
                   }),
-                  validator: this.tagNameValidator,
                 },
+                {
+                  validator: this.tagNameValidator,
+                }
               ]}
             >
               <Input

--- a/mlflow/server/js/src/common/forms/validations.js
+++ b/mlflow/server/js/src/common/forms/validations.js
@@ -3,7 +3,9 @@ import { Services as ModelRegistryService } from '../../model-registry/services'
 
 export const getExperimentNameValidator = (getExistingExperimentNames) => {
   return (rule, value, callback) => {
-    if (value.length === 0) {
+    console.log("checking ...")
+    // alert("checking..")
+    if (!value) {
       // no need to execute below validations when no value is entered
       // eslint-disable-next-line callback-return
       callback(undefined);
@@ -27,7 +29,7 @@ export const getExperimentNameValidator = (getExistingExperimentNames) => {
 };
 
 export const modelNameValidator = (rule, name, callback) => {
-  if (name.length === 0) {
+  if (!name) {
     callback(undefined);
     return;
   }

--- a/mlflow/server/js/src/common/forms/validations.js
+++ b/mlflow/server/js/src/common/forms/validations.js
@@ -31,7 +31,8 @@ export const modelNameValidator = (rule, name, callback) => {
     callback(undefined);
     return;
   }
-  ModelRegistryService.getRegisteredModel({ data: { name } })
+
+  ModelRegistryService.getRegisteredModel({ name: name })
     .then(() => callback(`Model "${name}" already exists.`))
     .catch((e) => callback(undefined));
 };

--- a/mlflow/server/js/src/common/forms/validations.js
+++ b/mlflow/server/js/src/common/forms/validations.js
@@ -3,8 +3,6 @@ import { Services as ModelRegistryService } from '../../model-registry/services'
 
 export const getExperimentNameValidator = (getExistingExperimentNames) => {
   return (rule, value, callback) => {
-    console.log("checking ...")
-    // alert("checking..")
     if (!value) {
       // no need to execute below validations when no value is entered
       // eslint-disable-next-line callback-return

--- a/mlflow/server/js/src/common/forms/validations.test.js
+++ b/mlflow/server/js/src/common/forms/validations.test.js
@@ -15,12 +15,22 @@ test('ExperimentNameValidator works properly', () => {
   // no input value passed, no error message expected
   experimentNameValidator(undefined, '', mockCallback);
   expect(mockCallback).toHaveBeenCalledWith(undefined);
+
+  // input value == undefined, no error message expected
+  experimentNameValidator(undefined, undefined, mockCallback);
+  expect(mockCallback).toHaveBeenCalledWith(undefined);
 });
 
 describe('modelNameValidator should work properly', () => {
   test('should invoke callback with undefined for empty name', () => {
     const mockCallback = jest.fn((err) => err);
     modelNameValidator(undefined, '', mockCallback);
+    expect(mockCallback).toHaveBeenCalledWith(undefined);
+  });
+
+  test('should invoke callback with undefined for empty name', () => {
+    const mockCallback = jest.fn((err) => err);
+    modelNameValidator(undefined, undefined, mockCallback);
     expect(mockCallback).toHaveBeenCalledWith(undefined);
   });
 

--- a/mlflow/server/js/src/experiment-tracking/components/modals/CreateExperimentForm.js
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/CreateExperimentForm.js
@@ -56,7 +56,7 @@ class CreateExperimentFormComponent extends Component {
           rules={[
             {
               required: false,
-            }
+            },
           ]}
         >
           <Input

--- a/mlflow/server/js/src/experiment-tracking/components/modals/CreateExperimentForm.js
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/CreateExperimentForm.js
@@ -33,6 +33,8 @@ class CreateExperimentFormComponent extends Component {
                 defaultMessage: 'Please input a new name for the new experiment.',
                 description: 'Error message for name requirement in create experiment for MLflow',
               }),
+            },
+            {
               validator: this.props.validator,
             },
           ]}
@@ -54,7 +56,7 @@ class CreateExperimentFormComponent extends Component {
           rules={[
             {
               required: false,
-            },
+            }
           ]}
         >
           <Input


### PR DESCRIPTION
Signed-off-by: subraman <subramaniam02@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #7801
closes #7801


## What changes are proposed in this pull request?

Fixed validations and enhanced error msgs 
- Empty experiment name
- Empty model name
- Existing experiment name
- Existing model name
- Existing Tag name for model

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

Enhanced validation message in create experiment and models modals.

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
