### PR TITLE
Replaces `np.dtype("datetime64")` and `np.datetime64` with `np.dtype("datetime64[ns]")` for pandas 2.0

### DIFF
--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -381,7 +381,7 @@ def _enforce_mlflow_datatype(name, values: pd.Series, t: DataType):
         # NB: Pyspark date columns get converted to object when converted to a pandas
         # DataFrame. To respect the original typing, we convert the column to datetime.
         try:
-            return values.astype(np.datetime64, errors="raise")
+            return values.astype(np.dtype("datetime64[ns]"), errors="raise")
         except ValueError as e:
             raise MlflowException(
                 "Failed to convert column {} from type {} to {}.".format(name, values.dtype, t)

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -375,7 +375,7 @@ def _enforce_mlflow_datatype(name, values: pd.Series, t: DataType):
         # NB: datetime values have variable precision denoted by brackets, e.g. datetime64[ns]
         # denotes nanosecond precision. Since MLflow datetime type is precision agnostic, we
         # ignore precision when matching datetime columns.
-        return values
+        return values.astype(np.dtype("datetime64[ns]"))
 
     if t == DataType.datetime and values.dtype == object:
         # NB: Pyspark date columns get converted to object when converted to a pandas

--- a/mlflow/types/schema.py
+++ b/mlflow/types/schema.py
@@ -39,7 +39,7 @@ class DataType(Enum):
     """Text data."""
     binary = (7, np.dtype("bytes"), "BinaryType", object)
     """Sequence of raw bytes."""
-    datetime = (8, np.dtype("datetime64"), "TimestampType")
+    datetime = (8, np.dtype("datetime64[ns]"), "TimestampType")
     """64b datetime data."""
 
     def __repr__(self):

--- a/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
+++ b/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
@@ -161,7 +161,7 @@ def test_column_schema_enforcement():
     pdf["b"] = pdf["b"].astype(np.int64)
     pdf["c"] = pdf["c"].astype(np.float32)
     pdf["d"] = pdf["d"].astype(np.float64)
-    pdf["h"] = pdf["h"].astype(np.datetime64)
+    pdf["h"] = pdf["h"].astype(np.dtype("datetime64[ns]"))
     # test that missing column raises
     match_missing_inputs = "Model is missing inputs"
     with pytest.raises(MlflowException, match=match_missing_inputs):


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Replaces `np.dtype("datetime64")` and `np.datetime64` with `np.dtype("datetime64[ns]")` for pandas 2.0.

```python
>>> pd.Series(["2022-01-01"]).astype("datetime64")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/pandas/core/generic.py", line 6305, in astype
    new_data = self._mgr.astype(dtype=dtype, copy=copy, errors=errors)
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/pandas/core/internals/managers.py", line 436, in astype
    return self.apply(
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/pandas/core/internals/managers.py", line 346, in apply
    applied = getattr(b, f)(**kwargs)
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/pandas/core/internals/blocks.py", line 509, in astype
    new_values = astype_array_safe(values, dtype, copy=copy, errors=errors)
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/pandas/core/dtypes/astype.py", line 242, in astype_array_safe
    new_values = astype_array(values, dtype, copy=copy)
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/pandas/core/dtypes/astype.py", line 187, in astype_array
    values = _astype_nansafe(values, dtype, copy=copy)
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/pandas/core/dtypes/astype.py", line 116, in _astype_nansafe
    return dta.astype(dtype, copy=False)._ndarray
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/pandas/core/arrays/datetimes.py", line 694, in astype
    raise TypeError(
TypeError: Casting to unit-less dtype 'datetime64' is not supported. Pass e.g. 'datetime64[ns]' instead.

>>> pd.Series(["2022-01-01"]).astype("datetime64[ns]")
0   2022-01-01
dtype: datetime64[ns]
```

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

Tested in #7876

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
