### PR TITLE
Reserve 'databricks-uc' registry URI scheme in MLflow Python client

### DIFF
--- a/mlflow/tracking/_model_registry/utils.py
+++ b/mlflow/tracking/_model_registry/utils.py
@@ -19,6 +19,7 @@ from mlflow.tracking._tracking_service.utils import (
 )
 from mlflow.utils import env, rest_utils
 from mlflow.utils.databricks_utils import get_databricks_host_creds
+from mlflow.utils.uri import _DATABRICKS_UNITY_CATALOG_SCHEME
 
 _REGISTRY_URI_ENV_VAR = "MLFLOW_REGISTRY_URI"
 
@@ -182,7 +183,9 @@ def _get_store_registry():
     _model_registry_store_registry.register("databricks", _get_databricks_rest_store)
     # Register a placeholder function that raises if users pass a registry URI with scheme
     # "databricks-uc"
-    _model_registry_store_registry.register("databricks-uc", _get_databricks_uc_rest_store)
+    _model_registry_store_registry.register(
+        _DATABRICKS_UNITY_CATALOG_SCHEME, _get_databricks_uc_rest_store
+    )
 
     for scheme in ["http", "https"]:
         _model_registry_store_registry.register(scheme, _get_rest_store)

--- a/mlflow/tracking/_model_registry/utils.py
+++ b/mlflow/tracking/_model_registry/utils.py
@@ -150,6 +150,17 @@ def _get_databricks_rest_store(store_uri, **_):
     return RestStore(partial(get_databricks_host_creds, store_uri))
 
 
+def _get_databricks_uc_rest_store(store_uri, **_):
+    from mlflow.exceptions import MlflowException
+    from mlflow.version import VERSION
+
+    raise MlflowException(
+        f"The current version of the MLflow client ({VERSION}) does not support models "
+        f"in the Unity Catalog. Please upgrade to the latest version of the MLflow Python client "
+        f"to access models in the Unity Catalog"
+    )
+
+
 # We define the global variable as `None` so that instantiating the store does not lead to circular
 # dependency issues.
 _model_registry_store_registry = None
@@ -166,6 +177,9 @@ def _get_store_registry():
 
     _model_registry_store_registry = ModelRegistryStoreRegistry()
     _model_registry_store_registry.register("databricks", _get_databricks_rest_store)
+    # Register a placeholder function that raises if users pass a registry URI with scheme
+    # "databricks-uc"
+    _model_registry_store_registry.register("databricks-uc", _get_databricks_uc_rest_store)
 
     for scheme in ["http", "https"]:
         _model_registry_store_registry.register(scheme, _get_rest_store)

--- a/mlflow/tracking/_model_registry/utils.py
+++ b/mlflow/tracking/_model_registry/utils.py
@@ -1,6 +1,7 @@
 import os
 from functools import partial
 
+import mlflow
 from mlflow.environment_variables import MLFLOW_TRACKING_AWS_SIGV4
 from mlflow.store.db.db_types import DATABASE_ENGINES
 from mlflow.store.model_registry.file_store import FileStore
@@ -155,9 +156,11 @@ def _get_databricks_uc_rest_store(store_uri, **_):
     from mlflow.version import VERSION
 
     raise MlflowException(
-        f"The current version of the MLflow client ({VERSION}) does not support models "
+        f"Detected Unity Catalog model registry URI '{mlflow.get_registry_uri()}'. "
+        f"However, the current version of the MLflow client ({VERSION}) does not support models "
         f"in the Unity Catalog. Please upgrade to the latest version of the MLflow Python client "
-        f"to access models in the Unity Catalog"
+        f"to access models in the Unity Catalog, or specify a different registry URI via "
+        f"mlflow.set_registry_uri()"
     )
 
 

--- a/mlflow/tracking/registry.py
+++ b/mlflow/tracking/registry.py
@@ -70,7 +70,9 @@ class StoreRegistry:
                  ``mlflow.store.{tracking|model_registry}.AbstractStore`` that fulfills the store
                   URI requirements.
         """
-        scheme = store_uri if store_uri == "databricks" else get_uri_scheme(store_uri)
+        scheme = (
+            store_uri if store_uri in {"databricks", "databricks-uc"} else get_uri_scheme(store_uri)
+        )
 
         try:
             store_builder = self._registry[scheme]

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -16,6 +16,7 @@ _INVALID_DB_URI_MSG = (
 
 _DBFS_FUSE_PREFIX = "/dbfs/"
 _DBFS_HDFS_URI_PREFIX = "dbfs:/"
+_DATABRICKS_UNITY_CATALOG_SCHEME = "databricks-uc"
 
 
 def is_local_uri(uri):

--- a/tests/tracking/_model_registry/test_utils.py
+++ b/tests/tracking/_model_registry/test_utils.py
@@ -1,7 +1,8 @@
 import io
 import pickle
-import pytest
 import os
+import pytest
+from unittest import mock
 
 import mlflow.tracking
 from mlflow.exceptions import MlflowException

--- a/tests/tracking/_model_registry/test_utils.py
+++ b/tests/tracking/_model_registry/test_utils.py
@@ -134,8 +134,9 @@ def test_get_store_caches_on_store_uri(tmpdir):
 @pytest.mark.parametrize("store_uri", ["databricks-uc", "databricks-uc://profile"])
 def test_get_store_raises_on_uc_registry_uri(store_uri, reset_registry_uri):
     set_registry_uri(store_uri)
+    client = mlflow.tracking.MlflowClient()
     with pytest.raises(MlflowException, match="does not support models in the Unity Catalog"):
-        mlflow.tracking.MlflowClient().search_registered_models()
+        client.search_registered_models()
 
 
 def test_store_object_can_be_serialized_by_pickle():


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Reserves the "databricks-uc" registry URI scheme in the MLflow Python client, in advance of the next MLflow release. For now, attempting to use this registry URI will cause calls to model registry client APIs to throw with a message encouraging the caller to upgrade to the latest MLflow client to access models in UC. We do this to provide better error UX than if we do nothing, in which case calling `set_registry_uri("databricks-uc")` will cause the client to just silently log to a local file named `databricks-uc`

## How is this patch tested?


- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
