### PR TITLE
Fix `tests/dev/test_update_ml_package_versions.py`

### DIFF
--- a/dev/update_ml_package_versions.py
+++ b/dev/update_ml_package_versions.py
@@ -7,12 +7,10 @@ $ pip install packaging pyyaml
 # How to run (make sure you're in the repository root):
 $ python dev/update_ml_package_versions.py
 """
-import argparse
 import json
 from pathlib import Path
 from packaging.version import Version
 import re
-import sys
 import urllib.request
 import yaml
 
@@ -90,18 +88,6 @@ def update_max_version(src, key, new_max_version, category):
     return re.sub(pattern, rf'\g<1>"{new_max_version}"', src, flags=re.DOTALL)
 
 
-def parse_args(args):
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "-p",
-        "--path",
-        help="Path to the ML package versions yaml (default: mlflow/ml-package-versions.yml)",
-        default="mlflow/ml-package-versions.yml",
-        required=False,
-    )
-    return parser.parse_args(args)
-
-
 def extract_field(d, keys):
     for key in keys:
         if key in d:
@@ -132,7 +118,7 @@ def update_ml_package_versions_py(config_path):
                 },
             }
 
-        this_file = Path(__file__).resolve().relative_to(Path.cwd())
+        this_file = Path(__file__).name
         dst = Path("mlflow", "ml_package_versions.py")
         config = json.dumps(config, indent=4)
         Path(dst).write_text(
@@ -145,10 +131,8 @@ _ML_PACKAGE_VERSIONS = {config}
         )
 
 
-def main(args):
-    args = parse_args(args)
-
-    yml_path = args.path
+def main():
+    yml_path = "mlflow/ml-package-versions.yml"
     old_src = read_file(yml_path)
     new_src = old_src
     config_dict = yaml.load(old_src, Loader=yaml.SafeLoader)
@@ -176,4 +160,4 @@ def main(args):
 
 
 if __name__ == "__main__":
-    main(sys.argv[1:])
+    main()


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #7913 broke tests

## What changes are proposed in this pull request?

Running `pytest tests/dev/test_update_ml_package_versions.py` modifies `mlflow/ml_package_versions.py` and makes `_ML_PACKAGE_VERSIONS` empty.

```
> pytest tests/dev/test_update_ml_package_versions.py
...

> cat mlflow/ml_package_versions.py
# This file was auto-generated by dev/update_ml_package_versions.py.
# Please do not edit it manually.

_ML_PACKAGE_VERSIONS = {}
```

Empty `_ML_PACKAGE_VERSIONS ` causes the following error. This PR fixes this issue.

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/runner/work/mlflow/mlflow/mlflow/__init__.py", line 53, in <module>
    from mlflow import fastai
  File "/home/runner/work/mlflow/mlflow/mlflow/fastai/__init__.py", line 423, in <module>
    def autolog(
  File "/home/runner/work/mlflow/mlflow/mlflow/utils/autologging_utils/__init__.py", line 422, in wrapper
    wrapped_autolog.__doc__ = gen_autologging_package_version_requirements_doc(name) + (
  File "/home/runner/work/mlflow/mlflow/mlflow/utils/autologging_utils/__init__.py", line 304, in gen_autologging_package_version_requirements_doc
    min_ver, max_ver, pip_release = get_min_max_version_and_pip_release(module_key)
  File "/home/runner/work/mlflow/mlflow/mlflow/utils/autologging_utils/versioning.py", line 59, in get_min_max_version_and_pip_release
    min_version = _ML_PACKAGE_VERSIONS[module_key]["autologging"]["minimum"]
KeyError: 'fastai'
```

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
