### PR TITLE
Add `--app-name` option to `mlflow server` to allow specifying mlflow app name

### DIFF
--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -218,7 +218,7 @@ plugin:
      - `DummyEvaluator <https://github.com/mlflow/mlflow/blob/branch-1.23/tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_evaluator.py>`_.
    * - [Experimental] Plugins for custom mlflow server flask app configuration `mlflow.server.app <https://github.com/mlflow/mlflow/blob/v2.2.0/mlflow/server/__init__.py#L30>`_.
      - mlflow.app
-     - The entry point name (e.g. ``mlflow_test_plugin:app``) specifies a customized flask application. This can be useful for implementing
+     - The entry point name (e.g. ``custom_app=mlflow_test_plugin.app:app``) specifies a customized flask application. This can be useful for implementing
        request hooks, custom logging and custom flask configurations. The plugin must import `mlflow.server.app` (e.g. ``from mlflow.server import app``) and may add custom configuration, middleware etc. to the app.
        The plugin should avoid altering the existing application routes, handlers and environment variables to avoid unexpected behavior.
        Users who install the example plugin will have a customized flask application. To run a tracking server with the customized flask application, ``mlflow server --app-name <app_name>`` can be used.

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -221,7 +221,7 @@ plugin:
      - The entry point name (e.g. ``mlflow_test_plugin:app``) specifies a customized flask application. This can be useful for implementing
        request hooks, custom logging and custom flask configurations. The plugin must import `mlflow.server.app` (e.g. ``from mlflow.server import app``) and may add custom configuration, middleware etc. to the app.
        The plugin should avoid altering the existing application routes, handlers and environment variables to avoid unexpected behavior.
-       Users who install the example plugin will have a customized flask application.
+       Users who install the example plugin will have a customized flask application. To run a tracking server with the customized flask application, ``mlflow server --app-name <app_name>`` can be used.
      - `app <https://github.com/mlflow/mlflow/blob/v2.3.0/tests/resources/mlflow-test-plugin/mlflow_test_plugin/app.py>`_.
 
 

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -216,12 +216,12 @@ plugin:
        ``dataset`` (an instance of ``mlflow.models.evaluation.base._EvaluationDataset`` containing features and labels (optional) for model evaluation),
        ``run_id`` (the ID of the MLflow Run to which to log results), and ``evaluator_config`` (a dictionary of additional configurations for the evaluator).
      - `DummyEvaluator <https://github.com/mlflow/mlflow/blob/branch-1.23/tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_evaluator.py>`_.
-   * - [Experimental] Plugins for custom mlflow server flask app configuration `mlflow.server.app <https://github.com/mlflow/mlflow/blob/v2.2.0/mlflow/server/__init__.py#L30>`_.
+   * - [Experimental] Plugins for custom mlflow server flask app configuration `mlflow.server.app <https://github.com/mlflow/mlflow/blob/v2.2.0/mlflow/server/__init__.py#L31>`_.
      - mlflow.app
-     - The entry point name (e.g. ``custom_app=mlflow_test_plugin.app:app``) specifies a customized flask application. This can be useful for implementing
-       request hooks, custom logging and custom flask configurations. The plugin must import `mlflow.server.app` (e.g. ``from mlflow.server import app``) and may add custom configuration, middleware etc. to the app.
+     - The entry point ``<app_name>=<object_reference>`` (e.g. ``custom_app=mlflow_test_plugin.app:app``) specifies a customized flask application. This can be useful for implementing
+       request hooks for authentication/authorization, custom logging and custom flask configurations. The plugin must import `mlflow.server.app` (e.g. ``from mlflow.server import app``) and may add custom configuration, middleware etc. to the app.
        The plugin should avoid altering the existing application routes, handlers and environment variables to avoid unexpected behavior.
-       Users who install the example plugin will have a customized flask application. To run a tracking server with the customized flask application, ``mlflow server --app-name <app_name>`` can be used.
+       Users who install the example plugin will have a customized flask application. To run the customized flask application, use ``mlflow server --app-name <app_name>``.
      - `app <https://github.com/mlflow/mlflow/blob/v2.3.0/tests/resources/mlflow-test-plugin/mlflow_test_plugin/app.py>`_.
 
 

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -5,7 +5,7 @@ import sys
 import logging
 
 import click
-import entrypoints
+import importlib.metadata
 from click import UsageError
 from datetime import timedelta
 
@@ -351,7 +351,7 @@ def _validate_static_prefix(ctx, param, value):  # pylint: disable=unused-argume
 @click.option(
     "--app-name",
     default=None,
-    type=click.Choice([e.name for e in entrypoints.get_group_all("mlflow.app")]),
+    type=click.Choice([e.name for e in importlib.metadata.entry_points().get("mlflow.app", [])]),
     show_default=True,
     help=(
         "Application name to be used for the tracking server. "

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -9,6 +9,7 @@ from click import UsageError
 from datetime import timedelta
 
 import mlflow.db
+import mlflow.server
 from mlflow.entities import ViewType
 import mlflow.experiments
 import mlflow.deployments.cli
@@ -347,6 +348,16 @@ def _validate_static_prefix(ctx, param, value):  # pylint: disable=unused-argume
     "doesn't exist, it will be created. "
     "Activate prometheus exporter to expose metrics on /metrics endpoint.",
 )
+@click.option(
+    "--app-name",
+    default=None,
+    type=click.Choice(mlflow.server._get_mlflow_app_names()),
+    show_default=True,
+    help=(
+        "Application name to be used for the tracking server. "
+        f"If not specified, '{mlflow.server.__name__}:app' will be used."
+    ),
+)
 def server(
     backend_store_uri,
     registry_store_uri,
@@ -361,6 +372,7 @@ def server(
     gunicorn_opts,
     waitress_opts,
     expose_prometheus,
+    app_name,
 ):
     """
     Run the MLflow tracking server.
@@ -410,6 +422,7 @@ def server(
             gunicorn_opts,
             waitress_opts,
             expose_prometheus,
+            app_name,
         )
     except ShellCommandException:
         eprint("Running the mlflow server failed. Please see the logs above for details.")

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -5,11 +5,11 @@ import sys
 import logging
 
 import click
+import entrypoints
 from click import UsageError
 from datetime import timedelta
 
 import mlflow.db
-import mlflow.server
 from mlflow.entities import ViewType
 import mlflow.experiments
 import mlflow.deployments.cli
@@ -351,11 +351,11 @@ def _validate_static_prefix(ctx, param, value):  # pylint: disable=unused-argume
 @click.option(
     "--app-name",
     default=None,
-    type=click.Choice(mlflow.server._get_mlflow_app_names()),
+    type=click.Choice([e.name for e in entrypoints.get_group_all("mlflow.app")]),
     show_default=True,
     help=(
         "Application name to be used for the tracking server. "
-        f"If not specified, '{mlflow.server.__name__}:app' will be used."
+        "If not specified, 'mlflow.server:app' will be used."
     ),
 )
 def server(

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -182,10 +182,10 @@ def _run_server(
     if expose_prometheus:
         env_map[PROMETHEUS_EXPORTER_ENV_VAR] = expose_prometheus
 
-    app_name = f"{__name__}:app" if app_name is None else _find_app(app_name)
+    app_spec = f"{__name__}:app" if app_name is None else _find_app(app_name)
     # TODO: eventually may want waitress on non-win32
     if sys.platform == "win32":
-        full_command = _build_waitress_command(waitress_opts, host, port, app_name)
+        full_command = _build_waitress_command(waitress_opts, host, port, app_spec)
     else:
-        full_command = _build_gunicorn_command(gunicorn_opts, host, port, workers or 4, app_name)
+        full_command = _build_gunicorn_command(gunicorn_opts, host, port, workers or 4, app_spec)
     _exec_cmd(full_command, extra_env=env_map, capture_output=False)

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -108,7 +108,6 @@ def serve():
 
 
 def _find_app(app_name: str) -> str:
-    """Find the entrypoint for the given app name."""
     apps = importlib.metadata.entry_points().get("mlflow.app", [])
     for app in apps:
         if app.name == app_name:

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -111,7 +111,8 @@ def _find_app(app_name: str) -> str:
     """Find the entrypoint for the given app name."""
     apps = entrypoints.get_group_all("mlflow.app")
     for app in apps:
-        return f"{app.module_name}:{app.object_name}"
+        if app.name == app_name:
+            return f"{app.module_name}:{app.object_name}"
 
     raise MlflowException(
         f"Failed to find app: {app_name}. Available apps: {[a.name for a in apps]}"

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -107,17 +107,9 @@ def serve():
     return Response(text, mimetype="text/plain")
 
 
-def _get_mlflow_app_entrypoints():
-    return entrypoints.get_group_all("mlflow.app")
-
-
-def _get_mlflow_app_names():
-    return [a.name for a in _get_mlflow_app_entrypoints()]
-
-
 def _find_app(app_name: str) -> str:
     """Find the entrypoint for the given app name."""
-    apps = _get_mlflow_app_entrypoints()
+    apps = entrypoints.get_group_all("mlflow.app")
     for app in apps:
         return f"{app.module_name}:{app.object_name}"
 

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -1,8 +1,8 @@
-import entrypoints
 import os
 import shlex
 import sys
 import textwrap
+import importlib.metadata
 
 from flask import Flask, send_from_directory, Response
 
@@ -109,13 +109,13 @@ def serve():
 
 def _find_app(app_name: str) -> str:
     """Find the entrypoint for the given app name."""
-    apps = entrypoints.get_group_all("mlflow.app")
+    apps = importlib.metadata.entry_points().get("mlflow.app", [])
     for app in apps:
         if app.name == app_name:
-            return f"{app.module_name}:{app.object_name}"
+            return app.value
 
     raise MlflowException(
-        f"Failed to find app: {app_name}. Available apps: {[a.name for a in apps]}"
+        f"Failed to find app '{app_name}'. Available apps: {[a.name for a in apps]}"
     )
 
 

--- a/tests/resources/mlflow-test-plugin/mlflow_test_plugin/app.py
+++ b/tests/resources/mlflow-test-plugin/mlflow_test_plugin/app.py
@@ -1,3 +1,6 @@
+"""
+To run a tracking server with this app, use `mlflow server --app-name custom_app`.
+"""
 import logging
 
 # This would be all that plugin author is required to import

--- a/tests/resources/mlflow-test-plugin/mlflow_test_plugin/app.py
+++ b/tests/resources/mlflow-test-plugin/mlflow_test_plugin/app.py
@@ -11,6 +11,7 @@ app_logger = logging.getLogger(__name__)
 
 # Configure the app
 custom_app.config["MY_VAR"] = "config-var"
+app_logger.warning(f"Using {__name__}")
 
 
 def is_logged_in():

--- a/tests/resources/mlflow-test-plugin/setup.py
+++ b/tests/resources/mlflow-test-plugin/setup.py
@@ -32,6 +32,6 @@ setup(
         # Define a Mlflow model evaluator with name "dummy_evaluator"
         "mlflow.model_evaluator": "dummy_evaluator=mlflow_test_plugin.dummy_evaluator:DummyEvaluator",  # pylint: disable=line-too-long
         # Define a custom Mlflow application with name custom_app
-        "mlflow.app": "app=mlflow_test_plugin.app:custom_app",
+        "mlflow.app": "custom_app=mlflow_test_plugin.app:custom_app",
     },
 )

--- a/tests/server/test_init.py
+++ b/tests/server/test_init.py
@@ -1,6 +1,5 @@
 from unittest import mock
 
-import entrypoints
 import pytest
 
 from mlflow.exceptions import MlflowException
@@ -13,26 +12,14 @@ def mock_exec_cmd():
         yield m
 
 
-def test_get_app_name():
-    # Hard to test if the test plugin is installed.
-    with mock.patch("mlflow.server.entrypoints.get_group_all", return_value=[]):
-        assert server._get_app_name() == f"{server.__name__}:app"
-
-
-def test_get_app_name_two_plugins():
-    """Two server apps cannot exist, which one would be served?"""
-    plugins = [
-        entrypoints.EntryPoint("one", "one.app", "app"),
-        entrypoints.EntryPoint("two", "two.app", "two"),
-    ]
-    with mock.patch("mlflow.server.entrypoints.get_group_all", return_value=plugins):
-        with pytest.raises(MlflowException, match=r"one.*two"):
-            server._get_app_name()
-
-
-def test_get_app_name_custom_app_plugin():
+def test_find_app_custom_app_plugin():
     """This test requires the package in tests/resources/mlflow-test-plugin to be installed"""
-    assert server._get_app_name() == "mlflow_test_plugin.app:custom_app"
+    assert server._find_app("custom_app") == "mlflow_test_plugin.app:custom_app"
+
+
+def test_find_app_non_existing_app():
+    with pytest.raises(MlflowException, match=r"Failed to find app 'does_not_exist'"):
+        server._find_app("does_not_exist")
 
 
 def test_build_waitress_command():


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #7757

## What changes are proposed in this pull request?

Adds an `--app-name` option to `mlflow server` to allow specifying the mlflow app name.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

```
> mlflow server --app-name custom_app
[2023-03-07 15:23:46 +0900] [26442] [INFO] Starting gunicorn 20.1.0
[2023-03-07 15:23:46 +0900] [26442] [INFO] Listening at: http://127.0.0.1:5000 (26442)
[2023-03-07 15:23:46 +0900] [26442] [INFO] Using worker: sync
[2023-03-07 15:23:46 +0900] [26453] [INFO] Booting worker with pid: 26453
[2023-03-07 15:23:46 +0900] [26454] [INFO] Booting worker with pid: 26454
[2023-03-07 15:23:46 +0900] [26455] [INFO] Booting worker with pid: 26455
[2023-03-07 15:23:46 +0900] [26456] [INFO] Booting worker with pid: 26456
Using mlflow_test_plugin.app
Using mlflow_test_plugin.app
Using mlflow_test_plugin.app
Using mlflow_test_plugin.app
```

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
