### PR TITLE
Fix: `TypeError: describe() got an unexpected keyword argument 'datetime_is_numeric'` in pandas 2.0.0rc0 

### DIFF
--- a/mlflow/recipes/cards/pandas_renderer.py
+++ b/mlflow/recipes/cards/pandas_renderer.py
@@ -5,6 +5,7 @@ import base64
 import numpy as np
 import pandas as pd
 import sys
+from packaging.version import Version
 
 from typing import Union, Iterable, Tuple
 from mlflow.protos import facet_feature_statistics_pb2
@@ -116,9 +117,12 @@ def convert_to_dataset_feature_statistics(
             if converter:
                 date_time_converted = converter(current_column_value)
                 current_column_value = pd.DataFrame(date_time_converted)[0]
-                pandas_describe_key = current_column_value.describe(
-                    datetime_is_numeric=True, include="all"
+                kwargs = (
+                    {}
+                    if Version(pd.__version__) > Version("1.5")
+                    else {"datetime_is_numeric": True}
                 )
+                pandas_describe_key = current_column_value.describe(include="all", **kwargs)
                 quantiles[key] = current_column_value.quantile(quantiles_to_get)
 
             default_value = 0

--- a/mlflow/recipes/cards/pandas_renderer.py
+++ b/mlflow/recipes/cards/pandas_renderer.py
@@ -91,7 +91,8 @@ def convert_to_dataset_feature_statistics(
     fs_proto = facet_feature_statistics_pb2.FeatureNameStatistics
     feature_stats = facet_feature_statistics_pb2.DatasetFeatureStatistics()
     data_type_custom_stat = facet_feature_statistics_pb2.CustomStatistic()
-    pandas_describe = df.describe(datetime_is_numeric=True, include="all")
+    kwargs = {} if Version(pd.__version__) > Version("1.5") else {"datetime_is_numeric": True}
+    pandas_describe = df.describe(include="all", **kwargs)
     feature_stats.num_examples = len(df)
     quantiles_to_get = [x * 10 / 100 for x in range(10 + 1)]
     try:

--- a/mlflow/recipes/cards/pandas_renderer.py
+++ b/mlflow/recipes/cards/pandas_renderer.py
@@ -91,7 +91,7 @@ def convert_to_dataset_feature_statistics(
     fs_proto = facet_feature_statistics_pb2.FeatureNameStatistics
     feature_stats = facet_feature_statistics_pb2.DatasetFeatureStatistics()
     data_type_custom_stat = facet_feature_statistics_pb2.CustomStatistic()
-    kwargs = {} if Version(pd.__version__) > Version("1.5") else {"datetime_is_numeric": True}
+    kwargs = {} if Version(pd.__version__) >= Version("2.0.0rc0") else {"datetime_is_numeric": True}
     pandas_describe = df.describe(include="all", **kwargs)
     feature_stats.num_examples = len(df)
     quantiles_to_get = [x * 10 / 100 for x in range(10 + 1)]
@@ -120,7 +120,7 @@ def convert_to_dataset_feature_statistics(
                 current_column_value = pd.DataFrame(date_time_converted)[0]
                 kwargs = (
                     {}
-                    if Version(pd.__version__) > Version("1.5")
+                    if Version(pd.__version__) >= Version("2.0.0rc0")
                     else {"datetime_is_numeric": True}
                 )
                 pandas_describe_key = current_column_value.describe(include="all", **kwargs)


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->


Fix #7878

## What changes are proposed in this pull request?

Added fix as per @harupy suggestion in #7878

(Please fill in changes proposed in this fix)

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
