### PR TITLE
Migrate `h2o`, `shap`, and `paddle` flavors to cross-version tests

### DIFF
--- a/dev/run-python-flavor-tests.sh
+++ b/dev/run-python-flavor-tests.sh
@@ -3,7 +3,6 @@ set -x
 
 export MLFLOW_HOME=$(pwd)
 
-# TODO: Run tests for h2o, shap, and paddle in the cross-version-tests workflow
 pytest \
   tests/utils/test_model_utils.py \
   tests/tracking/fluent/test_fluent_autolog.py \

--- a/dev/run-python-flavor-tests.sh
+++ b/dev/run-python-flavor-tests.sh
@@ -6,8 +6,5 @@ export MLFLOW_HOME=$(pwd)
 # TODO: Run tests for h2o, shap, and paddle in the cross-version-tests workflow
 pytest \
   tests/utils/test_model_utils.py \
-  tests/h2o \
-  tests/shap \
-  tests/paddle \
   tests/tracking/fluent/test_fluent_autolog.py \
   tests/autologging

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -419,3 +419,35 @@ diviner:
       "<= 0.1.0": ["pmdarima<2.0.0"]
     run: |
       pytest tests/diviner/test_diviner_model_export.py
+
+h2o:
+  package_info:
+    pip_release: "h2o"
+  models:
+    minimum: "3.40.0.1"
+    maximum: "3.40.0.1"
+    run: |
+      pytest tests/h2o
+
+shap:
+  package_info:
+    pip_release: "shap"
+  models:
+    minimum: "0.41.0"
+    maximum: "0.41.0"
+    run: |
+      pytest tests/shap
+
+paddle:
+  package_info:
+    pip_release: "paddlepaddle"
+  models:
+    minimum: "2.4.1"
+    maximum: "2.4.1"
+    run: |
+      pytest tests/paddle/test_paddle_model_export.py
+  autolog:
+    minimum: "2.4.1"
+    maximum: "2.4.1"
+    run: |
+      pytest tests/paddle/test_paddle_autolog.py


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Migrates h2o, shap, and paddle flavors to cross-version tests. This allows us to install ML packages separately and avoid issues such as #7828 where it takes forever for pip to resolve depedencies. In a follow-up PR, I'll remove `extra-ml-requirements.txt`.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
