### PR TITLE
Added proper headers for artifacts downloads

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -445,7 +445,7 @@ def _get_request_message(request_message, flask_request=request, schema=None):
 
 def _response_with_file_attachment_headers(file_path, response):
     mime_type = _guess_mime_type(file_path)
-    filename = posixpath.basename(pathlib.Path(file_path).as_posix())
+    filename = pathlib.Path(file_path).name
     response.mimetype = mime_type
     content_disposition_header_name = "Content-Disposition"
     if content_disposition_header_name not in response.headers:
@@ -508,7 +508,7 @@ _TEXT_EXTENSIONS = [
 
 
 def _guess_mime_type(file_path):
-    filename = posixpath.basename(pathlib.Path(file_path).as_posix())
+    filename = pathlib.Path(file_path).name
     extension = os.path.splitext(filename)[-1].replace(".", "")
     # for MLmodel/mlproject with no extensions
     if extension == "":

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -5,6 +5,7 @@ import re
 import tempfile
 import posixpath
 import urllib
+from mimetypes import guess_type
 
 import logging
 from functools import wraps
@@ -12,7 +13,6 @@ from functools import wraps
 from flask import Response, request, current_app, send_file
 from google.protobuf import descriptor
 from google.protobuf.json_format import ParseError
-import mimetypes
 
 from mlflow.entities import Metric, Param, RunTag, ViewType, ExperimentTag, FileInfo
 from mlflow.entities.model_registry import RegisteredModelTag, ModelVersionTag
@@ -89,7 +89,6 @@ _tracking_store = None
 _model_registry_store = None
 _artifact_repo = None
 STATIC_PREFIX_ENV_VAR = "_MLFLOW_STATIC_PREFIX"
-_mime_type = mimetypes.MimeTypes()
 
 
 class TrackingStoreRegistryWrapper(TrackingStoreRegistry):
@@ -514,7 +513,7 @@ def _guess_mime_type(filename):
         extension = filename
     if extension in _TEXT_EXTENSIONS:
         return "text/plain"
-    mime_type = _mime_type.guess_type(filename)[0]
+    mime_type, _ = guess_type(filename)
     if not mime_type:
         # As a fallback, if mime type is not detected, treat it as a binary file
         return "application/octet-stream"

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -446,8 +446,9 @@ def _get_request_message(request_message, flask_request=request, schema=None):
 def _response_with_file_attachment_headers(filename, response):
     mime_type = _guess_mime_type(filename)
     response.mimetype = mime_type
-    response.headers["Content-Disposition"] = "attachment"
-    response.headers["filename"] = filename
+    content_disposition_header_name = "Content-Disposition"
+    if content_disposition_header_name not in response.headers:
+        response.headers[content_disposition_header_name] = f"attachment; filename={filename}"
     response.headers["X-Content-Type-Options"] = "nosniff"
     response.headers["Content-Type"] = mime_type
     return response

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -651,6 +651,7 @@ def test_delete_model_version_tag(mock_get_request_message, mock_model_registry_
     [
         ("/a/b/c.txt", "text/plain"),
         ("c.txt", "text/plain"),
+        ("c.pkl", "application/octet-stream"),
         ("/a/b/c.pkl", "application/octet-stream"),
         ("/a/b/c.png", "image/png"),
         ("/a/b/c.pdf", "application/pdf"),
@@ -667,7 +668,8 @@ def test_guess_mime_type(file_path, expected_mime_type):
     ("file_path", "expected_mime_type"),
     [
         ("C:\\a\\b\\c.txt", "text/plain"),
-        ("c.txt", "application/octet-stream"),
+        ("c.txt", "text/plain"),
+        ("c.pkl", "application/octet-stream"),
         ("C:\\a\\b\\c.pkl", "application/octet-stream"),
         ("C:\\a\\b\\c.png", "image/png"),
         ("C:\\a\\b\\c.pdf", "application/pdf"),

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -40,6 +40,7 @@ from mlflow.server.handlers import (
     _delete_registered_model_tag,
     _set_model_version_tag,
     _delete_model_version_tag,
+    _guess_mime_type,
 )
 from mlflow.server import BACKEND_STORE_URI_ENV_VAR, app
 from mlflow.store.entities.paged_list import PagedList
@@ -66,6 +67,7 @@ from mlflow.protos.model_registry_pb2 import (
 )
 from mlflow.utils.proto_json_utils import message_to_json
 from mlflow.utils.validation import MAX_BATCH_LOG_REQUEST_SIZE
+from mlflow.utils.os import is_windows
 
 
 @pytest.fixture()
@@ -641,3 +643,36 @@ def test_delete_model_version_tag(mock_get_request_message, mock_model_registry_
     _delete_model_version_tag()
     _, args = mock_model_registry_store.delete_model_version_tag.call_args
     assert args == {"name": name, "version": version, "key": key}
+
+
+@pytest.mark.parametrize(
+    ("file_path", "expected_mime_type"),
+    [
+        ("/a/b/c.txt", "text/plain"),
+        ("c.txt", "text/plain"),
+        ("/a/b/c.pkl", "application/octet-stream"),
+        ("/a/b/c.png", "image/png"),
+        ("/a/b/c.pdf", "application/pdf"),
+        ("/a/b/MLmodel", "text/plain"),
+        ("/a/b/mlproject", "text/plain"),
+    ],
+)
+def test_guess_mime_type(file_path, expected_mime_type):
+    assert _guess_mime_type(file_path) == expected_mime_type
+
+
+@pytest.mark.skipif(not is_windows(), reason="This test only passes on Windows")
+@pytest.mark.parametrize(
+    ("file_path", "expected_mime_type"),
+    [
+        ("C:\\a\\b\\c.txt", "text/plain"),
+        ("c.txt", "application/octet-stream"),
+        ("C:\\a\\b\\c.pkl", "application/octet-stream"),
+        ("C:\\a\\b\\c.png", "image/png"),
+        ("C:\\a\\b\\c.pdf", "application/pdf"),
+        ("C:\\a\\b\\MLmodel", "text/plain"),
+        ("C:\\a\\b\\mlproject", "text/plain"),
+    ],
+)
+def test_guess_mime_type_on_windows(file_path, expected_mime_type):
+    assert _guess_mime_type(file_path) == expected_mime_type

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -645,6 +645,7 @@ def test_delete_model_version_tag(mock_get_request_message, mock_model_registry_
     assert args == {"name": name, "version": version, "key": key}
 
 
+@pytest.mark.skipif(is_windows(), reason="This test fails on Windows")
 @pytest.mark.parametrize(
     ("file_path", "expected_mime_type"),
     [

--- a/tests/tracking/test_mlflow_artifacts.py
+++ b/tests/tracking/test_mlflow_artifacts.py
@@ -79,8 +79,8 @@ def upload_file(path, url, headers=None):
         requests.put(url, data=f, headers=headers).raise_for_status()
 
 
-def download_file(url, local_path):
-    with requests.get(url, stream=True) as r:
+def download_file(url, local_path, headers=None):
+    with requests.get(url, stream=True, headers=headers) as r:
         r.raise_for_status()
         assert r.headers["X-Content-Type-Options"] == "nosniff"
         assert "Content-Type" in r.headers
@@ -383,9 +383,12 @@ def test_server_overrides_requested_mime_type(
     upload_file(
         test_file,
         f"{default_artifact_root}/dir/{filename}",
+    )
+    download_response = download_file(
+        f"{default_artifact_root}/dir/{filename}",
+        test_file,
         headers={"Accept": requested_mime_type},
     )
-    download_response = download_file(f"{default_artifact_root}/dir/{filename}", test_file)
 
     _, params = cgi.parse_header(download_response.headers["Content-Disposition"])
     assert params["filename"] == filename

--- a/tests/tracking/test_mlflow_artifacts.py
+++ b/tests/tracking/test_mlflow_artifacts.py
@@ -81,9 +81,14 @@ def upload_file(path, url):
 def download_file(url, local_path):
     with requests.get(url, stream=True) as r:
         r.raise_for_status()
+        assert r.headers["X-Content-Type-Options"] == "nosniff"
+        assert "filename" in r.headers
+        assert "Content-Type" in r.headers
+        assert "filename" in r.headers
         with open(local_path, "wb") as f:
             for chunk in r.iter_content(chunk_size=8192):
                 f.write(chunk)
+        return r
 
 
 def test_mlflow_artifacts_rest_apis(artifacts_server, tmpdir):
@@ -321,3 +326,38 @@ def test_rest_get_model_version_artifact_api_proxied_artifact_root(artifacts_ser
     )
     get_model_version_artifact_response.raise_for_status()
     assert get_model_version_artifact_response.text == "abcdefg"
+
+
+@pytest.mark.parametrize(
+    ("filename", "expected_mime_type"),
+    [
+        ("a.txt", "text/plain"),
+        ("b.pkl", "application/octet-stream"),
+        ("c.png", "image/png"),
+        ("d.pdf", "application/pdf"),
+        ("MLmodel", "text/plain"),
+        ("mlproject", "text/plain"),
+    ],
+)
+def test_mime_type_for_download_artifacts_api(
+    artifacts_server, tmpdir, filename, expected_mime_type
+):
+    default_artifact_root = artifacts_server.default_artifact_root
+    url = artifacts_server.url
+    test_file = tmpdir.join(filename)
+    test_file.write(None)
+    upload_file(test_file, f"{default_artifact_root}/dir/{filename}")
+    download_response = download_file(f"{default_artifact_root}/dir/{filename}", test_file)
+    assert download_response.headers["filename"] == filename
+    assert download_response.headers["Content-Type"] == expected_mime_type
+
+    mlflow.set_tracking_uri(url)
+    with mlflow.start_run() as run:
+        mlflow.log_artifact(test_file)
+    artifact_response = requests.get(
+        url=f"{url}/get-artifact", params={"run_id": run.info.run_id, "path": filename}
+    )
+    artifact_response.raise_for_status()
+    assert artifact_response.headers["filename"] == filename
+    assert artifact_response.headers["Content-Type"] == expected_mime_type
+    assert artifact_response.headers["X-Content-Type-Options"] == "nosniff"


### PR DESCRIPTION
Signed-off-by: Jas Bali <bali0019@gmail.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs



<!-- Resolve --> #7548

## What changes are proposed in this pull request?

For artifacts downloads API, ensured proper headers are added and mime type is correctly resolved.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
