### PR TITLE
Deflake tests in `tests/store/tracking/test_sqlalchemy_store.py`

### DIFF
--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -189,9 +189,14 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         shutil.rmtree(ARTIFACT_URI)
 
     def _experiment_factory(self, names):
-        if type(names) is list:
-            return [self.store.create_experiment(name=name) for name in names]
+        if isinstance(names, (list, tuple)):
+            ids = []
+            for name in names:
+                time.sleep(0.001)
+                ids.append(self.store.create_experiment(name=name))
+            return ids
 
+        time.sleep(0.001)
         return self.store.create_experiment(name=names)
 
     def test_default_experiment(self):

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -192,6 +192,8 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         if isinstance(names, (list, tuple)):
             ids = []
             for name in names:
+                # Sleep to ensure each experiment has a unique creation_time for
+                # deterministic experiment search results
                 time.sleep(0.001)
                 ids.append(self.store.create_experiment(name=name))
             return ids


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Tests in `tests/store/tracking/test_sqlalchemy_store.py` are flaky because of non-unique experiment creation time. This PR fixes them.

https://github.com/mlflow/mlflow/actions/runs/4162918858/jobs/7202671846#step:7:993

```
____________ TestSqlAlchemyStore.test_search_experiments_view_type _____________

self = <tests.store.tracking.test_sqlalchemy_store.TestSqlAlchemyStore testMethod=test_search_experiments_view_type>

    def test_search_experiments_view_type(self):
        experiment_names = ["a", "b"]
        experiment_ids = self._experiment_factory(experiment_names)
        self.store.delete_experiment(experiment_ids[1])
    
        experiments = self.store.search_experiments(view_type=ViewType.ACTIVE_ONLY)
>       assert [e.name for e in experiments] == ["a", "Default"]
E       AssertionError: assert ['Default', 'a'] == ['a', 'Default']
E         At index 0 diff: 'Default' != 'a'
E         Full diff:
E         - ['a', 'Default']
E         + ['Default', 'a']

experiment_ids = ['1', '2']
experiment_names = ['a', 'b']
experiments = [<Experiment: artifact_location='/mlflow/home/artifact_folder/0', creation_time=1676288961897, experiment_id='0', last_update_time=1676288961897, lifecycle_stage='active', name='Default', tags={}>,
 <Experiment: artifact_location='/mlflow/home/artifact_folder/1', creation_time=1676288961897, experiment_id='1', last_update_time=1676288961897, lifecycle_stage='active', name='a', tags={}>]
self       = <tests.store.tracking.test_sqlalchemy_store.TestSqlAlchemyStore testMethod=test_search_experiments_view_type>
```

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
