### PR TITLE
Add custom domain git (change git regex)

### DIFF
--- a/mlflow/server/js/src/common/utils/Utils.js
+++ b/mlflow/server/js/src/common/utils/Utils.js
@@ -285,7 +285,7 @@ class Utils {
       if (fileDir) {
         url = url + '/tree/master/' + fileDir;
       }
-    } 
+    }
     return url;
   }
 
@@ -329,7 +329,7 @@ class Utils {
         sourceVersion +
         '/' +
         fileDir;
-    } 
+    }
     return url;
   }
 
@@ -1063,8 +1063,7 @@ class Utils {
   }
 
   // eslint-disable-next-line prettier/prettier
-  static updatePageTitle(title) {
-  }
+  static updatePageTitle(title) {}
 
   /**
    * Check if current browser tab is the visible tab.
@@ -1150,4 +1149,3 @@ class Utils {
 }
 
 export default Utils;
-

--- a/mlflow/server/js/src/common/utils/Utils.js
+++ b/mlflow/server/js/src/common/utils/Utils.js
@@ -1062,7 +1062,8 @@ class Utils {
   }
 
   // eslint-disable-next-line prettier/prettier
-  static updatePageTitle(title) {}
+  static updatePageTitle(title) {
+  }
 
   /**
    * Check if current browser tab is the visible tab.

--- a/mlflow/server/js/src/common/utils/Utils.js
+++ b/mlflow/server/js/src/common/utils/Utils.js
@@ -236,6 +236,14 @@ class Utils {
     return withoutTrailingSlash;
   }
 
+  /**
+   * Regular expression for URLs containing the string 'git'.
+   * It can be http (e.g. https://github.com/mlflow/mlflow#examples/sklearn_elasticnet_wine),
+   * ssh (e.g. git@github.com:mlflow/mlflow.git) or
+   * custom git domain (e.g. https://git.custom.in/repo/dir#file/dir).
+   * Excluding the first overall match, there are three groups: git url, repo directory, and file directory.
+   * (e.g. group1: https://github.com, group2: mlflow/mlflow, group3: examples/sklearn_elasticnet_wine)
+   */
   static getGitRegex() {
     return /(.*?[@/][^?]*git.*?)[:/]([^#]+)(?:#(.*))?/;
   }
@@ -1110,4 +1118,5 @@ class Utils {
 }
 
 export default Utils;
+
 

--- a/mlflow/server/js/src/common/utils/Utils.js
+++ b/mlflow/server/js/src/common/utils/Utils.js
@@ -318,8 +318,7 @@ class Utils {
         '/' +
         bitbucketMatch[3];
     } else if (gitMatch) {
-      // eslint-disable-next-line no-unused-vars
-      const [_fullUrl, baseUrl, repoDir, fileDir] = gitMatch;
+      const [, baseUrl, repoDir, fileDir] = gitMatch;
       url =
         baseUrl.replace(/git@/, 'https://') +
         '/' +

--- a/mlflow/server/js/src/common/utils/Utils.js
+++ b/mlflow/server/js/src/common/utils/Utils.js
@@ -236,12 +236,8 @@ class Utils {
     return withoutTrailingSlash;
   }
 
-  static getGitHubRegex() {
-    return /[@/]github.com[:/]([^/.]+)\/([^/#]+)#?(.*)/;
-  }
-
-  static getGitLabRegex() {
-    return /[@/]gitlab.com[:/]([^/.]+)\/([^/#]+)#?(.*)/;
+  static getGitRegex() {
+    return /(.*?[@/][^?]*git.*?)[:/]([^#]+)(?:#(.*))?/;
   }
 
   static getBitbucketRegex() {
@@ -249,16 +245,14 @@ class Utils {
   }
 
   static getGitRepoUrl(sourceName) {
-    const gitHubMatch = sourceName.match(Utils.getGitHubRegex());
-    const gitLabMatch = sourceName.match(Utils.getGitLabRegex());
+    const gitMatch = sourceName.match(Utils.getGitRegex());
     const bitbucketMatch = sourceName.match(Utils.getBitbucketRegex());
     let url = null;
-    if (gitHubMatch || gitLabMatch) {
-      const baseUrl = gitHubMatch ? 'https://github.com/' : 'https://gitlab.com/';
-      const match = gitHubMatch || gitLabMatch;
-      url = baseUrl + match[1] + '/' + match[2].replace(/.git/, '');
-      if (match[3]) {
-        url = url + '/tree/master/' + match[3];
+    if (gitMatch) {
+      const [_, baseUrl, repoDir, fileDir] = gitMatch;
+      url = baseUrl.replace(/git@/, 'https://') + '/' + repoDir.replace(/.git/, '');
+      if (fileDir) {
+        url = url + '/tree/master/' + fileDir;
       }
     } else if (bitbucketMatch) {
       const baseUrl = 'https://bitbucket.org/';
@@ -271,22 +265,19 @@ class Utils {
   }
 
   static getGitCommitUrl(sourceName, sourceVersion) {
-    const gitHubMatch = sourceName.match(Utils.getGitHubRegex());
-    const gitLabMatch = sourceName.match(Utils.getGitLabRegex());
+    const gitMatch = sourceName.match(Utils.getGitRegex());
     const bitbucketMatch = sourceName.match(Utils.getBitbucketRegex());
     let url = null;
-    if (gitHubMatch || gitLabMatch) {
-      const baseUrl = gitHubMatch ? 'https://github.com/' : 'https://gitlab.com/';
-      const match = gitHubMatch || gitLabMatch;
+    if (gitMatch) {
+      const [_, baseUrl, repoDir, fileDir] = gitMatch;
       url =
-        baseUrl +
-        match[1] +
+        baseUrl.replace(/git@/, 'https://') +
         '/' +
-        match[2].replace(/.git/, '') +
+        repoDir.replace(/.git/, '') +
         '/tree/' +
         sourceVersion +
         '/' +
-        match[3];
+        fileDir;
     } else if (bitbucketMatch) {
       const baseUrl = 'https://bitbucket.org/';
       url =
@@ -1119,3 +1110,4 @@ class Utils {
 }
 
 export default Utils;
+

--- a/mlflow/server/js/src/common/utils/Utils.js
+++ b/mlflow/server/js/src/common/utils/Utils.js
@@ -251,7 +251,8 @@ class Utils {
   /**
    * Regular expression for URLs containing the string 'git'.
    * It can be a custom git domain (e.g. https://git.custom.in/repo/dir#file/dir).
-   * Excluding the first overall match, there are three groups: git url, repo directory, and file directory.
+   * Excluding the first overall match, there are three groups:
+   *    git url, repo directory, and file directory.
    * (e.g. group1: https://custom.git.domain, group2: repo/directory, group3: project/directory)
    */
   static getGitRegex() {
@@ -265,7 +266,6 @@ class Utils {
     const gitMatch = sourceName.match(Utils.getGitRegex());
     let url = null;
     if (gitHubMatch || gitLabMatch) {
-      console.log("getGitRepoUrl gitHubMatch");
       const baseUrl = gitHubMatch ? 'https://github.com/' : 'https://gitlab.com/';
       const match = gitHubMatch || gitLabMatch;
       url = baseUrl + match[1] + '/' + match[2].replace(/.git/, '');
@@ -279,8 +279,8 @@ class Utils {
         url = url + '/src/master/' + bitbucketMatch[3];
       }
     } else if (gitMatch) {
-      console.log("getGitRepoUrl gitMatch");
-      const [_, baseUrl, repoDir, fileDir] = gitMatch;
+      // eslint-disable-next-line no-unused-vars
+      const [_fullUrl, baseUrl, repoDir, fileDir] = gitMatch;
       url = baseUrl.replace(/git@/, 'https://') + '/' + repoDir.replace(/.git/, '');
       if (fileDir) {
         url = url + '/tree/master/' + fileDir;
@@ -296,7 +296,6 @@ class Utils {
     const gitMatch = sourceName.match(Utils.getGitRegex());
     let url = null;
     if (gitHubMatch || gitLabMatch) {
-      console.log("getGitCommitUrl gitHubMatch");
       const baseUrl = gitHubMatch ? 'https://github.com/' : 'https://gitlab.com/';
       const match = gitHubMatch || gitLabMatch;
       url =
@@ -320,8 +319,8 @@ class Utils {
         '/' +
         bitbucketMatch[3];
     } else if (gitMatch) {
-      console.log("getGitCommitUrl gitMatch");
-      const [_, baseUrl, repoDir, fileDir] = gitMatch;
+      // eslint-disable-next-line no-unused-vars
+      const [_fullUrl, baseUrl, repoDir, fileDir] = gitMatch;
       url =
         baseUrl.replace(/git@/, 'https://') +
         '/' +

--- a/mlflow/server/js/src/common/utils/Utils.js
+++ b/mlflow/server/js/src/common/utils/Utils.js
@@ -279,8 +279,7 @@ class Utils {
         url = url + '/src/master/' + bitbucketMatch[3];
       }
     } else if (gitMatch) {
-      // eslint-disable-next-line no-unused-vars
-      const [_fullUrl, baseUrl, repoDir, fileDir] = gitMatch;
+      const [, baseUrl, repoDir, fileDir] = gitMatch;
       url = baseUrl.replace(/git@/, 'https://') + '/' + repoDir.replace(/.git/, '');
       if (fileDir) {
         url = url + '/tree/master/' + fileDir;

--- a/mlflow/server/js/src/common/utils/Utils.test.js
+++ b/mlflow/server/js/src/common/utils/Utils.test.js
@@ -449,7 +449,7 @@ test('getGitRegex', () => {
     [
       'https://custom.git.domain/repo/directory#project/directory',
       ['https://custom.git.domain', 'repo/directory', 'project/directory']
-    ]
+    ],
   ];
   urlAndExpected.forEach((lst) => {
     const url = lst[0];

--- a/mlflow/server/js/src/common/utils/Utils.test.js
+++ b/mlflow/server/js/src/common/utils/Utils.test.js
@@ -413,43 +413,63 @@ test('dropExtension', () => {
   expect(Utils.dropExtension('.foo/.bar/.xyz')).toEqual('.foo/.bar/.xyz');
 });
 
-test('getGitRegex', () => {
-  const gitRegex = Utils.getGitRegex();
+test('getGitHubRegex', () => {
+  const gitHubRegex = Utils.getGitHubRegex();
   const urlAndExpected = [
     [
       'http://github.com/mlflow/mlflow-apps',
-      ['http://github.com', 'mlflow/mlflow-apps', undefined],
+      ['/github.com/mlflow/mlflow-apps', 'mlflow', 'mlflow-apps', ''],
     ],
     [
       'https://github.com/mlflow/mlflow-apps',
-      ['https://github.com', 'mlflow/mlflow-apps', undefined],
+      ['/github.com/mlflow/mlflow-apps', 'mlflow', 'mlflow-apps', ''],
     ],
     [
       'http://github.com/mlflow/mlflow-apps.git',
-      [ 'http://github.com', 'mlflow/mlflow-apps', undefined],
+      ['/github.com/mlflow/mlflow-apps.git', 'mlflow', 'mlflow-apps', ''],
     ],
     [
       'https://github.com/mlflow/mlflow-apps.git',
-      ['https://github.com', 'mlflow/mlflow-apps', undefined],
+      ['/github.com/mlflow/mlflow-apps.git', 'mlflow', 'mlflow-apps', ''],
     ],
     [
       'https://github.com/mlflow/mlflow#example/tutorial',
-      ['https://github.com', 'mlflow/mlflow', 'example/tutorial'],
+      ['/github.com/mlflow/mlflow#example/tutorial', 'mlflow', 'mlflow', 'example/tutorial'],
     ],
     [
       'https://github.com/username/repo.name#mlproject',
-      ['https://github.com', 'username/repo.name', 'mlproject'],
+      ['/github.com/username/repo.name#mlproject', 'username', 'repo.name', 'mlproject'],
     ],
     [
       'git@github.com:mlflow/mlflow-apps.git',
-      ['git@github.com', 'mlflow/mlflow-apps', undefined],
+      ['@github.com:mlflow/mlflow-apps.git', 'mlflow', 'mlflow-apps', ''],
     ],
-    ['https://some-other-site.com?q=github.com/mlflow/mlflow-apps.git', [undefined]],
-    ['ssh@some-server:mlflow/mlflow-apps.git', [undefined]],
+    ['https://some-other-site.com?q=github.com/mlflow/mlflow-apps.git', [null]],
+    ['ssh@some-server:mlflow/mlflow-apps.git', [null]],
+  ];
+  urlAndExpected.forEach((lst) => {
+    const url = lst[0];
+    const match = url.match(gitHubRegex);
+    if (match) {
+      match[2] = match[2].replace(/.git/, '');
+    }
+    expect([].concat(match)).toEqual(lst[1]);
+  });
+});
+
+test('getRegex', () => {
+  const gitRegex = Utils.getGitRegex();
+  const urlAndExpected = [
     [
       'https://custom.git.domain/repo/directory#project/directory',
       ['https://custom.git.domain', 'repo/directory', 'project/directory']
     ],
+    [
+      'git@git.custom.in/repo/directory#project/directory',
+      ['git@git.custom.in', 'repo/directory', 'project/directory']
+    ],
+    ['https://some-other-site.com?q=github.com/mlflow/mlflow-apps.git', [undefined]],
+    ['ssh@some-server:mlflow/mlflow-apps.git', [undefined]],
   ];
   urlAndExpected.forEach((lst) => {
     const url = lst[0];

--- a/mlflow/server/js/src/common/utils/Utils.test.js
+++ b/mlflow/server/js/src/common/utils/Utils.test.js
@@ -462,11 +462,11 @@ test('getRegex', () => {
   const urlAndExpected = [
     [
       'https://custom.git.domain/repo/directory#project/directory',
-      ['https://custom.git.domain', 'repo/directory', 'project/directory']
+      ['https://custom.git.domain', 'repo/directory', 'project/directory'],
     ],
     [
       'git@git.custom.in/repo/directory#project/directory',
-      ['git@git.custom.in', 'repo/directory', 'project/directory']
+      ['git@git.custom.in', 'repo/directory', 'project/directory'],
     ],
     ['https://some-other-site.com?q=github.com/mlflow/mlflow-apps.git', [undefined]],
     ['ssh@some-server:mlflow/mlflow-apps.git', [undefined]],
@@ -930,4 +930,3 @@ test('isValidHttpUrl', () => {
   /* eslint-disable no-script-url*/
   expect(Utils.isValidHttpUrl('javascript:void(0)')).toEqual(false);
 });
-

--- a/mlflow/server/js/src/common/utils/Utils.test.js
+++ b/mlflow/server/js/src/common/utils/Utils.test.js
@@ -413,47 +413,51 @@ test('dropExtension', () => {
   expect(Utils.dropExtension('.foo/.bar/.xyz')).toEqual('.foo/.bar/.xyz');
 });
 
-test('getGitHubRegex', () => {
-  const gitHubRegex = Utils.getGitHubRegex();
+test('getGitRegex', () => {
+  const gitRegex = Utils.getGitRegex();
   const urlAndExpected = [
     [
       'http://github.com/mlflow/mlflow-apps',
-      ['/github.com/mlflow/mlflow-apps', 'mlflow', 'mlflow-apps', ''],
+      ['http://github.com', 'mlflow/mlflow-apps', undefined],
     ],
     [
       'https://github.com/mlflow/mlflow-apps',
-      ['/github.com/mlflow/mlflow-apps', 'mlflow', 'mlflow-apps', ''],
+      ['https://github.com', 'mlflow/mlflow-apps', undefined],
     ],
     [
       'http://github.com/mlflow/mlflow-apps.git',
-      ['/github.com/mlflow/mlflow-apps.git', 'mlflow', 'mlflow-apps', ''],
+      [ 'http://github.com', 'mlflow/mlflow-apps', undefined],
     ],
     [
       'https://github.com/mlflow/mlflow-apps.git',
-      ['/github.com/mlflow/mlflow-apps.git', 'mlflow', 'mlflow-apps', ''],
+      ['https://github.com', 'mlflow/mlflow-apps', undefined],
     ],
     [
       'https://github.com/mlflow/mlflow#example/tutorial',
-      ['/github.com/mlflow/mlflow#example/tutorial', 'mlflow', 'mlflow', 'example/tutorial'],
+      ['https://github.com', 'mlflow/mlflow', 'example/tutorial'],
     ],
     [
       'https://github.com/username/repo.name#mlproject',
-      ['/github.com/username/repo.name#mlproject', 'username', 'repo.name', 'mlproject'],
+      ['https://github.com', 'username/repo.name', 'mlproject'],
     ],
     [
       'git@github.com:mlflow/mlflow-apps.git',
-      ['@github.com:mlflow/mlflow-apps.git', 'mlflow', 'mlflow-apps', ''],
+      ['git@github.com', 'mlflow/mlflow-apps', undefined],
     ],
-    ['https://some-other-site.com?q=github.com/mlflow/mlflow-apps.git', [null]],
-    ['ssh@some-server:mlflow/mlflow-apps.git', [null]],
+    ['https://some-other-site.com?q=github.com/mlflow/mlflow-apps.git', [undefined]],
+    ['ssh@some-server:mlflow/mlflow-apps.git', [undefined]],
+    [
+      'https://custom.git.domain/repo/directory#project/directory',
+      ['https://custom.git.domain', 'repo/directory', 'project/directory']
+    ]
   ];
   urlAndExpected.forEach((lst) => {
     const url = lst[0];
-    const match = url.match(gitHubRegex);
+    const match = url.match(gitRegex);
     if (match) {
       match[2] = match[2].replace(/.git/, '');
     }
-    expect([].concat(match)).toEqual(lst[1]);
+    expect([].concat(match?.slice(1))).toEqual(lst[1]);
   });
 });
 
@@ -906,3 +910,4 @@ test('isValidHttpUrl', () => {
   /* eslint-disable no-script-url*/
   expect(Utils.isValidHttpUrl('javascript:void(0)')).toEqual(false);
 });
+


### PR DESCRIPTION
## Related Issues/PRs

Resolve #7853 


## What changes are proposed in this pull request?

~~Merge `gitHubRegex` and `gitLabRegex` to `gitRegex`.~~
Add new`gitRegex`. (Allow any domain to contain `git`)


## How is this patch tested?
- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)


## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.


## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [x] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
