### PR TITLE
Fix flaky `test_recipe_batch_dag_clean_step_works`

### DIFF
--- a/tests/recipes/regression/v1/test_regression_pipeline_batch_scoring.py
+++ b/tests/recipes/regression/v1/test_regression_pipeline_batch_scoring.py
@@ -54,13 +54,13 @@ def test_recipe_batch_dag_execution_directories(enter_recipe_example_directory):
 # This test should run last as it cleans the batch scoring steps
 @pytest.mark.parametrize("step", _STEP_NAMES)
 def test_recipe_batch_dag_clean_step_works(step, run_batch_scoring, enter_recipe_example_directory):
-    # Running this test immediately after `test_recipe_batch_dag_get_artifacts` sometimes fails
-    # with the following error:
-    # ------------------------------
+    # On Windows, Running this test immediately after `test_recipe_batch_dag_get_artifacts`
+    # sometimes fails with an error that looks like the following:
+    # ----------------------------------------------------------------------------------------------
     # PermissionError: [WinError 32] The process cannot access the file because it is being used by
     # another process: 'C:\\path\\to\\custom\\steps\\predict\\outputs\\scored.parquet\\part-00000-5
     # 4161f55-351d-4e90-bb18-7f754bfbd467-c000.snappy.parquet'
-    # ------------------------------
+    # ----------------------------------------------------------------------------------------------
     # To ensure all the file handles to the parquet files are released, sleep for 3 seconds.
     time.sleep(3)
     r = run_batch_scoring

--- a/tests/recipes/regression/v1/test_regression_pipeline_batch_scoring.py
+++ b/tests/recipes/regression/v1/test_regression_pipeline_batch_scoring.py
@@ -54,15 +54,15 @@ def test_recipe_batch_dag_execution_directories(enter_recipe_example_directory):
 # This test should run last as it cleans the batch scoring steps
 @pytest.mark.parametrize("step", _STEP_NAMES)
 def test_recipe_batch_dag_clean_step_works(step, run_batch_scoring, enter_recipe_example_directory):
-    # On Windows, Running this test immediately after `test_recipe_batch_dag_get_artifacts`
-    # sometimes fails with an error that looks like the following:
+    # This test sometimes fails on Windows with an error that looks like the following:
     # ----------------------------------------------------------------------------------------------
     # PermissionError: [WinError 32] The process cannot access the file because it is being used by
     # another process: 'C:\\path\\to\\custom\\steps\\predict\\outputs\\scored.parquet\\part-00000-5
     # 4161f55-351d-4e90-bb18-7f754bfbd467-c000.snappy.parquet'
     # ----------------------------------------------------------------------------------------------
-    # To ensure all the file handles to the parquet files are released, sleep for 3 seconds.
-    time.sleep(3)
+    # To avoid this error, we sleep for 1 second to ensure all the handles to the parquet files are
+    # release before we try to delete them.
+    time.sleep(1)
     r = run_batch_scoring
     r.clean(step)
     expected_execution_directory_location = pathlib.Path(

--- a/tests/recipes/regression/v1/test_regression_pipeline_batch_scoring.py
+++ b/tests/recipes/regression/v1/test_regression_pipeline_batch_scoring.py
@@ -2,6 +2,7 @@ import pandas as pd
 import pathlib
 import pytest
 import shutil
+import time
 
 import mlflow
 from mlflow.recipes.utils.execution import get_or_create_base_execution_directory
@@ -53,6 +54,15 @@ def test_recipe_batch_dag_execution_directories(enter_recipe_example_directory):
 # This test should run last as it cleans the batch scoring steps
 @pytest.mark.parametrize("step", _STEP_NAMES)
 def test_recipe_batch_dag_clean_step_works(step, run_batch_scoring, enter_recipe_example_directory):
+    # Running this test immediately after `test_recipe_batch_dag_get_artifacts` sometimes fails
+    # with the following error:
+    # ------------------------------
+    # PermissionError: [WinError 32] The process cannot access the file because it is being used by
+    # another process: 'C:\\path\\to\\custom\\steps\\predict\\outputs\\scored.parquet\\part-00000-5
+    # 4161f55-351d-4e90-bb18-7f754bfbd467-c000.snappy.parquet'
+    # ------------------------------
+    # To ensure all the file handles to the parquet files are released, sleep for 3 seconds.
+    time.sleep(3)
     r = run_batch_scoring
     r.clean(step)
     expected_execution_directory_location = pathlib.Path(

--- a/tests/recipes/regression/v1/test_regression_pipeline_batch_scoring.py
+++ b/tests/recipes/regression/v1/test_regression_pipeline_batch_scoring.py
@@ -61,7 +61,7 @@ def test_recipe_batch_dag_clean_step_works(step, run_batch_scoring, enter_recipe
     # 4161f55-351d-4e90-bb18-7f754bfbd467-c000.snappy.parquet'
     # ----------------------------------------------------------------------------------------------
     # To avoid this error, we sleep for 1 second to ensure all the handles to the parquet files are
-    # release before we try to delete them.
+    # released before we try to delete them.
     time.sleep(1)
     r = run_batch_scoring
     r.clean(step)


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

`test_recipe_batch_dag_clean_step_works` has been flaky for a while. This PR fixes it.

https://github.com/mlflow/mlflow/actions/runs/4202099259/jobs/7289836062

```
path = 'C:\\Users\\runneradmin\\AppData\\Local\\Temp\\pytest-of-runneradmin\\pytest-0\\test_recipes_execution_directo1\\custom\\steps\\predict\\outputs\\scored.parquet'
onerror = <function rmtree.<locals>.onerror at 0x0000023B0141F1F0>

    def _rmtree_unsafe(path, onerror):
        try:
            with os.scandir(path) as scandir_it:
                entries = list(scandir_it)
        except OSError:
            onerror(os.scandir, path, sys.exc_info())
            entries = []
        for entry in entries:
            fullname = entry.path
            if _rmtree_isdir(entry):
                try:
                    if entry.is_symlink():
                        # This can only happen if someone replaces
                        # a directory with a symlink after the call to
                        # os.scandir or entry.is_dir above.
                        raise OSError("Cannot call rmtree on a symbolic link")
                except OSError:
                    onerror(os.path.islink, fullname, sys.exc_info())
                    continue
                _rmtree_unsafe(fullname, onerror)
            else:
                try:
>                   os.unlink(fullname)
E                   PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\runneradmin\\AppData\\Local\\Temp\\pytest-of-runneradmin\\pytest-0\\test_recipes_execution_directo1\\custom\\steps\\predict\\outputs\\scored.parquet\\part-00000-b79efe82-a26e-492c-9a38-e11eef0610f4-c000.snappy.parquet'
```

https://issues.apache.org/jira/browse/ARROW-16421 seems related.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
