### PR TITLE
Enhance GCS artifact repo to support passing custom client

### DIFF
--- a/mlflow/store/artifact/gcs_artifact_repo.py
+++ b/mlflow/store/artifact/gcs_artifact_repo.py
@@ -74,7 +74,9 @@ class GCSArtifactRepository(ArtifactRepository):
             return self.gcs.Client.create_anonymous_client()
 
     def _get_bucket(self, bucket):
-        return self._get_client().bucket(bucket)
+        client = self._get_client()
+        print(f"Got client {client}")
+        return client.bucket(bucket)
 
     def log_artifact(self, local_file, artifact_path=None):
         (bucket, dest_path) = self.parse_gcs_uri(self.artifact_uri)

--- a/mlflow/store/artifact/gcs_artifact_repo.py
+++ b/mlflow/store/artifact/gcs_artifact_repo.py
@@ -19,22 +19,13 @@ class GCSArtifactRepository(ArtifactRepository):
     Stores artifacts on Google Cloud Storage.
 
     :param artifact_uri: URI of GCS bucket
-    :param client: Optional, exposed for testing. Python module to use for GCS
-                   operations, defaults to google.cloud.storage.
-    :param gcs_client: Optional. The actual client to use for GCS operations; a default
+    :param client: Optional. The client to use for GCS operations; a default
                        client object will be created if unspecified, using default
                        credentials as described in https://google-cloud.readthedocs.io/en/latest/core/auth.html
     """
 
-    def __init__(self, artifact_uri, client=None, gcs_client=None):
-        if client:
-            self.gcs = client
-        else:
-            from google.cloud import storage as gcs_storage
-
-            self.gcs = gcs_storage
-        self.client = gcs_client
-
+    def __init__(self, artifact_uri, client=None):
+        self.client = client
         from google.cloud.storage.constants import _DEFAULT_TIMEOUT
 
         self._GCS_DOWNLOAD_CHUNK_SIZE = MLFLOW_GCS_DOWNLOAD_CHUNK_SIZE.get()
@@ -67,13 +58,14 @@ class GCSArtifactRepository(ArtifactRepository):
 
     def _get_client(self):
         from google.auth.exceptions import DefaultCredentialsError
+        from google.cloud import storage as gcs_storage
 
         if self.client is not None:
             return self.client
         try:
-            return self.gcs.Client()
+            return gcs_storage.Client()
         except DefaultCredentialsError:
-            return self.gcs.Client.create_anonymous_client()
+            return gcs_storage.Client.create_anonymous_client()
 
     def _get_bucket(self, bucket):
         return self._get_client().bucket(bucket)

--- a/mlflow/store/artifact/gcs_artifact_repo.py
+++ b/mlflow/store/artifact/gcs_artifact_repo.py
@@ -31,6 +31,7 @@ class GCSArtifactRepository(ArtifactRepository):
             self.gcs = client
         else:
             from google.cloud import storage as gcs_storage
+
             self.gcs = gcs_storage
         self.client = gcs_client
 
@@ -66,6 +67,7 @@ class GCSArtifactRepository(ArtifactRepository):
 
     def _get_client(self):
         from google.auth.exceptions import DefaultCredentialsError
+
         if self.client is not None:
             return self.client
         try:
@@ -74,9 +76,7 @@ class GCSArtifactRepository(ArtifactRepository):
             return self.gcs.Client.create_anonymous_client()
 
     def _get_bucket(self, bucket):
-        client = self._get_client()
-        print(f"Got client {client}")
-        return client.bucket(bucket)
+        return self._get_client().bucket(bucket)
 
     def log_artifact(self, local_file, artifact_path=None):
         (bucket, dest_path) = self.parse_gcs_uri(self.artifact_uri)

--- a/tests/store/artifact/test_gcs_artifact_repo.py
+++ b/tests/store/artifact/test_gcs_artifact_repo.py
@@ -13,18 +13,6 @@ from tests.helper_functions import mock_method_chain
 
 
 @pytest.fixture
-def gcs_mock():
-    # Make sure that the environment variable isn't set to actually make calls
-    old_G_APP_CREDS = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
-    os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = "/dev/null"
-
-    yield mock.MagicMock(autospec=gcs_client)
-
-    if old_G_APP_CREDS:
-        os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = old_G_APP_CREDS
-
-
-@pytest.fixture
 def mock_client():
     yield mock.MagicMock(autospec=gcs_client.Client)
 

--- a/tests/store/artifact/test_gcs_artifact_repo.py
+++ b/tests/store/artifact/test_gcs_artifact_repo.py
@@ -34,14 +34,13 @@ def test_list_artifacts_empty(gcs_mock):
     gcs_mock.Client.return_value.bucket.return_value.list_blobs.return_value = mock.MagicMock()
     assert repo.list_artifacts() == []
 
+
 def test_custom_gcs_client_used():
     mock_client = mock.MagicMock(autospec=gcs_client.Client)
-    print(f"Using client {mock_cliente}")
     repo = GCSArtifactRepository("gs://test_bucket/some/path", gcs_client=mock_client)
     mock_client.bucket.return_value.list_blobs.return_value = mock.MagicMock()
     repo.list_artifacts()
-    mock_client.bucket.list_blobs.assert_called()
-
+    mock_client.bucket.assert_called()
 
 
 def test_list_artifacts(gcs_mock):

--- a/tests/store/artifact/test_gcs_artifact_repo.py
+++ b/tests/store/artifact/test_gcs_artifact_repo.py
@@ -24,28 +24,33 @@ def gcs_mock():
         os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = old_G_APP_CREDS
 
 
+@pytest.fixture
+def mock_client():
+    yield mock.MagicMock(autospec=gcs_client.Client)
+
+
 def test_artifact_uri_factory():
     repo = get_artifact_repository("gs://test_bucket/some/path")
     assert isinstance(repo, GCSArtifactRepository)
 
 
-def test_list_artifacts_empty(gcs_mock):
-    repo = GCSArtifactRepository("gs://test_bucket/some/path", gcs_mock)
-    gcs_mock.Client.return_value.bucket.return_value.list_blobs.return_value = mock.MagicMock()
+def test_list_artifacts_empty(mock_client):
+    repo = GCSArtifactRepository("gs://test_bucket/some/path", client=mock_client)
+    mock_client.bucket.return_value.list_blobs.return_value = mock.MagicMock()
     assert repo.list_artifacts() == []
 
 
 def test_custom_gcs_client_used():
     mock_client = mock.MagicMock(autospec=gcs_client.Client)
-    repo = GCSArtifactRepository("gs://test_bucket/some/path", gcs_client=mock_client)
+    repo = GCSArtifactRepository("gs://test_bucket/some/path", client=mock_client)
     mock_client.bucket.return_value.list_blobs.return_value = mock.MagicMock()
     repo.list_artifacts()
     mock_client.bucket.assert_called()
 
 
-def test_list_artifacts(gcs_mock):
+def test_list_artifacts(mock_client):
     artifact_root_path = "/experiment_id/run_id/"
-    repo = GCSArtifactRepository("gs://test_bucket" + artifact_root_path, gcs_mock)
+    repo = GCSArtifactRepository("gs://test_bucket" + artifact_root_path, client=mock_client)
 
     # mocked bucket/blob structure
     # gs://test_bucket/experiment_id/run_id/
@@ -69,7 +74,7 @@ def test_list_artifacts(gcs_mock):
     mock_results.configure_mock(pages=[dir_mock])
     mock_results.__iter__.return_value = [obj_mock]
 
-    gcs_mock.Client.return_value.bucket.return_value.list_blobs.return_value = mock_results
+    mock_client.bucket.return_value.list_blobs.return_value = mock_results
 
     artifacts = repo.list_artifacts(path=None)
 
@@ -83,9 +88,9 @@ def test_list_artifacts(gcs_mock):
 
 
 @pytest.mark.parametrize("dir_name", ["model", "model/"])
-def test_list_artifacts_with_subdir(gcs_mock, dir_name):
+def test_list_artifacts_with_subdir(mock_client, dir_name):
     artifact_root_path = "/experiment_id/run_id/"
-    repo = GCSArtifactRepository("gs://test_bucket" + artifact_root_path, gcs_mock)
+    repo = GCSArtifactRepository("gs://test_bucket" + artifact_root_path, client=mock_client)
 
     # mocked bucket/blob structure
     # gs://test_bucket/experiment_id/run_id/
@@ -106,10 +111,10 @@ def test_list_artifacts_with_subdir(gcs_mock, dir_name):
     mock_results.configure_mock(pages=[subdir_mock])
     mock_results.__iter__.return_value = [obj_mock]
 
-    gcs_mock.Client.return_value.bucket.return_value.list_blobs.return_value = mock_results
+    mock_client.bucket.return_value.list_blobs.return_value = mock_results
 
     artifacts = repo.list_artifacts(path=dir_name)
-    gcs_mock.Client().bucket().list_blobs.assert_called_with(
+    mock_client.bucket().list_blobs.assert_called_with(
         prefix=posixpath.join(artifact_root_path[1:], "model/"), delimiter="/"
     )
     assert len(artifacts) == 2
@@ -121,8 +126,8 @@ def test_list_artifacts_with_subdir(gcs_mock, dir_name):
     assert artifacts[1].file_size is None
 
 
-def test_log_artifact(gcs_mock, tmpdir):
-    repo = GCSArtifactRepository("gs://test_bucket/some/path", gcs_mock)
+def test_log_artifact(mock_client, tmpdir):
+    repo = GCSArtifactRepository("gs://test_bucket/some/path", mock_client)
 
     d = tmpdir.mkdir("data")
     f = d.join("test.txt")
@@ -138,9 +143,8 @@ def test_log_artifact(gcs_mock, tmpdir):
         return os.path.isfile(kwargs.get("filename"))
 
     mock_method_chain(
-        gcs_mock,
+        mock_client,
         [
-            "Client",
             "bucket",
             "blob",
             "upload_from_filename",
@@ -149,17 +153,17 @@ def test_log_artifact(gcs_mock, tmpdir):
     )
     repo.log_artifact(fpath)
 
-    gcs_mock.Client().bucket.assert_called_with("test_bucket")
-    gcs_mock.Client().bucket().blob.assert_called_with(
+    mock_client.bucket.assert_called_with("test_bucket")
+    mock_client.bucket().blob.assert_called_with(
         "some/path/test.txt", chunk_size=repo._GCS_UPLOAD_CHUNK_SIZE
     )
-    gcs_mock.Client().bucket().blob().upload_from_filename.assert_called_with(
+    mock_client.bucket().blob().upload_from_filename.assert_called_with(
         fpath, timeout=repo._GCS_DEFAULT_TIMEOUT
     )
 
 
-def test_log_artifacts(gcs_mock, tmpdir):
-    repo = GCSArtifactRepository("gs://test_bucket/some/path", gcs_mock)
+def test_log_artifacts(mock_client, tmpdir):
+    repo = GCSArtifactRepository("gs://test_bucket/some/path", mock_client)
 
     subd = tmpdir.mkdir("data").mkdir("subdir")
     subd.join("a.txt").write("A")
@@ -172,9 +176,8 @@ def test_log_artifacts(gcs_mock, tmpdir):
         return os.path.isfile(kwargs.get("filename"))
 
     mock_method_chain(
-        gcs_mock,
+        mock_client,
         [
-            "Client",
             "bucket",
             "blob",
             "upload_from_filename",
@@ -183,8 +186,8 @@ def test_log_artifacts(gcs_mock, tmpdir):
     )
     repo.log_artifacts(subd.strpath)
 
-    gcs_mock.Client().bucket.assert_called_with("test_bucket")
-    gcs_mock.Client().bucket().blob().upload_from_filename.assert_has_calls(
+    mock_client.bucket.assert_called_with("test_bucket")
+    mock_client.bucket().blob().upload_from_filename.assert_has_calls(
         [
             mock.call(
                 os.path.normpath("%s/a.txt" % subd.strpath), timeout=repo._GCS_DEFAULT_TIMEOUT
@@ -200,8 +203,8 @@ def test_log_artifacts(gcs_mock, tmpdir):
     )
 
 
-def test_download_artifacts_calls_expected_gcs_client_methods(gcs_mock, tmpdir):
-    repo = GCSArtifactRepository("gs://test_bucket/some/path", gcs_mock)
+def test_download_artifacts_calls_expected_gcs_client_methods(mock_client, tmpdir):
+    repo = GCSArtifactRepository("gs://test_bucket/some/path", mock_client)
 
     def mkfile(fname, **kwargs):
         # pylint: disable=unused-argument
@@ -210,9 +213,8 @@ def test_download_artifacts_calls_expected_gcs_client_methods(gcs_mock, tmpdir):
         f.write("hello world!")
 
     mock_method_chain(
-        gcs_mock,
+        mock_client,
         [
-            "Client",
             "bucket",
             "blob",
             "download_to_filename",
@@ -222,29 +224,30 @@ def test_download_artifacts_calls_expected_gcs_client_methods(gcs_mock, tmpdir):
 
     repo.download_artifacts("test.txt")
     assert os.path.exists(os.path.join(tmpdir.strpath, "test.txt"))
-    gcs_mock.Client().bucket.assert_called_with("test_bucket")
-    gcs_mock.Client().bucket().blob.assert_called_with(
+    mock_client.bucket.assert_called_with("test_bucket")
+    mock_client.bucket().blob.assert_called_with(
         "some/path/test.txt", chunk_size=repo._GCS_DOWNLOAD_CHUNK_SIZE
     )
-    download_calls = gcs_mock.Client().bucket().blob().download_to_filename.call_args_list
+    download_calls = mock_client.bucket().blob().download_to_filename.call_args_list
     assert len(download_calls) == 1
     download_path_arg = download_calls[0][0][0]
     assert "test.txt" in download_path_arg
 
 
-def test_get_anonymous_bucket(gcs_mock):
-    gcs_mock.Client.side_effect = DefaultCredentialsError("Test")
-    repo = GCSArtifactRepository("gs://test_bucket", gcs_mock)
-    repo._get_bucket("gs://test_bucket")
-    anon_call_count = gcs_mock.Client.create_anonymous_client.call_count
-    assert anon_call_count == 1
-    bucket_call_count = gcs_mock.Client.create_anonymous_client.return_value.bucket.call_count
-    assert bucket_call_count == 1
+def test_get_anonymous_bucket():
+    with mock.patch("google.cloud.storage", autospec=True) as gcs_mock:
+        gcs_mock.Client.side_effect = DefaultCredentialsError("Test")
+        repo = GCSArtifactRepository("gs://test_bucket")
+        repo._get_bucket("gs://test_bucket")
+        anon_call_count = gcs_mock.Client.create_anonymous_client.call_count
+        assert anon_call_count == 1
+        bucket_call_count = gcs_mock.Client.create_anonymous_client.return_value.bucket.call_count
+        assert bucket_call_count == 1
 
 
-def test_download_artifacts_downloads_expected_content(gcs_mock, tmpdir):
+def test_download_artifacts_downloads_expected_content(mock_client, tmpdir):
     artifact_root_path = "/experiment_id/run_id/"
-    repo = GCSArtifactRepository("gs://test_bucket" + artifact_root_path, gcs_mock)
+    repo = GCSArtifactRepository("gs://test_bucket" + artifact_root_path, mock_client)
 
     obj_mock_1 = mock.Mock()
     file_path_1 = "file1"
@@ -280,18 +283,16 @@ def test_download_artifacts_downloads_expected_content(gcs_mock, tmpdir):
         f.write("hello world!")
 
     mock_method_chain(
-        gcs_mock,
+        mock_client,
         [
-            "Client",
             "bucket",
             "list_blobs",
         ],
         side_effect=get_mock_listing,
     )
     mock_method_chain(
-        gcs_mock,
+        mock_client,
         [
-            "Client",
             "bucket",
             "blob",
             "download_to_filename",
@@ -307,9 +308,9 @@ def test_download_artifacts_downloads_expected_content(gcs_mock, tmpdir):
     assert file_path_2 in dir_contents
 
 
-def test_delete_artifacts(gcs_mock):
+def test_delete_artifacts(mock_client):
     experiment_root_path = "/experiment_id/"
-    repo = GCSArtifactRepository("gs://test_bucket" + experiment_root_path, gcs_mock)
+    repo = GCSArtifactRepository("gs://test_bucket" + experiment_root_path, mock_client)
 
     def delete_file():
         del obj_mock.name
@@ -342,9 +343,8 @@ def test_delete_artifacts(gcs_mock):
             return mock_empty_results
 
     mock_method_chain(
-        gcs_mock,
+        mock_client,
         [
-            "Client",
             "bucket",
             "list_blobs",
         ],

--- a/tests/store/artifact/test_gcs_artifact_repo.py
+++ b/tests/store/artifact/test_gcs_artifact_repo.py
@@ -36,6 +36,7 @@ def test_list_artifacts_empty(gcs_mock):
 
 def test_custom_gcs_client_used():
     mock_client = mock.MagicMock(autospec=gcs_client.Client)
+    print(f"Using client {mock_cliente}")
     repo = GCSArtifactRepository("gs://test_bucket/some/path", gcs_client=mock_client)
     mock_client.bucket.return_value.list_blobs.return_value = mock.MagicMock()
     repo.list_artifacts()

--- a/tests/store/artifact/test_gcs_artifact_repo.py
+++ b/tests/store/artifact/test_gcs_artifact_repo.py
@@ -34,6 +34,14 @@ def test_list_artifacts_empty(gcs_mock):
     gcs_mock.Client.return_value.bucket.return_value.list_blobs.return_value = mock.MagicMock()
     assert repo.list_artifacts() == []
 
+def test_custom_gcs_client_used():
+    mock_client = mock.MagicMock(autospec=gcs_client.Client)
+    repo = GCSArtifactRepository("gs://test_bucket/some/path", gcs_client=mock_client)
+    mock_client.bucket.return_value.list_blobs.return_value = mock.MagicMock()
+    repo.list_artifacts()
+    mock_client.bucket.list_blobs.assert_called()
+
+
 
 def test_list_artifacts(gcs_mock):
     artifact_root_path = "/experiment_id/run_id/"


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

Similar to #7859 , #7858 

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Adds internal-facing support for passing a custom client, for custom auth, in the `GcsArtifactRepository`

## How is this patch tested?
Updated unit tests, and verified I could manually write to UC file storage using this updated client

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
