### PR TITLE
[Recipes][Bugfix] Correctly fixing the toPandas issue for datetime datatype to correctly render profiling

### DIFF
--- a/mlflow/recipes/steps/ingest/datasets.py
+++ b/mlflow/recipes/steps/ingest/datasets.py
@@ -522,7 +522,9 @@ class _SparkDatasetMixin:
     def _convert_spark_df_to_pandas(self, spark_df):
         import pandas as pd
 
-        datetime_cols = [schema[0] for schema in spark_df.dtypes if schema[1].startswith("date")]
+        datetime_cols = [
+            field.name for field in spark_df.schema.fields if str(field.dataType) == "DateType"
+        ]
         pandas_df = spark_df.toPandas()
         pandas_df[datetime_cols] = pandas_df[datetime_cols].apply(pd.to_datetime, errors="coerce")
 

--- a/tests/recipes/test_ingest_step.py
+++ b/tests/recipes/test_ingest_step.py
@@ -864,3 +864,58 @@ def test_ingest_skips_profiling_when_specified(pandas_df, tmp_path):
         step_card_html_content = f.read()
     assert "facets-overview" not in step_card_html_content
     mock_profiling.assert_not_called()
+
+
+@pytest.mark.usefixtures("enter_test_recipe_directory")
+def test_ingests_spark_sql_datetime_successfully(spark_session, tmp_path):
+    from pyspark.sql.functions import (
+        col,
+        rand,
+        lit,
+        date_sub,
+        unix_timestamp,
+        to_timestamp,
+        current_date,
+        current_timestamp,
+    )
+
+    spark = spark_session.builder.getOrCreate()
+    spark_df = (
+        spark.range(10)
+        .withColumn("f1", rand(seed=123))
+        .withColumn("date_today", current_date())
+        .withColumn("time_now", current_timestamp())
+        .withColumn(
+            "timestamp", to_timestamp(unix_timestamp("time_now") - col("f1") * 60 * 60 * 24)
+        )
+        .drop("time_now")
+    )
+    # data = [("2019-01-23", 1), ("2019-06-24", 2), ("2019-09-20", 3)]
+    # spark_df = spark_session.createDataFrame(data).toDF("date", "increment")
+    spark_df.write.mode("overwrite").saveAsTable("test_table")
+
+    IngestStep.from_recipe_config(
+        recipe_config={
+            "target_col": "f1",
+            "steps": {
+                "ingest": {
+                    "using": "spark_sql",
+                    "sql": "SELECT * FROM test_table ORDER BY id",
+                }
+            },
+        },
+        recipe_root=os.getcwd(),
+    ).run(output_directory=tmp_path)
+
+    # Spark DataFrames are not ingested with a consistent row order, as doing so would incur a
+    # substantial performance cost. Accordingly, we sort the ingested DataFrame and the original
+    # DataFrame on the `id` column and reset the DataFrame index to achieve a consistent ordering
+    # before testing their equivalence
+    reloaded_df = (
+        pd.read_parquet(str(tmp_path / "dataset.parquet"))
+        .sort_values(by="id")
+        .reset_index(drop=True)
+    )
+
+    assert reloaded_df["date_today"].dtype == "datetime64[ns]"
+    assert reloaded_df["timestamp"].dtype == "datetime64[ns]"


### PR DESCRIPTION
## What changes are proposed in this pull request?
[Recipes][Bugfix] Correctly fixing the toPandas issue for datetime datatype to correctly render profiling

## How is this patch tested?
- [x] Test passed

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
