### PR TITLE
Add sagemaker multi-container endpoint support

### DIFF
--- a/mlflow/models/container/__init__.py
+++ b/mlflow/models/container/__init__.py
@@ -8,8 +8,11 @@ import multiprocessing
 import os
 import signal
 import shutil
+import string
 from subprocess import check_call, Popen
 import sys
+import tempfile
+import typing
 import logging
 
 from pkg_resources import resource_filename
@@ -31,10 +34,14 @@ MODEL_PATH = "/opt/ml/model"
 
 DEPLOYMENT_CONFIG_KEY_FLAVOR_NAME = "MLFLOW_DEPLOYMENT_FLAVOR_NAME"
 
-DEFAULT_SAGEMAKER_SERVER_PORT = 8080
-DEFAULT_INFERENCE_SERVER_PORT = 8000
-DEFAULT_NGINX_SERVER_PORT = 8080
-DEFAULT_MLSERVER_PORT = 8080
+PRIMARY_HOST_ADDRESS = "0.0.0.0"
+UPSTREAM_HOST_ADDRESS = "127.0.0.1"
+
+DEFAULT_PRIMARY_PORT = 8080
+DEFAULT_UPSTREAM_PORT = 8000
+
+SAGEMAKER_BIND_TO_PORT = "SAGEMAKER_BIND_TO_PORT"
+SAGEMAKER_SAFE_PORT_RANGE = "SAGEMAKER_SAFE_PORT_RANGE"
 
 SUPPORTED_FLAVORS = [pyfunc.FLAVOR_NAME, mleap.FLAVOR_NAME]
 
@@ -171,9 +178,21 @@ def _serve_pyfunc(model, env_manager):
     if disable_nginx or enable_mlserver:
         start_nginx = False
 
+    upstream_host = PRIMARY_HOST_ADDRESS
+    primary_port = _derive_primary_port(DEFAULT_PRIMARY_PORT)
+    upstream_port = _derive_upstream_port(primary_port, DEFAULT_UPSTREAM_PORT)
+
     if start_nginx:
         nginx_conf = resource_filename(
             mlflow.models.__name__, "container/scoring_server/nginx.conf"
+        )
+
+        upstream_host = UPSTREAM_HOST_ADDRESS
+        nginx_conf = _interpolate_nginx_config(
+            nginx_conf,
+            upstream_host,
+            primary_port,
+            upstream_port,
         )
 
         nginx = Popen(["nginx", "-c", nginx_conf]) if start_nginx else None
@@ -191,8 +210,13 @@ def _serve_pyfunc(model, env_manager):
     inference_server = mlserver if enable_mlserver else scoring_server
     # Since MLServer will run without NGINX, expose the server in the `8080`
     # port, which is the assumed "public" port.
-    port = DEFAULT_MLSERVER_PORT if enable_mlserver else DEFAULT_INFERENCE_SERVER_PORT
-    cmd, cmd_env = inference_server.get_cmd(model_uri=MODEL_PATH, nworkers=cpu_count, port=port)
+    port = primary_port if disable_nginx else upstream_port
+    cmd, cmd_env = inference_server.get_cmd(
+        model_uri=MODEL_PATH,
+        nworkers=cpu_count,
+        host=upstream_host,
+        port=port,
+    )
 
     bash_cmds.append(cmd)
     inference_server_process = Popen(["/bin/bash", "-c", " && ".join(bash_cmds)], env=cmd_env)
@@ -205,13 +229,14 @@ def _serve_pyfunc(model, env_manager):
 
 
 def _serve_mleap():
+    primary_port = _derive_primary_port(DEFAULT_PRIMARY_PORT)
     serve_cmd = [
         "java",
         "-cp",
         '"/opt/java/jars/*"',
         "org.mlflow.sagemaker.ScoringServer",
         MODEL_PATH,
-        str(DEFAULT_SAGEMAKER_SERVER_PORT),
+        str(primary_port),
     ]
     # Invoke `Popen` with a single string command in the shell to support wildcard usage
     # with the mlflow jar version.
@@ -254,3 +279,81 @@ def _sigterm_handler(pids):
             pass
 
     sys.exit(0)
+
+
+def _derive_primary_port(default_port: int) -> int:
+    """
+    Returns SAGEMAKER_BIND_TO_PORT environment variable value, if present, or a given default port.
+    """
+    return int(os.getenv(SAGEMAKER_BIND_TO_PORT, default_port))
+
+
+def _derive_upstream_port(busy_port: int, default_port: int) -> int:
+    """
+    Returns port from SAGEMAKER_SAFE_PORT_RANGE environment variable value, if present,
+    or a given default port. SAGEMAKER_SAFE_PORT_RANGE specifies the value as an inclusive
+    range in the format "XXXX-YYYY".
+
+    :param busy_port: denotes an already occupied primary port;
+        the returned value must not coincide with this value.
+    """
+    port_range = os.getenv(SAGEMAKER_SAFE_PORT_RANGE)
+    if port_range is None:
+        return default_port
+    else:
+        lower_bound, upper_bound = _parse_sagemaker_safe_port_range(port_range)
+        port = _select_port_from_range(lower_bound, upper_bound, busy_port)
+        return port
+
+
+def _select_port_from_range(lower_bound: int, upper_bound: int, busy_port: int) -> int:
+    """
+    Returns a port value within lower and upper bounds excluding a given busy port.
+    """
+    port = lower_bound
+    if port != busy_port:
+        return port
+    else:
+        port += 1
+        if port > upper_bound:
+            # in case when lower_bound == busy_port AND lower_bound == upper_bound
+            raise ValueError(
+                f"Could not find a vacant port within an inclusive range"
+                f" '{lower_bound}'-'{upper_bound}' and a busy port '{busy_port}'."
+            )
+        return port
+
+
+def _parse_sagemaker_safe_port_range(port_range: str) -> typing.Tuple[int, int]:
+    """
+    Parses values range string in "XXXX-YYYY" format (SAGEMAKER_SAFE_PORT_RANGE environment
+    variable, if present) and returns a lower bound (XXXX) and an upper bound (YYYY) values.
+    """
+    lower_bound, upper_bound = port_range.split("-", maxsplit=1)
+    return int(lower_bound), int(upper_bound)
+
+
+def _interpolate_nginx_config(
+    config_path: str,
+    upstream_host: str,
+    primary_port: int,
+    upstream_port: int,
+) -> str:
+    """
+    Reads the original nginx config file, given as config_path, interpolates
+    upstream_host, primary_port, upstream_port values, writes an updated
+    nginx config file to a temporary destination, and returns its path.
+    """
+    with open(config_path) as file:
+        nginx_conf_content = file.read()
+
+    nginx_conf_content = string.Template(nginx_conf_content).safe_substitute(
+        upstream_host=upstream_host,
+        primary_port=primary_port,
+        upstream_port=upstream_port,
+    )
+
+    with tempfile.NamedTemporaryFile("w+", delete=False) as fp:
+        fp.write(nginx_conf_content)
+
+    return fp.name

--- a/mlflow/models/container/__init__.py
+++ b/mlflow/models/container/__init__.py
@@ -208,8 +208,10 @@ def _serve_pyfunc(model, env_manager):
     cpu_count = multiprocessing.cpu_count()
 
     inference_server = mlserver if enable_mlserver else scoring_server
-    # Since MLServer will run without NGINX, expose the server in the `8080`
-    # port, which is the assumed "public" port.
+    # If the scoring server runs without NGINX, expose the server in the "primary"
+    # port (DEFAULT_PRIMARY_PORT or SAGEMAKER_BIND_TO_PORT env var),
+    # which is the assumed "public" port; otherwise, expose the "upstream"
+    # port (DEFAULT_UPSTREAM_PORT or selected from SAGEMAKER_SAFE_PORT_RANGE).
     port = primary_port if disable_nginx else upstream_port
     cmd, cmd_env = inference_server.get_cmd(
         model_uri=MODEL_PATH,

--- a/mlflow/models/container/__init__.py
+++ b/mlflow/models/container/__init__.py
@@ -312,6 +312,12 @@ def _select_port_from_range(lower_bound: int, upper_bound: int, busy_port: int) 
     """
     Returns a port value within lower and upper bounds excluding a given busy port.
     """
+    if lower_bound > upper_bound:
+        raise ValueError(
+            f"The lower bound port value must be less than or equal to the upper one,"
+            f" '{lower_bound}' > '{upper_bound}' given."
+        )
+
     port = lower_bound
     if port != busy_port:
         return port

--- a/mlflow/models/container/__init__.py
+++ b/mlflow/models/container/__init__.py
@@ -301,6 +301,8 @@ def _derive_upstream_port(busy_port: int, default_port: int) -> int:
     """
     port_range = os.getenv(SAGEMAKER_SAFE_PORT_RANGE)
     if port_range is None:
+        if default_port == busy_port:
+            raise ValueError("Default upstream port is already busy.")
         return default_port
     else:
         lower_bound, upper_bound = _parse_sagemaker_safe_port_range(port_range)

--- a/mlflow/models/container/scoring_server/nginx.conf
+++ b/mlflow/models/container/scoring_server/nginx.conf
@@ -15,11 +15,11 @@ http {
   access_log /var/log/nginx/access.log combined;
   
   upstream gunicorn {
-    server 127.0.0.1:8000;
+    server ${upstream_host}:${upstream_port};
   }
 
   server {
-    listen 8080 deferred;
+    listen ${primary_port} deferred;
     client_max_body_size 5m;
 
     keepalive_timeout 75;

--- a/mlflow/models/docker_utils.py
+++ b/mlflow/models/docker_utils.py
@@ -82,6 +82,9 @@ _DOCKERFILE_TEMPLATE = """
 # Build an image that can serve mlflow models.
 FROM ubuntu:20.04
 
+# Set a docker label to enable container to use SAGEMAKER_BIND_TO_PORT environment variable if present 
+LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
+
 RUN apt-get -y update
 RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y --no-install-recommends \
          wget \

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -324,7 +324,7 @@ def _serve(model_uri, port, host):
 
 
 def get_cmd(
-    model_uri: str, port: int = None, host: int = None, timeout: int = None, nworkers: int = None
+    model_uri: str, port: int = None, host: str = None, timeout: int = None, nworkers: int = None
 ) -> Tuple[str, Dict[str, str]]:
     local_uri = path_to_local_file_uri(model_uri)
     timeout = timeout or MLFLOW_SCORING_SERVER_REQUEST_TIMEOUT.get()

--- a/tests/models/container/test_container.py
+++ b/tests/models/container/test_container.py
@@ -1,0 +1,195 @@
+import os
+import string
+
+import pytest
+
+from mlflow.models.container import (
+    _derive_primary_port,
+    _derive_upstream_port,
+    _interpolate_nginx_config,
+    _parse_sagemaker_safe_port_range,
+    _select_port_from_range,
+    SAGEMAKER_BIND_TO_PORT,
+    SAGEMAKER_SAFE_PORT_RANGE,
+)
+
+
+@pytest.fixture
+def default_port():
+    return "8080"
+
+
+@pytest.fixture
+def sagemaker_bind_to_port_env_value():
+    return "8081"
+
+
+@pytest.fixture
+def sagemaker_safe_port_range_env_value():
+    return "1000-1005"
+
+
+@pytest.fixture
+def sagemaker_safe_port_range_env_value_parsed():
+    return 1000, 1005
+
+
+@pytest.fixture
+def mock_sagemaker_bind_to_port_env(monkeypatch, sagemaker_bind_to_port_env_value):
+    monkeypatch.setenv(SAGEMAKER_BIND_TO_PORT, sagemaker_bind_to_port_env_value)
+
+
+@pytest.fixture
+def mock_sagemaker_bind_to_port_env_missing(monkeypatch):
+    monkeypatch.delenv(SAGEMAKER_BIND_TO_PORT, raising=False)
+
+
+@pytest.fixture
+def mock_sagemaker_safe_port_range_env(monkeypatch, sagemaker_safe_port_range_env_value):
+    monkeypatch.setenv(SAGEMAKER_SAFE_PORT_RANGE, sagemaker_safe_port_range_env_value)
+
+
+@pytest.fixture
+def mock_sagemaker_safe_port_range_env_missing(monkeypatch):
+    monkeypatch.delenv(SAGEMAKER_SAFE_PORT_RANGE, raising=False)
+
+
+@pytest.fixture
+def dummy_nginx_config_template():
+    return "${primary_port} ${upstream_host} ${upstream_port} $http_host"
+
+
+@pytest.fixture
+def dummy_nginx_config(dummy_nginx_config_template):
+    def _dummy_nginx_config(primary_port, upstream_host, upstream_port):
+        return string.Template(dummy_nginx_config_template).safe_substitute(
+            upstream_host=upstream_host,
+            primary_port=primary_port,
+            upstream_port=upstream_port,
+        )
+
+    return _dummy_nginx_config
+
+
+@pytest.fixture
+def dummy_nginx_config_template_file(tmp_path, dummy_nginx_config_template):
+    nginx_config_path = tmp_path / "nginx.conf"
+    with nginx_config_path.open("w") as file:
+        file.write(dummy_nginx_config_template)
+    return nginx_config_path
+
+
+def test_derive_primary_port(
+    mock_sagemaker_bind_to_port_env, sagemaker_bind_to_port_env_value, default_port
+):
+    default_port = int(default_port)
+    port = _derive_primary_port(default_port)
+    assert port == int(sagemaker_bind_to_port_env_value)
+
+
+def test_derive_primary_port_env_missing(
+    mock_sagemaker_bind_to_port_env_missing,
+    sagemaker_bind_to_port_env_value,
+    default_port,
+):
+    default_port = int(default_port)
+    port = _derive_primary_port(default_port)
+    assert port == default_port
+
+
+def test_parse_sagemaker_safe_port_range_valid_value(
+    sagemaker_safe_port_range_env_value,
+    sagemaker_safe_port_range_env_value_parsed,
+):
+    assert (
+        _parse_sagemaker_safe_port_range(sagemaker_safe_port_range_env_value)
+        == sagemaker_safe_port_range_env_value_parsed
+    )
+
+
+@pytest.mark.parametrize(
+    ("port_range", "error_message"),
+    (
+        ("", r"not enough values to unpack \(expected 2, got 1\)"),
+        ("1000", r"not enough values to unpack \(expected 2, got 1\)"),
+        ("1000-", r"invalid literal for int\(\) with base 10.*"),
+        ("mlflow", r"not enough values to unpack \(expected 2, got 1\)"),
+        ("ml-flow", r"invalid literal for int\(\) with base 10.*"),
+    ),
+)
+def test_parse_sagemaker_safe_port_range_invalid_values(port_range, error_message):
+    with pytest.raises(ValueError, match=error_message):
+        _ = _parse_sagemaker_safe_port_range(port_range)
+
+
+@pytest.mark.parametrize(
+    ("lower_bound", "upper_bound", "busy_port", "expected"),
+    (
+        (1000, 1005, 8080, 1000),
+        (1000, 1005, 1000, 1001),
+    ),
+)
+def test_select_port_from_range_valid_values(lower_bound, upper_bound, busy_port, expected):
+    assert _select_port_from_range(lower_bound, upper_bound, busy_port) == expected
+
+
+@pytest.mark.parametrize(
+    ("lower_bound", "upper_bound", "busy_port", "error_message"),
+    (
+        (1005, 1000, 8080, r"The lower bound port value must be less than or equal.*"),
+        (1000, 1000, 1000, r"Could not find a vacant port within an inclusive range.*"),
+    ),
+)
+def test_select_port_from_range_invalid_values(lower_bound, upper_bound, busy_port, error_message):
+    with pytest.raises(ValueError, match=error_message):
+        _ = _select_port_from_range(lower_bound, upper_bound, busy_port)
+
+
+def test_derive_upstream_port_env(
+    mock_sagemaker_safe_port_range_env,
+    default_port,
+    sagemaker_safe_port_range_env_value_parsed,
+):
+    default_port = int(default_port)
+    busy_port = default_port + 1
+    expected_port = sagemaker_safe_port_range_env_value_parsed[0]
+    assert _derive_upstream_port(busy_port, default_port) == expected_port
+
+
+def test_derive_upstream_port_env_missing(mock_sagemaker_safe_port_range_env_missing, default_port):
+    default_port = int(default_port)
+    busy_port = default_port + 1
+    assert _derive_upstream_port(busy_port, default_port) == default_port
+
+
+def test_derive_upstream_port_env_missing_invalid_input(
+    mock_sagemaker_safe_port_range_env_missing,
+    default_port,
+):
+    default_port = int(default_port)
+    with pytest.raises(ValueError, match=r"Default upstream port is already busy\."):
+        _ = _derive_upstream_port(default_port, default_port)
+
+
+def test_interpolate_nginx_config(dummy_nginx_config_template_file, dummy_nginx_config):
+    primary_port = 8080
+    upstream_host = "0.0.0.0"
+    upstream_port = 8000
+    expected = dummy_nginx_config(primary_port, upstream_host, upstream_port)
+
+    nginx_config_file_path = _interpolate_nginx_config(
+        dummy_nginx_config_template_file,
+        upstream_host,
+        primary_port,
+        upstream_port,
+    )
+    nginx_conf_content = _read_file(nginx_config_file_path)
+
+    assert nginx_conf_content == expected
+
+    os.unlink(nginx_config_file_path)
+
+
+def _read_file(path: str) -> str:
+    with open(path) as file:
+        return file.read()


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

Resolve #7900

## What changes are proposed in this pull request?

MLflow Sagemaker serving container, which is built by the `mlflow sagemaker build-and-push-container` command, now also supports deployment as Sagemaker multi-container or serial inference pipeline endpoints (documentation [link 1](https://docs.aws.amazon.com/sagemaker/latest/dg/multi-container-endpoints.html) and [link 2](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-pipelines.html) respectively).
In the Sagemaker environment, two environment variables - `SAGEMAKER_BIND_TO_PORT` and `SAGEMAKER_SAFE_PORT_RANGE` - are utilized as parameters to start various ML scoring services.

Thought process:

From the codebase standpoint, the following scoring server setups are available:
- `nginx -> gunicorn` / `nginx -> waitress-server` (for `nt` systems only; let's call such options `proxy -> upstream`),
- `gunicorn` / `waitress-server`,
- `mleap`,
- `MLServer`.

- In the Sagemaker environment in a single-container setup:
	- model container must listen to port 8080 (https://docs.aws.amazon.com/sagemaker/latest/dg/your-algorithms-inference-code.html#your-algorithms-inference-code-container-response);
	- in the case of `proxy -> upstream` scoring server setup, `proxy` listens to port 8080 while `upstream` should listen to another port (e.g. 8000).
- In a multi-container setup:
	- containers listen to the port specified in the `SAGEMAKER_BIND_TO_PORT` environment variable instead of port 8080 (https://docs.aws.amazon.com/sagemaker/latest/dg/multi-container-direct.html#multi-container-troubleshooting);
	- in the case of `proxy -> upstream`, `proxy` listens to the port specified in the `SAGEMAKER_BIND_TO_PORT` environment variable while `upstream` should listen to a port selected in the range specified by the `SAGEMAKER_SAFE_PORT_RANGE` environment variable (https://docs.aws.amazon.com/sagemaker/latest/dg/multi-container-direct.html#multi-container-troubleshooting).

- To let the container consume outbound traffic, a scoring server in the container should point to the `0.0.0.0` host address. This is true for the options w/ `nginx` disabled.
- In the case of `proxy -> upstream`, `upstream` should point to `127.0.0.1`.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

As far as I can tell, there are no tests (to date) that cover functionality I've been working on

An end-to-end (_almost_) example of running multi-container and inference pipeline Sagemaker endpoints - [mlflow-multi-container-endpoint.ipynb](https://github.com/morelen17/mlflow-pr-7979-test-example/blob/main/mlflow-multi-container-endpoint.ipynb). You can find there "tests" of `nginx -> gunicorn` and `gunicorn` scoring server setups.

Neither `MLServer` (reason - https://github.com/mlflow/mlflow/pull/7443) nor `mleap` (reason - not "tested" _for now_) have been "tested". `nginx -> waitress-server` and `waitress-server` scoring server options are not considered as well (reason - `waitress-server` works only on `nt` systems so it is not relevant for Sagemaker).

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

MLflow models can be deployed as part of a multi-container or inference pipeline endpoint in AWS Sagemaker now by supporting `SAGEMAKER_BIND_TO_PORT` and `SAGEMAKER_SAFE_PORT_RANGE` environment variables usage.

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [x] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
