### PR TITLE
Use a shorter timeout for `_await_server_up_or_die`

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,7 +36,7 @@ def test_mlflow_server_command(command):
     cmd = ["mlflow", command, "--port", str(port)]
     process = subprocess.Popen(cmd)
     try:
-        _await_server_up_or_die(port, timeout=20)
+        _await_server_up_or_die(port)
         resp = requests.get(f"http://localhost:{port}/health")
         augmented_raise_for_status(resp)
         assert resp.text == "OK"
@@ -436,7 +436,7 @@ def test_mlflow_tracking_disabled_in_artifacts_only_mode():
     port = get_safe_port()
     cmd = ["mlflow", "server", "--port", str(port), "--artifacts-only"]
     process = subprocess.Popen(cmd)
-    _await_server_up_or_die(port, timeout=20)
+    _await_server_up_or_die(port)
     resp = requests.get(f"http://localhost:{port}/api/2.0/mlflow/experiments/search")
     assert (
         "Endpoint: /api/2.0/mlflow/experiments/search disabled due to the mlflow server running "
@@ -450,7 +450,7 @@ def test_mlflow_artifact_list_in_artifacts_only_mode():
     cmd = ["mlflow", "server", "--port", str(port), "--artifacts-only"]
     process = subprocess.Popen(cmd)
     try:
-        _await_server_up_or_die(port, timeout=20)
+        _await_server_up_or_die(port)
         resp = requests.get(f"http://localhost:{port}/api/2.0/mlflow-artifacts/artifacts")
         augmented_raise_for_status(resp)
         assert resp.status_code == 200
@@ -464,7 +464,7 @@ def test_mlflow_artifact_service_unavailable_when_no_server_artifacts_is_specifi
     cmd = ["mlflow", "server", "--port", str(port), "--no-serve-artifacts"]
     process = subprocess.Popen(cmd)
     try:
-        _await_server_up_or_die(port, timeout=20)
+        _await_server_up_or_die(port)
         endpoint = "/api/2.0/mlflow-artifacts/artifacts"
         resp = requests.get(f"http://localhost:{port}{endpoint}")
         assert (

--- a/tests/tracking/integration_test_utils.py
+++ b/tests/tracking/integration_test_utils.py
@@ -18,12 +18,11 @@ def _await_server_up_or_die(port, timeout=5):
     _logger.info(f"Awaiting server to be up on {LOCALHOST}:{port}")
     start_time = time.time()
     while time.time() - start_time < timeout:
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.settimeout(2)
-        result = sock.connect_ex((LOCALHOST, port))
-        if result == 0:
-            _logger.info(f"Server is up on {LOCALHOST}:{port}!")
-            break
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.settimeout(2)
+            if sock.connect_ex((LOCALHOST, port)) == 0:
+                _logger.info(f"Server is up on {LOCALHOST}:{port}!")
+                break
         _logger.info("Server not yet up, waiting...")
         time.sleep(0.5)
     else:

--- a/tests/tracking/integration_test_utils.py
+++ b/tests/tracking/integration_test_utils.py
@@ -13,7 +13,7 @@ from tests.helper_functions import LOCALHOST, get_safe_port
 _logger = logging.getLogger(__name__)
 
 
-def _await_server_up_or_die(port, timeout=5):
+def _await_server_up_or_die(port, timeout=10):
     """Waits until the local flask server is listening on the given port."""
     _logger.info(f"Awaiting server to be up on {LOCALHOST}:{port}")
     start_time = time.time()

--- a/tests/tracking/integration_test_utils.py
+++ b/tests/tracking/integration_test_utils.py
@@ -17,19 +17,17 @@ def _await_server_up_or_die(port, timeout=5):
     """Waits until the local flask server is listening on the given port."""
     _logger.info(f"Awaiting server to be up on {LOCALHOST}:{port}")
     start_time = time.time()
-    connected = False
-    while not connected and time.time() - start_time < timeout:
+    while time.time() - start_time < timeout:
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.settimeout(2)
         result = sock.connect_ex((LOCALHOST, port))
         if result == 0:
-            connected = True
-        else:
-            _logger.info("Server not yet up, waiting...")
-            time.sleep(0.5)
-    if not connected:
+            _logger.info(f"Server is up on {LOCALHOST}:{port}!")
+            break
+        _logger.info("Server not yet up, waiting...")
+        time.sleep(0.5)
+    else:
         raise Exception(f"Failed to connect on {LOCALHOST}:{port} after {timeout} seconds")
-    _logger.info(f"Server is up on {LOCALHOST}:{port}!")
 
 
 # NB: We explicitly wait and timeout on server shutdown in order to ensure that pytest output

--- a/tests/tracking/integration_test_utils.py
+++ b/tests/tracking/integration_test_utils.py
@@ -26,7 +26,7 @@ def _await_server_up_or_die(port, timeout=5):
         _logger.info("Server not yet up, waiting...")
         time.sleep(0.5)
     else:
-        raise Exception(f"Failed to connect on {LOCALHOST}:{port} after {timeout} seconds")
+        raise Exception(f"Failed to connect on {LOCALHOST}:{port} within {timeout} seconds")
 
 
 # NB: We explicitly wait and timeout on server shutdown in order to ensure that pytest output

--- a/tests/tracking/integration_test_utils.py
+++ b/tests/tracking/integration_test_utils.py
@@ -13,7 +13,7 @@ from tests.helper_functions import LOCALHOST, get_safe_port
 _logger = logging.getLogger(__name__)
 
 
-def _await_server_up_or_die(port, timeout=60):
+def _await_server_up_or_die(port, timeout=5):
     """Waits until the local flask server is listening on the given port."""
     _logger.info(f"Awaiting server to be up on {LOCALHOST}:{port}")
     start_time = time.time()


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

The default timeout value of `_await_server_up_or_die` is too long. This PR reduces it to 5 seconds, which should be long enough for a tracking server to start.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
