### PR TITLE
Add internal-only ADLS artifact repo

### DIFF
--- a/mlflow/store/artifact/azure_data_lake_artifact_repo.py
+++ b/mlflow/store/artifact/azure_data_lake_artifact_repo.py
@@ -1,0 +1,135 @@
+import os
+import posixpath
+import pathlib
+import re
+import urllib.parse
+
+
+from mlflow.entities import FileInfo
+from mlflow.exceptions import MlflowException
+from mlflow.store.artifact.artifact_repo import ArtifactRepository
+
+from mlflow.environment_variables import MLFLOW_ARTIFACT_UPLOAD_DOWNLOAD_TIMEOUT
+
+
+def _parse_abfss_uri(uri):
+    """
+    Parse an ABFSS URI in the format "abfss://<file_system>@<account_name>.dbfs.core.windows.net/<path>",
+    returning a tuple consisting of the filesystem, account name, and path
+
+    See more details about ABFSS URIs at
+    https://learn.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-abfs-driver#uri-scheme-to-reference-data
+
+    :param uri: ABFSS URI to parse
+    :return: A tuple containing the name of the filesystem, account name, and path
+    """
+    parsed = urllib.parse.urlparse(uri)
+    if parsed.scheme != "abfss":
+        raise MlflowException("Not an ABFSS URI: %s" % uri)
+
+    match = re.match(r"([^@]+)@([^.]+)\.dfs\.core\.windows\.net", parsed.netloc)
+
+    if match is None:
+        raise MlflowException(
+            "ABFSS URI must be of the form " "abfss://<filesystem>@<account>.dfs.core.windows.net"
+        )
+    filesystem = match.group(1)
+    account_name = match.group(2)
+    path = parsed.path
+    if path.startswith("/"):
+        path = path[1:]
+    return filesystem, account_name, path
+
+
+def _get_data_lake_client(account_url, credential):
+    from azure.storage.filedatalake import DataLakeServiceClient, DataLakeDirectoryClient
+
+    return DataLakeServiceClient(account_url, credential)
+
+
+class AzureDataLakeArtifactRepository(ArtifactRepository):
+    """
+    Stores artifacts on Azure Data Lake Storage Gen2.
+
+    This repository is used with URIs of the form
+    ``abfs[s]://file_system@account_name.dfs.core.windows.net/<path>/<path>``.
+
+    :param credential: Azure credential (see options in https://learn.microsoft.com/en-us/python/api/azure-core/azure.core.credentials?view=azure-python)
+                       to use to authenticate to storage
+    """
+
+    def __init__(self, artifact_uri, credential):
+        super().__init__(artifact_uri)
+        _DEFAULT_TIMEOUT = 600  # 10 minutes
+        self.write_timeout = MLFLOW_ARTIFACT_UPLOAD_DOWNLOAD_TIMEOUT.get() or _DEFAULT_TIMEOUT
+
+        (filesystem, account_name, path) = _parse_abfss_uri(artifact_uri)
+
+        account_url = f"https://{account_name}.dfs.core.windows.net"
+        data_lake_client = _get_data_lake_client(account_url=account_url, credential=credential)
+        self.fs_client = data_lake_client.get_file_system_client(filesystem)
+        self.base_data_lake_directory = path
+        print(f"Got {self.base_data_lake_directory} from {artifact_uri}")
+
+    def log_artifact(self, local_file, artifact_path=None):
+        raise NotImplementedError(
+            "This artifact repository does not support logging single artifacts"
+        )
+
+    def log_artifacts(self, local_dir, artifact_path=None):
+        dest_path = self.base_data_lake_directory
+        if artifact_path:
+            dest_path = posixpath.join(dest_path, artifact_path)
+        print(f"Calling get_dir_client with '{dest_path}'")
+        dir_client = self.fs_client.get_directory_client(dest_path)
+        local_dir = os.path.abspath(local_dir)
+        for root, _, filenames in os.walk(local_dir):
+            rel_path = os.path.relpath(root, local_dir)
+            for f in filenames:
+                # TODO: can base directory client get file at path/to/directory? or do we need
+                # a new directory client per local `root` directory that we walk in os.walk?
+                file_client = dir_client.get_file_client(posixpath.join(rel_path, f))
+                local_file_path = os.path.join(root, f)
+                if os.path.getsize(local_file_path) == 0:
+                    file_client.create_file()
+                else:
+                    with open(local_file_path, "rb") as file:
+                        file_client.upload_data(data=file, overwrite=True)
+
+    def list_artifacts(self, path=None):
+        directory_to_list = self.base_data_lake_directory
+        if path:
+            directory_to_list = posixpath.join(directory_to_list, path)
+        infos = []
+        for result in self.fs_client.get_paths(path=directory_to_list, recursive=False):
+            if (
+                directory_to_list == result.name
+            ):  # result isn't actually a child of the path we're interested in, so skip it
+                continue
+            if result.is_directory:
+                subdir = posixpath.relpath(path=result.name, start=self.base_data_lake_directory)
+                if subdir.endswith("/"):
+                    subdir = subdir[:-1]
+                infos.append(FileInfo(subdir, is_dir=True, file_size=None))
+            else:
+                file_name = posixpath.relpath(path=result.name, start=self.base_data_lake_directory)
+                infos.append(FileInfo(file_name, is_dir=False, file_size=result.content_length))
+
+        # The list_artifacts API expects us to return an empty list if the
+        # the path references a single file.
+        rel_path = directory_to_list[len(self.base_data_lake_directory) + 1 :]
+        if (len(infos) == 1) and not infos[0].is_dir and (infos[0].path == rel_path):
+            return []
+        return sorted(infos, key=lambda f: f.path)
+
+    def _download_file(self, remote_file_path, local_path):
+        remote_full_path = posixpath.join(self.base_data_lake_directory, remote_file_path)
+        base_dir = posixpath.dirname(remote_full_path)
+        dir_client = self.fs_client.get_directory_client(base_dir)
+        filename = posixpath.basename(remote_full_path)
+        file_client = dir_client.get_file_client(filename)
+        with open(local_path, "wb") as file:
+            file_client.download_file().readinto(file)
+
+    def delete_artifacts(self, artifact_path=None):
+        raise NotImplementedError("This artifact repository does not support deleting artifacts")

--- a/mlflow/store/artifact/azure_data_lake_artifact_repo.py
+++ b/mlflow/store/artifact/azure_data_lake_artifact_repo.py
@@ -1,6 +1,5 @@
 import os
 import posixpath
-import pathlib
 import re
 import urllib.parse
 
@@ -14,7 +13,8 @@ from mlflow.environment_variables import MLFLOW_ARTIFACT_UPLOAD_DOWNLOAD_TIMEOUT
 
 def _parse_abfss_uri(uri):
     """
-    Parse an ABFSS URI in the format "abfss://<file_system>@<account_name>.dbfs.core.windows.net/<path>",
+    Parse an ABFSS URI in the format
+    "abfss://<file_system>@<account_name>.dbfs.core.windows.net/<path>",
     returning a tuple consisting of the filesystem, account name, and path
 
     See more details about ABFSS URIs at
@@ -31,7 +31,7 @@ def _parse_abfss_uri(uri):
 
     if match is None:
         raise MlflowException(
-            "ABFSS URI must be of the form " "abfss://<filesystem>@<account>.dfs.core.windows.net"
+            "ABFSS URI must be of the form abfss://<filesystem>@<account>.dfs.core.windows.net"
         )
     filesystem = match.group(1)
     account_name = match.group(2)
@@ -42,7 +42,7 @@ def _parse_abfss_uri(uri):
 
 
 def _get_data_lake_client(account_url, credential):
-    from azure.storage.filedatalake import DataLakeServiceClient, DataLakeDirectoryClient
+    from azure.storage.filedatalake import DataLakeServiceClient
 
     return DataLakeServiceClient(account_url, credential)
 
@@ -69,7 +69,6 @@ class AzureDataLakeArtifactRepository(ArtifactRepository):
         data_lake_client = _get_data_lake_client(account_url=account_url, credential=credential)
         self.fs_client = data_lake_client.get_file_system_client(filesystem)
         self.base_data_lake_directory = path
-        print(f"Got {self.base_data_lake_directory} from {artifact_uri}")
 
     def log_artifact(self, local_file, artifact_path=None):
         raise NotImplementedError(
@@ -80,7 +79,6 @@ class AzureDataLakeArtifactRepository(ArtifactRepository):
         dest_path = self.base_data_lake_directory
         if artifact_path:
             dest_path = posixpath.join(dest_path, artifact_path)
-        print(f"Calling get_dir_client with '{dest_path}'")
         dir_client = self.fs_client.get_directory_client(dest_path)
         local_dir = os.path.abspath(local_dir)
         for root, _, filenames in os.walk(local_dir):

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -7,6 +7,7 @@ pytest-cov
 pytest-localserver==0.5.0
 moto!=2.0.7
 azure-storage-blob>=12.0.0
+azure-storage-file-datalake>=12.9.1
 azure-identity>=1.6.1
 databricks-cli@git+https://github.com/databricks/databricks-cli.git
 pillow

--- a/tests/store/artifact/test_azure_data_lake_artifact_repo.py
+++ b/tests/store/artifact/test_azure_data_lake_artifact_repo.py
@@ -19,7 +19,7 @@ from mlflow.store.artifact.azure_data_lake_artifact_repo import (
 
 TEST_ROOT_PATH = "some/path"
 TEST_DATA_LAKE_URI_BASE = "abfss://filesystem@account.dfs.core.windows.net"
-TEST_DATA_LAKE_URI = posixpath.join(TEST_DATA_LAKE_URI_BASE, "some/path")
+TEST_DATA_LAKE_URI = posixpath.join(TEST_DATA_LAKE_URI_BASE, TEST_ROOT_PATH)
 
 
 class MockPathList:
@@ -35,9 +35,9 @@ class MockPathList:
 def mock_data_lake_client():
     mock_adls_client = mock.MagicMock(autospec=DataLakeServiceClient)
     with mock.patch(
-        "mlflow.store.artifact.azure_data_lake_artifact_repo._get_data_lake_client"
-    ) as mock_get_client:
-        mock_get_client.return_value = mock_adls_client
+        "mlflow.store.artifact.azure_data_lake_artifact_repo._get_data_lake_client",
+        return_value=mock_adls_client
+    ):
         yield mock_adls_client
 
 
@@ -233,5 +233,5 @@ def test_download_directory_artifact(
     assert file_path_1 in dir_contents
     assert file_path_2 in dir_contents
     assert dir_name in dir_contents
-    subdir_contents = os.listdir(str(dest_dir_obj.joinpath(dir_name)))
+    subdir_contents = os.listdir(dest_dir_obj.joinpath(dir_name))
     assert dir_file_name in subdir_contents

--- a/tests/store/artifact/test_azure_data_lake_artifact_repo.py
+++ b/tests/store/artifact/test_azure_data_lake_artifact_repo.py
@@ -11,7 +11,6 @@ from azure.storage.filedatalake import (
 )
 from azure.storage.filedatalake import PathProperties
 from mlflow.exceptions import MlflowException
-from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
 from mlflow.store.artifact.azure_data_lake_artifact_repo import (
     AzureDataLakeArtifactRepository,
     _parse_abfss_uri,
@@ -77,17 +76,17 @@ def test_parse_global_abfss_uri():
     global_abfs_with_multi_path = "abfss://filesystem@acct.dfs.core.windows.net/a/b"
     assert parse(global_abfs_with_multi_path) == ("filesystem", "acct", "a/b")
 
-    with pytest.raises(Exception, match="ABFSS URI must be of the form"):
+    with pytest.raises(MlflowException, match="ABFSS URI must be of the form"):
         parse("abfss://filesystem@acct.dfs.core.evil.net/path")
-    with pytest.raises(Exception, match="ABFSS URI must be of the form"):
+    with pytest.raises(MlflowException, match="ABFSS URI must be of the form"):
         parse("abfss://filesystem@acct/path")
-    with pytest.raises(Exception, match="ABFSS URI must be of the form"):
+    with pytest.raises(MlflowException, match="ABFSS URI must be of the form"):
         parse("abfss://acct.dfs.core.windows.net/path")
-    with pytest.raises(Exception, match="ABFSS URI must be of the form"):
+    with pytest.raises(MlflowException, match="ABFSS URI must be of the form"):
         parse("abfss://@acct.dfs.core.windows.net/path")
-    with pytest.raises(Exception, match="ABFSS URI must be of the form"):
+    with pytest.raises(MlflowException, match="ABFSS URI must be of the form"):
         parse("abfss://filesystem@acctxdfs.core.windows.net/path")
-    with pytest.raises(Exception, match="Not an ABFSS URI"):
+    with pytest.raises(MlflowException, match="Not an ABFSS URI"):
         parse("abfs://cont@acct.dfs.core.windows.net/path")
 
 

--- a/tests/store/artifact/test_azure_data_lake_artifact_repo.py
+++ b/tests/store/artifact/test_azure_data_lake_artifact_repo.py
@@ -62,32 +62,37 @@ def mock_file_client(mock_directory_client):
     yield mock_file_client
 
 
-def test_parse_global_abfss_uri():
-    parse = _parse_abfss_uri
-    global_abfs_with_short_path = "abfss://filesystem@acct.dfs.core.windows.net/path"
-    assert parse(global_abfs_with_short_path) == ("filesystem", "acct", "path")
+@pytest.mark.parametrize(
+    "uri, filesystem, account, path",
+    [
+        ("abfss://filesystem@acct.dfs.core.windows.net/path", "filesystem", "acct", "path"),
+        ("abfss://filesystem@acct.dfs.core.windows.net", "filesystem", "acct", ""),
+        ("abfss://filesystem@acct.dfs.core.windows.net/", "filesystem", "acct", ""),
+        ("abfss://filesystem@acct.dfs.core.windows.net/a/b", "filesystem", "acct", "a/b"),
+    ],
+)
+def test_parse_valid_abfss_uri(uri, filesystem, account, path):
+    assert _parse_abfss_uri(uri) == (filesystem, account, path)
 
-    global_abfs_without_path = "abfss://filesystem@acct.dfs.core.windows.net"
-    assert parse(global_abfs_without_path) == ("filesystem", "acct", "")
 
-    global_abfs_without_path2 = "abfss://filesystem@acct.dfs.core.windows.net/"
-    assert parse(global_abfs_without_path2) == ("filesystem", "acct", "")
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "abfss://filesystem@acct.dfs.core.evil.net/path",
+        "abfss://filesystem@acct/path",
+        "abfss://acct.dfs.core.windows.net/path",
+        "abfss://@acct.dfs.core.windows.net/path",
+        "abfss://filesystem@acctxdfs.core.windows.net/path",
+    ],
+)
+def test_parse_invalid_abfss_uri(uri):
+    with pytest.raises(MlflowException, match="ABFSS URI must be of the form"):
+        _parse_abfss_uri(uri)
 
-    global_abfs_with_multi_path = "abfss://filesystem@acct.dfs.core.windows.net/a/b"
-    assert parse(global_abfs_with_multi_path) == ("filesystem", "acct", "a/b")
 
-    with pytest.raises(MlflowException, match="ABFSS URI must be of the form"):
-        parse("abfss://filesystem@acct.dfs.core.evil.net/path")
-    with pytest.raises(MlflowException, match="ABFSS URI must be of the form"):
-        parse("abfss://filesystem@acct/path")
-    with pytest.raises(MlflowException, match="ABFSS URI must be of the form"):
-        parse("abfss://acct.dfs.core.windows.net/path")
-    with pytest.raises(MlflowException, match="ABFSS URI must be of the form"):
-        parse("abfss://@acct.dfs.core.windows.net/path")
-    with pytest.raises(MlflowException, match="ABFSS URI must be of the form"):
-        parse("abfss://filesystem@acctxdfs.core.windows.net/path")
+def test_parse_invalid_abfss_uri_bad_scheme():
     with pytest.raises(MlflowException, match="Not an ABFSS URI"):
-        parse("abfs://cont@acct.dfs.core.windows.net/path")
+        _parse_abfss_uri("abfs://cont@acct.dfs.core.windows.net/path")
 
 
 def test_list_artifacts_empty(mock_data_lake_client):
@@ -114,7 +119,7 @@ def test_list_artifacts(mock_data_lake_client, mock_filesystem_client):
     mock_filesystem_client.get_paths.return_value = MockPathList([dir_prefix, path_props])
 
     artifacts = repo.list_artifacts()
-    mock_filesystem_client.get_paths.assert_called_with(path=TEST_ROOT_PATH, recursive=False)
+    mock_filesystem_client.get_paths.assert_called_once_with(path=TEST_ROOT_PATH, recursive=False)
     assert artifacts[0].path == "dir"
     assert artifacts[0].is_dir is True
     assert artifacts[0].file_size is None
@@ -122,8 +127,9 @@ def test_list_artifacts(mock_data_lake_client, mock_filesystem_client):
     assert artifacts[1].is_dir is False
     assert artifacts[1].file_size == 42
 
+    mock_filesystem_client.reset_mock()
     repo.list_artifacts(path="nonexistent-dir")
-    mock_filesystem_client.get_paths.assert_called_with(
+    mock_filesystem_client.get_paths.assert_called_once_with(
         path=posixpath.join(TEST_ROOT_PATH, "nonexistent-dir"), recursive=False
     )
 
@@ -143,7 +149,7 @@ def test_log_artifacts(
 
     repo.log_artifacts(str(parentd))
 
-    mock_filesystem_client.get_directory_client.assert_called_with(TEST_ROOT_PATH)
+    mock_filesystem_client.get_directory_client.assert_called_once_with(TEST_ROOT_PATH)
     call_list = mock_directory_client.get_file_client.call_args_list
 
     # Ensure that we uploaded all the expected files
@@ -170,7 +176,7 @@ def test_download_file_artifact(
     mock_file_client.download_file().readinto.side_effect = create_file
     repo.download_artifacts("test.txt")
     assert os.path.exists(os.path.join(str(tmp_path), "test.txt"))
-    mock_directory_client.get_file_client.assert_called_with("test.txt")
+    mock_directory_client.get_file_client.assert_called_once_with("test.txt")
 
 
 def test_download_directory_artifact(

--- a/tests/store/artifact/test_azure_data_lake_artifact_repo.py
+++ b/tests/store/artifact/test_azure_data_lake_artifact_repo.py
@@ -1,0 +1,230 @@
+import os
+import posixpath
+import pytest
+from unittest import mock
+
+from azure.storage.filedatalake import (
+    DataLakeServiceClient,
+    FileSystemClient,
+    DataLakeDirectoryClient,
+    DataLakeFileClient,
+)
+from azure.storage.filedatalake import PathProperties
+from mlflow.exceptions import MlflowException
+from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
+from mlflow.store.artifact.azure_data_lake_artifact_repo import (
+    AzureDataLakeArtifactRepository,
+    _parse_abfss_uri,
+)
+
+
+TEST_ROOT_PATH = "some/path"
+TEST_DATA_LAKE_URI_BASE = "abfss://filesystem@account.dfs.core.windows.net"
+TEST_DATA_LAKE_URI = posixpath.join(TEST_DATA_LAKE_URI_BASE, "some/path")
+
+
+class MockPathList:
+    def __init__(self, items, next_marker=None):
+        self.items = items
+        self.next_marker = next_marker
+
+    def __iter__(self):
+        return iter(self.items)
+
+
+@pytest.fixture
+def mock_data_lake_client():
+    mock_adls_client = mock.MagicMock(autospec=DataLakeServiceClient)
+    with mock.patch(
+        "mlflow.store.artifact.azure_data_lake_artifact_repo._get_data_lake_client"
+    ) as mock_get_client:
+        mock_get_client.return_value = mock_adls_client
+        yield mock_adls_client
+
+
+@pytest.fixture
+def mock_filesystem_client(mock_data_lake_client):
+    mock_fs_client = mock.MagicMock(autospec=FileSystemClient)
+    mock_data_lake_client.get_file_system_client.return_value = mock_fs_client
+    yield mock_fs_client
+
+
+@pytest.fixture
+def mock_directory_client(mock_filesystem_client):
+    mock_directory_client = mock.MagicMock(autospec=DataLakeDirectoryClient)
+    mock_filesystem_client.get_directory_client.return_value = mock_directory_client
+    yield mock_directory_client
+
+
+@pytest.fixture
+def mock_file_client(mock_directory_client):
+    mock_file_client = mock.MagicMock(autospec=DataLakeFileClient)
+    mock_directory_client.get_file_client.return_value = mock_file_client
+    yield mock_file_client
+
+
+def test_parse_global_abfss_uri():
+    parse = _parse_abfss_uri
+    global_abfs_with_short_path = "abfss://filesystem@acct.dfs.core.windows.net/path"
+    assert parse(global_abfs_with_short_path) == ("filesystem", "acct", "path")
+
+    global_abfs_without_path = "abfss://filesystem@acct.dfs.core.windows.net"
+    assert parse(global_abfs_without_path) == ("filesystem", "acct", "")
+
+    global_abfs_without_path2 = "abfss://filesystem@acct.dfs.core.windows.net/"
+    assert parse(global_abfs_without_path2) == ("filesystem", "acct", "")
+
+    global_abfs_with_multi_path = "abfss://filesystem@acct.dfs.core.windows.net/a/b"
+    assert parse(global_abfs_with_multi_path) == ("filesystem", "acct", "a/b")
+
+    with pytest.raises(Exception, match="ABFSS URI must be of the form"):
+        parse("abfss://filesystem@acct.dfs.core.evil.net/path")
+    with pytest.raises(Exception, match="ABFSS URI must be of the form"):
+        parse("abfss://filesystem@acct/path")
+    with pytest.raises(Exception, match="ABFSS URI must be of the form"):
+        parse("abfss://acct.dfs.core.windows.net/path")
+    with pytest.raises(Exception, match="ABFSS URI must be of the form"):
+        parse("abfss://@acct.dfs.core.windows.net/path")
+    with pytest.raises(Exception, match="ABFSS URI must be of the form"):
+        parse("abfss://filesystem@acctxdfs.core.windows.net/path")
+    with pytest.raises(Exception, match="Not an ABFSS URI"):
+        parse("abfs://cont@acct.dfs.core.windows.net/path")
+
+
+def test_list_artifacts_empty(mock_data_lake_client):
+    repo = AzureDataLakeArtifactRepository(TEST_DATA_LAKE_URI, None)
+    mock_data_lake_client.get_file_system_client.get_paths.return_value = MockPathList([])
+    assert repo.list_artifacts() == []
+
+
+def test_list_artifacts_single_file(mock_data_lake_client):
+    repo = AzureDataLakeArtifactRepository(TEST_DATA_LAKE_URI, mock_data_lake_client)
+
+    # Evaluate single file
+    path_props = PathProperties(name=posixpath.join(TEST_DATA_LAKE_URI, "file"), content_length=42)
+    mock_data_lake_client.get_file_system_client.get_paths.return_value = MockPathList([path_props])
+    assert repo.list_artifacts("file") == []
+
+
+def test_list_artifacts(mock_data_lake_client, mock_filesystem_client):
+    repo = AzureDataLakeArtifactRepository(TEST_DATA_LAKE_URI, None)
+
+    # Create some files to return
+    dir_prefix = PathProperties(is_directory=True, name=posixpath.join(TEST_ROOT_PATH, "dir"))
+    path_props = PathProperties(content_length=42, name=posixpath.join(TEST_ROOT_PATH, "file"))
+    mock_filesystem_client.get_paths.return_value = MockPathList([dir_prefix, path_props])
+
+    artifacts = repo.list_artifacts()
+    mock_filesystem_client.get_paths.assert_called_with(path=TEST_ROOT_PATH, recursive=False)
+    assert artifacts[0].path == "dir"
+    assert artifacts[0].is_dir is True
+    assert artifacts[0].file_size is None
+    assert artifacts[1].path == "file"
+    assert artifacts[1].is_dir is False
+    assert artifacts[1].file_size == 42
+
+    repo.list_artifacts(path="nonexistent-dir")
+    mock_filesystem_client.get_paths.assert_called_with(
+        path=posixpath.join(TEST_ROOT_PATH, "nonexistent-dir"), recursive=False
+    )
+
+
+def test_log_artifacts(
+    mock_data_lake_client, mock_filesystem_client, mock_directory_client, mock_file_client, tmpdir
+):
+    repo = AzureDataLakeArtifactRepository(TEST_DATA_LAKE_URI, None)
+
+    parentd = tmpdir.mkdir("data")
+    subd = parentd.mkdir("subdir")
+    parentd.join("a.txt").write("A")
+    subd.join("b.txt").write("B")
+    subd.join("empty-file.txt").write("")
+
+    repo.log_artifacts(parentd.strpath)
+
+    mock_filesystem_client.get_directory_client.assert_called_with(TEST_ROOT_PATH)
+    call_list = mock_directory_client.get_file_client.call_args_list
+
+    # Ensure that we uploaded all the expected files
+    uploaded_filenames = [call[0][0] for call in call_list]
+    nonempty_files = {"./a.txt", "subdir/b.txt"}
+    empty_files = {"subdir/empty-file.txt"}
+    assert set(uploaded_filenames) == nonempty_files.union(empty_files)
+
+    mock_directory_client.get_file_client("./a.txt").upload_data.assert_called()
+    mock_directory_client.get_file_client("subdir/b.txt").upload_data.assert_called()
+    mock_directory_client.get_file_client("subdir/empty-file.txt").create_file.assert_called()
+
+
+def test_download_file_artifact(
+    mock_data_lake_client, mock_filesystem_client, mock_directory_client, mock_file_client, tmpdir
+):
+    repo = AzureDataLakeArtifactRepository(TEST_DATA_LAKE_URI, None)
+
+    def create_file(file):
+        local_path = os.path.basename(file.name)
+        f = tmpdir.join(local_path)
+        f.write("hello world!")
+
+    mock_file_client.download_file().readinto.side_effect = create_file
+    repo.download_artifacts("test.txt")
+    assert os.path.exists(os.path.join(tmpdir.strpath, "test.txt"))
+    mock_directory_client.get_file_client.assert_called_with("test.txt")
+
+
+def test_download_directory_artifact(
+    mock_data_lake_client, mock_filesystem_client, mock_file_client, tmpdir
+):
+    repo = AzureDataLakeArtifactRepository(TEST_DATA_LAKE_URI, mock_data_lake_client)
+
+    file_path_1 = "file_1"
+    file_path_2 = "file_2"
+
+    path_props_1 = PathProperties(
+        content_length=42, name=posixpath.join(TEST_ROOT_PATH, file_path_1)
+    )
+    path_props_2 = PathProperties(
+        content_length=42, name=posixpath.join(TEST_ROOT_PATH, file_path_2)
+    )
+
+    dir_name = "dir"
+    dir_path = posixpath.join(TEST_ROOT_PATH, dir_name)
+    dir_props = PathProperties(is_directory=True, name=dir_path)
+    dir_file_name = "subdir_file"
+    dir_file_props = PathProperties(content_length=42, name=posixpath.join(dir_path, dir_file_name))
+
+    def get_mock_listing(*args, **kwargs):
+        """
+        Produces a mock listing that only contains content if the
+        specified prefix is the artifact root. This allows us to mock
+        `list_artifacts` during the `_download_artifacts_into` subroutine
+        without recursively listing the same artifacts at every level of the
+        directory traversal.
+        """
+        # pylint: disable=unused-argument
+        path_arg = posixpath.abspath(kwargs["path"])
+        if path_arg == posixpath.abspath(TEST_ROOT_PATH):
+            return MockPathList([path_props_1, path_props_2, dir_props])
+        elif path_arg == posixpath.abspath(dir_path):
+            return MockPathList([dir_file_props])
+        else:
+            return MockPathList([])
+
+    def create_file(buffer):
+        buffer.write(b"hello world!")
+
+    mock_filesystem_client.get_paths.side_effect = get_mock_listing
+    mock_file_client.download_file().readinto.side_effect = create_file
+
+    # Ensure that the root directory can be downloaded successfully
+    dest_dir_obj = tmpdir.join("download_dir")
+    dest_dir_obj.mkdir()
+    dest_dir = dest_dir_obj.strpath
+    repo.download_artifacts(artifact_path="", dst_path=dest_dir)
+    # Ensure that the `mkfile` side effect copied all of the download artifacts into `tmpdir`
+    dir_contents = os.listdir(dest_dir)
+    assert file_path_1 in dir_contents
+    assert file_path_2 in dir_contents
+    assert dir_name in dir_contents
+    subdir_contents = os.listdir(dest_dir_obj.join(dir_name).strpath)
+    assert dir_file_name in subdir_contents


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Adds an internal-only implementation of ArtifactRepository for Azure Data Lake Storage Gen2, to support writing ML model version files to UC at storage locations like `abfss://filesystem@account.dfs.core.windows.net`. Future community contributions could complete support for other artifact operations in this repo (e.g. support for `log_artifact`, left unimplemented in this PR), and register it in the artifact repo registry to support logging artifacts to `abfss://...` URIs

## How is this patch tested?
Unit tests. Also manually verified I could use this artifact repo to write files to ADLS Gen2

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
