### PR TITLE
Improve error message if user tries to set tracking URI to UC

### DIFF
--- a/mlflow/tracking/_tracking_service/utils.py
+++ b/mlflow/tracking/_tracking_service/utils.py
@@ -178,7 +178,7 @@ def _get_databricks_uc_rest_store(store_uri, **_):
     global _tracking_store_registry
     supported_schemes = [
         scheme
-        for scheme in _tracking_store_registry._registry.keys()
+        for scheme in _tracking_store_registry._registry
         if scheme != _DATABRICKS_UNITY_CATALOG_SCHEME
     ]
     raise MlflowException(

--- a/mlflow/tracking/_tracking_service/utils.py
+++ b/mlflow/tracking/_tracking_service/utils.py
@@ -172,13 +172,15 @@ def _get_databricks_rest_store(store_uri, **_):
 
 def _get_databricks_uc_rest_store(store_uri, **_):
     from mlflow.exceptions import MlflowException
+    from mlflow.version import VERSION
 
     global _tracking_store_registry
     raise MlflowException(
         f"Detected Unity Catalog tracking URI '{store_uri}'. "
-        f"Setting the tracking URI to a Unity Catalog backend is currently unsupported. "
+        f"Setting the tracking URI to a Unity Catalog backend is not supported in the current "
+        f"version of the MLflow client ({VERSION}). "
         f"Please specify a different tracking URI via mlflow.set_tracking_uri, with "
-        f"one of the following supported schemes: "
+        f"one of the supported schemes: "
         f"{list(_tracking_store_registry._registry.keys())}. "
         f"If you're trying to access models in the Unity Catalog, please upgrade to the "
         f"latest version of the MLflow Python client, then specify a Unity Catalog "

--- a/mlflow/tracking/_tracking_service/utils.py
+++ b/mlflow/tracking/_tracking_service/utils.py
@@ -176,14 +176,16 @@ def _get_databricks_uc_rest_store(store_uri, **_):
     global _tracking_store_registry
     raise MlflowException(
         f"Detected Unity Catalog tracking URI '{store_uri}'. "
-        f"Setting the tracking URI to a Unity Catalog backend is currently unsupported. Please "
-        f"specify a different tracking URI via mlflow.set_tracking_uri, with one of the following supported "
-        f"schemes: {list(_tracking_store_registry._registry.keys())}. "
-        f"If you're trying to access models in the Unity Catalog, please upgrade to the latest version of the "
-        f"MLflow Python client, then specify a Unity Catalog "
+        f"Setting the tracking URI to a Unity Catalog backend is currently unsupported. "
+        f"Please specify a different tracking URI via mlflow.set_tracking_uri, with "
+        f"one of the following supported schemes: "
+        f"{list(_tracking_store_registry._registry.keys())}. "
+        f"If you're trying to access models in the Unity Catalog, please upgrade to the "
+        f"latest version of the MLflow Python client, then specify a Unity Catalog "
         f"model registry URI via mlflow.set_registry_uri('databricks-uc') or "
-        f"mlflow.set_registry_uri('databricks-uc://profile_name'), where 'profile_name' is the name of the "
-        f"Databricks CLI profile to use for authentication. Be sure to leave the tracking URI configured to use "
+        f"mlflow.set_registry_uri('databricks-uc://profile_name'), where "
+        f"'profile_name' is the name of the Databricks CLI profile to use for "
+        f"authentication. Be sure to leave the tracking URI configured to use "
         f"one of the supported schemes listed above."
     )
 

--- a/mlflow/tracking/_tracking_service/utils.py
+++ b/mlflow/tracking/_tracking_service/utils.py
@@ -176,12 +176,11 @@ def _get_databricks_uc_rest_store(store_uri, **_):
     from mlflow.version import VERSION
 
     global _tracking_store_registry
-    supported_schemes = list(
-        filter(
-            lambda scheme: scheme != _DATABRICKS_UNITY_CATALOG_SCHEME,
-            list(_tracking_store_registry._registry.keys()),
-        )
-    )
+    supported_schemes = [
+        scheme
+        for scheme in _tracking_store_registry._registry.keys()
+        if scheme != _DATABRICKS_UNITY_CATALOG_SCHEME
+    ]
     raise MlflowException(
         f"Detected Unity Catalog tracking URI '{store_uri}'. "
         "Setting the tracking URI to a Unity Catalog backend is not supported in the current "

--- a/mlflow/tracking/_tracking_service/utils.py
+++ b/mlflow/tracking/_tracking_service/utils.py
@@ -15,7 +15,6 @@ from mlflow.utils import env, rest_utils
 from mlflow.utils.file_utils import path_to_local_file_uri
 from mlflow.utils.databricks_utils import get_databricks_host_creds
 
-
 _TRACKING_URI_ENV_VAR = "MLFLOW_TRACKING_URI"
 
 # Extra environment variables which take precedence for setting the basic/bearer
@@ -171,10 +170,29 @@ def _get_databricks_rest_store(store_uri, **_):
     return RestStore(partial(get_databricks_host_creds, store_uri))
 
 
+def _get_databricks_uc_rest_store(store_uri, **_):
+    from mlflow.exceptions import MlflowException
+
+    global _tracking_store_registry
+    raise MlflowException(
+        f"Detected Unity Catalog tracking URI '{store_uri}'. "
+        f"Setting the tracking URI to a Unity Catalog backend is currently unsupported. Please "
+        f"specify a different tracking URI via mlflow.set_tracking_uri, with one of the following supported "
+        f"schemes: {list(_tracking_store_registry._registry.keys())}. "
+        f"If you're trying to access models in the Unity Catalog, please upgrade to the latest version of the "
+        f"MLflow Python client, then specify a Unity Catalog "
+        f"model registry URI via mlflow.set_registry_uri('databricks-uc') or "
+        f"mlflow.set_registry_uri('databricks-uc://profile_name'), where 'profile_name' is the name of the "
+        f"Databricks CLI profile to use for authentication. Be sure to leave the tracking URI configured to use "
+        f"one of the supported schemes listed above."
+    )
+
+
 _tracking_store_registry = TrackingStoreRegistry()
 _tracking_store_registry.register("", _get_file_store)
 _tracking_store_registry.register("file", _get_file_store)
 _tracking_store_registry.register("databricks", _get_databricks_rest_store)
+_tracking_store_registry.register("databricks-uc", _get_databricks_uc_rest_store)
 
 for scheme in ["http", "https"]:
     _tracking_store_registry.register(scheme, _get_rest_store)

--- a/tests/tracking/_tracking_service/test_utils.py
+++ b/tests/tracking/_tracking_service/test_utils.py
@@ -385,6 +385,7 @@ def test_get_store_raises_on_uc_uri(store_uri):
     set_tracking_uri(store_uri)
     with pytest.raises(
         MlflowException,
-        match="Setting the tracking URI to a Unity Catalog backend is currently unsupported",
+        match="Setting the tracking URI to a Unity Catalog backend is not "
+        "supported in the current version of the MLflow client",
     ):
         mlflow.tracking.MlflowClient()

--- a/tests/tracking/_tracking_service/test_utils.py
+++ b/tests/tracking/_tracking_service/test_utils.py
@@ -378,3 +378,13 @@ def test_set_tracking_uri_with_path(tmp_path, monkeypatch, absolute):
     with mock.patch("mlflow.tracking._tracking_service.utils._tracking_uri", None):
         set_tracking_uri(path)
         assert get_tracking_uri() == path.absolute().resolve().as_uri()
+
+
+@pytest.mark.parametrize("store_uri", ["databricks-uc", "databricks-uc://profile"])
+def test_get_store_raises_on_uc_uri(store_uri):
+    set_tracking_uri(store_uri)
+    with pytest.raises(
+        MlflowException,
+        match="Setting the tracking URI to a Unity Catalog backend is currently unsupported",
+    ):
+        mlflow.tracking.MlflowClient()


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs
This PR is similar to #7863, but for the MLflow tracking client

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Similarly to how #7863 reserved the `databricks-uc` URI scheme for the registry client, this PR reserves the `databricks-uc` URI scheme for the MLflow tracking client, so that users see a better + more actionable error message if they call `mlflow.set_tracking_uri("databricks-uc")`

## How is this patch tested?

Unit tests, also manually verified the updated error message. 

Before this PR:

```Python
>>> import mlflow; mlflow.set_tracking_uri("databricks-uc"); mlflow.log_param("a", "b")
Traceback (most recent call last):
  File "/Users/sid.murching/mlflow/mlflow/tracking/registry.py", line 77, in get_store_builder
    store_builder = self._registry[scheme]
KeyError: 'databricks-uc'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/sid.murching/mlflow/mlflow/tracking/fluent.py", line 544, in log_param
    run_id = _get_or_start_run().info.run_id
  File "/Users/sid.murching/mlflow/mlflow/tracking/fluent.py", line 1552, in _get_or_start_run
    return start_run()
  File "/Users/sid.murching/mlflow/mlflow/tracking/fluent.py", line 278, in start_run
    client = MlflowClient()
  File "/Users/sid.murching/mlflow/mlflow/tracking/client.py", line 69, in __init__
    self._tracking_client = TrackingServiceClient(final_tracking_uri)
  File "/Users/sid.murching/mlflow/mlflow/tracking/_tracking_service/client.py", line 51, in __init__
    self.store
  File "/Users/sid.murching/mlflow/mlflow/tracking/_tracking_service/client.py", line 55, in store
    return utils._get_store(self.tracking_uri)
  File "/Users/sid.murching/mlflow/mlflow/tracking/_tracking_service/utils.py", line 189, in _get_store
    return _tracking_store_registry.get_store(store_uri, artifact_uri)
  File "/Users/sid.murching/mlflow/mlflow/tracking/_tracking_service/registry.py", line 39, in get_store
    return self._get_store_with_resolved_uri(resolved_store_uri, artifact_uri)
  File "/Users/sid.murching/mlflow/mlflow/tracking/_tracking_service/registry.py", line 48, in _get_store_with_resolved_uri
    builder = self.get_store_builder(resolved_store_uri)
  File "/Users/sid.murching/mlflow/mlflow/tracking/registry.py", line 79, in get_store_builder
    raise UnsupportedModelRegistryStoreURIException(
mlflow.tracking.registry.UnsupportedModelRegistryStoreURIException:  Model registry functionality is unavailable; got unsupported URI 'databricks-uc' for model registry data storage. Supported URI schemes are: ['', 'file', 'databricks', 'http', 'https', 'postgresql', 'mysql', 'sqlite', 'mssql', 'file-plugin']. See https://www.mlflow.org/docs/latest/tracking.html#storage for how to run an MLflow server against one of the supported backend storage locations.
```

After this PR:

```Python
>>> import mlflow; mlflow.set_tracking_uri("databricks-uc"); mlflow.log_param("a", "b")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/sid.murching/mlflow/mlflow/tracking/fluent.py", line 544, in log_param
    run_id = _get_or_start_run().info.run_id
  File "/Users/sid.murching/mlflow/mlflow/tracking/fluent.py", line 1552, in _get_or_start_run
    return start_run()
  File "/Users/sid.murching/mlflow/mlflow/tracking/fluent.py", line 278, in start_run
    client = MlflowClient()
  File "/Users/sid.murching/mlflow/mlflow/tracking/client.py", line 69, in __init__
    self._tracking_client = TrackingServiceClient(final_tracking_uri)
  File "/Users/sid.murching/mlflow/mlflow/tracking/_tracking_service/client.py", line 51, in __init__
    self.store
  File "/Users/sid.murching/mlflow/mlflow/tracking/_tracking_service/client.py", line 55, in store
    return utils._get_store(self.tracking_uri)
  File "/Users/sid.murching/mlflow/mlflow/tracking/_tracking_service/utils.py", line 207, in _get_store
    return _tracking_store_registry.get_store(store_uri, artifact_uri)
  File "/Users/sid.murching/mlflow/mlflow/tracking/_tracking_service/registry.py", line 39, in get_store
    return self._get_store_with_resolved_uri(resolved_store_uri, artifact_uri)
  File "/Users/sid.murching/mlflow/mlflow/tracking/_tracking_service/registry.py", line 49, in _get_store_with_resolved_uri
    return builder(store_uri=resolved_store_uri, artifact_uri=artifact_uri)
  File "/Users/sid.murching/mlflow/mlflow/tracking/_tracking_service/utils.py", line 177, in _get_databricks_uc_rest_store
    raise MlflowException(
mlflow.exceptions.MlflowException: Detected Unity Catalog tracking URI 'databricks-uc'. Setting the tracking URI to a Unity Catalog backend is currently unsupported. Please specify a different tracking URI via mlflow.set_tracking_uri, with one of the following supported schemes: ['', 'file', 'databricks', 'databricks-uc', 'http', 'https', 'postgresql', 'mysql', 'sqlite', 'mssql', 'file-plugin']. If you're trying to access models in the Unity Catalog, please upgrade to the latest version of the MLflow Python client, then specify a Unity Catalog model registry URI via mlflow.set_registry_uri('databricks-uc') or mlflow.set_registry_uri('databricks-uc://profile_name'), where 'profile_name' is the name of the Databricks CLI profile to use for authentication. Be sure to leave the tracking URI configured to use one of the supported schemes listed above.
```

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
